### PR TITLE
(PC-8877) Bug fix : Add option to ignore allowIdCheckRegistration setting in useNavigateToIdCheck()

### DIFF
--- a/src/features/auth/signup/idCheck/useNavigateToIdCheck.test.tsx
+++ b/src/features/auth/signup/idCheck/useNavigateToIdCheck.test.tsx
@@ -1,0 +1,125 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { UseQueryResult } from 'react-query'
+import { mocked } from 'ts-jest/utils'
+
+import { navigate } from '__mocks__/@react-navigation/native'
+import { SettingsResponse } from 'api/gen'
+import { useAppSettings } from 'features/auth/settings'
+import { navigateToHome } from 'features/navigation/helpers'
+
+import { useNavigateToIdCheck } from './useNavigateToIdCheck'
+
+jest.mock('features/navigation/helpers')
+const mockedUseAppSettings = mocked(useAppSettings, true)
+jest.mock('features/auth/settings')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+const EMAIL = 'EMAIL'
+const LICENCE_TOKEN = 'LICENCE_TOKEN'
+
+describe('useNavigateToIdCheck()', () => {
+  it('should navigate to IdCheck v1 when shouldControlNavWithSetting=false, enableNativeIdCheckVersion=false, allowIdCheckRegistration=false', () => {
+    const navigateToIdCheck = mockNavigateToIdCheck({
+      enableNativeIdCheckVersion: false,
+      allowIdCheckRegistration: false,
+      shouldControlNavWithSetting: false,
+      onIdCheckNavigationBlocked: undefined,
+    })
+
+    navigateToIdCheck(EMAIL, LICENCE_TOKEN)
+
+    expect(navigate).toBeCalledWith('IdCheck', { email: EMAIL, licenceToken: LICENCE_TOKEN })
+  })
+
+  it('should navigate to IdCheck v2 when shouldControlNavWithSetting=false, enableNativeIdCheckVersion=true, allowIdCheckRegistration=false', () => {
+    const navigateToIdCheck = mockNavigateToIdCheck({
+      enableNativeIdCheckVersion: true,
+      allowIdCheckRegistration: false,
+      shouldControlNavWithSetting: false,
+      onIdCheckNavigationBlocked: undefined,
+    })
+
+    navigateToIdCheck(EMAIL, LICENCE_TOKEN)
+
+    expect(navigate).toBeCalledWith('IdCheckV2', { email: EMAIL, licence_token: LICENCE_TOKEN })
+  })
+
+  it('should navigate to home when shouldControlNavWithSetting=true, enableNativeIdCheckVersion=false, allowIdCheckRegistration=false', () => {
+    const navigateToIdCheck = mockNavigateToIdCheck({
+      enableNativeIdCheckVersion: false,
+      allowIdCheckRegistration: false,
+      shouldControlNavWithSetting: true,
+      onIdCheckNavigationBlocked: undefined,
+    })
+
+    navigateToIdCheck(EMAIL, LICENCE_TOKEN)
+
+    expect(navigateToHome).toBeCalled()
+  })
+
+  it('should call onIdCheckNavigationBlocked() when onIdCheckNavigationBlocked is defined and shouldControlNavWithSetting=true, enableNativeIdCheckVersion=false, allowIdCheckRegistration=false', () => {
+    const onIdCheckNavigationBlocked = jest.fn()
+    const navigateToIdCheck = mockNavigateToIdCheck({
+      enableNativeIdCheckVersion: true,
+      allowIdCheckRegistration: false,
+      shouldControlNavWithSetting: true,
+      onIdCheckNavigationBlocked,
+    })
+
+    navigateToIdCheck(EMAIL, LICENCE_TOKEN)
+
+    expect(onIdCheckNavigationBlocked).toBeCalled()
+    expect(navigateToHome).not.toBeCalled()
+  })
+
+  it('should navigate to IdCheck v1 when shouldControlNavWithSetting=true, enableNativeIdCheckVersion=false, allowIdCheckRegistration=true', () => {
+    const navigateToIdCheck = mockNavigateToIdCheck({
+      enableNativeIdCheckVersion: false,
+      allowIdCheckRegistration: true,
+      shouldControlNavWithSetting: true,
+      onIdCheckNavigationBlocked: undefined,
+    })
+
+    navigateToIdCheck(EMAIL, LICENCE_TOKEN)
+
+    expect(navigate).toBeCalledWith('IdCheck', { email: EMAIL, licenceToken: LICENCE_TOKEN })
+  })
+
+  it('should navigate to IdCheck v2 when shouldControlNavWithSetting=true, enableNativeIdCheckVersion=true, allowIdCheckRegistration=true', () => {
+    const navigateToIdCheck = mockNavigateToIdCheck({
+      enableNativeIdCheckVersion: true,
+      allowIdCheckRegistration: true,
+      shouldControlNavWithSetting: true,
+      onIdCheckNavigationBlocked: undefined,
+    })
+
+    navigateToIdCheck(EMAIL, LICENCE_TOKEN)
+
+    expect(navigate).toBeCalledWith('IdCheckV2', { email: EMAIL, licence_token: LICENCE_TOKEN })
+  })
+})
+
+function mockNavigateToIdCheck({
+  enableNativeIdCheckVersion,
+  allowIdCheckRegistration,
+  shouldControlNavWithSetting,
+  onIdCheckNavigationBlocked,
+}: {
+  enableNativeIdCheckVersion: boolean
+  allowIdCheckRegistration: boolean
+  shouldControlNavWithSetting: boolean
+  onIdCheckNavigationBlocked?: () => void
+}) {
+  mockedUseAppSettings.mockReturnValue({
+    data: { enableNativeIdCheckVersion, allowIdCheckRegistration },
+  } as UseQueryResult<SettingsResponse>)
+  const {
+    result: { current: navigateToIdCheck },
+  } = renderHook(() =>
+    useNavigateToIdCheck({ shouldControlNavWithSetting, onIdCheckNavigationBlocked })
+  )
+  return navigateToIdCheck
+}

--- a/src/features/auth/signup/idCheck/useNavigateToIdCheck.ts
+++ b/src/features/auth/signup/idCheck/useNavigateToIdCheck.ts
@@ -2,18 +2,30 @@ import { initialRouteName as idCheckInitialRouteName } from '@pass-culture/id-ch
 import { useNavigation } from '@react-navigation/native'
 
 import { useAppSettings } from 'features/auth/settings'
+import { navigateToHome } from 'features/navigation/helpers'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
 
-export const useNavigateToIdCheck = ({
-  onIdCheckNavigationBlocked,
-}: {
-  onIdCheckNavigationBlocked: () => void
-}) => {
+type Params = {
+  onIdCheckNavigationBlocked?: () => void
+  shouldControlNavWithSetting?: boolean
+}
+
+const defaultParams = {
+  onIdCheckNavigationBlocked: navigateToHome,
+  shouldControlNavWithSetting: true,
+}
+
+export function useNavigateToIdCheck({
+  onIdCheckNavigationBlocked = defaultParams.onIdCheckNavigationBlocked,
+  shouldControlNavWithSetting = defaultParams.shouldControlNavWithSetting,
+}: Params = defaultParams) {
   const { data: settings } = useAppSettings()
   const { navigate } = useNavigation<UseNavigationType>()
 
-  return (email: string, licenceToken: string) => {
-    if (settings?.allowIdCheckRegistration) {
+  function navigateToIdCheck(email: string, licenceToken: string) {
+    const shouldNavigateToIdCheck =
+      !shouldControlNavWithSetting || settings?.allowIdCheckRegistration
+    if (shouldNavigateToIdCheck) {
       if (settings?.enableNativeIdCheckVersion) {
         navigate(idCheckInitialRouteName, { email, licence_token: licenceToken })
       } else {
@@ -23,4 +35,6 @@ export const useNavigateToIdCheck = ({
       onIdCheckNavigationBlocked()
     }
   }
+
+  return navigateToIdCheck
 }

--- a/src/features/deeplinks/useDeeplinkUrlHandler.ts
+++ b/src/features/deeplinks/useDeeplinkUrlHandler.ts
@@ -2,7 +2,6 @@ import { t } from '@lingui/macro'
 import { useNavigation } from '@react-navigation/native'
 
 import { useNavigateToIdCheck } from 'features/auth/signup/idCheck/useNavigateToIdCheck'
-import { navigateToHome } from 'features/navigation/helpers'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 
@@ -74,7 +73,7 @@ export function useOnDeeplinkError() {
 export function useDeeplinkUrlHandler() {
   const onError = useOnDeeplinkError()
   const { navigate } = useNavigation<UseNavigationType>()
-  const navigateToIdCheck = useNavigateToIdCheck({ onIdCheckNavigationBlocked: navigateToHome })
+  const navigateToIdCheck = useNavigateToIdCheck({ shouldControlNavWithSetting: false })
 
   return (event: DeeplinkEvent) => {
     const url = unescape(event.url)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-8877

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).
