### PR TITLE
fix report offer request crash

### DIFF
--- a/src/features/offer/pages/OfferBody.tsx
+++ b/src/features/offer/pages/OfferBody.tsx
@@ -70,7 +70,7 @@ export const OfferBody: FunctionComponent<{
   const { data } = useQuery<UserReportedOffersResponse>(
     QueryKeys.REPORTED_OFFERS,
     () => api.getnativev1offersreports(),
-    { enabled: isLoggedIn }
+    { enabled: isLoggedIn, retry: true }
   )
 
   const reportedOffers = data?.reportedOffers

--- a/src/features/offer/services/useReasonsForReporting.ts
+++ b/src/features/offer/services/useReasonsForReporting.ts
@@ -11,5 +11,6 @@ export const useReasonsForReporting = () => {
   return useQuery(QueryKeys.REPORT_OFFER_REASONS, () => api.getnativev1offerreportreasons(), {
     enabled: isLoggedIn,
     staleTime: STALE_TIME_REPORT_OFFER_REASONS,
+    retry: true,
   })
 }


### PR DESCRIPTION
## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.

## Description du bug

La page de détail de l'offre ne peut pas s'afficher et affiche 'Oops' car les appels aux routes /native/v1/offers/reports et /native/v1/offers/reports/reasons échouent (réponse 401).
Il semble que cela arrive lorsque l'app est inactive pendant au moins 15 minutes (délai d'expiration du token d'authentification). Au retour sur l'app sur la page de détail de l'offre, les appels aux routes sont renouvelés, or le token est expiré. Après l'appel à la route /native/v1/refresh_access_token, les appels à reports et reports/reasons ne sont pas à nouveau exécutés ce qui provoque le crash de la page de détail de l'offre.

<img width="754" alt="Capture d’écran 2021-08-18 à 11 36 30" src="https://user-images.githubusercontent.com/22886846/129876010-eae877da-3ae1-4e45-a4f5-9eb058f3f73a.png">

## Solution

L'utilisation du paramètre `retry: true` dans useQuery permet de forcer le renouvellement des appels si le dernier appel a échoué (par défaut les appels qui échouent sont renouvelés 3 fois cf https://react-query.tanstack.com/guides/important-defaults "Queries that fail are silently retried 3 times, with exponential backoff delay before capturing and displaying an error to the UI"  mais cela ne semble pas suffisant dans ce cas)

<img width="759" alt="Capture d’écran 2021-08-18 à 11 35 38" src="https://user-images.githubusercontent.com/22886846/129876078-a2e260d7-8716-473a-b1cc-8d405644324e.png">

