### PR TITLE
(PC-7595) Disable loading button when signup call resolves successfully

### DIFF
--- a/src/features/auth/signup/AcceptCgu.test.tsx
+++ b/src/features/auth/signup/AcceptCgu.test.tsx
@@ -97,6 +97,7 @@ describe('AcceptCgu Page', () => {
 
     expect(recaptchaWebviewModal.props.visible).toBeFalsy()
     expect(renderAPI.queryByText('Hors connexion : en attente du réseau.')).toBeTruthy()
+    expect(renderAPI.queryByTestId('button-isloading-icon')).toBeFalsy()
   })
 
   it("should open reCAPTCHA challenge's modal when pressing on signup button", () => {
@@ -139,6 +140,7 @@ describe('AcceptCgu Page', () => {
       expect(navigate).toBeCalledWith('SignupConfirmationEmailSent', {
         email: 'john.doe@example.com',
       })
+      expect(renderAPI.queryByTestId('button-isloading-icon')).toBeFalsy()
     })
   })
 
@@ -156,6 +158,7 @@ describe('AcceptCgu Page', () => {
       ).toBeTruthy()
       expect(postnativev1accountSpy).not.toBeCalled()
       expect(navigate).not.toBeCalled()
+      expect(renderAPI.queryByTestId('button-isloading-icon')).toBeFalsy()
     })
   })
 
@@ -171,6 +174,7 @@ describe('AcceptCgu Page', () => {
       expect(renderAPI.queryByText('Le token reCAPTCHA a expiré, tu peux réessayer.')).toBeTruthy()
       expect(postnativev1accountSpy).not.toBeCalled()
       expect(navigate).not.toBeCalled()
+      expect(renderAPI.queryByTestId('button-isloading-icon')).toBeFalsy()
     })
   })
 

--- a/src/features/auth/signup/AcceptCgu.tsx
+++ b/src/features/auth/signup/AcceptCgu.tsx
@@ -68,8 +68,9 @@ export const AcceptCgu: FC<Props> = ({ route }) => {
       }
       navigate('SignupConfirmationEmailSent', { email })
     } catch (_error) {
-      setIsFetching(false)
       setErrorMessage(_(t`Un problème est survenu pendant l'inscription, réessaie plus tard.`))
+    } finally {
+      setIsFetching(false)
     }
   }
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7595

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).
