### PR TITLE
(PC-7022) App native - Favoris - Afficher le nombre de favoris dans la navbar fix

### DIFF
--- a/src/features/favorites/atoms/BicolorFavoriteCount.tsx
+++ b/src/features/favorites/atoms/BicolorFavoriteCount.tsx
@@ -22,7 +22,8 @@ export const BicolorFavoriteCount: React.FC<BicolorIconInterface> = ({
   testID,
 }) => {
   const { isLoggedIn } = useAuthContext()
-  const { data } = useFavorites()
+  // const { data } = useFavorites()
+  const data = { nbFavorites: 1000 }
   const scaleAnimation = useRef(new Animated.Value(1))
   useEffect(() => {
     if (data?.nbFavorites) {
@@ -104,5 +105,6 @@ const Count = styled(Typo.Caption).attrs({
   fontSize: 9,
   textAlign: 'center',
   height: 15,
+  bottom: 5,
   paddingRight,
 }))

--- a/src/features/favorites/atoms/BicolorFavoriteCount.tsx
+++ b/src/features/favorites/atoms/BicolorFavoriteCount.tsx
@@ -22,8 +22,7 @@ export const BicolorFavoriteCount: React.FC<BicolorIconInterface> = ({
   testID,
 }) => {
   const { isLoggedIn } = useAuthContext()
-  // const { data } = useFavorites()
-  const data = { nbFavorites: 1000 }
+  const { data } = useFavorites()
   const scaleAnimation = useRef(new Animated.Value(1))
   useEffect(() => {
     if (data?.nbFavorites) {
@@ -95,7 +94,8 @@ const Plus = styled(Typo.Caption).attrs({
   position: 'absolute',
   fontSize: 8,
   height: 15,
-  right: 3,
+  right: 2,
+  bottom: 1,
 })
 
 const Count = styled(Typo.Caption).attrs({
@@ -105,6 +105,6 @@ const Count = styled(Typo.Caption).attrs({
   fontSize: 9,
   textAlign: 'center',
   height: 15,
-  bottom: 5,
   paddingRight,
+  bottom: 1,
 }))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7022

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [x] Added new reusable components to the AppComponents page and communicate to the team on slack
- [x] Added a **screenshot** for UI tickets.

## Screenshots

| \*iOS - [Phone name] | \*Android - [s9] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      | ![image](https://user-images.githubusercontent.com/77674046/111465906-ebd25500-8722-11eb-89a3-473afe0367e8.png) |                       |                       |



## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
