### PR TITLE
(PC-7363) Redirect to the right screen when trying to open a universa…

### DIFF
--- a/jest/jest.setup.ts
+++ b/jest/jest.setup.ts
@@ -68,6 +68,8 @@ jest.mock('libs/environment', () => ({
     ID_CHECK_URL: 'https://id-check-unit-tests',
     RECOMMENDATION_ENDPOINT: 'https://recommmendation-endpoint',
     RECOMMENDATION_TOKEN: 'recommmendation-token',
+    CGU_LINK: 'https://passculture.cgu',
+    PRIVACY_POLICY_LINK: 'https://passculture.privacy',
   },
 }))
 

--- a/src/features/deeplinks/useDeeplinkUrlHandler.ts
+++ b/src/features/deeplinks/useDeeplinkUrlHandler.ts
@@ -63,7 +63,7 @@ export function useDeeplinkUrlHandler() {
   }
 }
 
-function getScreenFromDeeplink(url: string) {
+export function getScreenFromDeeplink(url: string) {
   const { routeName, params } = decodeDeeplinkParts(url)
 
   if (!isAllowedRouteTypeGuard(routeName)) {

--- a/src/features/navigation/__tests__/helpers.test.ts
+++ b/src/features/navigation/__tests__/helpers.test.ts
@@ -1,0 +1,50 @@
+import { Linking } from 'react-native'
+
+import { DEEPLINK_DOMAIN } from 'features/deeplinks'
+import { navigationRef } from 'features/navigation/navigationRef'
+
+import { openExternalUrl } from '../helpers'
+
+// Jest.Mocks are located at the end of file for a better reading
+
+describe('Navigation helpers', () => {
+  afterEach(jest.resetAllMocks)
+
+  it('should not capture links that doesnt start with the universal links domain', async () => {
+    const openUrl = jest.spyOn(Linking, 'openURL')
+    const link = 'https://www.google.com'
+    await openExternalUrl(link)
+
+    expect(openUrl).toBeCalled()
+  })
+  it('should capture links that start with the universal links domain', async () => {
+    const openUrl = jest.spyOn(Linking, 'openURL')
+    const link = DEEPLINK_DOMAIN + 'my-route-to-test?param1=ok'
+    await openExternalUrl(link)
+
+    expect(openUrl).not.toBeCalled()
+  })
+  it('should redirect universal links to the right screen', async () => {
+    const link = DEEPLINK_DOMAIN + 'my-route-to-test?param1=ok'
+    await openExternalUrl(link)
+
+    expect(navigationRef.current?.navigate).toBeCalledWith('UniqueTestRoute', { param1: 'ok' })
+  })
+})
+
+jest.mock('features/navigation/navigationRef')
+
+/** FAKING DEEPLINKS ROUTING */
+jest.mock('features/deeplinks/routing', () => ({
+  DEEPLINK_TO_SCREEN_CONFIGURATION: {
+    'my-route-to-test': function (params: Record<string, string>) {
+      return {
+        screen: 'UniqueTestRoute',
+        params: {
+          param1: params.param1,
+        },
+      }
+    },
+  },
+}))
+/** FAKING DEEPLINKS ROUTING END */

--- a/src/features/navigation/helpers.ts
+++ b/src/features/navigation/helpers.ts
@@ -1,6 +1,10 @@
 import { Route, useNavigationState } from '@react-navigation/native'
 import { Linking } from 'react-native'
 
+import { DEEPLINK_DOMAIN } from 'features/deeplinks'
+import { getScreenFromDeeplink } from 'features/deeplinks/useDeeplinkUrlHandler'
+
+import { navigationRef } from './navigationRef'
 import { RouteParams } from './RootNavigator'
 import { TabParamList } from './TabBar/types'
 
@@ -25,6 +29,11 @@ export const homeNavigateConfig: HomeNavigateConfig = {
 }
 
 export async function openExternalUrl(url: string) {
+  if (url.match('^' + DEEPLINK_DOMAIN)) {
+    const { screen, params } = getScreenFromDeeplink(url)
+    return navigationRef.current?.navigate(screen, params)
+  }
+
   const canOpen = await Linking.canOpenURL(url)
   if (canOpen) {
     Linking.openURL(url)


### PR DESCRIPTION
…l link from the app

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7363

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [-] Added new reusable components to the AppComponents page and communicate to the team on slack
- [-] Added a **screenshot** for UI tickets.
- [-] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
