### PR TITLE
[PC-10406] [FIX] Add correct navigation on filter search result butto…

### DIFF
--- a/src/features/search/pages/SearchWrapper.tsx
+++ b/src/features/search/pages/SearchWrapper.tsx
@@ -52,7 +52,10 @@ export const useCommit = (): { commit: () => void } => {
   const { stagedSearchState } = useContext(SearchContext)!
   return {
     commit() {
-      navigate('Search', stagedSearchState)
+      navigate('TabNavigator', {
+        screen: 'Search',
+        params: stagedSearchState,
+      } as any)
     },
   }
 }


### PR DESCRIPTION
When F5 is used to reload the filter search page, we cannot apply new filters and back to the search result with the submit button.

To avoid this situation, it's required to use the nesting-navigation method of react-navigation. Documentation is here : https://reactnavigation.org/docs/nesting-navigators/

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10406

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-10406] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`




[PC-10406]: https://passculture.atlassian.net/browse/PC-10406