### PR TITLE
(PC-5965) Close cultural survey on navigation state change instead of onSubmit

### DIFF
--- a/src/features/firstLogin/CulturalSurvey.test.tsx
+++ b/src/features/firstLogin/CulturalSurvey.test.tsx
@@ -31,12 +31,26 @@ describe('<CulturalSurvey />', () => {
     })
   })
 
-  it('should NOT close webview when emitted message is neither "onClose" nor "onSubmit"', async () => {
+  it('should NOT close webview when emitted message is not "onClose"', async () => {
     const renderAPI = renderCulturalSurveyWithNavigation()
 
     act(() => {
       const webview = renderAPI.getByTestId('cultural-survey-webview')
       webview.props.onMessage({ nativeEvent: { data: 'Something Else' } })
+    })
+
+    await waitFor(() => {
+      expect(renderAPI.queryByTestId('cultural-survey-webview')).toBeTruthy()
+      expect(renderAPI.queryByText('Home Page')).toBeFalsy()
+    })
+  })
+
+  it('should NOT close webview when emitted message is "onSubmit"', async () => {
+    const renderAPI = renderCulturalSurveyWithNavigation()
+
+    act(() => {
+      const webview = renderAPI.getByTestId('cultural-survey-webview')
+      webview.props.onMessage({ nativeEvent: { data: 'onSubmit' } })
     })
 
     await waitFor(() => {
@@ -59,12 +73,26 @@ describe('<CulturalSurvey />', () => {
     })
   })
 
-  it('should close webview when emitted message is "onSubmit"', async () => {
+  it('should NOT close webview when navigation state has NOT url containing "app.passculture"', async () => {
     const renderAPI = renderCulturalSurveyWithNavigation()
 
     act(() => {
       const webview = renderAPI.getByTestId('cultural-survey-webview')
-      webview.props.onMessage({ nativeEvent: { data: 'onSubmit' } })
+      webview.props.onNavigationStateChange({ url: 'app.example' })
+    })
+
+    await waitFor(() => {
+      expect(renderAPI.queryByTestId('cultural-survey-webview')).toBeTruthy()
+      expect(renderAPI.queryByText('Home Page')).toBeFalsy()
+    })
+  })
+
+  it('should close webview when navigation state has url containing "app.passculture"', async () => {
+    const renderAPI = renderCulturalSurveyWithNavigation()
+
+    act(() => {
+      const webview = renderAPI.getByTestId('cultural-survey-webview')
+      webview.props.onNavigationStateChange({ url: 'app.passculture-testing' })
     })
 
     await waitFor(() => {

--- a/src/features/firstLogin/CulturalSurvey.tsx
+++ b/src/features/firstLogin/CulturalSurvey.tsx
@@ -2,6 +2,7 @@ import { useNavigation } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useRef } from 'react'
 import { WebView, WebViewMessageEvent } from 'react-native-webview'
+import { WebViewNavigation } from 'react-native-webview/lib/WebViewTypes'
 import styled from 'styled-components/native'
 import { v1 as uuidv1 } from 'uuid'
 
@@ -51,7 +52,14 @@ export const CulturalSurvey: React.FC<Props> = function () {
 
   function onMessage(event: WebViewMessageEvent) {
     const message = event.nativeEvent.data
-    if (message === 'onSubmit' || message === 'onClose') {
+    if (message === 'onClose') {
+      navigation.navigate('Home', { shouldDisplayLoginModal: false })
+    }
+  }
+
+  function onNavigationStateChange(event: WebViewNavigation) {
+    const isWebViewRedirectedtoWebapp = event.url.includes('app.passculture')
+    if (isWebViewRedirectedtoWebapp) {
       navigation.navigate('Home', { shouldDisplayLoginModal: false })
     }
   }
@@ -64,6 +72,7 @@ export const CulturalSurvey: React.FC<Props> = function () {
       <StyledWebview
         onLoadEnd={onLoad}
         onMessage={onMessage}
+        onNavigationStateChange={onNavigationStateChange}
         ref={webviewRef}
         source={WEBVIEW_SOURCE}
         testID="cultural-survey-webview"

--- a/src/features/firstLogin/__snapshots__/CulturalSurvey.test.tsx.snap
+++ b/src/features/firstLogin/__snapshots__/CulturalSurvey.test.tsx.snap
@@ -337,6 +337,7 @@ exports[`<CulturalSurvey /> should render correctly 1`] = `
                         onLoadingProgress={[Function]}
                         onLoadingStart={[Function]}
                         onMessage={[Function]}
+                        onNavigationStateChange={[Function]}
                         onShouldStartLoadWithRequest={[Function]}
                         source={
                           Object {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-5965

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
