### PR TITLE
(PC-6532) set batch custom id from the cheatcodes page

### DIFF
--- a/__mocks__/@bam.tech/react-native-batch.ts
+++ b/__mocks__/@bam.tech/react-native-batch.ts
@@ -4,6 +4,7 @@ export const Batch = {
 
 export const BatchUser = {
   getInstallationID: jest.fn(),
+  editor: jest.fn(),
 }
 
 export const BatchPush = {

--- a/src/features/cheatcodes/pages/CheatCodes.test.tsx
+++ b/src/features/cheatcodes/pages/CheatCodes.test.tsx
@@ -12,6 +12,11 @@ const installationID = 'installationID'
 
 beforeAll(() => {
   BatchUser.getInstallationID.mockImplementation(() => Promise.resolve(installationID))
+  BatchUser.editor.mockImplementation(() => ({
+    setIdentifier: () => ({
+      save: jest.fn(),
+    }),
+  }))
 })
 
 jest.mock('features/auth/AuthContext')

--- a/src/features/cheatcodes/pages/CheatCodes.tsx
+++ b/src/features/cheatcodes/pages/CheatCodes.tsx
@@ -37,6 +37,7 @@ export const CheatCodes: FunctionComponent<Props> = function () {
   const [userEmail, setUserEmail] = useState('')
   useEffect(() => {
     getBatchInstallationID().then(setBatchInstallationId)
+    BatchUser.editor().setIdentifier('alainn').save()
   }, [])
   const ParsedDescription = highlightLinks(someOfferDescription)
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXX

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
