### PR TITLE
(tech) do not sanitize geolocation when not provided

### DIFF
--- a/src/features/search/utils/sanitizeSearchStateParams.ts
+++ b/src/features/search/utils/sanitizeSearchStateParams.ts
@@ -3,6 +3,7 @@ import { clampPrice } from 'features/search/pages/reducer.helpers'
 import { RecursivePartial, SearchState } from 'features/search/types'
 
 export const sanitizedSearchStateRequiredDefaults = {
+  geolocation: null,
   offerCategories: [],
   query: '',
   tags: [],
@@ -36,7 +37,7 @@ export const sanitizeSearchStateParams = (searchState: RecursivePartial<SearchSt
     ...(beginningDatetime ? { beginningDatetime } : {}),
     ...(date ? { date } : {}),
     ...(endingDatetime ? { endingDatetime } : {}),
-    ...(geolocation ? { geolocation } : {}),
+    geolocation: geolocation || sanitizedSearchStateRequiredDefaults.geolocation,
     ...(hitsPerPage ? { hitsPerPage } : {}),
     ...(locationType !== LocationType.EVERYWHERE ? { locationType } : {}),
     offerCategories: offerCategories || sanitizedSearchStateRequiredDefaults.offerCategories,

--- a/src/features/search/utils/tests/sanitizeSearchStateParams.test.ts
+++ b/src/features/search/utils/tests/sanitizeSearchStateParams.test.ts
@@ -25,6 +25,15 @@ describe('sanitizeSearchStateParams', () => {
     expect(offerCategories).not.toBeUndefined()
   })
 
+  it('should sanitize geolocation to null when not provided', () => {
+    let { geolocation } = sanitizeSearchStateParams({
+      geolocation: { latitude: 10, longitude: 5 },
+    })
+    expect(geolocation).toEqual({ latitude: 10, longitude: 5 })
+    geolocation = sanitizeSearchStateParams({ geolocation: undefined }).geolocation
+    expect(geolocation).toBeNull()
+  })
+
   it('should sanitize tags to empty array when not provided', () => {
     const sanitizedSearchStateParams = sanitizeSearchStateParams({ tags: ['special'] })
     expect(sanitizedSearchStateParams).toEqual({
@@ -45,7 +54,6 @@ describe('sanitizeSearchStateParams', () => {
     ${`beginningDatetime`} | ${new Date('2021-01-01')}
     ${`date`}              | ${new Date('2021-01-01')}
     ${`endingDatetime`}    | ${new Date('2021-01-01')}
-    ${`geolocation`}       | ${{ latitude: 10, longitude: 20 }}
     ${`offerIsDuo`}        | ${true}
     ${`offerIsFree`}       | ${true}
     ${`offerIsNew`}        | ${true}


### PR DESCRIPTION
Suite à l'ajout de la feature de sanitization des query params de search:

React Navigation 5 merge les `route.params`.

React Navigation 6 change ce comportement par un override et introduit un `{ merge: true }`

Source: https://reactnavigation.org/docs/params/#passing-params-to-a-previous-screen | https://reactnavigation.org/blog/2021/03/12/react-navigation-6.0-next/#highlights

Actuellement, si on set un `route.params`, à moins de le unset, re-naviguer vers `Search` qui autorise ces params à pour conséquence que les routes params se mergent.

Ce `route.params`, ensuite modifie le state ici : https://github.com/pass-culture/pass-culture-app-native/blob/master/src/features/search/pages/reducer.ts#L67

Donc la => https://github.com/pass-culture/pass-culture-app-native/blob/master/src/features/search/utils/searchRouteParamsToSearchState.ts#L7-L16

Normalement, l'ancien set pas défini devait se `reset` avec le default, sauf que le default vaut toujours l'ancienne valeur, du coup on set une nouvelle valeur.

Solution plus long term: upgrade to RN6


## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
