### PR TITLE
(PC-10595) Upgrade @pass-culture/id-check to v2.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@elastic/app-search-javascript": "^7.13.1",
     "@lingui/core": "^3.10.4",
     "@lingui/react": "^3.10.2",
-    "@pass-culture/id-check": "^2.4.6",
+    "@pass-culture/id-check": "^2.4.7",
     "@pass-culture/react-native-profiling": "1.0.19",
     "@ptomasroos/react-native-multi-slider": "^2.2.2",
     "@react-native-async-storage/async-storage": "^1.15.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3428,10 +3428,10 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
-"@pass-culture/id-check@^2.4.6":
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/@pass-culture/id-check/-/id-check-2.4.6.tgz#af0e221619a39f3df9f95eac9ab8648a614506dc"
-  integrity sha512-WIrDNxgiuoLLOE7NAtMzOWHSP2nZNBGSlrICQgAS3KAQ3jQMFXUOqVogadLpYfS75y54XsrScrMqGw2Z6SFtGA==
+"@pass-culture/id-check@^2.4.7":
+  version "2.4.7"
+  resolved "https://registry.yarnpkg.com/@pass-culture/id-check/-/id-check-2.4.7.tgz#4b7faa130ba8f77326cf650d16b6231ace796881"
+  integrity sha512-F16MPaDpUmnSkzz4mqlygwyTX3Rjw0msIJeZG65SAZbV/LQK2QCOOOhihvxBD+1wNNPGhulxuDHvv/YTve5M7Q==
   dependencies:
     deepmerge "^4.2.2"
     lodash "^4.17.21"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10595

L'upgrade en v2.4.7 force le mode retention causant un rerender du hook et un bug.

Une autre version remplacera le hook par un hoc class component

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
