### PR TITLE
(PC-6690) Fix booking date selection in western timezones

### DIFF
--- a/src/features/bookOffer/components/Calendar/DayComponent.tsx
+++ b/src/features/bookOffer/components/Calendar/DayComponent.tsx
@@ -26,7 +26,7 @@ export const DayComponent: React.FC<Props> = ({ status, selected, date }) => {
   const debouncedDispatch = useRef(debounce(dispatch, 500)).current
 
   const selectDate = () => {
-    dispatch({ type: 'SELECT_DATE', payload: new Date(date.timestamp) })
+    dispatch({ type: 'SELECT_DATE', payload: new Date(date.year, date.month - 1, date.day) })
     debouncedDispatch({ type: 'CHANGE_STEP', payload: Step.HOUR })
   }
 


### PR DESCRIPTION
`new Date("2021-03-21")` in a GMT-3 timezone results to the day before : `2021-03-20T21:00 GMT-3`.

So use the year, month, day to construct the desired "date".



Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-6690



## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.