### PR TITLE
(FIX-CI) --follow-tags only pushed annotated tags

### DIFF
--- a/scripts/deploy_new_production_version.sh
+++ b/scripts/deploy_new_production_version.sh
@@ -22,7 +22,7 @@ update_app_version(){
   
   git add package.json
   git commit -m "v${VERSION}"
-  git tag "v${VERSION}"
+  git tag -a "v${VERSION}" -m "v${VERSION}"
 }
 
 check_branch

--- a/scripts/deploy_new_staging_version.sh
+++ b/scripts/deploy_new_staging_version.sh
@@ -22,7 +22,7 @@ update_app_version(){
 
   git add package.json
   git commit -m "v${VERSION}"
-  git tag "v${VERSION}"
+  git tag -a "v${VERSION}" -m "v${VERSION}"
 }
 
 check_branch
@@ -32,4 +32,4 @@ git pull
 update_app_version
 git push --follow-tags
 
-git push -f origin HEAD:staging
+git push origin HEAD:staging

--- a/scripts/deploy_new_testing_version.sh
+++ b/scripts/deploy_new_testing_version.sh
@@ -22,7 +22,7 @@ update_app_version(){
 
   git add package.json
   git commit -m "v${VERSION}"
-  git tag "testing_v${VERSION}"
+  git tag -a "testing_v${VERSION}" -m "v${VERSION}"
 }
 
 


### PR DESCRIPTION
There are two types of tags: lightweight and annotated. 

![image](https://user-images.githubusercontent.com/10118284/110956340-d0de9a00-834a-11eb-874d-92015a78f69e.png)


Ref: https://git-scm.com/book/en/v2/Git-Basics-Tagging