### PR TITLE
(PC-7767) Fix scrolling detection behaviour

### DIFF
--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -114,7 +114,12 @@ export const Profile: React.FC = () => {
   }
 
   return (
-    <ScrollView bounces={false} ref={scrollViewRef} onScroll={onScroll} testID="profile-scrollview">
+    <ScrollView
+      bounces={false}
+      ref={scrollViewRef}
+      onScroll={onScroll}
+      scrollEventThrottle={400}
+      testID="profile-scrollview">
       <ProfileHeader user={user} />
       <ProfileContainer>
         <Spacer.Column numberOfSpaces={getSpacing(1)} />


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7767

### Explanation

When scrolling on iOS on the profile page, you get this warning:

> You specified `onScroll` on a <ScrollView> but not `scrollEventThrottle`. You will only receive one event. Using `16` you get all the events but be aware that it may cause frame drops, use a bigger number if you don't need as much precision.

Indeed [scrollEventThrottle](https://reactnative.dev/docs/scrollview#scrolleventthrottle-ios) is required if we want to detect if we have reach the bottom of the screen (to send the appropriate analytics event).
If we don't specify this property, `isCloseToBottom` will be called only once during a continuous scrolling, thus we may miss the moment when we reach the bottom of the screen.