### PR TITLE
(PC-9975) Page d'Accueil - Empêcher les regressions contentful

### DIFF
--- a/src/features/home/contentful/processHomepageEntry.test.ts
+++ b/src/features/home/contentful/processHomepageEntry.test.ts
@@ -1,6 +1,7 @@
+import { AlgoliaParameters } from 'features/home/contentful/contentful'
 import { adaptedHomepageEntry } from 'tests/fixtures/homepageEntries'
 
-import { processHomepageEntry } from './processHomepageEntry'
+import { buildSearchParams, processHomepageEntry } from './processHomepageEntry'
 
 describe('processHomepageEntry', () => {
   beforeEach(() => {
@@ -31,5 +32,50 @@ describe('processHomepageEntry', () => {
       },
     }
     expect(processHomepageEntry(emptyModulesHomepageEntries)).toEqual([])
+  })
+
+  describe('buildSearchParams', () => {
+    const algoliaParameters = {
+      metadata: { tags: [] },
+      sys: {
+        space: { sys: { type: 'Link', linkType: 'Space', id: '2bg01iqy0isv' } },
+        id: 'XSfVIg1577cOcs23K6m3n',
+        type: 'Entry',
+        createdAt: '2020-11-12T11:10:41.542Z',
+        updatedAt: '2021-07-07T08:53:35.350Z',
+        environment: { sys: { id: 'testing', type: 'Link', linkType: 'Environment' } },
+        revision: 35,
+        contentType: {
+          sys: { type: 'Link', linkType: 'ContentType', id: 'algoliaParameters' },
+        },
+        locale: 'en-US',
+      },
+      fields: { title: 'Livre', hitsPerPage: 1 },
+    }
+
+    it('should filter out unpublished modules', () => {
+      const additionalAlgoliaParameters = ([
+        { sys: { type: 'Link', linkType: 'Entry', id: '2nYjyMYFD6HXrrycEW74Km' } },
+      ] as unknown) as AlgoliaParameters[]
+
+      const search = buildSearchParams(algoliaParameters, additionalAlgoliaParameters)
+      expect(search).toHaveLength(1)
+      expect(search[0]).toStrictEqual({ title: 'Livre', hitsPerPage: 1 })
+    })
+
+    it('should compose a playlist with additional parameters', () => {
+      const additionalAlgoliaParameters = ([
+        { ...algoliaParameters, fields: { title: 'Musique', categories: ['Musique'] } },
+        { ...algoliaParameters, fields: { title: 'Ciné', categories: ['Cinéma'] } },
+      ] as unknown) as AlgoliaParameters[]
+
+      const search = buildSearchParams(algoliaParameters, additionalAlgoliaParameters)
+      expect(search).toHaveLength(3)
+      expect(search).toStrictEqual([
+        { title: 'Livre', hitsPerPage: 1 },
+        { title: 'Musique', categories: ['Musique'] },
+        { title: 'Ciné', categories: ['Cinéma'] },
+      ])
+    })
   })
 })

--- a/src/features/home/contentful/processHomepageEntry.ts
+++ b/src/features/home/contentful/processHomepageEntry.ts
@@ -7,6 +7,8 @@ import {
   CONTENT_TYPES,
   Image,
   RecommendationFields,
+  AlgoliaParameters,
+  SearchParametersFields,
 } from './contentful'
 import {
   Offers,
@@ -36,12 +38,9 @@ export const processHomepageEntry = (homepage: HomepageEntry): ProcessedModule[]
         cover,
         additionalAlgoliaParameters = [],
       } = fields as AlgoliaFields
-      if (!hasAtLeastOneField(algoliaParameters)) return
+      const search = buildSearchParams(algoliaParameters, additionalAlgoliaParameters)
+      if (search.length === 0) return
 
-      const search = [
-        algoliaParameters.fields,
-        ...additionalAlgoliaParameters.filter(hasAtLeastOneField).map(({ fields }) => fields),
-      ]
       const { fields: display } = displayParameters
 
       if (cover && hasAtLeastOneField(cover)) {
@@ -95,6 +94,18 @@ export const processHomepageEntry = (homepage: HomepageEntry): ProcessedModule[]
   })
 
   return processedModules.filter(Boolean) as ProcessedModule[]
+}
+
+export const buildSearchParams = (
+  params: AlgoliaParameters,
+  additionalParams: AlgoliaParameters[]
+): SearchParametersFields[] => {
+  const allParams = [params, ...additionalParams]
+  const publishedAdditionalSearchParams = allParams
+    .filter((params) => params.fields && hasAtLeastOneField(params.fields))
+    .map(({ fields }) => fields)
+
+  return publishedAdditionalSearchParams
 }
 
 const buildImageUrl = (image: Image): string | null => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-9975

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.

## Résolution de bug

Contentful précise que les modules non publiés ne sont pas listés dans la réponse. Ce qui n'est pas le cas 😡
Au lieu d'avoir un module complet avec les champs `sys` et `fields`, on a que `sys`.. Example:

Sous-module publié:
 
```json
      "additionalAlgoliaParameters": [
        {
          "metadata": { "tags": [] },
          "sys": {
            "space": { "sys": { "type": "Link", "linkType": "Space", "id": "2bg01iqy0isv" } },
            "id": "XSfVIg1577cOcs23K6m3n",
            "type": "Entry",
            "createdAt": "2020-11-12T11:10:41.542Z",
            "updatedAt": "2021-07-07T08:53:35.350Z",
            "environment": {
              "sys": { "id": "testing", "type": "Link", "linkType": "Environment" }
            },
            "revision": 35,
            "contentType": {
              "sys": { "type": "Link", "linkType": "ContentType", "id": "algoliaParameters" }
            },
            "locale": "en-US"
          },
          "fields": { "title": "Livre", "hitsPerPage": 1 }
        },
     ]
```

Sous-module non publié:

```json
      "additionalAlgoliaParameters": [
        { "sys": { "type": "Link", "linkType": "Entry", "id": "2nYjyMYFD6HXrrycEW74Km" } }
      ]
```

La condition https://github.com/pass-culture/pass-culture-app-native/blob/867542a9d66feb016f679b020ce820e56f04cbf5/src/features/home/contentful/processHomepageEntry.ts#L31 permet de filtrer les modules non publiés, mais non les sous-modules.

La liste des sous modules globalement tout ce qui est en **Référence** dans contentful:
![image](https://user-images.githubusercontent.com/10118284/125443053-2cb110cd-6fd5-4e97-892f-ed213a00efff.png)

Pour chaque sous-module, on a une condition correspondante qui permet de les filtrer si besoin. Pour le sous module `additionalAlgoliaParameters`, cette condition était mal faite:

Avant:
```typescript
additionalAlgoliaParameters.filter(hasAtLeastOneField)
```

Après ~
```typescript
additionalAlgoliaParameters.filter(params => params.field && hasAtLeastOneField(params.field))
```
