### PR TITLE
(PC-9483) ui: add radio button component

### DIFF
--- a/src/features/cheatcodes/pages/AppComponents.tsx
+++ b/src/features/cheatcodes/pages/AppComponents.tsx
@@ -40,6 +40,7 @@ import { TextInput } from 'ui/components/inputs/TextInput'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { ModalHeader } from 'ui/components/modals/ModalHeader'
 import { useModal } from 'ui/components/modals/useModal'
+import { RadioButton } from 'ui/components/RadioButton'
 import { SectionRow } from 'ui/components/SectionRow'
 import { useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { SocialNetworkCard } from 'ui/components/SocialNetworkCard'
@@ -144,6 +145,7 @@ export const AppComponents: FunctionComponent = () => {
   const [inputText, setInputText] = useState('')
   const [currentStep, setCurrentStep] = useState(1)
   const [year, setYear] = useState(THIS_YEAR - 18)
+  const [radioButtonChoice, setRadioButtonChoice] = useState('')
   const numberOfSteps = useSignInNumberOfSteps()
 
   function navigateToIdCheckUnavailable() {
@@ -645,6 +647,19 @@ export const AppComponents: FunctionComponent = () => {
         <AlignedText>
           <Banner title="Je suis une bannière" type={BannerType.INFO} />
         </AlignedText>
+      </AccordionItem>
+
+      <Divider />
+
+      <AccordionItem title="Radio button">
+        <RadioButton
+          choices={[
+            { key: '1', title: 'item 1', subtitle: 'description 1' },
+            { key: '2', title: 'item 2', subtitle: 'description 2' },
+          ]}
+          onSelect={setRadioButtonChoice}
+        />
+        <Typo.Caption>{`Selected : ${radioButtonChoice}`}</Typo.Caption>
       </AccordionItem>
 
       <Divider />

--- a/src/ui/components/RadioButton.tsx
+++ b/src/ui/components/RadioButton.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { useState } from 'react'
+import styled from 'styled-components/native'
+
+import { Validate } from 'ui/svg/icons/Validate'
+import { ColorsEnum, Spacer, Typo } from 'ui/theme'
+
+interface RadioButtonItem {
+  key: string
+  title: string
+  subtitle: string
+}
+
+interface RadioButtonProps {
+  choices: RadioButtonItem[]
+  onSelect: (value: string) => void
+}
+
+export function RadioButton(props: RadioButtonProps) {
+  const [selectedValue, setSelectedValue] = useState('')
+
+  function onSelect(value: string) {
+    setSelectedValue(value)
+    props.onSelect(value)
+  }
+
+  return (
+    <React.Fragment>
+      {props.choices.map((choice, index) => {
+        return (
+          <React.Fragment key={index}>
+            <PressableContainer key={choice.key} onPress={() => onSelect(choice.key)}>
+              <TitleContainer>
+                <Title color={selectedValue === choice.key ? ColorsEnum.PRIMARY : ColorsEnum.BLACK}>
+                  {choice.title}
+                </Title>
+                <Subtitle>{choice.subtitle}</Subtitle>
+              </TitleContainer>
+              {selectedValue === choice.key && <Validate color={ColorsEnum.PRIMARY} />}
+            </PressableContainer>
+            <Spacer.Column numberOfSpaces={6} />
+          </React.Fragment>
+        )
+      })}
+    </React.Fragment>
+  )
+}
+
+const PressableContainer = styled.TouchableOpacity({
+  flexDirection: 'row',
+  width: '100%',
+  alignItems: 'center',
+})
+
+const TitleContainer = styled.View({
+  flexDirection: 'column',
+  flex: 1,
+})
+
+const Title = styled(Typo.ButtonText)<{ color: ColorsEnum }>(({ color }) => ({
+  color: color,
+}))
+
+const Subtitle = styled(Typo.Caption)({
+  color: ColorsEnum.GREY_DARK,
+})


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-9483


## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [x] Added new reusable components to the AppComponents page and communicate to the team on slack
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|<img width="257" alt="Capture d’écran 2021-06-30 à 09 53 40" src="https://user-images.githubusercontent.com/22886846/123929900-86cc0380-d98f-11eb-9ea9-1366c4583243.png"><img width="256" alt="Capture d’écran 2021-06-30 à 09 53 49" src="https://user-images.githubusercontent.com/22886846/123929909-87fd3080-d98f-11eb-9ce6-8d875df9ba67.png"><img width="257" alt="Capture d’écran 2021-06-30 à 09 54 00" src="https://user-images.githubusercontent.com/22886846/123929916-87fd3080-d98f-11eb-96e8-f12dae2b9bf0.png">|                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
