### PR TITLE
(PC-10657) FDL: skip preview page by default

### DIFF
--- a/src/features/deeplinks/utils.ts
+++ b/src/features/deeplinks/utils.ts
@@ -11,7 +11,7 @@ export const FIREBASE_DYNAMIC_LINK_URL = `https://${env.FIREBASE_DYNAMIC_LINK_DO
  * @see https://firebase.google.com/docs/dynamic-links/create-manually
  */
 export function getLongDynamicLinkURI() {
-  return `apn=${env.ANDROID_APP_ID}&isi=${env.IOS_APP_STORE_ID}&ibi=${env.IOS_APP_ID}`
+  return `apn=${env.ANDROID_APP_ID}&isi=${env.IOS_APP_STORE_ID}&ibi=${env.IOS_APP_ID}&efr=1`
 }
 
 /**


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10657



> `efr`: If set to '1', skip the app preview page when the Dynamic Link is opened, and instead redirect to the app or store. The app preview page (enabled by default) can more reliably send users to the most appropriate destination when they open Dynamic Links in apps; however, if you expect a Dynamic Link to be opened only in apps that can open Dynamic Links reliably without this page, you can disable it with this parameter. This parameter will affect the behavior of the Dynamic Link only on iOS.


Source: https://firebase.google.com/docs/dynamic-links/create-manually


## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.