### PR TITLE
(PC-7917) App Native - Amélioration tech - Mise en place de la traduction au pluriel (avec i18n.plural)

### DIFF
--- a/src/libs/i18n.ts
+++ b/src/libs/i18n.ts
@@ -1,4 +1,6 @@
 import { MessageDescriptor, setupI18n } from '@lingui/core' //@translations
+/* PluralProps is provided by @types/lingui__core/select.d.ts therefore we can ignore no-unresolved error */
+import { PluralProps } from '@lingui/core/select' // eslint-disable-line import/no-unresolved
 import { findBestAvailableLanguage } from 'react-native-localize'
 
 import frenchCatalog from 'locales/fr/messages'
@@ -16,6 +18,8 @@ export const i18n = setupI18n({
   },
 })
 
-export function _(id: MessageDescriptor): string {
-  return i18n._(id)
+export function _(id: MessageDescriptor | PluralProps): string {
+  return !Object.prototype.hasOwnProperty.call(id, 'one')
+    ? i18n._(id as MessageDescriptor)
+    : i18n.plural(id as PluralProps)
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7917

```tsx
  console.log(
    _({
      value: (new Date().getTime() % 2) + 1,
      one: '# book',
      other: '# books',
    })
  )
```

```
[Wed Mar 31 2021 17:40:42.581]  LOG      2 books
[Wed Mar 31 2021 17:40:42.592]  LOG      1 book
[Wed Mar 31 2021 17:40:42.602]  LOG      2 books
[Wed Mar 31 2021 17:40:42.612]  LOG      2 books
[Wed Mar 31 2021 17:40:42.622]  LOG      1 book
[Wed Mar 31 2021 17:40:42.634]  LOG      1 book
```

Autre implémentation possible avec `i18n._`: https://github.com/pass-culture/pass-culture-app-native/pull/816
## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
