### PR TITLE
(PC-7917) App Native - Amélioration tech - Mise en place de la traduction au pluriel (avec i18n._)

### DIFF
--- a/src/libs/i18n.ts
+++ b/src/libs/i18n.ts
@@ -1,4 +1,4 @@
-import { MessageDescriptor, setupI18n } from '@lingui/core' //@translations
+import { MessageOptions, MessageDescriptor, setupI18n } from '@lingui/core' //@translations
 import { findBestAvailableLanguage } from 'react-native-localize'
 
 import frenchCatalog from 'locales/fr/messages'
@@ -16,6 +16,13 @@ export const i18n = setupI18n({
   },
 })
 
-export function _(id: MessageDescriptor): string {
+export function _(
+  id: MessageDescriptor | string,
+  values?: Record<string, unknown>,
+  messageOptions?: MessageOptions
+): string {
+  if (typeof id === 'string') {
+    return i18n._(id, values, messageOptions)
+  }
   return i18n._(id)
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7917

Ajout du pluriel, exemple :

```jsx
_('{numBooks, plural, one {# book} other {# books}}', { numBooks: new Date().getTime() % 2 + 1 })
// 1 book
// 2 books
// 1 book
// 2 books
// 2 books
// 1 book
// 2 books
```


Source: https://lingui.js.org/guides/plurals.html#using-plural-forms

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
