### PR TITLE
[PC-8923] error showing booking

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
   },
   rules: {
     'local-rules/no-allow-console': ['error'],
+    'local-rules/no-string-check-before-component': ['warn'],
     '@typescript-eslint/ban-ts-comment': [
       2, // error
       {
@@ -172,8 +173,8 @@ module.exports = {
         jest: true,
       },
       rules: {
-        '@typescript-eslint/no-empty-function' : 'off'
-      }
+        '@typescript-eslint/no-empty-function': 'off',
+      },
     },
   ],
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,7 @@ module.exports = {
   },
   rules: {
     'local-rules/no-allow-console': ['error'],
-    'local-rules/no-string-check-before-component': ['warn'],
+    'local-rules/no-string-check-before-component': ['error'],
     '@typescript-eslint/ban-ts-comment': [
       2, // error
       {

--- a/eslint-custom-rules/no-string-check-before-component.js
+++ b/eslint-custom-rules/no-string-check-before-component.js
@@ -1,0 +1,45 @@
+/* eslint-disable */
+
+/**
+ * This rule aims to prevent displaying empty string "" out of any <text>
+ */
+
+/* KO:
+string && <Component> 
+*/
+
+/* OK:
+string ? <Component> : null
+*/
+
+module.exports = {
+  name: 'no-string-check-before-component',
+  meta: {
+    docs: {
+      description: 'disallow check on a string before displaying a component',
+      category: 'Prevent from bugs String should be wrap in a Text component',
+      recommended: true,
+      url: 'https://eslint.org/docs/rules/',
+    },
+  },
+  create(context) {
+    return {
+      LogicalExpression: function LogicalExpression(node) {
+        const rightPart = node.right
+        const leftPart = node.left
+        if (
+          node.operator === '&&' &&
+          rightPart.type === 'JSXElement' &&
+          ((leftPart.type === 'UnaryExpression' && leftPart.operator !== '!') ||
+            (leftPart.type !== 'UnaryExpression' && leftPart.type !== 'BinaryExpression'))
+        ) {
+          context.report({
+            node,
+            message:
+              'Do not use string && component, use (string ? component : null) or ( !!string && component)',
+          })
+        }
+      },
+    }
+  },
+}

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -1,5 +1,7 @@
 const noAllowConsole = require('./eslint-custom-rules/no-allow-console')
+const noStringCheckBeforeComponent = require('./eslint-custom-rules/no-string-check-before-component')
 
 module.exports = {
   'no-allow-console': noAllowConsole,
+  'no-string-check-before-component': noStringCheckBeforeComponent,
 }

--- a/src/features/auth/forgottenPassword/ForgottenPassword.tsx
+++ b/src/features/auth/forgottenPassword/ForgottenPassword.tsx
@@ -109,7 +109,7 @@ export const ForgottenPassword: FunctionComponent = () => {
 
   return (
     <BottomContentPage>
-      {settings?.isRecaptchaEnabled && (
+      {!!settings?.isRecaptchaEnabled && (
         <ReCaptcha
           onClose={onReCaptchaClose}
           onError={onReCaptchaError}
@@ -144,7 +144,7 @@ export const ForgottenPassword: FunctionComponent = () => {
             textContentType="emailAddress"
             value={email}
           />
-          {errorMessage && <InputError visible messageId={errorMessage} numberOfSpacesTop={1} />}
+          {!!errorMessage && <InputError visible messageId={errorMessage} numberOfSpacesTop={1} />}
         </StyledInput>
         <Spacer.Column numberOfSpaces={6} />
         <ButtonPrimary

--- a/src/features/auth/idcheckUnavailable/IdCheckUnavailable.tsx
+++ b/src/features/auth/idcheckUnavailable/IdCheckUnavailable.tsx
@@ -30,7 +30,7 @@ export function IdCheckUnavailable() {
       icon={({ color }) => <HappyFaceStars size={220} color={color} />}>
       <StyledBody>{t`Vous êtes actuellement très nombreux à demander les 300€ et notre service rencontre quelques difficultés.`}</StyledBody>
       <Spacer.Column numberOfSpaces={6} />
-      {settings?.displayDmsRedirection && (
+      {!!settings?.displayDmsRedirection && (
         <React.Fragment>
           <StyledBody>{t`Cependant, tu peux nous transmettre ton dossier via la plateforme Démarches Simplifiées, et on reviendra vers toi d'ici quelques jours au plus tard :`}</StyledBody>
           <Spacer.Column numberOfSpaces={8} />

--- a/src/features/auth/signup/AcceptCgu.tsx
+++ b/src/features/auth/signup/AcceptCgu.tsx
@@ -118,7 +118,7 @@ export const AcceptCgu: FC<Props> = ({ route }) => {
   return (
     <React.Fragment>
       <BottomContentPage>
-        {settings?.isRecaptchaEnabled && (
+        {!!settings?.isRecaptchaEnabled && (
           <ReCaptcha
             onClose={onReCaptchaClose}
             onError={onReCaptchaError}
@@ -183,7 +183,9 @@ export const AcceptCgu: FC<Props> = ({ route }) => {
                 areSettingsLoading
               }
             />
-            {errorMessage && <InputError visible messageId={errorMessage} numberOfSpacesTop={5} />}
+            {!!errorMessage && (
+              <InputError visible messageId={errorMessage} numberOfSpacesTop={5} />
+            )}
             <Spacer.Column numberOfSpaces={5} />
             <StepDots numberOfSteps={numberOfSteps} currentStep={numberOfSteps} />
           </CardContent>

--- a/src/features/auth/signup/AccountCreated.tsx
+++ b/src/features/auth/signup/AccountCreated.tsx
@@ -27,7 +27,7 @@ export function AccountCreated() {
 
   return (
     <GenericInfoPage title={t`Ton compte a été activé !`} animation={IlluminatedSmileyAnimation}>
-      {shouldNavigateToCulturalSurvey && (
+      {!!shouldNavigateToCulturalSurvey && (
         <StyledBody>
           {t`Aide-nous à en savoir plus sur tes pratiques culturelles ! Ta sélection n'aura pas d'impact sur les offres proposées.`}
         </StyledBody>

--- a/src/features/auth/signup/EligibilityConfirmed.tsx
+++ b/src/features/auth/signup/EligibilityConfirmed.tsx
@@ -27,7 +27,7 @@ export function EligibilityConfirmed() {
 
   return (
     <GenericInfoPage title={t`Tu es éligible !`} animation={IlluminatedSmileyAnimation}>
-      {shouldNavigateToCulturalSurvey && (
+      {!!shouldNavigateToCulturalSurvey && (
         <StyledBody>
           {t`Aide-nous à en savoir plus sur tes pratiques culturelles ! Ta sélection n'aura pas d'impact sur les offres proposées.`}
         </StyledBody>

--- a/src/features/bookOffer/atoms/ChoiceBloc.tsx
+++ b/src/features/bookOffer/atoms/ChoiceBloc.tsx
@@ -52,7 +52,7 @@ export const ChoiceBloc: React.FC<Props> = ({ selected, onPress, testID, childre
           <Spacer.Row numberOfSpaces={5} />
         )}
         {children}
-        {disabled && <StrikeLine />}
+        {!!disabled && <StrikeLine />}
       </ChoiceContent>
     </ChoiceContainer>
   )

--- a/src/features/bookOffer/components/BookingEventChoices.tsx
+++ b/src/features/bookOffer/components/BookingEventChoices.tsx
@@ -41,7 +41,7 @@ export const BookingEventChoices: React.FC<Props> = ({ stocks }) => {
       <BookDateChoice stocks={stocks} userRemainingCredit={creditForOffer} />
 
       <Spacer.Column numberOfSpaces={6} />
-      {step && step >= Step.HOUR && (
+      {!!(step && step >= Step.HOUR) && (
         <React.Fragment>
           <Separator />
           <Spacer.Column numberOfSpaces={6} />
@@ -51,7 +51,7 @@ export const BookingEventChoices: React.FC<Props> = ({ stocks }) => {
           <Spacer.Column numberOfSpaces={6} />
         </React.Fragment>
       )}
-      {((step && step >= Step.DUO) || bookingState.quantity) && (
+      {!!((step && step >= Step.DUO) || bookingState.quantity) && (
         <React.Fragment>
           <Separator />
           <Spacer.Column numberOfSpaces={6} />

--- a/src/features/bookOffer/components/BookingInformations.tsx
+++ b/src/features/bookOffer/components/BookingInformations.tsx
@@ -49,7 +49,7 @@ export const BookingInformations: React.FC = () => {
     return (
       <React.Fragment>
         <Item Icon={Booking} message={name} />
-        {stock.beginningDatetime && (
+        {!!stock.beginningDatetime && (
           <Item Icon={Calendar} message={formatDate(stock.beginningDatetime)} />
         )}
         <Item Icon={LocationBuilding} message={address} />

--- a/src/features/bookings/components/BookingPropertiesSection.tsx
+++ b/src/features/bookings/components/BookingPropertiesSection.tsx
@@ -35,14 +35,14 @@ export const BookingPropertiesSection: React.FC<BookingPropertiesSectionProps> =
     <View style={style}>
       <Typo.Title4>{t`Ma réservation`}</Typo.Title4>
       <Spacer.Column numberOfSpaces={4.5} />
-      {user?.firstName && user?.lastName && (
+      {!!(user?.firstName && user?.lastName) && (
         <SectionRow
           title={user.firstName + '\u00a0' + user.lastName}
           renderTitle={(title) => (
             <TitleNameContainer>
               <Title>{title}</Title>
               <Spacer.Row numberOfSpaces={2} />
-              {properties.isDuo && <DuoBold testID="duo-icon" />}
+              {!!properties.isDuo && <DuoBold testID="duo-icon" />}
             </TitleNameContainer>
           )}
           type={'clickable'}

--- a/src/features/bookings/components/CancelBookingModal.tsx
+++ b/src/features/bookings/components/CancelBookingModal.tsx
@@ -70,7 +70,7 @@ export const CancelBookingModal: FunctionComponent<Props> = ({
       onRightIconPress={dismissModal}>
       <ModalContent>
         <OfferName>{booking.stock.offer.name}</OfferName>
-        {refundRule && (
+        {!!refundRule && (
           <React.Fragment>
             <Spacer.Column numberOfSpaces={2} />
             <Refund>{refundRule}</Refund>

--- a/src/features/bookings/components/OnGoingBookingItem.tsx
+++ b/src/features/bookings/components/OnGoingBookingItem.tsx
@@ -34,11 +34,11 @@ export const OnGoingBookingItem = ({ booking }: BookingItemProps) => {
         <OnGoingTicket image={stock.offer.image?.url} altIcon={mapCategoryToIcon(iconName)} />
         <AttributesView>
           <BookingItemTitle ticketWidth={onGoingTicketWidth} title={stock.offer.name} />
-          {Boolean(dateLabel) && <DateLabel color={ColorsEnum.GREY_DARK}>{dateLabel}</DateLabel>}
+          {!!dateLabel && <DateLabel color={ColorsEnum.GREY_DARK}>{dateLabel}</DateLabel>}
           <Spacer.Column numberOfSpaces={1} />
-          {bookingProperties.isDuo && <DuoBold />}
+          {!!bookingProperties.isDuo && <DuoBold />}
           <Spacer.Flex />
-          {Boolean(withdrawLabel) && (
+          {!!withdrawLabel && (
             <WithDrawContainer>
               <Clock size={20} color={ColorsEnum.PRIMARY} />
               <Spacer.Row numberOfSpaces={1} />

--- a/src/features/bookings/components/ThreeShapesTicket.tsx
+++ b/src/features/bookings/components/ThreeShapesTicket.tsx
@@ -22,7 +22,7 @@ export function ThreeShapesTicket(props: ThreeShapesTicketProps) {
       onLayout={(e) => setHeaderDimensions(e.nativeEvent.layout)}
       testID="three-shapes-ticket">
       <TicketHeader width={props.width} color={props.color} />
-      {headerDimensions && (
+      {!!headerDimensions && (
         <CenterView customWitdh={headerDimensions?.width} color={props.color}>
           {props.children}
         </CenterView>

--- a/src/features/bookings/pages/BookingDetails.tsx
+++ b/src/features/bookings/pages/BookingDetails.tsx
@@ -174,8 +174,10 @@ export function BookingDetails() {
           <Spacer.Column numberOfSpaces={4} />
           {renderOfferRules}
           <Spacer.Column numberOfSpaces={8} />
-          {appSettings && <BookingPropertiesSection booking={booking} appSettings={appSettings} />}
-          {shouldDisplayItineraryButton && (
+          {!!appSettings && (
+            <BookingPropertiesSection booking={booking} appSettings={appSettings} />
+          )}
+          {!!shouldDisplayItineraryButton && (
             <React.Fragment>
               <Spacer.Column numberOfSpaces={4} />
               <Separator />
@@ -183,7 +185,7 @@ export function BookingDetails() {
               <SeeItineraryButton openItinerary={openItinerary} />
             </React.Fragment>
           )}
-          {offer.withdrawalDetails && (
+          {!!offer.withdrawalDetails && (
             <React.Fragment>
               <Spacer.Column numberOfSpaces={8} />
               <Typo.Title4>{t`Modalités de retrait`}</Typo.Title4>

--- a/src/features/errors/pages/AsyncErrorBoundary.tsx
+++ b/src/features/errors/pages/AsyncErrorBoundary.tsx
@@ -93,7 +93,7 @@ export const AsyncErrorBoundary = (props: AsyncFallbackProps) => {
     <AsyncErrorBoundaryWithoutNavigation
       {...props}
       header={
-        canGoBack() && (
+        !!canGoBack() && (
           <HeaderContainer onPress={goBack} top={top + getSpacing(3.5)} testID="backArrow">
             <ArrowPrevious color={ColorsEnum.WHITE} size={getSpacing(10)} />
           </HeaderContainer>

--- a/src/features/favorites/atoms/Favorite.tsx
+++ b/src/features/favorites/atoms/Favorite.tsx
@@ -146,7 +146,7 @@ export const Favorite: React.FC<Props> = (props) => {
             </Row>
             <Spacer.Column numberOfSpaces={1} />
             <Body>{categoryLabel}</Body>
-            {formattedDate && <Body>{formattedDate}</Body>}
+            {!!formattedDate && <Body>{formattedDate}</Body>}
             <Spacer.Column numberOfSpaces={1} />
             <Typo.Caption>
               {getFavoriteDisplayPrice({ startPrice: offer.startPrice, price: offer.price })}

--- a/src/features/favorites/components/FavoritesResults.tsx
+++ b/src/features/favorites/components/FavoritesResults.tsx
@@ -93,7 +93,7 @@ export const FavoritesResults: React.FC = React.memo(function FavoritesResults()
 
   return (
     <React.Fragment>
-      {offerToBook && (
+      {!!offerToBook && (
         <BookingOfferModal
           visible
           dismissModal={() => setOfferToBook(null)}
@@ -116,7 +116,7 @@ export const FavoritesResults: React.FC = React.memo(function FavoritesResults()
           initialNumToRender={10}
         />
       </Container>
-      {sortedFavorites && sortedFavorites.length > 0 && (
+      {!!(sortedFavorites && sortedFavorites.length > 0) && (
         <SortContainer>
           <Sort />
           <Spacer.BottomScreen />

--- a/src/features/favorites/pages/FavoritesSorts.tsx
+++ b/src/features/favorites/pages/FavoritesSorts.tsx
@@ -101,9 +101,9 @@ export const FavoritesSorts: React.FC = () => {
                   {label}
                 </Typo.ButtonText>
                 <Spacer.Flex />
-                {isSelected && <Validate color={ColorsEnum.PRIMARY} size={getSpacing(8)} />}
+                {!!isSelected && <Validate color={ColorsEnum.PRIMARY} size={getSpacing(8)} />}
               </LabelContainer>
-              {sortBy === 'AROUND_ME' && isPositionUnavailable && (
+              {!!(sortBy === 'AROUND_ME' && isPositionUnavailable) && (
                 <InputError
                   visible
                   messageId={t`La géolocalisation est temporairement inutilisable sur ton téléphone`}

--- a/src/features/home/atoms/ImageCaption.tsx
+++ b/src/features/home/atoms/ImageCaption.tsx
@@ -19,7 +19,7 @@ export const ImageCaption = ({ category, imageWidth, distance }: ImageCaptionPro
           {category}
         </Typo.Caption>
       </TextWrapper>
-      {distance && (
+      {!!distance && (
         <React.Fragment>
           <Separator />
           <TextWrapper>

--- a/src/features/home/atoms/OfferCaption.tsx
+++ b/src/features/home/atoms/OfferCaption.tsx
@@ -20,7 +20,7 @@ export const OfferCaption = (props: OfferCaptionProps) => {
   return (
     <CaptionContainer imageWidth={imageWidth}>
       <Typo.Caption numberOfLines={1}>{name}</Typo.Caption>
-      {date && (
+      {!!date && (
         <Typo.Caption numberOfLines={1} color={ColorsEnum.GREY_DARK}>
           {date}
         </Typo.Caption>

--- a/src/features/home/components/HomeHeader.tsx
+++ b/src/features/home/components/HomeHeader.tsx
@@ -45,7 +45,7 @@ export const HomeHeader: FunctionComponent = function () {
       <HeaderBackgroundWrapper>
         <HeaderBackground />
       </HeaderBackgroundWrapper>
-      {env.FEATURE_FLIPPING_ONLY_VISIBLE_ON_TESTING && (
+      {!!env.FEATURE_FLIPPING_ONLY_VISIBLE_ON_TESTING && (
         <CheatCodeButtonContainer onPress={() => navigation.navigate('CheatMenu')}>
           <Text>{t`CheatMenu`}</Text>
         </CheatCodeButtonContainer>

--- a/src/features/home/components/OffersModule.tsx
+++ b/src/features/home/components/OffersModule.tsx
@@ -104,14 +104,14 @@ export const OffersModule = (props: OffersModuleProps) => {
         scrollEventThrottle={200}
         onScroll={checkIfAllTilesHaveBeenSeen}>
         <Spacer.Row numberOfSpaces={6} />
-        {props.cover && (
+        {!!props.cover && (
           <Row>
             <Cover layout={display.layout} uri={props.cover} />
             <Spacer.Row numberOfSpaces={4} />
           </Row>
         )}
         {hits.map(renderItem)}
-        {showSeeMore && <SeeMore layout={display.layout} onPress={onPressSeeMore} />}
+        {!!showSeeMore && <SeeMore layout={display.layout} onPress={onPressSeeMore} />}
         <Spacer.Row numberOfSpaces={6} />
       </ScrollView>
     </React.Fragment>

--- a/src/features/navigation/RootNavigator/RootNavigator.tsx
+++ b/src/features/navigation/RootNavigator/RootNavigator.tsx
@@ -50,7 +50,7 @@ export const RootNavigator: React.FC = () => {
       )}
       {/* The components below are those for which we do not want
       their rendering to happen while the splash is displayed. */}
-      {isSplashScreenHidden && <PrivacyPolicy navigationRef={navigationRef} />}
+      {!!isSplashScreenHidden && <PrivacyPolicy navigationRef={navigationRef} />}
     </React.Fragment>
   )
 }

--- a/src/features/navigation/TabBar/TabBarComponent.tsx
+++ b/src/features/navigation/TabBar/TabBarComponent.tsx
@@ -22,7 +22,7 @@ export const TabBarComponent: React.FC<TabComponentInterface> = ({
 }) => {
   return (
     <TabComponentContainer onPress={onPress} activeOpacity={1} testID={testID}>
-      {isSelected && (
+      {!!isSelected && (
         <BicolorSelector
           width={SELECTOR_WIDTH}
           height={SELECTOR_HEIGHT}
@@ -36,7 +36,7 @@ export const TabBarComponent: React.FC<TabComponentInterface> = ({
         thin: !isSelected,
       })}
       <Spacer.Flex />
-      {isSelected && <BicolorSelectorPlaceholder />}
+      {!!isSelected && <BicolorSelectorPlaceholder />}
     </TabComponentContainer>
   )
 }

--- a/src/features/offer/atoms/LocationCaption.tsx
+++ b/src/features/offer/atoms/LocationCaption.tsx
@@ -25,9 +25,9 @@ export const LocationCaption: FunctionComponent<Props> = ({ venue, isDigital }: 
         <IconContainer>
           {isDigital ? <Digital size={getSpacing(4)} /> : <LocationPointer size={getSpacing(4)} />}
         </IconContainer>
-        {locationName && <StyledText numberOfLines={1}>{`${locationName}, `}</StyledText>}
+        {!!locationName && <StyledText numberOfLines={1}>{`${locationName}, `}</StyledText>}
       </StyledView>
-      {where && (
+      {!!where && (
         <WhereText numberOfLines={1} isDigital={isDigital}>
           {where}
         </WhereText>

--- a/src/features/offer/components/AccessibilityBlock.tsx
+++ b/src/features/offer/components/AccessibilityBlock.tsx
@@ -28,8 +28,7 @@ const renderAccessibilityAtom = (
   handicap: HandicapCategory,
   addSpacer: boolean
 ) =>
-  disability !== null &&
-  disability !== undefined && (
+  !!(disability !== null && disability !== undefined) && (
     <React.Fragment>
       <AccessibilityAtom
         handicap={handicap}

--- a/src/features/offer/components/CallToAction.tsx
+++ b/src/features/offer/components/CallToAction.tsx
@@ -23,7 +23,7 @@ export const CallToAction: React.FC<Props> = ({
   <Container onPress={onPress} disabled={isDisabled}>
     {isDisabled ? <DisabledRectangle /> : <Rectangle height={getSpacing(12)} size="100%" />}
     <LegendContainer>
-      {isExternal && <ExternalLinkSite color={ColorsEnum.WHITE} />}
+      {!!isExternal && <ExternalLinkSite color={ColorsEnum.WHITE} />}
       <Title adjustsFontSizeToFit numberOfLines={1}>
         {wording}
       </Title>

--- a/src/features/offer/components/OfferIconCaptions.tsx
+++ b/src/features/offer/components/OfferIconCaptions.tsx
@@ -33,7 +33,7 @@ export const OfferIconCaptions: React.FC<Props> = ({ isDuo, stocks, category, la
     <Row>
       <Spacer.Row numberOfSpaces={6} />
       <OfferCategory category={category} label={label} />
-      {showDuo && (
+      {!!showDuo && (
         <React.Fragment>
           <Separator />
           <IconWithCaption testID="iconDuo" Icon={Duo} caption={t`À deux !`} />

--- a/src/features/offer/components/OfferWhereSection.tsx
+++ b/src/features/offer/components/OfferWhereSection.tsx
@@ -30,7 +30,7 @@ export const OfferWhereSection: React.FC<Props> = ({ address, offerCoordinates, 
     <React.Fragment>
       <Spacer.Column numberOfSpaces={6} />
       <Typo.Title4>{t`Où ?`}</Typo.Title4>
-      {address && (
+      {!!address && (
         <React.Fragment>
           <Spacer.Column numberOfSpaces={4} />
           <Typo.Caption>{t`Adresse`}</Typo.Caption>
@@ -38,7 +38,7 @@ export const OfferWhereSection: React.FC<Props> = ({ address, offerCoordinates, 
           <StyledAddress>{address}</StyledAddress>
         </React.Fragment>
       )}
-      {distanceToOffer && (
+      {!!distanceToOffer && (
         <React.Fragment>
           <Spacer.Column numberOfSpaces={4} />
           <Typo.Caption>{t`Distance`}</Typo.Caption>
@@ -47,7 +47,7 @@ export const OfferWhereSection: React.FC<Props> = ({ address, offerCoordinates, 
         </React.Fragment>
       )}
 
-      {canOpenItinerary && (
+      {!!canOpenItinerary && (
         <React.Fragment>
           <Spacer.Column numberOfSpaces={4} />
           <Separator />

--- a/src/features/profile/components/BeneficiaryHeader.tsx
+++ b/src/features/profile/components/BeneficiaryHeader.tsx
@@ -32,7 +32,7 @@ export function BeneficiaryHeader(props: PropsWithChildren<BeneficiaryHeaderProp
         <Spacer.Column numberOfSpaces={4.5} />
         <Typo.Hero color={ColorsEnum.WHITE}>{credit}</Typo.Hero>
         <Spacer.Column numberOfSpaces={2} />
-        {depositExpirationDate && (
+        {!!depositExpirationDate && (
           <Typo.Caption color={ColorsEnum.WHITE}>
             {t`crédit valable jusqu'au` + `\u00a0${depositExpirationDate}`}
           </Typo.Caption>

--- a/src/features/profile/components/ExBeneficiaryHeader.tsx
+++ b/src/features/profile/components/ExBeneficiaryHeader.tsx
@@ -29,7 +29,7 @@ export function ExBeneficiaryHeader(props: ExBeneficiaryHeaderProps) {
       <TitleContainer>
         <Typo.Title4 color={ColorsEnum.WHITE}>{name}</Typo.Title4>
         <Spacer.Column numberOfSpaces={4.5} />
-        {depositExpirationDate && (
+        {!!depositExpirationDate && (
           <Typo.Caption color={ColorsEnum.WHITE}>
             {t({
               id: 'credit expired on date',

--- a/src/features/profile/pages/ChangePassword.tsx
+++ b/src/features/profile/pages/ChangePassword.tsx
@@ -109,7 +109,7 @@ export function ChangePassword() {
             onChangeText={updateNewPassword}
             placeholder={t`Ton nouveau mot de passe`}
           />
-          {shouldDisplayPasswordRules && newPassword.length > 0 && (
+          {!!(shouldDisplayPasswordRules && newPassword.length > 0) && (
             <PasswordSecurityRules password={newPassword} />
           )}
         </StyledInput>
@@ -133,7 +133,7 @@ export function ChangePassword() {
           numberOfSpacesTop={0}
         />
         <Spacer.Flex flex={1} />
-        {Boolean(keyboardHeight) && <Spacer.Column numberOfSpaces={2} />}
+        {!!keyboardHeight && <Spacer.Column numberOfSpaces={2} />}
         <ButtonContainer paddingBottom={keyboardHeight ? 0 : bottom}>
           <ButtonPrimary
             title={t`Enregistrer`}

--- a/src/features/profile/pages/LegalNotices.tsx
+++ b/src/features/profile/pages/LegalNotices.tsx
@@ -38,7 +38,7 @@ export function LegalNotices() {
           style={styles.row}
           testID="row-data-privacy-chart"
         />
-        {user && (
+        {!!user && (
           <React.Fragment>
             <Separator />
             <Row

--- a/src/features/profile/pages/NotificationSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings.tsx
@@ -188,7 +188,7 @@ export function NotificationSettings() {
           </React.Fragment>
         )}
         <Spacer.Flex flex={1} />
-        {isLoggedIn && (
+        {!!isLoggedIn && (
           <ButtonPrimary
             title={t`Enregistrer`}
             isLoading={isUpdating}

--- a/src/features/profile/pages/PersonalData.tsx
+++ b/src/features/profile/pages/PersonalData.tsx
@@ -19,7 +19,7 @@ export function PersonalData() {
       <Spacer.TopScreen />
       <Spacer.Column numberOfSpaces={14} />
       <Container>
-        {user?.isBeneficiary && (
+        {!!user?.isBeneficiary && (
           <React.Fragment>
             <Row>
               <Typo.Caption>{t`Prénom et nom`}</Typo.Caption>
@@ -35,7 +35,7 @@ export function PersonalData() {
           <Typo.Body>{user?.email}</Typo.Body>
         </Row>
         <Separator />
-        {user?.isBeneficiary && (
+        {!!user?.isBeneficiary && (
           <React.Fragment>
             <Row>
               <Typo.Caption>{t`Numéro de téléphone`}</Typo.Caption>

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -124,7 +124,7 @@ export const Profile: React.FC = () => {
         <Spacer.Column numberOfSpaces={getSpacing(1)} />
         <ProfileSection
           title={isLoggedIn ? t`Paramètres du compte` : t`Paramètres de l'application`}>
-          {isLoggedIn && (
+          {!!isLoggedIn && (
             <React.Fragment>
               <Row
                 title={t`Informations personnelles`}
@@ -169,7 +169,7 @@ export const Profile: React.FC = () => {
             }
             testID="row-geolocation"
           />
-          {isPositionUnavailable && (
+          {!!isPositionUnavailable && (
             <InputError
               visible
               messageId={t`La géolocalisation est temporairement inutilisable sur ton téléphone`}
@@ -239,7 +239,7 @@ export const Profile: React.FC = () => {
             </NetworkRowContainer>
           </NetworkRow>
         </ProfileSection>
-        {isLoggedIn && (
+        {!!isLoggedIn && (
           <ProfileSection>
             <SectionRow
               title={t`Déconnexion`}

--- a/src/features/search/atoms/Buttons/DateFilter.tsx
+++ b/src/features/search/atoms/Buttons/DateFilter.tsx
@@ -17,7 +17,7 @@ export const DateFilter: React.FC<Props> = ({ text, onPress, isSelected }: Props
   return (
     <ButtonContainer onPress={onPress} activeOpacity={ACTIVE_OPACITY}>
       <Typo.ButtonText color={color}>{text}</Typo.ButtonText>
-      {isSelected && <Validate color={ColorsEnum.PRIMARY} size={getSpacing(8)} />}
+      {!!isSelected && <Validate color={ColorsEnum.PRIMARY} size={getSpacing(8)} />}
     </ButtonContainer>
   )
 }

--- a/src/features/search/atoms/Hit.tsx
+++ b/src/features/search/atoms/Hit.tsx
@@ -74,7 +74,7 @@ export const Hit: React.FC<Props> = ({ hit, query }) => {
           </Row>
           <Spacer.Column numberOfSpaces={1} />
           <Body>{categoryLabel}</Body>
-          {formattedDate && <Body>{formattedDate}</Body>}
+          {!!formattedDate && <Body>{formattedDate}</Body>}
           <Spacer.Column numberOfSpaces={1} />
           <Typo.Caption>{getDisplayPrice(offer.prices)}</Typo.Caption>
         </Column>

--- a/src/features/search/atoms/Sections.tsx
+++ b/src/features/search/atoms/Sections.tsx
@@ -40,7 +40,7 @@ export const InlineSection: React.FC<{
       <Spacer.Row numberOfSpaces={7} />
       {children}
     </InlineSectionTitleContainer>
-    {subtitle && (
+    {!!subtitle && (
       <React.Fragment>
         <Spacer.Column numberOfSpaces={2} />
         <Typo.Caption color={ColorsEnum.GREY_DARK}>{subtitle}</Typo.Caption>

--- a/src/features/search/components/LocationChoice.tsx
+++ b/src/features/search/components/LocationChoice.tsx
@@ -32,7 +32,7 @@ export const LocationChoice: React.FC<Props> = (props) => {
           {label}
         </Typo.ButtonText>
       </FirstPart>
-      {isSelected && (
+      {!!isSelected && (
         <ValidateIconContainer>
           <Validate color={ColorsEnum.PRIMARY} testID="validateIcon" />
         </ValidateIconContainer>

--- a/src/features/search/pages/Categories.tsx
+++ b/src/features/search/pages/Categories.tsx
@@ -56,7 +56,7 @@ export const Categories: React.FC = () => {
                 {label}
               </Typo.ButtonText>
               <Spacer.Flex />
-              {isSelected && <Validate color={ColorsEnum.PRIMARY} size={getSpacing(8)} />}
+              {!!isSelected && <Validate color={ColorsEnum.PRIMARY} size={getSpacing(8)} />}
             </LabelContainer>
           )
         })}

--- a/src/features/search/pages/LocationFilter.tsx
+++ b/src/features/search/pages/LocationFilter.tsx
@@ -97,7 +97,7 @@ export const LocationFilter: React.FC = () => {
           locationType={LocationType.AROUND_ME}
           onPress={onPressAroundMe}
         />
-        {isPositionUnavailable && (
+        {!!isPositionUnavailable && (
           <InputError
             visible
             messageId={t`La géolocalisation est temporairement inutilisable sur ton téléphone`}

--- a/src/features/search/pages/SearchFilter.tsx
+++ b/src/features/search/pages/SearchFilter.tsx
@@ -84,7 +84,7 @@ export const SearchFilter: React.FC = () => {
           <Separator marginVertical={getSpacing(6)} />
 
           {/* Uniquement les offres duo */}
-          {profile?.isBeneficiary && (
+          {!!profile?.isBeneficiary && (
             <React.Fragment>
               <Section.DuoOffer />
               <Separator marginVertical={getSpacing(6)} />

--- a/src/ui/components/ClippedImage.tsx
+++ b/src/ui/components/ClippedImage.tsx
@@ -59,7 +59,7 @@ export function ClippedImage(props: PropsWithChildren<ClippedImageProps>) {
           </G>
         )}
       </Svg>
-      {!props.image && Icon && (
+      {!!(props.image && !!Icon) && (
         <IconContainer>
           <Icon size={48} color={ColorsEnum.GREY_MEDIUM} />
         </IconContainer>

--- a/src/ui/components/GenericInfoPage.tsx
+++ b/src/ui/components/GenericInfoPage.tsx
@@ -38,7 +38,7 @@ export const GenericInfoPage: FunctionComponent<Props> = (props) => {
             <Spacer.Column numberOfSpaces={spacingMatrix.afterIcon} />
           </React.Fragment>
         ) : (
-          animation && (
+          !!animation && (
             <React.Fragment>
               <StyledLottieView source={animation} autoPlay loop={false} size={animationSize} />
               <Spacer.Column numberOfSpaces={spacingMatrix.afterLottieAnimation} />

--- a/src/ui/components/Section.tsx
+++ b/src/ui/components/Section.tsx
@@ -14,7 +14,7 @@ interface SectionProps {
 export function Section(props: PropsWithChildren<SectionProps>) {
   return (
     <Container style={props.style}>
-      {props.title && <Title>{props.title}</Title>}
+      {!!props.title && <Title>{props.title}</Title>}
       <Separator />
       {props.children}
     </Container>

--- a/src/ui/components/SectionRow.tsx
+++ b/src/ui/components/SectionRow.tsx
@@ -43,7 +43,7 @@ export function SectionRow(props: SectionRowProps) {
       onPress={props.onPress}
       testID={props.testID ? props.testID : 'section-row-touchable'}>
       <View style={[styles.container, props.style]}>
-        {Icon && <Icon />}
+        {!!Icon && <Icon />}
         <TitleContainer>{title}</TitleContainer>
         <CTAContainer>
           {props.type == 'navigable' ? (

--- a/src/ui/components/buttons/AppButton.tsx
+++ b/src/ui/components/buttons/AppButton.tsx
@@ -58,7 +58,7 @@ const _AppButton = <T extends AppButtonProps>(props: Only<T, AppButtonProps>) =>
         <Logo testID="button-isloading-icon" color={props.loadingIconColor} size={props.iconSize} />
       ) : (
         <Fragment>
-          {Icon && <Icon testID="button-icon" color={props.iconColor} size={props.iconSize} />}
+          {!!Icon && <Icon testID="button-icon" color={props.iconColor} size={props.iconSize} />}
           <Title
             testID={titleTestID}
             textColor={props.textColor}

--- a/src/ui/components/headers/PageHeader.tsx
+++ b/src/ui/components/headers/PageHeader.tsx
@@ -51,7 +51,7 @@ export const PageHeader: React.FC<Props> = (props) => {
         <Title color={ColorsEnum.WHITE}>{title}</Title>
 
         <ButtonContainer positionInHeader="right">
-          {RightComponent && (
+          {!!RightComponent && (
             <View onLayout={onLayout}>
               <RightComponent />
             </View>

--- a/src/ui/components/inputs/CheckboxInput.tsx
+++ b/src/ui/components/inputs/CheckboxInput.tsx
@@ -17,7 +17,7 @@ export function CheckboxInput({ isChecked, setIsChecked }: CustomCheckboxProps):
 
   return (
     <StyledCheckboxInput checked={isChecked} onPress={setToggleCheckbox} testID="checkbox">
-      {isChecked && <CheckboxMark testID={'checkbox-mark'} />}
+      {!!isChecked && <CheckboxMark testID={'checkbox-mark'} />}
     </StyledCheckboxInput>
   )
 }

--- a/src/ui/components/inputs/SearchInput.tsx
+++ b/src/ui/components/inputs/SearchInput.tsx
@@ -27,7 +27,7 @@ const WithRefSearchInput: React.ForwardRefRenderFunction<RNTextInput, SearchInpu
 
   return (
     <InputContainer inputHeight={props.inputHeight} isFocus={isFocus}>
-      {LeftIcon && <LeftIcon />}
+      {!!LeftIcon && <LeftIcon />}
       <Spacer.Row numberOfSpaces={2} />
       <BaseTextInput
         {...nativeProps}

--- a/src/ui/components/inputs/Slider.tsx
+++ b/src/ui/components/inputs/Slider.tsx
@@ -31,7 +31,7 @@ export const Slider: React.FC<Props> = (props) => {
 
   return (
     <React.Fragment>
-      {props.showValues && (
+      {!!props.showValues && (
         <Typo.ButtonText>
           {values.length === 1 && formatValues(values[0])}
           {values.length === 2 && `${formatValues(values[0])} - ${formatValues(values[1])}`}

--- a/src/ui/components/modals/AppInformationModal.tsx
+++ b/src/ui/components/modals/AppInformationModal.tsx
@@ -26,7 +26,7 @@ export const AppInformationModal: FunctionComponent<Props> = ({
   const paddingBottom = Math.max(bottom, getSpacing(3))
   return (
     <React.Fragment>
-      {visible && (
+      {!!visible && (
         <Modal
           animationType="fade"
           statusBarTranslucent

--- a/src/ui/components/modals/ModalHeader.tsx
+++ b/src/ui/components/modals/ModalHeader.tsx
@@ -34,13 +34,15 @@ export const ModalHeader: FunctionComponent<ModalHeaderProps> = ({
   return (
     <Container customStyle={customStyles?.container}>
       <LeftHeaderAction onPress={onLeftIconPress} testID="leftIconButton">
-        {LeftIcon && <LeftIcon size={32} testID="leftIcon" color={customStyles?.leftIcon?.color} />}
+        {!!LeftIcon && (
+          <LeftIcon size={32} testID="leftIcon" color={customStyles?.leftIcon?.color} />
+        )}
       </LeftHeaderAction>
       <TitleComponent customStyle={customStyles?.title} numberOfLines={numberOfLines}>
         {title}
       </TitleComponent>
       <RightHeaderAction onPress={onRightIconPress} testID="rightIconButton">
-        {RightIcon && (
+        {!!RightIcon && (
           <RightIcon size={32} testID="rightIcon" color={customStyles?.rightIcon?.color} />
         )}
       </RightHeaderAction>

--- a/src/ui/components/snackBar/SnackBar.tsx
+++ b/src/ui/components/snackBar/SnackBar.tsx
@@ -115,7 +115,7 @@ const _SnackBar = (props: SnackBarProps) => {
         duration={animationDuration}
         ref={containerRef}>
         <SnackBarContainer isVisible={isVisible} marginTop={top} testID="snackbar-container">
-          {Icon && <Icon testID="snackbar-icon" size={32} color={props.color} />}
+          {!!Icon && <Icon testID="snackbar-icon" size={32} color={props.color} />}
           <Spacer.Flex flex={1}>
             <Text testID="snackbar-message" color={props.color}>
               {props.message}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-8923

WHAT APPEND:
- on utilisait une string pour conditionner l'affichage d'un composant
         maString && `<MonComposant>`
- sauf que "" est falsy. Donc
        "" &&   `<MonComposant> `= ""
- ce qui provoque le crash de l'app car on ne peut pas rendre une string en dehors de bases texte

LE FIX:
- l'idée et de toujours caster la variable en boolean
    maString && `<MonComposant>` ======>  !!maString && <MonComposant>
- pour ça, ajout d'une règle eslint pour protéger les devs de refaire l'erreur

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
