### PR TITLE
(PC-4729): Add soft deploy for ios in testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,12 @@ commands:
           paths:
             - ~/.bundle/
             - vendor/bundle
+  skip_testing_soft_deploy_when_new_tag:
+    description:
+    steps:
+      - run:
+          name: Skip job when new tag to deploy
+          command: git tag --points-at HEAD | grep -E '^testing_v[0-9]+(\.[0-9]+){2}$' && circleci step halt || true
 
 jobs:
   run-tests:
@@ -60,18 +66,30 @@ jobs:
       - image: circleci/android:api-28-node
     steps:
       - checkout
-      - run:
-          name: Skip job when new tag to deploy
-          command: |
-            git tag --points-at HEAD | grep -E '^testing_v[0-9]+(\.[0-9]+){2}$' && circleci step halt || true
+      - skip_testing_soft_deploy_when_new_tag
       - install_node_modules
       - install_ruby_modules
       - run:
           name: Deploy Android App for testing environment
           command: |
-            export APPCENTER_API_TOKEN=$APPCENTER_API_TOKEN_TESTING
+            export APPCENTER_API_TOKEN=$APPCENTER_API_TOKEN_ANDROID_TESTING
             export CODEPUSH_KEY_ANDROID=$CODEPUSH_KEY_ANDROID_TESTING
             ./scripts/deploy.sh -o android -t soft -e testing
+
+  deploy-ios-testing-soft:
+    docker:
+      - image: circleci/android:api-28-node
+    steps:
+      - checkout
+      - skip_testing_soft_deploy_when_new_tag
+      - install_node_modules
+      - install_ruby_modules
+      - run:
+          name: Deploy IOS App for testing environment
+          command: |
+            export APPCENTER_API_TOKEN=$APPCENTER_API_TOKEN_IOS_TESTING
+            export CODEPUSH_KEY_IOS=$CODEPUSH_KEY_IOS_TESTING
+            ./scripts/deploy.sh -o ios -t soft -e testing
 
   deploy-android-testing-hard:
     docker:
@@ -138,6 +156,13 @@ workflows:
                 - master
           requires:
             - run-tests
+      - deploy-ios-testing-soft:
+          filters:
+            branches:
+              only:
+                - master
+              requires:
+                - run-tests
       - deploy-android-testing-hard:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,13 @@ commands:
       - restore_cache:
           name: Restore Node Modules
           keys:
-            - node-modules-{{ checksum "yarn.lock" }}
+            - node-modules-v1-{{ checksum "yarn.lock" }}
       - run:
           name: Install Dependencies
           command: yarn install --immutable
       - save_cache:
           name: Save Node Modules
-          key: node-modules-{{ checksum "yarn.lock" }}
+          key: node-modules-v1-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
   install_ruby_modules:
@@ -20,14 +20,14 @@ commands:
     steps:
       - restore_cache:
           name: Restore Gem dependencies
-          key: bundle-{{ checksum "Gemfile.lock" }}
+          key: bundle-v1-{{ checksum "Gemfile.lock" }}
       - run:
           name: Install Gem dependencies
           command: |
             bundle install --path=vendor/bundle
       - save_cache:
           name: Save Gem dependencies
-          key: bundle-{{ checksum "Gemfile.lock" }}
+          key: bundle-v1-{{ checksum "Gemfile.lock" }}
           paths:
             - ~/.bundle/
             - vendor/bundle
@@ -161,8 +161,8 @@ workflows:
             branches:
               only:
                 - master
-              requires:
-                - run-tests
+          requires:
+            - run-tests
       - deploy-android-testing-hard:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
       - run:
           name: Deploy Android App for testing environment
           command: |
-            export APPCENTER_API_TOKEN=$APPCENTER_API_TOKEN_ANDROID_TESTING
+            export APPCENTER_API_TOKEN=$ANDROID_TESTING_APPCENTER_API_TOKEN
             export CODEPUSH_KEY_ANDROID=$CODEPUSH_KEY_ANDROID_TESTING
             ./scripts/deploy.sh -o android -t soft -e testing
 
@@ -87,7 +87,7 @@ jobs:
       - run:
           name: Deploy IOS App for testing environment
           command: |
-            export APPCENTER_API_TOKEN=$APPCENTER_API_TOKEN_IOS_TESTING
+            export IOS_APPCENTER_API_TOKEN=$IOS_TESTING_APPCENTER_API_TOKEN
             export CODEPUSH_KEY_IOS=$CODEPUSH_KEY_IOS_TESTING
             ./scripts/deploy.sh -o ios -t soft -e testing
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,11 +32,9 @@ commands:
             - ~/.bundle/
             - vendor/bundle
   skip_testing_soft_deploy_when_new_tag:
-    description:
+    description: Skip job when new tag to deploy
     steps:
-      - run:
-          name: Skip job when new tag to deploy
-          command: git tag --points-at HEAD | grep -E '^testing_v[0-9]+(\.[0-9]+){2}$' && circleci step halt || true
+      - run: git tag --points-at HEAD | grep -E '^testing_v[0-9]+(\.[0-9]+){2}$' && circleci step halt || true
 
 jobs:
   run-tests:
@@ -61,7 +59,7 @@ jobs:
           command: |
             yarn test:unit
 
-  deploy-android-testing-soft:
+  deploy-soft-testing:
     docker:
       - image: circleci/android:api-28-node
     steps:
@@ -72,18 +70,9 @@ jobs:
       - run:
           name: Deploy Android App for testing environment
           command: |
-            export APPCENTER_API_TOKEN=$ANDROID_TESTING_APPCENTER_API_TOKEN
+            export ANDROID_APPCENTER_API_TOKEN=$ANDROID_TESTING_APPCENTER_API_TOKEN
             export CODEPUSH_KEY_ANDROID=$CODEPUSH_KEY_ANDROID_TESTING
             ./scripts/deploy.sh -o android -t soft -e testing
-
-  deploy-ios-testing-soft:
-    docker:
-      - image: circleci/android:api-28-node
-    steps:
-      - checkout
-      - skip_testing_soft_deploy_when_new_tag
-      - install_node_modules
-      - install_ruby_modules
       - run:
           name: Deploy IOS App for testing environment
           command: |
@@ -117,7 +106,7 @@ jobs:
       - run:
           name: Deploy Android App for testing environment
           command: |
-            export APPCENTER_API_TOKEN=$APPCENTER_API_TOKEN_TESTING
+            export ANDROID_APPCENTER_API_TOKEN=$ANDROID_TESTING_APPCENTER_API_TOKEN
             export CODEPUSH_KEY_ANDROID=$CODEPUSH_KEY_ANDROID_TESTING
             ./scripts/deploy.sh -o android -t hard -e testing
 
@@ -140,7 +129,7 @@ jobs:
       - run:
           name: Deploy Android App for staging environment
           command: |
-            export APPCENTER_API_TOKEN=$APPCENTER_API_TOKEN_STAGING
+            export ANDROID_APPCENTER_API_TOKEN=$ANDROID_STAGING_APPCENTER_API_TOKEN
             export CODEPUSH_KEY_ANDROID=$CODEPUSH_KEY_ANDROID_STAGING
             ./scripts/deploy.sh -o android -t hard -e staging
 
@@ -149,14 +138,7 @@ workflows:
   commit:
     jobs:
       - run-tests
-      - deploy-android-testing-soft:
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-            - run-tests
-      - deploy-ios-testing-soft:
+      - deploy-soft-testing:
           filters:
             branches:
               only:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,7 +24,7 @@ platform :ios do
 
   lane :deploy_appCenter do |options|
     appcenter_upload(
-      api_token: ENV['APPCENTER_API_TOKEN'],
+      api_token: ENV['IOS_APPCENTER_API_TOKEN'],
       owner_name: ENV['APPCENTER_ORGANISATION'],
       owner_type: "organization",
       app_name: ENV['APPCENTER_IOS_APP_ID'],
@@ -37,7 +37,7 @@ platform :ios do
   lane :deploy do |options|
     if options[:codepush] then # @codepush
       release_notes = %x[#{release_notes_command}]
-      sh "cd .. && yarn appcenter codepush release-react --token #{ENV['APPCENTER_API_TOKEN']} -d #{ENV['CODEPUSH_DEPLOYMENT_NAME']} -a #{ENV['APPCENTER_ORGANISATION']}/#{ENV['APPCENTER_IOS_APP_ID']} --target-binary-version \"#{ENV['VERSION']}\" --description \"#{release_notes}\" --disable-duplicate-release-error"
+      sh "cd .. && yarn appcenter codepush release-react --token #{ENV['IOS_APPCENTER_API_TOKEN']} -d #{ENV['CODEPUSH_DEPLOYMENT_NAME']} -a #{ENV['APPCENTER_ORGANISATION']}/#{ENV['APPCENTER_IOS_APP_ID']} --target-binary-version \"#{ENV['VERSION']}\" --description \"#{release_notes}\" --disable-duplicate-release-error"
     else
       match(
         shallow_clone: true,
@@ -78,7 +78,7 @@ platform :android do
   end
   lane :deploy_appCenter do |options|
     appcenter_upload(
-      api_token: ENV['APPCENTER_API_TOKEN'],
+      api_token: ENV['ANDROID_APPCENTER_API_TOKEN'],
       owner_name: ENV['APPCENTER_ORGANISATION'],
       owner_type: "organization",
       app_name: ENV['APPCENTER_ANDROID_APP_ID'],
@@ -91,7 +91,7 @@ platform :android do
   lane :deploy do |options|
     if options[:codepush] then # @codepush
       release_notes = %x[#{release_notes_command}]
-      sh "cd .. && yarn appcenter codepush release-react --token #{ENV['APPCENTER_API_TOKEN']} -d #{ENV['CODEPUSH_DEPLOYMENT_NAME']} -a #{ENV['APPCENTER_ORGANISATION']}/#{ENV['APPCENTER_ANDROID_APP_ID']} --target-binary-version \"#{ENV['VERSION']}\" --description \"#{release_notes}\" --disable-duplicate-release-error"
+      sh "cd .. && yarn appcenter codepush release-react --token #{ENV['ANDROID_APPCENTER_API_TOKEN']} -d #{ENV['CODEPUSH_DEPLOYMENT_NAME']} -a #{ENV['APPCENTER_ORGANISATION']}/#{ENV['APPCENTER_ANDROID_APP_ID']} --target-binary-version \"#{ENV['VERSION']}\" --description \"#{release_notes}\" --disable-duplicate-release-error"
     else
       build
       if ENV['DEPLOYMENT_PLATFORM'] === 'appcenter' then


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-4729

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Explained my technical strategy below if feature is complex.

## Deploy hard

If native code (ios/android) was modified, **before** the PR is merged, on the working branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`

## Technical strategy

> _Insert technical strategy_
