### PR TITLE
(PC-7393) Fix deeplink and universal link clash

### DIFF
--- a/src/features/deeplinks/listener.ios.test.ts
+++ b/src/features/deeplinks/listener.ios.test.ts
@@ -1,12 +1,10 @@
-import { env } from 'libs/environment'
-
 import {
   isFirebaseDynamicLink,
   isFirebaseLongDynamicLink,
   extractUniversalLinkFromLongFirebaseDynamicLink,
   resolveHandler,
 } from './listener.ios'
-import { FIREBASE_DYNAMIC_LINK_DOMAIN } from './utils'
+import { DEEPLINK_DOMAIN, FIREBASE_DYNAMIC_LINK_DOMAIN } from './utils'
 
 describe('listener.ios', () => {
   describe('isFirebaseDynamicLink', () => {
@@ -32,9 +30,9 @@ describe('listener.ios', () => {
       )
       expect(isLongDynamicLink).toBe(false)
     })
-    it('should return undefined when the given link is not a firebase dynamic link', () => {
+    it('should return false when the given link is not a firebase dynamic link', () => {
       const isLongDynamicLink = isFirebaseLongDynamicLink('https://www.not-google.fr/home')
-      expect(isLongDynamicLink).toBe(undefined)
+      expect(isLongDynamicLink).toBe(false)
     })
   })
   describe('convertLongDynamicLinkToUniversalLink', () => {
@@ -46,7 +44,7 @@ describe('listener.ios', () => {
   })
   describe('handleLinks', () => {
     it('should forward deeplink event for universal link', () => {
-      const url = env.UNIVERSAL_LINK + '/home'
+      const url = DEEPLINK_DOMAIN + '/home'
       const deeplinkEvent = { url }
       const handleDeeplinkUrl = jest.fn()
 

--- a/src/features/deeplinks/listener.ios.ts
+++ b/src/features/deeplinks/listener.ios.ts
@@ -5,13 +5,16 @@ import { omit } from 'search-params'
 
 import { DeeplinkEvent } from './types'
 import { useDeeplinkUrlHandler } from './useDeeplinkUrlHandler'
-import { FIREBASE_DYNAMIC_LINK_DOMAIN, FIREBASE_DYNAMIC_LINK_PARAMS } from './utils'
+import {
+  DEEPLINK_DOMAIN,
+  FIREBASE_DYNAMIC_LINK_DOMAIN,
+  FIREBASE_DYNAMIC_LINK_PARAMS,
+} from './utils'
 
+export const isUniversalLink = (url: string) => url.startsWith(DEEPLINK_DOMAIN)
 export const isFirebaseDynamicLink = (url: string) => url.startsWith(FIREBASE_DYNAMIC_LINK_DOMAIN)
-export const isFirebaseLongDynamicLink = (url: string): boolean | undefined => {
-  if (!isFirebaseDynamicLink(url)) return undefined
-  return url.includes('?link=')
-}
+export const isFirebaseLongDynamicLink = (url: string) =>
+  isFirebaseDynamicLink(url) && url.includes('?link=')
 
 /* For Firebase Dynamic Links with params (exemple /offer?id=234)
  * we must use long dynamic links, and there are not recognized by dynamicLinks().onLink
@@ -23,42 +26,46 @@ export const extractUniversalLinkFromLongFirebaseDynamicLink = (event: DeeplinkE
   return paramsString.replace(/^link=/, '')
 }
 
-/**
- * Moved this function outside the useListenDeepLinksEffect to be able to test its behavior
- */
 export const resolveHandler = (handleDeeplinkUrl: ReturnType<typeof useDeeplinkUrlHandler>) => (
   event: DeeplinkEvent
 ) => {
-  const isFirebaseLongLink = isFirebaseLongDynamicLink(event.url)
-  const isUniversalLink = isFirebaseLongLink === undefined
-  if (isUniversalLink) {
+  if (isUniversalLink(event.url)) {
     // Universal links: https://app.passculture-{env}.beta.gouv.fr/<routeName>
     return handleDeeplinkUrl(event)
-  } else if (isFirebaseLongLink === true) {
-    // Long Firebase Dynamic Links: https://passcultureapp{env}.page.link/?link=https://app.passculture-{env}.beta.gouv.fr/<routeName>?param=214906&apn=app.passculture.testing&isi=1557887412&ibi=app.passculture.test&efr=1
+  }
+
+  // Long Firebase Dynamic Links: https://passcultureapp{env}.page.link/?link=https://app.passculture-{env}.beta.gouv.fr/<routeName>?param=214906&apn=app.passculture.testing&isi=1557887412&ibi=app.passculture.test&efr=1
+  if (isFirebaseLongDynamicLink(event.url)) {
     return handleDeeplinkUrl({ url: extractUniversalLinkFromLongFirebaseDynamicLink(event) })
   }
+
   // Short Firebase Dynamic Links: https://passcultureapp{env}.page.link/<routeName>
   // => handled with dynamicLinks().onLink
 }
 
-export function useListenDeepLinksEffect() {
+function useListenUniversalLinks() {
   const handleDeeplinkUrl = useDeeplinkUrlHandler()
 
-  const handleDynamicLink = (event: DeeplinkEvent) => {
-    handleDeeplinkUrl(event)
-  }
-
   useEffect(() => {
-    // Universal links
     Linking.addEventListener('url', resolveHandler(handleDeeplinkUrl))
-    // Firebase Dynamic links
-    const unsubscribe = dynamicLinks().onLink(handleDynamicLink)
     return () => {
       Linking.removeEventListener('url', handleDeeplinkUrl)
+    }
+  }, [])
+}
+
+function useListenDynamicLinks() {
+  const handleDeeplinkUrl = useDeeplinkUrlHandler()
+
+  useEffect(() => {
+    const unsubscribe = dynamicLinks().onLink(handleDeeplinkUrl)
+    return () => {
       unsubscribe()
     }
   }, [])
+}
 
-  return null
+export function useListenDeepLinksEffect() {
+  useListenUniversalLinks()
+  useListenDynamicLinks()
 }

--- a/src/features/navigation/__tests__/useInitialScreenConfig.test.tsx
+++ b/src/features/navigation/__tests__/useInitialScreenConfig.test.tsx
@@ -91,10 +91,10 @@ describe('useInitialScreenConfig()', () => {
 })
 
 async function renderUseInitialScreenConfig() {
-  const wrapper = (props: { children: any }) => (
-    <SplashScreenProvider>{props.children}</SplashScreenProvider>
+  const wrapper = (props: { children: unknown }) => (
+    <SplashScreenProvider>{props.children as Element}</SplashScreenProvider>
   )
-  let testComponent: RenderHookResult<{ children: any }, void | undefined> | undefined
+  let testComponent: RenderHookResult<{ children: unknown }, void | undefined> | undefined
   await act(async () => {
     testComponent = renderHook(useInitialScreenConfig, { wrapper })
   })


### PR DESCRIPTION
# Investigation sur iPhone

## Depuis slack

- https://passcultureapptesting.page.link/recherche
Universal Links listener => isFirebaseShortDynamicLink // do nothing
Dynamic Links listener ✅

- https://app.passculture-testing.beta.gouv.fr/offer/?id=220134
Universal Links listener => isUniversalLink ✅

- https://passcultureapptesting.page.link/?link=https://app.passculture-testing.beta.gouv.fr/offer/?id=220134&apn=app.passculture.testing&isi=1557887412&ibi=app.passculture.test&efr=1
Universal Links listener => isFirebaseLongDynamicLink ✅


## Depuis Messenger

- https://passcultureapptesting.page.link/recherche
Universal Links listener => isFirebaseShortDynamicLink // do nothing
Dynamic Links listener ✅

- https://app.passculture-testing.beta.gouv.fr/offer/?id=220134
Ouvre la webapp. ❌

- https://passcultureapptesting.page.link/?link=https://app.passculture-testing.beta.gouv.fr/offer/?id=220134&apn=app.passculture.testing&isi=1557887412&ibi=app.passculture.test&efr=1
Universal Links listener => isFirebaseShortDynamicLink // do nothing
Dynamic Links listener ✅


#### Notes
- Le listener des liens universels écoute tous les liens (universels + dynamiques) et dispatch en fonction.
- Les liens universels ne marchent pas sur Messenger et ouvre la webapp => on a besoin des liens dynamiques.
- Slack ne modifie pas les liens.
- Slack détecte uniquement les liens dynamiques courts. Les longs sont gérés par le dispatcher des liens universels => on a besoin des liens universels.
- Messenger modifie les liens et parse les liens dynamic longs en liens courts.

### Conclusions
- on a besoin des 2 types de liens: dynamiques pour couvrir Messenger, et universel pour détecter tous les liens et dispatch en fonction.
- Préférer l’utilisation des liens dynamiques pour le partage (afin de couvrir toutes les apps)
