### PR TITLE
(PC-7827) App native - Recherche - Le scroll ne remonte pas en début de page lorsqu'on reboot la recherche ou les favoris en appliquant des filtres / tris

### DIFF
--- a/src/features/favorites/components/FavoritesResults.tsx
+++ b/src/features/favorites/components/FavoritesResults.tsx
@@ -68,7 +68,7 @@ export const FavoritesResults: React.FC = React.memo(function FavoritesResults()
   useEffect(() => {
     if (flatListRef && flatListRef.current)
       flatListRef.current.scrollToOffset({ animated: true, offset: 0 })
-  }, [sortedFavorites?.length])
+  }, [sortedFavorites?.length, favoritesState.sortBy])
 
   const onScrollEndDrag = useCallback(() => handleIsScrolling(false), [])
   const onScrollBeginDrag = useCallback(() => handleIsScrolling(true), [])


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7827

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
