### PR TITLE
(PC-6346) Add AccountCreated page to display for non-beneficiary users

### DIFF
--- a/src/features/auth/signup/AccountCreated.test.tsx
+++ b/src/features/auth/signup/AccountCreated.test.tsx
@@ -1,0 +1,29 @@
+import { render, fireEvent } from '@testing-library/react-native'
+import React from 'react'
+
+import { navigate } from '__mocks__/@react-navigation/native'
+
+import { AccountCreated } from './AccountCreated'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('<AccountCreated />', () => {
+  it('should render correctly', () => {
+    const renderAPI = render(<AccountCreated />)
+    expect(renderAPI).toMatchSnapshot()
+  })
+
+  it('should redirect to home page WHEN go back to home button is clicked', async () => {
+    const renderAPI = render(<AccountCreated />)
+
+    const button = await renderAPI.findByText('On y va !')
+    fireEvent.press(button)
+
+    expect(navigate).toBeCalledTimes(1)
+    expect(navigate).toBeCalledWith('Home', {
+      shouldDisplayLoginModal: false,
+    })
+  })
+})

--- a/src/features/auth/signup/AccountCreated.tsx
+++ b/src/features/auth/signup/AccountCreated.tsx
@@ -1,0 +1,38 @@
+import { t } from '@lingui/macro'
+import { useNavigation } from '@react-navigation/native'
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { UseNavigationType } from 'features/navigation/RootNavigator'
+import { _ } from 'libs/i18n'
+import IlluminatedSmileyAnimation from 'ui/animations/lottie_illuminated_smiley.json'
+import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
+import { GenericInfoPage } from 'ui/components/GenericInfoPage'
+import { ColorsEnum, Spacer, Typo } from 'ui/theme'
+
+export function AccountCreated() {
+  const { navigate } = useNavigation<UseNavigationType>()
+
+  function goToHomeWithoutModal() {
+    navigate('Home', { shouldDisplayLoginModal: false })
+  }
+
+  return (
+    <GenericInfoPage title={_(t`Ton compte a été activé !`)} animation={IlluminatedSmileyAnimation}>
+      <StyledBody>
+        {_(
+          t`Aide-nous à en savoir plus sur tes pratiques culturelles ! 
+          Ta sélection n'aura pas d'impact sur les offres proposées.`
+        )}
+      </StyledBody>
+      <Spacer.Column numberOfSpaces={15} />
+      <ButtonPrimaryWhite title={_(t`On y va !`)} onPress={goToHomeWithoutModal} />
+    </GenericInfoPage>
+  )
+}
+
+const StyledBody = styled(Typo.Body).attrs({
+  color: ColorsEnum.WHITE,
+})({
+  textAlign: 'center',
+})

--- a/src/features/auth/signup/AfterSignupEmailValidationBuffer.test.tsx
+++ b/src/features/auth/signup/AfterSignupEmailValidationBuffer.test.tsx
@@ -66,12 +66,8 @@ describe('<AfterSignupEmailValidationBuffer />', () => {
 
       await waitFor(() => {
         expect(loginRoutine).toBeCalledTimes(1)
-        expect(mockDisplayInfosSnackBar).toHaveBeenCalledTimes(1)
-        expect(mockDisplayInfosSnackBar).toHaveBeenCalledWith({
-          message: 'Ton compte est maintenant activé !',
-        })
         expect(navigate).toBeCalledTimes(1)
-        expect(navigate).toHaveBeenCalledWith('Home', { shouldDisplayLoginModal: false })
+        expect(navigate).toHaveBeenCalledWith('AccountCreated')
       })
       loginRoutine.mockRestore()
     })
@@ -106,10 +102,13 @@ describe('<AfterSignupEmailValidationBuffer />', () => {
     })
 
     it('should redirect to Home with a snackbar message on error', async () => {
+      // TODO(PC-6360): ignore warning displayed by react-query's useMutation onError callback.
+      // Note : it appears next to impossible to hide this warnibg by acting on the console object alone.
+      // The only solution probably lies in mocking partially or completely react-query.
       jest.spyOn(datesLib, 'isTimestampExpired').mockReturnValue(false)
       server.use(
         rest.post(env.API_BASE_URL + '/native/v1/validate_email', (_req, res, ctx) =>
-          res(ctx.status(400))
+          res(ctx.status(400), ctx.json({}))
         )
       )
 

--- a/src/features/auth/signup/AfterSignupEmailValidationBuffer.tsx
+++ b/src/features/auth/signup/AfterSignupEmailValidationBuffer.tsx
@@ -53,10 +53,7 @@ export function AfterSignupEmailValidationBuffer() {
         licenceToken: response.idCheckToken,
       })
     } else {
-      displayInfosSnackBar({
-        message: _(t`Ton compte est maintenant activé !`),
-      })
-      delayedNavigate('Home', { shouldDisplayLoginModal: false })
+      delayedNavigate('AccountCreated')
     }
   }
 

--- a/src/features/auth/signup/__snapshots__/AccountCreated.test.tsx.snap
+++ b/src/features/auth/signup/__snapshots__/AccountCreated.test.tsx.snap
@@ -1,0 +1,175 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AccountCreated /> should render correctly 1`] = `
+Array [
+  <View
+    style={
+      Array [
+        Object {
+          "height": "100%",
+          "left": 0,
+          "position": "absolute",
+          "top": 0,
+          "width": "100%",
+        },
+      ]
+    }
+  >
+    <View
+      height="100%"
+      width="100%"
+    >
+      undefined-SVG-Mock
+    </View>
+  </View>,
+  <RCTScrollView
+    contentContainerStyle={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "column",
+        "flexGrow": 1,
+        "justifyContent": "center",
+        "paddingHorizontal": 16,
+      }
+    }
+  >
+    <View>
+      <View
+        numberOfSpaces={18}
+        style={
+          Array [
+            Object {
+              "height": 72,
+            },
+          ]
+        }
+      />
+      <View>
+        undefined-Lottie-Mock
+      </View>
+      <View
+        numberOfSpaces={9}
+        style={
+          Array [
+            Object {
+              "height": 36,
+            },
+          ]
+        }
+      />
+      <Text
+        color="#ffffff"
+        style={
+          Array [
+            Object {
+              "color": "#ffffff",
+              "fontFamily": "Montserrat-MediumItalic",
+              "fontSize": 24,
+              "lineHeight": 28,
+              "textAlign": "center",
+            },
+          ]
+        }
+      >
+        Ton compte a été activé !
+      </Text>
+      <View
+        numberOfSpaces={5}
+        style={
+          Array [
+            Object {
+              "height": 20,
+            },
+          ]
+        }
+      />
+      <Text
+        color="#ffffff"
+        style={
+          Array [
+            Object {
+              "color": "#ffffff",
+              "fontFamily": "Montserrat-Regular",
+              "fontSize": 15,
+              "lineHeight": 20,
+              "textAlign": "center",
+            },
+          ]
+        }
+      >
+        Aide-nous à en savoir plus sur tes pratiques culturelles !  Ta sélection n'aura pas d'impact sur les offres proposées.
+      </Text>
+      <View
+        numberOfSpaces={15}
+        style={
+          Array [
+            Object {
+              "height": 60,
+            },
+          ]
+        }
+      />
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#ffffff",
+            "borderRadius": 24,
+            "borderWidth": 0,
+            "flexDirection": "row",
+            "height": 40,
+            "justifyContent": "center",
+            "maxWidth": 500,
+            "opacity": 1,
+            "paddingBottom": 2,
+            "paddingLeft": 2,
+            "paddingRight": 2,
+            "paddingTop": 2,
+            "width": "100%",
+          }
+        }
+        testID="button-container"
+      >
+        <Text
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "color": "#eb0055",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 15,
+                "lineHeight": 20,
+                "marginLeft": 5,
+                "maxWidth": 650,
+              },
+            ]
+          }
+          testID="button-title"
+          textColor="#eb0055"
+        >
+          On y va !
+        </Text>
+      </View>
+      <View
+        customHeight={8}
+        style={
+          Array [
+            Object {
+              "height": 8,
+            },
+          ]
+        }
+      />
+    </View>
+  </RCTScrollView>,
+]
+`;

--- a/src/features/cheatcodes/pages/Navigation.tsx
+++ b/src/features/cheatcodes/pages/Navigation.tsx
@@ -99,6 +99,12 @@ export function Navigation(): JSX.Element {
         </Row>
         <Row half>
           <NavigationButton
+            title={'Account Created'}
+            onPress={() => navigation.navigate('AccountCreated')}
+          />
+        </Row>
+        <Row half>
+          <NavigationButton
             title={'Reset mdp email envoyé'}
             onPress={() =>
               navigation.navigate('ResetPasswordEmailSent', {

--- a/src/features/navigation/RootNavigator/RootNavigator.tsx
+++ b/src/features/navigation/RootNavigator/RootNavigator.tsx
@@ -8,6 +8,7 @@ import { ResetPasswordEmailSent } from 'features/auth/forgottenPassword/ResetPas
 import { ResetPasswordExpiredLink } from 'features/auth/forgottenPassword/ResetPasswordExpiredLink'
 import { Login } from 'features/auth/login/Login'
 import { AcceptCgu } from 'features/auth/signup/AcceptCgu'
+import { AccountCreated } from 'features/auth/signup/AccountCreated'
 import { AfterSignupEmailValidationBuffer } from 'features/auth/signup/AfterSignupEmailValidationBuffer'
 import { EligibilityConfirmed } from 'features/auth/signup/EligibilityConfirmed'
 import { IdCheck } from 'features/auth/signup/IdCheck'
@@ -46,28 +47,29 @@ export const RootNavigator: React.FC = () => {
         initialRouteName="TabNavigator"
         headerMode="screen"
         screenOptions={{ headerShown: false }}>
-        <RootStack.Screen name="TabNavigator" component={TabNavigator} />
-        <RootStack.Screen name="Login" component={Login} />
-        <RootStack.Screen name="Offer" component={Offer} />
-        <RootStack.Screen name="OfferDescription" component={OfferDescription} />
-        <RootStack.Screen name="SearchFilter" component={SearchFilter} />
-        <RootStack.Screen name="LocationFilter" component={LocationFilter} />
-        <RootStack.Screen name="ReinitializePassword" component={ReinitializePassword} />
-        <RootStack.Screen name="IdCheck" component={IdCheck} />
-        <RootStack.Screen name="AppComponents" component={AppComponents} />
-        <RootStack.Screen name="Navigation" component={Navigation} />
-        <RootStack.Screen name="CheatCodes" component={CheatCodes} />
-        <RootStack.Screen name="ResetPasswordEmailSent" component={ResetPasswordEmailSent} />
-        <RootStack.Screen name="ForgottenPassword" component={ForgottenPassword} />
-        <RootStack.Screen name="SetEmail" component={SetEmail} />
-        <RootStack.Screen name="SetPassword" component={SetPassword} />
-        <RootStack.Screen name="SetBirthday" component={SetBirthday} />
         <RootStack.Screen name="AcceptCgu" component={AcceptCgu} />
+        <RootStack.Screen name="AccountCreated" component={AccountCreated} />
         <RootStack.Screen
           name="AfterSignupEmailValidationBuffer"
           component={AfterSignupEmailValidationBuffer}
         />
+        <RootStack.Screen name="AppComponents" component={AppComponents} />
+        <RootStack.Screen name="CheatCodes" component={CheatCodes} />
+        <RootStack.Screen name="EligibilityConfirmed" component={EligibilityConfirmed} />
+        <RootStack.Screen name="ForgottenPassword" component={ForgottenPassword} />
+        <RootStack.Screen name="IdCheck" component={IdCheck} />
+        <RootStack.Screen name="LocationFilter" component={LocationFilter} />
+        <RootStack.Screen name="Login" component={Login} />
+        <RootStack.Screen name="Navigation" component={Navigation} />
+        <RootStack.Screen name="Offer" component={Offer} />
+        <RootStack.Screen name="OfferDescription" component={OfferDescription} />
+        <RootStack.Screen name="ReinitializePassword" component={ReinitializePassword} />
+        <RootStack.Screen name="ResetPasswordEmailSent" component={ResetPasswordEmailSent} />
         <RootStack.Screen name="ResetPasswordExpiredLink" component={ResetPasswordExpiredLink} />
+        <RootStack.Screen name="SearchFilter" component={SearchFilter} />
+        <RootStack.Screen name="SetBirthday" component={SetBirthday} />
+        <RootStack.Screen name="SetEmail" component={SetEmail} />
+        <RootStack.Screen name="SetPassword" component={SetPassword} />
         <RootStack.Screen
           name="SignupConfirmationEmailSent"
           component={SignupConfirmationEmailSent}
@@ -76,8 +78,8 @@ export const RootNavigator: React.FC = () => {
           name="SignupConfirmationExpiredLink"
           component={SignupConfirmationExpiredLink}
         />
+        <RootStack.Screen name="TabNavigator" component={TabNavigator} />
         <RootStack.Screen name="VerifyEligibility" component={VerifyEligibility} />
-        <RootStack.Screen name="EligibilityConfirmed" component={EligibilityConfirmed} />
       </RootStack.Navigator>
     </NavigationContainer>
   )

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -16,13 +16,14 @@ export type RootStackParamList = {
     password: string
     birthday: string
   }
+  AccountCreated: undefined
   AfterSignupEmailValidationBuffer: { token: string; expirationTimestamp: number; email: string }
   AppComponents: undefined
   CheatCodes: undefined
   EligibilityConfirmed: undefined
   ForgottenPassword: undefined
-  Login: BackNavigationParams<'Home'> | undefined
   IdCheck: { email: string; licenceToken: string }
+  Login: BackNavigationParams<'Home'> | undefined
   Navigation: undefined
   Offer: { id: number }
   OfferDescription: { id: number }

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -79,6 +79,7 @@ msgstr "Afficher les {nbHits} résultats"
 msgid "Afficher {nbHits} résultat"
 msgstr "Afficher {nbHits} résultat"
 
+#: src/features/auth/signup/AccountCreated.tsx:17
 #: src/features/auth/signup/EligibilityConfirmed.tsx:17
 msgid "Aide-nous à en savoir plus sur tes pratiques culturelles !  Ta sélection n'aura pas d'impact sur les offres proposées."
 msgstr "Aide-nous à en savoir plus sur tes pratiques culturelles !  Ta sélection n'aura pas d'impact sur les offres proposées."
@@ -104,7 +105,7 @@ msgstr "Aucun refresh token à sauvegarder"
 msgid "Aucun résultat"
 msgstr "Aucun résultat"
 
-#: src/features/search/components/locationChoice.utils.tsx:11
+#: src/features/search/components/locationChoice.utils.tsx:9
 msgid "Autour de moi"
 msgstr "Autour de moi"
 
@@ -130,7 +131,7 @@ msgstr "CGU & Données"
 msgid "Catégories"
 msgstr "Catégories"
 
-#: src/features/auth/signup/AfterSignupEmailValidationBuffer.tsx:59
+#: src/features/auth/signup/AfterSignupEmailValidationBuffer.tsx:56
 msgid "Ce lien de validation n'est plus valide"
 msgstr "Ce lien de validation n'est plus valide"
 
@@ -155,7 +156,7 @@ msgstr "Chercher par titre, artiste..."
 msgid "Choisissez l'application pour vous rendre sur le lieu de l'offre :"
 msgstr "Choisissez l'application pour vous rendre sur le lieu de l'offre :"
 
-#: src/features/auth/forgottenPassword/ResetPasswordEmailSent.tsx:35
+#: src/features/auth/forgottenPassword/ResetPasswordEmailSent.tsx:34
 #: src/features/auth/signup/SignupConfirmationEmailSent.tsx:32
 msgid "Clique sur le lien reçu à l'adresse :"
 msgstr "Clique sur le lien reçu à l'adresse :"
@@ -188,12 +189,12 @@ msgstr "Confirmer le mot de passe"
 msgid "Connecte-toi !"
 msgstr "Connecte-toi !"
 
-#: src/features/auth/forgottenPassword/ResetPasswordEmailSent.tsx:48
+#: src/features/auth/forgottenPassword/ResetPasswordEmailSent.tsx:47
 #: src/features/auth/signup/SignupConfirmationEmailSent.tsx:45
 msgid "Consulter mes e-mails"
 msgstr "Consulter mes e-mails"
 
-#: src/features/auth/forgottenPassword/ResetPasswordEmailSent.tsx:45
+#: src/features/auth/forgottenPassword/ResetPasswordEmailSent.tsx:44
 #: src/features/auth/forgottenPassword/ResetPasswordExpiredLink.tsx:54
 #: src/features/auth/signup/AcceptCgu.tsx:71
 #: src/features/auth/signup/SignupConfirmationEmailSent.tsx:42
@@ -217,7 +218,7 @@ msgstr "Continuer l'inscription"
 msgid "Crédit insuffisant"
 msgstr "Crédit insuffisant"
 
-#: src/features/search/pages/SearchFilter.tsx:36
+#: src/features/search/pages/SearchFilter.tsx:38
 msgid "Date"
 msgstr "Date"
 
@@ -240,7 +241,7 @@ msgstr "Duo"
 msgid "Dès le {0}"
 msgstr "Dès le {0}"
 
-#: src/features/auth/forgottenPassword/ResetPasswordEmailSent.tsx:32
+#: src/features/auth/forgottenPassword/ResetPasswordEmailSent.tsx:31
 msgid "E-mail envoyé !"
 msgstr "E-mail envoyé !"
 
@@ -267,7 +268,7 @@ msgid "Favorites"
 msgstr "Favoris"
 
 #: src/features/search/atoms/FilterButton.tsx:17
-#: src/features/search/pages/SearchFilter.tsx:42
+#: src/features/search/pages/SearchFilter.tsx:44
 msgid "Filtrer"
 msgstr "Filtrer"
 
@@ -292,7 +293,7 @@ msgstr "Handicap moteur"
 msgid "Handicap visuel"
 msgstr "Handicap visuel"
 
-#: src/features/search/pages/SearchFilter.tsx:38
+#: src/features/search/pages/SearchFilter.tsx:40
 msgid "Heure"
 msgstr "Heure"
 
@@ -304,7 +305,7 @@ msgstr "ISBN"
 msgid "Impossible de réserver"
 msgstr "Impossible de réserver"
 
-#: src/features/search/pages/Search.tsx:45
+#: src/features/search/pages/Search.tsx:46
 msgid "Je cherche"
 msgstr "Je cherche"
 
@@ -314,7 +315,7 @@ msgstr "Je cherche"
 msgid "Keychain non accessible"
 msgstr "Keychain non accessible"
 
-#: src/features/auth/forgottenPassword/ResetPasswordEmailSent.tsx:40
+#: src/features/auth/forgottenPassword/ResetPasswordEmailSent.tsx:39
 #: src/features/auth/signup/SignupConfirmationEmailSent.tsx:37
 msgid "L'e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams !"
 msgstr "L'e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams !"
@@ -336,7 +337,7 @@ msgstr "Le pass Culture est accessible à tous !"
 msgid "Les informations que tu as renseignées ne seront pas enregistrées"
 msgstr "Les informations que tu as renseignées ne seront pas enregistrées"
 
-#: src/features/search/components/LocationSection.tsx:29
+#: src/features/search/components/LocationSection.tsx:30
 #: src/features/search/pages/LocationFilter.tsx:18
 msgid "Localisation"
 msgstr "Localisation"
@@ -376,10 +377,19 @@ msgstr "Nouveau mot de passe"
 msgid "Offre expirée"
 msgstr "Offre expirée"
 
+#: src/features/search/components/OfferTypeSection.tsx:10
+msgid "Offre numérique"
+msgstr "Offre numérique"
+
+#: src/features/search/components/OfferTypeSection.tsx:12
+msgid "Offre physique"
+msgstr "Offre physique"
+
 #: src/features/offer/services/useCtaWordingAndAction.ts:31
 msgid "Offre épuisée"
 msgstr "Offre épuisée"
 
+#: src/features/auth/signup/AccountCreated.tsx:21
 #: src/features/auth/signup/EligibilityConfirmed.tsx:21
 msgid "On y va !"
 msgstr "On y va !"
@@ -393,7 +403,7 @@ msgstr "Oops !"
 msgid "Oups"
 msgstr "Oups"
 
-#: src/features/search/pages/Search.tsx:47
+#: src/features/search/pages/Search.tsx:48
 msgid "Où"
 msgstr "Où"
 
@@ -401,8 +411,8 @@ msgstr "Où"
 msgid "Où ?"
 msgstr "Où ?"
 
+#: src/features/search/components/locationChoice.utils.tsx:11
 #: src/features/search/components/locationChoice.utils.tsx:13
-#: src/features/search/components/locationChoice.utils.tsx:15
 msgid "Partout"
 msgstr "Partout"
 
@@ -490,7 +500,7 @@ msgstr "Saisis ton adresse e-mail pour recevoir un lien qui te permettra de réi
 msgid "Se connecter"
 msgstr "Se connecter"
 
-#: src/features/search/components/LocationSection.tsx:20
+#: src/features/search/components/LocationSection.tsx:21
 msgid "Seules les offres Sorties et Physiques seront affichées"
 msgstr "Seules les offres Sorties et Physiques seront affichées"
 
@@ -498,12 +508,12 @@ msgstr "Seules les offres Sorties et Physiques seront affichées"
 msgid "Seules les offres Sorties et Physiques seront affichées pour une recherche avec une localisation"
 msgstr "Seules les offres Sorties et Physiques seront affichées pour une recherche avec une localisation"
 
-#: src/features/search/pages/SearchFilter.tsx:36
 #: src/features/search/pages/SearchFilter.tsx:38
+#: src/features/search/pages/SearchFilter.tsx:40
 msgid "Seules les offres Sorties seront affichées"
 msgstr "Seules les offres Sorties seront affichées"
 
-#: src/features/auth/forgottenPassword/ResetPasswordEmailSent.tsx:44
+#: src/features/auth/forgottenPassword/ResetPasswordEmailSent.tsx:43
 #: src/features/auth/signup/SignupConfirmationEmailSent.tsx:41
 msgid "Si l'e-mail n'arrive pas, tu peux :"
 msgstr "Si l'e-mail n'arrive pas, tu peux :"
@@ -517,13 +527,17 @@ msgstr "Si tu as 18 ans, tu es éligible pour obtenir une aide financière de 30
 msgid "Si tu as besoin d’aide n’hésite pas à :"
 msgstr "Si tu as besoin d’aide n’hésite pas à :"
 
+#: src/features/search/components/OfferTypeSection.tsx:11
+msgid "Sorties"
+msgstr "Sorties"
+
 #: src/features/auth/signup/SetBirthday.tsx:131
 msgid "Ton anniversaire"
 msgstr "Ton anniversaire"
 
-#: src/features/auth/signup/AfterSignupEmailValidationBuffer.tsx:51
-msgid "Ton compte est maintenant activé !"
-msgstr "Ton compte est maintenant activé !"
+#: src/features/auth/signup/AccountCreated.tsx:15
+msgid "Ton compte a été activé !"
+msgstr "Ton compte a été activé !"
 
 #: src/features/auth/signup/SetEmail.tsx:61
 msgid "Ton e-mail"
@@ -550,6 +564,10 @@ msgstr "Toute la culture dans ta main"
 msgid "Tu es éligible !"
 msgstr "Tu es éligible !"
 
+#: src/features/search/components/OfferTypeSection.tsx:20
+msgid "Type d'offre"
+msgstr "Type d'offre"
+
 #: src/features/errors/pages/RetryBoundary.tsx:37
 msgid "Une erreur s'est produite pendant le chargement."
 msgstr "Une erreur s'est produite pendant le chargement."
@@ -558,15 +576,15 @@ msgstr "Une erreur s'est produite pendant le chargement."
 msgid "Une erreur s’est produite, veuillez passer par une autre application de géolocalisation pour trouver l’itinéraire vers ce lieu."
 msgstr "Une erreur s’est produite, veuillez passer par une autre application de géolocalisation pour trouver l’itinéraire vers ce lieu."
 
-#: src/features/search/pages/SearchFilter.tsx:34
+#: src/features/search/pages/SearchFilter.tsx:36
 msgid "Uniquement les nouveautés"
 msgstr "Uniquement les nouveautés"
 
-#: src/features/search/pages/SearchFilter.tsx:32
+#: src/features/search/pages/SearchFilter.tsx:34
 msgid "Uniquement les offres duo"
 msgstr "Uniquement les offres duo"
 
-#: src/features/search/pages/SearchFilter.tsx:30
+#: src/features/search/pages/SearchFilter.tsx:32
 msgid "Uniquement les offres gratuites"
 msgstr "Uniquement les offres gratuites"
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-6346

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [x] Added new reusable components to the AppComponents page and communicate to the team on slack
- [x] Added a **screenshot** for UI tickets.
- [x] Attached a **ticket number** for any added TODO/FIXME \
      (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | 
| -------------------- |
| ![simulator_screenshot_41B9E249-65E4-40BC-9FDF-2C9D3D7AA873](https://user-images.githubusercontent.com/22399093/105340358-0fbf6180-5bde-11eb-8e35-f7af5b43d7fa.png) |