### PR TITLE
[PC-4838] test webview

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,9 @@ cd ios && bundle exec pod install && cd ..
 In order to launch the app in your simulator, you need to go to Android Studio first.
 Then open the Android Virtual Devices Manager and select (or create) a Virtual Device with the android version you want to run.
 Once the emulator is up and running, go to your terminal in the project workspace and run the following command:
-`yarn install yarn launch`
+`yarn install yarn android:testing`
 
-#### IOS
-
-On iOS you can run the following command:
-`react-native run-ios --scheme PassCulture-Staging`
-
-#### Development environment
+##### Development environment
 
 To run the app on a development environment in order to request a local API, you need to create a `.env.development` file,
 copy the `.env.testing` configuration and update the `API_BASE_URL` setting with you local server address. Then create a
@@ -71,9 +66,16 @@ storePassword=
 keyPassword=
 ```
 
+You will also need to copy the `google-services.json` file (you can find it in 1password) in `android/app` directory.
+
 Then run the app with this command:
 
-`react-native run-android --variant=developmentDebug`
+`yarn android`
+
+#### IOS
+
+On iOS you can run the following command:
+`yarn ios:testing`
 
 ### Debugging
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-native-screens": "^2.0.0-beta.8",
     "react-native-sensitive-info": "^5.5.5",
     "react-native-svg": "^12.1.0",
+    "react-native-webview": "^10.10.0",
     "react-query": "^2.23.1",
     "recompose": "^0.30.0",
     "styled-components": "^5.2.0",

--- a/src/features/cheatcodes/components/IdCheckButton.test.tsx
+++ b/src/features/cheatcodes/components/IdCheckButton.test.tsx
@@ -1,0 +1,16 @@
+import { render, fireEvent } from '@testing-library/react-native'
+import React from 'react'
+
+import { navigate } from '__mocks__/@react-navigation/native'
+import { IdCheckButton } from 'features/cheatcodes/components/IdCheckButton'
+
+describe('IdCheckButton component', () => {
+  it('calls navigate to IdCheck webview when pressed', () => {
+    const component = render(<IdCheckButton />)
+
+    const Button = component.getByText('IdCheck')
+    fireEvent.press(Button)
+
+    expect(navigate).toHaveBeenCalledWith('IdCheck')
+  })
+})

--- a/src/features/cheatcodes/components/IdCheckButton.tsx
+++ b/src/features/cheatcodes/components/IdCheckButton.tsx
@@ -1,0 +1,8 @@
+import { useNavigation } from '@react-navigation/native'
+import React from 'react'
+import { Button } from 'react-native'
+
+export const IdCheckButton: React.FC = () => {
+  const { navigate } = useNavigation()
+  return <Button title="IdCheck" onPress={() => navigate('IdCheck')} />
+}

--- a/src/features/cheatcodes/pages/CheatCodes.tsx
+++ b/src/features/cheatcodes/pages/CheatCodes.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components/native'
 
 import { CodePushButton } from 'features/cheatcodes/components/CodePushButton'
 import { CrashTestButton } from 'features/cheatcodes/components/CrashTestButton'
+import { IdCheckButton } from 'features/cheatcodes/components/IdCheckButton'
 import { NavigateHomeButton } from 'features/cheatcodes/components/NavigateHomeButton/NavigateHomeButton'
 import { RootStackParamList } from 'features/navigation/RootNavigator'
 import { env } from 'libs/environment'
@@ -30,6 +31,7 @@ export const CheatCodes: FunctionComponent<Props> = function () {
     <Container>
       <CrashTestButton />
       <NavigateHomeButton />
+      <IdCheckButton />
       <Text>{batchInstallationId}</Text>
       <Spacer.Flex />
       {env.FEATURE_FLAG_CODE_PUSH_MANUAL && <CodePushButton />}

--- a/src/features/cheatcodes/pages/IdCheck.test.tsx
+++ b/src/features/cheatcodes/pages/IdCheck.test.tsx
@@ -1,0 +1,16 @@
+import { StackScreenProps } from '@react-navigation/stack'
+import { render } from '@testing-library/react-native'
+import React from 'react'
+
+import { IdCheck } from 'features/cheatcodes/pages/IdCheck'
+import { RootStackParamList } from 'features/navigation/RootNavigator'
+import { navigationTestProps } from 'tests/navigation'
+
+describe('IdCheck component', () => {
+  it('should render correctly', async () => {
+    const instance = render(
+      <IdCheck {...(navigationTestProps as StackScreenProps<RootStackParamList, 'IdCheck'>)} />
+    )
+    expect(instance).toMatchSnapshot()
+  })
+})

--- a/src/features/cheatcodes/pages/IdCheck.tsx
+++ b/src/features/cheatcodes/pages/IdCheck.tsx
@@ -1,0 +1,29 @@
+import { StackNavigationProp } from '@react-navigation/stack'
+import React from 'react'
+import { StyleSheet, Text } from 'react-native'
+import { WebView } from 'react-native-webview'
+
+import { RootStackParamList } from 'features/navigation/RootNavigator'
+
+const ID_CHECK_URL = 'https://id-check-front-dev.passculture.app/'
+
+type CheatCodesNavigationProp = StackNavigationProp<RootStackParamList, 'IdCheck'>
+
+type Props = {
+  navigation: CheatCodesNavigationProp
+}
+
+export const IdCheck: React.FC<Props> = function () {
+  return (
+    <WebView
+      source={{ uri: ID_CHECK_URL }}
+      style={styles.webview}
+      startInLoadingState={true}
+      renderLoading={() => <Text>Loading...</Text>}
+    />
+  )
+}
+
+const styles = StyleSheet.create({
+  webview: { overflow: 'hidden', flex: 1 },
+})

--- a/src/features/cheatcodes/pages/__snapshots__/CheatCodes.test.tsx.snap
+++ b/src/features/cheatcodes/pages/__snapshots__/CheatCodes.test.tsx.snap
@@ -95,6 +95,47 @@ exports[`CheatCodes component should render correctly 1`] = `
       </Text>
     </View>
   </View>
+  <View
+    accessibilityRole="button"
+    accessibilityState={Object {}}
+    accessible={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "opacity": 1,
+      }
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {},
+        ]
+      }
+    >
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#007AFF",
+              "fontSize": 18,
+              "margin": 8,
+              "textAlign": "center",
+            },
+          ]
+        }
+      >
+        IdCheck
+      </Text>
+    </View>
+  </View>
   <Text>
     installationID
   </Text>

--- a/src/features/cheatcodes/pages/__snapshots__/IdCheck.test.tsx.snap
+++ b/src/features/cheatcodes/pages/__snapshots__/IdCheck.test.tsx.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IdCheck component should render correctly 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "flex": 1,
+        "overflow": "hidden",
+      },
+      undefined,
+    ]
+  }
+>
+  <RNCWebView
+    cacheEnabled={true}
+    injectedJavaScriptBeforeContentLoadedForMainFrameOnly={true}
+    injectedJavaScriptForMainFrameOnly={true}
+    javaScriptEnabled={true}
+    messagingEnabled={false}
+    onContentProcessDidTerminate={[Function]}
+    onHttpError={[Function]}
+    onLoadingError={[Function]}
+    onLoadingFinish={[Function]}
+    onLoadingProgress={[Function]}
+    onLoadingStart={[Function]}
+    onMessage={[Function]}
+    onShouldStartLoadWithRequest={[Function]}
+    source={
+      Object {
+        "uri": "https://id-check-front-dev.passculture.app/",
+      }
+    }
+    startInLoadingState={true}
+    style={
+      Array [
+        Object {
+          "flex": 1,
+          "overflow": "hidden",
+        },
+        Object {
+          "backgroundColor": "#ffffff",
+        },
+        Object {
+          "flex": 1,
+          "overflow": "hidden",
+        },
+      ]
+    }
+    useSharedProcessPool={true}
+  />
+  <Text>
+    Loading...
+  </Text>
+</View>
+`;

--- a/src/features/navigation/RootNavigator.tsx
+++ b/src/features/navigation/RootNavigator.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { Login } from 'features/auth/pages/Login'
 import AppComponents from 'features/cheatcodes/pages/AppComponents'
 import { CheatCodes } from 'features/cheatcodes/pages/CheatCodes'
+import { IdCheck } from 'features/cheatcodes/pages/IdCheck'
 import Navigation from 'features/cheatcodes/pages/Navigation'
 import { Home } from 'features/home/pages/Home'
 
@@ -15,6 +16,7 @@ export type RootStackParamList = {
   Navigation: undefined
   CheatCodes: undefined
   Home: undefined
+  IdCheck: undefined
   Login?: { userId: string }
 }
 
@@ -33,6 +35,7 @@ export const RootNavigator: React.FC = function () {
         <RootStack.Screen name="CheatCodes" component={CheatCodes} />
         <RootStack.Screen name="AppComponents" component={AppComponents} />
         <RootStack.Screen name="Navigation" component={Navigation} />
+        <RootStack.Screen name="IdCheck" component={IdCheck} />
       </RootStack.Navigator>
     </NavigationContainer>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -4612,6 +4612,11 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
+escape-string-regexp@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -6139,7 +6144,7 @@ interpret@^1.2.0, interpret@^1.4.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-invariant@^2.2.2, invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -9602,6 +9607,14 @@ react-native-svg@^12.1.0:
   dependencies:
     css-select "^2.1.0"
     css-tree "^1.0.0-alpha.39"
+
+react-native-webview@^10.10.0:
+  version "10.10.0"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-10.10.0.tgz#285703c35eac1eac5b4446df2cba8a146d3c8548"
+  integrity sha512-T0AnZ0LVhaFBqZpl5attDDYo83zqdFRsFVINbrgHaIm6w5r0d/QK/dJRgXRNyFhn1fSONhe0ejdcnCYCT73B6g==
+  dependencies:
+    escape-string-regexp "2.0.0"
+    invariant "2.2.4"
 
 react-native@0.63.3:
   version "0.63.3"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-4838

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Explained my technical strategy below if feature is complex.

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`

## Technical strategy

Exemple d'utilisation d'une webview avec le parcours Id check de la web app:

![Screenshot from 2020-11-02 10-16-57](https://user-images.githubusercontent.com/22886846/97851209-5d21e600-1cf5-11eb-83c9-2c48f001f9a0.png)

![Screenshot from 2020-11-02 10-17-09](https://user-images.githubusercontent.com/22886846/97851236-6448f400-1cf5-11eb-8fcd-463a758bf86e.png)

Pour que ce soit un minimum testable en l'état, j'ai fait en sorte de rediriger l'app vers la page de cheatcodes lorsque l'on quitte le parcours id check (qui redirige normalement vers la page d'accueil de la webapp). J'aimerais bien tester cette redirection mais je n'ai pas réussi ce matin.
