### PR TITLE
(PC-9615) App Native - Decli Web - @react-navigation/bottom-tabs Fair…

### DIFF
--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -1,35 +1,14 @@
 import 'react-app-polyfill/ie9'
 import 'react-app-polyfill/ie11'
 import 'react-app-polyfill/stable'
-import { LinkingOptions, NavigationContainer } from '@react-navigation/native'
+import { NavigationContainer } from '@react-navigation/native'
 import { createStackNavigator } from '@react-navigation/stack'
 import React from 'react'
-import { Text } from 'react-native'
 import styled from 'styled-components/native'
 
-import { TabNavigator } from 'features/navigation/TabBar/TabNavigator'
-import { env } from 'libs/environment'
+import { routes, linking } from 'features/navigation/RootNavigator/routes'
 
-const LINKING_PREFIXES = [
-  `https://app.passculture-${env.ENV}.gouv.fr/`,
-  `https://*.app.passculture-${env.ENV}.gouv.fr/`,
-  'passculture://',
-]
-
-const LINKING_CONFIG = {
-  initialRouteName: 'TabNavigator',
-  screens: {
-    Home: '',
-    Page1: 'page1',
-    TabNavigator: {
-      initialRouteName: 'Page3',
-      screens: {
-        Page2: 'page2',
-        Page3: 'page3',
-      },
-    },
-  },
-}
+const StackNavigator = createStackNavigator()
 
 const NAVIGATOR_SCREEN_OPTIONS = {
   headerShown: false,
@@ -38,27 +17,6 @@ const NAVIGATOR_SCREEN_OPTIONS = {
     flex: 1,
   },
 }
-
-const linking: LinkingOptions = { prefixes: LINKING_PREFIXES, config: LINKING_CONFIG }
-
-const StackNavigator = createStackNavigator()
-
-const Home = () => (
-  <Page>
-    <Text>Home</Text>
-  </Page>
-)
-const Page1 = () => (
-  <Page>
-    <Text>Page 1</Text>
-  </Page>
-)
-
-const routes = [
-  { name: 'Home', component: Home },
-  { name: 'Page1', component: Page1 },
-  { name: 'TabNavigator', component: TabNavigator },
-]
 
 export function App() {
   return (
@@ -108,11 +66,5 @@ const AppContent = styled.View({
   height: '100%',
   display: 'flex',
   flexDirection: 'column',
-  justifyContent: 'center',
-})
-
-const Page = styled.View({
-  flex: 1,
-  alignItems: 'center',
   justifyContent: 'center',
 })

--- a/src/features/navigation/RootNavigator/RootNavigator.tsx
+++ b/src/features/navigation/RootNavigator/RootNavigator.tsx
@@ -6,7 +6,7 @@ import { ForceUpdate } from 'features/forceUpdate/ForceUpdate'
 import { navigationRef } from 'features/navigation/navigationRef'
 import { useSplashScreenContext } from 'libs/splashscreen'
 
-import routes from './routes'
+import { initialRouteName, routes } from './routes'
 import { RootStackParamList, Route } from './types'
 
 export const RootStack = createStackNavigator<RootStackParamList>()
@@ -42,7 +42,7 @@ export const RootNavigator: React.FC = () => {
         <ForceUpdate />
       ) : (
         <RootStack.Navigator
-          initialRouteName="TabNavigator"
+          initialRouteName={initialRouteName}
           headerMode="screen"
           screenOptions={{ headerShown: false }}>
           {screens}

--- a/src/features/navigation/RootNavigator/routes.tsx
+++ b/src/features/navigation/RootNavigator/routes.tsx
@@ -45,6 +45,7 @@ import { CulturalSurvey } from 'features/firstLogin/CulturalSurvey'
 import { FirstTutorial } from 'features/firstTutorial/pages/FirstTutorial/FirstTutorial'
 import { ForceUpdate } from 'features/forceUpdate/ForceUpdate'
 import { Maintenance } from 'features/maintenance/Maintenance'
+import { linking as tabNavigatorLinking } from 'features/navigation/TabBar/routes'
 import { TabNavigator } from 'features/navigation/TabBar/TabNavigator'
 import { Offer, OfferDescription } from 'features/offer'
 import { ChangePassword } from 'features/profile/pages/ChangePassword'
@@ -62,7 +63,9 @@ import { SearchFilter } from 'features/search/pages/SearchFilter'
 
 import { Route } from './types'
 
-const routes: Array<Route> = [
+export const initialRouteName = 'TabNavigator'
+
+export const routes: Array<Route> = [
   { name: 'ABTestingPOC', component: ABTestingPOC },
   { name: 'AcceptCgu', component: AcceptCgu, hoc: withAsyncErrorBoundary },
   { name: 'AccountCreated', component: AccountCreated },
@@ -125,7 +128,7 @@ const routes: Array<Route> = [
   { name: 'SetPostalCode', component: SetPostalCode },
   { name: 'SignupConfirmationEmailSent', component: SignupConfirmationEmailSent },
   { name: 'SignupConfirmationExpiredLink', component: SignupConfirmationExpiredLink },
-  { name: 'TabNavigator', component: TabNavigator },
+  { name: 'TabNavigator', component: TabNavigator, linking: tabNavigatorLinking },
   { name: 'NextBeneficiaryStep', component: NextBeneficiaryStep },
   { name: 'SetPhoneNumber', component: SetPhoneNumber },
   { name: 'SetPhoneValidationCode', component: SetPhoneValidationCode },
@@ -141,11 +144,14 @@ const routes: Array<Route> = [
 export const linking: LinkingOptions = {
   prefixes: [],
   config: {
-    screens: routes.reduce(
-      (route, currentRoute) => ({ ...route, [currentRoute.name]: currentRoute.path }),
-      {}
-    ),
+    screens: {
+      ...routes.reduce(
+        (route, currentRoute) => ({
+          ...route,
+          [currentRoute.name]: currentRoute.linking?.config || currentRoute.path,
+        }),
+        {}
+      ),
+    },
   },
 }
-
-export default routes

--- a/src/features/navigation/RootNavigator/routes.web.tsx
+++ b/src/features/navigation/RootNavigator/routes.web.tsx
@@ -1,0 +1,193 @@
+/**
+ * THIS FILE CAN BE REMOVED AS SOON AS ALL THE ROUTES ARE WEB COMPATIBLE
+ */
+import {
+  routes as idCheckRoutes,
+  initialRouteName as idCheckInitialRouteName,
+  // withAsyncErrorBoundary as withIdCheckAsyncErrorBoundary,
+} from '@pass-culture/id-check'
+// // eslint-disable-next-line import/order
+import { Link, LinkingOptions } from '@react-navigation/native'
+//
+// // import { ForgottenPassword } from 'features/auth/forgottenPassword/ForgottenPassword'
+// // import { ReinitializePassword } from 'features/auth/forgottenPassword/ReinitializePassword'
+// // import { ResetPasswordEmailSent } from 'features/auth/forgottenPassword/ResetPasswordEmailSent'
+// // import { ResetPasswordExpiredLink } from 'features/auth/forgottenPassword/ResetPasswordExpiredLink'
+// // import { IdCheckUnavailable } from 'features/auth/idcheckUnavailable/IdCheckUnavailable'
+// // import { Login } from 'features/auth/login/Login'
+// // import { AcceptCgu } from 'features/auth/signup/AcceptCgu'
+// // import { AccountCreated } from 'features/auth/signup/AccountCreated'
+// // import { AfterSignupEmailValidationBuffer } from 'features/auth/signup/AfterSignupEmailValidationBuffer'
+// // import { BeneficiaryRequestSent } from 'features/auth/signup/BeneficiaryRequestSent'
+// // import { IdCheck } from 'features/auth/signup/IdCheck'
+import React from 'react'
+import { Text } from 'react-native'
+import styled from 'styled-components/native'
+
+//
+// import { IdCheckV2 } from 'features/auth/signup/IdCheckV2'
+import { Route } from 'features/navigation/RootNavigator/types'
+import { linking as tabNavigatorLinking } from 'features/navigation/TabBar/routes'
+import { TabNavigator } from 'features/navigation/TabBar/TabNavigator'
+import { env } from 'libs/environment'
+//
+//
+// // import { NextBeneficiaryStep } from 'features/auth/signup/NextBeneficiaryStep'
+// // import { PhoneValidationTooManyAttempts } from 'features/auth/signup/PhoneValidation/PhoneValidationTooManyAttempts'
+// // import { SetPhoneNumber } from 'features/auth/signup/PhoneValidation/SetPhoneNumber'
+// // import { SetPhoneValidationCode } from 'features/auth/signup/PhoneValidation/SetPhoneValidationCode'
+// // import { SetBirthday } from 'features/auth/signup/SetBirthday'
+// // import { SetEmail } from 'features/auth/signup/SetEmail'
+// // import { SetPassword } from 'features/auth/signup/SetPassword'
+// // import { SetPostalCode } from 'features/auth/signup/SetPostalCode'
+// // import { SignupConfirmationEmailSent } from 'features/auth/signup/SignupConfirmationEmailSent'
+// // import { SignupConfirmationExpiredLink } from 'features/auth/signup/SignupConfirmationExpiredLink'
+// // import { VerifyEligibility } from 'features/auth/signup/VerifyEligibility'
+// // import { BookingDetails } from 'features/bookings/pages/BookingDetails'
+// // import { EndedBookings } from 'features/bookings/pages/EndedBookings'
+// // import { BookingConfirmation } from 'features/bookOffer/pages/BookingConfirmation'
+// // import { ABTestingPOC } from 'features/cheatcodes/pages/ABTestingPOC'
+// // import { AppComponents } from 'features/cheatcodes/pages/AppComponents'
+// // import { CheatCodes } from 'features/cheatcodes/pages/CheatCodes'
+// // import { CheatMenu } from 'features/cheatcodes/pages/CheatMenu'
+// // import { Navigation } from 'features/cheatcodes/pages/Navigation'
+// // import { NavigationIdCheckErrors } from 'features/cheatcodes/pages/NavigationIdCheckErrors'
+// // import { DeeplinkImporter } from 'features/deeplinks/pages/DeeplinkImporter'
+// // import { EighteenBirthday } from 'features/eighteenBirthday/pages/EighteenBirthday'
+// // import { withAsyncErrorBoundary } from 'features/errors'
+// // import { FavoritesSorts } from 'features/favorites/pages/FavoritesSorts'
+// // import { CulturalSurvey } from 'features/firstLogin/CulturalSurvey'
+// // import { FirstTutorial } from 'features/firstTutorial/pages/FirstTutorial/FirstTutorial'
+// // import { ForceUpdate } from 'features/forceUpdate/ForceUpdate'
+// // import { Maintenance } from 'features/maintenance/Maintenance'
+// // import { TabNavigator } from 'features/navigation/TabBar/TabNavigator'
+// // import { Offer, OfferDescription } from 'features/offer'
+// // import { ChangePassword } from 'features/profile/pages/ChangePassword'
+// // import { ConfirmDeleteProfile } from 'features/profile/pages/ConfirmDeleteProfile'
+// // import { ConsentSettings } from 'features/profile/pages/ConsentSettings'
+// // import { DeleteProfileSuccess } from 'features/profile/pages/DeleteProfileSuccess'
+// // import { LegalNotices } from 'features/profile/pages/LegalNotices'
+// // import { NotificationSettings } from 'features/profile/pages/NotificationSettings'
+// // import { PersonalData } from 'features/profile/pages/PersonalData'
+// // import { Profile } from 'features/profile/pages/Profile'
+// // import { Categories as SearchCategories } from 'features/search/pages/Categories'
+// // import { LocationFilter } from 'features/search/pages/LocationFilter'
+// // import { LocationPicker } from 'features/search/pages/LocationPicker'
+// // import { SearchFilter } from 'features/search/pages/SearchFilter'
+//
+
+export const initialRouteName = 'ABTestingPOC'
+
+const LINKING_PREFIXES = [
+  `https://app.passculture-${env.ENV}.gouv.fr/`,
+  `https://*.app.passculture-${env.ENV}.gouv.fr/`,
+  'passculture://',
+]
+
+const Page = styled.View({
+  flex: 1,
+  alignItems: 'center',
+  justifyContent: 'center',
+})
+
+const ABTestingPOC = () => (
+  <Page>
+    <Text>ABTestingPOC</Text>
+    <Link to={'/search'}>
+      <Text>Go to TabNavigator/Search</Text>
+    </Link>
+  </Page>
+)
+
+export const routes: Array<Route> = [
+  { name: 'ABTestingPOC', component: ABTestingPOC, path: '/abtesting' },
+  { name: 'TabNavigator', component: TabNavigator, linking: tabNavigatorLinking },
+  //   // { name: 'ABTestingPOC', component: ABTestingPOC },
+  //   // { name: 'AcceptCgu', component: AcceptCgu, hoc: withAsyncErrorBoundary },
+  //   // { name: 'AccountCreated', component: AccountCreated },
+  //   // { name: 'AfterSignupEmailValidationBuffer', component: AfterSignupEmailValidationBuffer },
+  //   // { name: 'AppComponents', component: AppComponents },
+  //   // { name: 'CheatCodes', component: CheatCodes },
+  //   // { name: 'CheatMenu', component: CheatMenu },
+  //   // { name: 'ConsentSettings', component: ConsentSettings },
+  //   // { name: 'BeneficiaryRequestSent', component: BeneficiaryRequestSent },
+  //   // { name: 'BookingConfirmation', component: BookingConfirmation },
+  //   // { name: 'BookingDetails', component: BookingDetails },
+  //   // { name: 'CulturalSurvey', component: CulturalSurvey },
+  //   // { name: 'DeeplinkImporter', component: DeeplinkImporter },
+  //   // {
+  //   //   name: 'EighteenBirthday',
+  //   //   component: EighteenBirthday,
+  //   // },
+  //   // { name: 'EndedBookings', component: EndedBookings },
+  //   // {
+  //   //   name: 'FavoritesSorts',
+  //   //   component: FavoritesSorts,
+  //   // },
+  //   // {
+  //   //   name: 'ForgottenPassword',
+  //   //   component: ForgottenPassword,
+  //   //   hoc: withAsyncErrorBoundary,
+  //   // },
+  //   // { name: 'IdCheck', component: IdCheck, hoc: withIdCheckAsyncErrorBoundary },
+  //   // { name: 'LegalNotices', component: LegalNotices },
+  //   // { name: 'ConfirmDeleteProfile', component: ConfirmDeleteProfile },
+  //   // { name: 'DeleteProfileSuccess', component: DeleteProfileSuccess },
+  //   // { name: 'LocationFilter', component: LocationFilter },
+  //   // { name: 'LocationPicker', component: LocationPicker },
+  //   // { name: 'Login', component: Login, hoc: withAsyncErrorBoundary },
+  //   // { name: 'Maintenance', component: Maintenance },
+  //   // { name: 'Navigation', component: Navigation, hoc: withAsyncErrorBoundary },
+  //   // {
+  //   //   name: 'NavigationIdCheckErrors',
+  //   //   component: NavigationIdCheckErrors,
+  //   //   hoc: withIdCheckAsyncErrorBoundary,
+  //   // },
+  //   // { name: 'NotificationSettings', component: NotificationSettings },
+  //   // { name: 'Offer', component: Offer, hoc: withAsyncErrorBoundary },
+  //   // { name: 'OfferDescription', component: OfferDescription, hoc: withAsyncErrorBoundary },
+  //   // { name: 'Profile', component: Profile },
+  //   // { name: 'PersonalData', component: PersonalData },
+  //   // { name: 'ChangePassword', component: ChangePassword },
+  //   // { name: 'ReinitializePassword', component: ReinitializePassword },
+  //   // { name: 'ResetPasswordEmailSent', component: ResetPasswordEmailSent },
+  //   // {
+  //   //   name: 'ResetPasswordExpiredLink',
+  //   //   component: ResetPasswordExpiredLink,
+  //   //   hoc: withAsyncErrorBoundary,
+  //   // },
+  //   // { name: 'SearchCategories', component: SearchCategories },
+  //   // { name: 'SearchFilter', component: SearchFilter },
+  //   // { name: 'SetBirthday', component: SetBirthday },
+  //   // { name: 'SetEmail', component: SetEmail },
+  //   // { name: 'SetPassword', component: SetPassword },
+  //   // { name: 'SetPostalCode', component: SetPostalCode },
+  //   // { name: 'SignupConfirmationEmailSent', component: SignupConfirmationEmailSent },
+  //   // { name: 'SignupConfirmationExpiredLink', component: SignupConfirmationExpiredLink },
+  //   // { name: 'TabNavigator', component: TabNavigator },
+  //   // { name: 'NextBeneficiaryStep', component: NextBeneficiaryStep },
+  //   // { name: 'SetPhoneNumber', component: SetPhoneNumber },
+  //   // { name: 'SetPhoneValidationCode', component: SetPhoneValidationCode },
+  //   // { name: 'PhoneValidationTooManyAttempts', component: PhoneValidationTooManyAttempts },
+  //   // { name: 'VerifyEligibility', component: VerifyEligibility },
+  //   // { name: 'FirstTutorial', component: FirstTutorial },
+  //   // { name: 'ForceUpdate', component: ForceUpdate },
+  //   // { name: 'IdCheckUnavailable', component: IdCheckUnavailable },
+  ...idCheckRoutes.filter((screen) => screen.name !== idCheckInitialRouteName),
+  // { name: idCheckInitialRouteName, component: IdCheckV2 },
+]
+
+export const linking: LinkingOptions = {
+  prefixes: LINKING_PREFIXES,
+  config: {
+    screens: {
+      ...routes.reduce(
+        (route, currentRoute) => ({
+          ...route,
+          [currentRoute.name]: currentRoute.linking?.config || currentRoute.path,
+        }),
+        {}
+      ),
+    },
+  },
+}

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -1,5 +1,5 @@
 import { IdCheckRoute, IdCheckRootStackParamList } from '@pass-culture/id-check'
-import { RouteProp } from '@react-navigation/native'
+import { LinkingOptions, RouteProp } from '@react-navigation/native'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { StackNavigationOptions } from '@react-navigation/stack/lib/typescript/src/types'
 import { ComponentType } from 'react'
@@ -145,4 +145,5 @@ export type RouteParams<
  */
 export interface Route extends IdCheckRoute<StackNavigationOptions, RootStackParamList> {
   hoc?(component: ComponentType<any>): ComponentType<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+  linking?: Partial<LinkingOptions>
 }

--- a/src/features/navigation/TabBar/TabNavigator.tsx
+++ b/src/features/navigation/TabBar/TabNavigator.tsx
@@ -3,17 +3,12 @@ import React from 'react'
 import { StatusBar, Platform } from 'react-native'
 
 import { useAuthContext } from 'features/auth/AuthContext'
-import { Bookings } from 'features/bookings/pages/Bookings'
-import { withAsyncErrorBoundary } from 'features/errors'
-import { Favorites } from 'features/favorites/pages/Favorites'
 import { useUserProfileInfo } from 'features/home/api'
-import { Home as HomeComponent } from 'features/home/pages/Home'
-import { Profile } from 'features/profile/pages/Profile'
-import { Search } from 'features/search/pages/Search'
+import { initialRouteName, routes } from 'features/navigation/TabBar/routes'
 
 import { shouldDisplayTabIconPredicate } from './helpers'
 import { TabBar } from './TabBar'
-import { TabParamList, TabRoute } from './types'
+import { TabParamList } from './types'
 
 StatusBar.setBarStyle('light-content')
 if (Platform.OS === 'android') {
@@ -21,37 +16,7 @@ if (Platform.OS === 'android') {
   StatusBar.setBackgroundColor('transparent', false)
 }
 
-export const Tab = createBottomTabNavigator<TabParamList>()
-
-const Home = withAsyncErrorBoundary(HomeComponent)
-
-export const tabBarRoutes: Array<TabRoute> = [
-  {
-    name: 'Home',
-    component: Home,
-    key: 'Home-key',
-  },
-  {
-    name: 'Search',
-    component: Search,
-    key: 'Search-key',
-  },
-  {
-    name: 'Bookings',
-    component: Bookings,
-    key: 'Bookings-key',
-  },
-  {
-    name: 'Favorites',
-    component: Favorites,
-    key: 'Favorites-key',
-  },
-  {
-    name: 'Profile',
-    component: Profile,
-    key: 'Profile-key',
-  },
-]
+export const { Navigator, Screen } = createBottomTabNavigator<TabParamList>()
 
 export const TabNavigator: React.FC = () => {
   const authContext = useAuthContext()
@@ -59,17 +24,17 @@ export const TabNavigator: React.FC = () => {
   const { data: user } = useUserProfileInfo()
 
   return (
-    <Tab.Navigator
-      initialRouteName="Home"
+    <Navigator
+      initialRouteName={initialRouteName}
       tabBar={({ state, navigation }) => <TabBar state={state} navigation={navigation} />}>
-      {tabBarRoutes.filter(shouldDisplayTabIconPredicate(authContext, user)).map((route) => (
-        <Tab.Screen
+      {routes.filter(shouldDisplayTabIconPredicate(authContext, user)).map((route) => (
+        <Screen
           name={route.name}
           component={route.component}
           initialParams={route.params}
           key={route.key}
         />
       ))}
-    </Tab.Navigator>
+    </Navigator>
   )
 }

--- a/src/features/navigation/TabBar/TabNavigator.web.tsx
+++ b/src/features/navigation/TabBar/TabNavigator.web.tsx
@@ -1,46 +1,33 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
 import React from 'react'
-import { Text } from 'react-native'
-import styled from 'styled-components/native'
 
-import { TabBar } from 'features/navigation/TabBar/TabBar'
+// import { useAuthContext } from 'features/auth/AuthContext'
+// import { useUserProfileInfo } from 'features/home/api'
+import { initialRouteName, routes } from 'features/navigation/TabBar/routes'
 
-export const { Navigator, Screen } = createBottomTabNavigator()
+// import { shouldDisplayTabIconPredicate } from './helpers'
+import { TabBar } from './TabBar'
+import { TabParamList } from './types'
 
-const Page = styled.View({
-  flex: 1,
-  alignItems: 'center',
-  justifyContent: 'center',
-})
-const Page2 = () => (
-  <Page>
-    <Text>Page 2</Text>
-  </Page>
-)
-const Page3 = () => (
-  <Page>
-    <Text>Page 3</Text>
-  </Page>
-)
-
-export const tabBarRoutes = [
-  {
-    name: 'Page2',
-    component: Page2,
-  },
-  {
-    name: 'Page3',
-    component: Page3,
-  },
-]
+export const { Navigator, Screen } = createBottomTabNavigator<TabParamList>()
 
 export const TabNavigator: React.FC = () => {
+  // const authContext = useAuthContext()
+
+  // const { data: user } = useUserProfileInfo()
+
   return (
     <Navigator
-      initialRouteName="Page2"
+      initialRouteName={initialRouteName}
       tabBar={({ state, navigation }) => <TabBar state={state} navigation={navigation} />}>
-      {tabBarRoutes.map((route) => (
-        <Screen name={route.name} key={route.name} component={route.component} />
+      {/*{routes.filter(shouldDisplayTabIconPredicate(authContext, user)).map((route) => (*/}
+      {routes.map((route) => (
+        <Screen
+          name={route.name}
+          component={route.component}
+          initialParams={route.params}
+          key={route.key}
+        />
       ))}
     </Navigator>
   )

--- a/src/features/navigation/TabBar/__tests__/TabBar.native.test.tsx
+++ b/src/features/navigation/TabBar/__tests__/TabBar.native.test.tsx
@@ -5,8 +5,8 @@ import React from 'react'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { fireEvent, render } from 'tests/utils'
 
+import { routes as tabBarRoutes } from '../routes'
 import { TabBar } from '../TabBar'
-import { tabBarRoutes } from '../TabNavigator'
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: jest.fn(() => ({ bottom: 10 })),

--- a/src/features/navigation/TabBar/__tests__/TabBar.web.test.tsx
+++ b/src/features/navigation/TabBar/__tests__/TabBar.web.test.tsx
@@ -5,8 +5,8 @@ import React from 'react'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { fireEvent, render } from 'tests/utils/web'
 
+import { routes as tabBarRoutes } from '../routes'
 import { TabBar } from '../TabBar'
-import { tabBarRoutes } from '../TabNavigator'
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: jest.fn(() => ({ bottom: 10 })),

--- a/src/features/navigation/TabBar/routes.tsx
+++ b/src/features/navigation/TabBar/routes.tsx
@@ -1,0 +1,53 @@
+import { LinkingOptions } from '@react-navigation/native'
+
+import { Bookings } from 'features/bookings/pages/Bookings'
+import { withAsyncErrorBoundary } from 'features/errors'
+import { Favorites } from 'features/favorites/pages/Favorites'
+import { Home as HomeComponent } from 'features/home/pages/Home'
+import { TabRoute } from 'features/navigation/TabBar/types'
+import { Profile } from 'features/profile/pages/Profile'
+import { Search } from 'features/search/pages/Search'
+
+export const initialRouteName = 'Home'
+
+const Home = withAsyncErrorBoundary(HomeComponent)
+
+export const routes: Array<TabRoute> = [
+  {
+    name: 'Home',
+    component: Home,
+    path: '/home',
+  },
+  {
+    name: 'Search',
+    component: Search,
+    path: '/search',
+  },
+  {
+    name: 'Bookings',
+    component: Bookings,
+    path: '/bookings',
+  },
+  {
+    name: 'Favorites',
+    component: Favorites,
+    path: '/favorites',
+  },
+  {
+    name: 'Profile',
+    component: Profile,
+    path: '/profile',
+  },
+].map((r) => ({ ...r, key: r.name } as TabRoute))
+
+export const linking: Partial<LinkingOptions> = {
+  config: {
+    initialRouteName,
+    screens: {
+      ...routes.reduce(
+        (route, currentRoute) => ({ ...route, [currentRoute.name]: currentRoute.path }),
+        {}
+      ),
+    },
+  },
+}

--- a/src/features/navigation/TabBar/routes.web.tsx
+++ b/src/features/navigation/TabBar/routes.web.tsx
@@ -1,0 +1,100 @@
+import { Link, LinkingOptions } from '@react-navigation/native'
+import React from 'react'
+import { Text } from 'react-native'
+import styled from 'styled-components/native'
+
+import { TabRoute } from 'features/navigation/TabBar/types'
+
+// import { withAsyncErrorBoundary } from 'features/errors'
+// import { Home as HomeComponent } from 'features/home/pages/Home'
+
+// const Home = withAsyncErrorBoundary(HomeComponent)
+
+export const initialRouteName = 'Search'
+
+const Page = styled.View({
+  flex: 1,
+  alignItems: 'center',
+  justifyContent: 'center',
+})
+
+const Search = () => (
+  <Page>
+    <Text>Search page</Text>
+    <Link to={'/abtesting'}>
+      <Text>Go to ABTestingPOC</Text>
+    </Link>
+    <Link to={'/favorites'}>
+      <Text>Go to Favorites</Text>
+    </Link>
+  </Page>
+)
+
+const Favorites = () => (
+  <Page>
+    <Text>Favorites</Text>
+    <Link to={'/abtesting'}>
+      <Text>Go to ABTestingPOC</Text>
+    </Link>
+    <Link to={'/search'}>
+      <Text>Go to Search</Text>
+    </Link>
+  </Page>
+)
+
+const tabBarRoutes: Array<TabRoute> = [
+  {
+    name: 'Search',
+    component: Search,
+    path: '/search',
+  },
+  {
+    name: 'Favorites',
+    component: Favorites,
+    path: '/favorites',
+  },
+].map((r) => ({ ...r, key: r.name } as TabRoute))
+
+export const routes: Array<TabRoute> = [
+  ...tabBarRoutes,
+  // {
+  //   name: 'Home',
+  //   component: Home,
+  //   key: 'Home-key',
+  //   path: '/home',
+  // },
+  // {
+  //   name: 'Search',
+  //   component: Search,
+  //   key: 'Search-key',
+  //   path: '/search',
+  // },
+  // {
+  //   name: 'Bookings',
+  //   component: Bookings,
+  //   key: 'Bookings-key',
+  //   path: '/bookings',
+  // },
+  // {
+  //   name: 'Favorites',
+  //   component: Favorites,
+  //   key: 'Favorites-key',
+  //   path: '/favorites',
+  // },
+  // {
+  //   name: 'Profile',
+  //   component: Profile,
+  //   key: 'Profile-key',
+  //   path: '/profile',
+  // },
+]
+
+export const linking: Partial<LinkingOptions> = {
+  config: {
+    initialRouteName,
+    screens: routes.reduce(
+      (route, currentRoute) => ({ ...route, [currentRoute.name]: currentRoute.path }),
+      {}
+    ),
+  },
+}

--- a/src/features/navigation/TabBar/types.ts
+++ b/src/features/navigation/TabBar/types.ts
@@ -17,4 +17,5 @@ export type TabRoute = {
   component: ComponentType
   params?: TabParamList[TabRouteName]
   key: string
+  path: string
 }

--- a/src/features/profile/pages/Profile.native.test.tsx
+++ b/src/features/profile/pages/Profile.native.test.tsx
@@ -8,7 +8,7 @@ import { useAuthContext } from 'features/auth/AuthContext'
 import { FavoritesWrapper } from 'features/favorites/pages/FavoritesWrapper'
 import { initialFavoritesState } from 'features/favorites/pages/reducer'
 import * as NavigationHelpers from 'features/navigation/helpers'
-import { Tab } from 'features/navigation/TabBar/TabNavigator'
+import { Navigator, Screen } from 'features/navigation/TabBar/TabNavigator'
 import { analytics } from 'libs/analytics'
 import { env } from 'libs/environment'
 import { GeolocPermissionState } from 'libs/geolocation'
@@ -294,9 +294,9 @@ async function renderProfile(options: Options = defaultOptions) {
   const { wrapper } = { ...defaultOptions, ...options }
   const renderAPI = render(
     <NavigationContainer>
-      <Tab.Navigator initialRouteName="Profile">
-        <Tab.Screen name="Profile" component={Profile} />
-      </Tab.Navigator>
+      <Navigator initialRouteName="Profile">
+        <Screen name="Profile" component={Profile} />
+      </Navigator>
     </NavigationContainer>,
     { wrapper }
   )


### PR DESCRIPTION
…e un poc qui ressemble a ce qu on utilise pour le web

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-9615

Also include : https://passculture.atlassian.net/browse/PC-9613

## Temporary

We renamed `routes.ts` to `routes.tsx`, and created web files, many of those files will be later removed/restored in the process.

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
