### PR TITLE
[PC-6340]  Détail de l'offre - Polices large et rendu tablettes

### DIFF
--- a/src/features/offer/atoms/AccessibilityAtom.tsx
+++ b/src/features/offer/atoms/AccessibilityAtom.tsx
@@ -8,25 +8,15 @@ import { BorderRadiusEnum } from 'ui/theme/grid'
 
 import { getIconAndWording, HandicapCategory } from './AccessibilityAtom.service'
 
-const HandicapText: React.FC<{ wording: string; width: number }> = ({ wording, width }) => {
-  const [firstWord, ...otherWords] = wording.split(' ')
-
-  return (
-    <TextContainer testID={wording} width={width}>
-      <Text numberOfLines={1} adjustsFontSizeToFit={true}>
-        {firstWord}
+const HandicapText: React.FC<{ wording: string; width: number }> = ({ wording, width }) => (
+  <TextContainer testID={wording} width={width}>
+    {wording.split(' ').map((word) => (
+      <Text key={word} numberOfLines={1} adjustsFontSizeToFit={true}>
+        {word}
       </Text>
-      {otherWords.map((word) => (
-        <React.Fragment key={word}>
-          <Text> </Text>
-          <Text numberOfLines={1} adjustsFontSizeToFit={true}>
-            {word}
-          </Text>
-        </React.Fragment>
-      ))}
-    </TextContainer>
-  )
-}
+    ))}
+  </TextContainer>
+)
 
 interface Props {
   handicap: HandicapCategory
@@ -71,7 +61,7 @@ const Container = styled.View({
   flexDirection: 'column',
   flexShrink: 1,
 })
-const Text = styled(Typo.Caption)({ textAlign: 'center' })
+const Text = styled(Typo.Caption)({ textAlign: 'center', paddingHorizontal: 1 })
 const TextContainer = styled.View<{ width: number }>(({ width }) => ({
   flexDirection: 'row',
   flexWrap: 'wrap',

--- a/src/features/offer/components/OfferHeader.tsx
+++ b/src/features/offer/components/OfferHeader.tsx
@@ -89,7 +89,7 @@ const Row = styled.View({
   flexDirection: 'row',
   alignItems: 'center',
 })
-const Title = styled(Animated.Text).attrs({ numberOfLines: 2 })({
+const Title = styled(Animated.Text).attrs({ numberOfLines: 1 })({
   flexShrink: 1,
   textAlign: 'center',
 })

--- a/src/features/offer/components/__tests__/__snapshots__/OfferHeader.test.tsx.snap
+++ b/src/features/offer/components/__tests__/__snapshots__/OfferHeader.test.tsx.snap
@@ -176,7 +176,7 @@ Array [
         }
       />
       <Text
-        numberOfLines={2}
+        numberOfLines={1}
         style={
           Object {
             "flexShrink": 1,

--- a/src/features/offer/pages/tests/__snapshots__/Offer.test.tsx.snap
+++ b/src/features/offer/pages/tests/__snapshots__/Offer.test.tsx.snap
@@ -1228,27 +1228,13 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
                                     }
                                   >
                                     Handicap
-                                  </Text>
-                                  <Text
-                                    style={
-                                      Array [
-                                        Object {
-                                          "color": "#151515",
-                                          "fontFamily": "Montserrat-SemiBold",
-                                          "fontSize": 12,
-                                          "lineHeight": 16,
-                                          "textAlign": "center",
-                                        },
-                                      ]
-                                    }
-                                  >
-                                     
                                   </Text>
                                   <Text
                                     adjustsFontSizeToFit={true}
@@ -1260,6 +1246,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
@@ -1387,6 +1374,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
@@ -1395,21 +1383,6 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                     Handicap
                                   </Text>
                                   <Text
-                                    style={
-                                      Array [
-                                        Object {
-                                          "color": "#151515",
-                                          "fontFamily": "Montserrat-SemiBold",
-                                          "fontSize": 12,
-                                          "lineHeight": 16,
-                                          "textAlign": "center",
-                                        },
-                                      ]
-                                    }
-                                  >
-                                     
-                                  </Text>
-                                  <Text
                                     adjustsFontSizeToFit={true}
                                     numberOfLines={1}
                                     style={
@@ -1419,6 +1392,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
@@ -1427,21 +1401,6 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                     psychique
                                   </Text>
                                   <Text
-                                    style={
-                                      Array [
-                                        Object {
-                                          "color": "#151515",
-                                          "fontFamily": "Montserrat-SemiBold",
-                                          "fontSize": 12,
-                                          "lineHeight": 16,
-                                          "textAlign": "center",
-                                        },
-                                      ]
-                                    }
-                                  >
-                                     
-                                  </Text>
-                                  <Text
                                     adjustsFontSizeToFit={true}
                                     numberOfLines={1}
                                     style={
@@ -1451,6 +1410,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
@@ -1459,21 +1419,6 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                     ou
                                   </Text>
                                   <Text
-                                    style={
-                                      Array [
-                                        Object {
-                                          "color": "#151515",
-                                          "fontFamily": "Montserrat-SemiBold",
-                                          "fontSize": 12,
-                                          "lineHeight": 16,
-                                          "textAlign": "center",
-                                        },
-                                      ]
-                                    }
-                                  >
-                                     
-                                  </Text>
-                                  <Text
                                     adjustsFontSizeToFit={true}
                                     numberOfLines={1}
                                     style={
@@ -1483,6 +1428,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
@@ -1610,27 +1556,13 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
                                     }
                                   >
                                     Handicap
-                                  </Text>
-                                  <Text
-                                    style={
-                                      Array [
-                                        Object {
-                                          "color": "#151515",
-                                          "fontFamily": "Montserrat-SemiBold",
-                                          "fontSize": 12,
-                                          "lineHeight": 16,
-                                          "textAlign": "center",
-                                        },
-                                      ]
-                                    }
-                                  >
-                                     
                                   </Text>
                                   <Text
                                     adjustsFontSizeToFit={true}
@@ -1642,6 +1574,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
@@ -1769,27 +1702,13 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
                                     }
                                   >
                                     Handicap
-                                  </Text>
-                                  <Text
-                                    style={
-                                      Array [
-                                        Object {
-                                          "color": "#151515",
-                                          "fontFamily": "Montserrat-SemiBold",
-                                          "fontSize": 12,
-                                          "lineHeight": 16,
-                                          "textAlign": "center",
-                                        },
-                                      ]
-                                    }
-                                  >
-                                     
                                   </Text>
                                   <Text
                                     adjustsFontSizeToFit={true}
@@ -1801,6 +1720,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
@@ -2049,7 +1969,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                           }
                         />
                         <Text
-                          numberOfLines={2}
+                          numberOfLines={1}
                           style={
                             Object {
                               "flexShrink": 1,
@@ -4126,27 +4046,13 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
                                     }
                                   >
                                     Handicap
-                                  </Text>
-                                  <Text
-                                    style={
-                                      Array [
-                                        Object {
-                                          "color": "#151515",
-                                          "fontFamily": "Montserrat-SemiBold",
-                                          "fontSize": 12,
-                                          "lineHeight": 16,
-                                          "textAlign": "center",
-                                        },
-                                      ]
-                                    }
-                                  >
-                                     
                                   </Text>
                                   <Text
                                     adjustsFontSizeToFit={true}
@@ -4158,6 +4064,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
@@ -4285,6 +4192,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
@@ -4293,21 +4201,6 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                     Handicap
                                   </Text>
                                   <Text
-                                    style={
-                                      Array [
-                                        Object {
-                                          "color": "#151515",
-                                          "fontFamily": "Montserrat-SemiBold",
-                                          "fontSize": 12,
-                                          "lineHeight": 16,
-                                          "textAlign": "center",
-                                        },
-                                      ]
-                                    }
-                                  >
-                                     
-                                  </Text>
-                                  <Text
                                     adjustsFontSizeToFit={true}
                                     numberOfLines={1}
                                     style={
@@ -4317,6 +4210,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
@@ -4325,21 +4219,6 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                     psychique
                                   </Text>
                                   <Text
-                                    style={
-                                      Array [
-                                        Object {
-                                          "color": "#151515",
-                                          "fontFamily": "Montserrat-SemiBold",
-                                          "fontSize": 12,
-                                          "lineHeight": 16,
-                                          "textAlign": "center",
-                                        },
-                                      ]
-                                    }
-                                  >
-                                     
-                                  </Text>
-                                  <Text
                                     adjustsFontSizeToFit={true}
                                     numberOfLines={1}
                                     style={
@@ -4349,6 +4228,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
@@ -4357,21 +4237,6 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                     ou
                                   </Text>
                                   <Text
-                                    style={
-                                      Array [
-                                        Object {
-                                          "color": "#151515",
-                                          "fontFamily": "Montserrat-SemiBold",
-                                          "fontSize": 12,
-                                          "lineHeight": 16,
-                                          "textAlign": "center",
-                                        },
-                                      ]
-                                    }
-                                  >
-                                     
-                                  </Text>
-                                  <Text
                                     adjustsFontSizeToFit={true}
                                     numberOfLines={1}
                                     style={
@@ -4381,6 +4246,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
@@ -4508,27 +4374,13 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
                                     }
                                   >
                                     Handicap
-                                  </Text>
-                                  <Text
-                                    style={
-                                      Array [
-                                        Object {
-                                          "color": "#151515",
-                                          "fontFamily": "Montserrat-SemiBold",
-                                          "fontSize": 12,
-                                          "lineHeight": 16,
-                                          "textAlign": "center",
-                                        },
-                                      ]
-                                    }
-                                  >
-                                     
                                   </Text>
                                   <Text
                                     adjustsFontSizeToFit={true}
@@ -4540,6 +4392,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
@@ -4667,27 +4520,13 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
                                     }
                                   >
                                     Handicap
-                                  </Text>
-                                  <Text
-                                    style={
-                                      Array [
-                                        Object {
-                                          "color": "#151515",
-                                          "fontFamily": "Montserrat-SemiBold",
-                                          "fontSize": 12,
-                                          "lineHeight": 16,
-                                          "textAlign": "center",
-                                        },
-                                      ]
-                                    }
-                                  >
-                                     
                                   </Text>
                                   <Text
                                     adjustsFontSizeToFit={true}
@@ -4699,6 +4538,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
                                           "lineHeight": 16,
+                                          "paddingHorizontal": 1,
                                           "textAlign": "center",
                                         },
                                       ]
@@ -4947,7 +4787,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                           }
                         />
                         <Text
-                          numberOfLines={2}
+                          numberOfLines={1}
                           style={
                             Object {
                               "flexShrink": 1,

--- a/src/features/offer/pages/tests/__snapshots__/Offer.transition.test.tsx.snap
+++ b/src/features/offer/pages/tests/__snapshots__/Offer.transition.test.tsx.snap
@@ -128,7 +128,7 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
                               Array [
                                 Object {
                                   \\"backgroundColor\\": \\"#f5f5f5\\",
-@@ -939,1234 +856,26 @@
+@@ -939,1154 +856,26 @@
                           <View
                             style={
                               Array [
@@ -217,10 +217,10 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                               Array [
 -                                 Object {
 -                                   \\"height\\": 16,
--                                 },
--                               ]
--                             }
--                           />
+                                },
+                              ]
+                            }
+                          />
 -                           <Text
 -                             style={
 -                               Array [
@@ -253,9 +253,9 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                   \\"fontFamily\\": \\"Montserrat-Regular\\",
 -                                   \\"fontSize\\": 15,
 -                                   \\"lineHeight\\": 20,
-                                },
-                              ]
-                            }
+-                                 },
+-                               ]
+-                             }
 -                           >
 -                             900+ km
 -                           </Text>
@@ -268,7 +268,7 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                 },
 -                               ]
 -                             }
-                          />
+-                           />
 -                           <View
 -                             style={
 -                               Array [
@@ -312,7 +312,7 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                               width={24}
 -                             >
 -                               undefined-SVG-Mock
--                             </View>
+                        </View>
 -                             <View
 -                               numberOfSpaces={1}
 -                               style={
@@ -348,7 +348,7 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                               ]
 -                             }
 -                           />
-                        </View>
+-                         </View>
 -                         <View
 -                           style={
 -                             Array [
@@ -711,27 +711,13 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                           \\"fontFamily\\": \\"Montserrat-SemiBold\\",
 -                                           \\"fontSize\\": 12,
 -                                           \\"lineHeight\\": 16,
+-                                           \\"paddingHorizontal\\": 1,
 -                                           \\"textAlign\\": \\"center\\",
 -                                         },
 -                                       ]
 -                                     }
 -                                   >
 -                                     Handicap
--                                   </Text>
--                                   <Text
--                                     style={
--                                       Array [
--                                         Object {
--                                           \\"color\\": \\"#151515\\",
--                                           \\"fontFamily\\": \\"Montserrat-SemiBold\\",
--                                           \\"fontSize\\": 12,
--                                           \\"lineHeight\\": 16,
--                                           \\"textAlign\\": \\"center\\",
--                                         },
--                                       ]
--                                     }
--                                   >
--                                      
 -                                   </Text>
 -                                   <Text
 -                                     adjustsFontSizeToFit={true}
@@ -743,6 +729,7 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                           \\"fontFamily\\": \\"Montserrat-SemiBold\\",
 -                                           \\"fontSize\\": 12,
 -                                           \\"lineHeight\\": 16,
+-                                           \\"paddingHorizontal\\": 1,
 -                                           \\"textAlign\\": \\"center\\",
 -                                         },
 -                                       ]
@@ -870,6 +857,7 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                           \\"fontFamily\\": \\"Montserrat-SemiBold\\",
 -                                           \\"fontSize\\": 12,
 -                                           \\"lineHeight\\": 16,
+-                                           \\"paddingHorizontal\\": 1,
 -                                           \\"textAlign\\": \\"center\\",
 -                                         },
 -                                       ]
@@ -878,21 +866,6 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                     Handicap
 -                                   </Text>
 -                                   <Text
--                                     style={
--                                       Array [
--                                         Object {
--                                           \\"color\\": \\"#151515\\",
--                                           \\"fontFamily\\": \\"Montserrat-SemiBold\\",
--                                           \\"fontSize\\": 12,
--                                           \\"lineHeight\\": 16,
--                                           \\"textAlign\\": \\"center\\",
--                                         },
--                                       ]
--                                     }
--                                   >
--                                      
--                                   </Text>
--                                   <Text
 -                                     adjustsFontSizeToFit={true}
 -                                     numberOfLines={1}
 -                                     style={
@@ -902,6 +875,7 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                           \\"fontFamily\\": \\"Montserrat-SemiBold\\",
 -                                           \\"fontSize\\": 12,
 -                                           \\"lineHeight\\": 16,
+-                                           \\"paddingHorizontal\\": 1,
 -                                           \\"textAlign\\": \\"center\\",
 -                                         },
 -                                       ]
@@ -910,21 +884,6 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                     psychique
 -                                   </Text>
 -                                   <Text
--                                     style={
--                                       Array [
--                                         Object {
--                                           \\"color\\": \\"#151515\\",
--                                           \\"fontFamily\\": \\"Montserrat-SemiBold\\",
--                                           \\"fontSize\\": 12,
--                                           \\"lineHeight\\": 16,
--                                           \\"textAlign\\": \\"center\\",
--                                         },
--                                       ]
--                                     }
--                                   >
--                                      
--                                   </Text>
--                                   <Text
 -                                     adjustsFontSizeToFit={true}
 -                                     numberOfLines={1}
 -                                     style={
@@ -934,6 +893,7 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                           \\"fontFamily\\": \\"Montserrat-SemiBold\\",
 -                                           \\"fontSize\\": 12,
 -                                           \\"lineHeight\\": 16,
+-                                           \\"paddingHorizontal\\": 1,
 -                                           \\"textAlign\\": \\"center\\",
 -                                         },
 -                                       ]
@@ -942,21 +902,6 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                     ou
 -                                   </Text>
 -                                   <Text
--                                     style={
--                                       Array [
--                                         Object {
--                                           \\"color\\": \\"#151515\\",
--                                           \\"fontFamily\\": \\"Montserrat-SemiBold\\",
--                                           \\"fontSize\\": 12,
--                                           \\"lineHeight\\": 16,
--                                           \\"textAlign\\": \\"center\\",
--                                         },
--                                       ]
--                                     }
--                                   >
--                                      
--                                   </Text>
--                                   <Text
 -                                     adjustsFontSizeToFit={true}
 -                                     numberOfLines={1}
 -                                     style={
@@ -966,6 +911,7 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                           \\"fontFamily\\": \\"Montserrat-SemiBold\\",
 -                                           \\"fontSize\\": 12,
 -                                           \\"lineHeight\\": 16,
+-                                           \\"paddingHorizontal\\": 1,
 -                                           \\"textAlign\\": \\"center\\",
 -                                         },
 -                                       ]
@@ -1038,10 +984,12 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                       ]
 -                                     }
 -                                   />
--                                   <View
--                                     style={
--                                       Array [
--                                         Object {
++                     </RCTScrollView>
+                      <View
++                       numberOfSpaces={10}
+                        style={
+                          Array [
+                            Object {
 -                                           \\"bottom\\": -16,
 -                                           \\"position\\": \\"absolute\\",
 -                                         },
@@ -1057,8 +1005,7 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                     </View>
 -                                   </View>
 -                                 </View>
-+                     </RCTScrollView>
-                      <View
+-                                 <View
 -                                   numberOfSpaces={4}
 -                                   style={
 -                                     Array [
@@ -1087,22 +1034,6 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                   <Text
 -                                     adjustsFontSizeToFit={true}
 -                                     numberOfLines={1}
-+                       numberOfSpaces={10}
-                        style={
-                          Array [
-                            Object {
--                                           \\"color\\": \\"#151515\\",
--                                           \\"fontFamily\\": \\"Montserrat-SemiBold\\",
--                                           \\"fontSize\\": 12,
--                                           \\"lineHeight\\": 16,
--                                           \\"textAlign\\": \\"center\\",
--                                         },
--                                       ]
--                                     }
--                                   >
--                                     Handicap
--                                   </Text>
--                                   <Text
 -                                     style={
 -                                       Array [
 -                                         Object {
@@ -1110,12 +1041,13 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                           \\"fontFamily\\": \\"Montserrat-SemiBold\\",
 -                                           \\"fontSize\\": 12,
 -                                           \\"lineHeight\\": 16,
+-                                           \\"paddingHorizontal\\": 1,
 -                                           \\"textAlign\\": \\"center\\",
 -                                         },
 -                                       ]
 -                                     }
 -                                   >
--                                      
+-                                     Handicap
 -                                   </Text>
 -                                   <Text
 -                                     adjustsFontSizeToFit={true}
@@ -1127,6 +1059,7 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                           \\"fontFamily\\": \\"Montserrat-SemiBold\\",
 -                                           \\"fontSize\\": 12,
 -                                           \\"lineHeight\\": 16,
+-                                           \\"paddingHorizontal\\": 1,
 -                                           \\"textAlign\\": \\"center\\",
 -                                         },
 -                                       ]
@@ -1255,27 +1188,13 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                           \\"fontFamily\\": \\"Montserrat-SemiBold\\",
 -                                           \\"fontSize\\": 12,
 -                                           \\"lineHeight\\": 16,
+-                                           \\"paddingHorizontal\\": 1,
 -                                           \\"textAlign\\": \\"center\\",
 -                                         },
 -                                       ]
 -                                     }
 -                                   >
 -                                     Handicap
--                                   </Text>
--                                   <Text
--                                     style={
--                                       Array [
--                                         Object {
--                                           \\"color\\": \\"#151515\\",
--                                           \\"fontFamily\\": \\"Montserrat-SemiBold\\",
--                                           \\"fontSize\\": 12,
--                                           \\"lineHeight\\": 16,
--                                           \\"textAlign\\": \\"center\\",
--                                         },
--                                       ]
--                                     }
--                                   >
--                                      
 -                                   </Text>
 -                                   <Text
 -                                     adjustsFontSizeToFit={true}
@@ -1287,6 +1206,7 @@ exports[`<Offer  /> - OfferTile to Offer transition should open Offer with prepo
 -                                           \\"fontFamily\\": \\"Montserrat-SemiBold\\",
 -                                           \\"fontSize\\": 12,
 -                                           \\"lineHeight\\": 16,
+-                                           \\"paddingHorizontal\\": 1,
 -                                           \\"textAlign\\": \\"center\\",
 -                                         },
 -                                       ]


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-6340

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [x] Added a **screenshot** for UI tickets.


## What ?

- [x] Le header est d’une grande violence ; est-il possible de le réduire à 1 ligne de texte ?
- [x] Les intitulés “handicap” et “type de handicap” sont très loin l’un de l’autre, ce qui gêne la lecture ; possible de les rapprocher ?
- [ ] L’intitulé de CTA “Accéder a l’offre” sort de son cadre
 => **VETO**: il faut être en police extrêmement large pour reproduire, et c'est très léger.



## Screenshots
<img width="331" alt="Capture d’écran 2021-02-17 à 19 26 50" src="https://user-images.githubusercontent.com/10118284/108250833-054da480-7157-11eb-9c4c-74933d6b922e.png">
