### PR TITLE
Fix android deploy on testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ yarn launch`
 On iOS you can run the following command:
 `react-native run-ios --scheme PassCulture-Staging`
 
+#### Development environment
+
+To run the app on a development environment in order to request a local API, you need to create a `.env.development` file,
+copy the `.env.testing` configuration and update the `API_BASE_URL` setting with you local server address. Then create a
+`keystores/development.keystore.properties` under `/android` directory with this configuration (required in `build.gradle`):
+
+```
+keyAlias=passculture
+storeFile=development.keystore
+storePassword=
+keyPassword=
+```
+
+Then run the app with this command:
+
+`react-native run-android --variant=developmentDebug`
+
 ## Features
 
 When you generated the repository with [react-native-make](https://github.com/bamlab/react-native-make) the following feature must be present:

--- a/android/keystores/development.keystore.properties
+++ b/android/keystores/development.keystore.properties
@@ -1,4 +1,0 @@
-keyAlias=passculture
-storeFile=development.keystore
-storePassword=
-keyPassword=


### PR DESCRIPTION
## Technical strategy

Le merge de la PR sur l'authentification (PC-4562) a cassé le déploiement en testing sur android, à cause de ce commit: https://github.com/pass-culture/pass-culture-app-native/commit/763efe1dfb42e690fe8e1dea4c4d399bfa361959. Pour pouvoir lancer le build android en local et en environnement de dev, j'avais ajouté le fichier `android/keystores/development.keystore.properties` mais du coup ça plante le déploiement: https://app.circleci.com/pipelines/github/pass-culture/pass-culture-app-native/156/workflows/58570709-bf77-4cbf-b59b-3d3d895d7d6a/jobs/164. Pour corriger ça j'ai supprimé le fichier, et pour que le build de l'app en environnement de dev fonctionne, il faut le créer à la main (il sera ignoré par git ensuite) => cf README
