### PR TITLE
(CI Android) Increase gradle memory for android builds

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
@@ -30,4 +30,3 @@ FLIPPER_VERSION=0.54.0
 # Increase java max heap size
 org.gradle.daemon=false
 org.gradle.workers.max=2
-org.gradle.jvmargs=-Xmx1024m


### PR DESCRIPTION
### Problem

La CI android fail lors du build (exemple [ici](https://app.circleci.com/pipelines/github/pass-culture/pass-culture-app-native/5691/workflows/1ccd277e-81e3-47ab-a813-dbceed81018a/jobs/9360/parallel-runs/0/steps/0-110)).

```
* What went wrong:
Execution failed for task ':app:bundleApptestingReleaseJsAndAssets'.
> Process 'command 'node'' finished with non-zero exit value 137
```

### Explanation

Gradle [needs more memory](https://rnfirebase.io/#increasing-android-build-memory) for firebase librairies.