### PR TITLE
[PC-10745] add new error page to setPhoneNumber

### DIFF
--- a/src/features/auth/signup/PhoneValidation/SetPhoneNumber.tsx
+++ b/src/features/auth/signup/PhoneValidation/SetPhoneNumber.tsx
@@ -89,7 +89,7 @@ export const SetPhoneNumber = memo(() => {
   function onError(error: ApiError | unknown) {
     const { content } = error as ApiError
     if (content.code === 'TOO_MANY_SMS_SENT') {
-      navigate('PhoneValidationTooManyAttempts')
+      navigate('PhoneValidationTooManySMSSent')
     } else {
       const message = extractApiErrorMessage(error)
       setInvalidPhoneNumberMessage(message)

--- a/src/features/auth/signup/PhoneValidation/tests/SetPhoneNumber.native.test.tsx
+++ b/src/features/auth/signup/PhoneValidation/tests/SetPhoneNumber.native.test.tsx
@@ -152,7 +152,7 @@ describe('SetPhoneNumber', () => {
       }
     )
 
-    it('should navigate to SetPhoneNumberTooManyAttempts page if request fails with TOO_MANY_VALIDATION_ATTEMPTS code', async () => {
+    it('should navigate to SetPhoneNumberTooManySMSSent page if request fails with TOO_MANY_SMS_SENT code', async () => {
       const response = {
         content: {
           code: 'TOO_MANY_SMS_SENT',
@@ -171,7 +171,7 @@ describe('SetPhoneNumber', () => {
       await act(async () => {
         useMutationCallbacks.onError(response)
       })
-      expect(navigate).toHaveBeenCalledWith('PhoneValidationTooManyAttempts')
+      expect(navigate).toHaveBeenCalledWith('PhoneValidationTooManySMSSent')
     })
   })
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10745

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
