### PR TITLE
(PC-6169) intégrer le header bénéficiaire dans la page profile

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -111,6 +111,24 @@ export interface AccountRequest {
      */
     token: string;
 }/**
+ * 
+ * @export
+ * @interface BookOfferRequest
+ */
+export interface BookOfferRequest {
+    /**
+     * 
+     * @type {number}
+     * @memberof BookOfferRequest
+     */
+    quantity: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof BookOfferRequest
+     */
+    stockId: string;
+}/**
  * An enumeration.
  * @export
  * @enum {string}
@@ -656,6 +674,12 @@ export interface UserProfileResponse {
     dateOfBirth?: Date;
     /**
      * 
+     * @type {Date}
+     * @memberof UserProfileResponse
+     */
+    depositExpirationDate?: Date;
+    /**
+     * 
      * @type {number}
      * @memberof UserProfileResponse
      */
@@ -684,6 +708,12 @@ export interface UserProfileResponse {
      * @memberof UserProfileResponse
      */
     hasAllowedRecommendations: boolean;
+    /**
+     * 
+     * @type {number}
+     * @memberof UserProfileResponse
+     */
+    id: number;
     /**
      * 
      * @type {boolean}
@@ -865,6 +895,32 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             const needsSerialization = (<any>"AccountRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary book_offer <POST>
+         * @param {BookOfferRequest} [body] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async postnativev1bookOffer(body?: BookOfferRequest, options: any = {}): Promise<FetchArgs> {
+            const localVarPath = `/native/v1/book_offer`;
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({ method: 'POST' }, options);
+            const localVarHeaderParameter = await getAuthenticationHeaders();
+            const localVarQueryParameter = {} as any;
+            // authentication JWTAuth required
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            const needsSerialization = (<any>"BookOfferRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
             localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "");
             return {
                 url: url.format(localVarUrlObj),
@@ -1126,6 +1182,18 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
         },
         /**
          * 
+         * @summary book_offer <POST>
+         * @param {BookOfferRequest} [body] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async postnativev1bookOffer(basePath: string, body?: BookOfferRequest, options?: any): Promise<EmptyResponse> {
+            const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).postnativev1bookOffer(body, options);
+            const response = await safeFetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
+            return handleGeneratedApiResponse(response)
+        },
+        /**
+         * 
          * @summary change_password <POST>
          * @param {ChangePasswordRequest} [body] 
          * @param {*} [options] Override http request option.
@@ -1274,6 +1342,18 @@ export class DefaultApi extends BaseAPI {
     public async postnativev1account(body?: AccountRequest, options?: any) {
         const functionalApi = DefaultApiFp(this, this.configuration)
         return functionalApi.postnativev1account(this.basePath, body, options)
+    }
+    /**
+     * 
+     * @summary book_offer <POST>
+     * @param {BookOfferRequest} [body] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public async postnativev1bookOffer(body?: BookOfferRequest, options?: any) {
+        const functionalApi = DefaultApiFp(this, this.configuration)
+        return functionalApi.postnativev1bookOffer(this.basePath, body, options)
     }
     /**
      * 

--- a/src/features/home/api.test.ts
+++ b/src/features/home/api.test.ts
@@ -27,6 +27,7 @@ const userProfileAPIResponse: UserProfileResponse = {
   hasAllowedRecommendations: true,
   isEligible: true,
   needsToFillCulturalSurvey: true,
+  id: 1234,
 }
 server.use(
   rest.get(

--- a/src/features/offer/components/__tests__/OfferIconCaptions.test.tsx
+++ b/src/features/offer/components/__tests__/OfferIconCaptions.test.tsx
@@ -48,6 +48,7 @@ const userProfileAPIResponse: UserProfileResponse = {
   hasAllowedRecommendations: true,
   isEligible: true,
   needsToFillCulturalSurvey: true,
+  id: 1234,
 }
 
 describe('<OfferIconCaptions />', () => {

--- a/src/features/profile/components/BeneficiaryCeilings.tsx
+++ b/src/features/profile/components/BeneficiaryCeilings.tsx
@@ -10,6 +10,7 @@ import { CreditCeiling, getCreditCeilingProps } from 'features/profile/component
 import { ExpenseV2 } from 'features/profile/components/types'
 import { sortExpenses } from 'features/profile/utils'
 import { _ } from 'libs/i18n'
+import { convertCentsToEuros } from 'libs/parsers/pricesConversion'
 import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
 
 type BeneficiaryCeilingsProps =
@@ -45,8 +46,8 @@ export function BeneficiaryCeilings(props: BeneficiaryCeilingsProps) {
           return (
             <CreditCeiling
               key={index}
-              amount={expense.current}
-              max={expense.limit}
+              amount={convertCentsToEuros(expense.current)}
+              max={convertCentsToEuros(expense.limit)}
               {...getCreditCeilingProps(props.depositVersion, expense)}
             />
           )

--- a/src/features/profile/components/BeneficiaryHeader.tsx
+++ b/src/features/profile/components/BeneficiaryHeader.tsx
@@ -11,9 +11,10 @@ import { HeaderBackground } from 'ui/svg/HeaderBackground'
 import { getSpacing, ColorsEnum, Typo, Spacer } from 'ui/theme'
 
 type BeneficiaryHeaderProps = {
-  firstName: string
-  lastName: string
+  firstName?: string
+  lastName?: string
   remainingCredit: number
+  depositExpirationDate?: string
 } & (
   | {
       depositVersion: 1
@@ -26,15 +27,13 @@ type BeneficiaryHeaderProps = {
 )
 
 export function BeneficiaryHeader(props: PropsWithChildren<BeneficiaryHeaderProps>) {
-  const creditExpiracyDate = '25/12/2021' // TODO(PC-6748) display credit expiracy date when UserProfileResponse is updated (PC-6746)
-
   const expenses =
     props.depositVersion === 1
       ? (props.expenses as Array<Expense>)
       : (props.expenses as Array<ExpenseV2>)
 
   return (
-    <Container>
+    <Container testID={`beneficiary-header-${props.depositVersion}`}>
       <HeaderBackgroundWrapper>
         <HeaderBackground width={screenWidth} />
       </HeaderBackgroundWrapper>
@@ -46,9 +45,11 @@ export function BeneficiaryHeader(props: PropsWithChildren<BeneficiaryHeaderProp
         {/* eslint-disable-next-line react-native/no-raw-text */}
         <Typo.Hero color={ColorsEnum.WHITE}>{`${props.remainingCredit} €`}</Typo.Hero>
         <Spacer.Column numberOfSpaces={2} />
-        <Typo.Caption color={ColorsEnum.WHITE}>
-          {_(t`crédit valable jusqu'au ${creditExpiracyDate}`)}
-        </Typo.Caption>
+        {props.depositExpirationDate && (
+          <Typo.Caption color={ColorsEnum.WHITE}>
+            {_(t`crédit valable jusqu'au ${props.depositExpirationDate}`)}
+          </Typo.Caption>
+        )}
         <Spacer.Column numberOfSpaces={6} />
       </UserNameAndCredit>
       <Ceilings depositVersion={props.depositVersion} expenses={expenses} />

--- a/src/features/profile/components/ProfileHeader.test.tsx
+++ b/src/features/profile/components/ProfileHeader.test.tsx
@@ -1,0 +1,44 @@
+import { render } from '@testing-library/react-native'
+import React from 'react'
+
+import { ExpenseDomain, UserProfileResponse } from 'api/gen'
+import { ProfileHeader } from 'features/profile/components/ProfileHeader'
+
+const userV1: UserProfileResponse = {
+  email: 'email2@domain.ext',
+  firstName: 'Jean',
+  isBeneficiary: true,
+  dateOfBirth: new Date('2003-01-01T00:00:00'),
+  depositExpirationDate: new Date('2023-02-09T11:17:14.786670'),
+  depositVersion: 1,
+  expenses: [
+    { current: 30000, domain: ExpenseDomain.All, limit: 30000 },
+    { current: 0, domain: ExpenseDomain.Digital, limit: 10000 },
+    { current: 0, domain: ExpenseDomain.Physical, limit: 10000 },
+  ],
+  isEligible: true,
+  lastName: '93 HNMM 2',
+  hasAllowedRecommendations: true,
+  id: 1234,
+  needsToFillCulturalSurvey: true,
+}
+
+const userV2: UserProfileResponse = {
+  ...userV1,
+  depositVersion: 2,
+  expenses: [
+    { current: 30000, domain: ExpenseDomain.All, limit: 30000 },
+    { current: 0, domain: ExpenseDomain.Digital, limit: 10000 },
+  ],
+}
+
+describe('ProfileHeader', () => {
+  it('should display the BeneficiaryHeader version 1 if user is beneficiary and depositVersion = 1', () => {
+    const { getByTestId } = render(<ProfileHeader user={userV1} />)
+    expect(getByTestId('beneficiary-header-1')).toBeTruthy()
+  })
+  it('should display the BeneficiaryHeader version 2 if user is beneficiary and depositVersion = 2', () => {
+    const { getByTestId } = render(<ProfileHeader user={userV2} />)
+    expect(getByTestId('beneficiary-header-2')).toBeTruthy()
+  })
+})

--- a/src/features/profile/components/types.ts
+++ b/src/features/profile/components/types.ts
@@ -55,3 +55,13 @@ export const ExpenseDomainOrder = {
   [ExpenseDomain.Physical]: 2,
   [ExpenseDomain.Digital]: 3,
 }
+
+export type ExpensesAndDepositVersion =
+  | {
+      expenses: Expense[]
+      depositVersion: 1
+    }
+  | {
+      expenses: ExpenseV2[]
+      depositVersion: 2
+    }

--- a/src/features/profile/pages/Profile.test.tsx
+++ b/src/features/profile/pages/Profile.test.tsx
@@ -14,7 +14,7 @@ jest.mock('features/home/api', () => ({
     () =>
       ({
         isLoading: false,
-        data: { email: 'email2@domain.ext', firstName: 'Jean', isBeneficiary: true },
+        data: { email: 'email2@domain.ext', firstName: 'Jean', isBeneficiary: false },
       } as UseQueryResult<UserProfileResponse>)
   ),
 }))

--- a/src/features/profile/utils.test.ts
+++ b/src/features/profile/utils.test.ts
@@ -1,6 +1,6 @@
 import { Expense, ExpenseDomain } from 'api/gen/api'
 
-import { computeEligibilityExpiracy, sortExpenses } from './utils'
+import { computeEligibilityExpiracy, computeRemainingCredit, sortExpenses } from './utils'
 
 describe('computeEligibilityExpiracy', () => {
   it.each([
@@ -13,7 +13,7 @@ describe('computeEligibilityExpiracy', () => {
     expect(expiracy.toISOString()).toEqual(expectedExpiracy)
   })
 
-  it('should sort expenses in the right order', () => {
+  it('sortExpenses - should sort expenses in the right order', () => {
     const expenses: Array<Expense> = [
       { current: 60, domain: ExpenseDomain.Digital, limit: 100 },
       { current: 100, domain: ExpenseDomain.All, limit: 200 },
@@ -25,5 +25,14 @@ describe('computeEligibilityExpiracy', () => {
       { current: 0, domain: ExpenseDomain.Physical, limit: 200 },
       { current: 60, domain: ExpenseDomain.Digital, limit: 100 },
     ])
+  })
+
+  it('computeRemainingCredit - should return the right amount according to expenses', () => {
+    const expenses: Array<Expense> = [
+      { current: 600, domain: ExpenseDomain.Digital, limit: 1000 },
+      { current: 1500, domain: ExpenseDomain.All, limit: 2000 },
+      { current: 0, domain: ExpenseDomain.Physical, limit: 2000 },
+    ]
+    expect(computeRemainingCredit(expenses)).toBe(5)
   })
 })

--- a/src/features/profile/utils.ts
+++ b/src/features/profile/utils.ts
@@ -1,7 +1,9 @@
 import _ from 'lodash'
 
-import { Expense } from 'api/gen/api'
+import { Expense, ExpenseDomain } from 'api/gen/api'
 import { ExpenseDomainOrder } from 'features/profile/components/types'
+import { ExpenseV2 } from 'features/profile/components/types'
+import { convertCentsToEuros } from 'libs/parsers/pricesConversion'
 
 /**
  * Formats an iso date to a slashed french date.
@@ -21,4 +23,9 @@ export function sortExpenses(expenses: Expense[]) {
   return _.sortBy(expenses, function (expense: Expense) {
     return ExpenseDomainOrder[expense.domain]
   })
+}
+
+export function computeRemainingCredit(expenses: Expense[] | ExpenseV2[]): number {
+  const allExpense = expenses.find((expense) => expense.domain === ExpenseDomain.All)
+  return allExpense ? convertCentsToEuros(allExpense.limit - allExpense.current) : 0
 }

--- a/src/libs/parsers/pricesConversion.ts
+++ b/src/libs/parsers/pricesConversion.ts
@@ -8,6 +8,8 @@ export const CENTS_IN_EURO = 100
 
 export const convertEuroToCents = (p: number): number => Math.floor(p * CENTS_IN_EURO)
 
+export const convertCentsToEuros = (p: number): number => Math.floor(p / CENTS_IN_EURO)
+
 export const convertAlgoliaHitToCents = (hit: AlgoliaHit): AlgoliaHit => {
   const { prices, priceMax, priceMin, ...offer } = hit.offer
   return {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-6169

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

![Screenshot from 2021-02-12 09-43-30](https://user-images.githubusercontent.com/22886846/107746899-e2fef580-6d16-11eb-98fd-c96f6623912e.png)


## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
