### PR TITLE
(PC-10376) Remove unnecessary calendar horizontal margins + widening …

### DIFF
--- a/src/features/bookOffer/components/Calendar/Calendar.tsx
+++ b/src/features/bookOffer/components/Calendar/Calendar.tsx
@@ -61,6 +61,9 @@ export const getMinAvailableDate = (markedDates: MarkedDates): string | undefine
   )[0]
 }
 
+// Hack to remove unnecessary calendar horizontal margins
+const RNCalendarTheme = { marginHorizontal: getSpacing(-2) }
+
 export const Calendar: React.FC<Props> = ({ stocks, userRemainingCredit, offerId }) => {
   const markedDates = useMarkedDates(stocks, userRemainingCredit || 0)
   const minDate = getMinAvailableDate(markedDates) || new Date()
@@ -68,6 +71,7 @@ export const Calendar: React.FC<Props> = ({ stocks, userRemainingCredit, offerId
 
   return (
     <RNCalendar
+      style={RNCalendarTheme}
       current={minDate}
       firstDay={1}
       enableSwipeMonths={true}
@@ -113,5 +117,5 @@ const Container = styled.TouchableOpacity.attrs(() => ({
   hitSlop,
 }))({
   alignItems: 'center',
-  width: getSpacing(8),
+  width: getSpacing(9.25), // Max width limite for small devices
 })


### PR DESCRIPTION
…the width of day button

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10376

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Added a **screenshot** for UI tickets.

**Pourquoi ces changements ?**
En augmentant la largeur du calendrier (réduction des marges horizontales), on gagne quelques pixels qui permettent d'afficher correctement les prix dans les boutons sur petits devices. 

## Screenshots

| Calendar avec / sans marge | Taille des boutons | Résultat final | 
| -------------------- | :----------------------: | :----------------------: |
|  <img width="825" alt="Capture d’écran 2021-08-23 à 19 38 32" src="https://user-images.githubusercontent.com/62059034/130492423-db2e12ea-bd58-45c3-92d2-0ec3e7a5d628.png"> <img width="710" alt="Capture d’écran 2021-08-23 à 19 38 42" src="https://user-images.githubusercontent.com/62059034/130492427-131df7ee-18ec-4f78-a751-159595e93e19.png"> | <img width="786" alt="Capture d’écran 2021-08-23 à 19 39 00" src="https://user-images.githubusercontent.com/62059034/130492464-d6a3590b-ddd4-4da6-a109-26476b201587.png"> | <img width="779" alt="Capture d’écran 2021-08-23 à 19 45 25" src="https://user-images.githubusercontent.com/62059034/130493015-889b9cc3-2703-4a3e-9602-43e3404602e3.png"> |
