### PR TITLE
(PC-10579) SetBirthday / Dateinput : handle date comparison only with navigator local time

### DIFF
--- a/package.json
+++ b/package.json
@@ -263,6 +263,7 @@
     "snapshot-diff": "^0.8.1",
     "style-loader": "^2.0.0",
     "terser-webpack-plugin": "^4.2.3",
+    "timezone-mock": "^1.2.1",
     "ts-jest": "^26.5.6",
     "typescript": "^4.3.5",
     "url-loader": "^4.1.1",

--- a/src/features/auth/signup/SetBirthday/SetBirthday.tsx
+++ b/src/features/auth/signup/SetBirthday/SetBirthday.tsx
@@ -42,7 +42,6 @@ if (__DEV__ && env.SIGNUP_DATE) {
 }
 
 const YOUNGEST_AGE = 16
-
 const MIN_DATE = new Date('1900-01-01T00:00:00Z')
 
 interface State {
@@ -66,9 +65,8 @@ export const SetBirthday: FunctionComponent<Props> = ({ route }) => {
   const deposit = useDepositAmount()
 
   const now = new Date()
-  const currentYear = now.getUTCFullYear()
-  const maxDate = new Date(now)
-  maxDate.setFullYear(currentYear - YOUNGEST_AGE)
+  const maxYear = now.getFullYear() - YOUNGEST_AGE
+  const maxDate = new Date(maxYear, now.getMonth(), now.getDate())
 
   const {
     visible: informationModalVisible,

--- a/src/ui/components/inputs/DateInput.native.test.tsx
+++ b/src/ui/components/inputs/DateInput.native.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import timezoneMock from 'timezone-mock'
 
 import { fireEvent, render } from 'tests/utils'
 import { ColorsEnum } from 'ui/theme'
@@ -7,7 +8,6 @@ import { DateInput, DateInputRef, FULL_DATE_VALIDATOR } from './DateInput'
 
 describe('DateInput Component', () => {
   it('should render ref and give access to clearFocuses function', () => {
-    // given
     const myRef = React.createRef<DateInputRef>()
     render(<DateInput ref={myRef} />)
 
@@ -229,11 +229,12 @@ describe('DateInput Component', () => {
       [31, 9, 2005],
       [31, 11, 2005],
     ])('should return false when the date is invalid (DD-MM-AAAA) %s-%s-%s', (day, month, year) => {
-      const date = new Date(Date.UTC(year, month - 1, day))
+      const date = new Date(year, month - 1, day)
       expect(FULL_DATE_VALIDATOR.isValid(date, year, month, day)).toBeFalsy()
     })
 
-    it.each([
+    const VALID_DATES = [
+      [1, 2, 2003],
       [29, 2, 2004], // leap year
       [29, 2, 2008], // leap year
       [29, 2, 2012], // leap year
@@ -241,10 +242,23 @@ describe('DateInput Component', () => {
       [31, 5, 2005],
       [31, 7, 2005],
       [31, 8, 2005],
-    ])('should return true when the date is valid (DD-MM-AAAA) %s-%s-%s', (day, month, year) => {
-      const date = new Date(Date.UTC(year, month - 1, day))
-      expect(FULL_DATE_VALIDATOR.isValid(date, year, month, day)).toBeTruthy()
-    })
+    ]
+    it.each(VALID_DATES)(
+      'should return true when the date is valid (DD-MM-AAAA) %s-%s-%s with timezone Brazil/East',
+      (day, month, year) => {
+        timezoneMock.register('Brazil/East')
+        const date = new Date(year, month - 1, day)
+        expect(FULL_DATE_VALIDATOR.isValid(date, year, month, day)).toBeTruthy()
+      }
+    )
+    it.each(VALID_DATES)(
+      'should return true when the date is valid (DD-MM-AAAA) %s-%s-%s with timezone Europe/London',
+      (day, month, year) => {
+        timezoneMock.register('Europe/London')
+        const date = new Date(year, month - 1, day)
+        expect(FULL_DATE_VALIDATOR.isValid(date, year, month, day)).toBeTruthy()
+      }
+    )
   })
 
   describe('with date limits', () => {

--- a/src/ui/components/inputs/DateInput.tsx
+++ b/src/ui/components/inputs/DateInput.tsx
@@ -52,7 +52,7 @@ export const FULL_DATE_VALIDATOR = {
       date instanceof Date &&
       date.getFullYear() == year &&
       date.getMonth() == month - 1 &&
-      date.getUTCDate() == day
+      date.getDate() == day
     )
   },
 }
@@ -79,7 +79,7 @@ const WithRefDateInput: React.ForwardRefRenderFunction<DateInputRef, DateInputPr
   const dayNb = Number(day)
   const monthNb = Number(month)
   const yearNb = Number(year)
-  const date = new Date(Date.UTC(yearNb, monthNb - 1, dayNb))
+  const date = new Date(yearNb, monthNb - 1, dayNb)
 
   const isDayValid = DAY_VALIDATOR.isValid(dayNb) && DAY_VALIDATOR.hasRightLength(day)
   const isMonthValid = MONTH_VALIDATOR.isValid(monthNb) && MONTH_VALIDATOR.hasRightLength(month)

--- a/yarn.lock
+++ b/yarn.lock
@@ -17848,6 +17848,11 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+timezone-mock@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/timezone-mock/-/timezone-mock-1.2.1.tgz#f470559b2b4f7a0203f203d5e38a097150c4af2c"
+  integrity sha512-zpAS+mQtQ9NCR6pT1tuL/WS3n/rHvv9ueDF1pJU4PFtedLwdJf3pUgjgtpZLJ9sMIb96ELcM39YlM015kbtutw==
+
 timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10579

Problème : la validité de la date était vérifiée avec `getUTCMonth`, et avec le fuseau horaire de la martinique et mettant le 1er du mois (n'importe quel mois), on avait un mismatch et la fonction de validité considérait que la date était invalide...
My bad c'est moi qui l'ait conçu originalement. Je sais pas comment j'ai pu laissé les notions de UTC de base côté frontend, et en plus l'avoir mise sur le mois uniquement...

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.