### PR TITLE
(PC-7394) Fix price displayed on search page: sort improperly

### DIFF
--- a/src/libs/parsers/getDisplayPrice.ts
+++ b/src/libs/parsers/getDisplayPrice.ts
@@ -15,7 +15,8 @@ export const formatToFrenchDecimal = (cents: number) => {
 const getPricePerPlace = (prices: number[]): string => {
   const uniquePrices = Array.from(new Set(prices.filter((p) => p > 0)))
   if (uniquePrices.length === 1) return `${formatToFrenchDecimal(uniquePrices[0])}`
-  return `Dès ${formatToFrenchDecimal(uniquePrices.sort()[0])}`
+  const sortedPrices = uniquePrices.sort((a, b) => a - b)
+  return `Dès ${formatToFrenchDecimal(sortedPrices[0])}`
 }
 
 export const getDisplayPrice = (prices: number[] | undefined): string => {

--- a/src/libs/parsers/tests/getDisplayPrice.test.ts
+++ b/src/libs/parsers/tests/getDisplayPrice.test.ts
@@ -2,34 +2,36 @@ import { getDisplayPrice, getDisplayPriceWithDuoMention } from '../getDisplayPri
 
 describe('getDisplayPrice', () => {
   it.each`
-    prices         | expected
-    ${undefined}   | ${''}
-    ${[]}          | ${''}
-    ${[0]}         | ${'Gratuit'}
-    ${[0, 700]}    | ${'Gratuit'}
-    ${[100]}       | ${'1 €'}
-    ${[200]}       | ${'2 €'}
-    ${[345]}       | ${'3,45 €'}
-    ${[350]}       | ${'3,50 €'}
-    ${[560, 300]}  | ${'Dès 3 €'}
-    ${[-300, 560]} | ${'5,60 €'}
-    ${[800, 800]}  | ${'8 €'}
+    prices               | expected
+    ${undefined}         | ${''}
+    ${[]}                | ${''}
+    ${[0]}               | ${'Gratuit'}
+    ${[0, 700]}          | ${'Gratuit'}
+    ${[100]}             | ${'1 €'}
+    ${[200]}             | ${'2 €'}
+    ${[345]}             | ${'3,45 €'}
+    ${[350]}             | ${'3,50 €'}
+    ${[560, 300]}        | ${'Dès 3 €'}
+    ${[200, 1000, 3000]} | ${'Dès 2 €'}
+    ${[-300, 560]}       | ${'5,60 €'}
+    ${[800, 800]}        | ${'8 €'}
   `('getDisplayPrice($prices) \t= $expected', ({ prices, expected }) => {
     expect(getDisplayPrice(prices)).toBe(expected)
   })
 
   it.each`
-    prices         | expected
-    ${undefined}   | ${''}
-    ${[]}          | ${''}
-    ${[0]}         | ${'Gratuit'}
-    ${[0, 700]}    | ${'Gratuit'}
-    ${[100]}       | ${'1 € / place'}
-    ${[200]}       | ${'2 € / place'}
-    ${[345]}       | ${'3,45 € / place'}
-    ${[560, 300]}  | ${'Dès 3 € / place'}
-    ${[-300, 560]} | ${'5,60 € / place'}
-    ${[800, 800]}  | ${'8 € / place'}
+    prices               | expected
+    ${undefined}         | ${''}
+    ${[]}                | ${''}
+    ${[0]}               | ${'Gratuit'}
+    ${[0, 700]}          | ${'Gratuit'}
+    ${[100]}             | ${'1 € / place'}
+    ${[200]}             | ${'2 € / place'}
+    ${[345]}             | ${'3,45 € / place'}
+    ${[200, 1000, 3000]} | ${'Dès 2 € / place'}
+    ${[560, 300]}        | ${'Dès 3 € / place'}
+    ${[-300, 560]}       | ${'5,60 € / place'}
+    ${[800, 800]}        | ${'8 € / place'}
   `('getDisplayPriceWithDuoMention($prices) \t= $expected', ({ prices, expected }) => {
     expect(getDisplayPriceWithDuoMention(prices)).toBe(expected)
   })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7394

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.

## Bug explanation

In javascript:

```js
> [2, 10, 30].sort()
[ 10, 2, 30 ]
```

=> instead of "Dès 2€", we thus showed "Dès 10€".