### PR TITLE
(PC-8941) Navigate to cultural survey only if needsToFillCulturalSurvey is true

### DIFF
--- a/src/features/auth/login/Login.test.tsx
+++ b/src/features/auth/login/Login.test.tsx
@@ -82,7 +82,8 @@ describe('<Login/>', () => {
     await act(flushAllPromises)
 
     await waitForExpect(() => {
-      expect(navigate).toHaveBeenNthCalledWith(1, 'CulturalSurvey')
+      expect(navigate).toBeCalledTimes(1)
+      expect(navigate).toBeCalledWith('CulturalSurvey')
     })
   })
 

--- a/src/features/auth/signup/AccountCreated.test.tsx
+++ b/src/features/auth/signup/AccountCreated.test.tsx
@@ -16,7 +16,7 @@ jest.mock('features/navigation/helpers')
 
 beforeEach(() => {
   mockedUseUserProfileInfo.mockReturnValue({
-    data: { isBeneficiary: true },
+    data: { isBeneficiary: true, needsToFillCulturalSurvey: true },
   } as UseQueryResult<UserProfileResponse>)
   jest.clearAllMocks()
 })
@@ -30,8 +30,7 @@ describe('<AccountCreated />', () => {
   it('should redirect to cultural survey page WHEN "On y va !" button is clicked', async () => {
     const renderAPI = render(<AccountCreated />)
 
-    const button = await renderAPI.findByText('On y va !')
-    fireEvent.press(button)
+    fireEvent.press(await renderAPI.findByText('On y va !'))
 
     expect(navigateToHome).not.toBeCalledTimes(1)
     expect(navigate).toBeCalledTimes(1)
@@ -40,12 +39,23 @@ describe('<AccountCreated />', () => {
 
   it('should redirect to home page WHEN "On y va !" button is clicked and user is not beneficiary', async () => {
     mockedUseUserProfileInfo.mockReturnValue({
-      data: { isBeneficiary: false },
+      data: { isBeneficiary: false, needsToFillCulturalSurvey: true },
     } as UseQueryResult<UserProfileResponse>)
     const renderAPI = render(<AccountCreated />)
 
-    const button = await renderAPI.findByText('On y va !')
-    fireEvent.press(button)
+    fireEvent.press(await renderAPI.findByText('On y va !'))
+
+    expect(navigateToHome).toBeCalledTimes(1)
+    expect(navigate).not.toBeCalledWith('CulturalSurvey')
+  })
+
+  it('should redirect to home page WHEN "On y va !" button is clicked and user needs not to fill cultural survey', async () => {
+    mockedUseUserProfileInfo.mockReturnValue({
+      data: { isBeneficiary: true, needsToFillCulturalSurvey: false },
+    } as UseQueryResult<UserProfileResponse>)
+    const renderAPI = render(<AccountCreated />)
+
+    fireEvent.press(await renderAPI.findByText('On y va !'))
 
     expect(navigateToHome).toBeCalledTimes(1)
     expect(navigate).not.toBeCalledWith('CulturalSurvey')

--- a/src/features/auth/signup/AccountCreated.tsx
+++ b/src/features/auth/signup/AccountCreated.tsx
@@ -15,7 +15,7 @@ export function AccountCreated() {
   const { data: user } = useUserProfileInfo()
   const { navigate } = useNavigation<UseNavigationType>()
 
-  const shouldNavigateToCulturalSurvey = user?.isBeneficiary
+  const shouldNavigateToCulturalSurvey = user?.isBeneficiary && user?.needsToFillCulturalSurvey
 
   function onPress() {
     if (shouldNavigateToCulturalSurvey) {

--- a/src/features/auth/signup/BeneficiaryRequestSent.test.tsx
+++ b/src/features/auth/signup/BeneficiaryRequestSent.test.tsx
@@ -1,19 +1,30 @@
 import React from 'react'
-import { UseMutationResult } from 'react-query'
+import { UseMutationResult, UseQueryResult } from 'react-query'
+import { mocked } from 'ts-jest/utils'
 
 import { navigate } from '__mocks__/@react-navigation/native'
+import { UserProfileResponse } from 'api/gen'
 import * as AuthApi from 'features/auth/api'
+import { useUserProfileInfo } from 'features/home/api'
+import { navigateToHome } from 'features/navigation/helpers'
 import { EmptyResponse } from 'libs/fetch'
 import { render, fireEvent, waitFor } from 'tests/utils'
 
 import { BeneficiaryRequestSent } from './BeneficiaryRequestSent'
 
+const mockedUseUserProfileInfo = mocked(useUserProfileInfo)
+jest.mock('features/home/api')
 jest.mock('react-query')
+jest.mock('features/navigation/helpers')
 
 describe('<BeneficiaryRequestSent />', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockedUseUserProfileInfo.mockReturnValue({
+      data: { isBeneficiary: true, needsToFillCulturalSurvey: true },
+    } as UseQueryResult<UserProfileResponse>)
   })
+
   it('should call notifyIdCheckCompleted inconditonnally', () => {
     const notifyIdCheckCompleted = jest.fn()
     const useNotifyIdCheckCompletedMock = jest
@@ -28,13 +39,38 @@ describe('<BeneficiaryRequestSent />', () => {
     })
     useNotifyIdCheckCompletedMock.mockRestore()
   })
+
   it('should redirect to cultural survey page WHEN "On y va !" button is clicked', async () => {
     const { findByText } = render(<BeneficiaryRequestSent />)
 
-    const button = await findByText('On y va !')
-    fireEvent.press(button)
+    fireEvent.press(await findByText('On y va !'))
 
+    expect(navigateToHome).not.toBeCalled()
     expect(navigate).toBeCalledTimes(1)
     expect(navigate).toBeCalledWith('CulturalSurvey')
+  })
+
+  it('should redirect to home page WHEN "On y va !" button is clicked and user is not beneficiary', async () => {
+    mockedUseUserProfileInfo.mockReturnValue({
+      data: { isBeneficiary: false, needsToFillCulturalSurvey: true },
+    } as UseQueryResult<UserProfileResponse>)
+    const { findByText } = render(<BeneficiaryRequestSent />)
+
+    fireEvent.press(await findByText('On y va !'))
+
+    expect(navigateToHome).toBeCalledTimes(1)
+    expect(navigate).not.toBeCalledWith('CulturalSurvey')
+  })
+
+  it('should redirect to home page WHEN "On y va !" button is clicked and user needs not to fill cultural survey', async () => {
+    mockedUseUserProfileInfo.mockReturnValue({
+      data: { isBeneficiary: true, needsToFillCulturalSurvey: false },
+    } as UseQueryResult<UserProfileResponse>)
+    const { findByText } = render(<BeneficiaryRequestSent />)
+
+    fireEvent.press(await findByText('On y va !'))
+
+    expect(navigateToHome).toBeCalledTimes(1)
+    expect(navigate).not.toBeCalledWith('CulturalSurvey')
   })
 })

--- a/src/features/auth/signup/BeneficiaryRequestSent.tsx
+++ b/src/features/auth/signup/BeneficiaryRequestSent.tsx
@@ -4,6 +4,8 @@ import React, { useEffect } from 'react'
 import styled from 'styled-components/native'
 
 import { useNotifyIdCheckCompleted } from 'features/auth/api'
+import { useUserProfileInfo } from 'features/home/api'
+import { navigateToHome } from 'features/navigation/helpers'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { GenericInfoPage } from 'ui/components/GenericInfoPage'
@@ -12,25 +14,35 @@ import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
 
 export function BeneficiaryRequestSent() {
   const { navigate } = useNavigation<UseNavigationType>()
-
+  const { data: user } = useUserProfileInfo()
   const { mutate: notifyIdCheckCompleted } = useNotifyIdCheckCompleted()
 
   useEffect(() => {
     notifyIdCheckCompleted()
   }, [])
 
-  function goToCulturalSurvey() {
-    navigate('CulturalSurvey')
+  const shouldNavigateToCulturalSurvey = user?.isBeneficiary && user?.needsToFillCulturalSurvey
+
+  function onPress() {
+    if (shouldNavigateToCulturalSurvey) {
+      navigate('CulturalSurvey')
+    } else {
+      navigateToHome()
+    }
   }
 
   return (
     <GenericInfoPage title={t`Demande envoyée !`} icon={RequestSent} iconSize={getSpacing(42)}>
       <StyledBody>{t`Nous étudions ton dossier...`}</StyledBody>
-      <StyledBody>
-        {t`Tu recevras un e-mail lorsque ta demande sera validée. En attendant, aide-nous à en savoir plus sur tes pratiques culturelles !`}
-      </StyledBody>
+      {shouldNavigateToCulturalSurvey ? (
+        <StyledBody>
+          {t`Tu recevras un e-mail lorsque ta demande sera validée. En attendant, aide-nous à en savoir plus sur tes pratiques culturelles !`}
+        </StyledBody>
+      ) : (
+        <StyledBody>{t`Tu recevras un e-mail lorsque ta demande sera validée.`}</StyledBody>
+      )}
       <Spacer.Column numberOfSpaces={15} />
-      <ButtonPrimaryWhite title={t`On y va !`} onPress={goToCulturalSurvey} />
+      <ButtonPrimaryWhite title={t`On y va !`} onPress={onPress} />
     </GenericInfoPage>
   )
 }

--- a/src/features/auth/signup/EligibilityConfirmed.test.tsx
+++ b/src/features/auth/signup/EligibilityConfirmed.test.tsx
@@ -5,7 +5,7 @@ import { mocked } from 'ts-jest/utils'
 import { navigate } from '__mocks__/@react-navigation/native'
 import { UserProfileResponse } from 'api/gen'
 import { useUserProfileInfo } from 'features/home/api'
-import { homeNavigateConfig } from 'features/navigation/helpers'
+import { navigateToHome } from 'features/navigation/helpers'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, fireEvent } from 'tests/utils'
 
@@ -13,6 +13,7 @@ import { EligibilityConfirmed } from './EligibilityConfirmed'
 
 const mockedUseUserProfileInfo = mocked(useUserProfileInfo)
 jest.mock('features/home/api')
+jest.mock('features/navigation/helpers')
 
 describe('<EligibilityConfirmed />', () => {
   afterEach(jest.clearAllMocks)
@@ -21,24 +22,23 @@ describe('<EligibilityConfirmed />', () => {
     mockedUseUserProfileInfo.mockReturnValue({
       data: { needsToFillCulturalSurvey: false },
     } as UseQueryResult<UserProfileResponse>)
-
     const { findByText } = renderEligibilityConfirmed()
 
-    const button = await findByText('On y va !')
-    fireEvent.press(button)
+    fireEvent.press(await findByText('On y va !'))
 
-    expect(navigate).toBeCalledTimes(1)
-    expect(navigate).toBeCalledWith(homeNavigateConfig.screen, homeNavigateConfig.params)
+    expect(navigateToHome).toBeCalledTimes(1)
+    expect(navigate).not.toBeCalledWith('CulturalSurvey')
   })
-  it('should redirect to cultural survey page WHEN "On y va !" button is clicked  and user.needsToFillCulturalSurvey is true', async () => {
+
+  it('should redirect to cultural survey page WHEN "On y va !" button is clicked and user.needsToFillCulturalSurvey is true', async () => {
     mockedUseUserProfileInfo.mockReturnValue({
       data: { needsToFillCulturalSurvey: true },
     } as UseQueryResult<UserProfileResponse>)
     const { findByText } = renderEligibilityConfirmed()
 
-    const button = await findByText('On y va !')
-    fireEvent.press(button)
+    fireEvent.press(await findByText('On y va !'))
 
+    expect(navigateToHome).not.toBeCalled()
     expect(navigate).toBeCalledTimes(1)
     expect(navigate).toBeCalledWith('CulturalSurvey')
   })

--- a/src/features/auth/signup/EligibilityConfirmed.tsx
+++ b/src/features/auth/signup/EligibilityConfirmed.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { useUserProfileInfo } from 'features/home/api'
-import { homeNavigateConfig } from 'features/navigation/helpers'
+import { navigateToHome } from 'features/navigation/helpers'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
 import IlluminatedSmileyAnimation from 'ui/animations/lottie_illuminated_smiley.json'
 import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
@@ -15,19 +15,23 @@ export function EligibilityConfirmed() {
   const { navigate } = useNavigation<UseNavigationType>()
   const { data: user } = useUserProfileInfo()
 
+  const shouldNavigateToCulturalSurvey = user?.needsToFillCulturalSurvey
+
   function goToCulturalSurvey() {
-    if (user?.needsToFillCulturalSurvey) {
+    if (shouldNavigateToCulturalSurvey) {
       navigate('CulturalSurvey')
     } else {
-      navigate(homeNavigateConfig.screen, homeNavigateConfig.params)
+      navigateToHome()
     }
   }
 
   return (
     <GenericInfoPage title={t`Tu es éligible !`} animation={IlluminatedSmileyAnimation}>
-      <StyledBody>
-        {t`Aide-nous à en savoir plus sur tes pratiques culturelles ! Ta sélection n'aura pas d'impact sur les offres proposées.`}
-      </StyledBody>
+      {shouldNavigateToCulturalSurvey && (
+        <StyledBody>
+          {t`Aide-nous à en savoir plus sur tes pratiques culturelles ! Ta sélection n'aura pas d'impact sur les offres proposées.`}
+        </StyledBody>
+      )}
       <Spacer.Column numberOfSpaces={15} />
       <ButtonPrimaryWhite title={t`On y va !`} onPress={goToCulturalSurvey} />
     </GenericInfoPage>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-8941

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] |
| -------------------- | :----------------------: |
|                      |                          | 