### PR TITLE
(PC-10494) App Native - FrontEnd - Corriger le delai entre l appel au getProfile et le call backend sessionId

### DIFF
--- a/src/features/auth/signup/PhoneValidation/tests/SetPhoneValidationCode.native.test.tsx
+++ b/src/features/auth/signup/PhoneValidation/tests/SetPhoneValidationCode.native.test.tsx
@@ -41,6 +41,10 @@ jest.mock('features/home/api', () => ({
   })),
 }))
 
+jest.mock('@pass-culture/react-native-profiling', () => ({
+  profileDevice: jest.fn(),
+}))
+
 const mockedUseMutation = mocked(useMutation)
 const useMutationCallbacks: { onError: (error: unknown) => void; onSuccess: () => void } = {
   onSuccess: () => {},
@@ -112,7 +116,7 @@ describe('SetPhoneValidationCode', () => {
       })
     })
 
-    it.only.each([
+    it.each([
       ['empty', ''],
       ['is too short', '54'],
     ])('should not enable continue button when "%s"', async (_reason, codeTyped) => {

--- a/src/features/auth/signup/PhoneValidation/tests/SetPhoneValidationCode.web.test.tsx
+++ b/src/features/auth/signup/PhoneValidation/tests/SetPhoneValidationCode.web.test.tsx
@@ -44,6 +44,10 @@ jest.mock('features/home/api', () => ({
   })),
 }))
 
+jest.mock('@pass-culture/react-native-profiling', () => ({
+  profileDevice: jest.fn(),
+}))
+
 const mockedUseMutation = mocked(useMutation)
 const useMutationCallbacks: { onError: (error: unknown) => void; onSuccess: () => void } = {
   onSuccess: () => {},
@@ -105,7 +109,7 @@ describe('SetPhoneValidationCode', () => {
     })
   })
 
-  describe.skip('Continue button', () => {
+  describe('Continue button', () => {
     it('should enable continue button if input is valid and complete', async () => {
       const { getByTestId } = renderModalWithFilledCodeInput('123456')
       const continueButton = getByTestId('Continuer')


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10494

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
