### PR TITLE
[PC-4728] Yarn version tool for testing & CI for android hard deployment in testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           command: |
             yarn test:unit
 
-  deploy-android-testing:
+  deploy-android-testing-soft:
     working_directory: ~/pass-culture-app-native
     docker:
       - image: circleci/android:api-28-node
@@ -70,6 +70,29 @@ jobs:
             export APPCENTER_API_TOKEN=$APPCENTER_API_TOKEN_TESTING
             export CODEPUSH_KEY_ANDROID=$CODEPUSH_KEY_ANDROID_TESTING
             ./scripts/deploy.sh -o android -t soft -e testing
+
+  deploy-android-testing-hard:
+    docker:
+      - image: circleci/android:api-28-node
+    steps:
+      - checkout
+      - install_node_modules
+      - install_ruby_modules
+      - run:
+          name: Setup android keystore for testing environment
+          command: |
+            mkdir -p android/keystores
+            echo $ANDROID_KEYSTORE_TESTING | base64 -di > android/keystores/testing.keystore
+            echo "keyAlias=passculture" >> android/keystores/testing.keystore.properties
+            echo "storeFile=testing.keystore" >> android/keystores/testing.keystore.properties
+            echo "storePassword=$ANDROID_KEYSTORE_STORE_PASSWORD_TESTING" >> android/keystores/testing.keystore.properties
+            echo "keyPassword=$ANDROID_KEYSTORE_KEY_PASSWORD_TESTING" >>  android/keystores/testing.keystore.properties
+      - run:
+          name: Deploy Android App for testing environment
+          command: |
+            export APPCENTER_API_TOKEN=$APPCENTER_API_TOKEN_TESTING
+            export CODEPUSH_KEY_ANDROID=$CODEPUSH_KEY_ANDROID_TESTING
+            ./scripts/deploy.sh -o android -t hard -e testing
 
   deploy-android-staging:
     docker:
@@ -99,11 +122,21 @@ workflows:
   commit:
     jobs:
       - run-tests
-      - deploy-android-testing:
+      - deploy-android-testing-soft:
           filters:
             branches:
               only:
                 - master
+          requires:
+            - run-tests
+      - deploy-android-testing-hard:
+          filters:
+            branches:
+              only:
+                - master
+            tags:
+              only:
+                - /^testing_v[0-9]+(\.[0-9]+){2}$/
           requires:
             - run-tests
       - deploy-android-staging:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,10 +10,12 @@ I have:
 - [ ] Added a **screenshot** for UI tickets.
 - [ ] Explained my technical strategy below if feature is complex.
 
-If native code (ios/android) was modified, after the PR is merged go to master and upgrade the __app version__ (+1 patch):
+If native code (ios/android) was modified, after the PR is merged go to master and upgrade the **app version** (+1 patch):
 
-(later there will be a script to embed these commands) 
+(later there will be a script to embed these commands)
+
 - use `yarn version --patch` (it will create a commit and a tag)
+  - if you want an hard deployment of the testing environment, use `yarn version:testing` instead.
 - then `git push && git push origin <tag_name>`
 - then use the deploy script (temporary -> waiting for CI/CD to be ready)
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "postinstall": "patch-package && jetify && yarn translations:compile",
     "translations:add-locale": "lingui add-locale",
     "translations:extract": "lingui extract --clean",
-    "translations:compile": "lingui compile"
+    "translations:compile": "lingui compile",
+    "version:testing": "./scripts/update_testing_version.sh"
   },
   "dependencies": {
     "@bam.tech/react-native-config": "^0.13.0",

--- a/scripts/update_testing_version.sh
+++ b/scripts/update_testing_version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+yarn config set version-tag-prefix "testing_v"
+yarn version --patch
+yarn config set version-tag-prefix "v"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXX

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Explained my technical strategy below if feature is complex.

If native code (ios/android) was modified, after the PR is merged go to master and upgrade the __app version__ (+1 patch):

(later there will be a script to embed these commands) 
- use `yarn version --patch` (it will create a commit and a tag)
- then `git push && git push origin <tag_name>`
- then use the deploy script (temporary -> waiting for CI/CD to be ready)

## Technical strategy

> _Insert technical strategy_
