### PR TITLE
(PC-5831) Réinitialisation de mot de passe : le retour arrière sur l'écran de connexion n'est pas correct

### DIFF
--- a/src/features/auth/login/Login.tsx
+++ b/src/features/auth/login/Login.tsx
@@ -5,7 +5,7 @@ import { Keyboard, TouchableOpacity } from 'react-native'
 import styled from 'styled-components/native'
 
 import { useSignIn } from 'features/auth/AuthContext'
-import { NavigateToHomeWithoutModalOptions } from 'features/navigation/helpers'
+import { NavigateToHomeWithoutModalOptions, usePreviousRoute } from 'features/navigation/helpers'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { env } from 'libs/environment'
 import { _ } from 'libs/i18n'
@@ -36,7 +36,8 @@ export const Login: FunctionComponent = function () {
 
   const shouldDisableLoginButton = isValueEmpty(email) || isValueEmpty(password)
 
-  const { navigate } = useNavigation<UseNavigationType>()
+  const { goBack, navigate } = useNavigation<UseNavigationType>()
+  const previousRoute = usePreviousRoute()
 
   async function handleSignin() {
     Keyboard.dismiss()
@@ -50,7 +51,11 @@ export const Login: FunctionComponent = function () {
   }
 
   function onBackNavigation() {
-    navigate('Home', { shouldDisplayLoginModal: true })
+    if (previousRoute?.name == 'ReinitializePassword') {
+      goBack()
+    } else {
+      navigate('Home', { shouldDisplayLoginModal: true })
+    }
   }
 
   function onClose() {

--- a/src/features/navigation/helpers.ts
+++ b/src/features/navigation/helpers.ts
@@ -1,3 +1,4 @@
+import { Route, useNavigationState } from '@react-navigation/native'
 import { Linking } from 'react-native'
 
 import { RouteParams } from './RootNavigator'
@@ -12,4 +13,15 @@ export async function openExternalUrl(url: string) {
   if (canOpen) {
     Linking.openURL(url)
   }
+}
+
+export function usePreviousRoute(): Route<string> | null {
+  return useNavigationState((state) => {
+    const numberOfRoutes = state.routes.length
+    if (numberOfRoutes > 1) {
+      const previousRoute = state.routes[numberOfRoutes - 2]
+      return previousRoute
+    }
+    return null
+  })
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-5831

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`
