### PR TITLE
[pc-9674] Prevent info page from bouncing

### DIFF
--- a/__snapshots__/features/auth/signup/AccountCreated/tests/AccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/AccountCreated/tests/AccountCreated.native.test.tsx.native-snap
@@ -37,6 +37,7 @@ exports[`<AccountCreated /> should render correctly 1`] = `
     </View>
   </View>
   <RCTScrollView
+    bounces={false}
     contentContainerStyle={
       Object {
         "alignItems": "center",

--- a/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.native-snap
@@ -37,6 +37,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
     </View>
   </View>
   <RCTScrollView
+    bounces={false}
     contentContainerStyle={
       Object {
         "alignItems": "center",

--- a/src/ui/components/GenericInfoPage.tsx
+++ b/src/ui/components/GenericInfoPage.tsx
@@ -30,7 +30,7 @@ export const GenericInfoPage: FunctionComponent<Props> = (props) => {
   return (
     <Container>
       <Background />
-      <ScrollView contentContainerStyle={scrollViewContentContainerStyle}>
+      <ScrollView bounces={false} contentContainerStyle={scrollViewContentContainerStyle}>
         <Spacer.Column numberOfSpaces={spacingMatrix.top} />
         {Icon ? (
           <React.Fragment>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-9674

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
