### PR TITLE
(Tech): remove POC geolib and use previous distance method

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "algoliasearch": "^4.6.0",
     "babel-core": "^6.26.3",
     "contentful-resolve-response": "^1.2.2",
-    "geolib": "^3.3.1",
     "hi-base32": "^0.5.0",
     "highlight-words-core": "^1.2.2",
     "i18n-js": "^3.5.1",

--- a/src/features/cheatcodes/pages/Navigation.tsx
+++ b/src/features/cheatcodes/pages/Navigation.tsx
@@ -1,5 +1,4 @@
 import { useNavigation } from '@react-navigation/native'
-import getDistance from 'geolib/es/getDistance'
 import React, { useState, createElement } from 'react'
 import { Alert, ScrollView } from 'react-native'
 import { useQuery } from 'react-query'
@@ -9,7 +8,7 @@ import { DEEPLINK_DOMAIN } from 'features/deeplinks'
 import { AsyncError } from 'features/errors/pages/AsyncErrorBoundary'
 import { openExternalUrl } from 'features/navigation/helpers'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
-import { useGeolocation } from 'libs/geolocation'
+import { useDistance } from 'features/offer/components/useDistance'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ModalHeader } from 'ui/components/modals/ModalHeader'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
@@ -20,17 +19,18 @@ import { CheatCodesButton } from '../components/CheatCodesButton'
 const BadDeeplink = DEEPLINK_DOMAIN + 'unknown'
 const LoginDeeplink = DEEPLINK_DOMAIN + 'login'
 const MAX_ASYNC_TEST_REQ_COUNT = 3
+const EIFFEL_TOWER_COORDINATES = { lat: 48.8584, lng: 2.2945 }
 
 export function Navigation(): JSX.Element {
   const navigation = useNavigation<UseNavigationType>()
   const [renderedError, setRenderedError] = useState(undefined)
   const [asyncTestReqCount, setAsyncTestReqCount] = useState(0)
+  const distanceToEiffelTower = useDistance(EIFFEL_TOWER_COORDINATES)
+
   const { refetch: errorAsyncQuery, isFetching } = useQuery('errorAsync', () => errorAsync(), {
     cacheTime: 0,
     enabled: false,
   })
-  const { position } = useGeolocation()
-  const eiffelTowerCoordinates = { latitude: 48.8584, longitude: 2.2945 }
 
   async function errorAsync() {
     setAsyncTestReqCount((v) => ++v)
@@ -232,12 +232,7 @@ export function Navigation(): JSX.Element {
           <NavigationButton
             title={`Distance to Eiffel Tower`}
             onPress={() => {
-              if (position) {
-                const distance = getDistance(position, eiffelTowerCoordinates)
-                Alert.alert(`${distance / 1000}km`)
-              } else {
-                Alert.alert('Authorize geolocation first')
-              }
+              Alert.alert(distanceToEiffelTower || 'Authorize geolocation first')
             }}
           />
         </Row>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5820,11 +5820,6 @@ gensync@^1.0.0-beta.1:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
   integrity sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
 
-geolib@^3.3.1:
-  version "3.3.1"
-  resolved "https://npm.kopaxgroup.com:443/geolib/-/geolib-3.3.1.tgz#f144a53b6a6858e81111ff71d137318389927611"
-  integrity sha512-sfahBXFcgELdpumDZV5b3KWiINkZxC5myAkLk067UUcTmTXaiE9SWmxMEHztn/Eus4JX6kesHxaIuZlniYgUtg==
-
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXX

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
