### PR TITLE
[PC-8768] Revert commit

### DIFF
--- a/ios/PassCulture/AppDelegate.m
+++ b/ios/PassCulture/AppDelegate.m
@@ -56,8 +56,6 @@ static void InitializeFlipper(UIApplication *application) {
                                             initialProperties:nil];
 
   [RNBatch start:false]; // or true if you want the do not disturb mode
-  [BatchUNUserNotificationCenterDelegate registerAsDelegate];
-  [BatchUNUserNotificationCenterDelegate sharedInstance].showForegroundNotifications = true;
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -23,7 +23,6 @@ target 'PassCulture' do
   pod 'Permission-LocationWhenInUse', :path => "#{permissions_path}/LocationWhenInUse"
   pod 'Permission-Notifications', :path => "#{permissions_path}/Notifications"
   pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '7.11.0'
-  pod 'Batch', '~>1.17'
 
   # Enables react-native-text-input-mask
   #

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - AppsFlyerFramework/Main (= 6.2.4)
   - AppsFlyerFramework/Main (6.2.4)
   - Base64 (1.1.2)
-  - Batch (1.17.1)
+  - Batch (1.15.2)
   - boost-for-react-native (1.63.0)
   - BVLinearGradient (2.5.6):
     - React
@@ -497,7 +497,6 @@ PODS:
     - Yoga (~> 1.14)
 
 DEPENDENCIES:
-  - Batch (~> 1.17)
   - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
   - CodePush (from `../node_modules/react-native-code-push`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
@@ -761,7 +760,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   AppsFlyerFramework: f3f0e978cfb8e7dc09a3ab90da316f52cd9c56fe
   Base64: cecfb41a004124895a7bcee567a89bae5a89d49b
-  Batch: 01ccf9b1819b8a468196e9fad4e7da2623845172
+  Batch: cf8eb2939d662b1d68319d814528df7aef29f348
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
@@ -833,7 +832,7 @@ SPEC CHECKSUMS:
   React-RCTText: 65a6de06a7389098ce24340d1d3556015c38f746
   React-RCTVibration: 8e9fb25724a0805107fc1acc9075e26f814df454
   ReactCommon: 4167844018c9ed375cc01a843e9ee564399e53c3
-  RNBatchPush: 8b5ce832fcdb4f4ba94033f20e45df9157a73a5b
+  RNBatchPush: 3f65c36b08903567ebd0a4fb75a1a17db8fd6839
   RNCAsyncStorage: 2a692bcb9b69b76a2f1a95f33db057129700af64
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNDateTimePicker: 8a51a2216c307769e69ef827293d59549ab1ca23
@@ -857,6 +856,6 @@ SPEC CHECKSUMS:
   Yoga: 7d13633d129fd179e01b8953d38d47be90db185a
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: c20e47c85b228c8e37ac69429ba37601d337141e
+PODFILE CHECKSUM: 40318e93379c2de4d579821c977c6a0e09a56199
 
 COCOAPODS: 1.10.1

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@algolia/client-search": "^4.6.0",
-    "@bam.tech/react-native-batch": "^6.0.0-rc.1",
+    "@bam.tech/react-native-batch": "^5.2.1",
     "@bam.tech/react-native-config": "^0.13.0",
     "@lingui/core": "^3.8.9",
     "@lingui/react": "^3.8.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1320,10 +1320,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@bam.tech/react-native-batch@^6.0.0-rc.1":
-  version "6.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@bam.tech/react-native-batch/-/react-native-batch-6.0.0-rc.1.tgz#44765741e5b02966d76ca9e9ea9f367214903931"
-  integrity sha512-d6cXjBLZRY3G0Lz68kF+5DIHh1+6A+42nQPiLGEWpwkY8Ccfx1KXqlHlhN6VeyY5w8aPKXo4SC2roWUVMD154g==
+"@bam.tech/react-native-batch@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@bam.tech/react-native-batch/-/react-native-batch-5.2.1.tgz#c8dbe3ce5dca9f704e9522ba5b22bbad4d2c4088"
+  integrity sha512-yX4wIAlPgzhqcp6LLIxjywjXW4lr42wUEDVkiQgZA+ekqR8T8FdcRylo7T+tWz69kA2uIsYPojT3Ya9m0ErErQ==
 
 "@bam.tech/react-native-config@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-8768

## Explanation

The android build fails (cf [circle ci](https://app.circleci.com/pipelines/github/pass-culture/pass-culture-app-native/5392/workflows/610e2317-dc52-46c1-a585-7c2f0b4d96e1/jobs/8776)).

We temporarily revert this PR to prepare for the MES/MEP.

## References

batch android changelog: https://github.com/BatchLabs/Batch-Android-SDK/releases
and commits: https://github.com/BatchLabs/Batch-Android-SDK/commits/master.

Release 1.17.0 seems to break the build, with:
> Added a package query entry in AndroidManifest.xml for com.huawei.appmarket to enable detection of the Huawei AppGallery.

### Piste de résolution:

- update gradle tools (cf [react-native-batch breaking changes](https://github.com/bamlab/react-native-batch-push/releases))
> [BREAKING] Make sure to have up-to-date android build tools

- [android build tools](https://android-developers.googleblog.com/2020/07/preparing-your-build-for-package-visibility-in-android-11.html)

Donc il suffirait de passer de changer ça:

```
// classpath 'com.android.tools.build:gradle:4.0.0'
classpath 'com.android.tools.build:gradle:4.0.1'
```

![image](https://user-images.githubusercontent.com/10118284/118674544-24ada980-b7fa-11eb-8978-cbc80c87b2b1.png)
