### PR TITLE
[PC-8413] Affichage de la home impromptu au swipe sur les cartes tutos

### DIFF
--- a/src/features/firstTutorial/pages/FirstTutorial/components/FourthCard.test.tsx
+++ b/src/features/firstTutorial/pages/FirstTutorial/components/FourthCard.test.tsx
@@ -2,7 +2,7 @@ import AsyncStorage from '@react-native-community/async-storage'
 import React, { createRef } from 'react'
 import Swiper from 'react-native-web-swiper'
 
-import { navigate } from '__mocks__/@react-navigation/native'
+import { reset } from '__mocks__/@react-navigation/native'
 import { homeNavigateConfig } from 'features/navigation/helpers'
 import { fireEvent, render } from 'tests/utils'
 
@@ -48,7 +48,7 @@ describe('FourthCard', () => {
 
     fireEvent.press(getByText('Découvrir'))
 
-    expect(navigate).toBeCalledTimes(1)
-    expect(navigate).toHaveBeenCalledWith(homeNavigateConfig.screen, homeNavigateConfig.params)
+    expect(reset).toBeCalledTimes(1)
+    expect(reset).toHaveBeenCalledWith({ index: 0, routes: [{ name: homeNavigateConfig.screen }] })
   })
 })

--- a/src/features/firstTutorial/pages/FirstTutorial/components/FourthCard.tsx
+++ b/src/features/firstTutorial/pages/FirstTutorial/components/FourthCard.tsx
@@ -12,7 +12,7 @@ import {
 } from 'ui/components/achievements/components/GenericAchievementCard'
 
 export function FourthCard(props: AchievementCardKeyProps) {
-  const { navigate } = useNavigation<UseNavigationType>()
+  const { reset } = useNavigation<UseNavigationType>()
 
   const { activeIndex, index } = props
   const isActiveCard = index !== undefined && activeIndex === index
@@ -23,7 +23,7 @@ export function FourthCard(props: AchievementCardKeyProps) {
   }, [isActiveCard])
 
   function onButtonPress() {
-    navigate(homeNavigateConfig.screen, homeNavigateConfig.params)
+    reset({ index: 0, routes: [{ name: homeNavigateConfig.screen }] })
   }
 
   return (

--- a/src/features/navigation/RootNavigator/useInitialScreenConfig.tsx
+++ b/src/features/navigation/RootNavigator/useInitialScreenConfig.tsx
@@ -20,7 +20,7 @@ export type InitialScreenConfiguration =
   | ScreenConfiguration<'FirstTutorial'>
 
 export function useInitialScreenConfig(): void {
-  const { navigate } = useNavigation<UseNavigationType>()
+  const { navigate, reset } = useNavigation<UseNavigationType>()
   const { hideSplashScreen } = useSplashScreenContext()
   const { isLoggedIn } = useAuthContext()
 
@@ -39,7 +39,12 @@ export function useInitialScreenConfig(): void {
     if (!initialScreenConfig || !hideSplashScreen) {
       return
     }
-    navigate(initialScreenConfig.screen, initialScreenConfig.params)
+    if (initialScreenConfig.screen !== 'TabNavigator') {
+      const { screen: name, params } = initialScreenConfig
+      reset({ index: 0, routes: [{ name, params }] })
+    } else {
+      navigate(initialScreenConfig.screen, initialScreenConfig.params)
+    }
     hideSplashScreen()
   }, [initialScreenConfig, hideSplashScreen])
 }

--- a/src/features/navigation/__tests__/useInitialScreenConfig.test.tsx
+++ b/src/features/navigation/__tests__/useInitialScreenConfig.test.tsx
@@ -3,7 +3,7 @@ import { rest } from 'msw'
 import React from 'react'
 import waitForExpect from 'wait-for-expect'
 
-import { navigate } from '__mocks__/@react-navigation/native'
+import { navigate, reset } from '__mocks__/@react-navigation/native'
 import { UserProfileResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/AuthContext'
 import { analytics } from 'libs/analytics'
@@ -65,7 +65,14 @@ describe('useInitialScreenConfig()', () => {
       await renderUseInitialScreenConfig()
 
       await waitForExpect(() => {
-        expect(navigate).toHaveBeenNthCalledWith(1, expectedScreen, expectedScreenParams)
+        if (expectedScreen === 'TabNavigator') {
+          expect(navigate).toHaveBeenNthCalledWith(1, expectedScreen, expectedScreenParams)
+        } else {
+          expect(reset).toHaveBeenNthCalledWith(1, {
+            index: 0,
+            routes: [{ name: expectedScreen, params: expectedScreenParams }],
+          })
+        }
       })
       expect(analytics.logScreenView).toBeCalledTimes(1)
       expect(analytics.logScreenView).toBeCalledWith(expectedAnalyticsScreen)

--- a/src/libs/splashscreen.tsx
+++ b/src/libs/splashscreen.tsx
@@ -16,21 +16,15 @@ export function useSplashScreenContext() {
 }
 
 export function SplashScreenProvider(props: { children: Element }) {
-  const hideSplashScreen = useCallback(function () {
+  const [isSplashScreenHidden, setIsSplashScreenHidden] = useSafeState<boolean>(false)
+
+  const hideSplashScreen = useCallback(() => {
     SplashScreen.hide()
-    setContextValue((previousContextValue) => ({
-      ...previousContextValue,
-      isSplashScreenHidden: true,
-    }))
+    setIsSplashScreenHidden(true)
   }, [])
 
-  const [contextValue, setContextValue] = useSafeState({
-    isSplashScreenHidden: false,
-    hideSplashScreen,
-  })
-
   return (
-    <SplashScreenContext.Provider value={contextValue}>
+    <SplashScreenContext.Provider value={{ isSplashScreenHidden, hideSplashScreen }}>
       {props.children}
     </SplashScreenContext.Provider>
   )

--- a/src/ui/components/achievements/components/GenericAchievement.test.tsx
+++ b/src/ui/components/achievements/components/GenericAchievement.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Text, View } from 'react-native'
 import waitForExpect from 'wait-for-expect'
 
-import { navigate } from '__mocks__/@react-navigation/native'
+import { reset } from '__mocks__/@react-navigation/native'
 import { homeNavigateConfig } from 'features/navigation/helpers'
 import { analytics } from 'libs/analytics'
 import { fireEvent, render } from 'tests/utils'
@@ -40,7 +40,8 @@ describe('<GenericAchievement />', () => {
     })
     const skipAll = await getByText('Tout passer')
     fireEvent.press(skipAll)
-    expect(navigate).toHaveBeenCalledWith(homeNavigateConfig.screen, homeNavigateConfig.params)
+    expect(reset).toHaveBeenCalledTimes(1)
+    expect(reset).toHaveBeenCalledWith({ index: 0, routes: [{ name: homeNavigateConfig.screen }] })
     expect(analytics.logHasSkippedTutorial).toHaveBeenCalledWith(`${name}1`)
   })
 

--- a/src/ui/components/achievements/components/GenericAchievement.tsx
+++ b/src/ui/components/achievements/components/GenericAchievement.tsx
@@ -58,7 +58,7 @@ export const GenericAchievement: FunctionComponent<Props> = (props: Props) => {
       const index = swiperRef.current.getActiveIndex()
       analytics.logHasSkippedTutorial(`${props.screenName}${index + 1}`)
     }
-    navigation.navigate(homeNavigateConfig.screen, homeNavigateConfig.params)
+    navigation.reset({ index: 0, routes: [{ name: homeNavigateConfig.screen }] })
   }
 
   return (


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-8413

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.

### Explication

Avant cette PR, quand on ouvre l'application, on va sur la `Home` puis on est redirigé vers les cartes Tuto (possibilité dee swiper en arrière et donc d'afficher la Home de façon impromptue, cf ticket).
Maintenant, au lieu d'être redirigé vers les cartes Tutos, on reset l'état de navigation pour que ce soit le premier tuto soit à la racine.
Par conséquent, pour sortir de ces tutos, on remplace la racine de l'état de navigation par la Home.