### PR TITLE
(PC-4371) Dev : display access button  to "cheat" navigation page on home page

### DIFF
--- a/src/features/cheatcodes/pages/Navigation.tsx
+++ b/src/features/cheatcodes/pages/Navigation.tsx
@@ -1,0 +1,20 @@
+import { t } from '@lingui/macro'
+import { useNavigation } from '@react-navigation/native'
+import React from 'react'
+import { Button, ScrollView } from 'react-native'
+
+import { _ } from 'libs/i18n'
+import { Spacer } from 'ui/theme'
+
+function Navigation(): JSX.Element {
+  const navigation = useNavigation()
+  return (
+    <ScrollView>
+      <Spacer.Column numberOfSpaces={5} />
+      <Button title={_(t`Page Login`)} onPress={() => navigation.navigate('Login')} />
+      <Spacer.Column numberOfSpaces={5} />
+    </ScrollView>
+  )
+}
+
+export default Navigation

--- a/src/features/home/pages/Home.test.tsx
+++ b/src/features/home/pages/Home.test.tsx
@@ -23,14 +23,31 @@ describe('Home component', () => {
     expect(welcomeText.props.children).toBe('Bienvenue !')
   })
 
-  it('should render correctly', () => {
+  it('should render correctly', async () => {
     const home = render(<Home navigation={navigation} />)
+
     expect(home).toMatchSnapshot()
   })
 
   it('should not have code push button', async () => {
     env.FEATURE_FLAG_CODE_PUSH_MANUAL = false
     const home = render(<Home navigation={navigation} />)
+
     expect(() => home.getByText('Check update')).toThrowError()
+  })
+
+  it('should have components and navigation buttons when NOT in PROD', async () => {
+    const home = render(<Home navigation={navigation} />)
+
+    expect(() => home.getByText('Composants')).toBeTruthy()
+    expect(() => home.getByText('Navigation')).toBeTruthy()
+  })
+
+  it('should NOT have components or navigation buttons when in PROD', async () => {
+    env.ENV = 'production'
+    const home = render(<Home navigation={navigation} />)
+
+    expect(() => home.getByText('Composants')).toThrowError()
+    expect(() => home.getByText('Navigation')).toThrowError()
   })
 })

--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -1,16 +1,17 @@
 import { t } from '@lingui/macro'
 import { StackNavigationProp } from '@react-navigation/stack'
-import React, { FunctionComponent, useCallback } from 'react'
-import { Button, ScrollView } from 'react-native'
+import React, { FunctionComponent } from 'react'
+import { ScrollView, TouchableOpacity } from 'react-native'
 import styled from 'styled-components/native'
 
 import { useHomepageModules } from 'features/home/api'
 import { ExclusivityModule } from 'features/home/components/ExclusivityModule'
 import { ExclusivityPane, ProcessedModule } from 'features/home/contentful'
 import { RootStackParamList } from 'features/navigation/RootNavigator'
+import { env } from 'libs/environment'
 import { _ } from 'libs/i18n'
 import { HeaderBackground } from 'ui/svg/HeaderBackground'
-import { ColorsEnum, Spacer, Typo } from 'ui/theme'
+import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
 
 type HomeScreenNavigationProp = StackNavigationProp<RootStackParamList, 'Home'>
 
@@ -20,13 +21,18 @@ type Props = {
 
 export const Home: FunctionComponent<Props> = function ({ navigation }) {
   const { data: modules = [] } = useHomepageModules()
-
-  const goToLoginPage = useCallback((): void => navigation.navigate('Login'), [])
-  const goToComponentsPage = useCallback((): void => navigation.navigate('AppComponents'), [])
-
   return (
     <ScrollView>
-      <Button title={_(t`Composants`)} onPress={goToComponentsPage} />
+      {env.ENV !== 'production' && (
+        <CheatButtonsContainer>
+          <CheatTouchableOpacity onPress={() => navigation.navigate('AppComponents')}>
+            <Typo.Body>{_(t`Composants`)}</Typo.Body>
+          </CheatTouchableOpacity>
+          <CheatTouchableOpacity onPress={() => navigation.navigate('Navigation')}>
+            <Typo.Body>{_(t`Navigation`)}</Typo.Body>
+          </CheatTouchableOpacity>
+        </CheatButtonsContainer>
+      )}
       <Container>
         <HeaderBackgroundWrapper>
           <HeaderBackground />
@@ -47,8 +53,6 @@ export const Home: FunctionComponent<Props> = function ({ navigation }) {
           return <React.Fragment key={index} />
         })}
         <Spacer.Column numberOfSpaces={6} />
-        <Button title={_(t`Aller sur la page de connexion`)} onPress={goToLoginPage} />
-        <Spacer.Column numberOfSpaces={6} />
       </Container>
     </ScrollView>
   )
@@ -63,4 +67,16 @@ const HeaderBackgroundWrapper = styled.View({
   position: 'absolute',
   top: 0,
   left: 0,
+})
+
+const CheatButtonsContainer = styled.View({
+  width: '100%',
+  flexDirection: 'row',
+  justifyContent: 'space-around',
+})
+
+const CheatTouchableOpacity = styled(TouchableOpacity)({
+  borderColor: ColorsEnum.BLACK,
+  borderWidth: 2,
+  padding: getSpacing(1),
 })

--- a/src/features/home/pages/__snapshots__/Home.test.tsx.snap
+++ b/src/features/home/pages/__snapshots__/Home.test.tsx.snap
@@ -4,43 +4,90 @@ exports[`Home component should render correctly 1`] = `
 <RCTScrollView>
   <View>
     <View
-      accessibilityRole="button"
-      accessibilityState={Object {}}
-      accessible={true}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "opacity": 1,
-        }
+        Array [
+          Object {
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "width": "100%",
+          },
+        ]
       }
     >
       <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
-          Array [
-            Object {},
-          ]
+          Object {
+            "borderColor": "#151515",
+            "borderWidth": 2,
+            "opacity": 1,
+            "paddingBottom": 4,
+            "paddingLeft": 4,
+            "paddingRight": 4,
+            "paddingTop": 4,
+          }
         }
       >
         <Text
           style={
             Array [
               Object {
-                "color": "#007AFF",
-                "fontSize": 18,
-                "margin": 8,
-                "textAlign": "center",
+                "color": "#151515",
+                "fontFamily": "Montserrat-Regular",
+                "fontSize": 15,
+                "fontWeight": "normal",
+                "lineHeight": 20,
               },
             ]
           }
         >
           Composants
+        </Text>
+      </View>
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "borderColor": "#151515",
+            "borderWidth": 2,
+            "opacity": 1,
+            "paddingBottom": 4,
+            "paddingLeft": 4,
+            "paddingRight": 4,
+            "paddingTop": 4,
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#151515",
+                "fontFamily": "Montserrat-Regular",
+                "fontSize": 15,
+                "fontWeight": "normal",
+                "lineHeight": 20,
+              },
+            ]
+          }
+        >
+          Navigation
         </Text>
       </View>
     </View>
@@ -276,57 +323,6 @@ exports[`Home component should render correctly 1`] = `
           ]
         }
       />
-      <View
-        numberOfSpaces={6}
-        style={
-          Array [
-            Object {
-              "height": 24,
-            },
-          ]
-        }
-      />
-      <View
-        accessibilityRole="button"
-        accessibilityState={Object {}}
-        accessible={true}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "opacity": 1,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {},
-            ]
-          }
-        >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#007AFF",
-                  "fontSize": 18,
-                  "margin": 8,
-                  "textAlign": "center",
-                },
-              ]
-            }
-          >
-            Aller sur la page de connexion
-          </Text>
-        </View>
-      </View>
       <View
         numberOfSpaces={6}
         style={

--- a/src/features/navigation/RootNavigator.tsx
+++ b/src/features/navigation/RootNavigator.tsx
@@ -5,12 +5,14 @@ import React from 'react'
 import { Login } from 'features/auth/pages/Login'
 import AppComponents from 'features/cheatcodes/pages/AppComponents'
 import { CheatCodes } from 'features/cheatcodes/pages/CheatCodes'
+import Navigation from 'features/cheatcodes/pages/Navigation'
 import { Home } from 'features/home/pages/Home'
 
 import { onNavigationStateChange } from './services'
 
 export type RootStackParamList = {
   AppComponents: undefined
+  Navigation: undefined
   CheatCodes: undefined
   Home: undefined
   Login?: { userId: string }
@@ -30,6 +32,7 @@ export const RootNavigator: React.FC = function () {
         />
         <RootStack.Screen name="CheatCodes" component={CheatCodes} />
         <RootStack.Screen name="AppComponents" component={AppComponents} />
+        <RootStack.Screen name="Navigation" component={Navigation} />
       </RootStack.Navigator>
     </NavigationContainer>
   )

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/features/cheatcodes/pages/AppComponents.tsx:49
+msgid "Add components"
+msgstr "Add components"
+
 #: src/features/home/pages/Home.tsx:39
 msgid "Aller sur la page de connexion"
 msgstr "Aller sur la page de connexion"
@@ -31,38 +35,116 @@ msgstr "Aucun token à sauvegarder"
 msgid "Bienvenue !"
 msgstr "Bienvenue !"
 
-#: src/features/auth/pages/Login.tsx:36
-msgid "Connectez-vous :"
-msgstr "Connectez-vous :"
+#: src/features/cheatcodes/pages/AppComponents.tsx:23
+msgid "Button - Theme Primary"
+msgstr "Button - Theme Primary"
 
-#. login button
-#: src/features/auth/pages/Login.tsx:39
-msgid "Connexion"
-msgstr "Connexion"
+#: src/features/cheatcodes/pages/AppComponents.tsx:29
+msgid "Button - Theme Quaternary"
+msgstr "Button - Theme Quaternary"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:25
+msgid "Button - Theme Secondary"
+msgstr "Button - Theme Secondary"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:27
+msgid "Button - Theme Tertiary"
+msgstr "Button - Theme Tertiary"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:22
+msgid "Buttons"
+msgstr "Buttons"
+
+#: src/features/home/pages/Home.tsx:17
+msgid "Composants"
+msgstr "Composants"
 
 #. Authentication error message
 #: src/libs/fetch.ts:75
 msgid "Erreur d'authentification"
 msgstr "Erreur d'authentification"
 
+#: src/features/cheatcodes/pages/AppComponents.tsx:11
+msgid "Hero"
+msgstr "Hero"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:34
+msgid "Input - Any string"
+msgstr "Input - Any string"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:36
+msgid "Input - Email input"
+msgstr "Input - Email input"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:38
+msgid "Input - Email password"
+msgstr "Input - Email password"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:33
+msgid "Inputs"
+msgstr "Inputs"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:43
+msgid "Modal - Basic"
+msgstr "Modal - Basic"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:45
+msgid "Modal - Progressive"
+msgstr "Modal - Progressive"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:42
+msgid "Modals"
+msgstr "Modals"
+
+#: src/features/cheatcodes/pages/Navigation.tsx:10
+#: src/features/home/pages/Home.tsx:18
+msgid "Navigation"
+msgstr "Navigation"
+
+#: src/features/cheatcodes/pages/Navigation.tsx:12
+msgid "Page Login"
+msgstr "Page Login"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:16
+msgid "This is a body"
+msgstr "This is a body"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:17
+msgid "This is a button text"
+msgstr "This is a button text"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:18
+msgid "This is a caption"
+msgstr "This is a caption"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:12
+msgid "Title 1"
+msgstr "Title 1"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:13
+msgid "Title 2"
+msgstr "Title 2"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:14
+msgid "Title 3"
+msgstr "Title 3"
+
+#: src/features/cheatcodes/pages/AppComponents.tsx:15
+msgid "Title 4"
+msgstr "Title 4"
+
 #. Welcome body message
 #: src/features/home/pages/Home.tsx:29
 msgid "Toute la culture dans votre main"
 msgstr "Toute la culture dans votre main"
 
+#: src/features/cheatcodes/pages/AppComponents.tsx:9
+msgid "Typos"
+msgstr "Typos"
+
 #: src/libs/i18n.test.ts:8
 msgid "Welcome to Pass Culture"
 msgstr "Bienvenue à Pass Culture"
-
-#. email placeholder
-#: src/features/auth/pages/Login.tsx:37
-msgid "name@domain.com"
-msgstr "name@domain.com"
-
-#. password placeholder
-#: src/features/auth/pages/Login.tsx:38
-msgid "password"
-msgstr "password"
 
 #: src/features/auth/api.ts:31
 msgid "Échec de la connexion au Pass Culture: {0}"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-4371

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Explained my technical strategy below if feature is complex.

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`

## Screenshot 

| Home page | Navigation page |
| --------------- | ----------------------- |
| ![image](https://user-images.githubusercontent.com/22399093/97978637-22d84780-1dce-11eb-8cb3-8e9353b8ebc6.png) | ![image](https://user-images.githubusercontent.com/22399093/97978672-2c61af80-1dce-11eb-8b78-57f7ce2347be.png) | 