### PR TITLE
Doc: remove outdated sentry section from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,23 +67,6 @@ cd ios
 bundle exec pod install
 ```
 
-### Build the app
-
-To be able to build the app, you need to configure sentry:
-
-Run `yarn sentry:configure` and select the project `application-native`. This should create 2 files `sentry.properties`, in the `ios/` and `android/` folders.
-
-The content of this file should look like that:
-
-```
-defaults.url=https://sentry.internal-passculture.app/
-defaults.org=sentry
-defaults.project=application-native
-auth.token=<token>
-```
-
-The token is available in your sentry account: https://sentry.internal-passculture.app/settings/account/api/auth-tokens/.
-
 ### Run the app
 
 #### Android


### PR DESCRIPTION
### Description

There are several errors in the readme, in the 'Build the app' section about Sentry.
First you can build the app without the sentry step.
Second the command `yarn sentry:configure` does not exist anymore.
Third, there are no available token on my sentry account.