### PR TITLE
(Tech) restore bash cause posix script

### DIFF
--- a/scripts/check_branch.sh
+++ b/scripts/check_branch.sh
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
 check_branch(){
   CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
   echo $CURRENT_BRANCH
-  if [ "$CURRENT_BRANCH" != "master" ];
+  if [[ "$CURRENT_BRANCH" != "master" ]];
   then
     echo "Wrong branch, checkout master to deploy"
     exit 1

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,7 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -e
+
 RED='\033[0;31m'
 BLUE='\033[0;34m'
 CYAN='\033[0;36m'
@@ -72,7 +74,7 @@ check_environment(){
 check_dependency(){
   if ! which jq >/dev/null
   then
-    error "Please install jq at: https://stedolan.github.io/jq/download/" 
+    error "Please install jq at: https://stedolan.github.io/jq/download/"
     exit 1
   fi
 }

--- a/scripts/deploy_new_production_version.sh
+++ b/scripts/deploy_new_production_version.sh
@@ -1,4 +1,4 @@
- #!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/deploy_new_version.sh
+++ b/scripts/deploy_new_version.sh
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
-sh ./scripts/check_branch.sh
+./scripts/check_branch.sh
 git pull
 
 # $1 is the tag used to trigger the ci deployment (see .circleci/config.yml)
 # $2 is upgrade level (major, minor or patch)
-sh ./scripts/update_app_version.sh "$1" "$2"
+./scripts/update_app_version.sh "$1" "$2"
 git push --follow-tags

--- a/scripts/generate_api_client.sh
+++ b/scripts/generate_api_client.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -e
 
 docker run --rm -v ${PWD}:/local swaggerapi/swagger-codegen-cli-v3 generate \

--- a/scripts/print_project_version.sh
+++ b/scripts/print_project_version.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -e
 
 print_usage(){

--- a/scripts/update_app_version.sh
+++ b/scripts/update_app_version.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
-update_app_version(){  
-  yarn version --"$2" --no-git-tag-version    
+update_app_version(){
+  yarn version --"$2" --no-git-tag-version
 
   VERSION=`json -f package.json version`
 

--- a/scripts/upload_sourcemaps_to_sentry.sh
+++ b/scripts/upload_sourcemaps_to_sentry.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
@marionnousvalentin 

J'ai rencontré des soucis sur Debian avec le script deploy staging hard.


et
```
./scripts/update_app_version.sh: 12: ./scripts/update_app_version.sh: Bad substitution
```
Ce sont des posix script, du coup ça marche avec bash, une raison pour utiliser sh (l'interpreteur en haut de chaque fichier est bash)

Aussi, ce shebang est meilleur : 

```
#! /usr/bin/env bash
```

https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXX

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
