### PR TITLE
(PC-7631) Enable device go back button on FirstTutorial

### DIFF
--- a/src/features/eighteenBirthday/pages/EighteenBirthday.tsx
+++ b/src/features/eighteenBirthday/pages/EighteenBirthday.tsx
@@ -11,7 +11,7 @@ export function EighteenBirthday() {
   }, [])
 
   return (
-    <GenericAchievement name="EighteenBirthday">
+    <GenericAchievement screenName="EighteenBirthday">
       <EighteenBirthdayCard />
     </GenericAchievement>
   )

--- a/src/features/firstTutorial/pages/FirstTutorial/FirstTutorial.tsx
+++ b/src/features/firstTutorial/pages/FirstTutorial/FirstTutorial.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { BackHandler } from 'react-native'
 
 import { storage } from 'libs/storage'
 import { GenericAchievement } from 'ui/components/achievements'
@@ -9,16 +10,23 @@ import { SecondCard } from './components/SecondCard'
 import { ThirdCard } from './components/ThirdCard'
 
 export function FirstTutorial() {
-  function skip() {
-    storage.saveObject('has_seen_tutorials', true)
-  }
-
   return (
-    <GenericAchievement name="FirstTutorial" skip={skip}>
+    <GenericAchievement
+      screenName="FirstTutorial"
+      skip={onSkip}
+      onFirstCardBackAction={onFirstCardBackAction}>
       <FirstCard />
       <SecondCard />
       <ThirdCard />
       <FourthCard />
     </GenericAchievement>
   )
+}
+
+function onSkip() {
+  storage.saveObject('has_seen_tutorials', true)
+}
+
+function onFirstCardBackAction() {
+  BackHandler.exitApp()
 }

--- a/src/features/firstTutorial/pages/FirstTutorial/components/ThirdCard.test.tsx
+++ b/src/features/firstTutorial/pages/FirstTutorial/components/ThirdCard.test.tsx
@@ -19,7 +19,7 @@ describe('ThirdCard', () => {
     const ref = { current: { goToNext: jest.fn() } }
     const { getByText } = render(
       <GeolocationWrapper>
-        <GenericAchievement name="TestAchievement">
+        <GenericAchievement screenName="FirstTutorial">
           <ThirdCard
             swiperRef={(ref as unknown) as RefObject<Swiper>}
             index={0}
@@ -40,7 +40,7 @@ describe('ThirdCard', () => {
     const ref = { current: { goToNext: jest.fn() } }
     const { getByText } = render(
       <GeolocationWrapper>
-        <GenericAchievement name="TestAchievement">
+        <GenericAchievement screenName="FirstTutorial">
           <ThirdCard
             swiperRef={(ref as unknown) as RefObject<Swiper>}
             index={0}

--- a/src/ui/components/achievements/components/GenericAchievementCard.test.tsx
+++ b/src/ui/components/achievements/components/GenericAchievementCard.test.tsx
@@ -66,7 +66,7 @@ describe('<GenericAchievementCard />', () => {
 
   it('should call card analytics on active index', () => {
     const { getByTestId } = render(
-      <GenericAchievement name="TestAchievement">
+      <GenericAchievement screenName="FirstTutorial">
         <GenericAchievementCard
           buttonText={buttonText}
           animation={animation}
@@ -93,10 +93,10 @@ describe('<GenericAchievementCard />', () => {
         />
       </GenericAchievement>
     )
-    expect(analytics.logScreenView).toHaveBeenCalledWith('TestAchievement1')
+    expect(analytics.logScreenView).toHaveBeenCalledWith('FirstTutorial1')
     expect(analytics.logScreenView).toBeCalledTimes(1)
     fireEvent.press(getByTestId('controlButton'))
-    expect(analytics.logScreenView).toHaveBeenCalledWith('TestAchievement2')
+    expect(analytics.logScreenView).toHaveBeenCalledWith('FirstTutorial2')
     expect(analytics.logScreenView).toBeCalledTimes(2)
   })
 
@@ -300,7 +300,7 @@ describe('<GenericAchievementCard />', () => {
 
 function renderGenericAchievementCardComponent(props: AchievementCardProps) {
   return render(
-    <GenericAchievement name="TestAchievement">
+    <GenericAchievement screenName="FirstTutorial">
       <GenericAchievementCard {...props} />
     </GenericAchievement>
   )


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7631

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] |
| -------------------- | :---------------------: |
|                      |                          | 