### PR TITLE
Fix InitialRoutingScreen icon displayed in tab bar

### DIFF
--- a/src/features/navigation/TabBar/TabBar.tsx
+++ b/src/features/navigation/TabBar/TabBar.tsx
@@ -1,4 +1,5 @@
 import { BottomTabBarOptions, BottomTabBarProps } from '@react-navigation/bottom-tabs'
+import { Route } from '@react-navigation/native'
 import React from 'react'
 import styled from 'styled-components/native'
 
@@ -13,13 +14,13 @@ import { ColorsEnum, getShadow, getSpacing, Spacer, UniqueColors } from 'ui/them
 import { useCustomSafeInsets } from '../../../ui/theme/useCustomSafeInsets'
 
 import { TabBarComponent } from './TabBarComponent'
-import { TabRouteName } from './types'
+import { TabRouteName, TabParamList } from './types'
 
 const mapRouteToIcon = (
-  route: TabRouteName | string
+  route: Exclude<TabRouteName, 'InitialRoutingScreen'>
 ): ((props: BicolorIconInterface) => React.ReactNode) => {
   switch (route) {
-    case 'HomeNavigator':
+    case 'Home':
       return BicolorLogo
     case 'Search':
       return BicolorSearch
@@ -29,8 +30,6 @@ const mapRouteToIcon = (
       return BicolorFavorite
     case 'Profile':
       return BicolorProfile
-    default:
-      return BicolorLogo
   }
 }
 export const TabBar: React.FC<Pick<
@@ -38,13 +37,16 @@ export const TabBar: React.FC<Pick<
   'state' | 'navigation'
 >> = ({ navigation, state }) => {
   const { bottom } = useCustomSafeInsets()
+  const routes = state.routes as Route<TabRouteName, TabParamList>[]
   return (
     <MainContainer>
       <RowContainer>
         <Spacer.Row numberOfSpaces={4} />
-        {state.routes.map((route, index) => {
+        {routes.map((route, index) => {
+          if (route.name === 'InitialRoutingScreen') {
+            return null
+          }
           const isSelected = state.index === index
-          const routeName = state.routeNames[index]
           const onPress = () => {
             if (isSelected) return
 
@@ -61,9 +63,9 @@ export const TabBar: React.FC<Pick<
             <TabBarComponent
               key={`key-tab-nav-${index}-${route.key}`}
               isSelected={isSelected}
-              bicolorIcon={mapRouteToIcon(routeName)}
+              bicolorIcon={mapRouteToIcon(route.name)}
               onPress={onPress}
-              testID={`tab-${routeName}`}
+              testID={`tab-${route.name}`}
             />
           )
         })}

--- a/src/features/navigation/TabBar/TabNavigator.tsx
+++ b/src/features/navigation/TabBar/TabNavigator.tsx
@@ -1,5 +1,5 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
-import React from 'react'
+import React, { ComponentType } from 'react'
 import { StatusBar, Platform } from 'react-native'
 
 import { useAuthContext } from 'features/auth/AuthContext'
@@ -13,7 +13,7 @@ import { Search } from 'features/search/pages/Search'
 import { InitialRoutingScreen } from '../RootNavigator/InitialRoutingScreen'
 
 import { TabBar } from './TabBar'
-import { TabParamList } from './types'
+import { TabParamList, TabRouteName } from './types'
 
 StatusBar.setBarStyle('light-content')
 if (Platform.OS === 'android') {
@@ -25,6 +25,45 @@ export const Tab = createBottomTabNavigator<TabParamList>()
 
 const Home = withAsyncErrorBoundary(HomeComponent)
 
+export const tabBarRoutes: Array<{
+  name: TabRouteName
+  component: ComponentType
+  params?: TabParamList[TabRouteName]
+  key: string
+}> = [
+  {
+    name: 'Home',
+    component: Home,
+    params: { shouldDisplayLoginModal: false },
+    key: 'Home-key',
+  },
+  {
+    name: 'Search',
+    component: Search,
+    key: 'Search-key',
+  },
+  {
+    name: 'Bookings',
+    component: Bookings,
+    key: 'Bookings-key',
+  },
+  {
+    name: 'Favorites',
+    component: Favorites,
+    key: 'Favorites-key',
+  },
+  {
+    name: 'Profile',
+    component: Profile,
+    key: 'Profile-key',
+  },
+  {
+    name: 'InitialRoutingScreen',
+    component: InitialRoutingScreen,
+    key: 'InitialRoutingScreen-key',
+  },
+]
+
 export const TabNavigator: React.FC = () => {
   const authContext = useAuthContext()
 
@@ -32,12 +71,21 @@ export const TabNavigator: React.FC = () => {
     <Tab.Navigator
       initialRouteName="InitialRoutingScreen"
       tabBar={({ state, navigation }) => <TabBar state={state} navigation={navigation} />}>
-      <Tab.Screen name="InitialRoutingScreen" component={InitialRoutingScreen} />
-      <Tab.Screen name="Home" component={Home} initialParams={{ shouldDisplayLoginModal: false }} />
-      <Tab.Screen name="Search" component={Search} />
-      {authContext.isLoggedIn && <Tab.Screen name="Bookings" component={Bookings} />}
-      <Tab.Screen name="Favorites" component={Favorites} />
-      <Tab.Screen name="Profile" component={Profile} />
+      {tabBarRoutes
+        .filter((route) => {
+          if (route.name === 'Bookings' && !authContext.isLoggedIn) {
+            return false
+          }
+          return true
+        })
+        .map((route) => (
+          <Tab.Screen
+            name={route.name}
+            component={route.component}
+            initialParams={route.params}
+            key={route.key}
+          />
+        ))}
     </Tab.Navigator>
   )
 }

--- a/src/features/navigation/TabBar/__tests__/TabBar.test.tsx
+++ b/src/features/navigation/TabBar/__tests__/TabBar.test.tsx
@@ -4,6 +4,12 @@ import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 
 import { TabBar } from '../TabBar'
+import { tabBarRoutes } from '../TabNavigator'
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: jest.fn(() => ({ bottom: 10 })),
+}))
+jest.mock('@react-navigation/native', () => jest.requireActual('@react-navigation/native'))
 
 const state: TabNavigationState<Record<string, Record<string, unknown> | undefined>> = {
   history: [
@@ -11,25 +17,16 @@ const state: TabNavigationState<Record<string, Record<string, unknown> | undefin
     { key: 'route2-key', type: 'route' },
     { key: 'Bookings-key', type: 'route' },
     { key: 'Profile-key', type: 'route' },
-    { key: 'HomeNavigator-key', type: 'route' },
+    { key: 'Home-key', type: 'route' },
   ],
   index: 0,
   key: 'tab',
-  routeNames: ['HomeNavigator', 'Search', 'Bookings', 'Favorites', 'Profile'],
-  routes: [
-    {
-      key: 'HomeNavigator-key',
-      name: 'HomeNavigator',
-      params: undefined,
-    },
-    { key: 'Search-key', name: 'Search', params: undefined },
-    { key: 'Bookings-key', name: 'Bookings', params: undefined },
-    { key: 'Favorites-key', name: 'Favorites', params: undefined },
-    { key: 'Profile-key', name: 'Profile', params: undefined },
-  ],
+  routeNames: tabBarRoutes.map((route) => route.name),
+  routes: tabBarRoutes,
   stale: false,
   type: 'tab',
 }
+
 const navigation: NavigationHelpers<ParamListBase, BottomTabNavigationEventMap> = {
   canGoBack: jest.fn(),
   dangerouslyGetParent: jest.fn(),
@@ -44,9 +41,6 @@ const navigation: NavigationHelpers<ParamListBase, BottomTabNavigationEventMap> 
   setParams: jest.fn(),
 }
 
-jest.mock('react-native-safe-area-context', () => ({
-  useSafeAreaInsets: jest.fn(() => ({ bottom: 10 })),
-}))
 describe('TabBar', () => {
   afterEach(() => {
     jest.clearAllMocks()
@@ -57,14 +51,29 @@ describe('TabBar', () => {
     expect(tabBar).toMatchSnapshot()
   })
 
-  it('displays only one selected at a time', async () => {
+  it('should display the 5 following tabs', () => {
+    const tabBar = render(<TabBar state={state} navigation={navigation} />)
+    expect(tabBar.queryAllByTestId(/^tab-/)).toHaveLength(5)
+    expect(tabBar.queryByTestId('tab-Home')).toBeTruthy()
+    expect(tabBar.queryByTestId('tab-Search')).toBeTruthy()
+    expect(tabBar.queryByTestId('tab-Bookings')).toBeTruthy()
+    expect(tabBar.queryByTestId('tab-Favorites')).toBeTruthy()
+    expect(tabBar.queryByTestId('tab-Profile')).toBeTruthy()
+  })
+
+  it('should NOT display InitialRoutingScreen tab', () => {
+    const tabBar = render(<TabBar state={state} navigation={navigation} />)
+    expect(tabBar.queryByTestId('tab-InitialRoutingScreen')).toBeFalsy()
+  })
+
+  it('displays only one selected at a time', () => {
     const tabBar = render(<TabBar state={state} navigation={navigation} />)
     expect(tabBar.queryAllByTestId(/selector/)).toHaveLength(1)
   })
 
   it('switches tab when clicked on another tab', () => {
     const tabBar = render(<TabBar state={state} navigation={navigation} />)
-    expect(tabBar.queryByTestId('selector-tab-HomeNavigator')).toBeTruthy()
+    expect(tabBar.queryByTestId('selector-tab-Home')).toBeTruthy()
     expect(tabBar.queryByTestId('selector-tab-Search')).toBeFalsy()
 
     const searchTab = tabBar.getByTestId('tab-Search')
@@ -74,26 +83,27 @@ describe('TabBar', () => {
     expect(navigation.navigate).toHaveBeenCalledWith('Search')
     tabBar.rerender(<TabBar state={{ ...state, index: 1 }} navigation={navigation} />)
 
-    expect(tabBar.queryByTestId('selector-tab-HomeNavigator')).toBeFalsy()
+    expect(tabBar.queryByTestId('selector-tab-Home')).toBeFalsy()
     expect(tabBar.queryByTestId('selector-tab-Search')).toBeTruthy()
   })
 
   it('does not reset navigation when clicked on selected tab', () => {
     const tabBar = render(<TabBar state={state} navigation={navigation} />)
-    expect(tabBar.queryByTestId('selector-tab-HomeNavigator')).toBeTruthy()
+    expect(tabBar.queryByTestId('selector-tab-Home')).toBeTruthy()
 
-    const homeTab = tabBar.getByTestId('tab-HomeNavigator')
+    const homeTab = tabBar.getByTestId('tab-Home')
     fireEvent.press(homeTab)
 
     expect(navigation.emit).not.toHaveBeenCalled()
     expect(navigation.navigate).not.toHaveBeenCalled()
   })
 
-  it('navigates to Profile on Profile tab click', async () => {
+  it('navigates to Profile on Profile tab click', () => {
     const tabBar = render(<TabBar state={state} navigation={navigation} />)
 
     const profileTab = tabBar.getByTestId('tab-Profile')
     fireEvent.press(profileTab)
+
     expect(navigation.navigate).toHaveBeenCalledWith('Profile')
   })
 })

--- a/src/features/navigation/TabBar/__tests__/__snapshots__/TabBar.test.tsx.snap
+++ b/src/features/navigation/TabBar/__tests__/__snapshots__/TabBar.test.tsx.snap
@@ -64,14 +64,14 @@ exports[`TabBar renders correctly 1`] = `
           "opacity": 1,
         }
       }
-      testID="tab-HomeNavigator"
+      testID="tab-Home"
     >
       <View
         height={3}
-        testID="selector-tab-HomeNavigator"
+        testID="selector-tab-Home"
         width={44}
       >
-        selector-tab-HomeNavigator-SVG-Mock
+        selector-tab-Home-SVG-Mock
       </View>
       <View
         style={


### PR DESCRIPTION
**Bonus** : use actual routes in TabBar.test.tsx

Link to JIRA ticket: fix without ticket

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - iPhone 11 | 
| -------------------- | 
| <img width="326" alt="Capture d’écran 2021-03-02 à 11 59 23" src="https://user-images.githubusercontent.com/22399093/109638806-be947d00-7b4e-11eb-9e1d-4ba769f89057.png"> |
