### PR TITLE
[PC-10601][FIX] expect useOffer accepts only existing offerId and exe…

### DIFF
--- a/src/features/bookOffer/pages/BookingOfferWrapper.tsx
+++ b/src/features/bookOffer/pages/BookingOfferWrapper.tsx
@@ -44,7 +44,7 @@ export const useBooking = (): IBookingContext => {
 
 export const useBookingOffer = () => {
   const { bookingState } = useBooking()
-  const { data: offer } = useOffer({ offerId: bookingState.offerId || 0 })
+  const { data: offer } = useOffer({ offerId: bookingState.offerId! })
   return offer
 }
 

--- a/src/features/offer/api/useOffer.ts
+++ b/src/features/offer/api/useOffer.ts
@@ -54,6 +54,10 @@ async function getOfferById(offerId: number) {
 }
 
 export const useOffer = ({ offerId }: { offerId: number }) =>
-  useQuery<OfferAdaptedResponse | undefined>([QueryKeys.OFFER, offerId], () =>
-    getOfferById(offerId)
-  )
+  useQuery<OfferAdaptedResponse | undefined>([QueryKeys.OFFER, offerId], () => {
+    if (offerId) {
+      return getOfferById(offerId)
+    } else {
+      return undefined
+    }
+  })

--- a/src/features/offer/services/useHasEnoughCredit.ts
+++ b/src/features/offer/services/useHasEnoughCredit.ts
@@ -35,7 +35,7 @@ export const useHasEnoughCredit = (offerId: number): boolean => {
 }
 
 export const useCreditForOffer = (offerId: number | undefined): number => {
-  const { data: offer } = useOffer({ offerId: offerId || 0 })
+  const { data: offer } = useOffer({ offerId: offerId! })
   const { data: user } = useUserProfileInfo()
   if (!offer || !user) return 0
 


### PR DESCRIPTION
…cute query only when offerId is not null

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10601

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-10601] App Native - Decli Web - Page d'une offre - Fixer offerId a 0`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots
No screenshot needed

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`


[PC-10601]: https://passculture.atlassian.net/browse/PC-10601