### PR TITLE
(PC-10657) Correction du bug en prod de partage d'offre

### DIFF
--- a/src/features/deeplinks/utils.ts
+++ b/src/features/deeplinks/utils.ts
@@ -15,10 +15,15 @@ export function getLongDynamicLinkURI() {
 }
 
 /**
- * @param fullWebAppUrlWithParams The deeplink targetted path
+ * @see https://firebase.google.com/docs/dynamic-links/create-manually
+ * @param deepLink The deeplink targetted screen
+ * @param webAppLink The link to the current webapp. TODO: remove once webapp migration is complete
  */
-export function generateLongFirebaseDynamicLink(fullWebAppUrlWithParams: string) {
-  return `${FIREBASE_DYNAMIC_LINK_URL}/?link=${fullWebAppUrlWithParams}&${getLongDynamicLinkURI()}`
+export function generateLongFirebaseDynamicLink(deepLink: string, webAppLink?: string) {
+  // TODO(antoinewg): ofl won't be necessary once the webapp supports the deeplinks (ie: after the webapp's migration)
+  // For now, we make sure we have an ofl so that when opened from a browser, the link redirects to the current webapp.
+  const ofl = webAppLink ? `&ofl=${webAppLink}` : ''
+  return `${FIREBASE_DYNAMIC_LINK_URL}/?link=${deepLink}&${getLongDynamicLinkURI()}${ofl}`
 }
 
 export const isUniversalLink = (url: string) => url.startsWith(WEBAPP_NATIVE_REDIRECTION_URL)

--- a/src/features/offer/components/__tests__/OfferHeader.native.test.tsx
+++ b/src/features/offer/components/__tests__/OfferHeader.native.test.tsx
@@ -105,7 +105,9 @@ describe('<OfferHeader />', () => {
     fireEvent.press(getByTestId('icon-share'))
     expect(share).toHaveBeenCalledTimes(1)
     const fullWebAppUrlWithParams = getWebappOfferUrl(116656, env.WEBAPP_URL)
-    const url = generateLongFirebaseDynamicLink(fullWebAppUrlWithParams)
+    const deepLink = `https://webapp-v2.example.com/offre/116656`
+
+    const url = generateLongFirebaseDynamicLink(deepLink, fullWebAppUrlWithParams)
     const message =
       'Retrouve "Sous les étoiles de Paris - VF" chez "PATHE BEAUGRENELLE" sur le pass Culture'
     const title = "Je t'invite à découvrir une super offre sur le pass Culture !"
@@ -123,7 +125,9 @@ describe('<OfferHeader />', () => {
     fireEvent.press(getByTestId('icon-share'))
     expect(share).toHaveBeenCalledTimes(1)
     const fullWebAppUrlWithParams = getWebappOfferUrl(116656, env.WEBAPP_URL)
-    const url = generateLongFirebaseDynamicLink(fullWebAppUrlWithParams)
+    const deepLink = `https://webapp-v2.example.com/offre/116656`
+
+    const url = generateLongFirebaseDynamicLink(deepLink, fullWebAppUrlWithParams)
     const messageWithUrl =
       'Retrouve "Sous les étoiles de Paris - VF" chez "PATHE BEAUGRENELLE" sur le pass Culture\n\n' +
       url

--- a/src/features/offer/services/useShareOffer.ts
+++ b/src/features/offer/services/useShareOffer.ts
@@ -34,8 +34,12 @@ async function shareOffer(offer: OfferResponse, webAppUrl: string) {
     values: { name: offer.name, locationName },
     message: 'Retrouve "{name}" chez "{locationName}" sur le pass Culture',
   })
-  const fullWebAppUrlWithParams = getWebappOfferUrl(offer.id, webAppUrl)
-  const url = generateLongFirebaseDynamicLink(fullWebAppUrlWithParams)
+
+  const path = new DeeplinkPathWithPathParams(DeeplinkPath.OFFER, { id: offer.id.toString() })
+  const deepLink = `${WEBAPP_V2_URL}/${path.getFullPath()}`
+  const webAppLink = getWebappOfferUrl(offer.id, webAppUrl)
+
+  const url = generateLongFirebaseDynamicLink(deepLink, webAppLink)
 
   // url share content param is only for iOs, so we add url in message for android
   const completeMessage = Platform.OS === 'ios' ? message : message.concat(`\n\n${url}`)

--- a/src/features/venue/components/__tests__/VenueHeader.native.test.tsx
+++ b/src/features/venue/components/__tests__/VenueHeader.native.test.tsx
@@ -58,7 +58,9 @@ describe('<VenueHeader />', () => {
 
     expect(share).toHaveBeenCalledTimes(1)
     const fullWebappUrlWithParams = getWebappVenueUrl(5543, env.WEBAPP_URL)
-    const url = generateLongFirebaseDynamicLink(fullWebappUrlWithParams)
+    const deepLink = `https://webapp-v2.example.com/venue/5543`
+
+    const url = generateLongFirebaseDynamicLink(deepLink, fullWebappUrlWithParams)
     const message = 'Retrouve "Le Petit Rintintin 1" sur le pass Culture'
     expect(share).toHaveBeenCalledWith(
       { message, title: message, url },
@@ -75,7 +77,9 @@ describe('<VenueHeader />', () => {
 
     expect(share).toHaveBeenCalledTimes(1)
     const fullWebappUrlWithParams = getWebappVenueUrl(5543, env.WEBAPP_URL)
-    const url = generateLongFirebaseDynamicLink(fullWebappUrlWithParams)
+    const deepLink = `https://webapp-v2.example.com/venue/5543`
+
+    const url = generateLongFirebaseDynamicLink(deepLink, fullWebappUrlWithParams)
     const message = 'Retrouve "Le Petit Rintintin 1" sur le pass Culture'
     const messageWithUrl = `${message}\n\n${url}`
     expect(share).toHaveBeenCalledWith(

--- a/src/features/venue/services/useShareVenue.ts
+++ b/src/features/venue/services/useShareVenue.ts
@@ -31,8 +31,11 @@ const shareVenue = async (venue: VenueResponse, webAppUrl: string) => {
     message: 'Retrouve "{name}" sur le pass Culture',
   })
 
-  const fullWebAppUrlWithParams = getWebappVenueUrl(venue.id, webAppUrl)
-  const url = generateLongFirebaseDynamicLink(fullWebAppUrlWithParams)
+  const path = new DeeplinkPathWithPathParams(DeeplinkPath.VENUE, { id: venue.id.toString() })
+  const deepLink = `${WEBAPP_V2_URL}/${path.getFullPath()}`
+  const webAppLink = getWebappVenueUrl(venue.id, webAppUrl)
+
+  const url = generateLongFirebaseDynamicLink(deepLink, webAppLink)
 
   // url share content param is only for iOs, so we add url in message for android
   const completeMessage = Platform.OS === 'ios' ? message : message.concat(`\n\n${url}`)

--- a/src/libs/environment/__mocks__/useWebAppUrl.ts
+++ b/src/libs/environment/__mocks__/useWebAppUrl.ts
@@ -3,3 +3,5 @@ import { useWebAppUrl as actualUseWebAppUrl } from '../useWebAppUrl'
 import { env } from './envFixtures'
 
 export const useWebAppUrl: typeof actualUseWebAppUrl = () => env.WEBAPP_URL
+
+export const WEBAPP_V2_URL = `https://${env.WEBAPP_V2_DOMAIN}`


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10657

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [x] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).


## Details

Voir la [résolution de bug](https://www.notion.so/passcultureapp/Fonction-de-partage-KO-les-liens-n-aboutissent-pas-l-offre-b141797ba4f342cb9fa169b2f1a121f9)


Sur le master de la 148 (et donc en prod actuellement, voir ticket), un lien ressemble à ça:
- https://passcultureapp.page.link/?link=https://web.passculture.app/offer?id=13899281&apn=app.passculture.webapp&isi=1557887412&ibi=app.passculture&efr=1&ofl=https://web.passculture.app/accueil/details/2QLBC
- soit `${FDL_prefix}/?link=${active_webapp_domain}/${screen}?${universalLinkParams}&${FDL_parameters}`
- d'où la combinaison de "web.passculture.app/offer?id=13899281" qui n'a jamais marché..


Actuellement un lien partagé depuis master ressemble à ça:
- https://passcultureapptesting.page.link/?link=https://web.testing.passculture.team/accueil/details/BY&apn=app.passculture.testing&isi=1557887412&ibi=app.passculture.test
- soit `${FDL_prefix}/?link=${active_webapp_link}&${FDL_parameters}`


Avec cette PR, il devient ça:
- https://passcultureapptesting.page.link?link=https://app.testing.passculture.team/offre/14&apn=app.passculture.testing&isi=1557887412&ibi=app.passculture.test&ofl=https://web.testing.passculture.team/accueil/details/BY
- soit `${FDL_prefix}/?link=${webapp2_link}&${FDL_parameters}&ofl={active_webapp_link}`

Problème:
- si on ne spécifie pas de paramètre [ofl](https://firebase.google.com/docs/dynamic-links/create-manually), on ouvre le même lien indépendamment de la plateforme.
- Ainsi, depuis master, on ouvre le lien `active_webapp_link` (qui lui même dépend du Feature flag `isWebappV2Enabled`).
- En prod, ce lien correspond à la première webapp, avant la décli web.
- L'app native n'est pas configurée pour ouvrir les deeplinks de la première webapp (ex: `web.testing.passculture.team`) mais marche bien avec les deeplinks de la 2ème webapp (ex: `app.testing.passculture.team`)
 - Pk ? parce que le format des paramètres n'est pas le même (ex: `accueil/details/BY` vs `offre/14`. 
 - Donc, il faut utiliser le paramètre `ofl`, couplé avec l'utilisation d'un deeplink figé vers la webapp v2 permet de contourner ce problème.


En conclusion:
- Tant qu'on a pas migré la webapp vers l'app déclinée, on est obligé d'utiliser le paramètre ofl pour rediriger vers l'ancienne webapp sur desktop.
- grace aux travaux de la décli web, la nouvelle webapp aura le même rouuting que l'app native, donc on pourra se passer du paramètre `ofl`.