### PR TITLE
(PC-10560) Offer - Add safeAreaTop inset to OfferHeader height (fix iPhone 11)

### DIFF
--- a/__snapshots__/features/offer/components/__tests__/OfferHeader.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/__tests__/OfferHeader.native.test.tsx.native-snap
@@ -3,9 +3,11 @@
 exports[`<OfferHeader /> should render correctly 1`] = `
 Array [
   <View
+    safeAreaTop={16}
     style={
       Object {
         "backgroundColor": "rgba(255, 255, 255, 0)",
+        "height": 80,
         "position": "absolute",
         "top": 0,
         "width": "100%",

--- a/__snapshots__/features/offer/components/__tests__/OfferHeader.web.test.tsx.web-snap
+++ b/__snapshots__/features/offer/components/__tests__/OfferHeader.web.test.tsx.web-snap
@@ -9,7 +9,7 @@ Object {
       <div
         class="css-view-1dbjc4n"
         id="animatedComponent"
-        style="background-color: rgba(255, 255, 255, 0); position: absolute; top: 0px; width: 100%;"
+        style="background-color: rgba(255, 255, 255, 0); height: 80px; position: absolute; top: 0px; width: 100%;"
       >
         <div
           class="css-view-1dbjc4n"
@@ -372,7 +372,7 @@ Object {
     <div
       class="css-view-1dbjc4n"
       id="animatedComponent"
-      style="background-color: rgba(255, 255, 255, 0); position: absolute; top: 0px; width: 100%;"
+      style="background-color: rgba(255, 255, 255, 0); height: 80px; position: absolute; top: 0px; width: 100%;"
     >
       <div
         class="css-view-1dbjc4n"

--- a/src/features/offer/components/OfferHeader.tsx
+++ b/src/features/offer/components/OfferHeader.tsx
@@ -2,6 +2,7 @@ import { t } from '@lingui/macro'
 import { useNavigation, useRoute } from '@react-navigation/native'
 import React, { useRef } from 'react'
 import { Animated } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled from 'styled-components/native'
 
 import { isApiError } from 'api/helpers'
@@ -45,6 +46,7 @@ export const OfferHeader: React.FC<Props> = (props) => {
   const { params } = useRoute<UseRouteType<'Offer'>>()
   const favorite = useFavorite({ offerId })
   const { showErrorSnackBar } = useSnackBarContext()
+  const { top } = useSafeAreaInsets()
 
   const { mutate: addFavorite } = useAddFavorite({
     onSuccess: () => {
@@ -89,7 +91,7 @@ export const OfferHeader: React.FC<Props> = (props) => {
 
   return (
     <React.Fragment>
-      <HeaderContainer style={{ backgroundColor }}>
+      <HeaderContainer style={{ backgroundColor }} safeAreaTop={top}>
         <Spacer.TopScreen />
         <Spacer.Column numberOfSpaces={2} />
         <Row>
@@ -151,12 +153,14 @@ function animateIcon(animatedValue: Animated.Value): void {
   ]).start()
 }
 
-const HeaderContainer = styled(Animated.View)(({ theme }) => ({
-  position: 'absolute',
-  top: 0,
-  height: theme.appBarHeight,
-  width: '100%',
-}))
+const HeaderContainer = styled(Animated.View)<{ safeAreaTop: number }>(
+  ({ theme, safeAreaTop }) => ({
+    position: 'absolute',
+    top: 0,
+    height: theme.appBarHeight + safeAreaTop,
+    width: '100%',
+  })
+)
 
 const Row = styled.View({
   flex: 1,

--- a/src/features/offer/components/__tests__/OfferHeader.native.test.tsx
+++ b/src/features/offer/components/__tests__/OfferHeader.native.test.tsx
@@ -1,6 +1,7 @@
 import { rest } from 'msw'
 import React from 'react'
 import { Animated, Share, Platform } from 'react-native'
+import { ThemeProvider } from 'styled-components/native'
 import waitForExpect from 'wait-for-expect'
 
 import { useRoute, goBack } from '__mocks__/@react-navigation/native'
@@ -19,6 +20,7 @@ import { EmptyResponse } from 'libs/fetch'
 import { reactQueryProviderHOC, queryCache } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
 import { superFlushWithAct, act, cleanup, fireEvent, render } from 'tests/utils'
+import { theme } from 'theme'
 import {
   showSuccessSnackBar,
   showErrorSnackBar,
@@ -398,7 +400,9 @@ async function renderOfferHeader(options: Options = defaultOptions) {
   const animatedValue = new Animated.Value(0)
   const wrapper = render(
     reactQueryProviderHOC(
-      <OfferHeader title="Some very nice offer" headerTransition={animatedValue} offerId={id} />
+      <ThemeProvider theme={theme}>
+        <OfferHeader title="Some very nice offer" headerTransition={animatedValue} offerId={id} />
+      </ThemeProvider>
     )
   )
   await superFlushWithAct(20)

--- a/src/features/offer/components/__tests__/OfferHeader.web.test.tsx
+++ b/src/features/offer/components/__tests__/OfferHeader.web.test.tsx
@@ -1,6 +1,7 @@
 import { rest } from 'msw'
 import React from 'react'
 import { Animated, Share, Platform } from 'react-native'
+import { ThemeProvider } from 'styled-components/native'
 import waitForExpect from 'wait-for-expect'
 
 import { useRoute, goBack } from '__mocks__/@react-navigation/native'
@@ -18,6 +19,7 @@ import { EmptyResponse } from 'libs/fetch'
 import { reactQueryProviderHOC, queryCache } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
 import { superFlushWithAct, act, cleanup, fireEvent, render } from 'tests/utils/web'
+import { theme } from 'theme'
 import {
   showSuccessSnackBar,
   showErrorSnackBar,
@@ -396,7 +398,9 @@ async function renderOfferHeader(options: Options = defaultOptions) {
   const animatedValue = new Animated.Value(0)
   const wrapper = render(
     reactQueryProviderHOC(
-      <OfferHeader title="Some very nice offer" headerTransition={animatedValue} offerId={id} />
+      <ThemeProvider theme={theme}>
+        <OfferHeader title="Some very nice offer" headerTransition={animatedValue} offerId={id} />
+      </ThemeProvider>
     )
   )
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10560

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
