### PR TITLE
[PC-4710] script to bump verison and template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,13 @@ I have:
 - [ ] Made sure my feature is working on the relevant real / virtual devices.
 - [ ] Written **unit tests** for my feature.
 - [ ] Added a **screenshot** for UI tickets.
-- [ ] Upgraded the **app version** (+1 minor) if native code (ios/android) was modified.
 - [ ] Explained my technical strategy below if feature is complex.
+
+If native code (ios/android) was modified, after the PR is merged go to master and upgrade the __app version__ (+1 patch):
+
+- use `yarn version --patch` (it will create a commit and a tag)
+- then `git push`
+- then use the deploy script (temporary -> waiting for CI/CD to be ready)
 
 ## Technical strategy
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-4710

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [x] Added a **screenshot** for UI tickets.
- [x] Explained my technical strategy below if feature is complex.

If native code (ios/android) was modified, after the PR is merged go to master and upgrade the __app version__ (+1 patch):\$

- use `yarn version --patch` (it will create a commit and a tag)
- then `git push`

## Technical strategy

> _Insert technical strategy_
