### PR TITLE
(PC-8336) CulturalSurvey: invalidate userprofile request before navigating to home

### DIFF
--- a/src/features/auth/signup/IdCheck.test.tsx
+++ b/src/features/auth/signup/IdCheck.test.tsx
@@ -10,7 +10,6 @@ import { storage } from 'libs/storage'
 import { act, render, waitFor } from 'tests/utils'
 
 jest.mock('@react-navigation/native', () => jest.requireActual('@react-navigation/native'))
-jest.mock('react-query')
 
 allowConsole({ error: true })
 /* Explanation for allowConsole : 

--- a/src/features/auth/signup/IdCheck.tsx
+++ b/src/features/auth/signup/IdCheck.tsx
@@ -2,13 +2,11 @@ import { useNavigation } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useEffect, useRef, useState } from 'react'
 import { WebView, WebViewNavigation } from 'react-native-webview'
-import { useQueryClient } from 'react-query'
 import styled from 'styled-components/native'
 
 import { useCurrentRoute } from 'features/navigation/helpers'
 import { RootStackParamList, UseNavigationType } from 'features/navigation/RootNavigator'
 import { env } from 'libs/environment'
-import { QueryKeys } from 'libs/queryKeys'
 import { storage } from 'libs/storage'
 import { LoadingPage } from 'ui/components/LoadingPage'
 
@@ -21,7 +19,6 @@ export const IdCheck: React.FC<Props> = function (props) {
   const navigation = useNavigation<UseNavigationType>()
   const webviewRef = useRef<WebView>(null)
   const injectedJavascript = useKeyboardAdjustFixIdCheck()
-  const queryClient = useQueryClient()
 
   const [idCheckUri, setIdCheckUri] = useState<string | undefined>(undefined)
 
@@ -45,7 +42,6 @@ export const IdCheck: React.FC<Props> = function (props) {
     if (isEligibilityProcessAbandonned) {
       navigation.navigate('Home', { shouldDisplayLoginModal: false })
     } else if (isEligibilityProcessFinished) {
-      queryClient.invalidateQueries(QueryKeys.USER_PROFILE)
       navigation.navigate('EligibilityConfirmed')
     }
   }

--- a/src/features/firstLogin/CulturalSurvey.test.tsx
+++ b/src/features/firstLogin/CulturalSurvey.test.tsx
@@ -11,6 +11,8 @@ import { simulateWebviewMessage, superFlushWithAct, act, render } from 'tests/ut
 
 import { CulturalSurvey } from './CulturalSurvey'
 
+jest.mock('react-query')
+
 const mockedUseUserProfileInfo = useUserProfileInfo as jest.MockedFunction<
   typeof useUserProfileInfo
 >


### PR DESCRIPTION


Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-8336

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
