### PR TITLE
(PC-6344) Réduire l'espace entre l'icône et le texte sur les messages d'information (cf. pages SetEmail, SetPassword etc...)

### DIFF
--- a/src/features/auth/forgottenPassword/__snapshots__/ReinitializePassword.test.tsx.snap
+++ b/src/features/auth/forgottenPassword/__snapshots__/ReinitializePassword.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                   accessible={true}
                   focusable={true}
                   onClick={[Function onClick]}
-@@ -335,14 +335,14 @@
+@@ -335,21 +335,21 @@
                   ]
                 }
               >
@@ -31,29 +31,20 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
 -                 rule-icon-close-SVG-Mock
 +                 rule-icon-check-SVG-Mock
                 </View>
-                <View
+                <Text
+-                 color=\\"#b60025\\"
++                 color=\\"#15884f\\"
                   style={
                     Array [
                       Object {
-@@ -350,15 +350,15 @@
+-                       \\"color\\": \\"#b60025\\",
++                       \\"color\\": \\"#15884f\\",
+                        \\"fontFamily\\": \\"Montserrat-SemiBold\\",
+                        \\"fontSize\\": 12,
+                        \\"lineHeight\\": 16,
+                        \\"paddingLeft\\": 4,
                       },
-                    ]
-                  }
-                >
-                  <Text
--                   color=\\"#b60025\\"
-+                   color=\\"#15884f\\"
-                    style={
-                      Array [
-                        Object {
--                         \\"color\\": \\"#b60025\\",
-+                         \\"color\\": \\"#15884f\\",
-                          \\"fontFamily\\": \\"Montserrat-SemiBold\\",
-                          \\"fontSize\\": 12,
-                          \\"lineHeight\\": 16,
-                        },
-                      ]
-@@ -379,14 +379,14 @@
+@@ -370,21 +370,21 @@
                   ]
                 }
               >
@@ -66,29 +57,20 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
 -                 rule-icon-close-SVG-Mock
 +                 rule-icon-check-SVG-Mock
                 </View>
-                <View
+                <Text
+-                 color=\\"#b60025\\"
++                 color=\\"#15884f\\"
                   style={
                     Array [
                       Object {
-@@ -394,15 +394,15 @@
+-                       \\"color\\": \\"#b60025\\",
++                       \\"color\\": \\"#15884f\\",
+                        \\"fontFamily\\": \\"Montserrat-SemiBold\\",
+                        \\"fontSize\\": 12,
+                        \\"lineHeight\\": 16,
+                        \\"paddingLeft\\": 4,
                       },
-                    ]
-                  }
-                >
-                  <Text
--                   color=\\"#b60025\\"
-+                   color=\\"#15884f\\"
-                    style={
-                      Array [
-                        Object {
--                         \\"color\\": \\"#b60025\\",
-+                         \\"color\\": \\"#15884f\\",
-                          \\"fontFamily\\": \\"Montserrat-SemiBold\\",
-                          \\"fontSize\\": 12,
-                          \\"lineHeight\\": 16,
-                        },
-                      ]
-@@ -423,14 +423,14 @@
+@@ -405,21 +405,21 @@
                   ]
                 }
               >
@@ -101,29 +83,20 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
 -                 rule-icon-close-SVG-Mock
 +                 rule-icon-check-SVG-Mock
                 </View>
-                <View
+                <Text
+-                 color=\\"#b60025\\"
++                 color=\\"#15884f\\"
                   style={
                     Array [
                       Object {
-@@ -438,15 +438,15 @@
+-                       \\"color\\": \\"#b60025\\",
++                       \\"color\\": \\"#15884f\\",
+                        \\"fontFamily\\": \\"Montserrat-SemiBold\\",
+                        \\"fontSize\\": 12,
+                        \\"lineHeight\\": 16,
+                        \\"paddingLeft\\": 4,
                       },
-                    ]
-                  }
-                >
-                  <Text
--                   color=\\"#b60025\\"
-+                   color=\\"#15884f\\"
-                    style={
-                      Array [
-                        Object {
--                         \\"color\\": \\"#b60025\\",
-+                         \\"color\\": \\"#15884f\\",
-                          \\"fontFamily\\": \\"Montserrat-SemiBold\\",
-                          \\"fontSize\\": 12,
-                          \\"lineHeight\\": 16,
-                        },
-                      ]
-@@ -467,14 +467,14 @@
+@@ -440,21 +440,21 @@
                   ]
                 }
               >
@@ -136,29 +109,20 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
 -                 rule-icon-close-SVG-Mock
 +                 rule-icon-check-SVG-Mock
                 </View>
-                <View
+                <Text
+-                 color=\\"#b60025\\"
++                 color=\\"#15884f\\"
                   style={
                     Array [
                       Object {
-@@ -482,15 +482,15 @@
+-                       \\"color\\": \\"#b60025\\",
++                       \\"color\\": \\"#15884f\\",
+                        \\"fontFamily\\": \\"Montserrat-SemiBold\\",
+                        \\"fontSize\\": 12,
+                        \\"lineHeight\\": 16,
+                        \\"paddingLeft\\": 4,
                       },
-                    ]
-                  }
-                >
-                  <Text
--                   color=\\"#b60025\\"
-+                   color=\\"#15884f\\"
-                    style={
-                      Array [
-                        Object {
--                         \\"color\\": \\"#b60025\\",
-+                         \\"color\\": \\"#15884f\\",
-                          \\"fontFamily\\": \\"Montserrat-SemiBold\\",
-                          \\"fontSize\\": 12,
-                          \\"lineHeight\\": 16,
-                        },
-                      ]
-@@ -511,14 +511,14 @@
+@@ -475,21 +475,21 @@
                   ]
                 }
               >
@@ -171,26 +135,17 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
 -                 rule-icon-close-SVG-Mock
 +                 rule-icon-check-SVG-Mock
                 </View>
-                <View
+                <Text
+-                 color=\\"#b60025\\"
++                 color=\\"#15884f\\"
                   style={
                     Array [
                       Object {
-@@ -526,15 +526,15 @@
-                      },
-                    ]
-                  }
-                >
-                  <Text
--                   color=\\"#b60025\\"
-+                   color=\\"#15884f\\"
-                    style={
-                      Array [
-                        Object {
--                         \\"color\\": \\"#b60025\\",
-+                         \\"color\\": \\"#15884f\\",
-                          \\"fontFamily\\": \\"Montserrat-SemiBold\\",
-                          \\"fontSize\\": 12,
-                          \\"lineHeight\\": 16,
-                        },
-                      ]"
+-                       \\"color\\": \\"#b60025\\",
++                       \\"color\\": \\"#15884f\\",
+                        \\"fontFamily\\": \\"Montserrat-SemiBold\\",
+                        \\"fontSize\\": 12,
+                        \\"lineHeight\\": 16,
+                        \\"paddingLeft\\": 4,
+                      },"
 `;

--- a/src/features/auth/login/__snapshots__/Login.test.tsx.snap
+++ b/src/features/auth/login/__snapshots__/Login.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`<Login/> should show error message and error inputs AND not redirect to
 - First value
 + Second value
 
-@@ -167,10 +167,65 @@
+@@ -167,10 +167,56 @@
                 rightIcon-SVG-Mock
               </View>
             </View>
@@ -95,31 +95,22 @@ exports[`<Login/> should show error message and error inputs AND not redirect to
 +           >
 +             rule-icon-warn-SVG-Mock
 +           </View>
-+           <View
++           <Text
++             color=\\"#b60025\\"
 +             style={
 +               Array [
 +                 Object {
-+                   \\"paddingLeft\\": 8,
++                   \\"color\\": \\"#b60025\\",
++                   \\"fontFamily\\": \\"Montserrat-SemiBold\\",
++                   \\"fontSize\\": 12,
++                   \\"lineHeight\\": 16,
++                   \\"paddingLeft\\": 4,
 +                 },
 +               ]
 +             }
 +           >
-+             <Text
-+               color=\\"#b60025\\"
-+               style={
-+                 Array [
-+                   Object {
-+                     \\"color\\": \\"#b60025\\",
-+                     \\"fontFamily\\": \\"Montserrat-SemiBold\\",
-+                     \\"fontSize\\": 12,
-+                     \\"lineHeight\\": 16,
-+                   },
-+                 ]
-+               }
-+             >
-+               E-mail ou mot de passe incorrect
-+             </Text>
-+           </View>
++             E-mail ou mot de passe incorrect
++           </Text>
 +         </View>
 +         <View
             numberOfSpaces={7}
@@ -127,7 +118,7 @@ exports[`<Login/> should show error message and error inputs AND not redirect to
               Array [
                 Object {
                   \\"height\\": 28,
-@@ -214,18 +269,18 @@
+@@ -214,18 +260,18 @@
                   },
                 ]
               }
@@ -148,7 +139,7 @@ exports[`<Login/> should show error message and error inputs AND not redirect to
                     \\"borderWidth\\": 1,
                     \\"flexDirection\\": \\"row\\",
                     \\"height\\": 40,
-@@ -323,18 +378,18 @@
+@@ -323,18 +369,18 @@
                   },
                 ]
               }

--- a/src/features/auth/signup/QuitSignupModal.tsx
+++ b/src/features/auth/signup/QuitSignupModal.tsx
@@ -46,7 +46,7 @@ export const QuitSignupModal: FunctionComponent<Props> = ({
     <AppFullPageModal visible={visible} testIdSuffix={testIdSuffix}>
       <GenericInfoPage title={_(t`Veux-tu abandonner l'inscription ?`)} icon={Warning}>
         <StyledBody>
-          {_(t`Les informations que tu as renseignés ne seront pas enregistrées`)}
+          {_(t`Les informations que tu as renseignées ne seront pas enregistrées`)}
         </StyledBody>
         <Spacer.Column numberOfSpaces={8} />
         <ButtonPrimaryWhite title={_(t`Continuer l'inscription`)} onPress={resume} />

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -325,8 +325,8 @@ msgid "Le pass Culture est accessible à tous !"
 msgstr "Le pass Culture est accessible à tous !"
 
 #: src/features/auth/signup/QuitSignupModal.tsx:31
-msgid "Les informations que tu as renseignés ne seront pas enregistrées"
-msgstr "Les informations que tu as renseignés ne seront pas enregistrées"
+msgid "Les informations que tu as renseignées ne seront pas enregistrées"
+msgstr "Les informations que tu as renseignées ne seront pas enregistrées"
 
 #: src/features/auth/signup/SetBirthday.tsx:166
 msgid "L’application pass Culture est accessible à tous. Si tu as 18 ans, tu es éligible pour obtenir une aide financière de 300 € proposée par le Ministère de la Culture qui sera créditée directement sur ton compte pass Culture."

--- a/src/ui/components/inputs/rules/InputRule.tsx
+++ b/src/ui/components/inputs/rules/InputRule.tsx
@@ -15,21 +15,19 @@ type Props = {
 export const InputRule: FunctionComponent<Props> = (props) => {
   const Icon = props.icon
   return (
-    <AlignedText>
+    <StyledView>
       <Icon testID={`rule-icon-${props.testIdSuffix}`} color={props.color} size={props.iconSize} />
-      <TextContainer>
-        <Typo.Caption color={props.color}>{props.title}</Typo.Caption>
-      </TextContainer>
-    </AlignedText>
+      <StyledTypoCaption color={props.color}>{props.title}</StyledTypoCaption>
+    </StyledView>
   )
 }
 
-const AlignedText = styled.View({
+const StyledView = styled.View({
   flexDirection: 'row',
   alignItems: 'center',
   maxWidth: getSpacing(125),
 })
 
-const TextContainer = styled.View({
-  paddingLeft: getSpacing(2),
+const StyledTypoCaption = styled(Typo.Caption)({
+  paddingLeft: getSpacing(1),
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-6344

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
      (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
- then run `git push --follow-tags`