### PR TITLE
(PC-9844) Make sure the FastImages are not re-rendered too often [Perf]

### DIFF
--- a/src/features/home/atoms/OfferTile.tsx
+++ b/src/features/home/atoms/OfferTile.tsx
@@ -1,5 +1,5 @@
 import { useNavigation } from '@react-navigation/native'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { View, PixelRatio } from 'react-native'
 import FastImage from 'react-native-fast-image'
 import { useQueryClient } from 'react-query'
@@ -62,6 +62,22 @@ export const mergeOfferData = (offer: PartialOffer) => (
   ...(prevData || {}),
 })
 
+const ImageTile = (props: { imageWidth: number; imageHeight: number; uri?: string }) => {
+  const style = useMemo(
+    () => ({
+      height: props.imageHeight,
+      width: props.imageWidth,
+      borderTopLeftRadius: BorderRadiusEnum.BORDER_RADIUS,
+      borderTopRightRadius: BorderRadiusEnum.BORDER_RADIUS,
+    }),
+    [props.imageHeight, props.imageWidth]
+  )
+
+  const source = useMemo(() => ({ uri: props.uri }), [props.uri])
+
+  return props.uri ? <FastImage style={style} source={source} testID="offerTileImage" /> : null
+}
+
 export const OfferTile = (props: OfferTileProps) => {
   const navigation = useNavigation<UseNavigationType>()
   const { layout = 'one-item-medium', moduleName, isBeneficiary, ...offer } = props
@@ -79,19 +95,12 @@ export const OfferTile = (props: OfferTileProps) => {
       moduleName,
     })
   }
-  const imageStyle = {
-    height: imageHeight,
-    width: imageWidth,
-    borderTopLeftRadius: BorderRadiusEnum.BORDER_RADIUS,
-    borderTopRightRadius: BorderRadiusEnum.BORDER_RADIUS,
-  }
-  const imageSource = { uri: offer.thumbUrl }
 
   return (
     <Container>
       <TouchableHighlight imageHeight={imageHeight} onPress={handlePressOffer}>
         <View>
-          <FastImage style={imageStyle} source={imageSource} testID="offerTileImage" />
+          <ImageTile imageWidth={imageWidth} imageHeight={imageHeight} uri={offer.thumbUrl} />
           <ImageCaption
             imageWidth={imageWidth}
             category={offer.category}

--- a/src/features/home/components/ExclusivityModule.tsx
+++ b/src/features/home/components/ExclusivityModule.tsx
@@ -1,5 +1,6 @@
 import { useNavigation } from '@react-navigation/native'
-import React from 'react'
+import React, { useMemo } from 'react'
+import { useCallback } from 'react'
 import { Dimensions, PixelRatio } from 'react-native'
 import FastImage from 'react-native-fast-image'
 import styled from 'styled-components/native'
@@ -14,13 +15,15 @@ import { BorderRadiusEnum } from 'ui/theme/grid'
 export const ExclusivityModule = ({ alt, image, offerId }: ExclusivityPane) => {
   const { navigate } = useNavigation<UseNavigationType>()
 
-  const handlePressExclu = () => {
+  const handlePressExclu = useCallback(() => {
     const id = dehumanizeId(offerId)
     if (typeof id === 'number') {
       navigate('Offer', { id, from: 'home' })
       analytics.logClickExclusivityBlock(id)
     }
-  }
+  }, [offerId])
+
+  const source = useMemo(() => ({ uri: image }), [image])
 
   return (
     <Row>
@@ -28,7 +31,7 @@ export const ExclusivityModule = ({ alt, image, offerId }: ExclusivityPane) => {
       <ImageContainer>
         <TouchableHighlight onPress={handlePressExclu}>
           <FastImage
-            source={{ uri: image }}
+            source={source}
             accessible={!!alt}
             accessibilityLabel={alt}
             testID="imageExclu"

--- a/src/features/home/components/ExclusivityModule.tsx
+++ b/src/features/home/components/ExclusivityModule.tsx
@@ -1,6 +1,5 @@
 import { useNavigation } from '@react-navigation/native'
-import React, { useMemo } from 'react'
-import { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { Dimensions, PixelRatio } from 'react-native'
 import FastImage from 'react-native-fast-image'
 import styled from 'styled-components/native'

--- a/src/features/offer/atoms/OfferSeeMore.tsx
+++ b/src/features/offer/atoms/OfferSeeMore.tsx
@@ -1,6 +1,7 @@
 import { t } from '@lingui/macro'
 import { useNavigation } from '@react-navigation/native'
 import React from 'react'
+import { useCallback } from 'react'
 import styled from 'styled-components/native'
 
 import { UseNavigationType } from 'features/navigation/RootNavigator'
@@ -16,10 +17,10 @@ interface Props {
 export const OfferSeeMore: React.FC<Props> = ({ id, longWording = false }) => {
   const { navigate } = useNavigation<UseNavigationType>()
 
-  const onPressSeeMore = () => {
+  const onPressSeeMore = useCallback(() => {
     analytics.logConsultDescriptionDetails(id)
     navigate('OfferDescription', { id })
-  }
+  }, [id])
 
   return (
     <Container>

--- a/src/features/offer/components/OfferHero.tsx
+++ b/src/features/offer/components/OfferHero.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import FastImage from 'react-native-fast-image'
 import styled from 'styled-components/native'
 
@@ -17,17 +17,15 @@ interface Props {
 
 export const OfferHero: React.FC<Props> = ({ imageUrl, categoryName }) => {
   const { top } = useCustomSafeInsets()
+  const source = useMemo(() => ({ uri: imageUrl }), [imageUrl])
   const imageHeight = blurImageHeight + top
+
   return (
     <HeroHeader imageHeight={imageHeight} categoryName={categoryName} imageUrl={imageUrl || ''}>
       <Spacer.Column numberOfSpaces={22} />
       <ImageContainer>
         {imageUrl ? (
-          <FastImage
-            style={imageStyle}
-            source={{ uri: imageUrl }}
-            resizeMode={FastImage.resizeMode.cover}
-          />
+          <FastImage style={imageStyle} source={source} resizeMode={FastImage.resizeMode.cover} />
         ) : (
           <ImagePlaceholder categoryName={categoryName || null} size={getSpacing(24)} />
         )}

--- a/src/features/search/atoms/OfferImage.tsx
+++ b/src/features/search/atoms/OfferImage.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useMemo } from 'react'
 import FastImage from 'react-native-fast-image'
 import styled from 'styled-components/native'
 
@@ -11,23 +12,23 @@ interface Props {
   categoryName?: CategoryNameEnum | null
 }
 
-export const OfferImage: React.FC<Props> = ({ categoryName, imageUrl }) => (
-  <Container>
-    {imageUrl ? (
-      <FastImage
-        style={imageStyle}
-        source={{ uri: imageUrl }}
-        resizeMode={FastImage.resizeMode.cover}
-      />
-    ) : (
-      <ImagePlaceholder
-        categoryName={categoryName || null}
-        size={getSpacing(10)}
-        borderRadius={borderRadius}
-      />
-    )}
-  </Container>
-)
+export const OfferImage: React.FC<Props> = ({ categoryName, imageUrl }) => {
+  const source = useMemo(() => ({ uri: imageUrl }), [imageUrl])
+
+  return (
+    <Container>
+      {imageUrl ? (
+        <FastImage style={imageStyle} source={source} resizeMode={FastImage.resizeMode.cover} />
+      ) : (
+        <ImagePlaceholder
+          categoryName={categoryName || null}
+          size={getSpacing(10)}
+          borderRadius={borderRadius}
+        />
+      )}
+    </Container>
+  )
+}
 
 const borderRadius = 4
 const width = getSpacing(16)


### PR DESCRIPTION
## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.

### Details

After debugging with why-did-you-render on https://github.com/pass-culture/pass-culture-app-native/blob/f7d4077d48c1987c86bc8e05efccb884bd8d266e/src/why-did-you-render.js#L7, we can see that the home renders many times on load (due to the skeletons).

The props to FastImages (algolia modules) that are objects changes (like `source` or `style`) which means that those images re-renders.
To avoid that, we memoize those props.