### PR TITLE
Fix app launching

### DIFF
--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -32,12 +32,7 @@ const statusBarHeight = getStatusBarHeight(true)
 export const Home: FunctionComponent = function () {
   const navigation = useNavigation<UseNavigationType>()
   const { params } = useRoute<UseRouteType<'Home'>>()
-  const { data: userInfos, refetch } = useUserProfileInfo()
-  useFocusEffect(
-    useCallback(() => {
-      refetch()
-    }, [])
-  )
+  const { data: userInfos } = useUserProfileInfo()
   const { visible: signInModalVisible, showModal: showSignInModal, hideModal } = useModal(false)
   const showSkeleton = useShowSkeleton()
   const availableCredit = useAvailableCredit()

--- a/src/features/home/pages/tests/HomeWithModal.test.tsx
+++ b/src/features/home/pages/tests/HomeWithModal.test.tsx
@@ -8,7 +8,7 @@ import { flushAllPromises, render, act } from 'tests/utils'
 import { Home } from '../Home'
 
 jest.mock('features/home/api', () => ({
-  useUserProfileInfo: jest.fn(() => ({ data: undefined, refetch: jest.fn() })),
+  useUserProfileInfo: jest.fn(() => ({ data: undefined })),
 }))
 
 jest.mock('@react-navigation/native', () => jest.requireActual('@react-navigation/native'))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXX


The refetch make the app fail with this error : The 'navigation' object hasn't been initialized yet. This might happen if you don't have a navigator mounted, or if the navigator hasn't finished mounting.


## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
