### PR TITLE
[PC-6789] App native - Tutoriels & Typeform - Ajouter l'analytics à l'affichage d'une carte

### DIFF
--- a/src/features/firstLogin/tutorials/components/GenericCard.test.tsx
+++ b/src/features/firstLogin/tutorials/components/GenericCard.test.tsx
@@ -5,9 +5,16 @@ import React, { RefObject } from 'react'
 import { View } from 'react-native'
 import * as Animatable from 'react-native-animatable'
 
+import { analytics } from 'libs/analytics'
 import GeolocationAnimation from 'ui/animations/geolocalisation.json'
 
-import { CardProps, GenericCard, useButtonAnimation, usePlayAnimation } from './GenericCard'
+import {
+  CardProps,
+  GenericCard,
+  useAnalyticsLogScreenView,
+  useButtonAnimation,
+  usePlayAnimation,
+} from './GenericCard'
 
 describe('<GenericCard />', () => {
   const animation = GeolocationAnimation
@@ -80,6 +87,48 @@ describe('<GenericCard />', () => {
     )
     expect(ref.current.fadeIn).toHaveBeenCalledTimes(0)
     expect(ref.current.fadeOut).toHaveBeenCalledTimes(1)
+  })
+  it('should not log screen view when activeIndex is not index', async () => {
+    const index = 0
+    const activeIndex = 1
+    const tutorialName = 'Tuto'
+    const props: CardProps = {
+      index,
+      activeIndex,
+      name: `${tutorialName}${index + 1}`,
+      buttonText,
+      animation,
+      buttonCallback,
+      pauseAnimationOnRenderAtFrame,
+      subTitle,
+      text,
+      title,
+    }
+    renderHook(() => useAnalyticsLogScreenView(props))
+    expect(analytics.logScreenView).not.toHaveBeenCalledWith(props.name)
+    expect(analytics.logScreenView).not.toHaveBeenCalledTimes(1)
+  })
+  it('should log screen view when activeIndex is index', async () => {
+    const index = 0
+    const activeIndex = index
+    const tutorialName = 'Tuto'
+    const props: CardProps = {
+      index,
+      activeIndex,
+      name: `${tutorialName}${index + 1}`,
+      buttonText,
+      animation,
+      buttonCallback,
+      pauseAnimationOnRenderAtFrame,
+      subTitle,
+      text,
+      title,
+    }
+    renderHook(() => useAnalyticsLogScreenView(props))
+    await waitFor(async () => {
+      expect(analytics.logScreenView).toHaveBeenCalledWith(props.name)
+      expect(analytics.logScreenView).toHaveBeenCalledTimes(1)
+    })
   })
 })
 

--- a/src/features/firstLogin/tutorials/components/GenericCard.tsx
+++ b/src/features/firstLogin/tutorials/components/GenericCard.tsx
@@ -6,12 +6,14 @@ import * as Animatable from 'react-native-animatable'
 import Swiper from 'react-native-web-swiper'
 import styled from 'styled-components/native'
 
+import { analytics } from 'libs/analytics'
 import { AnimationObject } from 'ui/animations/type'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { Spacer } from 'ui/components/spacer/Spacer'
 import { getSpacing, Typo } from 'ui/theme'
 
 export type CardKey = {
+  name?: string
   key?: number
   swiperRef?: RefObject<Swiper>
 }
@@ -56,12 +58,20 @@ export const useButtonAnimation = (
   }, [ref])
 }
 
+export const useAnalyticsLogScreenView = (props: CardProps) => {
+  useEffect(() => {
+    if (props.name && props.index !== undefined && props.activeIndex === props.index) {
+      analytics.logScreenView(props.name)
+    }
+  }, [props.name, props.index, props.activeIndex])
+}
+
 export const GenericCard: FunctionComponent<CardProps> = (props: CardProps) => {
   const animationRef = useRef<AnimatedLottieView>(null)
   const animatedButtonRef = useRef<Animatable.View & View>(null)
   usePlayAnimation(animationRef, props.pauseAnimationOnRenderAtFrame)
   useButtonAnimation(animatedButtonRef, props.index, props.activeIndex)
-
+  useAnalyticsLogScreenView(props)
   return (
     <GenericCardContainer>
       <Spacer.Flex flex={2} />

--- a/src/features/firstLogin/tutorials/components/GenericTutorial.test.tsx
+++ b/src/features/firstLogin/tutorials/components/GenericTutorial.test.tsx
@@ -13,6 +13,7 @@ describe('<GenericTutorial />', () => {
   const TestCard = (props: CardKey) => (
     <View>
       <Text>{props.swiperRef ? 'swipeRef exist' : 'swipeRef does not exist'}</Text>
+      <Text>{props.name ? 'name exist' : 'name does not exist'}</Text>
     </View>
   )
   it('should render correctly', async () => {
@@ -42,6 +43,14 @@ describe('<GenericTutorial />', () => {
     })
     expect(await getByText('swipeRef exist')).toBeTruthy()
     expect(() => getByText('swipeRef does not exist')).toThrow()
+  })
+  it('should have an automatically set name passed to each children', async () => {
+    const { getByText } = renderGenericTutorialComponent({
+      name: 'Tuto',
+      children: [<TestCard key={undefined} />],
+    })
+    expect(await getByText('name exist')).toBeTruthy()
+    expect(() => getByText('name does not exist')).toThrow()
   })
 })
 

--- a/src/features/firstLogin/tutorials/components/GenericTutorial.tsx
+++ b/src/features/firstLogin/tutorials/components/GenericTutorial.tsx
@@ -53,7 +53,11 @@ export const GenericTutorial: FunctionComponent<Props> = (props: Props) => {
               }}
               slideWrapperStyle={slideWrapperStyle}>
               {React.Children.toArray(props.children).map((card, index: number) =>
-                cloneElement(card as ReactElement<CardKey>, { key: index, swiperRef: swiperRef })
+                cloneElement(card as ReactElement<CardKey>, {
+                  key: index,
+                  swiperRef: swiperRef,
+                  name: `${props.name}${index + 1}`,
+                })
               )}
             </Swiper>
           </SwiperContainer>


### PR DESCRIPTION
App native - Tutoriels & Typeform - Ajouter l'analytics à l'affichage d'une carte

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-6789

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [x] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
