### PR TITLE
(PC-10403) Home - Image principal mal positionné sur le Web

### DIFF
--- a/__snapshots__/features/home/pages/tests/Home.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/tests/Home.native.test.tsx.native-snap
@@ -49,7 +49,6 @@ exports[`Home component should render correctly without login modal 1`] = `
           style={
             Array [
               Object {
-                "flexBasis": 1,
                 "flexGrow": 1,
                 "flexShrink": 0,
               },
@@ -92,9 +91,7 @@ exports[`Home component should render correctly without login modal 1`] = `
               Array [
                 Object {
                   "alignItems": "center",
-                  "flexBasis": 0,
                   "flexGrow": 1,
-                  "flexShrink": 1,
                 },
               ]
             }

--- a/src/features/home/components/HomeBody.tsx
+++ b/src/features/home/components/HomeBody.tsx
@@ -35,10 +35,10 @@ const keyExtractor = (item: ProcessedModule, index: number) =>
 const ItemSeparatorComponent = () => <Spacer.Column numberOfSpaces={6} />
 
 const ListHeaderComponent = () => (
-  <Container>
+  <ListHeaderContainer>
     <Spacer.TopScreen />
     <HomeHeader />
-  </Container>
+  </ListHeaderContainer>
 )
 
 export const HomeBody = (props: HomeBodyProps) => {
@@ -131,4 +131,13 @@ export const HomeBody = (props: HomeBodyProps) => {
   )
 }
 
-const Container = styled.View({ flexBasis: 1, flexGrow: 1, flexShrink: 0 })
+const Container = styled.View({
+  flexBasis: 1,
+  flexGrow: 1,
+  flexShrink: 0,
+})
+
+const ListHeaderContainer = styled.View({
+  flexGrow: 1,
+  flexShrink: 0,
+})

--- a/src/features/home/components/HomeHeader.tsx
+++ b/src/features/home/components/HomeHeader.tsx
@@ -71,7 +71,7 @@ const StyledTitle1 = styled(Typo.Title1)({
 })
 
 const CenterContainer = styled.View({
-  flex: 1,
+  flexGrow: 1,
   alignItems: 'center',
 })
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10403

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [iPhone 6] | \*Android - [s9] | Web - [Chrome] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
| ![image](https://user-images.githubusercontent.com/77674046/133761677-ddb86273-fd9f-49d0-8440-e004803a6d5c.png) | ![image](https://user-images.githubusercontent.com/77674046/133760774-945d9f21-e6df-4ef8-80c8-b2838ef648fc.png) | ![image](https://user-images.githubusercontent.com/77674046/133760652-3f2dda2c-7734-4b55-9a10-769fb69bc747.png) |                       |





## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
