### PR TITLE
(PC-8501) Le temps de chargement des playlists est démesurément long

### DIFF
--- a/src/features/home/pages/tests/useHomeAlgoliaModules.test.ts
+++ b/src/features/home/pages/tests/useHomeAlgoliaModules.test.ts
@@ -39,16 +39,6 @@ describe('useHomeAlgoliaModules', () => {
     await cleanup()
   })
 
-  it('should not call fetchAlgolia if the position is still fetching', async () => {
-    renderHook(
-      () => useHomeAlgoliaModules(offerModules),
-      // eslint-disable-next-line react/display-name
-      { wrapper: ({ children }) => reactQueryProviderHOC(children) }
-    )
-
-    expect(mockFetchAlgolia).not.toHaveBeenCalled()
-  })
-
   it('calls fetchAlgolia with params and returns data', async () => {
     mockPositionReceived = true
     const { result, waitForNextUpdate } = renderHook(

--- a/src/features/home/pages/useHomeAlgoliaModules.ts
+++ b/src/features/home/pages/useHomeAlgoliaModules.ts
@@ -1,5 +1,5 @@
 import { SearchResponse } from '@algolia/client-search'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useQueries } from 'react-query'
 
 import { Offers, OffersWithCover } from 'features/home/contentful'
@@ -43,10 +43,10 @@ export const formatAlgoliaHit = <Hit extends AlgoliaHit | SearchAlgoliaHit>(hit:
 export const useHomeAlgoliaModules = (
   offerModules: Array<Offers | OffersWithCover>
 ): AlgoliaModuleResponse => {
-  const { position, positionReceived } = useGeolocation()
+  const { position } = useGeolocation()
   const [algoliaModules, setAlgoliaModules] = useState<AlgoliaModuleResponse>({})
 
-  useQueries(
+  const queries = useQueries(
     offerModules.map(({ algolia, moduleId }) => {
       const parsedParameters = parseAlgoliaParameters({
         geolocation: position,
@@ -73,10 +73,16 @@ export const useHomeAlgoliaModules = (
             }))
           }
         },
-        enabled: positionReceived,
       }
     })
   )
+
+  useEffect(() => {
+    // When we enable or disable the geolocation, we want to refetch the algolia modules
+    queries.forEach(({ refetch }) => {
+      refetch()
+    })
+  }, [!!position])
 
   return algoliaModules
 }

--- a/src/libs/geolocation/GeolocationWrapper.tsx
+++ b/src/libs/geolocation/GeolocationWrapper.tsx
@@ -17,7 +17,6 @@ type RequestGeolocPermissionParams = {
 
 export interface IGeolocationContext {
   position: GeoCoordinates | null
-  positionReceived: boolean
   setPosition: (position: GeoCoordinates | null) => void
   permissionState: GeolocPermissionState
   requestGeolocPermission: (params?: RequestGeolocPermissionParams) => Promise<void>
@@ -27,7 +26,6 @@ export interface IGeolocationContext {
 
 export const GeolocationContext = React.createContext<IGeolocationContext>({
   position: null,
-  positionReceived: false,
   setPosition: () => undefined,
   permissionState: GeolocPermissionState.DENIED,
   requestGeolocPermission: async () => {
@@ -45,7 +43,6 @@ export const GeolocationWrapper = ({ children }: { children: Element }) => {
     GeolocPermissionState.DENIED
   )
   const [shouldComputePosition, setShouldComputePosition] = useSafeState(0)
-  const [positionReceived, setPositionReceived] = useSafeState(false)
 
   useEffect(() => {
     contextualCheckPermission()
@@ -56,13 +53,9 @@ export const GeolocationWrapper = ({ children }: { children: Element }) => {
   useEffect(() => {
     if (shouldComputePosition === 0) return
     if (permissionState === GeolocPermissionState.GRANTED) {
-      getPosition((coordinates) => {
-        setPosition(coordinates)
-        setPositionReceived(true)
-      })
+      getPosition(setPosition)
     } else {
       setPosition(null)
-      setPositionReceived(true)
     }
   }, [shouldComputePosition])
 
@@ -122,7 +115,6 @@ export const GeolocationWrapper = ({ children }: { children: Element }) => {
     <GeolocationContext.Provider
       value={{
         position,
-        positionReceived,
         setPosition,
         permissionState,
         requestGeolocPermission: contextualRequestGeolocPermission,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-8501

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.

### Explication

La vidéo montre un utilisateur non connecté => pas de module de recommendation donc ce n'est pas un soucis de perf à ce niveau là.
Il s'agit d'une régression récente probablement dû à [cette PR](https://github.com/pass-culture/pass-culture-app-native/pull/972) (une des seules sur le chargement de la home).
Pour moi, l'explication est qu'on ne lance pas les requêtes à Algolia tant qu'on a pas la position, d'où le temps de latence.
Ce qui confirme le manque de skeleton puisque rien n'est en train d'être requêté (cf hook `useShowSkeleton`)