### PR TITLE
(PC-7827) App native - Recherche - Le scroll ne remonte pas en début de page lorsqu'on reboot la recherche en appliquant des filtres

### DIFF
--- a/src/features/search/components/SearchResults.tsx
+++ b/src/features/search/components/SearchResults.tsx
@@ -1,3 +1,4 @@
+import debounce from 'lodash.debounce'
 import flatten from 'lodash.flatten'
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 import { FlatList, ActivityIndicator } from 'react-native'
@@ -26,10 +27,19 @@ export const SearchResults: React.FC = () => {
   ])
   const { nbHits } = data?.pages[0] || { nbHits: 0 }
 
-  useEffect(() => {
-    if (flatListRef && flatListRef.current)
-      flatListRef.current.scrollToOffset({ animated: true, offset: 0 })
-  }, [nbHits])
+  useEffect(
+    // Despite the fact that the useEffect hook being called immediately,
+    // scrollToOffset may not always have an effect for unknown reason,
+    // debouncing scrollToOffset solves it.
+    debounce(
+      useCallback(() => {
+        if (flatListRef && flatListRef.current) {
+          flatListRef.current.scrollToOffset({ animated: true, offset: 0 })
+        }
+      }, [flatListRef])
+    ),
+    [nbHits, searchState]
+  )
 
   const onEndReached = useCallback(() => {
     if (data && hasNextPage) {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7827

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
