### PR TITLE
(TECH) Use expose-gc in test to slow down memory leaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:types": "tsc --noEmit",
     "test:unit": "TZ=UTC JEST=true jest --forceExit",
     "test:unit:web": "TZ=UTC JEST=true jest --forceExit",
-    "test:unit:ci": "TZ=UTC yarn test:unit --runInBand --logHeapUsage --forceExit",
+    "test:unit:ci": "TZ=UTC JEST=true node --expose-gc ./node_modules/.bin/jest --runInBand --logHeapUsage --forceExit",
     "test:unit:full": "TZ=UTC JEST=true jest --collect-coverage",
     "fix:lint": "eslint . --ext .js,.ts,.tsx --fix",
     "postinstall": "patch-package && jetify && yarn translations:compile",


### PR DESCRIPTION
PR non mergée car ralentit les tests malgré l'amélioration de l'utilisation de la mémoire
