### PR TITLE
(PC-8393) Bug fix: Les filtres d'une précédente recherche restent activés lorsque j'explore les offres depuis les favoris

### DIFF
--- a/src/features/search/utils/tests/useNavigateToSearchResults.test.ts
+++ b/src/features/search/utils/tests/useNavigateToSearchResults.test.ts
@@ -1,0 +1,35 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import { navigate } from '__mocks__/@react-navigation/native'
+import { initialSearchState } from 'features/search/pages/reducer'
+import { useNavigateToSearchResults } from 'features/search/utils/useNavigateToSearchResults'
+import { analytics } from 'libs/analytics'
+
+const mockSearchState = initialSearchState
+const mockDispatch = jest.fn()
+jest.mock('features/search/pages/SearchWrapper', () => ({
+  useSearch: () => ({ searchState: mockSearchState, dispatch: mockDispatch }),
+}))
+
+describe('useNavigateToSearchResults', () => {
+  beforeEach(jest.clearAllMocks)
+  it('should clear the previous search state', () => {
+    const { result } = renderHook(() => useNavigateToSearchResults({ from: 'bookings' }))
+    result.current()
+    expect(mockDispatch).toHaveBeenCalledTimes(2)
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'INIT' })
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'SHOW_RESULTS', payload: true })
+  })
+
+  it("should log the analytics event 'DiscoverOffers'", () => {
+    const { result } = renderHook(() => useNavigateToSearchResults({ from: 'bookings' }))
+    result.current()
+    expect(analytics.logDiscoverOffers).toHaveBeenNthCalledWith(1, 'bookings')
+  })
+
+  it('should navigate to Search', () => {
+    const { result } = renderHook(() => useNavigateToSearchResults({ from: 'bookings' }))
+    result.current()
+    expect(navigate).toHaveBeenNthCalledWith(1, 'Search')
+  })
+})

--- a/src/features/search/utils/useNavigateToSearchResults.ts
+++ b/src/features/search/utils/useNavigateToSearchResults.ts
@@ -11,6 +11,7 @@ export const useNavigateToSearchResults = ({ from }: { from: Referrals }) => {
 
   return () => {
     analytics.logDiscoverOffers(from)
+    dispatch({ type: 'INIT' })
     dispatch({ type: 'SHOW_RESULTS', payload: true })
     navigate('Search')
   }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-8393

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.