### PR TITLE
(PC-7631) Do not close app with back action (android) when tutorials are opened from profile screen

### DIFF
--- a/src/features/cheatcodes/pages/Navigation.tsx
+++ b/src/features/cheatcodes/pages/Navigation.tsx
@@ -155,7 +155,9 @@ export function Navigation(): JSX.Element {
         <Row half>
           <NavigationButton
             title={'First Tutorial'}
-            onPress={() => navigation.navigate('FirstTutorial')}
+            onPress={() =>
+              navigation.navigate('FirstTutorial', { shouldCloseAppOnBackAction: false })
+            }
           />
         </Row>
         <Row half>

--- a/src/features/firstTutorial/pages/FirstTutorial/FirstTutorial.test.tsx
+++ b/src/features/firstTutorial/pages/FirstTutorial/FirstTutorial.test.tsx
@@ -1,19 +1,29 @@
 import AsyncStorage from '@react-native-community/async-storage'
+import { StackScreenProps } from '@react-navigation/stack'
 import React from 'react'
 
+import { RootStackParamList } from 'features/navigation/RootNavigator'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { fireEvent, render } from 'tests/utils'
 
 import { FirstTutorial } from './FirstTutorial'
 
+const props = {
+  route: {
+    name: 'FirstTutorial',
+    key: 'key',
+    params: { shouldCloseAppOnBackAction: false },
+  },
+} as StackScreenProps<RootStackParamList, 'FirstTutorial'>
+
 describe('FirstTutorial page', () => {
   it('should render first tutorial', () => {
-    const firstTutorial = render(reactQueryProviderHOC(<FirstTutorial />))
+    const firstTutorial = render(reactQueryProviderHOC(<FirstTutorial {...props} />))
     expect(firstTutorial).toMatchSnapshot()
   })
 
   it('should set has_seen_tutorials in storage on skip', () => {
-    const { getByText } = render(reactQueryProviderHOC(<FirstTutorial />))
+    const { getByText } = render(reactQueryProviderHOC(<FirstTutorial {...props} />))
 
     fireEvent.press(getByText('Tout passer'))
     expect(AsyncStorage.setItem).toBeCalledWith('has_seen_tutorials', 'true')

--- a/src/features/firstTutorial/pages/FirstTutorial/FirstTutorial.tsx
+++ b/src/features/firstTutorial/pages/FirstTutorial/FirstTutorial.tsx
@@ -1,6 +1,8 @@
+import { StackScreenProps } from '@react-navigation/stack'
 import React from 'react'
 import { BackHandler } from 'react-native'
 
+import { RootStackParamList } from 'features/navigation/RootNavigator'
 import { storage } from 'libs/storage'
 import { GenericAchievement } from 'ui/components/achievements'
 
@@ -9,7 +11,12 @@ import { FourthCard } from './components/FourthCard'
 import { SecondCard } from './components/SecondCard'
 import { ThirdCard } from './components/ThirdCard'
 
-export function FirstTutorial() {
+type Props = StackScreenProps<RootStackParamList, 'FirstTutorial'>
+
+export function FirstTutorial({ route }: Props) {
+  const onFirstCardBackAction = route.params.shouldCloseAppOnBackAction
+    ? BackHandler.exitApp
+    : undefined
   return (
     <GenericAchievement
       screenName="FirstTutorial"
@@ -25,8 +32,4 @@ export function FirstTutorial() {
 
 function onSkip() {
   storage.saveObject('has_seen_tutorials', true)
-}
-
-function onFirstCardBackAction() {
-  BackHandler.exitApp()
 }

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -75,7 +75,7 @@ export type RootStackParamList = {
     params: TabParamList[TabRouteName]
   }
   VerifyEligibility: { email: string; licenceToken: string }
-  FirstTutorial: undefined
+  FirstTutorial: { shouldCloseAppOnBackAction: boolean }
   EighteenBirthday: undefined
 }
 

--- a/src/features/navigation/RootNavigator/useInitialScreenConfig.tsx
+++ b/src/features/navigation/RootNavigator/useInitialScreenConfig.tsx
@@ -66,7 +66,7 @@ async function getInitialScreenConfig({
     return homeNavigateConfig
   }
 
-  return { screen: 'FirstTutorial', params: undefined }
+  return { screen: 'FirstTutorial', params: { shouldCloseAppOnBackAction: true } }
 }
 
 function triggerInitialScreenNameAnalytics(screenName: ScreenNames) {

--- a/src/features/navigation/__tests__/useInitialScreenConfig.test.tsx
+++ b/src/features/navigation/__tests__/useInitialScreenConfig.test.tsx
@@ -44,7 +44,7 @@ describe('useInitialScreenConfig()', () => {
     ${true}          | ${null}             | ${true}  | ${{ needsToFillCulturalSurvey: true, showEligibleCard: true }}   | ${'EighteenBirthday'} | ${undefined}                                                      | ${'EighteenBirthday'}
     ${true}          | ${true}             | ${false} | ${{ needsToFillCulturalSurvey: true, showEligibleCard: false }}  | ${'TabNavigator'}     | ${{ screen: 'Home', params: { shouldDisplayLoginModal: false } }} | ${'Home'}
     ${true}          | ${true}             | ${false} | ${{ needsToFillCulturalSurvey: false, showEligibleCard: true }}  | ${'TabNavigator'}     | ${{ screen: 'Home', params: { shouldDisplayLoginModal: false } }} | ${'Home'}
-    ${null}          | ${true}             | ${false} | ${{ needsToFillCulturalSurvey: false, showEligibleCard: false }} | ${'FirstTutorial'}    | ${undefined}                                                      | ${'FirstTutorial'}
+    ${null}          | ${true}             | ${false} | ${{ needsToFillCulturalSurvey: false, showEligibleCard: false }} | ${'FirstTutorial'}    | ${{ shouldCloseAppOnBackAction: true }}                           | ${'FirstTutorial'}
   `(
     `should return $expectedScreen when 
       - has_seen_tutorials = $hasSeenTutorials 

--- a/src/features/profile/pages/Profile.test.tsx
+++ b/src/features/profile/pages/Profile.test.tsx
@@ -135,7 +135,7 @@ describe('Profile component', () => {
       const row = getByTestId('row-how-it-works')
       fireEvent.press(row)
 
-      expect(navigate).toBeCalledWith('FirstTutorial')
+      expect(navigate).toBeCalledWith('FirstTutorial', { shouldCloseAppOnBackAction: false })
     })
 
     it('should navigate when the faq row is clicked', async () => {

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -174,7 +174,7 @@ export const Profile: React.FC = () => {
           <Row
             title={t`Comment ça marche ?`}
             type="navigable"
-            onPress={() => navigate('FirstTutorial')}
+            onPress={() => navigate('FirstTutorial', { shouldCloseAppOnBackAction: false })}
             icon={LifeBuoy}
             style={styles.row}
             testID="row-how-it-works"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-7631

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] |
| -------------------- | :----------------------: |
|                      |                          |