### PR TITLE
Avoid crash on Cheatcode page for unauthenticated users

### DIFF
--- a/src/features/auth/api.ts
+++ b/src/features/auth/api.ts
@@ -15,7 +15,9 @@ export function useCurrentUser() {
         return json.logged_in_as
       } catch (err) {
         if (err instanceof NotAuthenticatedError) return undefined
-        throw err
+        // We don't throw an error as it is not caught on this page
+        // For instance, we can receive a status 422 if the access token is invalid
+        return undefined
       }
     },
     { retry: false }


### PR DESCRIPTION
C'était possible pour les utilisateurs qui ne se sont jamais connectés d'avoir un crash à cause d'une requête 422 sur la page des cheatcodes. Si ça arrive, maintenant, on ne throw pas l'erreur.