### PR TITLE
(PC-8135) SetPhoneValidationCode: dismiss modal on navigate to TooManyAttempts

### DIFF
--- a/src/features/auth/signup/SetPhoneValidationCodeModal.test.tsx
+++ b/src/features/auth/signup/SetPhoneValidationCodeModal.test.tsx
@@ -133,6 +133,7 @@ describe('SetPhoneNumberValidationCodeModal', () => {
     })
 
     it('should navigate to TooManyAttempts page if request fails with TOO_MANY_VALIDATION_ATTEMPTS code', async () => {
+      const mockDismissModal = jest.fn()
       const response = {
         content: {
           code: 'TOO_MANY_VALIDATION_ATTEMPTS',
@@ -141,7 +142,9 @@ describe('SetPhoneNumberValidationCodeModal', () => {
         name: 'ApiError',
       }
 
-      const { getByTestId } = renderModalWithFilledCodeInput('123456')
+      const { getByTestId } = renderModalWithFilledCodeInput('123456', {
+        dismissModal: mockDismissModal,
+      })
       const continueButton = getByTestId('button-container-continue')
 
       fireEvent.press(continueButton)
@@ -152,6 +155,7 @@ describe('SetPhoneNumberValidationCodeModal', () => {
 
       await waitForExpect(() => {
         expect(navigate).toHaveBeenCalledWith('TooManyAttempts')
+        expect(mockDismissModal).toHaveBeenCalled()
       })
     })
   })

--- a/src/features/auth/signup/SetPhoneValidationCodeModal.tsx
+++ b/src/features/auth/signup/SetPhoneValidationCodeModal.tsx
@@ -94,6 +94,7 @@ export const SetPhoneValidationCodeModal: FC<SetPhoneValidationCodeModalProps> =
   function onValidateError(error: unknown) {
     const { content } = error as { content: { code: string; message: string } }
     if (content.code === 'TOO_MANY_VALIDATION_ATTEMPTS') {
+      props.dismissModal()
       navigate('TooManyAttempts')
     } else {
       setInvalidCodeMessage(extractApiErrorMessage(error))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-8135

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
