### PR TITLE
(PC-5438) IdCheck: fix temporarily mailto link error on webview

### DIFF
--- a/src/features/auth/signup/IdCheck.tsx
+++ b/src/features/auth/signup/IdCheck.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack'
-import React from 'react'
+import React, { useRef } from 'react'
 import { WebView, WebViewNavigation } from 'react-native-webview'
 import styled from 'styled-components/native'
 
@@ -14,6 +14,7 @@ type Props = StackScreenProps<RootStackParamList, 'IdCheck'>
 export const IdCheck: React.FC<Props> = function (props) {
   const currentRoute = useCurrentRoute()
   const navigation = useNavigation<UseNavigationType>()
+  const webviewRef = useRef<WebView>(null)
 
   const { email, licenceToken } = props.route.params
   const encodedEmail = encodeURIComponent(email)
@@ -33,6 +34,7 @@ export const IdCheck: React.FC<Props> = function (props) {
   if (currentRoute?.name !== 'IdCheck') return null
   return (
     <StyledWebview
+      ref={webviewRef}
       testID="idcheck-webview"
       source={{ uri }}
       startInLoadingState={true}
@@ -42,6 +44,12 @@ export const IdCheck: React.FC<Props> = function (props) {
         </LoadingPageContainer>
       )}
       onNavigationStateChange={onNavigationStateChange}
+      onError={({ nativeEvent }) => {
+        if (nativeEvent.url.startsWith('mailto:') && nativeEvent.canGoBack) {
+          // Fallback for mailto links when ERR_UNKNOWN_URL_SCHEME error appears
+          webviewRef.current?.goBack()
+        }
+      }}
     />
   )
 }

--- a/src/features/auth/signup/__snapshots__/IdCheck.test.tsx.snap
+++ b/src/features/auth/signup/__snapshots__/IdCheck.test.tsx.snap
@@ -300,6 +300,7 @@ exports[`<IdCheck /> should render correctly 1`] = `
                         javaScriptEnabled={true}
                         messagingEnabled={false}
                         onContentProcessDidTerminate={[Function]}
+                        onError={[Function]}
                         onHttpError={[Function]}
                         onLoadingError={[Function]}
                         onLoadingFinish={[Function]}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-5438?focusedCommentId=19317

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

Solution temporaire au bug repéré par Lina (cf lien du commentaire dans le ticket): forcer un retour en arrière sur l'historique de la webview. Si on clique sur le lien "Contacter le support" (que ce soit sur la page "session expirée" ou "document invalide" du parcours idcheck) et que l'erreur survient (il semblerait que cela arrive au tout premier clic sur ce lien quand on lance l'appli), au retour en arrière sur l'appli on se retrouve sur la page où l'utilisateur est invité à ajouter sa carte d'identité, et non sur la page "session expirée" ou "document invalide".

On va créé un ticket de bug pour apporter une solution plus "propre" niveau UX et comprendre le problème en profondeur.
