### PR TITLE
(PC-10050) See BookingDetails without crashing

### DIFF
--- a/__snapshots__/features/bookings/pages/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails.native.test.tsx.native-snap
@@ -1,0 +1,1662 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BookingDetails should render correctly 1`] = `
+Array [
+  <RCTScrollView
+    bounces={false}
+    collapsable={false}
+    onContentSizeChange={[Function]}
+    onGestureHandlerEvent={[Function]}
+    onGestureHandlerStateChange={[Function]}
+    onScroll={[Function]}
+    scrollEventThrottle={10}
+    scrollIndicatorInsets={
+      Object {
+        "right": 1,
+      }
+    }
+    testID="BookingDetailsScrollView"
+  >
+    <View>
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "minHeight": 0,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "position": "absolute",
+              },
+            ]
+          }
+        >
+          <View
+            height={360}
+            testID="BackgroundPlaceholder"
+            width={751}
+          >
+            <Text>
+              BackgroundPlaceholder-SVG-Mock
+            </Text>
+          </View>
+          <View
+            height={8}
+            width={751}
+          >
+            <Text>
+              undefined-SVG-Mock
+            </Text>
+          </View>
+        </View>
+        <View
+          numberOfSpaces={22}
+          style={
+            Array [
+              Object {
+                "height": 88,
+              },
+            ]
+          }
+        />
+        <View
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "column",
+                "justifyContent": "center",
+                "shadowColor": "#151515",
+                "shadowOffset": Object {
+                  "height": 2,
+                  "width": 0,
+                },
+                "shadowOpacity": 0.1,
+                "shadowRadius": 3,
+              },
+            ]
+          }
+          testID="three-shapes-ticket"
+        >
+          <View
+            height={37.62376237623762}
+            width={300}
+          >
+            <Text>
+              undefined-SVG-Mock
+            </Text>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "flexBasis": 0,
+                  "flexGrow": 0,
+                  "flexShrink": 1,
+                  "width": 295,
+                },
+              ]
+            }
+            width={295}
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "minHeight": 250,
+                    "paddingHorizontal": 28,
+                    "paddingVertical": 8,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#151515",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 20,
+                      "lineHeight": 24,
+                      "paddingHorizontal": 4,
+                      "textAlign": "center",
+                    },
+                  ]
+                }
+              >
+                Avez-vous déjà vu ?
+              </Text>
+              <View
+                style={
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "flexBasis": 0,
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                      "justifyContent": "center",
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#eb0055",
+                        "fontFamily": "Montserrat-Medium",
+                        "fontSize": 18,
+                        "lineHeight": 22,
+                        "paddingBottom": 10,
+                        "paddingLeft": 10,
+                        "paddingRight": 10,
+                        "paddingTop": 10,
+                        "textAlign": "center",
+                      },
+                    ]
+                  }
+                >
+                  352UW4
+                </Text>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "flexDirection": "row",
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    accessibilityLabel="Accéder à l'offre"
+                    accessible={true}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      Object {
+                        "alignItems": "center",
+                        "backgroundColor": "#eb0055",
+                        "borderRadius": 24,
+                        "borderWidth": 0,
+                        "flexDirection": "row",
+                        "height": 40,
+                        "justifyContent": "center",
+                        "maxWidth": 500,
+                        "opacity": 1,
+                        "paddingBottom": 2,
+                        "paddingLeft": 2,
+                        "paddingRight": 2,
+                        "paddingTop": 2,
+                        "width": "100%",
+                      }
+                    }
+                    testID="Accéder à l'offre"
+                  >
+                    <Text
+                      adjustsFontSizeToFit={false}
+                      numberOfLines={1}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#ffffff",
+                            "fontFamily": "Montserrat-Bold",
+                            "fontSize": 15,
+                            "lineHeight": 20,
+                            "marginLeft": 5,
+                            "maxWidth": 650,
+                          },
+                        ]
+                      }
+                      textColor="#ffffff"
+                    >
+                      Accéder à l'offre
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            height={37.62376237623762}
+            width={300}
+          >
+            <Text>
+              undefined-SVG-Mock
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "paddingHorizontal": 20,
+            },
+          ]
+        }
+      >
+        <View
+          numberOfSpaces={4}
+          style={
+            Array [
+              Object {
+                "height": 16,
+              },
+            ]
+          }
+        />
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#626262",
+                "fontFamily": "Montserrat-SemiBold",
+                "fontSize": 12,
+                "lineHeight": 16,
+                "textAlign": "center",
+              },
+            ]
+          }
+        >
+          Ce code à 6 caractères est ta preuve d’achat ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder.
+        </Text>
+        <View
+          numberOfSpaces={8}
+          style={
+            Array [
+              Object {
+                "height": 32,
+              },
+            ]
+          }
+        />
+        <View>
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#151515",
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 18,
+                  "lineHeight": 22,
+                },
+              ]
+            }
+          >
+            Ma réservation
+          </Text>
+          <View
+            numberOfSpaces={4.5}
+            style={
+              Array [
+                Object {
+                  "height": 18,
+                },
+              ]
+            }
+          />
+          <View
+            numberOfSpaces={5}
+            style={
+              Array [
+                Object {
+                  "height": 20,
+                },
+              ]
+            }
+          />
+          <View
+            accessible={true}
+            focusable={false}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+            testID="section-row-touchable"
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <View
+                height={24}
+                width={24}
+              >
+                <Text>
+                  undefined-SVG-Mock
+                </Text>
+              </View>
+              <View
+                numberOfSpaces={2}
+                style={
+                  Array [
+                    Object {
+                      "width": 8,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  Array [
+                    Object {
+                      "flexBasis": 0,
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                      "textAlign": "left",
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#151515",
+                        "fontFamily": "Montserrat-Regular",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Le 15 mars 2021 à 20h00
+                </Text>
+              </View>
+              <View
+                style={
+                  Array [
+                    Object {
+                      "alignItems": "flex-end",
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            numberOfSpaces={5}
+            style={
+              Array [
+                Object {
+                  "height": 20,
+                },
+              ]
+            }
+          />
+        </View>
+        <View
+          numberOfSpaces={4}
+          style={
+            Array [
+              Object {
+                "height": 16,
+              },
+            ]
+          }
+        />
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "#f5f5f5",
+                "height": 1,
+                "width": "100%",
+              },
+            ]
+          }
+        />
+        <View
+          numberOfSpaces={4}
+          style={
+            Array [
+              Object {
+                "height": 16,
+              },
+            ]
+          }
+        />
+        <View
+          style={
+            Array [
+              Object {
+                "alignItems": "flex-start",
+              },
+            ]
+          }
+        >
+          <View
+            accessibilityLabel="Voir l'itinéraire"
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "alignItems": "center",
+                "backgroundColor": "transparent",
+                "borderRadius": 0,
+                "borderWidth": 0,
+                "flexDirection": "row",
+                "height": 20,
+                "justifyContent": "center",
+                "marginTop": 0,
+                "maxWidth": 500,
+                "opacity": 1,
+                "paddingBottom": 0,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+                "paddingTop": 0,
+                "width": "auto",
+              }
+            }
+            testID="Voir l'itinéraire"
+          >
+            <View
+              height={24}
+              width={24}
+            >
+              <Text>
+                undefined-SVG-Mock
+              </Text>
+            </View>
+            <Text
+              adjustsFontSizeToFit={false}
+              numberOfLines={1}
+              style={
+                Array [
+                  Object {
+                    "color": "#151515",
+                    "fontFamily": "Montserrat-Bold",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                    "marginLeft": 5,
+                    "maxWidth": 650,
+                  },
+                ]
+              }
+              textColor="#151515"
+            >
+              Voir l'itinéraire
+            </Text>
+          </View>
+        </View>
+        <View
+          numberOfSpaces={8}
+          style={
+            Array [
+              Object {
+                "height": 32,
+              },
+            ]
+          }
+        />
+        <View
+          accessibilityLabel="Voir le détail de l’offre"
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "#eb0055",
+              "borderRadius": 24,
+              "borderWidth": 0,
+              "flexDirection": "row",
+              "height": 40,
+              "justifyContent": "center",
+              "maxWidth": 500,
+              "opacity": 1,
+              "paddingBottom": 2,
+              "paddingLeft": 2,
+              "paddingRight": 2,
+              "paddingTop": 2,
+              "width": "100%",
+            }
+          }
+          testID="Voir le détail de l’offre"
+        >
+          <Text
+            adjustsFontSizeToFit={false}
+            numberOfLines={1}
+            style={
+              Array [
+                Object {
+                  "color": "#ffffff",
+                  "fontFamily": "Montserrat-Bold",
+                  "fontSize": 15,
+                  "lineHeight": 20,
+                  "marginLeft": 5,
+                  "maxWidth": 650,
+                },
+              ]
+            }
+            textColor="#ffffff"
+          >
+            Voir le détail de l’offre
+          </Text>
+        </View>
+        <View
+          numberOfSpaces={4}
+          style={
+            Array [
+              Object {
+                "height": 16,
+              },
+            ]
+          }
+        />
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#626262",
+                "fontFamily": "Montserrat-SemiBold",
+                "fontSize": 12,
+                "lineHeight": 16,
+                "textAlign": "center",
+              },
+            ]
+          }
+        >
+          Tu ne peux plus annuler ta réservation : elle devait être annulée avant le 15 mars 2021
+        </Text>
+      </View>
+      <View
+        numberOfSpaces={5}
+        style={
+          Array [
+            Object {
+              "height": 20,
+            },
+          ]
+        }
+      />
+    </View>
+  </RCTScrollView>,
+  <Modal
+    animationType="none"
+    deviceHeight={null}
+    deviceWidth={null}
+    hardwareAccelerated={false}
+    hideModalContentWhileAnimating={false}
+    onBackdropPress={[Function]}
+    onModalHide={[Function]}
+    onModalWillHide={[Function]}
+    onModalWillShow={[Function]}
+    onRequestClose={[Function]}
+    panResponderThreshold={4}
+    scrollHorizontal={false}
+    scrollOffset={0}
+    scrollOffsetMax={0}
+    scrollTo={null}
+    statusBarTranslucent={true}
+    supportedOrientations={
+      Array [
+        "portrait",
+        "landscape",
+      ]
+    }
+    swipeThreshold={100}
+    testID="modal"
+    transparent={true}
+    visible={false}
+  >
+    <View
+      accessible={true}
+      focusable={true}
+      forwardedRef={[Function]}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "backgroundColor": "#00000080",
+          "bottom": 0,
+          "height": 1334,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "width": 750,
+        }
+      }
+    />
+    <View
+      deviceHeight={null}
+      deviceWidth={null}
+      forwardedRef={[Function]}
+      hideModalContentWhileAnimating={false}
+      onBackdropPress={[Function]}
+      onModalHide={[Function]}
+      onModalWillHide={[Function]}
+      onModalWillShow={[Function]}
+      panResponderThreshold={4}
+      pointerEvents="box-none"
+      scrollHorizontal={false}
+      scrollOffset={0}
+      scrollOffsetMax={0}
+      scrollTo={null}
+      statusBarTranslucent={true}
+      style={
+        Object {
+          "backgroundColor": "#ffffff",
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
+          "bottom": 0,
+          "flex": 1,
+          "height": undefined,
+          "justifyContent": "center",
+          "margin": "auto",
+          "marginBottom": 0,
+          "marginLeft": 0,
+          "marginRight": 0,
+          "maxWidth": undefined,
+          "padding": 4,
+          "position": "absolute",
+          "transform": Array [
+            Object {
+              "translateY": 0,
+            },
+          ],
+          "width": "100%",
+        }
+      }
+      supportedOrientations={
+        Array [
+          "portrait",
+          "landscape",
+        ]
+      }
+      swipeThreshold={100}
+    >
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "flexDirection": "column",
+            "flexGrow": 1,
+            "height": "100%",
+            "justifyContent": "flex-start",
+            "opacity": 1,
+            "width": "100%",
+          }
+        }
+        testID="click-away-area"
+      >
+        <View
+          accessible={true}
+          focusable={false}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderTopEndRadius": 16,
+              "borderTopStartRadius": 16,
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
+              "maxHeight": "90%",
+              "opacity": 1,
+              "paddingBottom": 20,
+              "paddingLeft": 20,
+              "paddingRight": 20,
+              "paddingTop": 20,
+              "width": "100%",
+            }
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                  "width": "100%",
+                  "zIndex": 1,
+                },
+              ]
+            }
+          >
+            <View
+              accessible={true}
+              focusable={false}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "alignItems": "flex-start",
+                  "flexBasis": 0,
+                  "flexGrow": 0.1,
+                  "flexShrink": 1,
+                  "marginLeft": -4,
+                  "opacity": 1,
+                }
+              }
+              testID="leftIconButton"
+            />
+            <Text
+              numberOfLines={2}
+              style={
+                Array [
+                  Object {
+                    "color": "#151515",
+                    "flexBasis": 0,
+                    "flexGrow": 0.8,
+                    "flexShrink": 1,
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 18,
+                    "lineHeight": 22,
+                    "textAlign": "center",
+                  },
+                ]
+              }
+            >
+              Tu es sur le point d'annuler
+            </Text>
+            <View
+              accessible={true}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "alignItems": "flex-end",
+                  "flexBasis": 0,
+                  "flexGrow": 0.1,
+                  "flexShrink": 1,
+                  "marginRight": -4,
+                  "opacity": 1,
+                }
+              }
+              testID="rightIconButton"
+            >
+              <View
+                height={32}
+                testID="rightIcon"
+                width={32}
+              >
+                <Text>
+                  rightIcon-SVG-Mock
+                </Text>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "maxWidth": 500,
+                  "paddingTop": 20,
+                  "width": "100%",
+                },
+                Object {
+                  "paddingBottom": 8,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingHorizontal": 22,
+                    "width": "100%",
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#151515",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                      "textAlign": "center",
+                    },
+                  ]
+                }
+              >
+                Avez-vous déjà vu ?
+              </Text>
+              <View
+                numberOfSpaces={8}
+                style={
+                  Array [
+                    Object {
+                      "height": 32,
+                    },
+                  ]
+                }
+              />
+              <View
+                accessibilityLabel="Annuler ma réservation"
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "backgroundColor": "#eb0055",
+                    "borderRadius": 24,
+                    "borderWidth": 0,
+                    "flexDirection": "row",
+                    "height": 40,
+                    "justifyContent": "center",
+                    "maxWidth": 500,
+                    "opacity": 1,
+                    "paddingBottom": 2,
+                    "paddingLeft": 2,
+                    "paddingRight": 2,
+                    "paddingTop": 2,
+                    "width": "100%",
+                  }
+                }
+                testID="Annuler ma réservation"
+              >
+                <Text
+                  adjustsFontSizeToFit={false}
+                  numberOfLines={1}
+                  style={
+                    Array [
+                      Object {
+                        "color": "#ffffff",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                        "marginLeft": 5,
+                        "maxWidth": 650,
+                      },
+                    ]
+                  }
+                  textColor="#ffffff"
+                >
+                  Annuler ma réservation
+                </Text>
+              </View>
+              <View
+                numberOfSpaces={5}
+                style={
+                  Array [
+                    Object {
+                      "height": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                accessibilityLabel="Retourner à ma réservation"
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "backgroundColor": "#ffffff",
+                    "borderRadius": 24,
+                    "borderWidth": 0,
+                    "flexDirection": "row",
+                    "height": 40,
+                    "justifyContent": "center",
+                    "maxWidth": 500,
+                    "opacity": 1,
+                    "paddingBottom": 2,
+                    "paddingLeft": 2,
+                    "paddingRight": 2,
+                    "paddingTop": 2,
+                    "width": "100%",
+                  }
+                }
+                testID="Retourner à ma réservation"
+              >
+                <Text
+                  adjustsFontSizeToFit={false}
+                  numberOfLines={1}
+                  style={
+                    Array [
+                      Object {
+                        "color": "#eb0055",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                        "marginLeft": 5,
+                        "maxWidth": 650,
+                      },
+                    ]
+                  }
+                  textColor="#eb0055"
+                >
+                  Retourner à ma réservation
+                </Text>
+              </View>
+              <View
+                numberOfSpaces={1}
+                style={
+                  Array [
+                    Object {
+                      "height": 4,
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </Modal>,
+  <Modal
+    animationType="none"
+    deviceHeight={null}
+    deviceWidth={null}
+    hardwareAccelerated={false}
+    hideModalContentWhileAnimating={false}
+    onBackdropPress={[Function]}
+    onModalHide={[Function]}
+    onModalWillHide={[Function]}
+    onModalWillShow={[Function]}
+    onRequestClose={[Function]}
+    panResponderThreshold={4}
+    scrollHorizontal={false}
+    scrollOffset={0}
+    scrollOffsetMax={0}
+    scrollTo={null}
+    statusBarTranslucent={true}
+    supportedOrientations={
+      Array [
+        "portrait",
+        "landscape",
+      ]
+    }
+    swipeThreshold={100}
+    testID="modal"
+    transparent={true}
+    visible={false}
+  >
+    <View
+      accessible={true}
+      focusable={true}
+      forwardedRef={[Function]}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "backgroundColor": "#00000080",
+          "bottom": 0,
+          "height": 1334,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "width": 750,
+        }
+      }
+    />
+    <View
+      deviceHeight={null}
+      deviceWidth={null}
+      forwardedRef={[Function]}
+      hideModalContentWhileAnimating={false}
+      onBackdropPress={[Function]}
+      onModalHide={[Function]}
+      onModalWillHide={[Function]}
+      onModalWillShow={[Function]}
+      panResponderThreshold={4}
+      pointerEvents="box-none"
+      scrollHorizontal={false}
+      scrollOffset={0}
+      scrollOffsetMax={0}
+      scrollTo={null}
+      statusBarTranslucent={true}
+      style={
+        Object {
+          "backgroundColor": "#ffffff",
+          "borderTopLeftRadius": 20,
+          "borderTopRightRadius": 20,
+          "bottom": 0,
+          "flex": 1,
+          "height": undefined,
+          "justifyContent": "center",
+          "margin": "auto",
+          "marginBottom": 0,
+          "marginLeft": 0,
+          "marginRight": 0,
+          "maxWidth": undefined,
+          "padding": 4,
+          "position": "absolute",
+          "transform": Array [
+            Object {
+              "translateY": 0,
+            },
+          ],
+          "width": "100%",
+        }
+      }
+      supportedOrientations={
+        Array [
+          "portrait",
+          "landscape",
+        ]
+      }
+      swipeThreshold={100}
+    >
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "flexDirection": "column",
+            "flexGrow": 1,
+            "height": "100%",
+            "justifyContent": "flex-start",
+            "opacity": 1,
+            "width": "100%",
+          }
+        }
+        testID="click-away-area"
+      >
+        <View
+          accessible={true}
+          focusable={false}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderTopEndRadius": 16,
+              "borderTopStartRadius": 16,
+              "flexDirection": "column",
+              "justifyContent": "flex-start",
+              "maxHeight": "90%",
+              "opacity": 1,
+              "paddingBottom": 20,
+              "paddingLeft": 20,
+              "paddingRight": 20,
+              "paddingTop": 20,
+              "width": "100%",
+            }
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                  "width": "100%",
+                  "zIndex": 1,
+                },
+              ]
+            }
+          >
+            <View
+              accessible={true}
+              focusable={false}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "alignItems": "flex-start",
+                  "flexBasis": 0,
+                  "flexGrow": 0.1,
+                  "flexShrink": 1,
+                  "marginLeft": -4,
+                  "opacity": 1,
+                }
+              }
+              testID="leftIconButton"
+            />
+            <Text
+              numberOfLines={2}
+              style={
+                Array [
+                  Object {
+                    "color": "#151515",
+                    "flexBasis": 0,
+                    "flexGrow": 0.8,
+                    "flexShrink": 1,
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 18,
+                    "lineHeight": 22,
+                    "textAlign": "center",
+                  },
+                ]
+              }
+            >
+              Tu es sur le point d'archiver
+            </Text>
+            <View
+              accessible={true}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "alignItems": "flex-end",
+                  "flexBasis": 0,
+                  "flexGrow": 0.1,
+                  "flexShrink": 1,
+                  "marginRight": -4,
+                  "opacity": 1,
+                }
+              }
+              testID="rightIconButton"
+            >
+              <View
+                height={32}
+                testID="rightIcon"
+                width={32}
+              >
+                <Text>
+                  rightIcon-SVG-Mock
+                </Text>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "maxWidth": 500,
+                  "paddingTop": 20,
+                  "width": "100%",
+                },
+                Object {
+                  "paddingBottom": 8,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "paddingHorizontal": 22,
+                    "width": "100%",
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#151515",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                      "textAlign": "center",
+                    },
+                  ]
+                }
+              >
+                Avez-vous déjà vu ?
+              </Text>
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#151515",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                      "marginTop": 8,
+                      "textAlign": "center",
+                    },
+                  ]
+                }
+              >
+                Tu pourras retrouver l’offre dans tes réservations teminées
+              </Text>
+              <View
+                numberOfSpaces={6}
+                style={
+                  Array [
+                    Object {
+                      "height": 24,
+                    },
+                  ]
+                }
+              />
+              <View
+                accessibilityLabel="Terminer ma réservation"
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "backgroundColor": "#eb0055",
+                    "borderRadius": 24,
+                    "borderWidth": 0,
+                    "flexDirection": "row",
+                    "height": 40,
+                    "justifyContent": "center",
+                    "maxWidth": 500,
+                    "opacity": 1,
+                    "paddingBottom": 2,
+                    "paddingLeft": 2,
+                    "paddingRight": 2,
+                    "paddingTop": 2,
+                    "width": "100%",
+                  }
+                }
+                testID="Terminer ma réservation"
+              >
+                <Text
+                  adjustsFontSizeToFit={false}
+                  numberOfLines={1}
+                  style={
+                    Array [
+                      Object {
+                        "color": "#ffffff",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                        "marginLeft": 5,
+                        "maxWidth": 650,
+                      },
+                    ]
+                  }
+                  textColor="#ffffff"
+                >
+                  Terminer ma réservation
+                </Text>
+              </View>
+              <View
+                numberOfSpaces={3}
+                style={
+                  Array [
+                    Object {
+                      "height": 12,
+                    },
+                  ]
+                }
+              />
+              <View
+                accessibilityLabel="Retourner à ma réservation"
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "backgroundColor": "transparent",
+                    "borderRadius": 24,
+                    "borderWidth": 0,
+                    "flexDirection": "row",
+                    "height": 40,
+                    "justifyContent": "center",
+                    "maxWidth": 500,
+                    "opacity": 1,
+                    "paddingBottom": 2,
+                    "paddingLeft": 2,
+                    "paddingRight": 2,
+                    "paddingTop": 2,
+                    "width": "100%",
+                  }
+                }
+                testID="Retourner à ma réservation"
+              >
+                <Text
+                  adjustsFontSizeToFit={false}
+                  numberOfLines={1}
+                  style={
+                    Array [
+                      Object {
+                        "color": "#eb0055",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                        "marginLeft": 5,
+                        "maxWidth": 650,
+                      },
+                    ]
+                  }
+                  textColor="#eb0055"
+                >
+                  Retourner à ma réservation
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </Modal>,
+  <View
+    style={
+      Object {
+        "backgroundColor": "rgba(255, 255, 255, 0)",
+        "position": "absolute",
+        "top": 0,
+        "width": "100%",
+        "zIndex": 1,
+      }
+    }
+  >
+    <View
+      customHeight={16}
+      style={
+        Array [
+          Object {
+            "height": 16,
+          },
+        ]
+      }
+    />
+    <View
+      numberOfSpaces={2}
+      style={
+        Array [
+          Object {
+            "height": 8,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "paddingLeft": 12,
+            },
+          ]
+        }
+      >
+        <View
+          accessibilityLabel="Revenir en arrière"
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+          testID="Revenir en arrière"
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "aspectRatio": 1,
+                "backgroundColor": "rgba(255, 255, 255, 1)",
+                "borderColor": "rgba(245, 245, 245, 1)",
+                "borderRadius": 40,
+                "borderStyle": "solid",
+                "borderWidth": 1,
+                "justifyContent": "center",
+                "overflow": "hidden",
+                "transform": undefined,
+                "width": 40,
+              }
+            }
+            testID="headerIconRoundContainer"
+          >
+            <View
+              size={32}
+              style={
+                Array [
+                  Object {
+                    "height": 32,
+                    "width": 32,
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "opacity": 1,
+                    "position": "absolute",
+                  }
+                }
+                testID="initial-icon-container"
+              >
+                <View
+                  height={32}
+                  testID="icon-back"
+                  width={32}
+                >
+                  <Text>
+                    icon-back-SVG-Mock
+                  </Text>
+                </View>
+              </View>
+              <View
+                style={
+                  Object {
+                    "opacity": 0,
+                    "position": "absolute",
+                  }
+                }
+                testID="final-icon-container"
+              >
+                <View
+                  height={32}
+                  testID="final-icon-back"
+                  width={32}
+                >
+                  <Text>
+                    final-icon-back-SVG-Mock
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+      <Text
+        numberOfLines={1}
+        style={
+          Object {
+            "flexBasis": 0,
+            "flexGrow": 5,
+            "flexShrink": 1,
+            "opacity": 0,
+            "textAlign": "center",
+          }
+        }
+      >
+        <Text
+          color="#ffffff"
+          style={
+            Array [
+              Object {
+                "color": "#ffffff",
+                "fontFamily": "Montserrat-Regular",
+                "fontSize": 15,
+                "lineHeight": 20,
+              },
+            ]
+          }
+        >
+          Avez-vous déjà vu ?
+        </Text>
+      </Text>
+      <View
+        numberOfSpaces={3}
+        style={
+          Array [
+            Object {
+              "width": 12,
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          Array [
+            Object {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      numberOfSpaces={2}
+      style={
+        Array [
+          Object {
+            "height": 8,
+          },
+        ]
+      }
+    />
+  </View>,
+]
+`;

--- a/src/features/bookings/api/queries.ts
+++ b/src/features/bookings/api/queries.ts
@@ -1,17 +1,21 @@
-import { useQuery, useQueryClient } from 'react-query'
+import { useQuery } from 'react-query'
 
 import { api } from 'api/api'
 import { BookingReponse, BookingsResponse } from 'api/gen'
 import { QueryKeys } from 'libs/queryKeys'
 
+// Arbitrary. Make sure the cache is invalidated after each booking
+const STALE_TIME_BOOKINGS = 5 * 60 * 1000
+
 export function useBookings() {
-  return useQuery<BookingsResponse>(QueryKeys.BOOKINGS, () => api.getnativev1bookings())
+  return useQuery<BookingsResponse>(QueryKeys.BOOKINGS, () => api.getnativev1bookings(), {
+    staleTime: STALE_TIME_BOOKINGS,
+  })
 }
 
 export function useOngoingOrEndedBooking(id: number): BookingReponse | undefined {
-  const client = useQueryClient()
-  const state = client.getQueryState<BookingsResponse>(QueryKeys.BOOKINGS)
-  const onGoingBooking = state?.data?.ongoing_bookings?.find((item) => item.id === id)
-  const endedBooking = state?.data?.ended_bookings?.find((item) => item.id === id)
+  const { data: bookings } = useBookings()
+  const onGoingBooking = bookings?.ongoing_bookings?.find((item) => item.id === id)
+  const endedBooking = bookings?.ended_bookings?.find((item) => item.id === id)
   return onGoingBooking || endedBooking
 }

--- a/src/features/bookings/pages/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails.native.test.tsx
@@ -32,8 +32,7 @@ jest.mock('features/auth/settings', () => ({
   })),
 }))
 
-// FIXME: web integration
-describe.skip('BookingDetails', () => {
+describe('BookingDetails', () => {
   afterEach(jest.restoreAllMocks)
 
   beforeAll(() => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10050

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.


## Details

When we access the details of a booking without going to the bookings page first, the hook `useBookings` was not called. Thus the hook `useOngoingOrEndedBooking` returned `undefined` which caused a blank page.

Now, we make sure to call `useBookings` inside the hook `useOngoingOrEndedBooking`.

Furthermore, to prevent calling `/native/v1/bookings` too often, we cache the result using react-query's `staleTime`. To do that, we have to make sure we invalidate the cache when needed (ex: when booking a reservation).