### PR TITLE
[PC-10598][FIX] add TouchableOpacity to the checkbox

### DIFF
--- a/src/features/auth/signup/SetEmail/SetEmail.tsx
+++ b/src/features/auth/signup/SetEmail/SetEmail.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro'
 import { useNavigation, useRoute } from '@react-navigation/native'
 import React, { FunctionComponent, useRef, useState } from 'react'
-import { TextInput as RNTextInput } from 'react-native'
+import { TextInput as RNTextInput, TouchableOpacity } from 'react-native'
 import styled from 'styled-components/native'
 
 import { SIGNUP_NUMBER_OF_STEPS } from 'features/auth/api'
@@ -32,6 +32,7 @@ if (__DEV__ && env.SIGNUP_RANDOM_EMAIL) {
   INITIAL_EMAIL = `${randomAlphaString()}@${randomAlphaString()}.com`
 }
 
+const IS_NEWSLETTER_CHECKBOX_LABEL = t`Reçois nos recommandations culturelles à proximité de chez toi par e-mail.`
 export const SetEmail: FunctionComponent = () => {
   const [email, setEmail] = useState(INITIAL_EMAIL)
   const [hasError, setHasError] = useState(false)
@@ -106,7 +107,11 @@ export const SetEmail: FunctionComponent = () => {
           <StyledCheckBox>
             <CheckboxInput isChecked={isNewsletterChecked} setIsChecked={setIsNewsletterChecked} />
             <CheckBoxText>
-              {t`Reçois nos recommandations culturelles à proximité de chez toi par e-mail.`}
+              <TouchableOpacity
+                onPress={() => setIsNewsletterChecked(!isNewsletterChecked)}
+                {...testID(IS_NEWSLETTER_CHECKBOX_LABEL)}>
+                {IS_NEWSLETTER_CHECKBOX_LABEL}
+              </TouchableOpacity>
             </CheckBoxText>
           </StyledCheckBox>
           <Spacer.Column numberOfSpaces={6} />


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10598

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-10598] App Native - Décli Web - SetEmail - Le texte de la checkbox n'est pas cliquable.`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

No screenshot needed

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`


[PC-10598]: https://passculture.atlassian.net/browse/PC-10598