### PR TITLE
(PC-5142) Change the way error message is shown

### DIFF
--- a/__mocks__/@react-navigation/native.ts
+++ b/__mocks__/@react-navigation/native.ts
@@ -7,3 +7,5 @@ export const useNavigation = () => ({
   reset,
   goBack,
 })
+
+export const useRoute = jest.fn()

--- a/src/features/auth/pages/ReinitializePassword.test.tsx
+++ b/src/features/auth/pages/ReinitializePassword.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
+import React from 'react'
+
+import { useRoute } from '__mocks__/@react-navigation/native'
+import { ColorsEnum } from 'ui/theme'
+
+import { ReinitializePassword } from './ReinitializePassword'
+
+describe('ReinitializePassword Page', () => {
+  beforeAll(() => {
+    useRoute.mockImplementation(() => ({
+      params: {
+        token: 'reerereskjlmkdlsf',
+        expiration_date: 45465546445,
+      },
+    }))
+  })
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
+  it('should enable the submit button when passwords are equals and filled', async () => {
+    const { getByPlaceholderText, getByTestId } = render(<ReinitializePassword />)
+
+    const passwordInput = getByPlaceholderText('Ton mot de passe')
+    const confirmationInput = getByPlaceholderText('Confirmer le mot de passe')
+
+    fireEvent.changeText(passwordInput, '123456')
+    fireEvent.changeText(confirmationInput, '123456')
+
+    // assuming there's only one button in this page
+    const continueButton = getByTestId('button-container')
+
+    await waitFor(async () => {
+      const background = continueButton.props.style.backgroundColor
+      expect(background).toEqual(ColorsEnum.PRIMARY)
+    })
+  })
+  it('should display the matching error when the passwords dont match', async () => {
+    const { getByPlaceholderText, getByTestId } = render(<ReinitializePassword />)
+
+    const passwordInput = getByPlaceholderText('Ton mot de passe')
+    const confirmationInput = getByPlaceholderText('Confirmer le mot de passe')
+
+    fireEvent.changeText(passwordInput, '123456')
+    fireEvent.changeText(confirmationInput, '123456--')
+
+    // assuming there's only one button in this page
+    const notMatchingErrorText = getByTestId('not-matching-error')
+
+    await waitFor(async () => {
+      const color = notMatchingErrorText.props.style[0].color
+      expect(color).toEqual(ColorsEnum.ERROR)
+    })
+  })
+})

--- a/src/features/auth/pages/ReinitializePassword.tsx
+++ b/src/features/auth/pages/ReinitializePassword.tsx
@@ -27,8 +27,8 @@ export const ReinitializePassword = () => {
   const [confirmedPassword, setConfirmedPassword] = useState('')
   const [shouldShowConfirmationError] = useState(false)
 
-  const arePasswordsMatching = confirmedPassword === password
-  const allowSubmission = password.length > 0 && arePasswordsMatching
+  const allowSubmission = password.length > 0 && confirmedPassword === password
+  const displayNotMatchingError = confirmedPassword.length > 0 && confirmedPassword !== password
 
   function onClose() {
     navigation.navigate('Home', { shouldDisplayLoginModal: false })
@@ -72,7 +72,7 @@ export const ReinitializePassword = () => {
             />
           </StyledInput>
           <Spacer.Column numberOfSpaces={2} />
-          {!arePasswordsMatching && (
+          {displayNotMatchingError && (
             <ErrorLineContainer>
               <Warning size={24} color={ColorsEnum.ERROR} />
               <Typo.Caption color={ColorsEnum.ERROR}>

--- a/src/features/auth/pages/ReinitializePassword.tsx
+++ b/src/features/auth/pages/ReinitializePassword.tsx
@@ -67,7 +67,7 @@ export const ReinitializePassword = () => {
             <PasswordInput
               value={confirmedPassword}
               onChangeText={setConfirmedPassword}
-              placeholder={_(/*i18n: password placeholder */ t`Ton mot de passe`)}
+              placeholder={_(/*i18n: password placeholder */ t`Confirmer le mot de passe`)}
               isError={shouldShowConfirmationError}
             />
           </StyledInput>
@@ -75,7 +75,7 @@ export const ReinitializePassword = () => {
           {displayNotMatchingError && (
             <ErrorLineContainer>
               <Warning size={24} color={ColorsEnum.ERROR} />
-              <Typo.Caption color={ColorsEnum.ERROR}>
+              <Typo.Caption testID="not-matching-error" color={ColorsEnum.ERROR}>
                 {_(t`les mots de passe ne concordent pas`)}
               </Typo.Caption>
             </ErrorLineContainer>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXX

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [] Written **unit tests** for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Explained my technical strategy below if feature is complex.

<img width="200" alt="image" src="https://user-images.githubusercontent.com/6025710/99392665-55a93200-28dc-11eb-982b-111675f84694.png">
<img width="200" alt="image" src="https://user-images.githubusercontent.com/6025710/99392694-63f74e00-28dc-11eb-9f4b-d2583cb91257.png">

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`

## Technical strategy

> _Insert technical strategy_
