### PR TITLE
(PC-7445) Allow the access to the notifications settings page to unau…

### DIFF
--- a/src/features/profile/pages/NotificationSettings.test.tsx
+++ b/src/features/profile/pages/NotificationSettings.test.tsx
@@ -140,6 +140,20 @@ describe('NotificationSettings', () => {
     )
   })
   describe('The behavior of the save button', () => {
+    it('should be disabled when and grey for unauthenticated users', async () => {
+      const { getByTestId } = await renderNotificationSettings(
+        'granted',
+        {
+          subscriptions: {},
+        } as UserProfileResponse,
+        false
+      )
+      let saveButton: ReactTestInstance | null = null
+      await waitFor(() => {
+        saveButton = getByTestId('button-container')
+        expect(saveButton.props.style.backgroundColor).toEqual(ColorsEnum.GREY_LIGHT)
+      })
+    })
     it('should enable the save button when the email switch changed', async () => {
       mockApiUpdateProfile({
         subscriptions: {
@@ -147,12 +161,16 @@ describe('NotificationSettings', () => {
           marketingPush: true,
         },
       } as UserProfileResponse)
-      const { getByTestId } = await renderNotificationSettings('granted', {
-        subscriptions: {
-          marketingEmail: true,
-          marketingPush: true,
-        },
-      } as UserProfileResponse)
+      const { getByTestId } = await renderNotificationSettings(
+        'granted',
+        {
+          subscriptions: {
+            marketingEmail: true,
+            marketingPush: true,
+          },
+        } as UserProfileResponse,
+        true
+      )
 
       await waitFor(() => {
         const toggleSwitch = getByTestId('email')
@@ -180,12 +198,16 @@ describe('NotificationSettings', () => {
           marketingPush: true,
         },
       } as UserProfileResponse)
-      const { getByTestId } = await renderNotificationSettings('granted', {
-        subscriptions: {
-          marketingEmail: false,
-          marketingPush: false,
-        },
-      } as UserProfileResponse)
+      const { getByTestId } = await renderNotificationSettings(
+        'granted',
+        {
+          subscriptions: {
+            marketingEmail: false,
+            marketingPush: false,
+          },
+        } as UserProfileResponse,
+        true
+      )
 
       await waitFor(() => {
         const toggleSwitch = getByTestId('push')
@@ -214,9 +236,10 @@ const navigationRef = React.createRef<NavigationContainerRef>()
 
 async function renderNotificationSettings(
   expectedPermission: NotificationsResponse['status'],
-  user?: UserProfileResponse
+  user?: UserProfileResponse,
+  isLoggedIn?: boolean
 ) {
-  mockUseAuthContext.mockImplementation(() => ({ isLoggedIn: true } as IAuthContext))
+  mockUseAuthContext.mockImplementation(() => ({ isLoggedIn: isLoggedIn ?? true } as IAuthContext))
 
   const checkNotifications = jest.spyOn(RNP, 'checkNotifications')
   checkNotifications.mockResolvedValue({

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -115,16 +115,16 @@ export const Profile: React.FC = () => {
                 style={styles.row}
                 testID="row-password"
               />
-              <Row
-                type="navigable"
-                title={_(t`Notifications`)}
-                icon={Bell}
-                onPress={() => navigate('NotificationSettings')}
-                style={styles.row}
-                testID="row-notifications"
-              />
             </React.Fragment>
           )}
+          <SectionRow
+            type="navigable"
+            title={_(t`Notifications`)}
+            icon={Bell}
+            onPress={() => navigate('NotificationSettings')}
+            style={styles.row}
+            testID="row-notifications"
+          />
           <SectionRow
             type="clickable"
             title={_(t`Géolocalisation`)}


### PR DESCRIPTION
…thenticated users

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7445

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [x] Added new reusable components to the AppComponents page and communicate to the team on slack
- [x] Added a **screenshot** for UI tickets.
- [x] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Iphone 5s] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
| ![image](https://user-images.githubusercontent.com/6025710/110938271-e98f8580-8333-11eb-89aa-5e72743fc48b.png) |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
