### PR TITLE
(PC-10260) Use screen name instead of "path" as key of screenParamsParser

### DIFF
--- a/src/features/deeplinks/routing.ts
+++ b/src/features/deeplinks/routing.ts
@@ -73,7 +73,7 @@ export const DEEPLINK_TO_SCREEN_CONFIGURATION: DeepLinksToScreenConfiguration = 
     }
   },
   'signup-confirmation'(params) {
-    const parser = screenParamsParser['signup-confirmation']
+    const parser = screenParamsParser['AfterSignupEmailValidationBuffer']
     if (params && params.token && params.email && params.expiration_timestamp) {
       return {
         screen: 'AfterSignupEmailValidationBuffer',

--- a/src/features/navigation/RootNavigator/routes.web.tsx
+++ b/src/features/navigation/RootNavigator/routes.web.tsx
@@ -196,7 +196,7 @@ export const routes: Array<Route> = [
     component: AfterSignupEmailValidationBuffer,
     pathConfig: {
       path: 'signup-confirmation',
-      parse: screenParamsParser['signup-confirmation'],
+      parse: screenParamsParser['AfterSignupEmailValidationBuffer'],
     },
   },
   // { name: 'AppComponents', component: AppComponents, path: 'app-components' },
@@ -218,7 +218,7 @@ export const routes: Array<Route> = [
     component: BookingDetails,
     pathConfig: {
       path: 'booking/:id/details',
-      parse: screenParamsParser['booking-details'],
+      parse: screenParamsParser['BookingDetails'],
     },
   },
   // { name: 'CulturalSurvey', component: CulturalSurvey },

--- a/src/features/navigation/screenParamsParser.ts
+++ b/src/features/navigation/screenParamsParser.ts
@@ -1,21 +1,23 @@
 import { AllNavParamList, RouteParams, ScreenNames } from 'features/navigation/RootNavigator'
 
-type ParamsParsers<ScreenName extends ScreenNames> = {
-  [ParamName in keyof RouteParams<AllNavParamList, ScreenName>]: (
-    value: string
-  ) => RouteParams<AllNavParamList, ScreenName>[ParamName]
+type ScreensRequiringParsing = Extract<
+  ScreenNames,
+  'AfterSignupEmailValidationBuffer' | 'BookingDetails'
+>
+
+type ParamsParsers = {
+  [Screen in ScreensRequiringParsing]: {
+    [Param in keyof RouteParams<AllNavParamList, Screen>]: (
+      value: string
+    ) => RouteParams<AllNavParamList, Screen>[Param]
+  }
 }
 
-type ScreenParamsParsers = {
-  'booking-details': ParamsParsers<'BookingDetails'>
-  'signup-confirmation': ParamsParsers<'AfterSignupEmailValidationBuffer'>
-}
-
-export const screenParamsParser: ScreenParamsParsers = {
-  'booking-details': {
+export const screenParamsParser: ParamsParsers = {
+  BookingDetails: {
     id: (value) => Number(value),
   },
-  'signup-confirmation': {
+  AfterSignupEmailValidationBuffer: {
     email: (value) => decodeURIComponent(value),
     token: (value) => value,
     expiration_timestamp: (value) => Number(value),


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10260

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |
