### PR TITLE
Make sure versionCode is striclty increasing

### DIFF
--- a/scripts/update_app_version.sh
+++ b/scripts/update_app_version.sh
@@ -7,7 +7,31 @@ update_app_version(){
 
   VERSION=`json -f package.json version`
 
-  BUILD_NUMBER="${VERSION//./0}"
+  # We have to increment the build number because it is used as the versionCode
+  # in app/build.gradle: versionCode (packageJson.build as Integer) and the
+  # Play Store requires this value to be strictly increasing. Otherwise, we get this error:
+
+  # ERROR Google Api Error: forbidden: You cannot rollout this release because it does not allow
+  # any existing users to upgrade to the newly added APKs.
+
+  # As such, since the current version is 10136027 = 1 * 10_000_000 + 136 * 1_000 + 27, we build each new version
+  # as the sum of:
+  #  + 10_000_000 * MAJOR,
+  #  + 1_000 * MINOR,
+  #  + PATCH
+  # where <VERSION> = <MAJOR>.<MINOR>.<PATCH> (ex: 1.137.3) as we use semantic versioning.
+
+  # Examples:
+  #   1.136.27 => 10 000 000 + 136 000 + 027 => 10136027
+  #   1.137.1  => 10 000 000 + 137 000 + 001 => 10137001
+
+
+  SEMVER=( ${VERSION//./ } )
+  MAJOR=${SEMVER[0]}
+  MINOR=${SEMVER[1]}
+  PATCH=${SEMVER[2]}
+  BUILD_NUMBER="$((10000000 * MAJOR + 1000 * MINOR + PATCH))"
+
   json -I -f package.json -e "this.build=$BUILD_NUMBER"
 
   git add package.json


### PR DESCRIPTION
### Error:

```
INFO [2021-05-27 17:06:21.37]: Updating track 'internal'...
INFO [2021-05-27 17:06:21.67]: Uploading all changes to Google Play...
WARN [2021-05-27 17:06:22.20]: Lane Context:
INFO [2021-05-27 17:06:22.20]: {:ENVIRONMENT=>"production", :PLATFORM_NAME=>:android, :LANE_NAME=>"android deploy", :GRADLE_ALL_APK_OUTPUT_PATHS=>["/home/circleci/pass-culture/android/app/build/outputs/apk/production/release/app-production-release.apk"], :GRADLE_ALL_AAB_OUTPUT_PATHS=>[], :GRADLE_ALL_OUTPUT_JSON_OUTPUT_PATHS=>["/home/circleci/pass-culture/android/app/build/outputs/apk/production/release/output.json"], :GRADLE_ALL_MAPPING_TXT_OUTPUT_PATHS=>[], :GRADLE_APK_OUTPUT_PATH=>"/home/circleci/pass-culture/android/app/build/outputs/apk/production/release/app-production-release.apk", :GRADLE_OUTPUT_JSON_OUTPUT_PATH=>"/home/circleci/pass-culture/android/app/build/outputs/apk/production/release/output.json"}
ERROR [2021-05-27 17:06:22.20]: Google Api Error: forbidden: You cannot rollout this release because it does not allow any existing users to upgrade to the newly added APKs. - You cannot rollout this release because it does not allow any existing users to upgrade to the newly added APKs.

+------+-----------------------------------------+-------------+
|                       fastlane summary                       |
+------+-----------------------------------------+-------------+
| Step | Action                                  | Time (in s) |
+------+-----------------------------------------+-------------+
| 1    | Switch to android load_env_file lane    | 0           |
| 2    | Switch to android check_env_exists lane | 0           |
| 3    | load_json                               | 0           |
| 4    | Switch to android build lane            | 0           |
| 5    | assembleProductionRelease               | 426         |
| 6    | Switch to android deploy_playStore lane | 0           |
| 💥   | supply                                  | 6           |
+------+-----------------------------------------+-------------+

```

The previous version submitted to the Playstore was 10136027 (1.136.27).
The Play Store has a policy of a strictly increasing versionCode (10136027).
We tried to submit version 1.137.1 => versionCode `1013701`, because of the way we currently build the build number.
This PR fixes that.