### PR TITLE
(PC-5161) use Batch.start() inside useEffect

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,7 +7,7 @@ import * as BatchLocalLib from 'libs/notifications'
 import { App } from './App'
 
 jest.mock('./libs/notifications', () => ({
-  startBatchNotification: jest.fn(),
+  useStartBatchNotification: jest.fn(),
 }))
 jest.mock('features/navigation/RootTabNavigator', () => ({
   RootTabNavigator() {
@@ -25,7 +25,7 @@ describe('<App /> with mocked RootTabNavigator', () => {
   it('should call startBatchNotification() to optin to notifications', () => {
     render(<App />)
 
-    expect(BatchLocalLib.startBatchNotification).toHaveBeenCalled()
+    expect(BatchLocalLib.useStartBatchNotification).toHaveBeenCalled()
   })
 
   it('should call SplashScreen.hide() after 500ms', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { RootTabNavigator } from 'features/navigation/RootTabNavigator'
 import { env } from 'libs/environment'
 import { i18n } from 'libs/i18n' //@translations
 import 'libs/sentry'
-import { startBatchNotification } from 'libs/notifications'
+import { useStartBatchNotification } from 'libs/notifications'
 import { useHideSplashScreen } from 'libs/splashscreen'
 
 const codePushOptionsManual = {
@@ -31,8 +31,7 @@ if (__DEV__ && process.env.JEST !== 'true') {
 }
 
 const AppComponent: FunctionComponent = function () {
-  startBatchNotification()
-
+  useStartBatchNotification()
   useHideSplashScreen()
 
   return (

--- a/src/libs/notifications/index.ts
+++ b/src/libs/notifications/index.ts
@@ -1,1 +1,1 @@
-export { startBatchNotification } from './startBatchNotification'
+export { useStartBatchNotification } from './useStartBatchNotification'

--- a/src/libs/notifications/startBatchNotification.ts
+++ b/src/libs/notifications/startBatchNotification.ts
@@ -1,6 +1,0 @@
-import { Batch, BatchPush } from '@bam.tech/react-native-batch'
-
-export const startBatchNotification = (): void => {
-  Batch.start()
-  BatchPush.registerForRemoteNotifications() //  No effect on Android
-}

--- a/src/libs/notifications/useStartBatchNotification.test.ts
+++ b/src/libs/notifications/useStartBatchNotification.test.ts
@@ -1,15 +1,16 @@
 import { Batch, BatchPush } from '@bam.tech/react-native-batch'
+import { renderHook } from '@testing-library/react-hooks'
 
-import { startBatchNotification } from './startBatchNotification'
+import { useStartBatchNotification } from './useStartBatchNotification'
 
 describe('startBatchNotification', () => {
   it('should call Batch.start', () => {
-    startBatchNotification()
+    renderHook(useStartBatchNotification)
     expect(Batch.start).toHaveBeenCalledTimes(1)
   })
 
   it('should call BatchPush.registerForRemoteNotifications', () => {
-    startBatchNotification()
+    renderHook(useStartBatchNotification)
     expect(BatchPush.registerForRemoteNotifications).toHaveBeenCalled()
   })
 })

--- a/src/libs/notifications/useStartBatchNotification.ts
+++ b/src/libs/notifications/useStartBatchNotification.ts
@@ -1,0 +1,9 @@
+import { Batch, BatchPush } from '@bam.tech/react-native-batch'
+import { useEffect } from 'react'
+
+export const useStartBatchNotification = (): void => {
+  useEffect(() => {
+    Batch.start()
+    BatchPush.registerForRemoteNotifications() //  No effect on Android
+  }, [])
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-5161

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Explained my technical strategy below if feature is complex.

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`

## Technical strategy

> _Insert technical strategy_
