### PR TITLE
(PC-8139) bouton réessayer avec timer sur la modale de saisie du code de vérification

### DIFF
--- a/src/features/auth/signup/SetPhoneValidationCodeModal.test.tsx
+++ b/src/features/auth/signup/SetPhoneValidationCodeModal.test.tsx
@@ -1,14 +1,16 @@
 import React from 'react'
-import { useMutation } from 'react-query'
+import { useMutation, UseMutationResult } from 'react-query'
 import { mocked } from 'ts-jest/utils'
 import waitForExpect from 'wait-for-expect'
 
+import * as AuthApi from 'features/auth/api'
 import {
   SetPhoneValidationCodeModal,
   SetPhoneValidationCodeModalProps,
 } from 'features/auth/signup/SetPhoneValidationCodeModal'
 import { contactSupport } from 'features/auth/support.services'
-import { act, fireEvent, render, useMutationFactory } from 'tests/utils'
+import { EmptyResponse } from 'libs/fetch'
+import { act, fireEvent, render, superFlushWithAct, useMutationFactory } from 'tests/utils'
 import * as ModalModule from 'ui/components/modals/useModal'
 import { ColorsEnum } from 'ui/theme'
 
@@ -127,6 +129,23 @@ describe('SetPhoneNumberValidationCodeModal', () => {
       await waitForExpect(() => {
         expect(errorMessage).toBeTruthy()
       })
+    })
+  })
+
+  describe('retry button', () => {
+    it('should request new validation code on press', async () => {
+      const sendPhoneValidationCode = jest.fn()
+      jest.spyOn(AuthApi, 'useSendPhoneValidationMutation').mockReturnValue(({
+        mutate: sendPhoneValidationCode,
+      } as unknown) as UseMutationResult<EmptyResponse, unknown, string, unknown>)
+
+      const { getByTestId } = renderSetPhoneValidationCode()
+      await superFlushWithAct()
+
+      const retryButton = getByTestId('button-container-retry')
+      fireEvent.press(retryButton)
+
+      expect(sendPhoneValidationCode).toHaveBeenCalled()
     })
   })
 })

--- a/src/features/auth/signup/SetPhoneValidationCodeModal.tsx
+++ b/src/features/auth/signup/SetPhoneValidationCodeModal.tsx
@@ -47,13 +47,16 @@ export const SetPhoneValidationCodeModal: FC<SetPhoneValidationCodeModalProps> =
     hideModal: hideFullPageModal,
   } = useModal(props.visible)
 
-  const { mutate: validatePhoneNumber } = useValidatePhoneNumberMutation({ onSuccess, onError })
+  const { mutate: validatePhoneNumber } = useValidatePhoneNumberMutation({
+    onSuccess: onValidateSuccess,
+    onError: onValidateError,
+  })
 
-  function onSuccess() {
+  function onValidateSuccess() {
     props.dismissModal()
   }
 
-  function onError(error: unknown) {
+  function onValidateError(error: unknown) {
     setInvalidCodeMessage(extractApiErrorMessage(error))
   }
 

--- a/src/ui/components/buttons/ButtonPrimaryWhite.tsx
+++ b/src/ui/components/buttons/ButtonPrimaryWhite.tsx
@@ -10,7 +10,7 @@ export const ButtonPrimaryWhite: FunctionComponent<BaseButtonProps> = (props) =>
   const backgroundColor = ColorsEnum.WHITE
 
   if (props.disabled) {
-    iconColor = textColor = ColorsEnum.PRIMARY_DISABLED
+    iconColor = textColor = ColorsEnum.GREY_DARK
   }
 
   return (

--- a/src/ui/components/buttons/ButtonQuaternary.tsx
+++ b/src/ui/components/buttons/ButtonQuaternary.tsx
@@ -10,7 +10,7 @@ export const ButtonQuaternary: FunctionComponent<BaseButtonProps> = (props) => {
   let iconColor = ColorsEnum.PRIMARY
 
   if (props.disabled) {
-    textColor = iconColor = ColorsEnum.PRIMARY_DISABLED
+    textColor = iconColor = ColorsEnum.GREY_DARK
   }
 
   return (

--- a/src/ui/components/buttons/ButtonSecondary.tsx
+++ b/src/ui/components/buttons/ButtonSecondary.tsx
@@ -13,7 +13,7 @@ export const ButtonSecondary: FunctionComponent<BaseButtonProps> = (props) => {
   if (props.isLoading) {
     borderColor = ColorsEnum.PRIMARY_DARK
   } else if (props.disabled) {
-    borderColor = textColor = iconColor = ColorsEnum.PRIMARY_DISABLED
+    borderColor = textColor = iconColor = ColorsEnum.GREY_DARK
   }
 
   return (

--- a/src/ui/components/buttons/ButtonTertiary.tsx
+++ b/src/ui/components/buttons/ButtonTertiary.tsx
@@ -10,7 +10,7 @@ export const ButtonTertiary: FunctionComponent<BaseButtonProps> = (props) => {
   let iconColor = ColorsEnum.PRIMARY
 
   if (props.disabled) {
-    textColor = iconColor = ColorsEnum.PRIMARY_DISABLED
+    textColor = iconColor = ColorsEnum.GREY_DARK
   }
 
   return (

--- a/src/ui/components/buttons/ButtonTertiaryWhite.tsx
+++ b/src/ui/components/buttons/ButtonTertiaryWhite.tsx
@@ -10,7 +10,7 @@ export const ButtonTertiaryWhite: FunctionComponent<BaseButtonProps> = (props) =
   let iconColor = ColorsEnum.WHITE
 
   if (props.disabled) {
-    textColor = iconColor = ColorsEnum.PRIMARY_DISABLED
+    textColor = iconColor = ColorsEnum.GREY_DARK
   }
 
   return (


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-8139


## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |![Screenshot from 2021-05-25 14-42-51](https://user-images.githubusercontent.com/22886846/119513078-2f28ef80-bd74-11eb-97ab-0b0ac97d235d.png)|                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
