### PR TITLE
(PC-7332) App Native - MEP - Vérifier la remontée de bug/crash sur Se…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ import { useStartBatchNotification } from 'libs/notifications'
 import { SplashScreenProvider } from 'libs/splashscreen'
 import { SnackBarProvider } from 'ui/components/snackBar/SnackBarContext'
 
-LogBox.ignoreLogs(['Setting a timer'])
+LogBox.ignoreLogs(['Setting a timer', 'Expected style "elevation:'])
 
 const queryCache = new QueryCache()
 

--- a/src/features/errors/pages/AsyncErrorBoundary.tsx
+++ b/src/features/errors/pages/AsyncErrorBoundary.tsx
@@ -1,12 +1,12 @@
 import { t } from '@lingui/macro'
 import { useNavigation } from '@react-navigation/native'
-import React, { ReactNode, useEffect } from 'react'
+import React, { ReactNode } from 'react'
 import { FallbackProps } from 'react-error-boundary'
 import { useQueryErrorResetBoundary } from 'react-query'
 import styled from 'styled-components/native'
 
 import { UseNavigationType } from 'features/navigation/RootNavigator'
-import { errorMonitoring, MonitoringError } from 'libs/errorMonitoring'
+import { MonitoringError } from 'libs/errorMonitoring'
 import { AppButton } from 'ui/components/buttons/AppButton'
 import { Background } from 'ui/svg/Background'
 import { BrokenConnection } from 'ui/svg/BrokenConnection'
@@ -35,10 +35,6 @@ export const AsyncErrorBoundaryWithoutNavigation = ({
   header,
 }: AsyncFallbackProps) => {
   const { reset } = useQueryErrorResetBoundary()
-
-  useEffect(() => {
-    errorMonitoring.captureException(error)
-  }, [error])
 
   const handleRetry = async () => {
     reset()

--- a/src/features/errors/pages/tests/AsyncErrorBoundary.test.tsx
+++ b/src/features/errors/pages/tests/AsyncErrorBoundary.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { canGoBack, goBack } from '__mocks__/@react-navigation/native'
-import { errorMonitoring } from 'libs/errorMonitoring'
 import { render, fireEvent } from 'tests/utils'
 
 import {
@@ -19,14 +18,6 @@ describe('AsyncErrorBoundary component', () => {
       <AsyncErrorBoundary error={new Error('error')} resetErrorBoundary={resetErrorBoundary} />
     )
     expect(renderAPI).toMatchSnapshot()
-  })
-
-  it('should call errorMonitoring.captureException() on render', () => {
-    const resetErrorBoundary = jest.fn()
-    const error = new Error('error')
-    render(<AsyncErrorBoundary error={error} resetErrorBoundary={resetErrorBoundary} />)
-
-    expect(errorMonitoring.captureException).toBeCalledWith(error)
   })
 
   it('should have back arrow if possible', () => {

--- a/src/libs/errorMonitoring/__tests__/errors.test.ts
+++ b/src/libs/errorMonitoring/__tests__/errors.test.ts
@@ -1,0 +1,17 @@
+import { errorMonitoring } from 'libs/errorMonitoring'
+
+import { MonitoringError } from '../errors'
+
+describe('MonitoringError', () => {
+  it('should call errorMonitoring.captureException() on new MonitoringError instance', () => {
+    const error = new MonitoringError('error')
+    expect(errorMonitoring.captureException).toBeCalledWith(error)
+    expect(error.name).toBe(MonitoringError.name)
+  })
+
+  it('should rename MonitoringError to RenamedError', () => {
+    const error = new MonitoringError('error', 'RenamedError')
+    expect(errorMonitoring.captureException).toBeCalledWith(error)
+    expect(error.name).toBe('RenamedError')
+  })
+})

--- a/src/libs/errorMonitoring/errors.ts
+++ b/src/libs/errorMonitoring/errors.ts
@@ -1,6 +1,13 @@
+import { errorMonitoring } from 'libs/errorMonitoring/services'
+
 export class MonitoringError extends Error {
-  constructor(message: string, name = 'MonitoringError') {
+  constructor(message: string, name?: string) {
     super(message)
-    this.name = name
+    if (name) {
+      this.name = name
+    }
+    errorMonitoring.captureException(this)
   }
 }
+
+MonitoringError.prototype.name = 'MonitoringError'


### PR DESCRIPTION
…ntry App Native

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7332

Fixed `MonitoringError` class : 

- It does not require to be catched by the `AsyncErrorBoundary` to capture the exception on sentry (instead it does it within the error constructor)
- Override `prototype.name` from `Errror` to `MonitoringError`, so renamed `MonitoringError` can be identified in sentry dashboard. 

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
