### PR TITLE
[PC-5737] display code push button testing env

### DIFF
--- a/src/features/cheatcodes/pages/CheatCodes.test.tsx
+++ b/src/features/cheatcodes/pages/CheatCodes.test.tsx
@@ -2,6 +2,7 @@ import { act, render } from '@testing-library/react-native'
 import React from 'react'
 
 import { BatchUser } from '__mocks__/@bam.tech/react-native-batch'
+import { env } from 'libs/environment'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { flushAllPromises } from 'tests/utils'
 
@@ -31,6 +32,31 @@ describe('CheatCodes component', () => {
 
     expect(instance.toJSON()).toMatchSnapshot()
   })
+
+  it.each`
+    environment     | codePushManual | buttonIsdisplayed
+    ${'testing'}    | ${true}        | ${true}
+    ${'testing'}    | ${false}       | ${true}
+    ${'staging'}    | ${true}        | ${true}
+    ${'staging'}    | ${false}       | ${false}
+    ${'production'} | ${true}        | ${true}
+    ${'production'} | ${false}       | ${false}
+  `(
+    'should display/not display code push button',
+    async ({ environment, codePushManual, buttonIsdisplayed }) => {
+      env.ENV = environment
+      env.FEATURE_FLAG_CODE_PUSH_MANUAL = codePushManual
+      const instance = render(reactQueryProviderHOC(<CheatCodes navigation={navigation} />))
+
+      await act(async () => {
+        await flushAllPromises()
+      })
+      buttonIsdisplayed
+        ? expect(instance.queryByText('Check update')).toBeTruthy()
+        : expect(instance.queryByText('Check update')).toBeFalsy()
+      expect.assertions(1)
+    }
+  )
 
   it('should call installationID and display it', async () => {
     const { queryByText } = render(reactQueryProviderHOC(<CheatCodes navigation={navigation} />))

--- a/src/features/cheatcodes/pages/CheatCodes.tsx
+++ b/src/features/cheatcodes/pages/CheatCodes.tsx
@@ -43,7 +43,7 @@ export const CheatCodes: FunctionComponent<Props> = function () {
       <Spacer.Flex />
       <Typo.Body>{ParsedDescription}</Typo.Body>
       <Spacer.Flex />
-      {env.FEATURE_FLAG_CODE_PUSH_MANUAL && <CodePushButton />}
+      {(env.FEATURE_FLAG_CODE_PUSH_MANUAL || env.ENV === 'testing') && <CodePushButton />}
       <Spacer.BottomScreen />
     </Container>
   )

--- a/src/features/cheatcodes/pages/__snapshots__/CheatCodes.test.tsx.snap
+++ b/src/features/cheatcodes/pages/__snapshots__/CheatCodes.test.tsx.snap
@@ -338,6 +338,54 @@ exports[`CheatCodes component should render correctly 1`] = `
     }
   />
   <View
+    accessible={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "backgroundColor": "#c7c7cc",
+        "borderBottomLeftRadius": 5,
+        "borderColor": "#ffffff",
+        "borderRightWidth": 0,
+        "borderTopLeftRadius": 5,
+        "borderWidth": 1,
+        "bottom": 20,
+        "opacity": 1,
+        "padding": 10,
+        "position": "absolute",
+        "right": 0,
+      }
+    }
+    testID="container"
+  >
+    <Text
+      style={
+        Object {
+          "fontSize": 12,
+        }
+      }
+    >
+      Check update
+    </Text>
+    <Text
+      numberOfLines={3}
+      style={
+        Object {
+          "fontSize": 8,
+          "maxWidth": 150,
+        }
+      }
+    >
+      label (decription)
+    </Text>
+  </View>
+  <View
     customHeight={8}
     style={
       Array [


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-5737

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [x] Added new reusable components to the AppComponents page and communicate to the team on slack
- [x] Added a **screenshot** for UI tickets.

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`