### PR TITLE
[PC-5544] Fix signout Android

### DIFF
--- a/src/libs/keychain.ts
+++ b/src/libs/keychain.ts
@@ -18,7 +18,7 @@ export async function saveRefreshToken(refreshToken: string | undefined): Promis
 
 export async function clearRefreshToken(): Promise<void> {
   try {
-    await Keychain.setGenericPassword(REFRESH_TOKEN_KEY, '')
+    await Keychain.resetGenericPassword()
   } catch (error) {
     throw Error(_(t`Keychain non accessible`))
   }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-5544
Lien doc: https://github.com/oblador/react-native-keychain#resetgenericpassword-service-

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`