### PR TITLE
[PC-6414] Harmonize way to deploy to testing and staging

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ I have:
 - [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
 - [ ] Added a **screenshot** for UI tickets.
 - [ ] Attached a **ticket number** for any added TODO/FIXME \
-      (for tech tasks, give the best context about the TODO resolution: what/who/when).
+       (for tech tasks, give the best context about the TODO resolution: what/who/when).
 
 ## Screenshots
 
@@ -22,5 +22,4 @@ I have:
 
 If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):
 
-- if you want an hard deployment of the testing environment, use `yarn version:testing` (this will create a commit with a tag)
-- then run `git push --follow-tags`
+- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "translations:add-locale": "lingui add-locale",
     "translations:extract": "lingui extract --clean",
     "translations:compile": "lingui compile",
-    "version:testing": "./scripts/update_testing_version.sh",
     "trigger:staging:deploy": "./scripts/deploy_new_staging_version.sh",
     "trigger:testing:deploy": "./scripts/deploy_new_testing_version.sh",
     "generate:api:client": "./scripts/generate_api_client.sh"

--- a/scripts/deploy_new_staging_version.sh
+++ b/scripts/deploy_new_staging_version.sh
@@ -7,11 +7,14 @@ check_branch(){
 
   if [[ "$CURRENT_BRANCH" != "master" ]];
   then
-    warn "Wrong branch, checkout master to deploy to staging"
+    echo "Wrong branch, checkout master to deploy to staging"
+    exit 1
   fi
 }
 
 check_branch
+
+git pull
 
 yarn version --minor
 git push --follow-tags

--- a/scripts/deploy_new_testing_version.sh
+++ b/scripts/deploy_new_testing_version.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+check_branch(){
+  CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+
+  if [[ "$CURRENT_BRANCH" != "master" ]];
+  then
+    echo "Wrong branch, checkout master to deploy to testing"
+    exit 1
+  fi
+}
+
+check_branch
+
+git pull
+
+yarn config set version-tag-prefix "testing_v"
+yarn version --patch
+yarn config set version-tag-prefix "v"
+
+git push --follow-tags

--- a/scripts/update_testing_version.sh
+++ b/scripts/update_testing_version.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-
-yarn config set version-tag-prefix "testing_v"
-yarn version --patch
-yarn config set version-tag-prefix "v"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-6414

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [x] Added new reusable components to the AppComponents page and communicate to the team on slack
- [x] Added a **screenshot** for UI tickets.
- [x] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:version`