### PR TITLE
(PC-4408) fix: babel plugin resolver not to include mocks in build

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -7,7 +7,7 @@ module.exports = {
       {
         cwd: 'babelrc',
         extensions: ['.js', '.jsx', '.ts', '.tsx', '.js', '.ios.js', '.android.js'],
-        root: ['./src/', './__mocks__'],
+        root: ['./src/'],
         alias: {
           features: './src/features',
           libs: './src/libs',
@@ -15,7 +15,7 @@ module.exports = {
           types: './src/types',
           tests: './src/tests',
           ui: './src/ui',
-          __mocks__: './__mocks__',
+          __mocks__: './__mocks__/',
         },
       },
     ],


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXX

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Explained my technical strategy below if feature is complex.

## Deploy hard

If native code (ios/android) was modified, **before** the PR is merged, on the working branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`

## Technical strategy

> _Insert technical strategy_

* La ligne `root: ['./src/', './__mocks__'],` faisait que `./__mocks__` était présent dans le build
* Résultat, on a une erreur `ReferenceError: Can't find variable: jest` et plein d'autres au lancement de l'app "compilée"

* On a toujours besoin de l'alias, notamment pour runner les tests
