### PR TITLE
[PC-4727] ignore bundle install file in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ src/locales/*/*.js
 # Deploy
 android/keystores/*
 fastlane/playStoreServiceAccount.json
+
+# CircleCI
+vendor/
+.bundle/


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-4727

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [x] Added a **screenshot** for UI tickets.
- [x] Explained my technical strategy below if feature is complex.

If native code (ios/android) was modified, after the PR is merged go to master and upgrade the __app version__ (+1 patch):

(later there will be a script to embed these commands) 
- use `yarn version --patch` (it will create a commit and a tag)
- then `git push && git push origin <tag_name>`
- then use the deploy script (temporary -> waiting for CI/CD to be ready)

## Technical strategy

> _Insert technical strategy_
