### PR TITLE
Add signin error code instead of using status code

### DIFF
--- a/src/features/auth/login/Login.tsx
+++ b/src/features/auth/login/Login.tsx
@@ -91,7 +91,7 @@ export const Login: FunctionComponent = function () {
     } else if (failureCode === 'NETWORK_REQUEST_FAILED') {
       setIsLoading(false)
       setErrorMessage(t`Erreur réseau. Tu peux réessayer une fois la connexion réétablie.`)
-    } else if (response.statusCode === 429) {
+    } else if (response.statusCode === 429 || failureCode === 'TOO_MANY_ATTEMPTS') {
       setIsLoading(false)
       setErrorMessage(t`Nombre de tentatives dépassé. Réessaye dans 1 minute.`)
     } else {


### PR DESCRIPTION
Bots can easily use 429 status codes which are standard to know there is too many attempts going on for trying to signin.
Instead we would like to be more discreet and use an error code