### PR TITLE
(PC-5657) afficher la modale de connexion depuis le bouton profil de la navbar

### DIFF
--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -89,7 +89,7 @@ export const HomeComponent: FunctionComponent = function () {
       <HeaderBackgroundWrapper>
         <HeaderBackground />
       </HeaderBackgroundWrapper>
-      <UserProfileContainer onPress={showSignInModal}>
+      <UserProfileContainer onPress={() => navigation.navigate('Profile')}>
         <UserCircle size={32} color={ColorsEnum.WHITE} />
       </UserProfileContainer>
 

--- a/src/features/navigation/TabBar/TabBar.tsx
+++ b/src/features/navigation/TabBar/TabBar.tsx
@@ -2,6 +2,7 @@ import { BottomTabBarOptions, BottomTabBarProps } from '@react-navigation/bottom
 import React from 'react'
 import styled from 'styled-components/native'
 
+import { useAuthContext } from 'features/auth/AuthContext'
 import { BicolorBookings } from 'ui/svg/icons/BicolorBookings'
 import { BicolorFavorite } from 'ui/svg/icons/BicolorFavorite'
 import { BicolorLogo } from 'ui/svg/icons/BicolorLogo'
@@ -33,12 +34,12 @@ const mapRouteToIcon = (
       return BicolorLogo
   }
 }
-
 export const TabBar: React.FC<Pick<
   BottomTabBarProps<BottomTabBarOptions>,
   'state' | 'navigation'
 >> = ({ navigation, state }) => {
   const { bottom } = useCustomSafeInsets()
+  const authContext = useAuthContext()
   return (
     <MainContainer>
       <RowContainer>
@@ -48,13 +49,19 @@ export const TabBar: React.FC<Pick<
           const routeName = state.routeNames[index]
           const onPress = () => {
             if (isSelected) return
-            const event = navigation.emit({
-              type: 'tabPress',
-              target: route.key,
-              canPreventDefault: true,
-            })
-            if (!event.defaultPrevented) {
-              navigation.navigate(route.name)
+
+            const shouldNavigateLoggedIn = !route.key.includes('Profile') || authContext.isLoggedIn
+            if (shouldNavigateLoggedIn) {
+              const event = navigation.emit({
+                type: 'tabPress',
+                target: route.key,
+                canPreventDefault: true,
+              })
+              if (!event.defaultPrevented) {
+                navigation.navigate(route.name)
+              }
+            } else {
+              navigation.navigate('Home', { shouldDisplayLoginModal: true })
             }
           }
           return (

--- a/src/features/navigation/TabBar/__tests__/TabBar.test.tsx
+++ b/src/features/navigation/TabBar/__tests__/TabBar.test.tsx
@@ -3,7 +3,15 @@ import { NavigationHelpers, ParamListBase, TabNavigationState } from '@react-nav
 import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 
+import { useAuthContext } from 'features/auth/AuthContext'
+
 import { TabBar } from '../TabBar'
+
+const mockedUseAuthContext = useAuthContext as jest.Mock
+
+jest.mock('features/auth/AuthContext', () => ({
+  useAuthContext: jest.fn(() => ({ isLoggedIn: true })),
+}))
 
 const state: TabNavigationState<Record<string, Record<string, unknown> | undefined>> = {
   history: [
@@ -83,5 +91,21 @@ describe('TabBar', () => {
 
     expect(navigation.emit).not.toHaveBeenCalled()
     expect(navigation.navigate).not.toHaveBeenCalled()
+  })
+  it('navigates to HomePage with SignUpSignInChoiceModal visible on Profile tab click if not logged in', async () => {
+    mockedUseAuthContext.mockImplementationOnce(() => ({ isLoggedIn: false }))
+    const tabBar = render(<TabBar state={state} navigation={navigation} />)
+
+    const profileTab = tabBar.getByTestId('tab-Profile')
+    fireEvent.press(profileTab)
+    expect(navigation.navigate).toHaveBeenCalledWith('Home', { shouldDisplayLoginModal: true })
+  })
+  it('navigates to Profile on Profile tab click if logged in', async () => {
+    mockedUseAuthContext.mockImplementationOnce(() => ({ isLoggedIn: true }))
+    const tabBar = render(<TabBar state={state} navigation={navigation} />)
+
+    const profileTab = tabBar.getByTestId('tab-Profile')
+    fireEvent.press(profileTab)
+    expect(navigation.navigate).toHaveBeenCalledWith('Profile')
   })
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-5657

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`
