### PR TITLE
[Hors-ticket] TypeScript improvement: use ts-expect-error instead of ts-ignore

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
       2, // error
       {
         'ts-ignore': 'allow-with-description',
+        'ts-expect-error': 'allow-with-description',
         minimumDescriptionLength: 5,
       },
     ],

--- a/__mocks__/@react-native-async-storage/async-storage.ts
+++ b/__mocks__/@react-native-async-storage/async-storage.ts
@@ -1,2 +1,1 @@
-// @ts-ignore
 export { default } from '@react-native-async-storage/async-storage/jest/async-storage-mock'

--- a/__mocks__/react-native-svg.tsx
+++ b/__mocks__/react-native-svg.tsx
@@ -1,22 +1,24 @@
 import React from 'react'
-import { Text, View } from "react-native";
+import { Text, View } from 'react-native'
 
 const mockReactNativeSvg = jest.genMockFromModule('react-native-svg')
 
 const Svg = ({ testID, fill, width, height }) => {
-    const displayNameForTest = `${testID}-SVG-Mock`
-    return <View 
-        // @ts-ignore : fill, width, height do not exists on View, but for test purposes setting the props can be useful
-        fill={fill}
-        width={width}
-        height={height}
-        testID={testID}>  
-        <Text>{displayNameForTest}</Text>
+  const displayNameForTest = `${testID}-SVG-Mock`
+  return (
+    <View
+      // @ts-expect-error : fill, width, height do not exists on View, but for test purposes setting the props can be useful
+      fill={fill}
+      width={width}
+      height={height}
+      testID={testID}>
+      <Text>{displayNameForTest}</Text>
     </View>
-} 
+  )
+}
 
 module.exports = {
-    // @ts-ignore : the error is "Spread types may only be created from object types". Well the mock works anyway.
-    ...mockReactNativeSvg, 
-    default: Svg,
+  // @ts-expect-error : the error is "Spread types may only be created from object types". Well the mock works anyway.
+  ...mockReactNativeSvg,
+  default: Svg,
 }

--- a/src/api/__mocks__/helpers.ts
+++ b/src/api/__mocks__/helpers.ts
@@ -70,7 +70,7 @@ export const safeFetch = async (
     }
   }
 
-  // @ts-ignore
+  // @ts-expect-error
   const authorizationHeader: string = options.headers?.['Authorization'] || ''
   const token = authorizationHeader.replace('Bearer ', '')
   const tokenContent = decodeAccessToken(token)
@@ -185,4 +185,3 @@ export function extractApiErrorMessage(error: unknown) {
   }
   return message
 }
-

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -73,7 +73,7 @@ export const safeFetch = async (
     }
   }
 
-  // @ts-ignore
+  // @ts-expect-error
   const authorizationHeader: string = options.headers?.['Authorization'] || ''
   const token = authorizationHeader.replace('Bearer ', '')
   const tokenContent = decodeAccessToken(token)

--- a/src/features/auth/components/QuitSignupModal.native.test.tsx
+++ b/src/features/auth/components/QuitSignupModal.native.test.tsx
@@ -11,7 +11,7 @@ const resumeMock = jest.fn()
 
 describe('QuitSignupModal', () => {
   beforeEach(() => {
-    // @ts-ignore: logCancelSignup is the mock function but is seen as the real function
+    // @ts-expect-error: logCancelSignup is the mock function but is seen as the real function
     analytics.logCancelSignup.mockClear()
   })
 

--- a/src/features/auth/login/Login.native.test.tsx
+++ b/src/features/auth/login/Login.native.test.tsx
@@ -242,7 +242,7 @@ function simulateSigninWrongCredentials() {
       async (req, res, ctx) =>
         res(
           ctx.status(400),
-          // @ts-ignore: signin response type does not account for "not success" responses
+          // @ts-expect-error: signin response type does not account for "not success" responses
           ctx.json({
             general: ['Identifiant ou Mot de passe incorrect'],
           })
@@ -258,7 +258,7 @@ function simulateSigninRateLimitExceeded() {
       async (req, res, ctx) =>
         res(
           ctx.status(429),
-          // @ts-ignore: signin response type does not account for "not success" responses
+          // @ts-expect-error: signin response type does not account for "not success" responses
           ctx.json({
             general: [
               'Nombre de tentative de connexion dépassé. Veuillez réessayer dans 1 minute.',
@@ -276,7 +276,7 @@ function simulateSigninEmailNotValidated() {
       async (req, res, ctx) =>
         res(
           ctx.status(400),
-          // @ts-ignore: signin response type does not account for "not success" responses
+          // @ts-expect-error: signin response type does not account for "not success" responses
           ctx.json({
             code: 'EMAIL_NOT_VALIDATED',
             general: ["L'email n'a pas été validé."],

--- a/src/features/auth/signup/IdCheckV2.tsx
+++ b/src/features/auth/signup/IdCheckV2.tsx
@@ -97,7 +97,7 @@ export const IdCheckV2 = function IdCheckV2(props: ScreenNavigationProp<'IdCheck
     return <LoadingPage />
   }
 
-  // @ts-ignore : props typing issue with IdCheck screen from module.
+  // @ts-expect-error : props typing issue with IdCheck screen from module.
   // Probably needs some change on the side of the module.
   return <IdCheckHomePage {...props} />
 }

--- a/src/features/auth/signup/PhoneValidation/tests/SetPhoneNumber.native.test.tsx
+++ b/src/features/auth/signup/PhoneValidation/tests/SetPhoneNumber.native.test.tsx
@@ -36,7 +36,7 @@ let mockedSendSetPhoneNumberCode = jest.fn()
 describe('SetPhoneNumber', () => {
   beforeEach(() => {
     mockedSendSetPhoneNumberCode = mockedUseMutation.mockImplementation(
-      // @ts-ignore ts(2345)
+      // @ts-expect-error ts(2345)
       useMutationFactory(useMutationCallbacks)
     )
   })
@@ -147,7 +147,6 @@ describe('SetPhoneNumber', () => {
 
         await flushAllPromises()
 
-        // @ts-ignore use mock to get inner mutate
         const sendSetPhoneNumberCode = mockedSendSetPhoneNumberCode().mutate
         expect(sendSetPhoneNumberCode).toHaveBeenCalledTimes(numberOfCall)
       }

--- a/src/features/auth/signup/PhoneValidation/tests/SetPhoneValidationCode.native.test.tsx
+++ b/src/features/auth/signup/PhoneValidation/tests/SetPhoneValidationCode.native.test.tsx
@@ -49,7 +49,7 @@ const useMutationCallbacks: { onError: (error: unknown) => void; onSuccess: () =
 
 describe('SetPhoneValidationCode', () => {
   beforeEach(() => {
-    // @ts-ignore ts(2345)
+    // @ts-expect-error ts(2345)
     mockedUseMutation.mockImplementationOnce(useMutationFactory(useMutationCallbacks))
   })
 

--- a/src/features/auth/signup/PhoneValidation/tests/SetPhoneValidationCode.web.test.tsx
+++ b/src/features/auth/signup/PhoneValidation/tests/SetPhoneValidationCode.web.test.tsx
@@ -52,7 +52,7 @@ const useMutationCallbacks: { onError: (error: unknown) => void; onSuccess: () =
 
 describe('SetPhoneValidationCode', () => {
   beforeEach(() => {
-    // @ts-ignore ts(2345)
+    // @ts-expect-error ts(2345)
     mockedUseMutation.mockImplementationOnce(useMutationFactory(useMutationCallbacks))
   })
 

--- a/src/features/bookOffer/components/BookHourChoice.tsx
+++ b/src/features/bookOffer/components/BookHourChoice.tsx
@@ -53,7 +53,7 @@ export const BookHourChoice: React.FC = () => {
         })
         .sort(
           (a, b) =>
-            //@ts-ignore : stocks with no beginningDatetime was filtered
+            //@ts-expect-error : stocks with no beginningDatetime was filtered
             new Date(a.beginningDatetime).getTime() - new Date(b.beginningDatetime).getTime()
         )
         .map((stock) => (

--- a/src/features/bookOffer/components/__tests__/BookingImpossible.test.tsx
+++ b/src/features/bookOffer/components/__tests__/BookingImpossible.test.tsx
@@ -53,9 +53,9 @@ describe('<BookingImpossible />', () => {
     )
 
     mockedUseMutation
-      // @ts-ignore ts(2345)
+      // @ts-expect-error ts(2345)
       .mockImplementationOnce(mockUseMutationNotifyWebappLinkSent)
-      // @ts-ignore ts(2345)
+      // @ts-expect-error ts(2345)
       .mockImplementationOnce(useMutationFactory(useMutationAddFavoriteCallbacks))
 
     const { getByText } = render(<BookingImpossible />)

--- a/src/features/bookOffer/components/__tests__/BookingInformations.test.tsx
+++ b/src/features/bookOffer/components/__tests__/BookingInformations.test.tsx
@@ -41,7 +41,7 @@ describe('<BookingInformations />', () => {
   })
 
   it('should render event date section when event', async () => {
-    // @ts-ignore mock is not real type
+    // @ts-expect-error mock is not real type
     mockedUseBookingOffer.mockReturnValueOnce({
       category: { categoryType: CategoryType.Event, label: 'categoryLabel' },
       isDigital: false,
@@ -54,7 +54,7 @@ describe('<BookingInformations />', () => {
   })
 
   it('should display free wording is free', async () => {
-    // @ts-ignore mock is not real type
+    // @ts-expect-error mock is not real type
     mockedUseBookingOffer.mockReturnValueOnce({
       category: { categoryType: CategoryType.Event, label: 'categoryLabel' },
       isDigital: false,
@@ -62,7 +62,7 @@ describe('<BookingInformations />', () => {
       name: 'mon nom',
       stocks: [],
     })
-    // @ts-ignore mock is not real type
+    // @ts-expect-error mock is not real type
     mockedUseBookingStock.mockReturnValueOnce({
       beginningDatetime: new Date('2020-12-01T00:00:00Z'),
       price: 0,
@@ -72,7 +72,7 @@ describe('<BookingInformations />', () => {
     expect(myComponent).toMatchSnapshot()
   })
   it('should display unique price when quantity is unique', async () => {
-    // @ts-ignore mock is not real type
+    // @ts-expect-error mock is not real type
     mockedUseBookingOffer.mockReturnValueOnce({
       category: { categoryType: CategoryType.Event, label: 'categoryLabel' },
       isDigital: false,
@@ -94,7 +94,7 @@ describe('<BookingInformations />', () => {
   })
 
   it('should display expirationDate section when offer is digital and has expirationDate', async () => {
-    // @ts-ignore mock is not real type
+    // @ts-expect-error mock is not real type
     mockedUseBookingOffer.mockReturnValueOnce({
       category: { categoryType: CategoryType.Thing, label: 'categoryLabel' },
       isDigital: true,
@@ -106,7 +106,7 @@ describe('<BookingInformations />', () => {
     expect(myComponent).toMatchSnapshot()
   })
   it('should not display expirationDate section when offer is digital and has no expirationDate', async () => {
-    // @ts-ignore mock is not real type
+    // @ts-expect-error mock is not real type
     mockedUseBookingOffer.mockReturnValueOnce({
       category: { categoryType: CategoryType.Thing, label: 'categoryLabel' },
       isDigital: true,
@@ -114,7 +114,7 @@ describe('<BookingInformations />', () => {
       name: 'mon nom',
       stocks: [],
     })
-    // @ts-ignore mock is not real type
+    // @ts-expect-error mock is not real type
     mockedUseBookingStock.mockReturnValueOnce({
       beginningDatetime: new Date('2020-12-01T00:00:00Z'),
       price: 0,

--- a/src/features/bookings/components/CancelBookingModal.native.test.tsx
+++ b/src/features/bookings/components/CancelBookingModal.native.test.tsx
@@ -101,7 +101,7 @@ describe('<CancelBookingModal />', () => {
       onSuccess: () => {},
       onError: () => {},
     }
-    // @ts-ignore ts(2345)
+    // @ts-expect-error ts(2345)
     mockedUseMutation.mockImplementationOnce(useMutationFactory(useMutationCallbacks))
     const response = {
       content: { code: 'ALREADY_USED', message: 'La réservation a déjà été utilisée.' },

--- a/src/features/bookings/services/__tests__/useCancelBookingMutation.test.ts
+++ b/src/features/bookings/services/__tests__/useCancelBookingMutation.test.ts
@@ -27,7 +27,7 @@ describe('[hook] useCancelBookingMutation', () => {
 
   it('invalidates me and bookings after successfully cancel a booking', () => {
     const returnedMutationValue = useCancelBookingMutation({ onSuccess, onError })
-    // @ts-ignore returned value is mocked
+    // @ts-expect-error returned value is mocked
     const { mutationOptions } = returnedMutationValue
     mutationOptions.onSuccess()
     expect(onSuccess).toHaveBeenCalledWith()
@@ -37,14 +37,14 @@ describe('[hook] useCancelBookingMutation', () => {
 
   it('call api to cancel a booking', () => {
     const returnedMutationValue = useCancelBookingMutation({ onSuccess, onError })
-    // @ts-ignore returned value is mocked
+    // @ts-expect-error returned value is mocked
     const { mutationFunction } = returnedMutationValue
     mutationFunction('bookingId')
     expect(api.postnativev1bookingsbookingIdcancel).toHaveBeenCalledWith('bookingId')
   })
   it('call onError input after cancel a booking on error', () => {
     const returnedMutationValue = useCancelBookingMutation({ onSuccess, onError })
-    // @ts-ignore returned value is mocked
+    // @ts-expect-error returned value is mocked
     const { mutationOptions } = returnedMutationValue
     mutationOptions.onError()
     expect(onError).toHaveBeenCalledWith()

--- a/src/features/cheatcodes/pages/Navigation/Navigation.tsx
+++ b/src/features/cheatcodes/pages/Navigation/Navigation.tsx
@@ -213,7 +213,7 @@ export function Navigation(): JSX.Element {
             title={'Erreur rendering'}
             onPress={() => {
               // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
+              // @ts-expect-error
               setRenderedError(createElement(CenteredText, { children: CenteredText }))
             }}
           />

--- a/src/features/home/pages/tests/Home.native.test.tsx
+++ b/src/features/home/pages/tests/Home.native.test.tsx
@@ -166,7 +166,7 @@ describe('Home component - Analytics', () => {
     })
     expect(analytics.logAllModulesSeen).toHaveBeenCalledWith(0)
 
-    // @ts-ignore: logAllModulesSeen is the mock function but is seen as the real function
+    // @ts-expect-error: logAllModulesSeen is the mock function but is seen as the real function
     analytics.logAllModulesSeen.mockClear()
 
     await act(async () => {

--- a/src/features/navigation/NavigationContainer/NavigationContainer.tsx
+++ b/src/features/navigation/NavigationContainer/NavigationContainer.tsx
@@ -15,14 +15,14 @@ export const AppNavigationContainer = () => {
 
   useEffect(() => {
     return () => {
-      /* @ts-ignore : Cannot assign to 'current' because it is a read-only property. */
+      /* @ts-expect-error : Cannot assign to 'current' because it is a read-only property. */
       isNavigationReadyRef.current = false
     }
   }, [])
 
   function setRef(ref: NavigationContainerRef | null) {
     if (ref) {
-      /* @ts-ignore : Cannot assign to 'current' because it is a read-only property. */
+      /* @ts-expect-error : Cannot assign to 'current' because it is a read-only property. */
       navigationRef.current = ref
       setIsRefDefined(true)
     }
@@ -34,7 +34,7 @@ export const AppNavigationContainer = () => {
       onStateChange={onNavigationStateChange}
       ref={setRef}
       onReady={() => {
-        /* @ts-ignore : Cannot assign to 'current' because it is a read-only property. */
+        /* @ts-expect-error : Cannot assign to 'current' because it is a read-only property. */
         isNavigationReadyRef.current = true
       }}
       theme={NAV_THEME}>

--- a/src/features/navigation/TabBar/__tests__/TabBar.native.test.tsx
+++ b/src/features/navigation/TabBar/__tests__/TabBar.native.test.tsx
@@ -34,7 +34,7 @@ const navigation: NavigationHelpers<ParamListBase, BottomTabNavigationEventMap> 
   dangerouslyGetParent: jest.fn(),
   dangerouslyGetState: jest.fn(),
   dispatch: jest.fn(),
-  // @ts-ignore : ignore type of emit to facilitate testing
+  // @ts-expect-error : ignore type of emit to facilitate testing
   emit: jest.fn(() => ({ defaultPrevented: false })),
   goBack: jest.fn(),
   isFocused: jest.fn(),

--- a/src/features/navigation/TabBar/__tests__/TabBar.web.test.tsx
+++ b/src/features/navigation/TabBar/__tests__/TabBar.web.test.tsx
@@ -34,7 +34,7 @@ const navigation: NavigationHelpers<ParamListBase, BottomTabNavigationEventMap> 
   dangerouslyGetParent: jest.fn(),
   dangerouslyGetState: jest.fn(),
   dispatch: jest.fn(),
-  // @ts-ignore : ignore type of emit to facilitate testing
+  // @ts-expect-error : ignore type of emit to facilitate testing
   emit: jest.fn(() => ({ defaultPrevented: false })),
   goBack: jest.fn(),
   isFocused: jest.fn(),

--- a/src/features/offer/components/__tests__/OfferPartialDescription.web.test.tsx
+++ b/src/features/offer/components/__tests__/OfferPartialDescription.web.test.tsx
@@ -14,14 +14,14 @@ describe('OfferPartialDescription', () => {
   it('centers CTA when provided description is empty', async () => {
     const { getByTestId } = await renderOfferDescription('')
     const offerSeeMoreContainer = getByTestId('offerSeeMoreContainer')
-    // @ts-ignore FIXME see how to fix typing
+    // @ts-expect-error FIXME see how to fix typing
     const { 'align-self': alignSelf } = offerSeeMoreContainer.style
     expect(alignSelf).toBe('center')
   })
   it('places CTA on flex-end when provided a description', async () => {
     const { getByTestId } = await renderOfferDescription(description)
     const offerSeeMoreContainer = getByTestId('offerSeeMoreContainer')
-    // @ts-ignore FIXME see how to fix typing
+    // @ts-expect-error FIXME see how to fix typing
     const { 'align-self': alignSelf } = offerSeeMoreContainer.style
     expect(alignSelf).toBe('flex-end')
   })

--- a/src/features/offer/components/__tests__/ReportOfferOtherReasonModal.native.test.tsx
+++ b/src/features/offer/components/__tests__/ReportOfferOtherReasonModal.native.test.tsx
@@ -47,7 +47,7 @@ describe('<ReportOfferOtherReasonModal />', () => {
         onSuccess: () => {},
         onError: () => {},
       }
-      // @ts-ignore ts(2345)
+      // @ts-expect-error ts(2345)
       mockedUseMutation.mockImplementationOnce(useMutationFactory(useMutationCallbacks))
 
       const { getByTestId } = renderReportOtherReasonModal()
@@ -69,7 +69,7 @@ describe('<ReportOfferOtherReasonModal />', () => {
         onSuccess: () => {},
         onError: () => {},
       }
-      // @ts-ignore ts(2345)
+      // @ts-expect-error ts(2345)
       mockedUseMutation.mockImplementationOnce(useMutationFactory(useMutationCallbacks))
       const response = {
         content: { code: 'ERROR', message: "Une erreur s'est produite" },

--- a/src/features/offer/components/__tests__/ReportOfferReasonModal.native.test.tsx
+++ b/src/features/offer/components/__tests__/ReportOfferReasonModal.native.test.tsx
@@ -76,7 +76,7 @@ describe('<ReportOfferReasonModal />', () => {
         onSuccess: () => {},
         onError: () => {},
       }
-      // @ts-ignore ts(2345)
+      // @ts-expect-error ts(2345)
       mockedUseMutation.mockImplementationOnce(useMutationFactory(useMutationCallbacks))
 
       const { getByTestId } = renderReportReasonModal()
@@ -98,7 +98,7 @@ describe('<ReportOfferReasonModal />', () => {
         onSuccess: () => {},
         onError: () => {},
       }
-      // @ts-ignore ts(2345)
+      // @ts-expect-error ts(2345)
       mockedUseMutation.mockImplementationOnce(useMutationFactory(useMutationCallbacks))
       const response = {
         content: { code: 'ERROR', message: "Une erreur s'est produite" },

--- a/src/features/offer/pages/tests/Offer.analytics.native.test.tsx
+++ b/src/features/offer/pages/tests/Offer.analytics.native.test.tsx
@@ -99,7 +99,7 @@ describe('<Offer /> - Analytics', () => {
     await superFlushWithAct(25)
     expect(analytics.logConsultWholeOffer).toHaveBeenCalledWith(offerId)
 
-    // @ts-ignore: logConsultWholeOffer is the mock function but is seen as the real function
+    // @ts-expect-error: logConsultWholeOffer is the mock function but is seen as the real function
     analytics.logConsultWholeOffer.mockClear()
 
     await act(async () => {

--- a/src/features/profile/pages/ConfirmDeleteProfile.test.tsx
+++ b/src/features/profile/pages/ConfirmDeleteProfile.test.tsx
@@ -38,7 +38,7 @@ describe('ConfirmDeleteProfile component', () => {
     const useMutationCallbacks: { onSuccess: () => void } = {
       onSuccess: () => {},
     }
-    // @ts-ignore ts(2345)
+    // @ts-expect-error ts(2345)
     mockedUseMutation.mockImplementationOnce(useMutationFactory(useMutationCallbacks))
     const renderAPI = render(reactQueryProviderHOC(<ConfirmDeleteProfile />))
     fireEvent.press(renderAPI.getByText('Supprimer mon compte'))
@@ -55,7 +55,7 @@ describe('ConfirmDeleteProfile component', () => {
     const useMutationCallbacks: { onError: (error: unknown) => void } = {
       onError: () => {},
     }
-    // @ts-ignore ts(2345)
+    // @ts-expect-error ts(2345)
     mockedUseMutation.mockImplementationOnce(useMutationFactory(useMutationCallbacks))
     const renderAPI = render(reactQueryProviderHOC(<ConfirmDeleteProfile />))
     fireEvent.press(renderAPI.getByText('Supprimer mon compte'))

--- a/src/features/profile/pages/Profile.native.test.tsx
+++ b/src/features/profile/pages/Profile.native.test.tsx
@@ -23,7 +23,7 @@ import { Profile } from './Profile'
 
 const mockNavigate = jest.fn()
 jest.mock('@react-navigation/native', () => ({
-  // @ts-ignore : Spread types may only be created from object types.
+  // @ts-expect-error : Spread types may only be created from object types.
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({ navigate: mockNavigate }),
 }))

--- a/src/features/search/components/CalendarPicker.android.tsx
+++ b/src/features/search/components/CalendarPicker.android.tsx
@@ -27,7 +27,7 @@ export const CalendarPicker: React.FC<Props> = ({
       mode="date"
       is24Hour={true}
       display="spinner"
-      // @ts-ignore FIXME: Types of parameters 'event' and 'event' are incompatible. Type 'Event' is not assignable to type 'AndroidEvent'. Added with PR #1272 when adding Web support
+      // @ts-expect-error FIXME: Types of parameters 'event' and 'event' are incompatible. Type 'Event' is not assignable to type 'AndroidEvent'. Added with PR #1272 when adding Web support
       onChange={onChange}
     />
   )

--- a/src/features/search/components/CalendarPicker.ios.tsx
+++ b/src/features/search/components/CalendarPicker.ios.tsx
@@ -36,7 +36,7 @@ export const CalendarPicker: React.FC<Props> = ({
           mode="date"
           is24Hour={true}
           display="spinner"
-          // @ts-ignore FIXME: Type '(_event: Event, newDate: Date | undefined) => void' is not assignable to type '(event: Event, date?: Date | undefined) => void'. Added with PR #1272 when adding Web support
+          // @ts-expect-error FIXME: Type '(_event: Event, newDate: Date | undefined) => void' is not assignable to type '(event: Event, date?: Date | undefined) => void'. Added with PR #1272 when adding Web support
           onChange={onChange}
           textColor={ColorsEnum.BLACK}
           locale="fr-FR"

--- a/src/features/search/pages/__tests__/SearchFilter.native.test.tsx
+++ b/src/features/search/pages/__tests__/SearchFilter.native.test.tsx
@@ -11,7 +11,7 @@ import { render } from 'tests/utils'
 import { initialSearchState } from '../reducer'
 import { SearchFilter } from '../SearchFilter'
 
-// @ts-ignore: solution find on the github repo to the issue https://github.com/react-native-datetimepicker/datetimepicker/issues/216
+// @ts-expect-error: solution find on the github repo to the issue https://github.com/react-native-datetimepicker/datetimepicker/issues/216
 RNDateTimePicker.mockImplementation((props) => <View testID={props.testID} />)
 
 const mockSearchState = initialSearchState

--- a/src/libs/__tests__/remoteStore.test.ts
+++ b/src/libs/__tests__/remoteStore.test.ts
@@ -11,7 +11,7 @@ describe('remoteStore', () => {
     firestore()
       .collection('maintenance')
       .doc('testing')
-      // @ts-ignore is a mock
+      // @ts-expect-error is a mock
       .onSnapshot.mockImplementationOnce((localOnNext) => {
         onNext = localOnNext
       })
@@ -28,7 +28,7 @@ describe('remoteStore', () => {
     })
     it('should set up listener with given callback', () => {
       const get = jest.fn().mockReturnValue('getReturn')
-      // @ts-ignore is an incomplete mock
+      // @ts-expect-error is an incomplete mock
       const docSnapshot: FirebaseFirestoreTypes.DocumentSnapshot = { get }
       onNext(docSnapshot)
       expect(get).toHaveBeenCalledWith('maintenanceIsOn')

--- a/src/libs/codepush/CodePushProvider.tsx
+++ b/src/libs/codepush/CodePushProvider.tsx
@@ -13,11 +13,11 @@ const codePushOptionsAuto = {
 const CodePushWrapper = (AppComponent: React.Component) =>
   CodePush(codePushOptionsAuto)(AppComponent)
 
-// @ts-ignore no-param
+// @ts-expect-error no-param
 const CodePushContext = createContext<CodePushContext>({})
 
 export const CodePushProvider = CodePushWrapper(
-  // @ts-ignore no-param
+  // @ts-expect-error no-param
   class App extends React.Component<Record<string, unknown>, CodePushContext> {
     state = {
       status: null,

--- a/src/libs/geolocation/requestGeolocPermission.web.test.ts
+++ b/src/libs/geolocation/requestGeolocPermission.web.test.ts
@@ -50,7 +50,7 @@ describe('requestGeolocPermission web', () => {
   })
 
   it('should return NEVER_ASK_AGAIN if web permission is something else', async () => {
-    // @ts-ignore : we purposely return an "impossible value" for the sake of the test
+    // @ts-expect-error : we purposely return an "impossible value" for the sake of the test
     mockQuery.mockResolvedValueOnce({ state: 'something else' })
     const state = await requestGeolocPermission()
     expect(state).toEqual(GeolocPermissionState.NEVER_ASK_AGAIN)

--- a/src/libs/itinerary/useItinerary.native.test.ts
+++ b/src/libs/itinerary/useItinerary.native.test.ts
@@ -58,11 +58,11 @@ describe('useItinerary', () => {
       { cancelable: true }
     )
 
-    // @ts-ignore: precedent expect garanties what follows
+    // @ts-expect-error: precedent expect garanties what follows
     const wazeAlertButton = alertMock.mock.calls[0][2][1]
     expect(wazeAlertButton.text).toBe('Waze')
 
-    // @ts-ignore: same reason
+    // @ts-expect-error: same reason
     wazeAlertButton.onPress()
     expect(navigate).toHaveBeenCalledWith([48.85837, 2.294481], { app: 'waze' })
   })
@@ -157,9 +157,9 @@ describe('useItinerary', () => {
       ],
       { cancelable: true }
     )
-    // @ts-ignore: precedent assertion garanties next line
+    // @ts-expect-error: precedent assertion garanties next line
     const { onPress: onWazePress } = alertMock.mock.calls[0][2][1]
-    // @ts-ignore: same reason
+    // @ts-expect-error: same reason
     onWazePress()
     await waitForExpect(() =>
       expect(mockShowInfoSnackBar).toHaveBeenCalledWith({

--- a/src/libs/react-native-svg/Image.web.tsx
+++ b/src/libs/react-native-svg/Image.web.tsx
@@ -2,6 +2,6 @@ import React from 'react'
 import { Image as ImageDefault, ImageProps as ImagePropsDefault } from 'react-native-svg'
 
 export const Image = function Image({ href, ...rest }: ImagePropsDefault) {
-  // @ts-ignore on the web, react-native-svg Image expect the href to be a string, not an object with { uri }
+  // @ts-expect-error on the web, react-native-svg Image expect the href to be a string, not an object with { uri }
   return <ImageDefault href={href?.uri} {...rest} />
 }

--- a/src/serviceWorkerRegistration.ts
+++ b/src/serviceWorkerRegistration.ts
@@ -26,7 +26,7 @@ type Config = {
 export function register(config?: Config) {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
-    // @ts-ignore TODO: fix typing
+    // @ts-expect-error TODO: fix typing
     const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href)
     if (publicUrl.origin !== window.location.origin) {
       // Our service worker won't work if PUBLIC_URL is on a different origin

--- a/src/tests/utils.tsx
+++ b/src/tests/utils.tsx
@@ -83,7 +83,6 @@ const LinguiProvider: React.FC = ({ children }) => {
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const customRender = (ui: React.ReactElement<any>, options?: RenderOptions) =>
   render(ui, {

--- a/src/tests/utils/web.tsx
+++ b/src/tests/utils/web.tsx
@@ -83,7 +83,6 @@ const LinguiProvider: React.FC = ({ children }) => {
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const customRender = (ui: React.ReactElement<any>, options?: RenderOptions) =>
   render(ui, {

--- a/src/ui/components/achievements/components/GenericAchievementCard.tsx
+++ b/src/ui/components/achievements/components/GenericAchievementCard.tsx
@@ -108,7 +108,6 @@ Those props are provided by the GenericAchievementCard and must be passed down t
       <StyledBody>{props.text}</StyledBody>
       <Spacer.Flex flex={2} />
       <BottomButtonsContainer>
-        {/* @ts-ignore: incompatible types relative to animatable */}
         <Animatable.View ref={animatedButtonRef}>
           {props.activeIndex === props.index ? (
             <ButtonPrimary title={props.buttonText} onPress={props.buttonCallback} />

--- a/src/ui/components/hero/__tests__/Hero.native.test.tsx
+++ b/src/ui/components/hero/__tests__/Hero.native.test.tsx
@@ -13,7 +13,7 @@ describe('HeroImage', () => {
   })
 
   it('shows both placeholders when url is undefined', () => {
-    // @ts-ignore : for test purpose
+    // @ts-expect-error : for test purpose
     const { queryByTestId } = render(<Hero imageUrl={undefined} />)
     expect(queryByTestId('BackgroundPlaceholder')).toBeTruthy()
     expect(queryByTestId('categoryIcon')).toBeTruthy()

--- a/src/ui/components/hero/__tests__/Hero.web.test.tsx
+++ b/src/ui/components/hero/__tests__/Hero.web.test.tsx
@@ -13,7 +13,7 @@ describe('HeroImage', () => {
   })
 
   it('shows both placeholders when url is undefined', () => {
-    // @ts-ignore : for test purpose
+    // @ts-expect-error : for test purpose
     const { queryByTestId } = render(<Hero imageUrl={undefined} />)
     expect(queryByTestId('BackgroundPlaceholder')).toBeTruthy()
     expect(queryByTestId('categoryIcon')).toBeTruthy()

--- a/src/ui/components/inputs/BaseTextInput.tsx
+++ b/src/ui/components/inputs/BaseTextInput.tsx
@@ -52,10 +52,10 @@ export const BaseTextInput = forwardRef<RNTextInput, RNTextInputProps>(function 
       placeholder={restOfProps.placeholder || ''}
       ref={(ref) => {
         if (ref) {
-          /* @ts-ignore Conflicts between types */
+          /* @ts-expect-error Conflicts between types */
           inputRef.current = ref
           if (forwardedRef) {
-            /* @ts-ignore Conflicts between types */
+            /* @ts-expect-error Conflicts between types */
             forwardedRef.current = ref
           }
         }

--- a/src/ui/components/snackBar/SnackBar.tsx
+++ b/src/ui/components/snackBar/SnackBar.tsx
@@ -113,7 +113,6 @@ const _SnackBar = (props: SnackBarProps) => {
         backgroundColor={props.backgroundColor}
         easing="ease"
         duration={animationDuration}
-        // @ts-ignore: incompatible types relative to animatable
         ref={containerRef}>
         <SnackBarContainer isVisible={isVisible} marginTop={top} testID="snackbar-container">
           {!!Icon && <Icon testID="snackbar-icon" size={32} color={props.color} />}
@@ -130,7 +129,6 @@ const _SnackBar = (props: SnackBarProps) => {
           </TouchableOpacity>
         </SnackBarContainer>
       </ColoredAnimatableView>
-      {/* @ts-ignore: incompatible types relattive to animatable */}
       <AnimatableView easing="ease" duration={animationDuration} ref={progressBarContainerRef}>
         <ProgressBar
           testID="snackbar-progressbar"
@@ -184,6 +182,6 @@ const ProgressBar = styled(Animated.View)<{
   display: isVisible ? 'flex' : 'none',
   height: 4,
   backgroundColor: backgroundColor,
-  // @ts-ignore: avoid typescript error due to not supported Animated Css/Styles types
+  // @ts-expect-error: avoid typescript error due to not supported Animated Css/Styles types
   width: width._value /* The alternative is to use inline style */,
 }))


### PR DESCRIPTION
Une proposition de migration de @ts-ignore vers @ts-expect-error disponible depuis TypeScript 3.9.

Le défaut majeur des commentaires ts-ignore est qu'on ne peut pas savoir facilement quand est-ce qu'il ne servent plus à rien (que ce soit parce qu'on a réparé le typage ou parce que TypeScript a été mis à jour et donc interprète mieux des types qu'il considérait comme incorrects avant).

Il s'agit de la même feature mais ts-expect-error throw une erreur ts si jamais il est utilisé pour rien. Les ts-expect-error deviennent donc un indicateur plus précis des vraies erreurs de typage de notre code.

Cette PR me permet de supprimer 6 ts-ignore inutiles sur les 44 présents dans le code (sauf erreur de ma part).
