### PR TITLE
(Tech) undo jest-mock-canvas-test-utils

### DIFF
--- a/__mocks__/fragmentMock.ts
+++ b/__mocks__/fragmentMock.ts
@@ -1,4 +1,3 @@
 import { createElement, Fragment, ReactNode } from 'react'
 
-
 export default ({ children }: { children: ReactNode }) => createElement(Fragment, { children })

--- a/jest/jest.setup.ts
+++ b/jest/jest.setup.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-undef */
 import 'cross-fetch/polyfill'
-import 'jest-canvas-mock'
 jest.unmock('react-query')
 /* We disable the following warning, which can be safely ignored as the code
   is not executed on a device :

--- a/package.json
+++ b/package.json
@@ -208,7 +208,6 @@
     "fs-extra": "^9.1.0",
     "html-webpack-plugin": "^4.5.2",
     "jest": "^26.6.3",
-    "jest-canvas-mock": "^2.3.1",
     "jest-styled-components": "^7.0.4",
     "jetifier": "^1.6.5",
     "json": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10544,14 +10544,6 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-jest-canvas-mock@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.3.1.tgz#9535d14bc18ccf1493be36ac37dd349928387826"
-  integrity sha512-5FnSZPrX3Q2ZfsbYNE3wqKR3+XorN8qFzDzB5o0golWgt6EOX1+emBnpOc9IAQ+NXFj8Nzm3h7ZdE/9H0ylBcg==
-  dependencies:
-    cssfontparser "^1.2.1"
-    moo-color "^1.0.2"
-
 jest-changed-files@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-26.6.2.tgz#f6198479e1cc66f22f9ae1e22acaa0b429c042d0"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXX

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
