### PR TITLE
(PC-7499) Make headers titles perfectly centered no matter the icons sizes

### DIFF
--- a/src/features/favorites/pages/__tests__/__snapshots__/FavoritesSorts.test.tsx.snap
+++ b/src/features/favorites/pages/__tests__/__snapshots__/FavoritesSorts.test.tsx.snap
@@ -337,62 +337,47 @@ Array [
       }
     >
       <View
-        numberOfSpaces={5}
+        positionInHeader="left"
         style={
           Array [
             Object {
-              "width": 20,
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "flex-start",
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "width": 60,
             },
           ]
-        }
-      />
-      <View
-        accessible={true}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "opacity": 1,
-          }
         }
       >
         <View
-          height={32}
-          testID="icon-back"
-          width={32}
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
         >
-          <Text>
-            icon-back-SVG-Mock
-          </Text>
+          <View
+            height={32}
+            testID="icon-back"
+            width={32}
+          >
+            <Text>
+              icon-back-SVG-Mock
+            </Text>
+          </View>
         </View>
       </View>
-      <View
-        numberOfSpaces={0}
-        style={
-          Array [
-            Object {
-              "width": 0,
-            },
-          ]
-        }
-      />
-      <View
-        style={
-          Array [
-            Object {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-          ]
-        }
-      />
       <Text
         color="#ffffff"
         numberOfLines={1}
@@ -400,6 +385,8 @@ Array [
           Array [
             Object {
               "color": "#ffffff",
+              "flexBasis": 0,
+              "flexGrow": 1,
               "flexShrink": 1,
               "fontFamily": "Montserrat-Regular",
               "fontSize": 15,
@@ -412,32 +399,16 @@ Array [
         Trier
       </Text>
       <View
+        positionInHeader="right"
         style={
           Array [
             Object {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-          ]
-        }
-      />
-      <View
-        numberOfSpaces={10}
-        style={
-          Array [
-            Object {
-              "width": 40,
-            },
-          ]
-        }
-      />
-      <View
-        numberOfSpaces={6}
-        style={
-          Array [
-            Object {
-              "width": 24,
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "width": 60,
             },
           ]
         }

--- a/src/features/offer/pages/tests/__snapshots__/OfferDescription.test.tsx.snap
+++ b/src/features/offer/pages/tests/__snapshots__/OfferDescription.test.tsx.snap
@@ -586,62 +586,47 @@ Tous les détails du film sur AlloCiné:
                         }
                       >
                         <View
-                          numberOfSpaces={5}
+                          positionInHeader="left"
                           style={
                             Array [
                               Object {
-                                "width": 20,
+                                "alignItems": "center",
+                                "flexDirection": "row",
+                                "justifyContent": "flex-start",
+                                "paddingLeft": 12,
+                                "paddingRight": 12,
+                                "width": 60,
                               },
                             ]
-                          }
-                        />
-                        <View
-                          accessible={true}
-                          focusable={true}
-                          onClick={[Function]}
-                          onResponderGrant={[Function]}
-                          onResponderMove={[Function]}
-                          onResponderRelease={[Function]}
-                          onResponderTerminate={[Function]}
-                          onResponderTerminationRequest={[Function]}
-                          onStartShouldSetResponder={[Function]}
-                          style={
-                            Object {
-                              "opacity": 1,
-                            }
                           }
                         >
                           <View
-                            height={32}
-                            testID="icon-back"
-                            width={32}
+                            accessible={true}
+                            focusable={true}
+                            onClick={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              Object {
+                                "opacity": 1,
+                              }
+                            }
                           >
-                            <Text>
-                              icon-back-SVG-Mock
-                            </Text>
+                            <View
+                              height={32}
+                              testID="icon-back"
+                              width={32}
+                            >
+                              <Text>
+                                icon-back-SVG-Mock
+                              </Text>
+                            </View>
                           </View>
                         </View>
-                        <View
-                          numberOfSpaces={0}
-                          style={
-                            Array [
-                              Object {
-                                "width": 0,
-                              },
-                            ]
-                          }
-                        />
-                        <View
-                          style={
-                            Array [
-                              Object {
-                                "flexBasis": 0,
-                                "flexGrow": 1,
-                                "flexShrink": 1,
-                              },
-                            ]
-                          }
-                        />
                         <Text
                           color="#ffffff"
                           numberOfLines={1}
@@ -649,6 +634,8 @@ Tous les détails du film sur AlloCiné:
                             Array [
                               Object {
                                 "color": "#ffffff",
+                                "flexBasis": 0,
+                                "flexGrow": 1,
                                 "flexShrink": 1,
                                 "fontFamily": "Montserrat-Regular",
                                 "fontSize": 15,
@@ -661,32 +648,16 @@ Tous les détails du film sur AlloCiné:
                           Description
                         </Text>
                         <View
+                          positionInHeader="right"
                           style={
                             Array [
                               Object {
-                                "flexBasis": 0,
-                                "flexGrow": 1,
-                                "flexShrink": 1,
-                              },
-                            ]
-                          }
-                        />
-                        <View
-                          numberOfSpaces={10}
-                          style={
-                            Array [
-                              Object {
-                                "width": 40,
-                              },
-                            ]
-                          }
-                        />
-                        <View
-                          numberOfSpaces={6}
-                          style={
-                            Array [
-                              Object {
-                                "width": 24,
+                                "alignItems": "center",
+                                "flexDirection": "row",
+                                "justifyContent": "flex-end",
+                                "paddingLeft": 12,
+                                "paddingRight": 12,
+                                "width": 60,
                               },
                             ]
                           }

--- a/src/features/search/pages/__tests__/__snapshots__/Categories.test.tsx.snap
+++ b/src/features/search/pages/__tests__/__snapshots__/Categories.test.tsx.snap
@@ -1082,62 +1082,47 @@ Array [
       }
     >
       <View
-        numberOfSpaces={5}
+        positionInHeader="left"
         style={
           Array [
             Object {
-              "width": 20,
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "flex-start",
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "width": 60,
             },
           ]
-        }
-      />
-      <View
-        accessible={true}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "opacity": 1,
-          }
         }
       >
         <View
-          height={32}
-          testID="icon-back"
-          width={32}
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
         >
-          <Text>
-            icon-back-SVG-Mock
-          </Text>
+          <View
+            height={32}
+            testID="icon-back"
+            width={32}
+          >
+            <Text>
+              icon-back-SVG-Mock
+            </Text>
+          </View>
         </View>
       </View>
-      <View
-        numberOfSpaces={0}
-        style={
-          Array [
-            Object {
-              "width": 0,
-            },
-          ]
-        }
-      />
-      <View
-        style={
-          Array [
-            Object {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-          ]
-        }
-      />
       <Text
         color="#ffffff"
         numberOfLines={1}
@@ -1145,6 +1130,8 @@ Array [
           Array [
             Object {
               "color": "#ffffff",
+              "flexBasis": 0,
+              "flexGrow": 1,
               "flexShrink": 1,
               "fontFamily": "Montserrat-Regular",
               "fontSize": 15,
@@ -1157,32 +1144,16 @@ Array [
         Catégories
       </Text>
       <View
+        positionInHeader="right"
         style={
           Array [
             Object {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-          ]
-        }
-      />
-      <View
-        numberOfSpaces={10}
-        style={
-          Array [
-            Object {
-              "width": 40,
-            },
-          ]
-        }
-      />
-      <View
-        numberOfSpaces={6}
-        style={
-          Array [
-            Object {
-              "width": 24,
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "width": 60,
             },
           ]
         }

--- a/src/features/search/pages/__tests__/__snapshots__/LocationFilter.test.tsx.snap
+++ b/src/features/search/pages/__tests__/__snapshots__/LocationFilter.test.tsx.snap
@@ -477,62 +477,47 @@ Array [
       }
     >
       <View
-        numberOfSpaces={5}
+        positionInHeader="left"
         style={
           Array [
             Object {
-              "width": 20,
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "flex-start",
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "width": 60,
             },
           ]
-        }
-      />
-      <View
-        accessible={true}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "opacity": 1,
-          }
         }
       >
         <View
-          height={32}
-          testID="icon-back"
-          width={32}
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
         >
-          <Text>
-            icon-back-SVG-Mock
-          </Text>
+          <View
+            height={32}
+            testID="icon-back"
+            width={32}
+          >
+            <Text>
+              icon-back-SVG-Mock
+            </Text>
+          </View>
         </View>
       </View>
-      <View
-        numberOfSpaces={0}
-        style={
-          Array [
-            Object {
-              "width": 0,
-            },
-          ]
-        }
-      />
-      <View
-        style={
-          Array [
-            Object {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-          ]
-        }
-      />
       <Text
         color="#ffffff"
         numberOfLines={1}
@@ -540,6 +525,8 @@ Array [
           Array [
             Object {
               "color": "#ffffff",
+              "flexBasis": 0,
+              "flexGrow": 1,
               "flexShrink": 1,
               "fontFamily": "Montserrat-Regular",
               "fontSize": 15,
@@ -552,32 +539,16 @@ Array [
         Localisation
       </Text>
       <View
+        positionInHeader="right"
         style={
           Array [
             Object {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-          ]
-        }
-      />
-      <View
-        numberOfSpaces={10}
-        style={
-          Array [
-            Object {
-              "width": 40,
-            },
-          ]
-        }
-      />
-      <View
-        numberOfSpaces={6}
-        style={
-          Array [
-            Object {
-              "width": 24,
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "width": 60,
             },
           ]
         }

--- a/src/features/search/pages/__tests__/__snapshots__/SearchFilter.test.tsx.snap
+++ b/src/features/search/pages/__tests__/__snapshots__/SearchFilter.test.tsx.snap
@@ -2786,93 +2786,19 @@ Array [
       }
     >
       <View
-        numberOfSpaces={5}
+        positionInHeader="left"
         style={
           Array [
             Object {
-              "width": 20,
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "flex-start",
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "width": 60,
             },
           ]
         }
-      />
-      <View
-        accessible={true}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "opacity": 1,
-          }
-        }
-      >
-        <View
-          height={32}
-          testID="icon-back"
-          width={32}
-        >
-          <Text>
-            icon-back-SVG-Mock
-          </Text>
-        </View>
-      </View>
-      <View
-        numberOfSpaces={0}
-        style={
-          Array [
-            Object {
-              "width": 0,
-            },
-          ]
-        }
-      />
-      <View
-        style={
-          Array [
-            Object {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-          ]
-        }
-      />
-      <Text
-        color="#ffffff"
-        numberOfLines={1}
-        style={
-          Array [
-            Object {
-              "color": "#ffffff",
-              "flexShrink": 1,
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
-              "textAlign": "center",
-            },
-          ]
-        }
-      >
-        Filtrer
-      </Text>
-      <View
-        style={
-          Array [
-            Object {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-          ]
-        }
-      />
-      <View
-        onLayout={[Function]}
       >
         <View
           accessible={true}
@@ -2890,33 +2816,89 @@ Array [
             }
           }
         >
-          <Text
-            color="#ffffff"
-            style={
-              Array [
-                Object {
-                  "color": "#ffffff",
-                  "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
-                },
-              ]
-            }
+          <View
+            height={32}
+            testID="icon-back"
+            width={32}
           >
-            Réinitialiser
-          </Text>
+            <Text>
+              icon-back-SVG-Mock
+            </Text>
+          </View>
         </View>
       </View>
-      <View
-        numberOfSpaces={6}
+      <Text
+        color="#ffffff"
+        numberOfLines={1}
         style={
           Array [
             Object {
-              "width": 24,
+              "color": "#ffffff",
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "fontFamily": "Montserrat-Regular",
+              "fontSize": 15,
+              "lineHeight": 20,
+              "textAlign": "center",
             },
           ]
         }
-      />
+      >
+        Filtrer
+      </Text>
+      <View
+        positionInHeader="right"
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "width": 60,
+            },
+          ]
+        }
+      >
+        <View
+          onLayout={[Function]}
+        >
+          <View
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <Text
+              color="#ffffff"
+              style={
+                Array [
+                  Object {
+                    "color": "#ffffff",
+                    "fontFamily": "Montserrat-Bold",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              Réinitialiser
+            </Text>
+          </View>
+        </View>
+      </View>
     </View>
     <View
       numberOfSpaces={2}

--- a/src/ui/components/headers/PageHeader.tsx
+++ b/src/ui/components/headers/PageHeader.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components/native'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { useElementWidth } from 'ui/hooks/useElementWidth'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
-import { ColorsEnum, Spacer, Typo } from 'ui/theme'
+import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
 import { ACTIVE_OPACITY } from 'ui/theme/colors'
 
 interface Props {
@@ -36,31 +36,29 @@ const HeaderIconBack: React.FC<HeaderIconProps> = ({ onGoBack }) => {
 
 export const PageHeader: React.FC<Props> = (props) => {
   const { title, RightComponent } = props
-  const { width: rightComponentWidth, onLayout } = useElementWidth()
-  const spaceToAddBeforeTitle = rightComponentWidth ? rightComponentWidth / 6 : 0
+  const { onLayout } = useElementWidth()
 
   return (
     <HeaderContainer>
       <Spacer.TopScreen />
       <Spacer.Column numberOfSpaces={2} />
+
       <Row>
-        <Spacer.Row numberOfSpaces={5} />
-        <HeaderIconBack onGoBack={props.onGoBack} />
-        <Spacer.Row numberOfSpaces={spaceToAddBeforeTitle} />
-        <Spacer.Flex />
+        <IconContainer positionInHeader="left">
+          <HeaderIconBack onGoBack={props.onGoBack} />
+        </IconContainer>
 
         <Title color={ColorsEnum.WHITE}>{title}</Title>
 
-        <Spacer.Flex />
-        {RightComponent ? (
-          <View onLayout={onLayout}>
-            <RightComponent />
-          </View>
-        ) : (
-          <Spacer.Row numberOfSpaces={10} />
-        )}
-        <Spacer.Row numberOfSpaces={6} />
+        <IconContainer positionInHeader="right">
+          {RightComponent && (
+            <View onLayout={onLayout}>
+              <RightComponent />
+            </View>
+          )}
+        </IconContainer>
       </Row>
+
       <Spacer.Column numberOfSpaces={2} />
     </HeaderContainer>
   )
@@ -74,7 +72,7 @@ const HeaderContainer = styled.View({
 })
 
 const Title = styled(Typo.Body).attrs({ numberOfLines: 1, color: ColorsEnum.WHITE })({
-  flexShrink: 1,
+  flex: 1,
   textAlign: 'center',
 })
 
@@ -83,3 +81,14 @@ const Row = styled.View({
   flexDirection: 'row',
   alignItems: 'center',
 })
+
+const IconContainer = styled.View<{ positionInHeader: 'left' | 'right' }>(
+  ({ positionInHeader = 'left' }) => ({
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: positionInHeader === 'left' ? 'flex-start' : 'flex-end',
+    width: getSpacing(15),
+    paddingLeft: getSpacing(3),
+    paddingRight: getSpacing(3),
+  })
+)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7499

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - iPhone 11 | \*Android - Pixel 3a |
| -------------------- | :----------------------: |
| <img width="335" alt="Capture d’écran 2021-03-29 à 17 57 23" src="https://user-images.githubusercontent.com/22399093/112864580-399e7400-90b8-11eb-91df-542b2b8c2c5d.png"> |  <img width="311" alt="Capture d’écran 2021-03-29 à 18 14 08" src="https://user-images.githubusercontent.com/22399093/112866943-a61a7280-90ba-11eb-8f21-51a8229de9f8.png">     | 
