### PR TITLE
Hide Close icon on Login/SetEmail when coming from the profile page

### DIFF
--- a/src/features/auth/login/Login.tsx
+++ b/src/features/auth/login/Login.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro'
-import { useNavigation } from '@react-navigation/native'
+import { useNavigation, useRoute } from '@react-navigation/native'
 import React, { FunctionComponent, useState } from 'react'
 import { Keyboard, TouchableOpacity } from 'react-native'
 import styled from 'styled-components/native'
@@ -8,7 +8,7 @@ import { api } from 'api/api'
 import { useSignIn, SignInResponseFailure } from 'features/auth/api'
 import { useBackNavigation } from 'features/navigation/backNavigation'
 import { NavigateToHomeWithoutModalOptions } from 'features/navigation/helpers'
-import { UseNavigationType } from 'features/navigation/RootNavigator'
+import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator'
 import { env } from 'libs/environment'
 import { _ } from 'libs/i18n'
 import { BottomContentPage } from 'ui/components/BottomContentPage'
@@ -39,6 +39,7 @@ export const Login: FunctionComponent = function () {
 
   const shouldDisableLoginButton = isValueEmpty(email) || isValueEmpty(password) || isLoading
 
+  const { params } = useRoute<UseRouteType<'Login'>>()
   const { navigate } = useNavigation<UseNavigationType>()
   const complexGoBack = useBackNavigation<'Login'>()
 
@@ -96,7 +97,7 @@ export const Login: FunctionComponent = function () {
         title={_(t`Connecte-toi !`)}
         leftIcon={ArrowPrevious}
         onLeftIconPress={complexGoBack}
-        rightIcon={Close}
+        rightIcon={params?.preventCancellation ? undefined : Close}
         onRightIconPress={onClose}
       />
       {!!errorMessage && <InputError visible messageId={errorMessage} numberOfSpacesTop={5} />}

--- a/src/features/auth/signup/SetEmail.tsx
+++ b/src/features/auth/signup/SetEmail.tsx
@@ -1,12 +1,12 @@
 import { t } from '@lingui/macro'
-import { useNavigation } from '@react-navigation/native'
+import { useNavigation, useRoute } from '@react-navigation/native'
 import React, { FunctionComponent, useRef, useState } from 'react'
 import { TextInput as RNTextInput } from 'react-native'
 import styled from 'styled-components/native'
 
 import { QuitSignupModal, SignupSteps } from 'features/auth/signup/QuitSignupModal'
 import { useBackNavigation } from 'features/navigation/backNavigation'
-import { UseNavigationType } from 'features/navigation/RootNavigator'
+import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator'
 import { _ } from 'libs/i18n'
 import { BottomContentPage } from 'ui/components/BottomContentPage'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
@@ -27,6 +27,7 @@ export const SetEmail: FunctionComponent = () => {
   const [hasError, setHasError] = useState(false)
   const [isNewsletterChecked, setIsNewsletterChecked] = useState(false)
 
+  const { params } = useRoute<UseRouteType<'SetEmail'>>()
   const navigation = useNavigation<UseNavigationType>()
 
   const shouldDisableValidateButton = isValueEmpty(email)
@@ -68,7 +69,7 @@ export const SetEmail: FunctionComponent = () => {
           title={_(t`Ton e-mail`)}
           leftIcon={ArrowPrevious}
           onLeftIconPress={complexGoBack}
-          rightIcon={Close}
+          rightIcon={params?.preventCancellation ? undefined : Close}
           onRightIconPress={showQuitSignupModal}
         />
         <ModalContent>

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -26,7 +26,7 @@ export type RootStackParamList = {
   EligibilityConfirmed: undefined
   ForgottenPassword: undefined
   IdCheck: { email: string; licenceToken: string }
-  Login: BackNavigationParams<'Home'> | undefined
+  Login: ({ preventCancellation?: boolean } & BackNavigationParams<'Home'>) | undefined
   Navigation: undefined
   Offer: { id: number }
   OfferDescription: { id: number }
@@ -39,7 +39,7 @@ export type RootStackParamList = {
   SearchCategories: undefined
   SearchFilter: undefined
   SetBirthday: { email: string; isNewsletterChecked: boolean; password: string }
-  SetEmail: BackNavigationParams<'Home'> | undefined
+  SetEmail: ({ preventCancellation?: boolean } & BackNavigationParams<'Home'>) | undefined
   SetPassword: { email: string; isNewsletterChecked: boolean }
   SignupConfirmationEmailSent: { email: string }
   SignupConfirmationExpiredLink: { email: string }
@@ -62,7 +62,7 @@ export type ScreenNames = keyof AllNavParamList
  * }
  */
 export type BackNavigationParams<ScreenName extends ScreenNames> = {
-  backNavigation: {
+  backNavigation?: {
     from: ScreenName
     params: AllNavParamList[ScreenName]
   }

--- a/src/features/navigation/backNavigation.ts
+++ b/src/features/navigation/backNavigation.ts
@@ -26,8 +26,8 @@ export function useBackNavigation<CurrentScreenName extends ScreenNames>(
 
   return () => {
     if (hasBackNavigationParameter<CurrentScreenName>(currentRouteParams)) {
-      const { from, params } = currentRouteParams.backNavigation
-      navigate(from, params)
+      const { from, params } = currentRouteParams.backNavigation || {}
+      from && navigate(from, params)
     } else {
       if (typeof previousRoute?.name !== 'undefined' && canGoBack()) {
         goBack()

--- a/src/features/profile/components/LoggedOutHeader.test.tsx
+++ b/src/features/profile/components/LoggedOutHeader.test.tsx
@@ -12,7 +12,7 @@ describe('LoggedOutHeader', () => {
     const signupButton = getByTestId('button-container')
     signupButton.props.onClick()
 
-    expect(navigate).toBeCalledWith('SetEmail')
+    expect(navigate).toBeCalledWith('SetEmail', { preventCancellation: true })
   })
   it('should navigate to the login page', () => {
     const { getByTestId } = render(<LoggedOutHeader />)
@@ -20,6 +20,6 @@ describe('LoggedOutHeader', () => {
     const connectButton = getByTestId('login-button')
     connectButton.props.onClick()
 
-    expect(navigate).toBeCalledWith('Login')
+    expect(navigate).toBeCalledWith('Login', { preventCancellation: true })
   })
 })

--- a/src/features/profile/components/LoggedOutHeader.tsx
+++ b/src/features/profile/components/LoggedOutHeader.tsx
@@ -22,11 +22,16 @@ export function LoggedOutHeader() {
           {_(t`Inscris-toi pour accéder à toutes les fonctionnalités de l’appication`)}
         </Description>
         <Spacer.Column numberOfSpaces={8} />
-        <ButtonPrimaryWhite title={_(t`S'inscrire`)} onPress={() => navigate('SetEmail')} />
+        <ButtonPrimaryWhite
+          title={_(t`S'inscrire`)}
+          onPress={() => navigate('SetEmail', { preventCancellation: true })}
+        />
         <Spacer.Column numberOfSpaces={4} />
         <ConnecteToi>
           <Typo.Body color={ColorsEnum.WHITE}>{_(t`Tu as déjà un compte ?\u00a0`)}</Typo.Body>
-          <TouchableOpacity onPress={() => navigate('Login')} testID="login-button">
+          <TouchableOpacity
+            onPress={() => navigate('Login', { preventCancellation: true })}
+            testID="login-button">
             <Typo.ButtonText color={ColorsEnum.WHITE}>{_(t`Connecte-toi`)}</Typo.ButtonText>
           </TouchableOpacity>
         </ConnecteToi>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-6372

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [-] Added new reusable components to the AppComponents page and communicate to the team on slack
- [x] Added a **screenshot** for UI tickets.
- [-] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Set Email] | \*iOS - [Login] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
| ![image](https://user-images.githubusercontent.com/6025710/108087512-d14f8200-7077-11eb-9b6e-eb73a9f3e890.png)| ![image](https://user-images.githubusercontent.com/6025710/108087627-e9270600-7077-11eb-88cc-c7dbbb955544.png) |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
