### PR TITLE
(PC-8948) IdCheck: catch webview DMS redirection

### DIFF
--- a/src/features/auth/signup/IdCheck.tsx
+++ b/src/features/auth/signup/IdCheck.tsx
@@ -6,7 +6,7 @@ import { WebView, WebViewNavigation } from 'react-native-webview'
 import styled from 'styled-components/native'
 
 import { useAppSettings } from 'features/auth/settings'
-import { navigateToHome, useCurrentRoute } from 'features/navigation/helpers'
+import { navigateToHome, openExternalUrl, useCurrentRoute } from 'features/navigation/helpers'
 import { RootStackParamList, UseNavigationType } from 'features/navigation/RootNavigator'
 import { env } from 'libs/environment'
 import { storage } from 'libs/storage'
@@ -49,10 +49,15 @@ export const IdCheck: React.FC<Props> = function (props) {
     // For more info, see the buffer pages (i.e. to exit the webview) of the Id Check web app
     const isEligibilityProcessAbandonned = event.url.includes('/exit')
     const isEligibilityProcessFinished = event.url.includes('/end')
+    const isRedirectedToDMS = event.url.includes('demarches-simplifiees')
     if (isEligibilityProcessAbandonned) {
       navigateToHome()
     } else if (isEligibilityProcessFinished) {
       navigation.navigate('BeneficiaryRequestSent')
+    } else if (isRedirectedToDMS) {
+      openExternalUrl(event.url)
+      // we need to force the webview to go back otherwise it opens DMS url
+      webviewRef.current?.goBack()
     }
   }
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-8948 => On veut qu'au clic sur "déposer un dossier en ligne" l'utilisateur soit redirigé vers le navigateur de son téléphone, sans cette redirection, le site de DMS s'ouvre dans la webview

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

/!\ ne pas faire attention au design, j'ai bidouillé un truc pour pouvoir tester rapidement en local, la vidéo sert à montrer le comportement au clic sur  "déposer un dossier en ligne" , le vrai design est dans cette PR https://github.com/pass-culture/id-check-front/pull/138

https://user-images.githubusercontent.com/22886846/119375942-b49c9900-bcbb-11eb-90e3-39e23665c1ed.mp4



## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
