### PR TITLE
(PC-5531) feat: add analytics event for click on exlcu block

### DIFF
--- a/src/features/home/components/ExclusivityModule.tsx
+++ b/src/features/home/components/ExclusivityModule.tsx
@@ -5,17 +5,22 @@ import styled from 'styled-components/native'
 
 import { ExclusivityPane } from 'features/home/contentful'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
+import { logClickExclusivityBlock } from 'libs/analytics'
 import { MARGIN_DP, LENGTH_XL, RATIO_EXCLU, Spacer } from 'ui/theme'
 import { BorderRadiusEnum } from 'ui/theme/grid'
 
 export const ExclusivityModule = ({ alt, image, offerId }: ExclusivityPane) => {
-  const navigation = useNavigation<UseNavigationType>()
+  const { navigate } = useNavigation<UseNavigationType>()
 
   return (
     <Row>
       <Spacer.Row numberOfSpaces={6} />
       <ImageContainer>
-        <TouchableHighlight onPress={() => navigation.navigate('Offer', { offerId })}>
+        <TouchableHighlight
+          onPress={() => {
+            navigate('Offer', { offerId })
+            logClickExclusivityBlock(offerId)
+          }}>
           <Image
             source={{ uri: image }}
             accessible={!!alt}

--- a/src/features/home/components/tests/ExclusivityModule.test.tsx
+++ b/src/features/home/components/tests/ExclusivityModule.test.tsx
@@ -2,6 +2,7 @@ import { render, fireEvent } from '@testing-library/react-native'
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
+import { logClickExclusivityBlock } from 'libs/analytics'
 
 import { ExclusivityModule } from '../ExclusivityModule'
 
@@ -11,6 +12,7 @@ const props = {
   offerId: 'AZBE',
   moduleId: 'module-id',
 }
+
 describe('ExclusivityModule component', () => {
   afterAll(() => jest.resetAllMocks())
 
@@ -19,9 +21,14 @@ describe('ExclusivityModule component', () => {
     expect(toJSON()).toMatchSnapshot()
   })
 
-  it('should navigate to the offer when clicking on the image', async () => {
+  it('should navigate to the offer when clicking on the image', () => {
     const { getByTestId } = render(<ExclusivityModule {...props} />)
     fireEvent.press(getByTestId('imageExclu'))
     expect(navigate).toHaveBeenCalledWith('Offer', { offerId: 'AZBE' })
+  })
+  it('should log a click event when clicking on the image', () => {
+    const { getByTestId } = render(<ExclusivityModule {...props} />)
+    fireEvent.press(getByTestId('imageExclu'))
+    expect(logClickExclusivityBlock).toHaveBeenCalledWith('AZBE')
   })
 })

--- a/src/libs/__mocks__/analytics.ts
+++ b/src/libs/__mocks__/analytics.ts
@@ -11,5 +11,6 @@ export const analytics: jest.Mocked<AnalyticsReturn> = {
 export const logAllModulesSeen = jest.fn()
 export const logAllTilesSeen = jest.fn()
 export const logConsultOffer = jest.fn()
+export const logClickExclusivityBlock = jest.fn()
 export const logClickSeeMore = jest.fn()
 export const logClickBusinessBlock = jest.fn()

--- a/src/libs/analytics.ts
+++ b/src/libs/analytics.ts
@@ -8,6 +8,7 @@ export enum AnalyticsEvent {
   CONSULT_OFFER = 'ConsultOffer',
   SEE_MORE_CLICKED = 'SeeMoreClicked',
   BUSINESS_BLOCK_CLICKED = 'BusinessBlockClicked',
+  EXCLUSIVITY_BLOCK_CLICKED = 'ExclusivityBlockClicked',
 }
 
 export const logAllModulesSeen = async (numberOfModules: number) =>
@@ -18,6 +19,9 @@ export const logAllTilesSeen = async (moduleName: string, numberOfTiles: number)
 
 export const logConsultOffer = async (offerId: string) =>
   await analytics.logEvent(AnalyticsEvent.CONSULT_OFFER, { offerId })
+
+export const logClickExclusivityBlock = async (offerId: string) =>
+  await analytics.logEvent(AnalyticsEvent.EXCLUSIVITY_BLOCK_CLICKED, { offerId })
 
 export const logClickSeeMore = async (moduleName: string) =>
   await analytics.logEvent(AnalyticsEvent.SEE_MORE_CLICKED, { moduleName })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-5531

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|![image](https://user-images.githubusercontent.com/66383742/100747564-84e29780-33e2-11eb-92e9-c4c63b01a4ad.png)|                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`
