### PR TITLE
(Tech) fix favorite.test.tsx test timeout

### DIFF
--- a/src/features/favorites/atoms/__tests__/Favorite.test.tsx
+++ b/src/features/favorites/atoms/__tests__/Favorite.test.tsx
@@ -120,6 +120,7 @@ describe('<Favorite /> component', () => {
 
   it('should fail to delete favorite on button click', async () => {
     const id = 0
+    const timeout = 222222 // prevent act warning
     simulateBackend({ id, hasRemoveFavoriteError: true })
     mockDistance = '10 km'
     const { getByText } = renderFavorite({
@@ -128,13 +129,13 @@ describe('<Favorite /> component', () => {
 
     await superFlushWithAct()
     fireEvent.press(getByText('Supprimer'))
-    await superFlushWithAct(222222)
+    await superFlushWithAct(timeout)
     await waitForExpect(async () => {
       expect(mockShowErrorSnackBar).toBeCalledWith({
         message: `L'offre n'a pas été retirée de tes favoris`,
         timeout: SNACK_BAR_TIME_OUT,
       })
-    })
+    }, timeout)
   })
 })
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXX

## Fix

```ruby
 FAIL  src/features/favorites/atoms/__tests__/Favorite.test.tsx (5.861s)
  ● <Favorite /> component › should fail to delete favorite on button click

    : Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Error:

      119 |   })
      120 | 
    > 121 |   it('should fail to delete favorite on button click', async () => {
          |   ^
      122 |     const id = 0
      123 |     simulateBackend({ id, hasRemoveFavoriteError: true })
      124 |     mockDistance = '10 km'

      at new Spec (node_modules/jest-jasmine2/build/jasmine/Spec.js:116:22)
      at Suite.<anonymous> (src/features/favorites/atoms/__tests__/Favorite.test.tsx:121:3)

```



## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
