### PR TITLE
(PC-4997): Add tag for deploy staging command

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ You can automatically generate files by running the following commands:
 
 ## Deploy
 
+### Deploy to staging
+
+When you want to deploy the current version of master in staging, you can run the following command:
+
+`yarn trigger:staging:deploy`
+
+
 ### Manual deploy for the moment => will be automated by ticket 4558
 
 You can find the testing app at:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "translations:add-locale": "lingui add-locale",
     "translations:extract": "lingui extract --clean",
     "translations:compile": "lingui compile",
-    "version:testing": "./scripts/update_testing_version.sh"
+    "version:testing": "./scripts/update_testing_version.sh",
+    "version:staging": "./scripts/deploy_new_staging_version.sh"
   },
   "dependencies": {
     "@bam.tech/react-native-batch": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "translations:extract": "lingui extract --clean",
     "translations:compile": "lingui compile",
     "version:testing": "./scripts/update_testing_version.sh",
-    "version:staging": "./scripts/deploy_new_staging_version.sh"
+    "trigger:staging:deploy": "./scripts/deploy_new_staging_version.sh"
   },
   "dependencies": {
     "@bam.tech/react-native-batch": "^5.2.1",

--- a/scripts/deploy_new_staging_version.sh
+++ b/scripts/deploy_new_staging_version.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+check_branch(){
+  CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+
+  if [[ "$CURRENT_BRANCH" != "master" ]];
+  then
+    warn "Wrong branch, checkout master to deploy to staging"
+  fi
+}
+
+check_branch
+
+yarn version --minor
+git push --follow-tags
+
+git push -f origin HEAD:staging


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-4997

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Explained my technical strategy below if feature is complex.

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`

## Technical strategy

Je pensais faire un déploiement sur l'événement 'nouveau tag' mais apparemment pas possible côté circleci :(
Donc j'ai ajouté un script qui permet d'ajouter un nouveau tag sur master + push sur la branche staging pour effectuer un nouveau déploiement


