### PR TITLE
(PC-7849) App Native - Tunnel de résa - Tracking -  Clic sur le bouton voir ma réservation de fin de tunnel

### DIFF
--- a/src/features/bookOffer/components/BookingDetails.tsx
+++ b/src/features/bookOffer/components/BookingDetails.tsx
@@ -39,12 +39,14 @@ export const BookingDetails: React.FC<Props> = ({ stocks }) => {
   const { bookingState, dismissModal, dispatch } = useBooking()
   const stock = useBookingStock()
   const { showErrorSnackBar } = useSnackBarContext()
-  const { quantity } = bookingState
+  const { quantity, offerId } = bookingState
 
   const { mutate } = useBookOfferMutation({
     onSuccess: () => {
       dismissModal()
-      navigate('BookingConfirmation')
+      if (offerId) {
+        navigate('BookingConfirmation', { offerId })
+      }
     },
     onError: (error) => {
       let message = _(t`En raison d’une erreur technique, l’offre n’a pas pu être réservée`)

--- a/src/features/bookOffer/components/__tests__/BookingDetails.test.tsx
+++ b/src/features/bookOffer/components/__tests__/BookingDetails.test.tsx
@@ -24,10 +24,12 @@ const mockDispatch = jest.fn()
 
 const mockInitialBookingState = initialBookingState
 
+const mockOfferId = 1337
+
 jest.mock('features/bookOffer/pages/BookingOfferWrapper', () => ({
   useBooking: jest
     .fn(() => ({
-      bookingState: { quantity: 1 } as BookingState,
+      bookingState: { quantity: 1, offerId: mockOfferId } as BookingState,
       dismissModal: mockDismissModal,
       dispatch: mockDispatch,
     }))
@@ -91,7 +93,7 @@ describe('<BookingDetails />', () => {
 
     await waitForExpect(() => {
       expect(mockDismissModal).toHaveBeenCalled()
-      expect(navigate).toHaveBeenCalledWith('BookingConfirmation')
+      expect(navigate).toHaveBeenCalledWith('BookingConfirmation', { offerId: mockOfferId })
     })
   })
 

--- a/src/features/bookOffer/pages/BookingConfirmation.tsx
+++ b/src/features/bookOffer/pages/BookingConfirmation.tsx
@@ -1,10 +1,11 @@
 import { t } from '@lingui/macro'
-import { useNavigation } from '@react-navigation/native'
+import { useNavigation, useRoute } from '@react-navigation/native'
 import React from 'react'
 import styled from 'styled-components/native'
 
 import { useAvailableCredit } from 'features/home/services/useAvailableCredit'
-import { UseNavigationType } from 'features/navigation/RootNavigator'
+import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator'
+import { analytics } from 'libs/analytics'
 import { env } from 'libs/environment'
 import { _ } from 'libs/i18n'
 import { formatToFrenchDecimal } from 'libs/parsers'
@@ -15,6 +16,8 @@ import { TicketBooked } from 'ui/svg/icons/TicketBooked'
 import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
 
 export function BookingConfirmation() {
+  const { params } = useRoute<UseRouteType<'BookingConfirmation'>>()
+
   const { navigate } = useNavigation<UseNavigationType>()
   const credit = useAvailableCredit()
 
@@ -38,7 +41,10 @@ export function BookingConfirmation() {
       {env.FEATURE_FLIPPING_ONLY_VISIBLE_ON_TESTING && (
         <ButtonPrimaryWhite
           title={_(t`Voir ma réservation`)}
-          onPress={() => navigate('Bookings')}
+          onPress={() => {
+            analytics.logSeeMyBooking(params.offerId)
+            navigate('Bookings')
+          }}
         />
       )}
       <Spacer.Column numberOfSpaces={4} />

--- a/src/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx
+++ b/src/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx
@@ -1,6 +1,9 @@
-import { render } from '@testing-library/react-native'
+import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
+import waitForExpect from 'wait-for-expect'
 
+import { navigate, useRoute } from '__mocks__/@react-navigation/native'
+import { analytics } from 'libs/analytics'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 
 import { BookingConfirmation } from '../BookingConfirmation'
@@ -10,8 +13,27 @@ jest.mock('features/home/services/useAvailableCredit', () => ({
 }))
 
 describe('<BookingConfirmation />', () => {
+  const mockOfferId = 1337
+  beforeEach(() => {
+    useRoute.mockImplementation(() => ({
+      params: {
+        offerId: mockOfferId,
+      },
+    }))
+  })
+  afterEach(jest.clearAllMocks)
+
   it('should render correctly', () => {
     const page = render(reactQueryProviderHOC(<BookingConfirmation />))
     expect(page).toMatchSnapshot()
+  })
+
+  it('should go to Bookings and log analytics event', async () => {
+    const renderAPI = render(reactQueryProviderHOC(<BookingConfirmation />))
+    fireEvent.press(renderAPI.getByText('Voir ma réservation'))
+    await waitForExpect(() => {
+      expect(analytics.logSeeMyBooking).toBeCalledWith(mockOfferId)
+      expect(navigate).toBeCalledWith('Bookings')
+    })
   })
 })

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -27,7 +27,7 @@ export type RootStackParamList = {
   ChangePassword: undefined
   CheatCodes: undefined
   CheatMenu: undefined
-  BookingConfirmation: undefined
+  BookingConfirmation: { offerId: number }
   BookingDetails: { id: number }
   ConsentSettings: { onGoBack?: () => void } | undefined
   CulturalSurvey: undefined

--- a/src/libs/__mocks__/analytics.ts
+++ b/src/libs/__mocks__/analytics.ts
@@ -55,6 +55,7 @@ export const analytics: typeof actualAnalytics = {
   logScreenView: jest.fn(),
   logSearchQuery: jest.fn(),
   logSearchScrollToPage: jest.fn(),
+  logSeeMyBooking: jest.fn(),
   logShareOffer: jest.fn(),
   logSignUpBetween14And15Included: jest.fn(),
   logSignUpLessThanOrEqualTo13: jest.fn(),

--- a/src/libs/analytics.ts
+++ b/src/libs/analytics.ts
@@ -54,6 +54,7 @@ export enum AnalyticsEvent {
   SEARCH_QUERY = 'SearchQuery',
   SEARCH_SCROLL_TO_PAGE = 'SearchScrollToPage',
   SEE_MORE_CLICKED = 'SeeMoreClicked',
+  SEE_MY_BOOKING = 'SeeMyBooking',
   SHARE_OFFER = 'Share',
   SIGN_UP_BETWEEN_14_AND_15_INCLUDED = 'SignUpBetween14And15Included',
   SIGN_UP_LESS_THAN_OR_EQUAL_TO_13 = 'SignUpLessThanOrEqualTo13',
@@ -243,6 +244,12 @@ type FavoriteSortBy = 'ASCENDING_PRICE' | 'AROUND_ME' | 'RECENTLY_ADDED'
 const logHasAppliedFavoritesSorting = ({ sortBy }: { sortBy: FavoriteSortBy }) =>
   firebaseAnalytics.logEvent(AnalyticsEvent.HAS_APPLIED_FAVORITES_SORTING, { type: sortBy })
 
+/**
+ * Bookings
+ */
+const logSeeMyBooking = (offerId: number) =>
+  firebaseAnalytics.logEvent(AnalyticsEvent.SEE_MY_BOOKING, { offerId })
+
 export const analytics = {
   logAllModulesSeen,
   logAllTilesSeen,
@@ -287,6 +294,7 @@ export const analytics = {
   logScreenView,
   logSearchQuery,
   logSearchScrollToPage,
+  logSeeMyBooking,
   logShareOffer,
   logSignUpBetween14And15Included,
   logSignUpLessThanOrEqualTo13,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7849

**SVP: n'ayant pas travaillé sur booking, l'intégration implique que l'`offerId` est toujours défini dans le `onSuccess` du mutate de `useBookOfferMutation` (et donc dans le navigate) : 

```jsx
if (offerId) {
  navigate('BookingConfirmation', { offerId })
}
```

Merci de confirmer ici que c'est bien le cas, et donc que l'intégration est OK

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [x] Added new reusable components to the AppComponents page and communicate to the team on slack

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
