### PR TITLE
[PC-4792] Integrate React-query

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
     },
   },
   rules: {
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
     'react/prop-types': 'off',
     'react-native/sort-styles': 'off',
     // This is essential. Without this misplaced hooks would go straight to production
@@ -64,6 +65,7 @@ module.exports = {
           '.ios.js',
           '.ios.jsx',
           '.ts',
+          '.d.ts',
           '.tsx',
           '.android.ts',
           '.android.tsx',

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -146,7 +146,7 @@ def enableHermes = project.ext.react.get("enableHermes", false);
  * Keystores passwords are crypted with transcrypt and located in
  * keystores/*.keystore.properties files.
  */
- def keystorePropertiesFile = rootProject.file("keystores/${project.env.get("ENV")}.keystore.properties")
+def keystorePropertiesFile = rootProject.file("keystores/${project.env.get("ENV")}.keystore.properties")
 def keystoreProperties = new Properties()
 keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "node": ">=12.13.0 <13.0.0"
   },
   "scripts": {
-    "install:android": "react-native run-android --variant=developmentDebug",
-    "install:android:testing": "react-native run-android --variant=apptestingDebug",
+    "run:android": "react-native run-android --variant=developmentDebug",
+    "run:android:testing": "react-native run-android --variant=apptestingDebug",
     "start": "react-native start",
     "test": "yarn test:lint && yarn test:types && yarn test:unit",
     "test:lint": "eslint . --ext .js,.ts,.tsx --cache",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "node": ">=12.13.0 <13.0.0"
   },
   "scripts": {
-    "install:android": "react-native run-android --variant=apptestingDebug",
+    "install:android": "react-native run-android --variant=developmentDebug",
+    "install:android:testing": "react-native run-android --variant=apptestingDebug",
     "start": "react-native start",
     "test": "yarn test:lint && yarn test:types && yarn test:unit",
     "test:lint": "eslint . --ext .js,.ts,.tsx --cache",

--- a/src/features/auth/api.ts
+++ b/src/features/auth/api.ts
@@ -1,4 +1,6 @@
-import { post } from 'libs/fetch'
+import { useQuery } from 'react-query'
+
+import { get, post } from 'libs/fetch'
 import { IUser } from 'types'
 
 type Credentials = {
@@ -8,5 +10,13 @@ type Credentials = {
 
 export async function signin({ email, password }: Credentials): Promise<IUser> {
   const body = { identifier: email, password }
-  return post<IUser>('/users/signin', { body })
+  return post<IUser>('/users/signin', { body, credentials: 'omit' })
+}
+
+export function useCurrentUser() {
+  const { data: user, isFetching, refetch, error, isError } = useQuery<IUser>({
+    querykey: 'currentUser',
+    queryFn: async () => get<IUser>('/users/current'),
+  })
+  return { user, isFetching, refetch, error, isError }
 }

--- a/src/features/auth/api.ts
+++ b/src/features/auth/api.ts
@@ -1,22 +1,46 @@
+import { t } from '@lingui/macro'
+import { Alert } from 'react-native'
 import { useQuery } from 'react-query'
 
 import { get, post } from 'libs/fetch'
-import { IUser } from 'types'
+import { _ } from 'libs/i18n'
+import { saveToken } from 'libs/storage'
 
 type Credentials = {
   email: string
   password: string
 }
 
-export async function signin({ email, password }: Credentials): Promise<IUser> {
+type SigninResponse = {
+  access_token: string
+}
+
+export async function signin({ email, password }: Credentials): Promise<boolean> {
   const body = { identifier: email, password }
-  return post<IUser>('/users/signin', { body, credentials: 'omit' })
+  try {
+    const { access_token } = await post<SigninResponse>('/native/v1/signin', {
+      body,
+      credentials: 'omit',
+    })
+    await saveToken(access_token)
+    return true
+  } catch (error) {
+    Alert.alert(_(t`Échec de la connexion au Pass Culture: ${error.message}`))
+    return false
+  }
+}
+
+type LoggedInAs = {
+  logged_in_as: string
 }
 
 export function useCurrentUser() {
-  const { data: user, isFetching, refetch, error, isError } = useQuery<IUser>({
+  const { data: email, isFetching, refetch, error, isError } = useQuery<string>({
     querykey: 'currentUser',
-    queryFn: async () => get<IUser>('/users/current'),
+    queryFn: async function () {
+      const json = await get<LoggedInAs>('/native/v1/protected')
+      return json.logged_in_as
+    },
   })
-  return { user, isFetching, refetch, error, isError }
+  return { email, isFetching, refetch, error, isError }
 }

--- a/src/features/auth/pages/Login.test.tsx
+++ b/src/features/auth/pages/Login.test.tsx
@@ -4,9 +4,6 @@ import { render, fireEvent, waitFor, act } from '@testing-library/react-native'
 import React from 'react'
 import { Text } from 'react-native'
 
-import { NotAuthenticatedError } from 'libs/fetch'
-import { IUser } from 'types'
-
 import * as api from '../api'
 
 import { Login } from './Login'
@@ -36,9 +33,7 @@ describe('<Login/>', () => {
   })
 
   it('should NOT redirect to home page when signin has failed', async () => {
-    jest.spyOn(api, 'signin').mockImplementation(() => {
-      throw new NotAuthenticatedError()
-    })
+    jest.spyOn(api, 'signin').mockImplementation(signingFailure)
     const { getByText, queryByText } = render(
       <NavigationContainer>
         <RootStack.Navigator initialRouteName="Login">
@@ -58,5 +53,9 @@ describe('<Login/>', () => {
 })
 
 async function signingSuccess() {
-  return {} as IUser
+  return true
+}
+
+async function signingFailure() {
+  return false
 }

--- a/src/features/auth/pages/Login.tsx
+++ b/src/features/auth/pages/Login.tsx
@@ -2,7 +2,7 @@ import { t } from '@lingui/macro'
 import { RouteProp } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { FunctionComponent, useState } from 'react'
-import { Button, View, Text, TextInput, StyleSheet, Alert } from 'react-native'
+import { Button, View, Text, TextInput, StyleSheet } from 'react-native'
 
 import { CheatCodesButton } from 'features/cheatcodes/components/CheatCodesButton'
 import { RootStackParamList } from 'features/navigation/RootNavigator'
@@ -33,13 +33,9 @@ export const Login: FunctionComponent<Props> = function (props: Props) {
   const [password, setPassword] = useState(INITIAL_PASSWORD)
 
   async function handleSignin() {
-    try {
-      const user = await signin({ email, password })
-      if (user) {
-        props.navigation.navigate('Home')
-      }
-    } catch (err) {
-      Alert.alert(_(t`Échec de la connexion au Pass Culture: ${err.message}`))
+    const isSigninSuccessful = await signin({ email, password })
+    if (isSigninSuccessful) {
+      props.navigation.navigate('Home')
     }
   }
 

--- a/src/features/home/pages/Home.test.tsx
+++ b/src/features/home/pages/Home.test.tsx
@@ -1,7 +1,9 @@
 import { render, fireEvent, waitFor } from '@testing-library/react-native'
 import React from 'react'
 
+import * as authApi from 'features/auth/api'
 import { env } from 'libs/environment'
+import { IUser } from 'types'
 
 import { Home } from './Home'
 
@@ -16,30 +18,98 @@ describe('Home component', () => {
     navigate: jest.fn(),
   } as any // eslint-disable-line @typescript-eslint/no-explicit-any
 
-  it('should have a welcome message', async () => {
-    const { getByText } = render(<Home navigation={navigation} />)
+  afterAll(() => jest.resetAllMocks())
 
-    const welcomeText = await waitFor(() => getByText('Bienvenue à Pass Culture'))
-    expect(welcomeText.props.children).toBe('Bienvenue à Pass Culture')
-  })
+  describe('With current user loaded', () => {
+    beforeEach(() => {
+      jest.spyOn(authApi, 'useCurrentUser').mockReturnValue({
+        user: {
+          firstName: 'John',
+          lastName: 'Doe',
+          email: 'john.doe@passculture.app',
+        } as IUser,
+      } as ReturnType<typeof authApi.useCurrentUser>)
+    })
 
-  it('should render correctly', () => {
-    const home = render(<Home navigation={navigation} />)
-    expect(home).toMatchSnapshot()
-  })
+    it('should have a welcome message', async () => {
+      const { getByText } = render(<Home navigation={navigation} />)
 
-  it('should have a button to go to login page with params', () => {
-    const { getByText } = render(<Home navigation={navigation} />)
-    const LoginButton = getByText('Aller sur la page de connexion avec params')
-    fireEvent.press(LoginButton)
-    expect(navigation.navigate).toHaveBeenCalledWith('Login', {
-      userId: 'I have been Set by params',
+      const welcomeText = await waitFor(() => getByText('Bienvenue à Pass Culture'))
+      expect(welcomeText.props.children).toBe('Bienvenue à Pass Culture')
+    })
+
+    it('should render correctly', () => {
+      const home = render(<Home navigation={navigation} />)
+      expect(home).toMatchSnapshot()
+    })
+
+    it('should have a button to go to login page with params', () => {
+      const { getByText } = render(<Home navigation={navigation} />)
+      const LoginButton = getByText('Aller sur la page de connexion avec params')
+      fireEvent.press(LoginButton)
+      expect(navigation.navigate).toHaveBeenCalledWith('Login', {
+        userId: 'I have been Set by params',
+      })
+    })
+
+    it('should not have code push button', async () => {
+      env.FEATURE_FLAG_CODE_PUSH_MANUAL = false
+      const home = render(<Home navigation={navigation} />)
+      expect(() => home.getByText('Check update')).toThrowError()
     })
   })
+  describe('Without current user', () => {
+    it('should display activity indicator when loading', () => {
+      jest.spyOn(authApi, 'useCurrentUser').mockReturnValue({
+        isFetching: true,
+      } as ReturnType<typeof authApi.useCurrentUser>)
 
-  it('should not have code push button', async () => {
-    env.FEATURE_FLAG_CODE_PUSH_MANUAL = false
-    const home = render(<Home navigation={navigation} />)
-    expect(() => home.getByText('Check update')).toThrowError()
+      const { getByTestId } = render(<Home navigation={navigation} />)
+      const activityIndicator = getByTestId('user-activity-indicator')
+      expect(activityIndicator).toBeTruthy()
+    })
+    it('should not display activity indicator when not loading', () => {
+      jest.spyOn(authApi, 'useCurrentUser').mockReturnValue({
+        isFetching: false,
+      } as ReturnType<typeof authApi.useCurrentUser>)
+      const { getByTestId } = render(<Home navigation={navigation} />)
+      let activityIndicator
+      try {
+        activityIndicator = getByTestId('user-activity-indicator')
+        fail()
+      } catch (error) {
+        expect(activityIndicator).toBeFalsy()
+      }
+    })
+    it('should not display user view on error', () => {
+      jest.spyOn(authApi, 'useCurrentUser').mockReturnValue({
+        isError: true,
+      } as ReturnType<typeof authApi.useCurrentUser>)
+      const { getByText } = render(<Home navigation={navigation} />)
+      let refreshButton
+      try {
+        refreshButton = getByText("Rafraîchir les données de l'utilisateur")
+        fail()
+      } catch (error) {
+        expect(refreshButton).toBeFalsy()
+      }
+    })
+    it('should call refetch when the refetchbutton is clicked', () => {
+      const refetch = jest.fn()
+      jest.spyOn(authApi, 'useCurrentUser').mockReturnValue({
+        user: {
+          firstName: 'John',
+          lastName: 'Doe',
+          email: 'john.doe@passculture.app',
+        } as IUser,
+        refetch: () => refetch(),
+      } as ReturnType<typeof authApi.useCurrentUser>)
+      const { getByTestId } = render(<Home navigation={navigation} />)
+
+      const refreshButton = getByTestId('refreshUserInformationsButton')
+      refreshButton.props.onClick()
+
+      expect(refetch).toBeCalled()
+    })
   })
 })

--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -1,8 +1,9 @@
 import { t } from '@lingui/macro'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React, { FunctionComponent, useCallback } from 'react'
-import { Button, StyleSheet, View, Text } from 'react-native'
+import { Button, StyleSheet, View, Text, ActivityIndicator } from 'react-native'
 
+import { useCurrentUser } from 'features/auth/api'
 import { RootStackParamList } from 'features/navigation/RootNavigator'
 import { env } from 'libs/environment'
 import { useGeolocation, CoordinatesView } from 'libs/geolocation'
@@ -19,13 +20,18 @@ type Props = {
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
   geolocation: { position: 'absolute', alignItems: 'center', bottom: 50 },
+  userInformations: { alignItems: 'center', paddingVertical: 20 },
 })
 
 export const Home: FunctionComponent<Props> = function ({ navigation }) {
   const position = useGeolocation()
+  const { user, isFetching, refetch, isError } = useCurrentUser()
+
   const goToLoginPageWithParams = useCallback((): void => {
     navigation.navigate('Login', { userId: 'I have been Set by params' })
   }, [])
+
+  const refetchUserInformations = useCallback((): void => void refetch(), [])
 
   return (
     <View style={styles.container}>
@@ -34,6 +40,19 @@ export const Home: FunctionComponent<Props> = function ({ navigation }) {
         title={_(t`Aller sur la page de connexion avec params`)}
         onPress={goToLoginPageWithParams}
       />
+      {isFetching && <ActivityIndicator testID="user-activity-indicator" />}
+      {user && !isError && (
+        <View style={styles.userInformations}>
+          <Text>{`FIRSTNAME: ${user.firstName}`}</Text>
+          <Text>{`LASTNAME: ${user.lastName}`}</Text>
+          <Text>{`EMAIL: ${user.email}`}</Text>
+          <Button
+            title={_(t`Rafraîchir les données de l'utilisateur`)}
+            onPress={refetchUserInformations}
+            testID="refreshUserInformationsButton"
+          />
+        </View>
+      )}
       <CoordinatesView position={position} style={styles.geolocation} />
       {env.FEATURE_FLAG_CODE_PUSH_MANUAL && <CodePushButton />}
     </View>

--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
 
 export const Home: FunctionComponent<Props> = function ({ navigation }) {
   const position = useGeolocation()
-  const { user, isFetching, refetch, isError } = useCurrentUser()
+  const { email, isFetching, refetch, isError } = useCurrentUser()
 
   const goToLoginPageWithParams = useCallback((): void => {
     navigation.navigate('Login', { userId: 'I have been Set by params' })
@@ -41,11 +41,9 @@ export const Home: FunctionComponent<Props> = function ({ navigation }) {
         onPress={goToLoginPageWithParams}
       />
       {isFetching && <ActivityIndicator testID="user-activity-indicator" />}
-      {user && !isError && (
+      {email && !isError && (
         <View style={styles.userInformations}>
-          <Text>{`FIRSTNAME: ${user.firstName}`}</Text>
-          <Text>{`LASTNAME: ${user.lastName}`}</Text>
-          <Text>{`EMAIL: ${user.email}`}</Text>
+          <Text>{`EMAIL: ${email}`}</Text>
           <Button
             title={_(t`Rafraîchir les données de l'utilisateur`)}
             onPress={refetchUserInformations}

--- a/src/features/home/pages/__snapshots__/Home.test.tsx.snap
+++ b/src/features/home/pages/__snapshots__/Home.test.tsx.snap
@@ -63,12 +63,6 @@ exports[`Home component With current user loaded should render correctly 1`] = `
     }
   >
     <Text>
-      FIRSTNAME: John
-    </Text>
-    <Text>
-      LASTNAME: Doe
-    </Text>
-    <Text>
       EMAIL: john.doe@passculture.app
     </Text>
     <View

--- a/src/features/home/pages/__snapshots__/Home.test.tsx.snap
+++ b/src/features/home/pages/__snapshots__/Home.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Home component should render correctly 1`] = `
+exports[`Home component With current user loaded should render correctly 1`] = `
 <View
   style={
     Object {
@@ -52,6 +52,66 @@ exports[`Home component should render correctly 1`] = `
       >
         Aller sur la page de connexion avec params
       </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "paddingVertical": 20,
+      }
+    }
+  >
+    <Text>
+      FIRSTNAME: John
+    </Text>
+    <Text>
+      LASTNAME: Doe
+    </Text>
+    <Text>
+      EMAIL: john.doe@passculture.app
+    </Text>
+    <View
+      accessibilityRole="button"
+      accessibilityState={Object {}}
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "opacity": 1,
+        }
+      }
+      testID="refreshUserInformationsButton"
+    >
+      <View
+        style={
+          Array [
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#007AFF",
+                "fontSize": 18,
+                "margin": 8,
+                "textAlign": "center",
+              },
+            ]
+          }
+        >
+          Rafraîchir les données de l'utilisateur
+        </Text>
+      </View>
     </View>
   </View>
   <View

--- a/src/libs/storage.ts
+++ b/src/libs/storage.ts
@@ -1,18 +1,40 @@
 import { t } from '@lingui/macro'
 import AsyncStorage from '@react-native-community/async-storage'
+import { Alert } from 'react-native'
 
 import { _ } from 'libs/i18n'
 
-const COOKIE_STORAGE_KEY = 'cookie'
+const TOKEN_STORAGE_KEY = 'authent_token'
 
-export async function getCookie(): Promise<string | null> {
-  return await AsyncStorage.getItem(COOKIE_STORAGE_KEY)
+export async function getToken(): Promise<string | null> {
+  return readString(TOKEN_STORAGE_KEY)
 }
 
-export async function setCookieFromResponse(response: Response): Promise<void> {
-  const cookie = response.headers.get('set-cookie')
-  if (!cookie) {
-    throw Error(_(/*i18n setCookieFromResponse error */ t`La réponse ne contient pas de cookie`))
+export async function saveToken(token: string | undefined): Promise<void> {
+  if (!token) {
+    throw Error(_(t`Aucun token à sauvegarder`))
   }
-  await AsyncStorage.setItem(COOKIE_STORAGE_KEY, cookie)
+  await saveString(TOKEN_STORAGE_KEY, token)
+}
+
+async function readString(storageKey: string): Promise<string | null> {
+  try {
+    return AsyncStorage.getItem(storageKey)
+  } catch (error) {
+    onAsyncStorageError(error)
+    return null
+  }
+}
+
+async function saveString(storageKey: string, value: string) {
+  try {
+    await AsyncStorage.setItem(storageKey, value)
+  } catch (error) {
+    onAsyncStorageError(error)
+  }
+}
+
+function onAsyncStorageError(error: Error | undefined): void {
+  const stringifiedError = JSON.stringify(error)
+  Alert.alert('AsyncStorage Error', stringifiedError)
 }

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/features/home/pages/Home.tsx:19
+#: src/features/home/pages/Home.tsx:23
 msgid "Aller sur la page de connexion avec params"
 msgstr "Aller sur la page de connexion avec params"
 
@@ -22,7 +22,11 @@ msgstr "Aller sur la page de connexion avec params"
 msgid "An error has occured while obtaining the Batch installation ID : {e}"
 msgstr "Une erreur a eu lieu en obtenant l'ID d'installation Batch : {e}"
 
-#: src/features/home/pages/Home.tsx:18
+#: src/libs/storage.ts:23
+msgid "Aucun token à sauvegarder"
+msgstr "Aucun token à sauvegarder"
+
+#: src/features/home/pages/Home.tsx:22
 msgid "Bienvenue à Pass Culture"
 msgstr "Bienvenue à Pass Culture"
 
@@ -40,10 +44,9 @@ msgstr "Connexion"
 msgid "Erreur d'authentification"
 msgstr "Erreur d'authentification"
 
-#. setCookieFromResponse error
-#: src/libs/storage.ts:23
-msgid "La réponse ne contient pas de cookie"
-msgstr "La réponse ne contient pas de cookie"
+#: src/features/home/pages/Home.tsx:29
+msgid "Rafraîchir les données de l'utilisateur"
+msgstr "Rafraîchir les données de l'utilisateur"
 
 #: src/libs/i18n.test.ts:8
 msgid "Welcome to Pass Culture"
@@ -59,15 +62,10 @@ msgstr "name@domain.com"
 msgid "password"
 msgstr "password"
 
-#: src/libs/fetch.ts:43
-msgid "Échec dans la récupération du cookie: {err}"
-msgstr "Échec dans la récupération du cookie: {err}"
-
 #: src/features/auth/pages/Login.tsx:36
 msgid "Échec de la connexion au Pass Culture: {0}"
 msgstr "Échec de la connexion au Pass Culture: {0}"
 
-#. Http error message
-#: src/libs/fetch.ts:37
+#: src/libs/fetch.ts:43
 msgid "Échec de la requête {url}, code: {0}"
 msgstr "Échec de la requête {url}, code: {0}"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXX

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [x] Added a **screenshot** for UI tickets.
- [] Explained my technical strategy below if feature is complex.

![image](https://user-images.githubusercontent.com/6025710/96756479-701ee700-13d4-11eb-8fc9-e12e931b1212.png)

If native code (ios/android) was modified, after the PR is merged go to master and upgrade the **app version** (+1 patch):

(later there will be a script to embed these commands)

- use `yarn version --patch` (it will create a commit and a tag)
  - if you want an hard deployment of the testing environment, use `yarn version:testing` instead.
- then `git push && git push origin <tag_name>`
- then use the deploy script (temporary -> waiting for CI/CD to be ready)

## Technical strategy

voici mon avancement sur les cookies pour celui qui veut reprendre le ticket demain:

- l’authentification de la requete react-query fonctionne sur Android (device) et iOS (simulateur)
- quelques lectures m’ont appris un truc sur l’utilisation des cookies avec react-native:
— le header cookie est interdit (https://fetch.spec.whatwg.org/#forbidden-header-name) : c’est fait de la sorte pour laisser le navigateur gérer les sessions. C’est au backend d’injecter le header set-cookie dans les headers response pour initier la gestion des cookies par le navigateur
— la librairie CookieManager est seulement une API permettant d’accéder aux cookies pour les manipuler, modifier la valeur de certains champs, changer les dates d’expiration, les supprimer... mais c’est le navigateur qui se charge d’injecter le header Cookie dans la requete XHR. On peut tout de même piloter l’envoie des cookies grâce à l’option Credentials qui se place au même niveau que l’option headers.
- BAD NEWS: sur la doc de react-native ils disent que l’authentification par cookie est instable pour l’instant à la version 0.63, celle qu’on utilise (https://reactnative.dev/docs/network#known-issues-with-fetch-and-cookie-based-authentication) . Est-ce que dans ce contexte, on veut quand même utiliser les cookies ? les web tokens pourraient être une alternative intéressante: je pense à JWT en particulier
