### PR TITLE
(PC-9110) Affichage d'un message d'erreur custom selon l'erreur de géoloc

### DIFF
--- a/__mocks__/react-native-geolocation-service.ts
+++ b/__mocks__/react-native-geolocation-service.ts
@@ -1,6 +1,9 @@
-export default {
+const { PositionError } = jest.requireActual('react-native-geolocation-service')
+
+module.exports = {
   addListener: jest.fn(),
   getCurrentPosition: jest.fn(),
+  PositionError,
   removeListeners: jest.fn(),
   requestAuthorization: jest.fn().mockResolvedValue('granted'),
   setConfiguration: jest.fn(),

--- a/src/features/favorites/pages/FavoritesSorts.tsx
+++ b/src/features/favorites/pages/FavoritesSorts.tsx
@@ -128,7 +128,11 @@ export const FavoritesSorts: React.FC = () => {
   )
 }
 
-const contentContainerStyle: ViewStyle = { flexGrow: 1, marginRight: getSpacing(6) }
+const contentContainerStyle: ViewStyle = {
+  flexGrow: 1,
+  paddingLeft: getSpacing(2),
+  paddingRight: getSpacing(6),
+}
 
 const LabelContainer = styled.TouchableOpacity.attrs({
   activeOpacity: ACTIVE_OPACITY,

--- a/src/features/favorites/pages/FavoritesSorts.tsx
+++ b/src/features/favorites/pages/FavoritesSorts.tsx
@@ -27,12 +27,7 @@ const SORT_OPTIONS_LIST = Object.entries(SORT_OPTIONS) as Array<[FavoriteSortBy,
 
 export const FavoritesSorts: React.FC = () => {
   const { goBack } = useNavigation()
-  const {
-    position,
-    isPositionUnavailable,
-    permissionState,
-    requestGeolocPermission,
-  } = useGeolocation()
+  const { position, positionError, permissionState, requestGeolocPermission } = useGeolocation()
   const { sortBy: selectedSortBy, dispatch } = useFavoritesState()
   const [stagedSelectedSortBy, setStagedSelectedSortBy] = useState(selectedSortBy)
   const {
@@ -103,13 +98,9 @@ export const FavoritesSorts: React.FC = () => {
                 <Spacer.Flex />
                 {!!isSelected && <Validate color={ColorsEnum.PRIMARY} size={getSpacing(8)} />}
               </LabelContainer>
-              {!!(sortBy === 'AROUND_ME' && isPositionUnavailable) && (
-                <InputError
-                  visible
-                  messageId={t`La géolocalisation est temporairement inutilisable sur ton téléphone`}
-                  numberOfSpacesTop={1}
-                />
-              )}
+              {sortBy === 'AROUND_ME' && positionError ? (
+                <InputError visible messageId={positionError.message} numberOfSpacesTop={1} />
+              ) : null}
             </React.Fragment>
           )
         })}

--- a/src/features/favorites/pages/__tests__/__snapshots__/FavoritesSorts.test.tsx.snap
+++ b/src/features/favorites/pages/__tests__/__snapshots__/FavoritesSorts.test.tsx.snap
@@ -6,7 +6,8 @@ Array [
     contentContainerStyle={
       Object {
         "flexGrow": 1,
-        "marginRight": 24,
+        "paddingLeft": 8,
+        "paddingRight": 24,
       }
     }
   >

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -51,11 +51,17 @@ export const Profile: React.FC = () => {
   const signOut = useLogoutRoutine()
   const scrollViewRef = useRef<ScrollView | null>(null)
 
-  const { isPositionUnavailable, permissionState, requestGeolocPermission } = useGeolocation()
+  const {
+    positionError,
+    permissionState,
+    requestGeolocPermission,
+    triggerPositionUpdate,
+  } = useGeolocation()
   const [isGeolocSwitchActive, setIsGeolocSwitchActive] = useState<boolean>(false)
 
   useFocusEffect(() => {
-    if (isPositionUnavailable) {
+    triggerPositionUpdate()
+    if (positionError) {
       new MonitoringError('Position is unavailable', 'NoPositionProfilePage')
     }
     if (permissionState === GeolocPermissionState.GRANTED) {
@@ -169,12 +175,8 @@ export const Profile: React.FC = () => {
             }
             testID="row-geolocation"
           />
-          {!!isPositionUnavailable && (
-            <InputError
-              visible
-              messageId={t`La géolocalisation est temporairement inutilisable sur ton téléphone`}
-              numberOfSpacesTop={1}
-            />
+          {!!positionError && (
+            <InputError visible messageId={positionError.message} numberOfSpacesTop={1} />
           )}
         </ProfileSection>
         <ProfileSection title={t`Aides`}>

--- a/src/features/search/pages/LocationFilter.tsx
+++ b/src/features/search/pages/LocationFilter.tsx
@@ -122,6 +122,10 @@ export const LocationFilter: React.FC = () => {
   )
 }
 
-const contentContainerStyle: ViewStyle = { flexGrow: 1 }
+const contentContainerStyle: ViewStyle = {
+  flexGrow: 1,
+  paddingLeft: getSpacing(2),
+  paddingRight: getSpacing(2),
+}
 
 const BannerContainer = styled.View({ marginHorizontal: getSpacing(6) })

--- a/src/features/search/pages/LocationFilter.tsx
+++ b/src/features/search/pages/LocationFilter.tsx
@@ -22,12 +22,7 @@ const DEBOUNCED_CALLBACK = 500
 
 export const LocationFilter: React.FC = () => {
   const { navigate, goBack } = useNavigation<UseNavigationType>()
-  const {
-    position,
-    isPositionUnavailable,
-    permissionState,
-    requestGeolocPermission,
-  } = useGeolocation()
+  const { position, positionError, permissionState, requestGeolocPermission } = useGeolocation()
   const { dispatch } = useStagedSearch()
   const debouncedGoBack = useRef(debounce(goBack, DEBOUNCED_CALLBACK)).current
   const {
@@ -97,12 +92,8 @@ export const LocationFilter: React.FC = () => {
           locationType={LocationType.AROUND_ME}
           onPress={onPressAroundMe}
         />
-        {!!isPositionUnavailable && (
-          <InputError
-            visible
-            messageId={t`La géolocalisation est temporairement inutilisable sur ton téléphone`}
-            numberOfSpacesTop={1}
-          />
+        {!!positionError && (
+          <InputError visible messageId={positionError.message} numberOfSpacesTop={1} />
         )}
         <Spacer.Column numberOfSpaces={4} />
         <LocationChoice

--- a/src/features/search/pages/__tests__/__snapshots__/LocationFilter.test.tsx.snap
+++ b/src/features/search/pages/__tests__/__snapshots__/LocationFilter.test.tsx.snap
@@ -16,6 +16,8 @@ Array [
     contentContainerStyle={
       Object {
         "flexGrow": 1,
+        "paddingLeft": 8,
+        "paddingRight": 8,
       }
     }
   >

--- a/src/libs/geolocation/GeolocationWrapper.tsx
+++ b/src/libs/geolocation/GeolocationWrapper.tsx
@@ -5,7 +5,7 @@ import { useAppStateChange } from 'libs/appState'
 import { useSafeState } from 'libs/hooks'
 
 import { checkGeolocPermission } from './checkGeolocPermission'
-import { getPosition } from './getPosition'
+import { getPosition, GeolocationError } from './getPosition'
 import { GeolocPermissionState } from './permissionState.d'
 import { requestGeolocPermission } from './requestGeolocPermission'
 
@@ -17,7 +17,7 @@ type RequestGeolocPermissionParams = {
 
 export interface IGeolocationContext {
   position: GeoCoordinates | null
-  isPositionUnavailable: boolean
+  positionError: GeolocationError | null
   setPosition: (position: GeoCoordinates | null) => void
   permissionState: GeolocPermissionState
   requestGeolocPermission: (params?: RequestGeolocPermissionParams) => Promise<void>
@@ -27,7 +27,7 @@ export interface IGeolocationContext {
 
 export const GeolocationContext = React.createContext<IGeolocationContext>({
   position: null,
-  isPositionUnavailable: false,
+  positionError: null,
   setPosition: () => undefined,
   permissionState: GeolocPermissionState.DENIED,
   requestGeolocPermission: async () => {
@@ -40,8 +40,8 @@ export const GeolocationContext = React.createContext<IGeolocationContext>({
 })
 
 export const GeolocationWrapper = ({ children }: { children: Element }) => {
-  const [isPositionUnavailable, setIsPositionUnavailable] = useSafeState(false)
   const [position, setPosition] = useSafeState<GeoCoordinates | null>(null)
+  const [positionError, setPositionError] = useSafeState<GeolocationError | null>(null)
   const [permissionState, setPermissionState] = useSafeState<GeolocPermissionState>(
     GeolocPermissionState.DENIED
   )
@@ -51,8 +51,7 @@ export const GeolocationWrapper = ({ children }: { children: Element }) => {
   }, [])
 
   function triggerPositionUpdate() {
-    setIsPositionUnavailable(false)
-    getPosition(setPosition, setIsPositionUnavailable)
+    getPosition(setPosition, setPositionError)
   }
 
   // this function is used to set OS permissions according to user choice on native geolocation popup
@@ -96,7 +95,7 @@ export const GeolocationWrapper = ({ children }: { children: Element }) => {
     <GeolocationContext.Provider
       value={{
         position,
-        isPositionUnavailable,
+        positionError,
         setPosition,
         permissionState,
         requestGeolocPermission: contextualRequestGeolocPermission,

--- a/src/libs/geolocation/getPosition.ts
+++ b/src/libs/geolocation/getPosition.ts
@@ -1,67 +1,77 @@
+import { t } from '@lingui/macro'
 import { Dispatch, SetStateAction } from 'react'
 import AgonTukGeolocation, { GeoCoordinates, PositionError } from 'react-native-geolocation-service'
 
 import { MonitoringError } from 'libs/errorMonitoring'
 
+const GET_POSITION_SETTINGS = {
+  enableHighAccuracy: false,
+  timeout: 20000,
+  maximumAge: 10000,
+  showLocationDialog: false,
+  forceRequestLocation: false,
+}
+
+export const GEOLOCATION_USER_ERROR_MESSAGE: Record<PositionError, string> = {
+  [PositionError.PERMISSION_DENIED]: t`La géolocalisation est inutilisable sur ton téléphone car le réglage de l'application est désactivé`,
+  [PositionError.POSITION_UNAVAILABLE]: t`La géolocalisation est temporairement inutilisable sur ton téléphone`,
+  [PositionError.TIMEOUT]: t`La géolocalisation est temporairement inutilisable sur ton téléphone`,
+  [PositionError.PLAY_SERVICE_NOT_AVAILABLE]: t`La géolocalisation est possiblement inutilisable sur ton téléphone parce que les services Google Play ne sont pas disponibles`,
+  [PositionError.SETTINGS_NOT_SATISFIED]: t`La géolocalisation est possiblement inutilisable sur ton téléphone pour l'une des raisons suivantes: réglage du téléphone désactivé, réseau hors-ligne...`,
+  [PositionError.INTERNAL_ERROR]: t`La géolocalisation est temporairement inutilisable sur ton téléphone`,
+}
+
+export type GeolocationError = {
+  type: PositionError
+  message: string
+}
+
 export const getPosition = (
-  setInitialPosition: (coordinates: GeoCoordinates | null) => void,
-  setIsPositionUnavailable: Dispatch<SetStateAction<boolean>>
+  setPosition: Dispatch<SetStateAction<GeoCoordinates | null>>,
+  setPositionError: Dispatch<SetStateAction<GeolocationError | null>>
 ): void =>
   AgonTukGeolocation.getCurrentPosition(
     (position) => {
-      setInitialPosition(position.coords)
+      setPositionError(null)
+      setPosition(position.coords)
     },
-    ({ code }) => {
+    ({ code, message }) => {
       switch (code) {
         case PositionError.PERMISSION_DENIED:
-          setInitialPosition(null)
+          setPositionError(null)
+          setPosition(null)
           break
         case PositionError.POSITION_UNAVAILABLE:
           // since we don't know if the previous request was successful
           // we do nothing to avoid side effects with existing features
-          setIsPositionUnavailable(true)
-          new MonitoringError(
-            'AgonTukGeolocation.getCurrentPosition() - POSITION_UNAVAILABLE',
-            'PositionError_PositionUnavailable'
-          )
+          setPositionError({ type: code, message: GEOLOCATION_USER_ERROR_MESSAGE[code] })
+          new MonitoringError(message, 'PositionError_PositionUnavailable')
           break
         case PositionError.TIMEOUT:
           // TODO: we could implement a retry pattern if we got time ??
-          setIsPositionUnavailable(true)
-          setInitialPosition(null)
-          new MonitoringError(
-            'AgonTukGeolocation.getCurrentPosition() - TIMEOUT',
-            'PositionError_Timeout'
-          )
+          setPositionError({ type: code, message: GEOLOCATION_USER_ERROR_MESSAGE[code] })
+          setPosition(null)
+          new MonitoringError(message, 'PositionError_Timeout')
           break
         case PositionError.PLAY_SERVICE_NOT_AVAILABLE:
-          setIsPositionUnavailable(true)
-          setInitialPosition(null)
-          new MonitoringError(
-            'AgonTukGeolocation.getCurrentPosition() - PLAY_SERVICE_NOT_AVAILABLE',
-            'PositionError_PlayServiceNotAvailable'
-          )
+          setPositionError({ type: code, message: GEOLOCATION_USER_ERROR_MESSAGE[code] })
+          setPosition(null)
+          new MonitoringError(message, 'PositionError_PlayServiceNotAvailable')
           break
         case PositionError.SETTINGS_NOT_SATISFIED:
           // global localisation parameter setting is off
           // OR network is off
           // OR offline id on
-          setIsPositionUnavailable(true)
-          setInitialPosition(null)
-          new MonitoringError(
-            'AgonTukGeolocation.getCurrentPosition() - SETTINGS_NOT_SATISFIED',
-            'PositionError_SettingsNotSatisfied'
-          )
+          setPositionError({ type: code, message: GEOLOCATION_USER_ERROR_MESSAGE[code] })
+          setPosition(null)
+          new MonitoringError(message, 'PositionError_SettingsNotSatisfied')
           break
         case PositionError.INTERNAL_ERROR:
-          setIsPositionUnavailable(true)
-          setInitialPosition(null)
-          new MonitoringError(
-            'AgonTukGeolocation.getCurrentPosition() - INTERNAL_ERROR',
-            'PositionError_InternalError'
-          )
+          setPositionError({ type: code, message: GEOLOCATION_USER_ERROR_MESSAGE[code] })
+          setPosition(null)
+          new MonitoringError(message, 'PositionError_InternalError')
           break
       }
     },
-    { enableHighAccuracy: false, timeout: 20000, maximumAge: 10000, showLocationDialog: true }
+    GET_POSITION_SETTINGS
   )


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-9110

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] |
| -------------------- | :----------------------: |
|                      |                          | 