### PR TITLE
(PC-5740) feat: clear react-query cache after each test file

### DIFF
--- a/scripts/detect_ko_test.py
+++ b/scripts/detect_ko_test.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import json
+import subprocess
+from time import time
+
+
+def verify_arguments(): 
+	if (len(sys.argv) == 2):
+		return True
+	else:
+		print("Compatible with yarn packager and jest")
+		print("Usage: detetect_ko_test <path_to_repo>")
+		return False
+
+def get_test_array():
+	process = subprocess.Popen('cd ' + sys.argv[1] + ' && yarn jest --listTests --json', shell=True, stdout=subprocess.PIPE)
+	process.wait()
+	return json.loads(process.stdout.readlines()[2])
+
+def get_test_name(test_path):
+	test_path_array = test_path.split('/')
+	return test_path_array[-1]
+
+def main():
+	if(not(verify_arguments())):
+		return
+	test_list = get_test_array()
+	total_time = 0
+	max_duration = 0
+	longest_test = ''
+	for test in test_list:
+		timestmp = time()
+		print(get_test_name(test))
+		process = subprocess.Popen('cd ' + sys.argv[1] + ' && yarn jest ' + test + ' --detectOpenHandles --runTestsByPath', shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+		process.wait()
+		test_time = time() - timestmp
+		total_time += test_time
+		if(test_time > max_duration):
+			max_duration = test_time 
+			longest_test = get_test_name(test)
+		print('\033[31m' + '---- Time it took to do this test: ', str(test_time) + 's')
+		print('\033[39m')
+	print('Total time:', str(total_time) + 's')
+	print('Max duration is:', str(max_duration) + 's', 'For the test:', longest_test)
+
+main()

--- a/src/tests/reactQueryProviderHOC.tsx
+++ b/src/tests/reactQueryProviderHOC.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { QueryCache, QueryClient, QueryClientProvider } from 'react-query'
 
+export const queryCache = new QueryCache()
+
 export const reactQueryProviderHOC = (component: React.ReactNode) => {
-  const queryClient = new QueryClient({ cache: new QueryCache() })
+  const queryClient = new QueryClient({ cache: queryCache })
   return <QueryClientProvider client={queryClient}>{component}</QueryClientProvider>
 }

--- a/src/tests/setupTests.js
+++ b/src/tests/setupTests.js
@@ -2,6 +2,8 @@ import { toMatchDiffSnapshot } from 'snapshot-diff'
 
 import { server } from 'tests/server'
 
+import { queryCache } from './reactQueryProviderHOC'
+
 global.expect.extend({ toMatchDiffSnapshot })
 
 global.beforeAll(() => server.listen())
@@ -9,4 +11,5 @@ global.beforeAll(() => server.listen())
 global.afterAll(() => {
   server.resetHandlers()
   server.close()
+  queryCache.clear()
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-5740
| Before | After |
| ------- | ----- |
|![image](https://user-images.githubusercontent.com/66383742/102102533-35fa2080-3e2c-11eb-9efb-79b8f16bce23.png) |![image](https://user-images.githubusercontent.com/66383742/102102462-2084f680-3e2c-11eb-890d-15a724c39cc9.png)| 

## Stratégie

Jest conseille `yarn jest --detectOpenHandles --runInBand` pour détecter les fuites, faire cela sur notre répo donnera le même résultat qu'en CI: les tests finis en ~70s et la commande qui continue de tourner dans le vide 5min.

Pour identifier la source j'ai lancé chaque test avec `yarn jest <test_name> --detectOpenHandles`
Et identifier ceux qui sont anormalement longs. (script)
```
...
Offer.test.tsx
---- Time it took to do this test:  310.40674090385437s

...

BusinessModule.test.tsx
---- Time it took to do this test:  303.2644901275635s

CodePushButton.test.tsx
---- Time it took to do this test:  3.6475729942321777s

AcceptCgu.test.tsx
---- Time it took to do this test:  3.421457290649414s

...

ExclusivityModule.test.tsx
---- Time it took to do this test:  2.934148073196411s

useHomeAlgoliaModules.test.ts
---- Time it took to do this test:  302.83230209350586s

highlightLinks.test.tsx
---- Time it took to do this test:  3.235327959060669s

...
...
```

Certains tests prennent 5minutes lancés **tout seuls**
Ces tests partagent entre autre l'utilisation de `react-query`

Quelques recherches dans ce sens et je tombe sur une issue: `react-query` (n° 270)
On y lit notamment
>Right now it’s recommended to clear the query cache after each test, so what if the timeout or rerender checked to see if the query still exists in the cache or is mounted. Would that work?

Bingo. (NB: 5min <-> durée de vie par défaut du cache, possible que ce ne soit pas une coïncidence)