### PR TITLE
(PC-8357) Refacto: move the cancellation button in a dedicated component

### DIFF
--- a/src/features/bookings/components/BookingDetailsCancelButton.test.tsx
+++ b/src/features/bookings/components/BookingDetailsCancelButton.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+
+import {
+  BookingDetailsCancelButton,
+  BookingDetailsCancelButtonProps,
+} from 'features/bookings/components/BookingDetailsCancelButton'
+import { fireEvent, render } from 'tests/utils'
+
+import { bookingsSnap } from '../api/bookingsSnap'
+
+import { Booking } from './types'
+
+describe('<BookingDetailsCancelButton />', () => {
+  it('should display the "Terminer" button for digital offers when autoActivateDigitalBookings is true', () => {
+    const booking = { ...bookingsSnap.ongoing_bookings[0] }
+    booking.stock.offer.isDigital = true
+    booking.activationCode = {
+      code: 'someCode',
+    }
+    const { getByTestId } = renderBookingDetailsCancelButton(booking, {
+      activationCodeFeatureEnabled: true,
+    })
+    getByTestId('button-title-archive')
+  })
+  it('should display button if confirmationDate is null', () => {
+    const booking = { ...bookingsSnap.ongoing_bookings[0] }
+    booking.confirmationDate = null
+    const { getByTestId } = renderBookingDetailsCancelButton(booking)
+    getByTestId('button-title-cancel')
+  })
+
+  it('should display button if confirmation date is not expired', () => {
+    const booking = { ...bookingsSnap.ongoing_bookings[0] }
+    const date = new Date()
+    date.setDate(date.getDate() + 1)
+    booking.confirmationDate = date
+    const { getByTestId } = renderBookingDetailsCancelButton(booking)
+    getByTestId('button-title-cancel')
+  })
+
+  it('should not display button if confirmation date is expired', async () => {
+    const booking = { ...bookingsSnap.ongoing_bookings[0] }
+    booking.stock.offer.isPermanent = false
+    booking.confirmationDate = new Date('2020-03-15T23:01:37.925926')
+    const { queryByTestId } = renderBookingDetailsCancelButton(booking)
+    expect(queryByTestId('button-title-cancel')).toBeFalsy()
+  })
+
+  it('should call onCancel', () => {
+    const booking = { ...bookingsSnap.ongoing_bookings[0] }
+    const date = new Date()
+    date.setDate(date.getDate() + 1)
+    booking.confirmationDate = date
+    const onCancel = jest.fn()
+    const { getByTestId } = renderBookingDetailsCancelButton(booking, {
+      onCancel,
+    })
+    const button = getByTestId('button-container-cancel')
+    fireEvent.press(button)
+
+    expect(onCancel).toBeCalled()
+  })
+  it('should call onTerminate', () => {
+    const booking = { ...bookingsSnap.ongoing_bookings[0], activationCode: { code: 'someCode' } }
+    const onTerminate = jest.fn()
+    const { getByTestId } = renderBookingDetailsCancelButton(booking, {
+      activationCodeFeatureEnabled: true,
+      onTerminate,
+    })
+    const button = getByTestId('button-container-archive')
+    fireEvent.press(button)
+
+    expect(onTerminate).toBeCalled()
+  })
+})
+
+function renderBookingDetailsCancelButton(
+  booking: Booking,
+  props?: Omit<BookingDetailsCancelButtonProps, 'booking'>
+) {
+  return render(<BookingDetailsCancelButton booking={booking} {...props} />)
+}

--- a/src/features/bookings/components/BookingDetailsCancelButton.tsx
+++ b/src/features/bookings/components/BookingDetailsCancelButton.tsx
@@ -1,0 +1,70 @@
+import { t } from '@lingui/macro'
+import * as React from 'react'
+import styled from 'styled-components/native'
+
+import { getBookingProperties } from 'features/bookings/helpers'
+import { formatToCompleteFrenchDate } from 'libs/parsers'
+import { ButtonSecondary } from 'ui/components/buttons/ButtonSecondary'
+import { ColorsEnum, Spacer, Typo } from 'ui/theme'
+
+import { Booking } from './types'
+
+export interface BookingDetailsCancelButtonProps {
+  booking: Booking
+  activationCodeFeatureEnabled?: boolean
+  onCancel?: () => void
+  onTerminate?: () => void
+}
+
+export const BookingDetailsCancelButton = (props: BookingDetailsCancelButtonProps) => {
+  const { booking } = props
+  const properties = getBookingProperties(booking)
+
+  if (properties.hasActivationCode == true && props.activationCodeFeatureEnabled) {
+    return (
+      <ButtonSecondary title={t`Terminer`} onPress={props.onTerminate} testIdSuffix={'archive'} />
+    )
+  }
+
+  const renderButton = (
+    <ButtonSecondary
+      title={t`Annuler ma réservation`}
+      onPress={props.onCancel}
+      testIdSuffix={'cancel'}
+    />
+  )
+
+  if (booking.confirmationDate) {
+    const isStillCancellable = new Date(booking.confirmationDate) > new Date()
+    const formattedConfirmationDate = formatToCompleteFrenchDate(
+      new Date(booking.confirmationDate),
+      false
+    )
+    if (isStillCancellable) {
+      return (
+        <React.Fragment>
+          {renderButton}
+          <Spacer.Column numberOfSpaces={4} />
+          <CancellationCaption>
+            {t`La réservation est annulable jusqu'au` + '\u00a0' + formattedConfirmationDate}
+          </CancellationCaption>
+        </React.Fragment>
+      )
+    } else {
+      return (
+        <CancellationCaption>
+          {t`Tu ne peux plus annuler ta réservation : elle devait être annulée avant le` +
+            '\u00a0' +
+            formattedConfirmationDate}
+        </CancellationCaption>
+      )
+    }
+  }
+
+  return renderButton
+}
+
+const CancellationCaption = styled(Typo.Caption)({
+  textAlign: 'center',
+  color: ColorsEnum.GREY_DARK,
+})

--- a/src/features/bookings/pages/BookingDetails.test.tsx
+++ b/src/features/bookings/pages/BookingDetails.test.tsx
@@ -194,40 +194,6 @@ describe('BookingDetails', () => {
   })
 
   describe('cancellation button', () => {
-    it('should display the "Terminer" button for digital offers when autoActivateDigitalBookings is true', () => {
-      mockSettings.autoActivateDigitalBookings = true
-      const booking = { ...bookingsSnap.ongoing_bookings[0] }
-      booking.stock.offer.isDigital = true
-      booking.activationCode = {
-        code: 'someCode',
-      }
-      const { getByTestId } = renderBookingDetails(booking)
-      getByTestId('button-title-archive')
-    })
-    it('should display button if confirmationDate is null', () => {
-      const booking = { ...bookingsSnap.ongoing_bookings[0] }
-      booking.confirmationDate = null
-      const { getByTestId } = renderBookingDetails(booking)
-      getByTestId('button-title-cancel')
-    })
-
-    it('should display button if confirmation date is not expired', () => {
-      const booking = { ...bookingsSnap.ongoing_bookings[0] }
-      const date = new Date()
-      date.setDate(date.getDate() + 1)
-      booking.confirmationDate = date
-      const { getByTestId } = renderBookingDetails(booking)
-      getByTestId('button-title-cancel')
-    })
-
-    it('should not display button if confirmation date is expired', async () => {
-      const booking = { ...bookingsSnap.ongoing_bookings[0] }
-      booking.stock.offer.isPermanent = false
-      booking.confirmationDate = new Date('2020-03-15T23:01:37.925926')
-      const { queryByTestId } = renderBookingDetails(booking)
-      expect(queryByTestId('button-title-cancel')).toBeFalsy()
-    })
-
     it('should log event "CancelBooking" when cancelling booking', () => {
       const booking = { ...bookingsSnap.ongoing_bookings[0] }
       const date = new Date()

--- a/src/features/bookings/pages/BookingDetails.tsx
+++ b/src/features/bookings/pages/BookingDetails.tsx
@@ -13,6 +13,7 @@ import styled from 'styled-components/native'
 
 import { useAppSettings } from 'features/auth/settings'
 import { useOngoingBooking } from 'features/bookings/api/queries'
+import { BookingDetailsCancelButton } from 'features/bookings/components/BookingDetailsCancelButton'
 import { BookingDetailsHeader } from 'features/bookings/components/BookingDetailsHeader'
 import { BookingDetailsTicketContent } from 'features/bookings/components/BookingDetailsTicketContent'
 import { BookingPropertiesSection } from 'features/bookings/components/BookingPropertiesSection'
@@ -28,9 +29,7 @@ import { analytics } from 'libs/analytics'
 import { isCloseToBottom } from 'libs/analytics.utils'
 import { SeeItineraryButton } from 'libs/itinerary/components/SeeItineraryButton'
 import useOpenItinerary from 'libs/itinerary/useOpenItinerary'
-import { formatToCompleteFrenchDate } from 'libs/parsers'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
-import { ButtonSecondary } from 'ui/components/buttons/ButtonSecondary'
 import { interpolationConfig } from 'ui/components/headers/animationHelpers'
 import { blurImageHeight, HeroHeader } from 'ui/components/headers/HeroHeader'
 import { useModal } from 'ui/components/modals/useModal'
@@ -105,47 +104,6 @@ export function BookingDetails() {
   const cancelBooking = () => {
     showCancelModal()
     analytics.logCancelBooking(offer.id)
-  }
-
-  const renderCancellationCTA = () => {
-    if (properties.hasActivationCode == true && activationCodeFeatureEnabled) {
-      return <ButtonSecondary title={t`Terminer`} onPress={() => null} testIdSuffix={'archive'} />
-    }
-
-    const renderButton = (
-      <ButtonSecondary
-        title={t`Annuler ma réservation`}
-        onPress={cancelBooking}
-        testIdSuffix={'cancel'}
-      />
-    )
-    if (booking.confirmationDate) {
-      const isStillCancellable = new Date(booking.confirmationDate) > new Date()
-      const formattedConfirmationDate = formatToCompleteFrenchDate(
-        new Date(booking.confirmationDate),
-        false
-      )
-      if (isStillCancellable) {
-        return (
-          <React.Fragment>
-            {renderButton}
-            <Spacer.Column numberOfSpaces={4} />
-            <CancellationCaption>
-              {t`La réservation est annulable jusqu'au` + '\u00a0' + formattedConfirmationDate}
-            </CancellationCaption>
-          </React.Fragment>
-        )
-      } else {
-        return (
-          <CancellationCaption>
-            {t`Tu ne peux plus annuler ta réservation : elle devait être annulée avant le` +
-              '\u00a0' +
-              formattedConfirmationDate}
-          </CancellationCaption>
-        )
-      }
-    }
-    return renderButton
   }
 
   const navigateToOffer = () => {
@@ -229,7 +187,11 @@ export function BookingDetails() {
             onPress={navigateToOffer}
           />
           <Spacer.Column numberOfSpaces={4} />
-          {renderCancellationCTA()}
+          <BookingDetailsCancelButton
+            booking={booking}
+            activationCodeFeatureEnabled={activationCodeFeatureEnabled}
+            onCancel={cancelBooking}
+          />
         </ViewWithPadding>
         <Spacer.Column numberOfSpaces={5} />
       </ScrollView>
@@ -253,9 +215,4 @@ const OfferRules = styled(Typo.Caption)({
 
 const ViewWithPadding = styled.View({
   paddingHorizontal,
-})
-
-const CancellationCaption = styled(Typo.Caption)({
-  textAlign: 'center',
-  color: ColorsEnum.GREY_DARK,
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-8357

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
