### PR TITLE
(Booking) Update Booking footer when new props

### DIFF
--- a/src/features/bookings/components/OnGoingBookingsList.tsx
+++ b/src/features/bookings/components/OnGoingBookingsList.tsx
@@ -29,6 +29,7 @@ export function OnGoingBookingsList(props: OnGoingBookingsListProps) {
   const bookings = props.bookings || emptyBookings
   const onGoingBookingsCount = bookings.length
   const hasBookings = onGoingBookingsCount > 0
+  const hasEndedBookings = (props.endedBookings || []).length > 0
   const bookingsCountLabel = plural(onGoingBookingsCount, {
     one: '# réservation en cours',
     other: '# réservations en cours',
@@ -45,7 +46,7 @@ export function OnGoingBookingsList(props: OnGoingBookingsListProps) {
         <EndedBookingsSection endedBookings={props.endedBookings} />
       </FooterContainer>
     ),
-    [hasBookings, bookingsCountLabel]
+    [hasBookings, bookingsCountLabel, props.endedBookings]
   )
 
   const logBookingsScrolledToBottom = useFunctionOnce(analytics.logBookingsScrolledToBottom)
@@ -57,7 +58,7 @@ export function OnGoingBookingsList(props: OnGoingBookingsListProps) {
   }
 
   return (
-    <Container flex={hasBookings ? 1 : undefined}>
+    <Container flex={hasBookings || hasEndedBookings ? 1 : undefined}>
       <FlatList
         testID="OnGoingBookingsList"
         keyExtractor={keyExtractor}


### PR DESCRIPTION
## Problem

The banner was displayed but underneath the TabBar.

### Screenshots

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/10118284/121923433-37ed5f80-cd3b-11eb-8bb1-39858a622602.png) | ![image](https://user-images.githubusercontent.com/10118284/121923349-2015db80-cd3b-11eb-9949-c5319e9b315f.png) |
