### PR TITLE
(PC-4939) Rendre la page "Icon - Titre" réutilisable

### DIFF
--- a/src/features/auth/pages/ResetPasswordExpiredLink.tsx
+++ b/src/features/auth/pages/ResetPasswordExpiredLink.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro'
 import { StackScreenProps } from '@react-navigation/stack'
 import React from 'react'
-import { Alert, ScrollView, ViewStyle } from 'react-native'
+import { Alert } from 'react-native'
 import styled from 'styled-components/native'
 
 import {
@@ -11,11 +11,10 @@ import {
 import { _ } from 'libs/i18n'
 import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { ButtonTertiaryWhite } from 'ui/components/buttons/ButtonTertiaryWhite'
-import { SafeContainer } from 'ui/components/SafeContainer'
-import { Background } from 'ui/svg/Background'
+import { GenericInfoPage } from 'ui/components/GenericInfoPage'
 import { Email } from 'ui/svg/icons/Email'
 import { SadFace } from 'ui/svg/icons/SadFace'
-import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
+import { ColorsEnum, Spacer, Typo } from 'ui/theme'
 
 import { requestPasswordReset } from '../api'
 
@@ -36,60 +35,29 @@ export function ResetPasswordExpiredLink(props: Props) {
   }
 
   return (
-    <SafeContainer noTabBarSpacing>
-      <Background />
-      <ScrollView contentContainerStyle={scrollViewContentContainerStyle}>
-        <StyledView>
-          <Spacer.Column numberOfSpaces={18} />
-          <SadFace color={ColorsEnum.WHITE} size={100} />
-          <Spacer.Column numberOfSpaces={9} />
-          <StyledTitle2>{_(t`Oups`)}</StyledTitle2>
-          <Spacer.Column numberOfSpaces={5} />
-          <StyledBody>{_(t`Le lien est expiré !`)}</StyledBody>
-          <StyledBody>
-            {_(t`Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien.`)}
-          </StyledBody>
-          <Spacer.Column numberOfSpaces={4} />
-          <StyledBody>{_(t`Si tu as besoin d’aide n’hésite pas à :`)}</StyledBody>
-          <Spacer.Column numberOfSpaces={4} />
-          <ButtonTertiaryWhite
-            title={_(t`Contacter le support`)}
-            onPress={contactSupport}
-            icon={Email}
-          />
-          <Spacer.Column numberOfSpaces={4} />
-          <ButtonPrimaryWhite
-            title={_(t`Renvoyer l'email`)}
-            onPress={resendEmailForResetPassword}
-          />
-          <Spacer.Column numberOfSpaces={4} />
-          <ButtonTertiaryWhite
-            title={_(t`Retourner à l'accueil`)}
-            onPress={navigateToHomeWithoutModal}
-          />
-        </StyledView>
-      </ScrollView>
-      <Spacer.TabBar />
-    </SafeContainer>
+    <GenericInfoPage title={_(t`Oups`)} icon={SadFace}>
+      <StyledBody>{_(t`Le lien est expiré !`)}</StyledBody>
+      <StyledBody>
+        {_(t`Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien.`)}
+      </StyledBody>
+      <Spacer.Column numberOfSpaces={4} />
+      <StyledBody>{_(t`Si tu as besoin d’aide n’hésite pas à :`)}</StyledBody>
+      <Spacer.Column numberOfSpaces={4} />
+      <ButtonTertiaryWhite
+        title={_(t`Contacter le support`)}
+        onPress={contactSupport}
+        icon={Email}
+      />
+      <Spacer.Column numberOfSpaces={4} />
+      <ButtonPrimaryWhite title={_(t`Renvoyer l'email`)} onPress={resendEmailForResetPassword} />
+      <Spacer.Column numberOfSpaces={4} />
+      <ButtonTertiaryWhite
+        title={_(t`Retourner à l'accueil`)}
+        onPress={navigateToHomeWithoutModal}
+      />
+    </GenericInfoPage>
   )
 }
-
-const scrollViewContentContainerStyle: ViewStyle = {
-  flexGrow: 1,
-  justifyContent: 'center',
-}
-
-const StyledView = styled.View({
-  flexDirection: 'column',
-  alignSelf: 'center',
-  alignItems: 'center',
-  width: '90%',
-  maxWidth: getSpacing(125),
-})
-
-const StyledTitle2 = styled(Typo.Title2).attrs({
-  color: ColorsEnum.WHITE,
-})({})
 
 const StyledBody = styled(Typo.Body).attrs({
   color: ColorsEnum.WHITE,

--- a/src/ui/components/GenericInfoPage.tsx
+++ b/src/ui/components/GenericInfoPage.tsx
@@ -1,0 +1,46 @@
+import React, { FunctionComponent } from 'react'
+import { ScrollView, ViewStyle } from 'react-native'
+import styled from 'styled-components/native'
+
+import { SafeContainer } from 'ui/components/SafeContainer'
+import { Background } from 'ui/svg/Background'
+import { IconInterface } from 'ui/svg/icons/types'
+import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
+
+type Props = {
+  icon: FunctionComponent<IconInterface>
+  title: string
+}
+
+export const GenericInfoPage: FunctionComponent<Props> = (props) => {
+  return (
+    <SafeContainer noTabBarSpacing>
+      <Background />
+      <ScrollView contentContainerStyle={scrollViewContentContainerStyle}>
+        <Spacer.Column numberOfSpaces={18} />
+        <props.icon color={ColorsEnum.WHITE} size={100} />
+        <Spacer.Column numberOfSpaces={9} />
+        <StyledTitle2>{props.title}</StyledTitle2>
+        <Spacer.Column numberOfSpaces={5} />
+        {props.children}
+      </ScrollView>
+      <Spacer.TabBar />
+    </SafeContainer>
+  )
+}
+
+const scrollViewContentContainerStyle: ViewStyle = {
+  flexDirection: 'column',
+  flexGrow: 1,
+  justifyContent: 'center',
+  alignSelf: 'center',
+  alignItems: 'center',
+  width: '90%',
+  maxWidth: getSpacing(125),
+}
+
+const StyledTitle2 = styled(Typo.Title2).attrs({
+  color: ColorsEnum.WHITE,
+})({
+  textAlign: 'center',
+})


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-4939

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [ ] ~Written **unit tests** for my feature.~
- [ ] ~Added new reusable components to the AppComponents page and communicate to the team on slack~
- [x] Added a **screenshot** for UI tickets.

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - Pixel C | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |   ![Screenshot_1605869056](https://user-images.githubusercontent.com/22399093/99791463-f2aadb80-2b25-11eb-811b-ec1333af6683.png)        | |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`
