### PR TITLE
(PC-7442) AppModalInformation: fade animation type

### DIFF
--- a/src/ui/components/modals/AppInformationModal.tsx
+++ b/src/ui/components/modals/AppInformationModal.tsx
@@ -3,9 +3,8 @@ import { Modal, TouchableOpacity } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled from 'styled-components/native'
 
-import { ModalOverlay } from 'ui/components/modals/ModalOverlay'
 import { Close } from 'ui/svg/icons/Close'
-import { ColorsEnum, getSpacing, Spacer } from 'ui/theme'
+import { ColorsEnum, getSpacing, Spacer, UniqueColors } from 'ui/theme'
 
 import { ModalHeader } from './ModalHeader'
 
@@ -27,10 +26,9 @@ export const AppInformationModal: FunctionComponent<Props> = ({
   const paddingBottom = Math.max(bottom, getSpacing(3))
   return (
     <React.Fragment>
-      <ModalOverlay visible={visible} />
       {visible && (
         <Modal
-          animationType="slide"
+          animationType="fade"
           statusBarTranslucent
           transparent={true}
           visible={visible}
@@ -60,6 +58,7 @@ const ClicAwayArea = styled(TouchableOpacity)({
   justifyContent: 'flex-end',
   height: '100%',
   width: '100%',
+  backgroundColor: UniqueColors.GREY_OVERLAY,
 })
 
 const Container = styled(TouchableOpacity)({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7442

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

**Avant**: la modale apparaissait du bas vers le milieu de l'écran, mais pour la page profile cela posait problème car le composant `ModalOverlay` n'apparaissait pas au-dessus de la NavBar comme le montre le screenshot.

**Après**: j'ai supprimé la ModalOverlay et coloré la zone de clic en dehors de la modale. Pour que le rendu soit "joli" il a fallu modifier le type d'apparition de la modale en mode "fondu" :

|Avant| Après|
| -------------------- | :----------------------: |
|![Screenshot_20210304-094235](https://user-images.githubusercontent.com/22886846/110515492-bfa64b00-8108-11eb-94e6-78fbe66925fb.jpg)|![modal](https://user-images.githubusercontent.com/22886846/110515244-79e98280-8108-11eb-8518-932cda3b0631.gif)|


## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
