### PR TITLE
(PC-4371) Le bouton login est disabled si les deux text inputs ne sont pas remplis

### DIFF
--- a/src/features/auth/pages/Login.test.tsx
+++ b/src/features/auth/pages/Login.test.tsx
@@ -61,4 +61,19 @@ describe('<Login/>', () => {
       expect(navigationTestProps.navigation.navigate).not.toBeCalled()
     })
   })
+
+  it('should enable login button when both text inputs are filled', async () => {
+    const { getByPlaceholderText, toJSON } = renderLogin()
+    const disabledButtonSnapshot = toJSON()
+
+    const emailInput = getByPlaceholderText('tonadresse@email.com')
+    const passwordInput = getByPlaceholderText('Ton mot de passe')
+    fireEvent.changeText(emailInput, 'email@gmail.com')
+    fireEvent.changeText(passwordInput, 'mypassword')
+
+    await waitForExpect(() => {
+      const enabledButtonSnapshot = toJSON()
+      expect(disabledButtonSnapshot).toMatchDiffSnapshot(enabledButtonSnapshot)
+    })
+  })
 })

--- a/src/features/auth/pages/Login.tsx
+++ b/src/features/auth/pages/Login.tsx
@@ -9,6 +9,7 @@ import { env } from 'libs/environment'
 import { _ } from 'libs/i18n'
 import { BottomCard } from 'ui/components/BottomCard'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { isValueEmpty } from 'ui/components/inputs/helpers'
 import { PasswordInput } from 'ui/components/inputs/PasswordInput'
 import { TextInput } from 'ui/components/inputs/TextInput'
 import { ModalHeader } from 'ui/components/modals/ModalHeader'
@@ -34,6 +35,8 @@ export const Login: FunctionComponent<Props> = function (props: Props) {
   const [email, setEmail] = useState(INITIAL_IDENTIFIER)
   const [password, setPassword] = useState(INITIAL_PASSWORD)
   const [shouldShowErrorMessage, setShouldShowErrorMessage] = useState(false)
+
+  const shouldDisableLoginButton = isValueEmpty(email) || isValueEmpty(password)
 
   async function handleSignin() {
     setShouldShowErrorMessage(false)
@@ -109,7 +112,11 @@ export const Login: FunctionComponent<Props> = function (props: Props) {
           <Typo.ButtonText>{_(t`Mot de passe oublié ?`)}</Typo.ButtonText>
         </StyledForgottenPasswordTouchableOpacity>
         <Spacer.Column numberOfSpaces={8} />
-        <ButtonPrimary title={_(t`Se connecter`)} onPress={handleSignin} />
+        <ButtonPrimary
+          title={_(t`Se connecter`)}
+          onPress={handleSignin}
+          disabled={shouldDisableLoginButton}
+        />
       </BottomCard>
     </SafeContainer>
   )

--- a/src/features/auth/pages/__snapshots__/Login.test.tsx.snap
+++ b/src/features/auth/pages/__snapshots__/Login.test.tsx.snap
@@ -1,5 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Login/> should enable login button when both text inputs are filled 1`] = `
+"Snapshot Diff:
+- First value
++ Second value
+
+@@ -563,11 +563,13 @@
+                      \\"fontWeight\\": \\"normal\\",
+                      \\"lineHeight\\": 20,
+                    },
+                  ]
+                }
+-             />
++             >
++               email@gmail.com
++             </Text>
+            </TextInput>
+          </View>
+        </View>
+        <View
+          numberOfSpaces={6}
+@@ -679,11 +681,13 @@
+                      \\"fontWeight\\": \\"normal\\",
+                      \\"lineHeight\\": 20,
+                    },
+                  ]
+                }
+-             />
++             >
++               mypassword
++             </Text>
+            </TextInput>
+            <View
+              accessible={true}
+              focusable={true}
+              onClick={[Function onClick]}
+@@ -802,22 +806,22 @@
+            ]
+          }
+        />
+        <View
+          accessible={true}
+-         focusable={false}
++         focusable={true}
+          onClick={[Function onClick]}
+          onResponderGrant={[Function onResponderGrant]}
+          onResponderMove={[Function onResponderMove]}
+          onResponderRelease={[Function onResponderRelease]}
+          onResponderTerminate={[Function onResponderTerminate]}
+          onResponderTerminationRequest={[Function onResponderTerminationRequest]}
+          onStartShouldSetResponder={[Function onStartShouldSetResponder]}
+          style={
+            Object {
+              \\"alignItems\\": \\"center\\",
+-             \\"backgroundColor\\": \\"#ff99be\\",
++             \\"backgroundColor\\": \\"#eb0055\\",
+              \\"borderRadius\\": 24,
+              \\"borderWidth\\": 0,
+              \\"flexDirection\\": \\"row\\",
+              \\"height\\": 40,
+              \\"justifyContent\\": \\"center\\","
+`;
+
 exports[`<Login/> should show error message and error inputs AND not redirect to home page WHEN signin has failed 1`] = `
 "Snapshot Diff:
 - First value

--- a/src/ui/components/inputs/helpers.test.ts
+++ b/src/ui/components/inputs/helpers.test.ts
@@ -1,0 +1,15 @@
+import { isValueEmpty } from './helpers'
+
+describe('isValueEmpty()', () => {
+  it('should return true if value is undefined', () => {
+    expect(isValueEmpty(undefined)).toBe(true)
+  })
+
+  it('should return true if value is empty string', () => {
+    expect(isValueEmpty('')).toBe(true)
+  })
+
+  it('should return false if value is a non-empty string', () => {
+    expect(isValueEmpty('value')).toBe(false)
+  })
+})

--- a/src/ui/components/inputs/helpers.ts
+++ b/src/ui/components/inputs/helpers.ts
@@ -1,0 +1,11 @@
+import React from 'react'
+import { TextInput as RNTextInput } from 'react-native'
+
+type Value = React.ComponentProps<typeof RNTextInput>['value']
+
+export function isValueEmpty(value: Value): boolean {
+  if (value && value.trim().length > 0) {
+    return false
+  }
+  return true
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-4371

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [x] Added a **screenshot** for UI tickets.

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`

## Screenshots 

| Android phone button disabled | Android phone button enabled |
| -------------------- | -------------- |
| ![image](https://user-images.githubusercontent.com/22399093/98944261-1308e380-24f1-11eb-8a4d-7ec62d2ca68f.png) | ![image](https://user-images.githubusercontent.com/22399093/98944292-1ac88800-24f1-11eb-9403-bf3f7c71118b.png) |

