### PR TITLE
(PC-7014) profile pages: fix PageHeader position

### DIFF
--- a/src/features/profile/pages/ChangePassword.tsx
+++ b/src/features/profile/pages/ChangePassword.tsx
@@ -78,7 +78,6 @@ export function ChangePassword() {
 
   return (
     <React.Fragment>
-      <PageHeader title={_(t`Mot de passe`)} />
       <Spacer.TopScreen />
       <Spacer.Column numberOfSpaces={20} />
       <StyledScrollView
@@ -139,6 +138,8 @@ export function ChangePassword() {
         </ButtonContainer>
         <Spacer.Column numberOfSpaces={6} />
       </StyledScrollView>
+
+      <PageHeader title={_(t`Mot de passe`)} />
     </React.Fragment>
   )
 }

--- a/src/features/profile/pages/ConsentSettings.tsx
+++ b/src/features/profile/pages/ConsentSettings.tsx
@@ -56,7 +56,6 @@ export const ConsentSettings: FunctionComponent<Props> = ({ route }) => {
 
   return (
     <React.Fragment>
-      <PageHeader title={_(t`Paramètres de confidentialité`)} onGoBack={route.params?.onGoBack} />
       <Spacer.TopScreen />
       <Spacer.Column numberOfSpaces={18} />
       <ProfileContainer>
@@ -93,6 +92,8 @@ export const ConsentSettings: FunctionComponent<Props> = ({ route }) => {
         <ButtonPrimary title={_(t`Enregistrer`)} onPress={save} disabled={isSaveButtonDisabled} />
         <Spacer.Column numberOfSpaces={8} />
       </ProfileContainer>
+
+      <PageHeader title={_(t`Paramètres de confidentialité`)} onGoBack={route.params?.onGoBack} />
     </React.Fragment>
   )
 }

--- a/src/features/profile/pages/LegalNotices.tsx
+++ b/src/features/profile/pages/LegalNotices.tsx
@@ -19,7 +19,6 @@ export function LegalNotices() {
   const { data: user } = useUserProfileInfo()
   return (
     <React.Fragment>
-      <PageHeader title={_(t`Mentions légales`)} />
       <Spacer.TopScreen />
       <Spacer.Column numberOfSpaces={14} />
       <Container>
@@ -54,6 +53,8 @@ export function LegalNotices() {
           </React.Fragment>
         )}
       </Container>
+
+      <PageHeader title={_(t`Mentions légales`)} />
     </React.Fragment>
   )
 }

--- a/src/features/profile/pages/NotificationSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings.tsx
@@ -105,7 +105,6 @@ export function NotificationSettings() {
 
   return (
     <React.Fragment>
-      <PageHeader title={_(t`Notifications`)} />
       <Spacer.TopScreen />
       <Spacer.Column numberOfSpaces={18} />
       <ProfileContainer>
@@ -162,6 +161,8 @@ export function NotificationSettings() {
         />
         <Spacer.Column numberOfSpaces={8} />
       </ProfileContainer>
+
+      <PageHeader title={_(t`Notifications`)} />
     </React.Fragment>
   )
 }

--- a/src/features/profile/pages/PersonalData.tsx
+++ b/src/features/profile/pages/PersonalData.tsx
@@ -16,7 +16,6 @@ export function PersonalData() {
 
   return (
     <React.Fragment>
-      <PageHeader title={_(t`Informations personnelles`)} />
       <Spacer.TopScreen />
       <Spacer.Column numberOfSpaces={14} />
       <Container>
@@ -47,6 +46,8 @@ export function PersonalData() {
           </React.Fragment>
         )}
       </Container>
+
+      <PageHeader title={_(t`Informations personnelles`)} />
     </React.Fragment>
   )
 }

--- a/src/features/profile/pages/__snapshots__/ChangePassword.test.tsx.snap
+++ b/src/features/profile/pages/__snapshots__/ChangePassword.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ChangePassword should validate PasswordSecurityRules when password is c
 - First value
 + Second value
 
-@@ -442,11 +442,11 @@
+@@ -281,11 +281,11 @@
                     \\"flexShrink\\": 1,
                   },
                 ]
@@ -18,7 +18,7 @@ exports[`ChangePassword should validate PasswordSecurityRules when password is c
               accessible={true}
               focusable={true}
               onClick={[Function onClick]}
-@@ -470,11 +470,197 @@
+@@ -309,11 +309,197 @@
                 height=\\"100%\\"
                 testID=\\"eye-slash\\"
                 width=\\"100%\\"

--- a/src/ui/components/headers/PageHeader.tsx
+++ b/src/ui/components/headers/PageHeader.tsx
@@ -23,7 +23,7 @@ const HeaderIconBack: React.FC<HeaderIconProps> = ({ onGoBack }) => {
   const { goBack } = useNavigation<UseNavigationType>()
   function onPress() {
     if (onGoBack) {
-      onGoBack()
+      return onGoBack()
     }
     goBack()
   }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7014

Sur iOS, le chevron back ne fonctionne pas si le composant PageHeader est situé avant les composants de spacing en haut de l'écran.

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
