### PR TITLE
[PC-5029] Circle CI - Ajouter le fichier GoogleService-Info.plist dans le dossier /ios avant le build iOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,9 @@ jobs:
           name: Install cocoapods
           command: cd ios/ && bundle exec pod install
       - run:
+          name: Setup iOS Google services config
+          command: echo $IOS_GOOGLE_SERVICES_PLIST > ios/GoogleService-Info.plist
+      - run:
           name: Decode match secrets
           command: export MATCH_PASSWORD=$MATCH_PASSWORD_CERTIFICATES
       - run:


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-5029

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
-  [ ] ~Made sure my feature is working on the relevant real / virtual devices.~
- [ ] ~Written **unit tests** for my feature.~
- [ ] ~Added a **screenshot** for UI tickets.~

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`