### PR TITLE
(PC-8696) Upgrade react-native-geolocation-service from 5.0.0 to 5.3.0-beta.1 to get android LocationManager Fallback 

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -356,7 +356,7 @@ PODS:
     - React
   - react-native-flipper (0.61.0):
     - React
-  - react-native-geolocation-service (5.0.0):
+  - react-native-geolocation-service (5.3.0-beta.1):
     - React
   - react-native-get-random-values (1.5.1):
     - React-Core
@@ -808,7 +808,7 @@ SPEC CHECKSUMS:
   react-native-appsflyer: ec4692492ff4f889d207fe2fe60c0dfcc0a0235b
   react-native-config: 056581a0891d0269428219c45c696dd91c6f9eee
   react-native-flipper: 7936453fec474d5360a14cf6ac035bd689611ffd
-  react-native-geolocation-service: 141e33bdb179bcba10b216ee13962611e21f2be4
+  react-native-geolocation-service: 4030de78cdeb93ebef1fdc1971668bea6c0bc59b
   react-native-get-random-values: 41f0c91ac0da870e47b307e07752e9e54bc2dc7e
   react-native-image-picker: c6d75c4ab2cf46f9289f341242b219cb3c1180d3
   react-native-netinfo: 30fb89fa913c342be82a887b56e96be6d71201dd

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "react-native-dash": "^0.0.11",
     "react-native-device-info": "^8.1.0",
     "react-native-email-link": "^1.10.0",
-    "react-native-geolocation-service": "^5.0.0",
+    "react-native-geolocation-service": "5.3.0-beta.1",
     "react-native-gesture-handler": "^1.6.0",
     "react-native-get-random-values": "^1.5.1",
     "react-native-image-picker": "2.3.4",

--- a/src/features/favorites/pages/FavoritesSorts.tsx
+++ b/src/features/favorites/pages/FavoritesSorts.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro'
 import { useNavigation } from '@react-navigation/native'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Linking, ScrollView, ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
 
@@ -36,6 +36,12 @@ export const FavoritesSorts: React.FC = () => {
     showModal: showGeolocPermissionModal,
     hideModal: hideGeolocPermissionModal,
   } = useModal(false)
+
+  useEffect(() => {
+    if (noPositionError && position) {
+      setNoPositionError(false)
+    }
+  }, [noPositionError, position])
 
   async function onSortBySelection(sortBy: FavoriteSortBy) {
     setNoPositionError(false)

--- a/src/features/search/pages/LocationFilter.tsx
+++ b/src/features/search/pages/LocationFilter.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro'
 import { useNavigation } from '@react-navigation/native'
 import debounce from 'lodash.debounce'
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { ScrollView, ViewStyle, Linking } from 'react-native'
 import styled from 'styled-components/native'
 
@@ -32,6 +32,12 @@ export const LocationFilter: React.FC = () => {
     showModal: showGeolocPermissionModal,
     hideModal: hideGeolocPermissionModal,
   } = useModal(false)
+
+  useEffect(() => {
+    if (noPositionError && position) {
+      setNoPositionError(false)
+    }
+  }, [noPositionError, position])
 
   const onPressPickPlace = () => {
     if (debouncedGoBack) debouncedGoBack.cancel()

--- a/yarn.lock
+++ b/yarn.lock
@@ -10280,10 +10280,10 @@ react-native-flipper@^0.61.0:
   resolved "https://registry.yarnpkg.com/react-native-flipper/-/react-native-flipper-0.61.0.tgz#9613f1e8a7f90d1564f44ffc9fd7ced4f366debc"
   integrity sha512-wRa2Y2pXBoW3m+p3QbtL4NesuRXQW4gJgRHnDe6nkm+ifgt/6+WHGNcWqngmKdNCsNtWTIoDiLOc3/CNdhyfHQ==
 
-react-native-geolocation-service@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-geolocation-service/-/react-native-geolocation-service-5.0.0.tgz#eaf0541c99db9cbed5af5e2ad2822d166e3a7543"
-  integrity sha512-y0uTtt/wT78i/7QestJJrZea9ZoYOzCP4fBgGbINWXU4f+OV3D8ndH7+nEOtnDKDhQc6YtJUeV7VqNxRI+hwBQ==
+react-native-geolocation-service@5.3.0-beta.1:
+  version "5.3.0-beta.1"
+  resolved "https://registry.yarnpkg.com/react-native-geolocation-service/-/react-native-geolocation-service-5.3.0-beta.1.tgz#91b78e8f87caa0fd4fd1a2384bb48a6309ec715a"
+  integrity sha512-VfocBBSrUfXAdMikWYy8IY9ndzzn0uOM15ncs7DUMQvCpnayC92PJtRSZrSGKEuUubUkcXRqvZIMowZDMwHGVA==
 
 react-native-gesture-handler@^1.6.0:
   version "1.8.0"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-8696

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
