### PR TITLE
(PC-9002) Force refetch of user profile data after succesful completion of idcheck

### DIFF
--- a/src/features/auth/signup/IdCheckV2.tsx
+++ b/src/features/auth/signup/IdCheckV2.tsx
@@ -4,10 +4,8 @@ import React, { useEffect } from 'react'
 import { useQueryClient } from 'react-query'
 
 import { useAppSettings } from 'features/auth/settings'
-import { useUserProfileInfo } from 'features/home/api'
 import { homeNavigateConfig } from 'features/navigation/helpers'
 import { ScreenNavigationProp, UseNavigationType } from 'features/navigation/RootNavigator'
-import { errorMonitoring } from 'libs/errorMonitoring'
 import { QueryKeys } from 'libs/queryKeys'
 
 export const IdCheckV2 = (props: ScreenNavigationProp<'IdCheckV2'>) => {
@@ -16,26 +14,13 @@ export const IdCheckV2 = (props: ScreenNavigationProp<'IdCheckV2'>) => {
   const { data: settings } = useAppSettings()
   const queryClient = useQueryClient()
 
-  const { refetch } = useUserProfileInfo({
-    cacheTime: 0,
-  })
-
-  function goToBeneficiaryRequestSent() {
-    replace('BeneficiaryRequestSent')
-  }
-
   function onAbandon() {
     replace(homeNavigateConfig.screen, homeNavigateConfig.params)
   }
 
-  function onSuccess() {
-    queryClient.invalidateQueries(QueryKeys.USER_PROFILE)
-    refetch()
-      .then(goToBeneficiaryRequestSent)
-      .catch((err) => {
-        errorMonitoring.captureException(err)
-        goToBeneficiaryRequestSent()
-      })
+  async function onSuccess() {
+    await queryClient.invalidateQueries(QueryKeys.USER_PROFILE)
+    replace('BeneficiaryRequestSent')
   }
 
   useEffect(() => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-9002

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] |
| -------------------- | :----------------------: | 
|                      |                          |  
