### PR TITLE
(PC-7149) App native - Favoris - Bouton Crédit insuffisant fix

### DIFF
--- a/src/features/favorites/atoms/Favorite.tsx
+++ b/src/features/favorites/atoms/Favorite.tsx
@@ -130,7 +130,8 @@ export const Favorite: React.FC<Props> = (props) => {
     return <ButtonPrimary title={_(t`Réserver`)} onPress={bookInApp} buttonHeight="tall" />
   }
 
-  const buttons = useMemo(renderBookingButton, [offer, props])
+  const bookingButton = useMemo(renderBookingButton, [props])
+
   return (
     <Container onPress={handlePressOffer} testID="favorite">
       <Row>
@@ -173,7 +174,7 @@ export const Favorite: React.FC<Props> = (props) => {
             disabled={isLoading}
           />
         </ButtonContainer>
-        <ButtonContainer>{buttons}</ButtonContainer>
+        <ButtonContainer>{bookingButton}</ButtonContainer>
       </ButtonsRow>
     </Container>
   )


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7149

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
