### PR TITLE
(PC-5143) Fix du renvoie de l'email si le lien reset MDP est expiré

### DIFF
--- a/src/features/deeplinks/routing.test.ts
+++ b/src/features/deeplinks/routing.test.ts
@@ -7,29 +7,32 @@ describe('DEEPLINK_TO_SCREEN_CONFIGURATION', () => {
     it('should return Home page when no params are passed', () => {
       const configureScreen = DEEPLINK_TO_SCREEN_CONFIGURATION['mot-de-passe-perdu']()
       expect(configureScreen.screen).toBe('Home')
+      expect(configureScreen.params).toEqual({ shouldDisplayLoginModal: false })
     })
 
     it.each`
       params
-      ${{ tok: '', expiration_timestamp: '' }}
-      ${{ token: '', expiration_time: '' }}
-      ${{ tok: '', expiration_time: '' }}
+      ${{ tok: '', expiration_timestamp: '', email: '' }}
+      ${{ token: '', expiration_time: '', email: '' }}
+      ${{ token: '', expiration_timestamp: '', em: '' }}
     `('should return Home page when params are invalid', ({ params }) => {
       const configureScreen = DEEPLINK_TO_SCREEN_CONFIGURATION['mot-de-passe-perdu'](params)
       expect(configureScreen.screen).toBe('Home')
+      expect(configureScreen.params).toEqual({ shouldDisplayLoginModal: false })
     })
 
     it('should return ResetPasswordExpiredLink page when expiration_timestamp is expired', () => {
       jest.spyOn(datesLib, 'isTimestampExpired').mockReturnValue(true)
-      const params = { token: 'token', expiration_timestamp: '11111111' }
+      const params = { token: 'token', expiration_timestamp: '11111', email: 'test@gmail.com' }
       const configureScreen = DEEPLINK_TO_SCREEN_CONFIGURATION['mot-de-passe-perdu'](params)
 
       expect(configureScreen.screen).toBe('ResetPasswordExpiredLink')
+      expect(configureScreen.params).toEqual({ email: params.email })
     })
 
     it('should return ReinitializePassword page when expiration_timestamp is NOT expired', () => {
       jest.spyOn(datesLib, 'isTimestampExpired').mockReturnValue(false)
-      const params = { token: 'token', expiration_timestamp: '11111' }
+      const params = { token: 'token', expiration_timestamp: '11111', email: 'test@gmail.com' }
       const configureScreen = DEEPLINK_TO_SCREEN_CONFIGURATION['mot-de-passe-perdu'](params)
 
       expect(configureScreen.screen).toBe('ReinitializePassword')
@@ -41,6 +44,7 @@ describe('DEEPLINK_TO_SCREEN_CONFIGURATION', () => {
     it('should return Home page when no params are passed', () => {
       const configureScreen = DEEPLINK_TO_SCREEN_CONFIGURATION['default']()
       expect(configureScreen.screen).toBe('Home')
+      expect(configureScreen.params).toEqual({ shouldDisplayLoginModal: false })
     })
   })
 
@@ -48,6 +52,7 @@ describe('DEEPLINK_TO_SCREEN_CONFIGURATION', () => {
     it('should return Favorites page when no params are passed', () => {
       const configureScreen = DEEPLINK_TO_SCREEN_CONFIGURATION['favoris']()
       expect(configureScreen.screen).toBe('Favorites')
+      expect(configureScreen.params).toBe(undefined)
     })
   })
 
@@ -55,6 +60,7 @@ describe('DEEPLINK_TO_SCREEN_CONFIGURATION', () => {
     it('should return Login page when no params are passed', () => {
       const configureScreen = DEEPLINK_TO_SCREEN_CONFIGURATION['login']()
       expect(configureScreen.screen).toBe('Login')
+      expect(configureScreen.params).toBe(undefined)
     })
   })
 
@@ -62,6 +68,7 @@ describe('DEEPLINK_TO_SCREEN_CONFIGURATION', () => {
     it('should return Profile page when no params are passed', () => {
       const configureScreen = DEEPLINK_TO_SCREEN_CONFIGURATION['profil']()
       expect(configureScreen.screen).toBe('Profile')
+      expect(configureScreen.params).toBe(undefined)
     })
   })
 
@@ -69,6 +76,7 @@ describe('DEEPLINK_TO_SCREEN_CONFIGURATION', () => {
     it('should return Search page when no params are passed', () => {
       const configureScreen = DEEPLINK_TO_SCREEN_CONFIGURATION['recherche']()
       expect(configureScreen.screen).toBe('Search')
+      expect(configureScreen.params).toBe(undefined)
     })
   })
 })

--- a/src/features/deeplinks/routing.ts
+++ b/src/features/deeplinks/routing.ts
@@ -1,18 +1,24 @@
-import { AllNavParamList } from 'features/navigation/RootNavigator'
 import { isTimestampExpired } from 'libs/dates'
 
-import { DeepLinksToScreenConfiguration, DeepLinksToScreenMap } from './types'
+import { DeepLinksToScreenConfiguration } from './types'
 
-export const DEEPLINK_TO_SCREEN_CONFIGURATION: DeepLinksToScreenConfiguration<
-  DeepLinksToScreenMap,
-  AllNavParamList
-> = {
+export const DEEPLINK_TO_SCREEN_CONFIGURATION: DeepLinksToScreenConfiguration = {
+  default: function () {
+    return { screen: 'Home', params: { shouldDisplayLoginModal: false } }
+  },
+  favoris: function () {
+    return { screen: 'Favorites', params: undefined }
+  },
+  login: function () {
+    return { screen: 'Login', params: undefined }
+  },
   'mot-de-passe-perdu': function (params) {
-    if (params && params.token && params.expiration_timestamp) {
+    if (params && params.token && params.email && params.expiration_timestamp) {
       const parsedExpirationTimestamp = Number(params.expiration_timestamp)
       if (isTimestampExpired(parsedExpirationTimestamp)) {
         return {
           screen: 'ResetPasswordExpiredLink',
+          params: { email: params.email },
         }
       }
       return {
@@ -23,21 +29,12 @@ export const DEEPLINK_TO_SCREEN_CONFIGURATION: DeepLinksToScreenConfiguration<
         },
       }
     }
-    return { screen: 'Home' }
+    return { screen: 'Home', params: { shouldDisplayLoginModal: false } }
   },
   profil: function () {
-    return { screen: 'Profile' }
-  },
-  favoris: function () {
-    return { screen: 'Favorites' }
+    return { screen: 'Profile', params: undefined }
   },
   recherche: function () {
-    return { screen: 'Search' }
-  },
-  login: function () {
-    return { screen: 'Login' }
-  },
-  default: function () {
-    return { screen: 'Home' }
+    return { screen: 'Search', params: undefined }
   },
 }

--- a/src/features/deeplinks/types.ts
+++ b/src/features/deeplinks/types.ts
@@ -1,4 +1,4 @@
-import { RouteParams } from 'features/navigation/RootNavigator'
+import { RouteParams, AllNavParamList } from 'features/navigation/RootNavigator'
 
 export interface DeeplinkParts {
   routeName: string
@@ -9,25 +9,25 @@ export interface DeeplinkEvent {
   url: string
 }
 
-export type DeepLinksToScreenMap = {
-  default: 'Home'
-  favoris: 'Favorites'
-  login: 'Login'
-  'mot-de-passe-perdu': 'ReinitializePassword'
-  profil: 'Profile'
-  recherche: 'Search'
+type SerializedParams = Record<string, string>
+
+type ScreenConfiguration<ScreenName extends keyof AllNavParamList> = {
+  screen: ScreenName
+  params: RouteParams<AllNavParamList, ScreenName>
 }
 
-export type AllowedDeeplinkRoutes = keyof DeepLinksToScreenMap
+export type AllowedDeeplinkRoutes = keyof DeepLinksToScreenConfiguration
 
-export type DeepLinksToScreenConfiguration<
-  Routes extends Record<string, string>, // 2nd string targets ScreenNames
-  StackParamList extends Record<string, unknown> // unknow targets any screen params type
-> = {
-  [routename in keyof Routes]: (
-    params?: Record<string, string>
-  ) => {
-    screen: keyof StackParamList
-    params?: RouteParams<StackParamList, keyof StackParamList>
-  }
+export type DeepLinksToScreenConfiguration = {
+  default: (params?: SerializedParams) => ScreenConfiguration<'Home'>
+  favoris: (params?: SerializedParams) => ScreenConfiguration<'Favorites'>
+  login: (params?: SerializedParams) => ScreenConfiguration<'Login'>
+  'mot-de-passe-perdu': (
+    params?: SerializedParams
+  ) =>
+    | ScreenConfiguration<'ReinitializePassword'>
+    | ScreenConfiguration<'ResetPasswordExpiredLink'>
+    | ScreenConfiguration<'Home'>
+  profil: (params?: SerializedParams) => ScreenConfiguration<'Profile'>
+  recherche: (params?: SerializedParams) => ScreenConfiguration<'Search'>
 }

--- a/src/features/deeplinks/useDeeplinkUrlHandler.test.ts
+++ b/src/features/deeplinks/useDeeplinkUrlHandler.test.ts
@@ -2,7 +2,6 @@ import { renderHook } from '@testing-library/react-hooks'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 
-import { DeepLinksToScreenConfiguration } from './types'
 import { decodeDeeplinkParts, useDeeplinkUrlHandler } from './useDeeplinkUrlHandler'
 import { DEEPLINK_DOMAIN } from './utils'
 
@@ -66,14 +65,7 @@ describe('useDeeplinkUrlHandler', () => {
   })
 })
 
-/** FAKING NAVIGATION BY REDEFINING A LOCAL STACK PARAMLIST */
-type DeepLinksToScreenMapForTest = { 'my-route-to-test': 'UniqueTestRoute'; default: 'Home' }
-
-type RootStackParamListForTest = {
-  UniqueTestRoute: { param1: string; param2: number; param3: boolean; param4: boolean }
-  Home: undefined
-}
-
+/** FAKING DEEPLINKS ROUTING */
 jest.mock('features/deeplinks/routing', () => ({
   DEEPLINK_TO_SCREEN_CONFIGURATION: {
     'my-route-to-test': function (params: Record<string, string>) {
@@ -90,7 +82,6 @@ jest.mock('features/deeplinks/routing', () => ({
     default: function () {
       return { screen: 'Home' }
     },
-  } as DeepLinksToScreenConfiguration<DeepLinksToScreenMapForTest, RootStackParamListForTest>,
+  },
 }))
-
-/** FAKING NAVIGATION END */
+/** FAKING DEEPLINKS ROUTING END */


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-5143

Fix suite au retour de validation PO : https://passculture.atlassian.net/browse/PC-5143?focusedCommentId=17486

Problème : le param `email` n'était pas passé au Screen `ResetPasswordExpiredLink`.

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [ ] ~Added new reusable components to the AppComponents page and communicate to the team on slack~
- [ ] ~Added a **screenshot** for UI tickets.~