### PR TITLE
[PC-5746] Offer Tiles categories not trunc

### DIFF
--- a/src/features/home/atoms/ImageCaption.tsx
+++ b/src/features/home/atoms/ImageCaption.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { PixelRatio } from 'react-native'
 import styled from 'styled-components/native'
 
-import { ColorsEnum, Typo, MARGIN_DP, GUTTER_DP } from 'ui/theme'
+import { ColorsEnum, Typo, MARGIN_DP, GUTTER_DP, getSpacing } from 'ui/theme'
 import { BorderRadiusEnum } from 'ui/theme/grid'
 
 interface ImageCaptionProps {
@@ -15,7 +15,7 @@ export const ImageCaption = ({ category, imageWidth, distance }: ImageCaptionPro
   return (
     <Row width={imageWidth}>
       <TextWrapper>
-        <Typo.Caption color={ColorsEnum.WHITE} numberOfLines={1} testID="categoryImageCaption">
+        <Typo.Caption color={ColorsEnum.WHITE} testID="categoryImageCaption">
           {category}
         </Typo.Caption>
       </TextWrapper>
@@ -55,6 +55,6 @@ const Separator = styled.View({
 const TextWrapper = styled.View({
   alignItems: 'center',
   justifyContent: 'center',
-  paddingHorizontal: 8,
+  paddingHorizontal: getSpacing(1),
   flex: 1,
 })

--- a/src/features/home/atoms/tests/ImageCaption.test.tsx
+++ b/src/features/home/atoms/tests/ImageCaption.test.tsx
@@ -13,13 +13,8 @@ describe('ImageCaption component', () => {
   afterAll(() => jest.resetAllMocks())
 
   it('should render correctly', () => {
-    const { toJSON } = render(<ImageCaption {...props} />)
+    const { toJSON, queryByTestId } = render(<ImageCaption {...props} />)
     expect(toJSON()).toMatchSnapshot()
-  })
-
-  it('should have an ellipsis', () => {
-    const { getByTestId, queryByTestId } = render(<ImageCaption {...props} />)
-    expect(getByTestId('categoryImageCaption').parent?.props.numberOfLines).toEqual(1)
     expect(queryByTestId('distanceImageCaption')).toBeTruthy()
   })
 

--- a/src/features/home/atoms/tests/__snapshots__/ImageCaption.test.tsx.snap
+++ b/src/features/home/atoms/tests/__snapshots__/ImageCaption.test.tsx.snap
@@ -26,14 +26,13 @@ exports[`ImageCaption component should render correctly 1`] = `
           "flexGrow": 1,
           "flexShrink": 1,
           "justifyContent": "center",
-          "paddingHorizontal": 8,
+          "paddingHorizontal": 4,
         },
       ]
     }
   >
     <Text
       color="#ffffff"
-      numberOfLines={1}
       style={
         Array [
           Object {
@@ -69,7 +68,7 @@ exports[`ImageCaption component should render correctly 1`] = `
           "flexGrow": 1,
           "flexShrink": 1,
           "justifyContent": "center",
-          "paddingHorizontal": 8,
+          "paddingHorizontal": 4,
         },
       ]
     }

--- a/src/features/home/atoms/tests/__snapshots__/OfferTile.test.tsx.snap
+++ b/src/features/home/atoms/tests/__snapshots__/OfferTile.test.tsx.snap
@@ -77,14 +77,13 @@ exports[`OfferTile component should render correctly 1`] = `
                 "flexGrow": 1,
                 "flexShrink": 1,
                 "justifyContent": "center",
-                "paddingHorizontal": 8,
+                "paddingHorizontal": 4,
               },
             ]
           }
         >
           <Text
             color="#ffffff"
-            numberOfLines={1}
             style={
               Array [
                 Object {
@@ -120,7 +119,7 @@ exports[`OfferTile component should render correctly 1`] = `
                 "flexGrow": 1,
                 "flexShrink": 1,
                 "justifyContent": "center",
-                "paddingHorizontal": 8,
+                "paddingHorizontal": 4,
               },
             ]
           }

--- a/src/features/home/components/OffersModule.tsx
+++ b/src/features/home/components/OffersModule.tsx
@@ -59,7 +59,7 @@ export const OffersModule = (props: OffersModuleProps) => {
     ({ item }: { item: Hit<AlgoliaHit> }) => (
       <OfferTile
         key={item.objectID}
-        category={parseCategory(item.offer.category, item.offer.label)}
+        category={parseCategory(item.offer.category)}
         offerId={item.offer.id}
         distance={formatDistance(item._geoloc, position)}
         name={item.offer.name}

--- a/src/features/home/components/tests/__snapshots__/OffersModule.test.tsx.snap
+++ b/src/features/home/components/tests/__snapshots__/OffersModule.test.tsx.snap
@@ -394,14 +394,13 @@ Array [
                         "flexGrow": 1,
                         "flexShrink": 1,
                         "justifyContent": "center",
-                        "paddingHorizontal": 8,
+                        "paddingHorizontal": 4,
                       },
                     ]
                   }
                 >
                   <Text
                     color="#ffffff"
-                    numberOfLines={1}
                     style={
                       Array [
                         Object {
@@ -562,14 +561,13 @@ Array [
                         "flexGrow": 1,
                         "flexShrink": 1,
                         "justifyContent": "center",
-                        "paddingHorizontal": 8,
+                        "paddingHorizontal": 4,
                       },
                     ]
                   }
                 >
                   <Text
                     color="#ffffff"
-                    numberOfLines={1}
                     style={
                       Array [
                         Object {
@@ -730,14 +728,13 @@ Array [
                         "flexGrow": 1,
                         "flexShrink": 1,
                         "justifyContent": "center",
-                        "paddingHorizontal": 8,
+                        "paddingHorizontal": 4,
                       },
                     ]
                   }
                 >
                   <Text
                     color="#ffffff"
-                    numberOfLines={1}
                     style={
                       Array [
                         Object {
@@ -914,14 +911,13 @@ Array [
                         "flexGrow": 1,
                         "flexShrink": 1,
                         "justifyContent": "center",
-                        "paddingHorizontal": 8,
+                        "paddingHorizontal": 4,
                       },
                     ]
                   }
                 >
                   <Text
                     color="#ffffff"
-                    numberOfLines={1}
                     style={
                       Array [
                         Object {

--- a/src/libs/parsers/category.ts
+++ b/src/libs/parsers/category.ts
@@ -5,16 +5,16 @@ import { IconInterface } from 'ui/svg/icons/types'
 // Map the facetFilter (in algolia) to the label displayed in the front
 const MAP_CATEGORY_TO_LABEL: { [k in AlgoliaCategory]: string } = {
   CINEMA: 'Cinéma',
-  VISITE: 'Visite, exposition',
+  VISITE: 'Visite',
   MUSIQUE: 'Musique',
   SPECTACLE: 'Spectacle',
-  LECON: 'Cours, atelier',
+  LECON: 'Cours',
   LIVRE: 'Livre',
-  FILM: 'Film, série, podcast',
+  FILM: 'Films',
   PRESSE: 'Presse',
-  JEUX_VIDEO: 'Jeu vidéo',
-  CONFERENCE: 'Conférence, rencontre',
-  INSTRUMENT: 'Instrument',
+  JEUX_VIDEO: 'Jeux',
+  CONFERENCE: 'Rencontre',
+  INSTRUMENT: 'Musique',
 }
 
 export const parseCategory = (category: AlgoliaCategory | null, label?: string): string => {

--- a/src/libs/parsers/category.ts
+++ b/src/libs/parsers/category.ts
@@ -2,6 +2,9 @@ import { AlgoliaCategory } from 'libs/algolia'
 import { Category } from 'ui/svg/icons/categories'
 import { IconInterface } from 'ui/svg/icons/types'
 
+// All offers without category are the 'Art' ones
+const DEFAULT_CATEGORY = 'Art'
+
 // Map the facetFilter (in algolia) to the label displayed in the front
 const MAP_CATEGORY_TO_LABEL: { [k in AlgoliaCategory]: string } = {
   CINEMA: 'Cinéma',
@@ -17,9 +20,9 @@ const MAP_CATEGORY_TO_LABEL: { [k in AlgoliaCategory]: string } = {
   INSTRUMENT: 'Musique',
 }
 
-export const parseCategory = (category: AlgoliaCategory | null, label?: string): string => {
+export const parseCategory = (category: AlgoliaCategory | null): string => {
   if (category && category in MAP_CATEGORY_TO_LABEL) return MAP_CATEGORY_TO_LABEL[category]
-  return label || ''
+  return DEFAULT_CATEGORY || ''
 }
 
 // Map the facetFilter (in algolia) to the category Icon


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-5746

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [x] Added new reusable components to the AppComponents page and communicate to the team on slack
- [x] Added a **screenshot** for UI tickets.

## Screenshots


![image](https://user-images.githubusercontent.com/33832992/102071851-5a8cd300-3e01-11eb-93b3-fa9333256398.png)

Catégorie la pus longue = 'Rencontre', distance la plus longue= '900+ km'
![image](https://user-images.githubusercontent.com/33832992/102071895-69738580-3e01-11eb-8eb3-07e2ef93faf7.png)


## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`