### PR TITLE
(PC-9110) Ne pas afficher la modale système pour demander la permission géoloc si celle-ci est désactivée de manière globale

### DIFF
--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -65,17 +65,19 @@ export const Profile: React.FC = () => {
   } = useGeolocation()
   const [isGeolocSwitchActive, setIsGeolocSwitchActive] = useState<boolean>(false)
 
-  useFocusEffect(() => {
-    triggerPositionUpdate()
-    if (positionError) {
-      new MonitoringError('Position is unavailable', 'NoPositionProfilePage')
-    }
-    if (permissionState === GeolocPermissionState.GRANTED) {
-      setIsGeolocSwitchActive(true)
-    } else {
-      setIsGeolocSwitchActive(false)
-    }
-  })
+  useFocusEffect(
+    useCallback(() => {
+      if (positionError) {
+        new MonitoringError('Position is unavailable', 'NoPositionProfilePage')
+      }
+      if (permissionState === GeolocPermissionState.GRANTED) {
+        triggerPositionUpdate()
+        setIsGeolocSwitchActive(true)
+      } else {
+        setIsGeolocSwitchActive(false)
+      }
+    }, [positionError, permissionState])
+  )
 
   const {
     visible: isGeolocPermissionModalVisible,

--- a/src/libs/appState.ts
+++ b/src/libs/appState.ts
@@ -7,11 +7,12 @@ export const useAppStateChange = (
   deps: DependencyList | undefined = []
 ) => {
   const appState = useRef(AppState.currentState)
-  const handleAppStateChange = (nextAppState: AppStateStatus) => {
-    if (appState.current === 'active' && nextAppState.match(/inactive|background/)) {
+
+  function handleAppStateChange(nextAppState: AppStateStatus) {
+    if (isActive(appState.current) && isInactiveOrBackground(nextAppState)) {
       onAppBecomeInactive()
     }
-    if (appState.current.match(/inactive|background/) && nextAppState === 'active') {
+    if (isInactiveOrBackground(appState.current) && isActive(nextAppState)) {
       onAppBecomeActive()
     }
     appState.current = nextAppState
@@ -24,4 +25,12 @@ export const useAppStateChange = (
     }
   }, deps)
   return appState
+}
+
+function isActive(stateStatus: AppStateStatus) {
+  return stateStatus === 'active'
+}
+
+function isInactiveOrBackground(stateStatus: AppStateStatus) {
+  return stateStatus === 'inactive' || stateStatus === 'background'
 }

--- a/src/libs/geolocation/GeolocationWrapper.ios.test.tsx
+++ b/src/libs/geolocation/GeolocationWrapper.ios.test.tsx
@@ -81,16 +81,16 @@ describe('useGeolocation()', () => {
     renderGeolocationHook()
 
     await waitFor(() => {
-      expect(mockGetPosition).toBeCalledTimes(1)
+      expect(mockGetPosition).not.toBeCalled()
     })
   })
 
-  it('should call get position when permission is blocked', async () => {
+  it('should not get position when permission is blocked', async () => {
     jest.spyOn(permissions, 'check').mockResolvedValueOnce('blocked')
     renderGeolocationHook()
 
     await waitFor(() => {
-      expect(mockGetPosition).toBeCalledTimes(1)
+      expect(mockGetPosition).not.toBeCalled()
     })
   })
 })

--- a/src/libs/geolocation/GeolocationWrapper.tsx
+++ b/src/libs/geolocation/GeolocationWrapper.tsx
@@ -58,16 +58,14 @@ export const GeolocationWrapper = ({ children }: { children: Element }) => {
   async function contextualRequestGeolocPermission(params?: RequestGeolocPermissionParams) {
     const newPermissionState = await requestGeolocPermission()
     setPermissionState(newPermissionState)
-    triggerPositionUpdate()
 
-    if (params?.onSubmit) {
-      params.onSubmit()
-    }
-    const isPermissionGranted = newPermissionState === GeolocPermissionState.GRANTED
-    if (isPermissionGranted && params?.onAcceptance) {
-      params.onAcceptance()
-    } else if (!isPermissionGranted && params?.onRefusal) {
-      params.onRefusal()
+    !!params?.onSubmit && params.onSubmit()
+
+    if (isGranted(newPermissionState)) {
+      triggerPositionUpdate()
+      !!params?.onAcceptance && params.onAcceptance()
+    } else {
+      !!params?.onRefusal && params.onRefusal()
     }
   }
 
@@ -75,7 +73,9 @@ export const GeolocationWrapper = ({ children }: { children: Element }) => {
   // storage choice is consistent with phone permissions, and update position if not
   async function contextualCheckPermission() {
     const newPermissionState: GeolocPermissionState = await checkGeolocPermission()
-    triggerPositionUpdate()
+    if (isGranted(newPermissionState)) {
+      triggerPositionUpdate()
+    }
     setPermissionState(newPermissionState)
   }
 
@@ -109,4 +109,8 @@ export const GeolocationWrapper = ({ children }: { children: Element }) => {
 
 export function useGeolocation(): IGeolocationContext {
   return useContext(GeolocationContext)
+}
+
+function isGranted(permissionState: GeolocPermissionState) {
+  return permissionState === GeolocPermissionState.GRANTED
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-9110

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] |
| -------------------- | :----------------------: | 
|                      |                          |  