### PR TITLE
(PC-7214) App native - Backend - déplacer l'information  hasAllowedRecommendations dans la colonne notification_subscriptions

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -97,7 +97,7 @@ export interface AccountRequest {
      * @type {boolean}
      * @memberof AccountRequest
      */
-    hasAllowedRecommendations: boolean;
+    marketingEmailSubscription?: boolean | null;
     /**
      * 
      * @type {string}
@@ -252,6 +252,42 @@ export interface GetIdCheckTokenResponse {
      * @memberof GetIdCheckTokenResponse
      */
     token?: string | null;
+}/**
+ * 
+ * @export
+ * @interface NotificationSubscriptions
+ */
+export interface NotificationSubscriptions {
+    /**
+     * 
+     * @type {boolean}
+     * @memberof NotificationSubscriptions
+     */
+    marketing_email?: boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof NotificationSubscriptions
+     */
+    marketing_push?: boolean;
+}/**
+ * 
+ * @export
+ * @interface NotificationSubscriptionsUpdate
+ */
+export interface NotificationSubscriptionsUpdate {
+    /**
+     * 
+     * @type {boolean}
+     * @memberof NotificationSubscriptionsUpdate
+     */
+    marketing_email: boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof NotificationSubscriptionsUpdate
+     */
+    marketing_push: boolean;
 }/**
  * 
  * @export
@@ -734,12 +770,6 @@ export interface UserProfileResponse {
     firstName?: string | null;
     /**
      * 
-     * @type {boolean}
-     * @memberof UserProfileResponse
-     */
-    hasAllowedRecommendations: boolean;
-    /**
-     * 
      * @type {number}
      * @memberof UserProfileResponse
      */
@@ -786,6 +816,12 @@ export interface UserProfileResponse {
      * @memberof UserProfileResponse
      */
     showEligibleCard: boolean;
+    /**
+     * 
+     * @type {NotificationSubscriptions}
+     * @memberof UserProfileResponse
+     */
+    subscriptions: NotificationSubscriptions;
 }/**
  * 
  * @export
@@ -794,10 +830,10 @@ export interface UserProfileResponse {
 export interface UserProfileUpdateRequest {
     /**
      * 
-     * @type {boolean}
+     * @type {NotificationSubscriptionsUpdate}
      * @memberof UserProfileUpdateRequest
      */
-    hasAllowedRecommendations?: boolean | null;
+    subscriptions?: NotificationSubscriptionsUpdate | null;
 }/**
  * 
  * @export

--- a/src/features/auth/signup/AcceptCgu.test.tsx
+++ b/src/features/auth/signup/AcceptCgu.test.tsx
@@ -130,7 +130,7 @@ describe('AcceptCgu Page', () => {
         {
           birthdate: '12-2-1995',
           email: 'john.doe@example.com',
-          hasAllowedRecommendations: true,
+          marketingEmailSubscription: true,
           password: 'password',
           token: 'fakeToken',
         },

--- a/src/features/auth/signup/AcceptCgu.tsx
+++ b/src/features/auth/signup/AcceptCgu.tsx
@@ -59,7 +59,7 @@ export const AcceptCgu: FC<Props> = ({ route }) => {
       const signupResponse = await signUp({
         birthdate: birthday,
         email,
-        hasAllowedRecommendations: isNewsletterChecked,
+        marketingEmailSubscription: isNewsletterChecked,
         password,
         token,
       })

--- a/src/features/home/api.test.ts
+++ b/src/features/home/api.test.ts
@@ -24,11 +24,14 @@ const userProfileAPIResponse: UserProfileResponse = {
   email: 'email@domain.ext',
   firstName: 'Jean',
   isBeneficiary: true,
-  hasAllowedRecommendations: true,
   isEligible: true,
   needsToFillCulturalSurvey: true,
   showEligibleCard: false,
   id: 1234,
+  subscriptions: {
+    marketing_email: true,
+    marketing_push: true,
+  },
 }
 server.use(
   rest.get(

--- a/src/features/offer/components/__tests__/OfferIconCaptions.test.tsx
+++ b/src/features/offer/components/__tests__/OfferIconCaptions.test.tsx
@@ -45,11 +45,14 @@ const userProfileAPIResponse: UserProfileResponse = {
       limit: 200,
     },
   ],
-  hasAllowedRecommendations: true,
   isEligible: true,
   needsToFillCulturalSurvey: true,
   showEligibleCard: false,
   id: 1234,
+  subscriptions: {
+    marketing_email: true,
+    marketing_push: true,
+  },
 }
 
 describe('<OfferIconCaptions />', () => {

--- a/src/features/profile/components/ProfileHeader.test.tsx
+++ b/src/features/profile/components/ProfileHeader.test.tsx
@@ -18,10 +18,13 @@ const userV1: UserProfileResponse = {
   ],
   isEligible: true,
   lastName: '93 HNMM 2',
-  hasAllowedRecommendations: true,
   id: 1234,
   needsToFillCulturalSurvey: true,
   showEligibleCard: false,
+  subscriptions: {
+    marketing_email: true,
+    marketing_push: true,
+  },
 }
 
 const userV2: UserProfileResponse = {


### PR DESCRIPTION
(PC-7214) App native - Backend - déplacer l'information  hasAllowedRecommendations dans la colonne notification_subscriptions

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7214

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
