### PR TITLE
[PC-5189] Création du contentmodel Contentful homepageNatif

### DIFF
--- a/src/features/home/api.test.ts
+++ b/src/features/home/api.test.ts
@@ -8,7 +8,7 @@ import { getHomepageEntries, CONTENTFUL_BASE_URL } from './api'
 
 server.use(
   rest.get(
-    `${CONTENTFUL_BASE_URL}/spaces/${env.CONTENTFUL_SPACE_ID}/environments/${env.CONTENTFUL_ENVIRONMENT}/entries?include=2&content_type=homepage&access_token=${env.CONTENTFUL_ACCESS_TOKEN}`,
+    `${CONTENTFUL_BASE_URL}/spaces/${env.CONTENTFUL_SPACE_ID}/environments/${env.CONTENTFUL_ENVIRONMENT}/entries?include=2&content_type=homepageNatif&access_token=${env.CONTENTFUL_ACCESS_TOKEN}`,
     async (req, res, ctx) => {
       return res(ctx.status(200), ctx.json(homepageEntriesAPIResponse))
     }

--- a/src/features/home/api.ts
+++ b/src/features/home/api.ts
@@ -28,7 +28,7 @@ export async function getHomepageEntries() {
     `${CONTENTFUL_BASE_URL}` +
       `/spaces/${env.CONTENTFUL_SPACE_ID}` +
       `/environments/${env.CONTENTFUL_ENVIRONMENT}` +
-      `/entries?include=${DEPTH_LEVEL}&content_type=homepage&access_token=${env.CONTENTFUL_ACCESS_TOKEN}`
+      `/entries?include=${DEPTH_LEVEL}&content_type=homepageNatif&access_token=${env.CONTENTFUL_ACCESS_TOKEN}`
   )
   return adaptHomepageEntries(json)
 }

--- a/src/features/home/contentful/contentful.ts
+++ b/src/features/home/contentful/contentful.ts
@@ -3,7 +3,7 @@ export const CONTENT_TYPES = {
   ALGOLIA_PARAMETERS: 'algoliaParameters',
   DISPLAY_PARAMETERS: 'displayParameters',
   EXCLUSIVITY: 'exclusivity',
-  HOMEPAGE: 'homepage',
+  HOMEPAGE_NATIF: 'homepageNatif',
   INFORMATION: 'information',
   BUSINESS: 'business',
 }
@@ -14,7 +14,7 @@ export enum ContentTypes {
   EXCLUSIVITY = 'exclusivity',
   DISPLAY = 'display',
   DISPLAY_PARAMETERS = 'displayParameters',
-  HOMEPAGE = 'homepage',
+  HOMEPAGE_NATIF = 'homepageNatif',
   INFORMATION = 'information',
   BUSINESS = 'business',
 }
@@ -185,8 +185,8 @@ interface ExclusivityFields {
   offerId: string
 }
 
-// Taken from https://app.contentful.com/spaces/2bg01iqy0isv/content_types/homepage/fields
-interface HomepageFields {
+// Taken from https://app.contentful.com/spaces/2bg01iqy0isv/content_types/homepageNatif/fields
+interface HomepageNatifFields {
   title: string
   modules: HomepageModule[]
 }
@@ -217,8 +217,8 @@ interface Image {
 }
 
 interface HomepageEntries {
-  sys: Sys<typeof CONTENT_TYPES.HOMEPAGE>
-  fields: HomepageFields
+  sys: Sys<typeof CONTENT_TYPES.HOMEPAGE_NATIF>
+  fields: HomepageNatifFields
 }
 
 export type {

--- a/src/features/home/contentful/processHomepageEntries.test.ts
+++ b/src/features/home/contentful/processHomepageEntries.test.ts
@@ -19,7 +19,7 @@ describe('processHomepageEntries', () => {
       updatedAt: '2020-10-30T10:07:29.549Z',
       environment: { sys: { id: 'testing', type: 'Link', linkType: 'Environment' } },
       revision: 154,
-      contentType: { sys: { type: 'Link', linkType: 'ContentType', id: 'homepage' } },
+      contentType: { sys: { type: 'Link', linkType: 'ContentType', id: 'homepageNatif' } },
       locale: 'en-US',
     }
 

--- a/src/features/home/contentful/processHomepageEntries.ts
+++ b/src/features/home/contentful/processHomepageEntries.ts
@@ -15,14 +15,6 @@ import {
   ProcessedModule,
 } from './moduleTypes'
 
-function moveExcluModuleOnTop(modules: Array<ProcessedModule>) {
-  const excluModules = modules.filter((m) => m instanceof ExclusivityPane)
-  if (!excluModules.length) return modules
-
-  const otherModules = modules.filter((m) => !(m instanceof ExclusivityPane))
-  return [excluModules[0], ...otherModules]
-}
-
 export const processHomepageEntries = (homepage: HomepageEntries): ProcessedModule[] => {
   const {
     fields: { modules },
@@ -74,8 +66,7 @@ export const processHomepageEntries = (homepage: HomepageEntries): ProcessedModu
     return
   })
 
-  const filteredModules = processedModules.filter(Boolean) as ProcessedModule[]
-  return moveExcluModuleOnTop(filteredModules)
+  return processedModules.filter(Boolean) as ProcessedModule[]
 }
 
 const buildImageUrl = (image: Image): string | null => {

--- a/src/tests/fixtures/homepageEntries.ts
+++ b/src/tests/fixtures/homepageEntries.ts
@@ -20,6 +20,7 @@ export const homepageEntriesAPIResponse = {
       },
       fields: {
         modules: [
+          { sys: { type: 'Link', linkType: 'Entry', id: 'KiG6rWuQYhHuGIBXZNeB2' } },
           { sys: { type: 'Link', linkType: 'Entry', id: 'GlQb8Zg3n1PoYVmOyVCgW' } },
           { sys: { type: 'Link', linkType: 'Entry', id: '5u3NaFTcu2XR5KgJ1OAg8C' } },
           { sys: { type: 'Link', linkType: 'Entry', id: '1LgDMVOKdH3agA0WG2LFEr' } },
@@ -29,7 +30,6 @@ export const homepageEntriesAPIResponse = {
           { sys: { type: 'Link', linkType: 'Entry', id: '2Fjxhdirgh17ZvdPNZGDP4' } },
           { sys: { type: 'Link', linkType: 'Entry', id: '7c7xq3ulzqO2yDRJLDmths' } },
           { sys: { type: 'Link', linkType: 'Entry', id: '6lk6vCol5Qza2mfdtsTzW' } },
-          { sys: { type: 'Link', linkType: 'Entry', id: 'KiG6rWuQYhHuGIBXZNeB2' } },
         ],
         title: "Page d'accueil de la webappp",
       },
@@ -73,6 +73,25 @@ export const homepageEntriesAPIResponse = {
   ],
   includes: {
     Entry: [
+      {
+        sys: {
+          space: { sys: { type: 'Link', linkType: 'Space', id: '2bg01iqy0isv' } },
+          id: 'KiG6rWuQYhHuGIBXZNeB2',
+          type: 'Entry',
+          createdAt: '2020-10-30T10:07:22.489Z',
+          updatedAt: '2020-10-30T10:07:22.489Z',
+          environment: { sys: { id: 'testing', type: 'Link', linkType: 'Environment' } },
+          revision: 1,
+          contentType: { sys: { type: 'Link', linkType: 'ContentType', id: 'exclusivity' } },
+          locale: 'en-US',
+        },
+        fields: {
+          title: 'Exclusitivité du moment',
+          alt: 'Exclusitivité du moment',
+          image: { sys: { type: 'Link', linkType: 'Asset', id: '2qTXOFUocq1HhgB7Wzl23K' } },
+          offerId: 'AE67',
+        },
+      },
       {
         sys: {
           space: { sys: { type: 'Link', linkType: 'Space', id: '2bg01iqy0isv' } },
@@ -541,25 +560,6 @@ export const homepageEntriesAPIResponse = {
       {
         sys: {
           space: { sys: { type: 'Link', linkType: 'Space', id: '2bg01iqy0isv' } },
-          id: 'KiG6rWuQYhHuGIBXZNeB2',
-          type: 'Entry',
-          createdAt: '2020-10-30T10:07:22.489Z',
-          updatedAt: '2020-10-30T10:07:22.489Z',
-          environment: { sys: { id: 'testing', type: 'Link', linkType: 'Environment' } },
-          revision: 1,
-          contentType: { sys: { type: 'Link', linkType: 'ContentType', id: 'exclusivity' } },
-          locale: 'en-US',
-        },
-        fields: {
-          title: 'Exclusitivité du moment',
-          alt: 'Exclusitivité du moment',
-          image: { sys: { type: 'Link', linkType: 'Asset', id: '2qTXOFUocq1HhgB7Wzl23K' } },
-          offerId: 'AE67',
-        },
-      },
-      {
-        sys: {
-          space: { sys: { type: 'Link', linkType: 'Space', id: '2bg01iqy0isv' } },
           id: 'eLESwUjpZNqJyn9haXWGt',
           type: 'Entry',
           createdAt: '2020-10-12T20:40:08.977Z',
@@ -658,6 +658,46 @@ export const adaptedHomepageEntries: HomepageEntries = {
   },
   fields: {
     modules: [
+      {
+        sys: {
+          space: { sys: { type: 'Link', linkType: 'Space', id: '2bg01iqy0isv' } },
+          id: 'KiG6rWuQYhHuGIBXZNeB2',
+          type: 'Entry',
+          createdAt: '2020-10-30T10:07:22.489Z',
+          updatedAt: '2020-10-30T10:07:22.489Z',
+          environment: { sys: { id: 'testing', type: 'Link', linkType: 'Environment' } },
+          revision: 1,
+          contentType: { sys: { type: 'Link', linkType: 'ContentType', id: 'exclusivity' } },
+          locale: 'en-US',
+        },
+        fields: {
+          title: 'Exclusitivité du moment',
+          alt: 'Exclusitivité du moment',
+          image: {
+            sys: {
+              space: { sys: { type: 'Link', linkType: 'Space', id: '2bg01iqy0isv' } },
+              id: '2qTXOFUocq1HhgB7Wzl23K',
+              type: 'Asset',
+              createdAt: '2020-10-28T14:41:35.898Z',
+              updatedAt: '2020-10-28T14:41:35.898Z',
+              environment: { sys: { id: 'testing', type: 'Link', linkType: 'Environment' } },
+              revision: 1,
+              locale: 'en-US',
+            },
+            fields: {
+              title: 'Image spécial carnaval',
+              file: {
+                url:
+                  '//images.ctfassets.net/2bg01iqy0isv/2qTXOFUocq1HhgB7Wzl23K/a48ab7bedde13545231c0f843fbcfe10/image__3_.png',
+                details: { size: 128147, image: { width: 596, height: 559 } },
+                fileName: 'image (3).png',
+                contentType: 'image/png',
+              },
+            },
+          },
+          offerId: 'AE67',
+        },
+      },
       {
         sys: {
           space: { sys: { type: 'Link', linkType: 'Space', id: '2bg01iqy0isv' } },
@@ -1141,46 +1181,6 @@ export const adaptedHomepageEntries: HomepageEntries = {
               minOffers: 2,
             },
           },
-        },
-      },
-      {
-        sys: {
-          space: { sys: { type: 'Link', linkType: 'Space', id: '2bg01iqy0isv' } },
-          id: 'KiG6rWuQYhHuGIBXZNeB2',
-          type: 'Entry',
-          createdAt: '2020-10-30T10:07:22.489Z',
-          updatedAt: '2020-10-30T10:07:22.489Z',
-          environment: { sys: { id: 'testing', type: 'Link', linkType: 'Environment' } },
-          revision: 1,
-          contentType: { sys: { type: 'Link', linkType: 'ContentType', id: 'exclusivity' } },
-          locale: 'en-US',
-        },
-        fields: {
-          title: 'Exclusitivité du moment',
-          alt: 'Exclusitivité du moment',
-          image: {
-            sys: {
-              space: { sys: { type: 'Link', linkType: 'Space', id: '2bg01iqy0isv' } },
-              id: '2qTXOFUocq1HhgB7Wzl23K',
-              type: 'Asset',
-              createdAt: '2020-10-28T14:41:35.898Z',
-              updatedAt: '2020-10-28T14:41:35.898Z',
-              environment: { sys: { id: 'testing', type: 'Link', linkType: 'Environment' } },
-              revision: 1,
-              locale: 'en-US',
-            },
-            fields: {
-              title: 'Image spécial carnaval',
-              file: {
-                url:
-                  '//images.ctfassets.net/2bg01iqy0isv/2qTXOFUocq1HhgB7Wzl23K/a48ab7bedde13545231c0f843fbcfe10/image__3_.png',
-                details: { size: 128147, image: { width: 596, height: 559 } },
-                fileName: 'image (3).png',
-                contentType: 'image/png',
-              },
-            },
-          },
-          offerId: 'AE67',
         },
       },
     ],

--- a/src/tests/fixtures/homepageEntries.ts
+++ b/src/tests/fixtures/homepageEntries.ts
@@ -15,7 +15,7 @@ export const homepageEntriesAPIResponse = {
         updatedAt: '2020-10-30T10:07:29.549Z',
         environment: { sys: { id: 'testing', type: 'Link', linkType: 'Environment' } },
         revision: 154,
-        contentType: { sys: { type: 'Link', linkType: 'ContentType', id: 'homepage' } },
+        contentType: { sys: { type: 'Link', linkType: 'ContentType', id: 'homepageNatif' } },
         locale: 'en-US',
       },
       fields: {
@@ -43,7 +43,7 @@ export const homepageEntriesAPIResponse = {
         updatedAt: '2020-10-28T17:32:42.192Z',
         environment: { sys: { id: 'testing', type: 'Link', linkType: 'Environment' } },
         revision: 1,
-        contentType: { sys: { type: 'Link', linkType: 'ContentType', id: 'homepage' } },
+        contentType: { sys: { type: 'Link', linkType: 'ContentType', id: 'homepageNatif' } },
         locale: 'en-US',
       },
       fields: {
@@ -653,7 +653,7 @@ export const adaptedHomepageEntries: HomepageEntries = {
     updatedAt: '2020-10-30T10:07:29.549Z',
     environment: { sys: { id: 'testing', type: 'Link', linkType: 'Environment' } },
     revision: 154,
-    contentType: { sys: { type: 'Link', linkType: 'ContentType', id: 'homepage' } },
+    contentType: { sys: { type: 'Link', linkType: 'ContentType', id: 'homepageNatif' } },
     locale: 'en-US',
   },
   fields: {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-5189

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [x] Explained my technical strategy below if feature is complex.

## Technical strategy

 - Rajout d'un ContentType `homepageNatif` dans [Contentful](https://app.contentful.com/spaces/2bg01iqy0isv/environments/testing/content_types)
 - Modification du code pour appeler ce content type (au lieu de `homepage` => réservé pour la web app)
 -  en passant, j'ai créé un content de contentType `homepageNatif` pour que la transition soit smooth pour les devs.

## Screenshots:

Content Types:

![image](https://user-images.githubusercontent.com/10118284/98933729-552a2900-24e1-11eb-8657-3f01a8d96c13.png)


Content:
![image](https://user-images.githubusercontent.com/10118284/98933758-5d826400-24e1-11eb-9f6e-7ddebb66b78b.png)
