### PR TITLE
(PC-6690) Use eligibility start/end date for NonBeneficiaryHeader

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,3 +207,9 @@ You can use test accounts:
 
 - email: `pctest.jeune97.has-signed-up.v2@example.com`
 - mdp: `user@AZERTY123`
+
+## API Schema
+
+To update the API schema, run: `yarn generate:api:client`
+
+If the file `src/api/gen/.swagger-codegen/VERSION` changes, make sure you locally have the desired version of `swagger-codegen-cli`, otherwise run `docker pull swaggerapi/swagger-codegen-cli-v3:3.0.24`

--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -1157,10 +1157,10 @@ export interface SigninResponse {
 export interface UserProfileResponse {
     /**
      * 
-     * @type {Date}
+     * @type {string}
      * @memberof UserProfileResponse
      */
-    dateOfBirth?: Date | null;
+    dateOfBirth?: string | null;
     /**
      * 
      * @type {Date}
@@ -1179,6 +1179,18 @@ export interface UserProfileResponse {
      * @memberof UserProfileResponse
      */
     domainsCredit?: DomainsCredit | null;
+    /**
+     * 
+     * @type {Date}
+     * @memberof UserProfileResponse
+     */
+    eligibilityEndDatetime?: Date | null;
+    /**
+     * 
+     * @type {Date}
+     * @memberof UserProfileResponse
+     */
+    eligibilityStartDatetime?: Date | null;
     /**
      * 
      * @type {string}
@@ -1209,12 +1221,6 @@ export interface UserProfileResponse {
      * @memberof UserProfileResponse
      */
     isBeneficiary: boolean;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof UserProfileResponse
-     */
-    isEligible: boolean;
     /**
      * 
      * @type {string}

--- a/src/features/cheatcodes/pages/AppComponents.tsx
+++ b/src/features/cheatcodes/pages/AppComponents.tsx
@@ -596,7 +596,11 @@ export const AppComponents: FunctionComponent = () => {
         </View>
         <Spacer.Column numberOfSpaces={4} />
         <View>
-          <NonBeneficiaryHeader email="john@doe.com" dateOfBirth={`${year}-01-28T01:32:15`} />
+          <NonBeneficiaryHeader
+            email="john@doe.com"
+            eligibilityStartDatetime={`${year + 18}-01-28T00:00Z`}
+            eligibilityEndDatetime={`${year + 19}-01-28T00:00Z`}
+          />
         </View>
         <View>
           <AlignedText>

--- a/src/features/home/api.test.ts
+++ b/src/features/home/api.test.ts
@@ -24,7 +24,6 @@ const userProfileAPIResponse: UserProfileResponse = {
   email: 'email@domain.ext',
   firstName: 'Jean',
   isBeneficiary: true,
-  isEligible: true,
   needsToFillCulturalSurvey: true,
   showEligibleCard: false,
   id: 1234,

--- a/src/features/offer/components/__tests__/OfferIconCaptions.test.tsx
+++ b/src/features/offer/components/__tests__/OfferIconCaptions.test.tsx
@@ -45,7 +45,6 @@ const userProfileAPIResponse: UserProfileResponse = {
       limit: 200,
     },
   ],
-  isEligible: true,
   needsToFillCulturalSurvey: true,
   showEligibleCard: false,
   id: 1234,

--- a/src/features/profile/components/NonBeneficiaryHeader.test.tsx
+++ b/src/features/profile/components/NonBeneficiaryHeader.test.tsx
@@ -22,21 +22,27 @@ describe('NonBeneficiaryHeader', () => {
   afterAll(() => mockdate.reset())
 
   it('should render the right body for user under 18 years old', () => {
-    const today = '2021-01-30T00:00:00'
-    const birthday = '2003-01-31T00:00:00'
+    const today = '2021-01-30T00:00:00Z'
     mockdate.set(new Date(today))
     const { getByTestId } = render(
-      <NonBeneficiaryHeader email="john@doe.com" dateOfBirth={birthday} />
+      <NonBeneficiaryHeader
+        email="john@doe.com"
+        eligibilityStartDatetime="2021-01-31T00:00Z"
+        eligibilityEndDatetime="2022-01-31T00:00Z"
+      />
     )
 
     getByTestId('younger-badge')
   })
   it('should render the right body for 18 years old users', () => {
-    const today = '2021-02-30T00:00:00'
-    const birthday = '2003-01-31T00:00:00'
+    const today = '2021-02-30T00:00:00Z'
     mockdate.set(new Date(today))
     const { getByTestId } = render(
-      <NonBeneficiaryHeader email="john@doe.com" dateOfBirth={birthday} />
+      <NonBeneficiaryHeader
+        email="john@doe.com"
+        eligibilityStartDatetime="2021-02-30T00:00Z"
+        eligibilityEndDatetime="2022-02-30T00:00Z"
+      />
     )
 
     getByTestId('body-container-18')
@@ -51,10 +57,13 @@ describe('NonBeneficiaryHeader', () => {
   })
   it('should render the right body for user above 18 years old', () => {
     const today = '2021-02-30T00:00:00'
-    const birthday = '2002-01-31T00:00:00'
     mockdate.set(new Date(today))
     const { queryByTestId } = render(
-      <NonBeneficiaryHeader email="john@doe.com" dateOfBirth={birthday} />
+      <NonBeneficiaryHeader
+        email="john@doe.com"
+        eligibilityStartDatetime="2020-02-30T00:00Z"
+        eligibilityEndDatetime="2021-02-30T00:00Z"
+      />
     )
     const container = queryByTestId('body-container')
     expect(container).toBeNull()

--- a/src/features/profile/components/NonBeneficiaryHeader.tsx
+++ b/src/features/profile/components/NonBeneficiaryHeader.tsx
@@ -5,60 +5,60 @@ import styled from 'styled-components/native'
 
 import { useGetIdCheckToken } from 'features/auth/api'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
-import { dateDiffInFullYears, formatToSlashedFrenchDate } from 'libs/dates'
+import { formatToSlashedFrenchDate } from 'libs/dates'
 import { _ } from 'libs/i18n'
 import SvgPageHeader from 'ui/components/headers/SvgPageHeader'
 import { ModuleBanner } from 'ui/components/ModuleBanner'
 import { ThumbUp } from 'ui/svg/icons/ThumbUp'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
-import { computeEligibilityExpiracy } from '../utils'
-
 import { YoungerBadge } from './YoungerBadge'
 
 interface NonBeneficiaryHeaderProps {
   email: string
-  dateOfBirth: string
+  eligibilityStartDatetime: string
+  eligibilityEndDatetime: string
 }
 
 function NonBeneficiaryHeaderComponent(props: PropsWithChildren<NonBeneficiaryHeaderProps>) {
   const { navigate } = useNavigation<UseNavigationType>()
-  const age = dateDiffInFullYears(new Date(props.dateOfBirth), new Date())
-  const expiracyDate = formatToSlashedFrenchDate(
-    computeEligibilityExpiracy(props.dateOfBirth).toISOString()
-  )
+  const today = new Date()
+  const eligibilityStartDatetime = new Date(props.eligibilityStartDatetime)
+  const eligibilityEndDatetime = new Date(props.eligibilityEndDatetime)
 
-  const shouldLoadIdCheckToken = age === 18
-  const { data } = useGetIdCheckToken(shouldLoadIdCheckToken)
+  const isEligible = today >= eligibilityStartDatetime && today < eligibilityEndDatetime
+  const { data } = useGetIdCheckToken(isEligible)
   const licenceToken = data?.token || ''
 
   let body = null
-  switch (true) {
-    case age > 18:
-      body = <BodyContainer testID="body-container-above-18" padding={1} />
-      break
-    case age === 18:
-      body = (
-        <BodyContainer testID="body-container-18">
-          <Typo.Caption>{_(t`Tu es éligible jusqu'au\u00a0${expiracyDate}`)}</Typo.Caption>
-          <Spacer.Column numberOfSpaces={1} />
-          <ModuleBanner
-            onPress={() => navigate('IdCheck', { email: props.email, licenceToken })}
-            leftIcon={<ThumbUp size={68} />}
-            title={_(t`Profite de 300\u00a0€\u00a0`)}
-            subTitle={_(t`à dépenser dans l'application`)}
-            testID="18-banner"
-          />
-        </BodyContainer>
-      )
-      break
-    case age < 18:
-      body = (
-        <BodyContainer testID="body-container-under-18">
-          <YoungerBadge />
-        </BodyContainer>
-      )
-      break
+  if (today >= eligibilityEndDatetime) {
+    body = <BodyContainer testID="body-container-above-18" padding={1} />
+  } else if (today >= eligibilityStartDatetime) {
+    body = (
+      <BodyContainer testID="body-container-18">
+        <Typo.Caption>
+          {_(
+            t`Tu es éligible jusqu'au\u00a0${formatToSlashedFrenchDate(
+              eligibilityEndDatetime.toISOString()
+            )}`
+          )}
+        </Typo.Caption>
+        <Spacer.Column numberOfSpaces={1} />
+        <ModuleBanner
+          onPress={() => navigate('IdCheck', { email: props.email, licenceToken })}
+          leftIcon={<ThumbUp size={68} />}
+          title={_(t`Profite de 300\u00a0€\u00a0`)}
+          subTitle={_(t`à dépenser dans l'application`)}
+          testID="18-banner"
+        />
+      </BodyContainer>
+    )
+  } else {
+    body = (
+      <BodyContainer testID="body-container-under-18">
+        <YoungerBadge />
+      </BodyContainer>
+    )
   }
 
   return (

--- a/src/features/profile/components/ProfileHeader.test.tsx
+++ b/src/features/profile/components/ProfileHeader.test.tsx
@@ -8,7 +8,7 @@ const userV1: UserProfileResponse = {
   email: 'email2@domain.ext',
   firstName: 'Jean',
   isBeneficiary: true,
-  dateOfBirth: new Date('2003-01-01T00:00:00'),
+  dateOfBirth: '2003-01-01',
   depositExpirationDate: new Date('2023-02-09T11:17:14.786670'),
   depositVersion: 1,
   expenses: [
@@ -16,7 +16,6 @@ const userV1: UserProfileResponse = {
     { current: 0, domain: ExpenseDomain.Digital, limit: 10000 },
     { current: 0, domain: ExpenseDomain.Physical, limit: 10000 },
   ],
-  isEligible: true,
   lastName: '93 HNMM 2',
   id: 1234,
   needsToFillCulturalSurvey: true,

--- a/src/features/profile/components/ProfileHeader.tsx
+++ b/src/features/profile/components/ProfileHeader.tsx
@@ -46,11 +46,17 @@ export function ProfileHeader(props: ProfileHeaderProps) {
     )
   }
 
-  if (!user.dateOfBirth) {
+  if (!user.eligibilityStartDatetime || !user.eligibilityEndDatetime) {
     return null
   }
 
-  return <NonBeneficiaryHeader email={user.email} dateOfBirth={user.dateOfBirth.toString()} />
+  return (
+    <NonBeneficiaryHeader
+      email={user.email}
+      eligibilityStartDatetime={user.eligibilityStartDatetime.toString()}
+      eligibilityEndDatetime={user.eligibilityEndDatetime.toString()}
+    />
+  )
 }
 
 export function getBeneficiaryHeaderProps(

--- a/src/features/profile/utils.test.ts
+++ b/src/features/profile/utils.test.ts
@@ -1,12 +1,7 @@
 import { Expense, ExpenseDomain } from 'api/gen/api'
 import { ExpenseV2 } from 'features/profile/components/types'
 
-import {
-  computeEligibilityExpiracy,
-  computeRemainingCredit,
-  computeWalletBalance,
-  sortExpenses,
-} from './utils'
+import { computeRemainingCredit, computeWalletBalance, sortExpenses } from './utils'
 
 const expensesV1: Array<Expense> = [
   { current: 50, domain: ExpenseDomain.Digital, limit: 100 },
@@ -20,18 +15,6 @@ const expensesV2: Array<ExpenseV2> = [
 ]
 
 describe('profile utils', () => {
-  describe('computeEligibilityExpiracy', () => {
-    it.each([
-      // [birthday, expiracy]
-      ['2003-01-13T00:00:00', '2022-01-12T23:59:59.000Z'], // check year variation
-      ['2003-02-01T00:00:00', '2022-01-31T23:59:59.000Z'], // check month variation
-    ])('', (birthday, expectedExpiracy) => {
-      const expiracy = computeEligibilityExpiracy(birthday)
-
-      expect(expiracy.toISOString()).toEqual(expectedExpiracy)
-    })
-  })
-
   describe('sortExpenses', () => {
     it('should sort version 1 expenses in the right order', () => {
       expect(sortExpenses(1, expensesV1)).toEqual([

--- a/src/features/profile/utils.ts
+++ b/src/features/profile/utils.ts
@@ -4,20 +4,6 @@ import { Expense, ExpenseDomain } from 'api/gen/api'
 import { ExpenseDomainOrderV1, ExpenseDomainOrderV2 } from 'features/profile/components/types'
 import { ExpenseV2 } from 'features/profile/components/types'
 
-/**
- * Formats an iso date to a slashed french date.
- * @param ISOBirthday the birthday date into the ISO 8601 format %Y-%m-%dT%H:%M:%S
- */
-export function computeEligibilityExpiracy(ISOBirthday: string) {
-  const date = new Date(ISOBirthday)
-  date.setFullYear(date.getFullYear() + 19)
-  date.setDate(date.getDate() - 1)
-  date.setHours(23)
-  date.setMinutes(59)
-  date.setSeconds(59)
-  return date
-}
-
 export function sortExpenses(depositVersion: 1 | 2, expenses: Expense[] | ExpenseV2[]) {
   if (depositVersion === 1) {
     return _.sortBy(expenses, function (expense: Expense) {


### PR DESCRIPTION
This prevents from having timezone offsets: In china frontend hour would say the user is 18, although the user is still 17 for the server which would reject id-check request.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXX

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.