### PR TITLE
(PC-10549) Use nested navigate config for Search screen to avoid missing screen issue on web after reload

### DIFF
--- a/src/features/bookings/components/NoBookingsView.test.tsx
+++ b/src/features/bookings/components/NoBookingsView.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
+import { getTabNavigateConfig } from 'features/navigation/TabBar/helpers'
 import { analytics } from 'libs/analytics'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { fireEvent, render } from 'tests/utils'
@@ -22,7 +23,8 @@ describe('<NoBookingsView />', () => {
     const renderAPI = render(reactQueryProviderHOC(<NoBookingsView />))
     const button = renderAPI.getByText('Explorer les offres')
     fireEvent.press(button)
-    expect(navigate).toBeCalledWith('Search')
+    const tabNavigateConfig = getTabNavigateConfig('Search')
+    expect(navigate).toBeCalledWith(tabNavigateConfig.screen, tabNavigateConfig.params)
     expect(mockDispatchSearch).toBeCalledWith({ type: 'SHOW_RESULTS', payload: true })
     expect(analytics.logDiscoverOffers).toHaveBeenCalledWith('bookings')
   })

--- a/src/features/favorites/components/__tests__/NoFavoritesResult.test.tsx
+++ b/src/features/favorites/components/__tests__/NoFavoritesResult.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 import { initialFavoritesState } from 'features/favorites/pages/reducer'
+import { getTabNavigateConfig } from 'features/navigation/TabBar/helpers'
 import { analytics } from 'libs/analytics'
 import { fireEvent, render } from 'tests/utils'
 
@@ -38,7 +39,8 @@ describe('NoFavoritesResult component', () => {
     const renderAPI = render(<NoFavoritesResult />)
     const button = renderAPI.getByText('Explorer les offres')
     fireEvent.press(button)
-    expect(navigate).toBeCalledWith('Search')
+    const tabNavigateConfig = getTabNavigateConfig('Search')
+    expect(navigate).toBeCalledWith(tabNavigateConfig.screen, tabNavigateConfig.params)
     expect(mockDispatchSearch).toBeCalledWith({ type: 'SHOW_RESULTS', payload: true })
     expect(analytics.logDiscoverOffers).toHaveBeenCalledWith('favorites')
   })

--- a/src/features/home/components/OffersModule.tsx
+++ b/src/features/home/components/OffersModule.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components/native'
 import { OfferTile, ModuleTitle, SeeMore } from 'features/home/atoms'
 import { SearchParametersFields, DisplayParametersFields } from 'features/home/contentful'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
+import { getTabNavigateConfig } from 'features/navigation/TabBar/helpers'
 import { useFunctionOnce } from 'features/offer/services/useFunctionOnce'
 import { analytics, isCloseToEndHorizontal } from 'libs/analytics'
 import { GeoCoordinates } from 'libs/geolocation'
@@ -81,7 +82,8 @@ export const OffersModule = (props: OffersModuleProps) => {
 
   const onPressSeeMore = useCallback(() => {
     analytics.logClickSeeMore(moduleName)
-    navigate('Search', parseSearchParameters(parameters))
+    const tabNavigateConfig = getTabNavigateConfig('Search', parseSearchParameters(parameters))
+    navigate(tabNavigateConfig.screen, tabNavigateConfig.params)
   }, [])
 
   const ListHeaderComponent = useCallback(() => {

--- a/src/features/navigation/TabBar/helpers.ts
+++ b/src/features/navigation/TabBar/helpers.ts
@@ -1,7 +1,7 @@
 import { UserProfileResponse } from 'api/gen'
 import { IAuthContext } from 'features/auth/AuthContext'
 
-import { TabRoute } from './types'
+import { TabRoute, TabRouteName, TabParamList, TabNavigateConfig } from './types'
 
 export const shouldDisplayTabIconPredicate = (
   authContext: IAuthContext,
@@ -11,4 +11,11 @@ export const shouldDisplayTabIconPredicate = (
     return false
   }
   return true
+}
+
+export function getTabNavigateConfig<Screen extends TabRouteName>(
+  screen: Screen,
+  params?: TabParamList[Screen]
+): TabNavigateConfig<Screen> {
+  return { screen: 'TabNavigator', params: { screen, params } }
 }

--- a/src/features/navigation/TabBar/types.ts
+++ b/src/features/navigation/TabBar/types.ts
@@ -17,3 +17,10 @@ export type TabParamList = {
 export interface TabRoute extends IdCheckRoute<StackNavigationOptions, TabParamList> {
   pathConfig?: PathConfig
 }
+export interface TabNavigateConfig<Screen extends TabRouteName> {
+  screen: 'TabNavigator'
+  params: {
+    screen: Screen
+    params: TabParamList[Screen]
+  }
+}

--- a/src/features/navigation/helpers.ts
+++ b/src/features/navigation/helpers.ts
@@ -3,20 +3,13 @@ import { Linking } from 'react-native'
 
 import { WEBAPP_NATIVE_REDIRECTION_URL } from 'features/deeplinks'
 import { getScreenFromDeeplink } from 'features/deeplinks/getScreenFromDeeplink'
+import { TabNavigateConfig } from 'features/navigation/TabBar/types'
 import { analytics } from 'libs/analytics'
 import { WEBAPP_V2_URL } from 'libs/environment'
 
 import { navigationRef } from './navigationRef'
 
-interface HomeNavigateConfig {
-  screen: 'TabNavigator'
-  params: {
-    screen: 'Home'
-    params: undefined
-  }
-}
-
-export const homeNavigateConfig: HomeNavigateConfig = {
+export const homeNavigateConfig: TabNavigateConfig<'Home'> = {
   screen: 'TabNavigator',
   params: {
     screen: 'Home',

--- a/src/features/offer/components/OfferHeader.tsx
+++ b/src/features/offer/components/OfferHeader.tsx
@@ -13,6 +13,7 @@ import {
   useRemoveFavorite,
 } from 'features/favorites/pages/useFavorites'
 import { UseRouteType } from 'features/navigation/RootNavigator'
+import { getTabNavigateConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { SignUpSignInChoiceOfferModal } from 'features/offer/components/SignUpSignInChoiceOfferModal'
 import { isSharingSupported } from 'features/offer/services/isSharingSupported'
@@ -32,6 +33,8 @@ interface Props {
   offerId: number
 }
 
+const searchTabNavigateConfig = getTabNavigateConfig('Search')
+
 /**
  * @param props.headerTransition should be between animated between 0 and 1
  */
@@ -43,7 +46,7 @@ export const OfferHeader: React.FC<Props> = (props) => {
     showModal: showSignInModal,
     hideModal: hideSignInModal,
   } = useModal(false)
-  const { goBack } = useGoBack('Search')
+  const { goBack } = useGoBack(searchTabNavigateConfig.screen, searchTabNavigateConfig.params)
   const shareOffer = useShareOffer(offerId)
   const { params } = useRoute<UseRouteType<'Offer'>>()
   const favorite = useFavorite({ offerId })

--- a/src/features/search/components/SearchBox.tsx
+++ b/src/features/search/components/SearchBox.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native'
 
 import { UseNavigationType } from 'features/navigation/RootNavigator'
+import { getTabNavigateConfig } from 'features/navigation/TabBar/helpers'
 import { useSearch } from 'features/search/pages/SearchWrapper'
 import { analytics } from 'libs/analytics'
 import { SearchInput } from 'ui/components/inputs/SearchInput'
@@ -46,7 +47,8 @@ export const SearchBox: React.FC = () => {
   )
 
   const resetSearch = () => {
-    navigate('Search', { query: '' })
+    const tabNavigateConfig = getTabNavigateConfig('Search', { query: '' })
+    navigate(tabNavigateConfig.screen, tabNavigateConfig.params)
     setQuery('')
   }
 
@@ -58,10 +60,11 @@ export const SearchBox: React.FC = () => {
   }
 
   const onSubmitQuery = (event: NativeSyntheticEvent<TextInputSubmitEditingEventData>) => {
-    navigate('Search', {
+    const tabNavigateConfig = getTabNavigateConfig('Search', {
       query: event.nativeEvent.text,
       showResults: true,
     })
+    navigate(tabNavigateConfig.screen, tabNavigateConfig.params)
     dispatch({ type: 'SET_QUERY', payload: event.nativeEvent.text })
     dispatch({ type: 'SHOW_RESULTS', payload: true })
     analytics.logSearchQuery(event.nativeEvent.text)

--- a/src/features/search/components/__tests__/SearchBox.test.tsx
+++ b/src/features/search/components/__tests__/SearchBox.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
+import { getTabNavigateConfig } from 'features/navigation/TabBar/helpers'
 import { initialSearchState } from 'features/search/pages/reducer'
 import { analytics } from 'libs/analytics'
 import { fireEvent, render } from 'tests/utils'
@@ -27,6 +28,10 @@ describe('SearchBox component', () => {
     fireEvent(searchInput, 'onSubmitEditing', { nativeEvent: { text: 'jazzaza' } })
     expect(analytics.logSearchQuery).toBeCalledWith('jazzaza')
     expect(mockDispatch).toBeCalledWith({ type: 'SHOW_RESULTS', payload: true })
-    expect(navigate).toBeCalledWith('Search', { query: 'jazzaza', showResults: true })
+    const tabNavigateConfig = getTabNavigateConfig('Search', {
+      query: 'jazzaza',
+      showResults: true,
+    })
+    expect(navigate).toBeCalledWith(tabNavigateConfig.screen, tabNavigateConfig.params)
   })
 })

--- a/src/features/search/pages/LocationFilter.tsx
+++ b/src/features/search/pages/LocationFilter.tsx
@@ -6,6 +6,7 @@ import { ScrollView, ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
 
 import { UseNavigationType } from 'features/navigation/RootNavigator'
+import { getTabNavigateConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { LocationChoice } from 'features/search/components/LocationChoice'
 import { LocationType } from 'features/search/enums'
@@ -18,9 +19,12 @@ import { getSpacing, Spacer } from 'ui/theme'
 
 const DEBOUNCED_CALLBACK = 500
 
+const searchTabNavigateConfig = getTabNavigateConfig('Search')
+
 export const LocationFilter: React.FC = () => {
   const { navigate } = useNavigation<UseNavigationType>()
-  const { goBack } = useGoBack('Search')
+
+  const { goBack } = useGoBack(searchTabNavigateConfig.screen, searchTabNavigateConfig.params)
   const {
     position,
     positionError,

--- a/src/features/search/pages/SearchWrapper.tsx
+++ b/src/features/search/pages/SearchWrapper.tsx
@@ -2,6 +2,7 @@ import { useNavigation } from '@react-navigation/native'
 import React, { memo, useContext, useEffect, useReducer } from 'react'
 
 import { UseNavigationType } from 'features/navigation/RootNavigator'
+import { getTabNavigateConfig } from 'features/navigation/TabBar/helpers'
 import { Action, initialSearchState, searchReducer } from 'features/search/pages/reducer'
 import { SearchState } from 'features/search/types'
 import { useGeolocation } from 'libs/geolocation'
@@ -52,10 +53,8 @@ export const useCommit = (): { commit: () => void } => {
   const { stagedSearchState } = useContext(SearchContext)!
   return {
     commit() {
-      navigate('TabNavigator', {
-        screen: 'Search',
-        params: stagedSearchState,
-      })
+      const { screen, params } = getTabNavigateConfig('Search', stagedSearchState)
+      navigate(screen, params)
     },
   }
 }

--- a/src/features/search/pages/SuggestedPlaces.tsx
+++ b/src/features/search/pages/SuggestedPlaces.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { FlatList } from 'react-native'
 import styled from 'styled-components/native'
 
+import { getTabNavigateConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { usePlaces, useVenues } from 'features/search/api'
 import { MAX_RADIUS } from 'features/search/pages/reducer.helpers'
@@ -49,11 +50,13 @@ const Hit: React.FC<{ hit: SuggestedPlaceOrVenue; onPress: () => void }> = ({ hi
   )
 }
 
+const searchTabNavigateConfig = getTabNavigateConfig('Search')
+
 export const SuggestedPlaces: React.FC<{ query: string }> = ({ query }) => {
   const { data: places = [], isLoading: isLoadingPlaces } = usePlaces(query)
   const { data: venues = [], isLoading: isLoadingVenues } = useVenues(query)
   const { dispatch } = useStagedSearch()
-  const { goBack } = useGoBack('Search')
+  const { goBack } = useGoBack(searchTabNavigateConfig.screen, searchTabNavigateConfig.params)
 
   const onPickPlace = (hit: SuggestedPlaceOrVenue) => () => {
     if (isVenue(hit) && hit.venueId) {

--- a/src/features/search/utils/tests/useNavigateToSearchResults.test.ts
+++ b/src/features/search/utils/tests/useNavigateToSearchResults.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks'
 
 import { navigate } from '__mocks__/@react-navigation/native'
+import { getTabNavigateConfig } from 'features/navigation/TabBar/helpers'
 import { initialSearchState } from 'features/search/pages/reducer'
 import { useNavigateToSearchResults } from 'features/search/utils/useNavigateToSearchResults'
 import { analytics } from 'libs/analytics'
@@ -30,6 +31,7 @@ describe('useNavigateToSearchResults', () => {
   it('should navigate to Search', () => {
     const { result } = renderHook(() => useNavigateToSearchResults({ from: 'bookings' }))
     result.current()
-    expect(navigate).toHaveBeenNthCalledWith(1, 'Search')
+    const tabNavigateConfig = getTabNavigateConfig('Search')
+    expect(navigate).toHaveBeenNthCalledWith(1, tabNavigateConfig.screen, tabNavigateConfig.params)
   })
 })

--- a/src/features/search/utils/useNavigateToSearchResults.ts
+++ b/src/features/search/utils/useNavigateToSearchResults.ts
@@ -2,8 +2,11 @@ import { useNavigation } from '@react-navigation/native'
 
 import { Referrals } from 'features/navigation/RootNavigator'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
+import { getTabNavigateConfig } from 'features/navigation/TabBar/helpers'
 import { useSearch } from 'features/search/pages/SearchWrapper'
 import { analytics } from 'libs/analytics'
+
+const searchTabNavigateConfig = getTabNavigateConfig('Search')
 
 export const useNavigateToSearchResults = ({ from }: { from: Referrals }) => {
   const { navigate } = useNavigation<UseNavigationType>()
@@ -13,6 +16,6 @@ export const useNavigateToSearchResults = ({ from }: { from: Referrals }) => {
     analytics.logDiscoverOffers(from)
     dispatch({ type: 'INIT' })
     dispatch({ type: 'SHOW_RESULTS', payload: true })
-    navigate('Search')
+    navigate(searchTabNavigateConfig.screen, searchTabNavigateConfig.params)
   }
 }

--- a/src/features/venue/components/VenueHeader.tsx
+++ b/src/features/venue/components/VenueHeader.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { Animated } from 'react-native'
 import styled from 'styled-components/native'
 
+import { getTabNavigateConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { isSharingSupported } from 'features/offer/services/isSharingSupported'
 import { getAnimationState } from 'ui/components/headers/animationHelpers'
@@ -17,12 +18,14 @@ interface Props {
   venueId: number
 }
 
+const searchTabNavigateConfig = getTabNavigateConfig('Search')
+
 /**
  * @param props.headerTransition should be between animated between 0 and 1
  */
 export const VenueHeader: React.FC<Props> = (props) => {
   const { headerTransition, title, venueId } = props
-  const { goBack } = useGoBack('Search')
+  const { goBack } = useGoBack(searchTabNavigateConfig.screen, searchTabNavigateConfig.params)
 
   const shareVenue = useShareVenue(venueId)
 

--- a/src/features/venue/components/VenueOffers.tsx
+++ b/src/features/venue/components/VenueOffers.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components/native'
 
 import { SeeMore } from 'features/home/atoms'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
+import { getTabNavigateConfig } from 'features/navigation/TabBar/helpers'
 import { useSearch, useStagedSearch } from 'features/search/pages/SearchWrapper'
 import { useVenue } from 'features/venue/api/useVenue'
 import { useVenueOffers } from 'features/venue/api/useVenueOffers'
@@ -60,7 +61,8 @@ export const VenueOffers: React.FC<Props> = ({ venueId }) => {
   const seeAllOffers = useCallback(() => {
     dispatch({ type: 'SET_STATE', payload: params })
     stagedDispatch({ type: 'SET_STATE', payload: params })
-    navigate('Search', params)
+    const tabNavigateConfig = getTabNavigateConfig('Search', params)
+    navigate(tabNavigateConfig.screen, tabNavigateConfig.params)
   }, [params])
 
   const onPressSeeMore = useCallback(() => {
@@ -68,7 +70,8 @@ export const VenueOffers: React.FC<Props> = ({ venueId }) => {
     analytics.logVenueSeeMoreClicked(venueId)
     dispatch({ type: 'SET_STATE', payload: params })
     stagedDispatch({ type: 'SET_STATE', payload: params })
-    navigate('Search', params)
+    const tabNavigateConfig = getTabNavigateConfig('Search', params)
+    navigate(tabNavigateConfig.screen, tabNavigateConfig.params)
   }, [params])
 
   const showSeeMore = nbHits > hits.length


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10549

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] |
| -------------------- | :----------------------: | 
|                      |                          |  