### PR TITLE
[PC-6100] Masquer le bouton 'Voir plus' si le descriptif détaillé est vide

### DIFF
--- a/src/features/offer/components/OfferPartialDescription.tsx
+++ b/src/features/offer/components/OfferPartialDescription.tsx
@@ -4,28 +4,38 @@ import styled from 'styled-components/native'
 import { highlightLinks } from 'libs/parsers/highlightLinks'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
+import { useOffer } from '../api/useOffer'
 import { OfferSeeMore } from '../atoms/OfferSeeMore'
+import { getContentFromOffer } from '../pages/OfferDescription'
 
 interface Props {
   id: number
   description?: string
 }
 
-export const OfferPartialDescription: React.FC<Props> = ({ id, description = '' }) => (
-  <DescriptionContainer>
-    {!!description && (
-      <React.Fragment>
-        <TypoDescription testID="offerPartialDescriptionBody" numberOfLines={8}>
-          {highlightLinks(description)}
-        </TypoDescription>
-        <Spacer.Column numberOfSpaces={2} />
-      </React.Fragment>
-    )}
-    <OfferSeeMoreContainer testID="offerSeeMoreContainer" description={description}>
-      <OfferSeeMore id={id} longWording={!description} />
-    </OfferSeeMoreContainer>
-  </DescriptionContainer>
-)
+export const OfferPartialDescription: React.FC<Props> = ({ id, description = '' }) => {
+  const { data: offerResponse } = useOffer({ offerId: id })
+  const { extraData = {}, image } = offerResponse || {}
+  const contentOfferDescription = getContentFromOffer(extraData, description, image?.credit)
+
+  return (
+    <DescriptionContainer>
+      {!!description && (
+        <React.Fragment>
+          <TypoDescription testID="offerPartialDescriptionBody" numberOfLines={8}>
+            {highlightLinks(description)}
+          </TypoDescription>
+          <Spacer.Column numberOfSpaces={2} />
+        </React.Fragment>
+      )}
+      {contentOfferDescription.length > 0 && (
+        <OfferSeeMoreContainer testID="offerSeeMoreContainer" description={description}>
+          <OfferSeeMore id={id} longWording={!description} />
+        </OfferSeeMoreContainer>
+      )}
+    </DescriptionContainer>
+  )
+}
 
 const OfferSeeMoreContainer = styled.View<{ description: string }>(({ description }) => ({
   alignSelf: description ? 'flex-end' : 'center',

--- a/src/features/offer/components/__tests__/OfferPartialDescription.test.tsx
+++ b/src/features/offer/components/__tests__/OfferPartialDescription.test.tsx
@@ -1,5 +1,9 @@
 import { render } from '@testing-library/react-native'
 import React from 'react'
+import { QueryClient } from 'react-query'
+
+import { offerResponseSnap } from 'features/offer/api/snaps/offerResponseSnap'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 
 import { OfferPartialDescription } from '../OfferPartialDescription'
 
@@ -7,22 +11,50 @@ const description =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua: https://google.com'
 
 describe('OfferPartialDescription', () => {
-  it('centers CTA when provided description is empty', () => {
-    const { getByTestId } = render(<OfferPartialDescription id={123} description={''} />)
+  it('centers CTA when provided description is empty', async () => {
+    const { getByTestId } = await renderOfferDescription('')
     const offerSeeMoreContainer = getByTestId('offerSeeMoreContainer')
     expect(offerSeeMoreContainer.props.style[0].alignSelf).toBe('center')
   })
-  it('places CTA on flex-end when provided a description', () => {
-    const { getByTestId } = render(<OfferPartialDescription id={123} description={description} />)
+  it('places CTA on flex-end when provided a description', async () => {
+    const { getByTestId } = await renderOfferDescription(description)
     const offerSeeMoreContainer = getByTestId('offerSeeMoreContainer')
     expect(offerSeeMoreContainer.props.style[0].alignSelf).toBe('flex-end')
   })
-  it('renders externalLinks if http(s) url are present in the description', () => {
-    const { queryByTestId } = render(<OfferPartialDescription id={123} description={description} />)
+  it('renders externalLinks if http(s) url are present in the description', async () => {
+    const { queryByTestId } = await renderOfferDescription(description)
     expect(queryByTestId('externalSiteIcon')).toBeTruthy()
   })
-  it("shouldn't render an empty line and a spacer when description is undefined", () => {
-    const { queryByTestId } = render(<OfferPartialDescription id={123} description={undefined} />)
+  it("shouldn't render an empty line and a spacer when description is undefined", async () => {
+    const { queryByTestId } = await renderOfferDescription(undefined)
     expect(queryByTestId('offerPartialDescriptionBody')).toBeFalsy()
   })
+  it("shouldn't render the SeeMore button if no content is on description page", async () => {
+    const { queryByTestId } = render(
+      reactQueryProviderHOC(
+        <OfferPartialDescription id={offerId} description={undefined} />,
+        (queryClient: QueryClient) => {
+          queryClient.setQueryData(['offer', offerId], {
+            ...offerResponseSnap,
+            image: {},
+            extraData: {},
+          })
+        }
+      )
+    )
+    expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
+  })
 })
+
+const offerId = 123
+const renderOfferDescription = async (description?: string) => {
+  const setup = (queryClient: QueryClient) => {
+    queryClient.removeQueries()
+    queryClient.setQueryData(['offer', offerId], offerResponseSnap)
+  }
+
+  const wrapper = render(
+    reactQueryProviderHOC(<OfferPartialDescription id={offerId} description={description} />, setup)
+  )
+  return wrapper
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-c

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [x] Added a **screenshot** for UI tickets.

## Screenshots

![image](https://user-images.githubusercontent.com/10118284/103897519-fdc8c380-50f3-11eb-97c0-c7d59da44962.png)
