### PR TITLE
(PC-8164) modale de saisie du code de vérification: comportement du bouton continuer

### DIFF
--- a/src/features/auth/signup/SetPhoneNumberValidationCode.test.tsx
+++ b/src/features/auth/signup/SetPhoneNumberValidationCode.test.tsx
@@ -5,6 +5,7 @@ import { SetPhoneNumberValidationCode } from 'features/auth/signup/SetPhoneNumbe
 import { contactSupport } from 'features/auth/support.services'
 import { fireEvent, render } from 'tests/utils'
 import * as ModalModule from 'ui/components/modals/useModal'
+import { ColorsEnum } from 'ui/theme'
 
 describe('SetPhoneNumberValidationCode', () => {
   describe('Quit process', () => {
@@ -44,6 +45,48 @@ describe('SetPhoneNumberValidationCode', () => {
 
       await waitForExpect(() => {
         expect(contactSupport.forPhoneNumberConfirmation).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('Continue button', () => {
+    it('should enable continue button if input is valid and complete', async () => {
+      const { getByTestId, rerender } = render(
+        <SetPhoneNumberValidationCode dismissModal={jest.fn()} visible={true} />
+      )
+
+      const continueButton = getByTestId('button-container-continue')
+      expect(continueButton.props.style.backgroundColor).toEqual(ColorsEnum.GREY_LIGHT)
+
+      const codeInputContainer = getByTestId('code-input-container')
+      for (let i = 0; i < codeInputContainer.props.children.length; i++) {
+        fireEvent.changeText(getByTestId(`input-${i}`), '1')
+        rerender(<SetPhoneNumberValidationCode dismissModal={jest.fn()} visible={true} />)
+      }
+
+      await waitForExpect(() => {
+        expect(continueButton.props.style.backgroundColor).toEqual(ColorsEnum.PRIMARY)
+      })
+    })
+
+    it.each([
+      ['empty', ''],
+      ['includes string', 's09453'],
+      ['is too short', '54'],
+    ])('should not enable continue button when "%s"', async (_reason, codeTyped) => {
+      const { getByTestId, rerender } = render(
+        <SetPhoneNumberValidationCode dismissModal={jest.fn()} visible={true} />
+      )
+
+      const continueButton = getByTestId('button-container-continue')
+
+      for (let i = 0; i < codeTyped.length; i++) {
+        fireEvent.changeText(getByTestId(`input-${i}`), codeTyped[i])
+        rerender(<SetPhoneNumberValidationCode dismissModal={jest.fn()} visible={true} />)
+      }
+
+      await waitForExpect(() => {
+        expect(continueButton.props.style.backgroundColor).toEqual(ColorsEnum.GREY_LIGHT)
       })
     })
   })

--- a/src/features/auth/signup/SetPhoneNumberValidationCode.tsx
+++ b/src/features/auth/signup/SetPhoneNumberValidationCode.tsx
@@ -6,7 +6,7 @@ import { QuitSignupModal, SignupSteps } from 'features/auth/components/QuitSignu
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ButtonQuaternary } from 'ui/components/buttons/ButtonQuaternary'
 import { ButtonTertiary } from 'ui/components/buttons/ButtonTertiary'
-import { CodeInput } from 'ui/components/inputs/CodeInput'
+import { CodeInput, CodeValidation } from 'ui/components/inputs/CodeInput'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { useModal } from 'ui/components/modals/useModal'
 import { Separator } from 'ui/components/Separator'
@@ -25,13 +25,29 @@ interface Props {
   // TODO(PC-8137) create phone number property retrieved from SetPhoneNumberModal
 }
 
+interface CodeInputState extends CodeValidation {
+  code: string | null
+}
+
 export const SetPhoneNumberValidationCode: FC<Props> = (props) => {
-  const [_code, setCode] = useState<string | null>('')
+  const [codeInputState, setCodeInputState] = useState<CodeInputState>({
+    code: null,
+    isComplete: false,
+    isValid: false,
+  })
+
   const {
     visible: fullPageModalVisible,
     showModal: showFullPageModal,
     hideModal: hideFullPageModal,
   } = useModal(props.visible)
+
+  function onChangeValue(value: string | null, validation: CodeValidation) {
+    setCodeInputState({
+      code: value,
+      ...validation,
+    })
+  }
 
   return (
     <AppModal
@@ -54,10 +70,14 @@ export const SetPhoneNumberValidationCode: FC<Props> = (props) => {
           enableValidation
           isValid={isCodeValid}
           isInputValid={isInputValid}
-          onChangeValue={(code, _validation) => setCode(code)}
+          onChangeValue={onChangeValue}
         />
         <Spacer.Column numberOfSpaces={8} />
-        <ButtonPrimary title={t`Continuer`} />
+        <ButtonPrimary
+          title={t`Continuer`}
+          disabled={!codeInputState.isValid}
+          testIdSuffix={t`continue`}
+        />
         <Spacer.Column numberOfSpaces={4} />
         <HelpRow>
           <Typo.Body>{t`Tu n'as pas reçu le sms ?`}</Typo.Body>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-8164



## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |![Screenshot from 2021-05-04 18-31-25](https://user-images.githubusercontent.com/22886846/117037745-1b571400-ad07-11eb-996b-6a9d750cb221.png)![Screenshot from 2021-05-04 18-31-12](https://user-images.githubusercontent.com/22886846/117037749-1befaa80-ad07-11eb-8fc8-4c4afd097445.png)|                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
