### PR TITLE
(PC-7428) Bookings: fix plural

### DIFF
--- a/src/features/bookings/components/OnGoingBookingsList.tsx
+++ b/src/features/bookings/components/OnGoingBookingsList.tsx
@@ -1,3 +1,4 @@
+import { t } from '@lingui/macro'
 import { useNavigation } from '@react-navigation/native'
 import React, { useCallback } from 'react'
 import { FlatList, ListRenderItem, View } from 'react-native'
@@ -5,7 +6,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled from 'styled-components/native'
 
 import { UseNavigationType } from 'features/navigation/RootNavigator'
-import { i18n } from 'libs/i18n'
+import { _ } from 'libs/i18n'
 import { Badge } from 'ui/components/Badge'
 import { SectionRow } from 'ui/components/SectionRow'
 import { TAB_BAR_COMP_HEIGHT } from 'ui/theme'
@@ -28,21 +29,13 @@ export function OnGoingBookingsList(props: OnGoingBookingsListProps) {
   const { bottom } = useSafeAreaInsets()
 
   const bookings = props.bookings || emptyBookings
-  const hasBookings = bookings.length > 0
+  const onGoingBookingsCount = bookings.length
+  const hasBookings = onGoingBookingsCount > 0
   const bookingsCountLabel =
-    `${bookings.length}\u00a0` +
-    i18n.plural({
-      value: bookings.length,
-      one: 'réservation en cours',
-      other: 'réservations en cours',
-    })
+    `${onGoingBookingsCount}\u00a0` + getBookingsCountLabel(onGoingBookingsCount > 1)
 
   const endedBookings = props?.endedBookings || emptyBookings
-  const endedBookingsLabel = i18n.plural({
-    value: endedBookings.length,
-    one: 'Réservation terminée',
-    other: 'Réservations terminées',
-  })
+  const endedBookingsLabel = getEndedBookingsCountLabel(endedBookings.length > 1)
 
   const ListEmptyComponent = useCallback(() => <NoBookingsView />, [])
   const ListHeaderComponent = useCallback(
@@ -84,6 +77,13 @@ export function OnGoingBookingsList(props: OnGoingBookingsListProps) {
     </Container>
   )
 }
+
+const getBookingsCountLabel = (plural: boolean) =>
+  plural ? _(t`réservations en cours`) : _(t`réservation en cours`)
+
+const getEndedBookingsCountLabel = (plural: boolean) =>
+  plural ? _(t`Réservations terminées`) : _(t`Réservation terminée`)
+
 const Container = styled.View<{ flex?: number }>(({ flex }) => ({
   flex,
   height: '100%',

--- a/src/features/bookings/pages/EndedBookings.tsx
+++ b/src/features/bookings/pages/EndedBookings.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { ScrollView } from 'react-native-gesture-handler'
 import styled from 'styled-components/native'
 
-import { i18n, _ } from 'libs/i18n'
+import { _ } from 'libs/i18n'
 import { PageHeader } from 'ui/components/headers/PageHeader'
 import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
 
@@ -14,12 +14,7 @@ export const EndedBookings: React.FC = () => {
 
   const endedBookingsCount = bookings?.ended_bookings?.length || 0
   const endedBookingsLabel =
-    `${endedBookingsCount}\u00a0` +
-    i18n.plural({
-      value: endedBookingsCount,
-      one: 'réservation terminée',
-      other: 'réservations terminées',
-    })
+    `${endedBookingsCount}\u00a0` + getEndedBookingsCountLabel(endedBookingsCount > 1)
 
   return (
     <ScrollView>
@@ -32,6 +27,9 @@ export const EndedBookings: React.FC = () => {
     </ScrollView>
   )
 }
+
+const getEndedBookingsCountLabel = (plural: boolean) =>
+  plural ? _(t`réservations terminées`) : _(t`réservation terminée`)
 
 const EndedBookingsCount = styled(Typo.Body)({
   color: ColorsEnum.GREY_DARK,

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -53,8 +53,8 @@ msgstr "Abandonner l'inscription"
 msgid "Accepter et s’inscrire"
 msgstr "Accepter et s’inscrire"
 
-#: src/features/offer/pages/Offer.tsx:91
-#: src/features/profile/pages/Profile.tsx:101
+#: src/features/offer/pages/OfferBody.tsx:59
+#: src/features/profile/pages/Profile.tsx:105
 msgid "Accessibilité"
 msgstr "Accessibilité"
 
@@ -71,7 +71,7 @@ msgid "Active la géolocalisation pour découvrir toutes les offres existantes a
 msgstr "Active la géolocalisation pour découvrir toutes les offres existantes autour de toi."
 
 #: src/features/firstTutorial/pages/FirstTutorial/components/ThirdCard.tsx:32
-#: src/libs/geolocation/components/GeolocationActivationModal.tsx:25
+#: src/libs/geolocation/components/GeolocationActivationModal.tsx:26
 msgid "Activer la géolocalisation"
 msgstr "Activer la géolocalisation"
 
@@ -102,7 +102,7 @@ msgstr "Afficher {nbHits} résultat"
 msgid "Aide-nous à en savoir plus sur tes pratiques culturelles ! Ta sélection n'aura pas d'impact sur les offres proposées."
 msgstr "Aide-nous à en savoir plus sur tes pratiques culturelles ! Ta sélection n'aura pas d'impact sur les offres proposées."
 
-#: src/features/profile/pages/Profile.tsx:96
+#: src/features/profile/pages/Profile.tsx:100
 msgid "Aides"
 msgstr "Aides"
 
@@ -110,7 +110,7 @@ msgstr "Aides"
 msgid "Ajoute cette offre à tes favoris et rends-toi vite sur le site pass Culture afin de la réserver."
 msgstr "Ajoute cette offre à tes favoris et rends-toi vite sur le site pass Culture afin de la réserver."
 
-#: src/features/favorites/pages/FavoritesSorts.tsx:51
+#: src/features/favorites/pages/FavoritesSorts.tsx:28
 msgid "Ajouté récemment"
 msgstr "Ajouté récemment"
 
@@ -147,19 +147,20 @@ msgstr "Aucun résultat"
 msgid "Aucune valeur à sauvegarder"
 msgstr "Aucune valeur à sauvegarder"
 
+#: src/features/bookings/components/OnGoingBookingItem.tsx:84
 #: src/features/search/sections/OfferDate.tsx:34
 msgid "Aujourd'hui"
 msgstr "Aujourd'hui"
 
-#: src/libs/notifications/components/PushNotificationsModal.tsx:22
+#: src/libs/notifications/components/PushNotificationsModal.tsx:23
 msgid "Autoriser les notifications"
 msgstr "Autoriser les notifications"
 
-#: src/features/profile/pages/NotificationSettings.tsx:131
+#: src/features/profile/pages/NotificationSettings.tsx:133
 msgid "Autoriser les notifications marketing"
 msgstr "Autoriser les notifications marketing"
 
-#: src/features/profile/pages/NotificationSettings.tsx:121
+#: src/features/profile/pages/NotificationSettings.tsx:123
 msgid "Autoriser l’envoi d’e\\u2011mails"
 msgstr "Autoriser l’envoi d’e\\u2011mails"
 
@@ -171,9 +172,13 @@ msgstr "Autoriser l’utilisation de mes données de navigation"
 msgid "Autour de moi"
 msgstr "Autour de moi"
 
-#: src/features/profile/pages/Profile.tsx:100
+#: src/features/profile/pages/Profile.tsx:104
 msgid "Autres"
 msgstr "Autres"
+
+#: src/features/bookings/components/OnGoingBookingItem.tsx:98
+msgid "Avant dernier jour pour retirer"
+msgstr "Avant dernier jour pour retirer"
 
 #. Welcome title message
 #: src/features/home/pages/Home.tsx:76
@@ -202,7 +207,7 @@ msgstr "Catégories"
 msgid "Ce lien de validation n'est plus valide"
 msgstr "Ce lien de validation n'est plus valide"
 
-#: src/features/profile/components/BeneficiaryCeilings.tsx:18
+#: src/features/profile/components/BeneficiaryCeilings.tsx:19
 msgid "Ce plafond a été mis en place pour favoriser la diversification des pratiques culturelles."
 msgstr "Ce plafond a été mis en place pour favoriser la diversification des pratiques culturelles."
 
@@ -210,7 +215,7 @@ msgstr "Ce plafond a été mis en place pour favoriser la diversification des pr
 msgid "Ce week-end"
 msgstr "Ce week-end"
 
-#: src/features/profile/components/BeneficiaryCeilings.tsx:17
+#: src/features/profile/components/BeneficiaryCeilings.tsx:18
 msgid "Ces plafonds ont été mis en place pour favoriser la diversification des pratiques culturelles."
 msgstr "Ces plafonds ont été mis en place pour favoriser la diversification des pratiques culturelles."
 
@@ -265,7 +270,7 @@ msgstr "Clique sur le lien reçu à l'adresse :"
 msgid "Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien."
 msgstr "Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien."
 
-#: src/features/profile/pages/Profile.tsx:97
+#: src/features/profile/pages/Profile.tsx:101
 msgid "Comment ça marche ?"
 msgstr "Comment ça marche ?"
 
@@ -285,7 +290,7 @@ msgstr "Conditions Générales d’Utilisation"
 msgid "Conditions d'annulation"
 msgstr "Conditions d'annulation"
 
-#: src/features/profile/pages/Profile.tsx:103
+#: src/features/profile/pages/Profile.tsx:107
 msgid "Confidentialité"
 msgstr "Confidentialité"
 
@@ -297,14 +302,14 @@ msgstr "Confirme ton e\\u2011mail"
 msgid "Confirmer la réservation"
 msgstr "Confirmer la réservation"
 
-#: src/features/auth/forgottenPassword/ReinitializePassword.tsx:62
 #: src/features/auth/forgottenPassword/ReinitializePassword.tsx:64
-#: src/features/profile/pages/ChangePassword.tsx:79
+#: src/features/auth/forgottenPassword/ReinitializePassword.tsx:66
 #: src/features/profile/pages/ChangePassword.tsx:81
+#: src/features/profile/pages/ChangePassword.tsx:83
 msgid "Confirmer le mot de passe"
 msgstr "Confirmer le mot de passe"
 
-#: src/features/profile/components/LoggedOutHeader.tsx:28
+#: src/features/profile/components/LoggedOutHeader.tsx:32
 msgid "Connecte-toi"
 msgstr "Connecte-toi"
 
@@ -333,7 +338,7 @@ msgstr "Consulter mes e-mails"
 msgid "Contacter le support"
 msgstr "Contacter le support"
 
-#: src/features/auth/forgottenPassword/ReinitializePassword.tsx:69
+#: src/features/auth/forgottenPassword/ReinitializePassword.tsx:71
 #: src/features/auth/signup/SetBirthday.tsx:141
 #: src/features/auth/signup/SetEmail.tsx:78
 #: src/features/auth/signup/SetPassword.tsx:44
@@ -374,6 +379,14 @@ msgstr "Date de l'offre"
 msgid "Date précise"
 msgstr "Date précise"
 
+#: src/features/bookings/components/OnGoingBookingItem.tsx:87
+msgid "Demain"
+msgstr "Demain"
+
+#: src/features/bookings/components/OnGoingBookingItem.tsx:95
+msgid "Dernier jour pour retirer"
+msgstr "Dernier jour pour retirer"
+
 #: src/features/firstTutorial/pages/FirstTutorial/components/FourthCard.tsx:21
 msgid "Des nouveautés"
 msgstr "Des nouveautés"
@@ -386,12 +399,12 @@ msgstr "Des offres pour tous"
 msgid "Distance"
 msgstr "Distance"
 
-#: src/libs/parsers/formatDates.ts:66
-#: src/libs/parsers/formatDates.ts:70
+#: src/libs/parsers/formatDates.ts:76
+#: src/libs/parsers/formatDates.ts:80
 msgid "Du {0} au {formattedEndDate}"
 msgstr "Du {0} au {formattedEndDate}"
 
-#: src/libs/parsers/formatDates.ts:68
+#: src/libs/parsers/formatDates.ts:78
 msgid "Du {0} {1} au {formattedEndDate}"
 msgstr "Du {0} {1} au {formattedEndDate}"
 
@@ -403,11 +416,11 @@ msgid "Duo"
 msgstr "Duo"
 
 #: src/features/favorites/atoms/Favorite.tsx:49
-#: src/libs/parsers/formatDates.ts:54
+#: src/libs/parsers/formatDates.ts:64
 msgid "Dès le {0}"
 msgstr "Dès le {0}"
 
-#: src/features/profile/pages/Profile.tsx:116
+#: src/features/profile/pages/Profile.tsx:120
 msgid "Déconnexion"
 msgstr "Déconnexion"
 
@@ -444,9 +457,9 @@ msgstr "En raison d’une erreur technique, l’offre n’a pas pu être réserv
 msgid "En voir plus"
 msgstr "En voir plus"
 
-#: src/features/profile/pages/ChangePassword.tsx:90
+#: src/features/profile/pages/ChangePassword.tsx:92
 #: src/features/profile/pages/ConsentSettings.tsx:82
-#: src/features/profile/pages/NotificationSettings.tsx:136
+#: src/features/profile/pages/NotificationSettings.tsx:138
 msgid "Enregistrer"
 msgstr "Enregistrer"
 
@@ -464,8 +477,8 @@ msgstr "Erreur lors de la récupération du token d'accès"
 msgid "Erreur réseau. Tu peux réessayer une fois la connexion réétablie."
 msgstr "Erreur réseau. Tu peux réessayer une fois la connexion réétablie."
 
-#: src/features/bookings/components/NoBookingsView.tsx:22
-#: src/features/favorites/components/NoFavoritesResult.tsx:31
+#: src/features/bookings/components/NoBookingsView.tsx:21
+#: src/features/favorites/components/NoFavoritesResult.tsx:21
 msgid "Explorer les offres"
 msgstr "Explorer les offres"
 
@@ -485,7 +498,7 @@ msgstr "Format de l'e-mail incorrect"
 msgid "Gratuit"
 msgstr "Gratuit"
 
-#: src/features/profile/pages/Profile.tsx:94
+#: src/features/profile/pages/Profile.tsx:98
 msgid "Géolocalisation"
 msgstr "Géolocalisation"
 
@@ -529,11 +542,11 @@ msgid "Il y a eu un problème. Tu peux réessayer plus tard."
 msgstr "Il y a eu un problème. Tu peux réessayer plus tard."
 
 #: src/features/profile/pages/PersonalData.tsx:41
-#: src/features/profile/pages/Profile.tsx:90
+#: src/features/profile/pages/Profile.tsx:94
 msgid "Informations personnelles"
 msgstr "Informations personnelles"
 
-#: src/features/profile/components/LoggedOutHeader.tsx:20
+#: src/features/profile/components/LoggedOutHeader.tsx:21
 msgid "Inscris-toi pour accéder à toutes les fonctionnalités de l’application"
 msgstr "Inscris-toi pour accéder à toutes les fonctionnalités de l’application"
 
@@ -545,11 +558,11 @@ msgstr "Je cherche"
 msgid "Je t'invite à découvrir une super offre sur le pass Culture !"
 msgstr "Je t'invite à découvrir une super offre sur le pass Culture !"
 
-#: src/features/profile/pages/NotificationSettings.tsx:118
+#: src/features/profile/pages/NotificationSettings.tsx:120
 msgid "Je veux recevoir les actualités et les meilleures offres du pass Culture par e\\u2011mail."
 msgstr "Je veux recevoir les actualités et les meilleures offres du pass Culture par e\\u2011mail."
 
-#: src/features/profile/pages/NotificationSettings.tsx:128
+#: src/features/profile/pages/NotificationSettings.tsx:130
 msgid "Je veux être alerté des actualités et des meilleures offres du pass Culture directement sur mon appareil."
 msgstr "Je veux être alerté des actualités et des meilleures offres du pass Culture directement sur mon appareil."
 
@@ -583,7 +596,7 @@ msgstr "L'offre n'a pas été ajoutée à tes favoris"
 msgid "L'offre n'a pas été retirée de tes favoris"
 msgstr "L'offre n'a pas été retirée de tes favoris"
 
-#: src/features/profile/components/BeneficiaryCeilings.tsx:22
+#: src/features/profile/components/BeneficiaryCeilings.tsx:35
 msgid "Le but du pass Culture est de renforcer tes pratiques culturelles, mais aussi d'en créer de nouvelles.\\u0020"
 msgstr "Le but du pass Culture est de renforcer tes pratiques culturelles, mais aussi d'en créer de nouvelles.\\u0020"
 
@@ -604,7 +617,7 @@ msgstr "Le pass Culture"
 msgid "Le pass Culture est accessible à tous !"
 msgstr "Le pass Culture est accessible à tous !"
 
-#: src/features/profile/pages/NotificationSettings.tsx:77
+#: src/features/profile/pages/NotificationSettings.tsx:78
 msgid "Le réglage est sauvegardé"
 msgstr "Le réglage est sauvegardé"
 
@@ -635,7 +648,7 @@ msgid "L’application pass Culture est accessible à tous. Si tu as 18 ans, tu 
 msgstr "L’application pass Culture est accessible à tous. Si tu as 18 ans, tu es éligible pour obtenir une aide financière de 300 € proposée par le Ministère de la Culture qui sera créditée directement sur ton compte pass Culture."
 
 #: src/features/profile/pages/LegalNotices.tsx:30
-#: src/features/profile/pages/Profile.tsx:102
+#: src/features/profile/pages/Profile.tsx:106
 msgid "Mentions légales"
 msgstr "Mentions légales"
 
@@ -643,7 +656,7 @@ msgstr "Mentions légales"
 msgid "Mes options"
 msgstr "Mes options"
 
-#: src/features/bookings/pages/EndedBookings.tsx:25
+#: src/features/bookings/pages/EndedBookings.tsx:20
 msgid "Mes réservations terminées"
 msgstr "Mes réservations terminées"
 
@@ -651,7 +664,7 @@ msgstr "Mes réservations terminées"
 msgid "Mettre en favoris"
 msgstr "Mettre en favoris"
 
-#: src/features/offer/pages/Offer.tsx:83
+#: src/features/offer/pages/OfferBody.tsx:51
 msgid "Modalités de retrait"
 msgstr "Modalités de retrait"
 
@@ -665,16 +678,16 @@ msgstr "Mon crédit est expiré, que faire ?"
 
 #: src/features/auth/login/Login.tsx:119
 #: src/features/auth/signup/SetPassword.tsx:38
-#: src/features/profile/pages/ChangePassword.tsx:95
-#: src/features/profile/pages/Profile.tsx:91
+#: src/features/profile/pages/ChangePassword.tsx:97
+#: src/features/profile/pages/Profile.tsx:95
 msgid "Mot de passe"
 msgstr "Mot de passe"
 
-#: src/features/profile/pages/ChangePassword.tsx:64
+#: src/features/profile/pages/ChangePassword.tsx:66
 msgid "Mot de passe actuel"
 msgstr "Mot de passe actuel"
 
-#: src/features/profile/pages/ChangePassword.tsx:41
+#: src/features/profile/pages/ChangePassword.tsx:42
 msgid "Mot de passe modifié"
 msgstr "Mot de passe modifié"
 
@@ -698,8 +711,8 @@ msgstr "Nombre de place"
 msgid "Nos nombreux partenaires ajoutent de nouvelles offres quotidiennement. Découvre les dès maintenant !"
 msgstr "Nos nombreux partenaires ajoutent de nouvelles offres quotidiennement. Découvre les dès maintenant !"
 
-#: src/features/profile/pages/NotificationSettings.tsx:139
-#: src/features/profile/pages/Profile.tsx:93
+#: src/features/profile/pages/NotificationSettings.tsx:141
+#: src/features/profile/pages/Profile.tsx:97
 msgid "Notifications"
 msgstr "Notifications"
 
@@ -711,8 +724,8 @@ msgstr "Nous ne pouvons pas vérifier ton identité pour le moment, reviens plus
 msgid "Nous utilisons des outils pour réaliser des statistiques de navigation et offrir une experience plus sûre. En cliquant sur Continuer, tu acceptes l'utilisation de ces services détaillés dans notre"
 msgstr "Nous utilisons des outils pour réaliser des statistiques de navigation et offrir une experience plus sûre. En cliquant sur Continuer, tu acceptes l'utilisation de ces services détaillés dans notre"
 
-#: src/features/auth/forgottenPassword/ReinitializePassword.tsx:55
-#: src/features/profile/pages/ChangePassword.tsx:72
+#: src/features/auth/forgottenPassword/ReinitializePassword.tsx:57
+#: src/features/profile/pages/ChangePassword.tsx:74
 msgid "Nouveau mot de passe"
 msgstr "Nouveau mot de passe"
 
@@ -779,19 +792,19 @@ msgstr "Où ?"
 msgid "Paramètres de confidentialité"
 msgstr "Paramètres de confidentialité"
 
-#: src/features/profile/pages/Profile.tsx:88
+#: src/features/profile/pages/Profile.tsx:92
 msgid "Paramètres de l'application"
 msgstr "Paramètres de l'application"
 
-#: src/libs/geolocation/components/GeolocationActivationModal.tsx:10
+#: src/libs/geolocation/components/GeolocationActivationModal.tsx:11
 msgid "Paramètres de localisation"
 msgstr "Paramètres de localisation"
 
-#: src/libs/notifications/components/PushNotificationsModal.tsx:9
+#: src/libs/notifications/components/PushNotificationsModal.tsx:10
 msgid "Paramètres de notifications"
 msgstr "Paramètres de notifications"
 
-#: src/features/profile/pages/Profile.tsx:88
+#: src/features/profile/pages/Profile.tsx:92
 msgid "Paramètres du compte"
 msgstr "Paramètres du compte"
 
@@ -844,11 +857,11 @@ msgstr "Pour que tu puisses bénéficier de l’aide financière de 300 € offe
 msgid "Pourquoi ?"
 msgstr "Pourquoi ?"
 
-#: src/features/profile/components/BeneficiaryCeilings.tsx:14
+#: src/features/profile/components/BeneficiaryCeilings.tsx:15
 msgid "Pourquoi les biens numériques sont-ils limités ?"
 msgstr "Pourquoi les biens numériques sont-ils limités ?"
 
-#: src/features/profile/components/BeneficiaryCeilings.tsx:13
+#: src/features/profile/components/BeneficiaryCeilings.tsx:14
 msgid "Pourquoi les biens physiques et numériques sont-ils limités ?"
 msgstr "Pourquoi les biens physiques et numériques sont-ils limités ?"
 
@@ -856,20 +869,20 @@ msgstr "Pourquoi les biens physiques et numériques sont-ils limités ?"
 msgid "Prix"
 msgstr "Prix"
 
-#: src/features/favorites/pages/FavoritesSorts.tsx:54
+#: src/features/favorites/pages/FavoritesSorts.tsx:29
 msgid "Prix croissant"
 msgstr "Prix croissant"
 
 #: src/features/profile/components/ExBeneficiaryHeader.tsx:16
-#: src/features/profile/components/LoggedOutHeader.tsx:17
+#: src/features/profile/components/LoggedOutHeader.tsx:18
 msgid "Profil"
 msgstr "Profil"
 
-#: src/features/profile/components/NonBeneficiaryHeader.tsx:31
+#: src/features/profile/components/NonBeneficiaryHeader.tsx:35
 msgid "Profite de 300\\u00a0€\\u00a0"
 msgstr "Profite de 300\\u00a0€\\u00a0"
 
-#: src/features/favorites/pages/FavoritesSorts.tsx:57
+#: src/features/favorites/pages/FavoritesSorts.tsx:30
 msgid "Proximité géographique"
 msgstr "Proximité géographique"
 
@@ -877,11 +890,11 @@ msgstr "Proximité géographique"
 msgid "Prénom et nom"
 msgstr "Prénom et nom"
 
-#: src/features/offer/pages/Offer.tsx:74
+#: src/features/offer/pages/OfferBody.tsx:42
 msgid "Quand ?"
 msgstr "Quand ?"
 
-#: src/features/profile/pages/Profile.tsx:98
+#: src/features/profile/pages/Profile.tsx:102
 msgid "Questions fréquentes"
 msgstr "Questions fréquentes"
 
@@ -906,11 +919,11 @@ msgstr "Renvoyer l'email"
 msgid "Respect de ta vie privée"
 msgstr "Respect de ta vie privée"
 
-#: src/libs/notifications/components/PushNotificationsModal.tsx:14
+#: src/libs/notifications/components/PushNotificationsModal.tsx:15
 msgid "Reste informé des actualités du pass Culture en activant les notifications."
 msgstr "Reste informé des actualités du pass Culture en activant les notifications."
 
-#: src/features/profile/pages/NotificationSettings.tsx:111
+#: src/features/profile/pages/NotificationSettings.tsx:113
 msgid "Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans."
 msgstr "Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans."
 
@@ -929,11 +942,11 @@ msgstr "Retourner à l'offre"
 msgid "Retrouve \"{name}\" chez \"{locationName}\" sur le pass Culture"
 msgstr "Retrouve \"{name}\" chez \"{locationName}\" sur le pass Culture"
 
-#: src/libs/geolocation/components/GeolocationActivationModal.tsx:15
+#: src/libs/geolocation/components/GeolocationActivationModal.tsx:16
 msgid "Retrouve toutes les offres autour de chez toi en activant les données de localisation."
 msgstr "Retrouve toutes les offres autour de chez toi en activant les données de localisation."
 
-#: src/features/favorites/components/NoFavoritesResult.tsx:23
+#: src/features/favorites/components/NoFavoritesResult.tsx:17
 msgid "Retrouve toutes tes offres en un clin d'oeil en les ajoutant à tes favoris !"
 msgstr "Retrouve toutes tes offres en un clin d'oeil en les ajoutant à tes favoris !"
 
@@ -957,6 +970,14 @@ msgstr "Réservation confirmée !"
 msgid "Réservation impossible"
 msgstr "Réservation impossible"
 
+#: src/features/bookings/components/OnGoingBookingsList.tsx:36
+msgid "Réservation terminée"
+msgstr "Réservation terminée"
+
+#: src/features/bookings/components/OnGoingBookingsList.tsx:36
+msgid "Réservations terminées"
+msgstr "Réservations terminées"
+
 #: src/features/favorites/atoms/BookingButton.tsx:48
 #: src/features/favorites/atoms/BookingButton.tsx:49
 #: src/features/offer/services/useCtaWordingAndAction.ts:38
@@ -966,7 +987,7 @@ msgstr "Réserver"
 #: src/features/favorites/components/NotConnectedFavorites.tsx:35
 #: src/features/home/components/SignUpSignInChoiceModal.tsx:39
 #: src/features/offer/components/SignUpSignInChoiceOfferModal.tsx:39
-#: src/features/profile/components/LoggedOutHeader.tsx:23
+#: src/features/profile/components/LoggedOutHeader.tsx:24
 msgid "S'inscrire"
 msgstr "S'inscrire"
 
@@ -1021,7 +1042,7 @@ msgstr "Solo"
 msgid "Sortie"
 msgstr "Sortie"
 
-#: src/features/profile/pages/Profile.tsx:105
+#: src/features/profile/pages/Profile.tsx:109
 msgid "Suivre pass Culture"
 msgstr "Suivre pass Culture"
 
@@ -1062,25 +1083,25 @@ msgstr "Ton crédit pass Culture est arrivé à expiration mais l’aventure con
 msgid "Ton e-mail"
 msgstr "Ton e-mail"
 
-#: src/features/auth/forgottenPassword/ReinitializePassword.tsx:51
-#: src/features/auth/forgottenPassword/ReinitializePassword.tsx:57
+#: src/features/auth/forgottenPassword/ReinitializePassword.tsx:53
+#: src/features/auth/forgottenPassword/ReinitializePassword.tsx:59
 #: src/features/auth/login/Login.tsx:121
 #: src/features/auth/signup/SetPassword.tsx:34
 #: src/features/auth/signup/SetPassword.tsx:40
 msgid "Ton mot de passe"
 msgstr "Ton mot de passe"
 
-#: src/features/auth/forgottenPassword/ReinitializePassword.tsx:31
+#: src/features/auth/forgottenPassword/ReinitializePassword.tsx:32
 msgid "Ton mot de passe a été modifié !"
 msgstr "Ton mot de passe a été modifié !"
 
 #. password placeholder
-#: src/features/profile/pages/ChangePassword.tsx:66
+#: src/features/profile/pages/ChangePassword.tsx:68
 msgid "Ton mot de passe actuel"
 msgstr "Ton mot de passe actuel"
 
 #. password placeholder
-#: src/features/profile/pages/ChangePassword.tsx:74
+#: src/features/profile/pages/ChangePassword.tsx:76
 msgid "Ton nouveau mot de passe"
 msgstr "Ton nouveau mot de passe"
 
@@ -1097,11 +1118,11 @@ msgid "Toute la culture dans ta main"
 msgstr "Toute la culture dans ta main"
 
 #: src/features/favorites/atoms/Buttons/Sort.tsx:20
-#: src/features/favorites/pages/FavoritesSorts.tsx:105
+#: src/features/favorites/pages/FavoritesSorts.tsx:97
 msgid "Trier"
 msgstr "Trier"
 
-#: src/features/favorites/pages/FavoritesSorts.tsx:83
+#: src/features/favorites/pages/FavoritesSorts.tsx:79
 msgid "Trier par"
 msgstr "Trier par"
 
@@ -1113,7 +1134,7 @@ msgstr "Trop de favoris enregistrés. Supprime des favoris pour en ajouter de no
 msgid "Tu as 18 ans..."
 msgstr "Tu as 18 ans..."
 
-#: src/features/profile/components/LoggedOutHeader.tsx:26
+#: src/features/profile/components/LoggedOutHeader.tsx:30
 msgid "Tu as déjà un compte ?\\u00a0"
 msgstr "Tu as déjà un compte ?\\u00a0"
 
@@ -1121,7 +1142,7 @@ msgstr "Tu as déjà un compte ?\\u00a0"
 msgid "Tu as {0} sur ton pass"
 msgstr "Tu as {0} sur ton pass"
 
-#: src/features/profile/pages/NotificationSettings.tsx:112
+#: src/features/profile/pages/NotificationSettings.tsx:114
 msgid "Tu dois être connecté pour activer les notifications et rester informé des actualités du pass Culture"
 msgstr "Tu dois être connecté pour activer les notifications et rester informé des actualités du pass Culture"
 
@@ -1129,7 +1150,7 @@ msgstr "Tu dois être connecté pour activer les notifications et rester inform�
 msgid "Tu es éligible !"
 msgstr "Tu es éligible !"
 
-#: src/features/profile/components/NonBeneficiaryHeader.tsx:28
+#: src/features/profile/components/NonBeneficiaryHeader.tsx:29
 msgid "Tu es éligible jusqu'au\\u00a0{0}"
 msgstr "Tu es éligible jusqu'au\\u00a0{0}"
 
@@ -1137,19 +1158,19 @@ msgstr "Tu es éligible jusqu'au\\u00a0{0}"
 msgid "Tu n'es pas connecté !"
 msgstr "Tu n'es pas connecté !"
 
-#: src/features/bookings/components/NoBookingsView.tsx:16
+#: src/features/bookings/components/NoBookingsView.tsx:15
 msgid "Tu n’as pas de réservations en cours. Découvre les offres disponibles  sans attendre !"
 msgstr "Tu n’as pas de réservations en cours. Découvre les offres disponibles  sans attendre !"
 
-#: src/libs/geolocation/components/GeolocationActivationModal.tsx:21
+#: src/libs/geolocation/components/GeolocationActivationModal.tsx:22
 msgid "Tu peux activer ou désactiver cette fonctionnalité dans Autorisations > Localisation."
 msgstr "Tu peux activer ou désactiver cette fonctionnalité dans Autorisations > Localisation."
 
-#: src/libs/geolocation/components/GeolocationActivationModal.tsx:22
+#: src/libs/geolocation/components/GeolocationActivationModal.tsx:23
 msgid "Tu peux activer ou désactiver cette fonctionnalité dans les paramètres de localisation ton téléphone."
 msgstr "Tu peux activer ou désactiver cette fonctionnalité dans les paramètres de localisation ton téléphone."
 
-#: src/libs/notifications/components/PushNotificationsModal.tsx:19
+#: src/libs/notifications/components/PushNotificationsModal.tsx:20
 msgid "Tu peux activer ou désactiver cette fonctionnalité dans les paramètres de ton appareil."
 msgstr "Tu peux activer ou désactiver cette fonctionnalité dans les paramètres de ton appareil."
 
@@ -1157,7 +1178,7 @@ msgstr "Tu peux activer ou désactiver cette fonctionnalité dans les paramètre
 msgid "Tu peux aussi découvrir les autres activités culturelles sur l'application mais leur réservation s'effectuera sur les sites de nos partenaires !"
 msgstr "Tu peux aussi découvrir les autres activités culturelles sur l'application mais leur réservation s'effectuera sur les sites de nos partenaires !"
 
-#: src/features/profile/components/BeneficiaryCeilings.tsx:26
+#: src/features/profile/components/BeneficiaryCeilings.tsx:38
 msgid "Tu peux encore dépenser :"
 msgstr "Tu peux encore dépenser :"
 
@@ -1191,7 +1212,7 @@ msgstr "Un problème est survenu pendant l'inscription, réessaie plus tard."
 msgid "Un problème est survenu pendant la réinitialisation, réessaie plus tard."
 msgstr "Un problème est survenu pendant la réinitialisation, réessaie plus tard."
 
-#: src/features/profile/pages/NotificationSettings.tsx:88
+#: src/features/profile/pages/NotificationSettings.tsx:90
 msgid "Une erreur est survenue"
 msgstr "Une erreur est survenue"
 
@@ -1220,7 +1241,7 @@ msgid "VISA"
 msgstr "VISA"
 
 #: src/features/auth/forgottenPassword/ForgottenPassword.tsx:117
-#: src/features/favorites/pages/FavoritesSorts.tsx:107
+#: src/features/favorites/pages/FavoritesSorts.tsx:99
 msgid "Valider"
 msgstr "Valider"
 
@@ -1236,7 +1257,7 @@ msgstr "Valider la date"
 msgid "Verifier mon identité"
 msgstr "Verifier mon identité"
 
-#: src/features/profile/pages/Profile.tsx:120
+#: src/features/profile/pages/Profile.tsx:127
 msgid "Version {0}"
 msgstr "Version {0}"
 
@@ -1298,7 +1319,7 @@ msgstr "crédit insuffisant"
 msgid "crédit photo"
 msgstr "crédit photo"
 
-#: src/features/profile/components/BeneficiaryHeader.tsx:26
+#: src/features/profile/components/BeneficiaryHeader.tsx:24
 msgid "crédit valable jusqu'au {0}"
 msgstr "crédit valable jusqu'au {0}"
 
@@ -1335,6 +1356,10 @@ msgstr "interprète"
 msgid "intervenant"
 msgstr "intervenant"
 
+#: src/features/bookings/components/OnGoingBookingItem.tsx:81
+msgid "le\\u00a0"
+msgstr "le\\u00a0"
+
 #: src/features/offer/pages/OfferDescription.tsx:22
 msgid "metteur en scène"
 msgstr "metteur en scène"
@@ -1342,6 +1367,22 @@ msgstr "metteur en scène"
 #: src/features/firstTutorial/pages/FirstTutorial/components/FourthCard.tsx:21
 msgid "quotidiennes"
 msgstr "quotidiennes"
+
+#: src/features/bookings/components/OnGoingBookingsList.tsx:35
+msgid "réservation en cours"
+msgstr "réservation en cours"
+
+#: src/features/bookings/pages/EndedBookings.tsx:23
+msgid "réservation terminée"
+msgstr "réservation terminée"
+
+#: src/features/bookings/components/OnGoingBookingsList.tsx:35
+msgid "réservations en cours"
+msgstr "réservations en cours"
+
+#: src/features/bookings/pages/EndedBookings.tsx:23
+msgid "réservations terminées"
+msgstr "réservations terminées"
 
 #: src/features/offer/pages/OfferDescription.tsx:16
 #: src/features/offer/pages/OfferDescription.tsx:20
@@ -1368,14 +1409,6 @@ msgstr "voir plus"
 msgid "{0}"
 msgstr "{0}"
 
-#: src/features/bookings/pages/Bookings.tsx:24
-msgid "{endedBookingsCount, plural, one {Réservation terminée} other {Réservations terminées}}"
-msgstr "{endedBookingsCount, plural, one {Réservation terminée} other {Réservations terminées}}"
-
-#: src/features/bookings/pages/EndedBookings.tsx:14
-msgid "{endedBookingsCount, plural, one {réservation terminée} other {réservations terminées}}"
-msgstr "{endedBookingsCount, plural, one {réservation terminée} other {réservations terminées}}"
-
 #: src/features/favorites/atoms/NumberOfResults.tsx:8
 msgid "{nbHits} favori"
 msgstr "{nbHits} favori"
@@ -1392,10 +1425,6 @@ msgstr "{nbHits} résultat"
 msgid "{nbHits} résultats"
 msgstr "{nbHits} résultats"
 
-#: src/features/bookings/pages/Bookings.tsx:18
-msgid "{onGoingBookingsCount, plural, one {réservation en cours} other {réservations en cours}}"
-msgstr "{onGoingBookingsCount, plural, one {réservation en cours} other {réservations en cours}}"
-
 #: src/features/bookOffer/components/BookingDetails.tsx:70
 msgid "{price} seront déduits de ton crédit pass Culture"
 msgstr "{price} seront déduits de ton crédit pass Culture"
@@ -1403,6 +1432,10 @@ msgstr "{price} seront déduits de ton crédit pass Culture"
 #: src/features/offer/components/OfferIconCaptions.tsx:27
 msgid "À deux !"
 msgstr "À deux !"
+
+#: src/features/bookings/components/OnGoingBookingItem.tsx:92
+msgid "À retirer avant\\u00a0"
+msgstr "À retirer avant\\u00a0"
 
 #: src/api/helpers.ts:112
 msgid "Échec de la requête {0}, code: {1}"
@@ -1412,7 +1445,7 @@ msgstr "Échec de la requête {0}, code: {1}"
 msgid "Échec de la requête {url}, code: {0}"
 msgstr "Échec de la requête {url}, code: {0}"
 
-#: src/features/profile/components/NonBeneficiaryHeader.tsx:31
+#: src/features/profile/components/NonBeneficiaryHeader.tsx:35
 msgid "à dépenser dans l'application"
 msgstr "à dépenser dans l'application"
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXX

L'utilisation de `i18n.plural` introduisait un bug "Cannot find variable intl" et malgré l'installation du package le bug persiste, il faut donc creuser un peu plus le problème. Pour ne pas bloquer la recette PO et graphique on repasse à la méthode de pluriel "fait main" et on essaiera d'utiliser `i18n.plural` dans un ticket d'amélioration technique.

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
