### PR TITLE
(PC-10699) Try another fix for back button and preserving GenericPage

### DIFF
--- a/__snapshots__/features/auth/signup/AccountCreated/tests/AccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/AccountCreated/tests/AccountCreated.native.test.tsx.native-snap
@@ -1,7 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<AccountCreated /> should render correctly 1`] = `
-Array [
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+      },
+    ]
+  }
+>
   <View
     style={
       Array [
@@ -24,7 +35,7 @@ Array [
         undefined-SVG-Mock
       </Text>
     </View>
-  </View>,
+  </View>
   <RCTScrollView
     bounces={false}
     contentContainerStyle={
@@ -176,6 +187,6 @@ Array [
         }
       />
     </View>
-  </RCTScrollView>,
-]
+  </RCTScrollView>
+</View>
 `;

--- a/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.native-snap
@@ -1,7 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<BookingConfirmation /> should render correctly 1`] = `
-Array [
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+      },
+    ]
+  }
+>
   <View
     style={
       Array [
@@ -24,7 +35,7 @@ Array [
         undefined-SVG-Mock
       </Text>
     </View>
-  </View>,
+  </View>
   <RCTScrollView
     bounces={false}
     contentContainerStyle={
@@ -268,6 +279,6 @@ Array [
         }
       />
     </View>
-  </RCTScrollView>,
-]
+  </RCTScrollView>
+</View>
 `;

--- a/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.web-snap
@@ -1,7 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<BookingConfirmation /> should render correctly 1`] = `
-Array [
+<div
+  className="css-view-1dbjc4n"
+  style={
+    Object {
+      "WebkitAlignItems": "center",
+      "WebkitBoxAlign": "center",
+      "WebkitBoxFlex": 1,
+      "WebkitFlexBasis": "0px",
+      "WebkitFlexGrow": 1,
+      "WebkitFlexShrink": 1,
+      "alignItems": "center",
+      "flexBasis": "0px",
+      "flexGrow": 1,
+      "flexShrink": 1,
+      "msFlexAlign": "center",
+      "msFlexNegative": 1,
+      "msFlexPositive": 1,
+      "msFlexPreferredSize": "0px",
+    }
+  }
+>
   <div
     className="css-view-1dbjc4n"
     style={
@@ -25,7 +45,7 @@ Array [
         undefined-SVG-Mock
       </div>
     </div>
-  </div>,
+  </div>
   <div
     className="css-view-1dbjc4n"
     onScroll={[Function]}
@@ -336,6 +356,6 @@ Array [
         }
       />
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;

--- a/src/features/auth/components/QuitSignupModal.tsx
+++ b/src/features/auth/components/QuitSignupModal.tsx
@@ -44,7 +44,7 @@ export const QuitSignupModal: FunctionComponent<Props> = ({
 
   return (
     <AppFullPageModal visible={visible} testIdSuffix={testIdSuffix}>
-      <GenericInfoPage title={title} icon={Warning}>
+      <GenericInfoPage title={title} icon={Warning} flex={false}>
         <StyledBody>{description}</StyledBody>
         <Spacer.Column numberOfSpaces={8} />
         <ButtonPrimaryWhite title={t`Continuer l'inscription`} onPress={resume} />

--- a/src/ui/components/GenericInfoPage.tsx
+++ b/src/ui/components/GenericInfoPage.tsx
@@ -28,7 +28,7 @@ export const GenericInfoPage: FunctionComponent<Props> = (props) => {
   const spacingMatrix: SpacingMatrix = Object.assign(defaultSpacingMatrix, props.spacingMatrix)
 
   return (
-    <React.Fragment>
+    <Container>
       <Background />
       <ScrollView bounces={false} contentContainerStyle={scrollViewContentContainerStyle}>
         <Spacer.Column numberOfSpaces={spacingMatrix.top} />
@@ -50,7 +50,7 @@ export const GenericInfoPage: FunctionComponent<Props> = (props) => {
         {props.children}
         <Spacer.BottomScreen />
       </ScrollView>
-    </React.Fragment>
+    </Container>
   )
 }
 
@@ -62,6 +62,11 @@ const defaultSpacingMatrix = {
 }
 
 type SpacingMatrix = typeof defaultSpacingMatrix
+
+const Container = styled.View({
+  flex: 1,
+  alignItems: 'center',
+})
 
 const scrollViewContentContainerStyle: ViewStyle = {
   flexDirection: 'column',

--- a/src/ui/components/GenericInfoPage.tsx
+++ b/src/ui/components/GenericInfoPage.tsx
@@ -1,5 +1,5 @@
 import LottieView from 'lottie-react-native'
-import React, { FunctionComponent } from 'react'
+import React, { useMemo, FunctionComponent } from 'react'
 import { ScrollView, ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
 
@@ -9,6 +9,7 @@ import { IconInterface } from 'ui/svg/icons/types'
 import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
 
 type Props = {
+  flex?: boolean
   animation?: AnimationObject
   animationSize?: number
   icon?: FunctionComponent<IconInterface>
@@ -24,11 +25,13 @@ export const GenericInfoPage: FunctionComponent<Props> = (props) => {
     icon: Icon,
     iconSize = getSpacing(25),
     title,
+    flex = true,
   } = props
   const spacingMatrix: SpacingMatrix = Object.assign(defaultSpacingMatrix, props.spacingMatrix)
 
+  const Wrapper = useMemo(() => (flex ? Container : React.Fragment), [flex])
   return (
-    <Container>
+    <Wrapper>
       <Background />
       <ScrollView bounces={false} contentContainerStyle={scrollViewContentContainerStyle}>
         <Spacer.Column numberOfSpaces={spacingMatrix.top} />
@@ -50,8 +53,14 @@ export const GenericInfoPage: FunctionComponent<Props> = (props) => {
         {props.children}
         <Spacer.BottomScreen />
       </ScrollView>
-    </Container>
+    </Wrapper>
   )
+}
+
+GenericInfoPage.defaultProps = {
+  animationSize: getSpacing(45),
+  iconSize: getSpacing(25),
+  flex: true,
 }
 
 const defaultSpacingMatrix = {

--- a/src/ui/components/modals/AppFullPageModal.tsx
+++ b/src/ui/components/modals/AppFullPageModal.tsx
@@ -21,6 +21,7 @@ export const AppFullPageModal: FunctionComponent<Props> = ({ visible, children, 
 }
 
 const Container = styled(TouchableOpacity)({
+  flex: 1,
   alignItems: 'center',
   alignSelf: 'center',
   width: '100%',

--- a/src/ui/components/modals/AppFullPageModal.tsx
+++ b/src/ui/components/modals/AppFullPageModal.tsx
@@ -21,7 +21,6 @@ export const AppFullPageModal: FunctionComponent<Props> = ({ visible, children, 
 }
 
 const Container = styled(TouchableOpacity)({
-  flex: 1,
   alignItems: 'center',
   alignSelf: 'center',
   width: '100%',


### PR DESCRIPTION
Suite au fix sur le back btn, j'ai modifié le comportement de la generic page en ayant vérifié au préalable son utilisation, unique pour cette modal d'abandon. J'ai visiblement fait ce check sur le workspace id check car je n'avais vu que un usage.

J'ai donc rajouté la `props.flex` pour conserver le comportement defaut et le comportement voulu par le fix.


Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10699

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
