### PR TITLE
(PC-10484) Search Reducer - renommer action INIT_FROM_SEE_MORE en SET_STATE_FROM_NAVIGATE

### DIFF
--- a/src/features/search/pages/Search.tsx
+++ b/src/features/search/pages/Search.tsx
@@ -43,7 +43,7 @@ export const Search: React.FC = () => {
 
   useEffect(() => {
     if (params) {
-      dispatch({ type: 'INIT_FROM_SEE_MORE', payload: params })
+      dispatch({ type: 'SET_STATE_FROM_NAVIGATE', payload: params })
       dispatch({ type: 'SHOW_RESULTS', payload: true })
     }
   }, [params])

--- a/src/features/search/pages/__tests__/Search.native.test.tsx
+++ b/src/features/search/pages/__tests__/Search.native.test.tsx
@@ -57,7 +57,7 @@ describe('Search component', () => {
   it('should handle coming from "See More" correctly', () => {
     useRoute.mockReturnValueOnce({ params: parameters })
     render(reactQueryProviderHOC(<Search />))
-    expect(mockDispatch).toBeCalledWith({ type: 'INIT_FROM_SEE_MORE', payload: parameters })
+    expect(mockDispatch).toBeCalledWith({ type: 'SET_STATE_FROM_NAVIGATE', payload: parameters })
     expect(mockDispatch).toBeCalledWith({ type: 'SHOW_RESULTS', payload: true })
   })
 })

--- a/src/features/search/pages/__tests__/reducer.test.ts
+++ b/src/features/search/pages/__tests__/reducer.test.ts
@@ -36,7 +36,7 @@ describe('Search reducer', () => {
     })
   })
 
-  it('should handle INIT_FROM_SEE_MORE', () => {
+  it('should handle SET_STATE_FROM_NAVIGATE', () => {
     const parameters = {
       geolocation: { latitude: 48.8557, longitude: 2.3469 },
       offerCategories: [
@@ -50,7 +50,7 @@ describe('Search reducer', () => {
       ],
       tags: [],
     }
-    const action: Action = { type: 'INIT_FROM_SEE_MORE', payload: parameters }
+    const action: Action = { type: 'SET_STATE_FROM_NAVIGATE', payload: parameters }
     expect(searchReducer(state, action)).toStrictEqual({
       ...initialSearchState,
       ...parameters,
@@ -58,13 +58,13 @@ describe('Search reducer', () => {
     })
   })
 
-  it('should handle INIT_FROM_SEE_MORE - MAX_PRICE', () => {
+  it('should handle SET_STATE_FROM_NAVIGATE - MAX_PRICE', () => {
     const parameters = {
       offerCategories: ['CINEMA', 'MUSIQUE'],
       priceRange: [30, 500],
     }
     const action: Action = {
-      type: 'INIT_FROM_SEE_MORE',
+      type: 'SET_STATE_FROM_NAVIGATE',
       payload: parameters as Partial<SearchState>,
     }
     expect(searchReducer(state, action)).toStrictEqual({

--- a/src/features/search/pages/reducer.ts
+++ b/src/features/search/pages/reducer.ts
@@ -31,7 +31,7 @@ export const initialSearchState: SearchState = {
 export type Action =
   | { type: 'INIT' }
   | { type: 'SET_STATE'; payload: Partial<SearchState> }
-  | { type: 'INIT_FROM_SEE_MORE'; payload: Partial<SearchState> }
+  | { type: 'SET_STATE_FROM_NAVIGATE'; payload: Partial<SearchState> }
   | { type: 'PRICE_RANGE'; payload: SearchState['priceRange'] }
   | { type: 'RADIUS'; payload: number }
   | { type: 'TIME_RANGE'; payload: SearchState['timeRange'] }
@@ -60,7 +60,7 @@ export const searchReducer = (state: SearchState, action: Action): SearchState =
       return { ...initialSearchState, ...action.payload }
     case 'SHOW_RESULTS':
       return { ...state, showResults: action.payload }
-    case 'INIT_FROM_SEE_MORE':
+    case 'SET_STATE_FROM_NAVIGATE':
       return {
         ...state,
         ...action.payload,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10484

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
