### PR TITLE
(PC-10260) Use dynamic webapp url in generateLongFirebaseDynamicLink()

### DIFF
--- a/__snapshots__/libs/recaptcha/ReCaptcha.native.test.tsx.native-snap
+++ b/__snapshots__/libs/recaptcha/ReCaptcha.native.test.tsx.native-snap
@@ -42,7 +42,7 @@ exports[`<ReCaptcha /> should render correctly 1`] = `
       onShouldStartLoadWithRequest={[Function]}
       source={
         Object {
-          "baseUrl": undefined,
+          "baseUrl": "https://webapp.example.com",
           "html": "
     <!DOCTYPE html>
     <html lang=\\"fr\\">

--- a/jest/jest.setup.ts
+++ b/jest/jest.setup.ts
@@ -65,6 +65,7 @@ jest.mock('react-native-flipper')
 
 /* See the corresponding mock in libs/environment/__mocks__ */
 jest.mock('libs/environment/env')
+jest.mock('libs/environment/useWebAppUrl')
 
 /* See the corresponding mock in libs/deeplinks/__mocks__ */
 jest.mock('features/deeplinks/listener')

--- a/src/features/cheatcodes/pages/Navigation/Navigation.tsx
+++ b/src/features/cheatcodes/pages/Navigation/Navigation.tsx
@@ -21,8 +21,8 @@ import { padding, Spacer } from 'ui/theme'
 
 import { CheatCodesButton } from '../../components/CheatCodesButton'
 
-const BadDeeplink = WEBAPP_NATIVE_REDIRECTION_URL + 'unknown'
-const LoginDeeplink = WEBAPP_NATIVE_REDIRECTION_URL + 'login'
+const BadDeeplink = WEBAPP_NATIVE_REDIRECTION_URL + '/unknown'
+const LoginDeeplink = WEBAPP_NATIVE_REDIRECTION_URL + '/login'
 const MAX_ASYNC_TEST_REQ_COUNT = 3
 const EIFFEL_TOWER_COORDINATES = { lat: 48.8584, lng: 2.2945 }
 

--- a/src/features/deeplinks/analytics.test.ts
+++ b/src/features/deeplinks/analytics.test.ts
@@ -13,7 +13,7 @@ describe('useDeeplinkUrlHandler Analytics', () => {
       result: { current: handleDeeplinkUrl },
     } = renderHook(useDeeplinkUrlHandler)
 
-    const url = WEBAPP_NATIVE_REDIRECTION_URL + 'offer/?id=1234'
+    const url = WEBAPP_NATIVE_REDIRECTION_URL + '/offer/?id=1234'
 
     handleDeeplinkUrl({ url })
 

--- a/src/features/deeplinks/pages/DeeplinkImporter.native.test.tsx
+++ b/src/features/deeplinks/pages/DeeplinkImporter.native.test.tsx
@@ -23,7 +23,7 @@ describe('DeeplinkImporter', () => {
     })
   })
   it('should resolve the link', async () => {
-    const url = FIREBASE_DYNAMIC_LINK_URL + 'home'
+    const url = FIREBASE_DYNAMIC_LINK_URL + '/home'
 
     const resolveHandlerSpy = jest.spyOn(DeeplinkUtils, 'resolveHandler')
 

--- a/src/features/deeplinks/useDeeplinkUrlHandler.test.ts
+++ b/src/features/deeplinks/useDeeplinkUrlHandler.test.ts
@@ -43,8 +43,8 @@ describe('useDeeplinkUrlHandler', () => {
   })
 
   describe('Url parts', () => {
-    const uri = 'my-route?param1=one&param2=2&param3=true&param4=false'
-    const uriWithoutParams = 'my-route/test' // slash will be included in the route name
+    const uri = '/my-route?param1=one&param2=2&param3=true&param4=false'
+    const uriWithoutParams = '/my-route/test' // slash will be included in the route name
 
     it.each([
       ['Android', WEBAPP_NATIVE_REDIRECTION_URL + uri],
@@ -73,7 +73,7 @@ describe('useDeeplinkUrlHandler', () => {
 
     it("doesn't take into account the trailing slash", () => {
       const { routeName, params } = decodeDeeplinkParts(
-        WEBAPP_NATIVE_REDIRECTION_URL + 'offer/?id=ABCDE'
+        WEBAPP_NATIVE_REDIRECTION_URL + '/offer/?id=ABCDE'
       )
       expect(routeName).toEqual('offer')
       expect(params).toEqual({ id: 'ABCDE' })
@@ -92,7 +92,7 @@ describe('useDeeplinkUrlHandler', () => {
 
       const url =
         WEBAPP_NATIVE_REDIRECTION_URL +
-        'my-route-to-test?param1=one&param2=2&param3=true&param4=false'
+        '/my-route-to-test?param1=one&param2=2&param3=true&param4=false'
 
       handleDeeplinkUrl({ url })
 
@@ -108,7 +108,7 @@ describe('useDeeplinkUrlHandler', () => {
       const {
         result: { current: handleDeeplinkUrl },
       } = renderHook(useDeeplinkUrlHandler)
-      const url = WEBAPP_NATIVE_REDIRECTION_URL + 'unknwon-route?param1=one&param2=2'
+      const url = WEBAPP_NATIVE_REDIRECTION_URL + '/unknwon-route?param1=one&param2=2'
 
       handleDeeplinkUrl({ url })
 

--- a/src/features/deeplinks/useDeeplinkUrlHandler.ts
+++ b/src/features/deeplinks/useDeeplinkUrlHandler.ts
@@ -40,17 +40,13 @@ export function parseURI(uri: string) {
   return parameterFields
 }
 
+const ROUTE_NAME_REGEX = /^([a-zA-Z0-9-_]+)/g
+
 export function decodeDeeplinkParts(url: string): DeeplinkParts {
-  const route = url.replace(WEBAPP_NATIVE_REDIRECTION_URL, '')
-
-  const routeNameRegexp = /^([a-zA-Z0-9-_]+)/g
-
-  const routeName = route.match(routeNameRegexp)?.[0] || 'unknown'
-  const searchParams = route.replace(routeNameRegexp, '')
-
-  const params = parseURI(decodeURI(searchParams))
-
-  return { routeName: routeName, params }
+  const pathWithQueryString = url.replace(`${WEBAPP_NATIVE_REDIRECTION_URL}/`, '')
+  const path = pathWithQueryString.match(ROUTE_NAME_REGEX)?.[0] || 'unknown'
+  const queryString = pathWithQueryString.replace(ROUTE_NAME_REGEX, '')
+  return { routeName: path, params: parseURI(decodeURI(queryString)) }
 }
 
 const DEFAULT_ERROR_MESSAGE = t`Le lien est incorrect`

--- a/src/features/deeplinks/utils.test.ts
+++ b/src/features/deeplinks/utils.test.ts
@@ -16,9 +16,7 @@ describe('Formatting deeplink url', () => {
   afterAll(() => jest.resetAllMocks())
 
   it('should format properly the universal link', () => {
-    expect(WEBAPP_NATIVE_REDIRECTION_URL).toEqual(
-      `https://${env.WEBAPP_NATIVE_REDIRECTION_DOMAIN}/`
-    )
+    expect(WEBAPP_NATIVE_REDIRECTION_URL).toEqual(`https://${env.WEBAPP_NATIVE_REDIRECTION_DOMAIN}`)
   })
 
   describe('getLongDynamicLinkURI', () => {
@@ -43,11 +41,11 @@ describe('Formatting deeplink url', () => {
   describe('generateLongFirebaseDynamicLink', () => {
     it('should return a format long firebase dynamic link', () => {
       const screen = 'offer'
+      const webAppUrl = 'https://web.example.com'
       const uri = 'id=345&test_params=est_ce_que_cest_ok'
-      const url = generateLongFirebaseDynamicLink(screen, uri)
-
+      const url = generateLongFirebaseDynamicLink(screen, webAppUrl, uri)
       expect(url).toEqual(
-        `${FIREBASE_DYNAMIC_LINK_URL}?link=${WEBAPP_NATIVE_REDIRECTION_URL}${screen}?${uri}&${getLongDynamicLinkURI()}`
+        `${FIREBASE_DYNAMIC_LINK_URL}/?link=${webAppUrl}/${screen}?${uri}&${getLongDynamicLinkURI()}`
       )
     })
   })
@@ -66,13 +64,13 @@ describe('Formatting deeplink url', () => {
   describe('isFirebaseLongDynamicLink', () => {
     it('should return true when the given firebase link has a "link" uri param', () => {
       const isLongDynamicLink = isFirebaseLongDynamicLink(
-        FIREBASE_DYNAMIC_LINK_URL + '?link=https://a.link'
+        FIREBASE_DYNAMIC_LINK_URL + '/?link=https://a.link'
       )
       expect(isLongDynamicLink).toBe(true)
     })
     it('should return false when the given firebase link has not a "link" uri param', () => {
       const isLongDynamicLink = isFirebaseLongDynamicLink(
-        FIREBASE_DYNAMIC_LINK_URL + '?not-link=https://a.link'
+        FIREBASE_DYNAMIC_LINK_URL + '/?not-link=https://a.link'
       )
       expect(isLongDynamicLink).toBe(false)
     })
@@ -82,9 +80,9 @@ describe('Formatting deeplink url', () => {
     })
   })
 
-  describe('convertLongDynamicLinkToUniversalLink', () => {
+  describe('extractUniversalLinkFromLongFirebaseDynamicLink', () => {
     it('should convert long dynamic link to the injected universal link', () => {
-      const url = FIREBASE_DYNAMIC_LINK_URL + '?link=https://a.link'
+      const url = FIREBASE_DYNAMIC_LINK_URL + '/?link=https://a.link'
       const extracted = extractUniversalLinkFromLongFirebaseDynamicLink({ url })
       expect(extracted).toBe('https://a.link')
     })
@@ -102,7 +100,7 @@ describe('Formatting deeplink url', () => {
       expect(handleDeeplinkUrl).toBeCalledWith(deeplinkEvent)
     })
     it('should extract universal link for firebase long dynamic link', () => {
-      const url = FIREBASE_DYNAMIC_LINK_URL + '?link=https://a.link'
+      const url = FIREBASE_DYNAMIC_LINK_URL + '/?link=https://a.link'
       const handleDeeplinkUrl = jest.fn()
 
       const handler = resolveHandler(handleDeeplinkUrl)

--- a/src/features/deeplinks/utils.ts
+++ b/src/features/deeplinks/utils.ts
@@ -5,8 +5,8 @@ import { env } from 'libs/environment'
 
 import { DeeplinkEvent } from './types'
 
-export const WEBAPP_NATIVE_REDIRECTION_URL = `https://${env.WEBAPP_NATIVE_REDIRECTION_DOMAIN}/`
-export const FIREBASE_DYNAMIC_LINK_URL = `https://${env.FIREBASE_DYNAMIC_LINK_DOMAIN}/`
+export const WEBAPP_NATIVE_REDIRECTION_URL = `https://${env.WEBAPP_NATIVE_REDIRECTION_DOMAIN}`
+export const FIREBASE_DYNAMIC_LINK_URL = `https://${env.FIREBASE_DYNAMIC_LINK_DOMAIN}`
 
 /**
  * @param ignoreMiddlePage S'il est défini sur true («1»), ignorez la page d'aperçu de
@@ -32,10 +32,11 @@ export function getLongDynamicLinkURI(ignoreMiddlePage = true) {
  */
 export function generateLongFirebaseDynamicLink(
   screen: keyof DeepLinksToScreenConfiguration,
+  webAppUrl: string,
   universalLinksParams: string,
   customDynamicLinksParams = ''
 ) {
-  return `${FIREBASE_DYNAMIC_LINK_URL}?link=${WEBAPP_NATIVE_REDIRECTION_URL}${screen}?${universalLinksParams}&${getLongDynamicLinkURI()}${customDynamicLinksParams}`
+  return `${FIREBASE_DYNAMIC_LINK_URL}/?link=${webAppUrl}/${screen}?${universalLinksParams}&${getLongDynamicLinkURI()}${customDynamicLinksParams}`
 }
 
 export const isUniversalLink = (url: string) => url.startsWith(WEBAPP_NATIVE_REDIRECTION_URL)
@@ -48,7 +49,7 @@ export const isFirebaseLongDynamicLink = (url: string) =>
  * so we handle it manually
  */
 export const extractUniversalLinkFromLongFirebaseDynamicLink = (event: DeeplinkEvent): string => {
-  const searchParams = event.url.replace(`${FIREBASE_DYNAMIC_LINK_URL}?`, '')
+  const searchParams = event.url.replace(`${FIREBASE_DYNAMIC_LINK_URL}/?`, '')
   const paramsString = omit(searchParams, FIREBASE_DYNAMIC_LINK_PARAMS).querystring
   return paramsString.replace(/^link=/, '')
 }

--- a/src/features/navigation/__tests__/helpers.test.ts
+++ b/src/features/navigation/__tests__/helpers.test.ts
@@ -22,7 +22,7 @@ describe('Navigation helpers', () => {
 
   it('should capture links that start with the universal links domain', async () => {
     const openUrl = jest.spyOn(Linking, 'openURL').mockResolvedValueOnce(undefined)
-    const link = WEBAPP_NATIVE_REDIRECTION_URL + 'my-route-to-test?param1=ok'
+    const link = WEBAPP_NATIVE_REDIRECTION_URL + '/my-route-to-test?param1=ok'
     await openExternalUrl(link)
 
     expect(openUrl).not.toBeCalled()
@@ -51,7 +51,7 @@ describe('Navigation helpers', () => {
   })
 
   it('should redirect universal links to the right screen', async () => {
-    const link = WEBAPP_NATIVE_REDIRECTION_URL + 'my-route-to-test?param1=ok'
+    const link = WEBAPP_NATIVE_REDIRECTION_URL + '/my-route-to-test?param1=ok'
     await openExternalUrl(link)
 
     expect(navigationRef.current?.navigate).toBeCalledWith('UniqueTestRoute', { param1: 'ok' })

--- a/src/features/offer/components/__tests__/OfferHeader.native.test.tsx
+++ b/src/features/offer/components/__tests__/OfferHeader.native.test.tsx
@@ -103,6 +103,7 @@ describe('<OfferHeader />', () => {
     expect(share).toHaveBeenCalledTimes(1)
     const url = generateLongFirebaseDynamicLink(
       'offer',
+      env.WEBAPP_URL,
       'id=116656',
       `&ofl=${env.WEBAPP_URL}/accueil/details/AHD3A`
     )
@@ -124,6 +125,7 @@ describe('<OfferHeader />', () => {
     expect(share).toHaveBeenCalledTimes(1)
     const url = generateLongFirebaseDynamicLink(
       'offer',
+      env.WEBAPP_URL,
       'id=116656',
       `&ofl=${env.WEBAPP_URL}/accueil/details/AHD3A`
     )

--- a/src/features/offer/components/__tests__/OfferHeader.web.test.tsx
+++ b/src/features/offer/components/__tests__/OfferHeader.web.test.tsx
@@ -101,8 +101,10 @@ describe('<OfferHeader />', () => {
 
     fireEvent.click(getByTestId('icon-share'))
     expect(share).toHaveBeenCalledTimes(1)
+    const webAppUrl = 'https://web.example.com'
     const url = generateLongFirebaseDynamicLink(
       'offer',
+      webAppUrl,
       'id=116656',
       '&ofl=undefined/accueil/details/AHD3A'
     )
@@ -122,8 +124,10 @@ describe('<OfferHeader />', () => {
 
     fireEvent.click(getByTestId('icon-share'))
     expect(share).toHaveBeenCalledTimes(1)
+    const webAppUrl = 'https://web.example.com'
     const url = generateLongFirebaseDynamicLink(
       'offer',
+      webAppUrl,
       'id=116656',
       '&ofl=undefined/accueil/details/AHD3A'
     )

--- a/src/features/offer/services/useShareOffer.ts
+++ b/src/features/offer/services/useShareOffer.ts
@@ -12,7 +12,7 @@ import { getLocationName } from '../atoms/LocationCaption'
 
 import { useFunctionOnce } from './useFunctionOnce'
 
-const shareOffer = async (offer: OfferResponse, webAppUrl?: string) => {
+const shareOffer = async (offer: OfferResponse, webAppUrl: string) => {
   const { id, isDigital, name, venue } = offer
   const locationName = getLocationName(venue, isDigital)
   const message = t({
@@ -22,6 +22,7 @@ const shareOffer = async (offer: OfferResponse, webAppUrl?: string) => {
   })
   const url = generateLongFirebaseDynamicLink(
     'offer',
+    webAppUrl,
     `id=${id}`,
     `&ofl=${webAppUrl}/accueil/details/${humanizeId(id)}`
   )
@@ -57,7 +58,7 @@ export const useShareOffer = (offerId: number): (() => Promise<void>) => {
 
   return async () => {
     logShareOffer()
-    if (!offerResponse) return
+    if (!offerResponse || !webAppUrl) return
     await shareOffer(offerResponse, webAppUrl)
   }
 }

--- a/src/features/venue/components/__tests__/VenueHeader.native.test.tsx
+++ b/src/features/venue/components/__tests__/VenueHeader.native.test.tsx
@@ -5,6 +5,7 @@ import waitForExpect from 'wait-for-expect'
 import { goBack } from '__mocks__/@react-navigation/native'
 import { generateLongFirebaseDynamicLink } from 'features/deeplinks'
 import { venueResponseSnap } from 'features/venue/fixtures/venueResponseSnap'
+import { env } from 'libs/environment'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { fireEvent, render } from 'tests/utils'
 
@@ -55,7 +56,7 @@ describe('<VenueHeader />', () => {
     fireEvent.press(getByTestId('icon-share'))
 
     expect(share).toHaveBeenCalledTimes(1)
-    const url = generateLongFirebaseDynamicLink('venue', 'id=5543')
+    const url = generateLongFirebaseDynamicLink('venue', env.WEBAPP_URL, 'id=5543')
     const message = 'Retrouve "Le Petit Rintintin 1" sur le pass Culture'
     expect(share).toHaveBeenCalledWith(
       { message, title: message, url },
@@ -71,7 +72,7 @@ describe('<VenueHeader />', () => {
     fireEvent.press(getByTestId('icon-share'))
 
     expect(share).toHaveBeenCalledTimes(1)
-    const url = generateLongFirebaseDynamicLink('venue', 'id=5543')
+    const url = generateLongFirebaseDynamicLink('venue', env.WEBAPP_URL, 'id=5543')
     const message = 'Retrouve "Le Petit Rintintin 1" sur le pass Culture'
     const messageWithUrl = `${message}\n\n${url}`
     expect(share).toHaveBeenCalledWith(

--- a/src/features/venue/services/useShareVenue.ts
+++ b/src/features/venue/services/useShareVenue.ts
@@ -3,10 +3,11 @@ import { Platform, Share } from 'react-native'
 
 import { VenueResponse } from 'api/gen'
 import { generateLongFirebaseDynamicLink } from 'features/deeplinks'
+import { useWebAppUrl } from 'libs/environment'
 
 import { useVenue } from '../api/useVenue'
 
-const shareVenue = async (venue: VenueResponse) => {
+const shareVenue = async (venue: VenueResponse, webAppUrl: string) => {
   const { id, name } = venue
 
   const message = t({
@@ -15,7 +16,7 @@ const shareVenue = async (venue: VenueResponse) => {
     message: 'Retrouve "{name}" sur le pass Culture',
   })
 
-  const url = generateLongFirebaseDynamicLink('venue', `id=${id}`)
+  const url = generateLongFirebaseDynamicLink('venue', webAppUrl, `id=${id}`)
 
   // url share content param is only for iOs, so we add url in message for android
   const completeMessage = Platform.OS === 'ios' ? message : message.concat(`\n\n${url}`)
@@ -36,9 +37,10 @@ const shareVenue = async (venue: VenueResponse) => {
 
 export const useShareVenue = (venueId: number): (() => Promise<void>) => {
   const { data: venue } = useVenue(venueId)
+  const webAppUrl = useWebAppUrl()
 
   return async () => {
-    if (!venue) return
-    await shareVenue(venue)
+    if (!venue || !webAppUrl) return
+    await shareVenue(venue, webAppUrl)
   }
 }

--- a/src/libs/environment/__mocks__/useWebAppUrl.ts
+++ b/src/libs/environment/__mocks__/useWebAppUrl.ts
@@ -1,0 +1,4 @@
+import { env } from './envFixtures'
+import { useWebAppUrl as actualUseWebAppUrl } from '../useWebAppUrl'
+
+export const useWebAppUrl: typeof actualUseWebAppUrl = () => env.WEBAPP_URL


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10260

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] |
| -------------------- | :----------------------: | 
|                      |                          |  