### PR TITLE
(PC-10934) Optimisation des requêtes de la page de recherche

### DIFF
--- a/src/features/home/components/OffersModule.tsx
+++ b/src/features/home/components/OffersModule.tsx
@@ -82,7 +82,10 @@ export const OffersModule = (props: OffersModuleProps) => {
 
   const onPressSeeMore = useCallback(() => {
     analytics.logClickSeeMore(moduleName)
-    const tabNavigateConfig = getTabNavigateConfig('Search', parseSearchParameters(parameters))
+    // When we navigate to the search page, we want to show 20 results per page,
+    // not what is configured in contentful
+    const params = { ...parseSearchParameters(parameters), hitsPerPage: 20 }
+    const tabNavigateConfig = getTabNavigateConfig('Search', params)
     navigate(tabNavigateConfig.screen, tabNavigateConfig.params)
   }, [])
 

--- a/src/features/home/selectPlaylist.ts
+++ b/src/features/home/selectPlaylist.ts
@@ -10,7 +10,7 @@ const scorePlaylistByTags = (
   entry: HomepageEntry,
   user?: UserProfileResponse
 ): HomepageEntry & { score: number } => {
-  const isUnderage = user ? isUserUnderageBeneficiary(user) : false
+  const isUnderage = isUserUnderageBeneficiary(user)
   const tags: TagId[] = entry.metadata.tags.map(({ sys }) => sys.id)
 
   let score = 0

--- a/src/features/offer/services/useCtaWordingAndAction.ts
+++ b/src/features/offer/services/useCtaWordingAndAction.ts
@@ -122,11 +122,11 @@ export const useCtaWordingAndAction = (props: {
 }): ICTAWordingAndAction | undefined => {
   const { offerId } = props
   const { isLoggedIn } = useAuthContext()
-  const { data: profileInfo } = useUserProfileInfo()
+  const { data: user } = useUserProfileInfo()
   const { data: offer } = useOffer({ offerId })
   const hasEnoughCredit = useHasEnoughCredit(offerId)
   const availableCategories = useAvailableCategories()
-  const isUnderageBeneficiary = !!(profileInfo && isUserUnderageBeneficiary(profileInfo))
+  const isUnderageBeneficiary = isUserUnderageBeneficiary(user)
 
   if (!offer) return
 
@@ -135,13 +135,13 @@ export const useCtaWordingAndAction = (props: {
    */
   if (
     isLoggedIn === null ||
-    profileInfo === null ||
+    user === null ||
     offer.category.categoryType === null ||
     offer.category.categoryType === undefined
   )
     return
 
-  const { isBeneficiary = false, bookedOffers = {} } = profileInfo || {}
+  const { isBeneficiary = false, bookedOffers = {} } = user || {}
   return getCtaWordingAndAction({
     isLoggedIn,
     isBeneficiary,

--- a/src/features/profile/utils.ts
+++ b/src/features/profile/utils.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash'
-
 import { UserProfileResponse, DomainsCredit, UserRole } from 'api/gen/api'
 import { useUserProfileInfo } from 'features/home/api'
 import { Credit } from 'features/home/services/useAvailableCredit'

--- a/src/features/profile/utils.ts
+++ b/src/features/profile/utils.ts
@@ -14,12 +14,13 @@ export const computeCredit = (domainsCredit?: DomainsCredit | null) => {
   return domainsCredit ? domainsCredit.all.remaining : 0
 }
 
-export function isUserUnderageBeneficiary(user: UserProfileResponse): boolean {
-  const hasUserUnderageRole = user?.roles?.find((role) => role === UserRole.UNDERAGEBENEFICIARY)
+export function isUserUnderageBeneficiary(user: UserProfileResponse | undefined): boolean {
+  if (!user) return false
+  const hasUserUnderageRole = user.roles?.find((role) => role === UserRole.UNDERAGEBENEFICIARY)
   return !!hasUserUnderageRole
 }
 
 export const useIsUserUnderage = () => {
   const { data: user } = useUserProfileInfo()
-  return !!(user && isUserUnderageBeneficiary(user))
+  return isUserUnderageBeneficiary(user)
 }

--- a/src/features/search/pages/SearchWrapper.tsx
+++ b/src/features/search/pages/SearchWrapper.tsx
@@ -49,10 +49,12 @@ export const useStagedSearch = (): Pick<ISearchContext, 'searchState' | 'dispatc
 
 export const useCommit = (): { commit: () => void } => {
   const { navigate } = useNavigation<UseNavigationType>()
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const { stagedSearchState } = useContext(SearchContext)!
+  const { dispatch } = useSearch()
+  const { searchState: stagedSearchState } = useStagedSearch()
+
   return {
     commit() {
+      dispatch({ type: 'SET_STATE', payload: stagedSearchState })
       const { screen, params } = getTabNavigateConfig('Search', stagedSearchState)
       navigate(screen, params)
     },

--- a/src/features/search/pages/reducer.ts
+++ b/src/features/search/pages/reducer.ts
@@ -1,6 +1,6 @@
 import { LocationType } from 'features/search/enums'
 import { DATE_FILTER_OPTIONS } from 'features/search/enums'
-import { MAX_RADIUS } from 'features/search/pages/reducer.helpers'
+import { MAX_PRICE, MAX_RADIUS, MIN_PRICE } from 'features/search/pages/reducer.helpers'
 import { SearchState } from 'features/search/types'
 import { SuggestedPlace } from 'libs/place'
 import { SuggestedVenue } from 'libs/venue'
@@ -22,7 +22,7 @@ export const initialSearchState: SearchState = {
     isEvent: false,
     isThing: false,
   },
-  priceRange: null,
+  priceRange: [MIN_PRICE, MAX_PRICE],
   query: '',
   showResults: false,
   tags: [],

--- a/src/features/search/pages/useSearchResults.ts
+++ b/src/features/search/pages/useSearchResults.ts
@@ -1,10 +1,11 @@
 import { SearchResponse } from '@algolia/client-search'
 import flatten from 'lodash.flatten'
+import omit from 'lodash.omit'
 import { useMemo } from 'react'
 import { QueryFunctionContext, useInfiniteQuery } from 'react-query'
 
 import { useIsUserUnderage } from 'features/profile/utils'
-import { SearchState } from 'features/search/types'
+import { PartialSearchState } from 'features/search/types'
 import { useAvailableCategories } from 'features/search/utils/useAvailableCategories'
 import { useGeolocation } from 'libs/geolocation'
 import { QueryKeys } from 'libs/queryKeys'
@@ -19,7 +20,7 @@ import { useSearch, useStagedSearch } from './SearchWrapper'
 
 export type Response = Pick<SearchResponse<SearchHit>, 'hits' | 'nbHits' | 'page' | 'nbPages'>
 
-const useSearchInfiniteQuery = (searchState: SearchState) => {
+const useSearchInfiniteQuery = (searchState: PartialSearchState) => {
   const { enabled, isAppSearchBackend } = useAppSearchBackend()
   const { position } = useGeolocation()
   const algoliaBackend = useAlgoliaQuery()
@@ -33,7 +34,7 @@ const useSearchInfiniteQuery = (searchState: SearchState) => {
 
   const { data, ...infiniteQuery } = useInfiniteQuery<Response>(
     [QueryKeys.SEARCH_RESULTS, searchState],
-    async (context: QueryFunctionContext<[string, SearchState], number>) => {
+    async (context: QueryFunctionContext<[string, PartialSearchState], number>) => {
       const page = context.pageParam || 0
       const searchState = context.queryKey[1]
       const newSearchState = {
@@ -66,10 +67,10 @@ const useSearchInfiniteQuery = (searchState: SearchState) => {
 
 export const useStagedSearchResults = () => {
   const { searchState } = useStagedSearch()
-  return useSearchInfiniteQuery(searchState)
+  return useSearchInfiniteQuery(omit(searchState, ['showResults']) as PartialSearchState)
 }
 
 export const useSearchResults = () => {
   const { searchState } = useSearch()
-  return useSearchInfiniteQuery(searchState)
+  return useSearchInfiniteQuery(omit(searchState, ['showResults']) as PartialSearchState)
 }

--- a/src/features/search/pages/useSearchResults.ts
+++ b/src/features/search/pages/useSearchResults.ts
@@ -14,7 +14,7 @@ import { useAlgoliaQuery } from 'libs/search/fetch/useAlgoliaQuery'
 import { useAppSearchBackend } from 'libs/search/fetch/useAppSearchBackend'
 import { useSearchQuery } from 'libs/search/fetch/useSearchQuery'
 import { useSendAdditionalRequestToAppSearch } from 'libs/search/useSendAdditionalRequestToAppSearch'
-import { filterAvailableCategories } from 'libs/search/utils/filterAvailableCategories'
+import { filterAvailableCategories } from 'libs/search/utils'
 
 import { useSearch, useStagedSearch } from './SearchWrapper'
 

--- a/src/features/search/sections/Category.tsx
+++ b/src/features/search/sections/Category.tsx
@@ -15,8 +15,8 @@ export const Category: React.FC = () => {
   const logUseFilter = useLogFilterOnce(SectionTitle.Category)
   const categories = useAvailableSearchCategories()
 
-  const onPress = (label: string) => () => {
-    dispatch({ type: 'TOGGLE_CATEGORY', payload: label })
+  const onPress = (facetFilter: string) => () => {
+    dispatch({ type: 'TOGGLE_CATEGORY', payload: facetFilter })
     logUseFilter()
   }
 

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -37,3 +37,5 @@ export interface SearchState {
   tags: string[]
   query: string
 }
+
+export type PartialSearchState = Omit<SearchState, 'showResults'>

--- a/src/features/search/utils/useAvailableCategories.ts
+++ b/src/features/search/utils/useAvailableCategories.ts
@@ -1,16 +1,10 @@
 import { omit } from 'lodash'
 
 import { CategoryNameEnum } from 'api/gen'
-import { useUserProfileInfo } from 'features/home/api'
-import { isUserUnderageBeneficiary } from 'features/profile/utils'
+import { useIsUserUnderage } from 'features/profile/utils'
 import { CATEGORY_CRITERIA } from 'features/search/enums'
 
 export const useAvailableCategories = () => {
-  const { data: user } = useUserProfileInfo()
-  const isUserUnderage = user && isUserUnderageBeneficiary(user)
-
-  if (isUserUnderage) {
-    return omit(CATEGORY_CRITERIA, CategoryNameEnum.JEUXVIDEO)
-  }
-  return CATEGORY_CRITERIA
+  const isUserUnderage = useIsUserUnderage()
+  return isUserUnderage ? omit(CATEGORY_CRITERIA, CategoryNameEnum.JEUXVIDEO) : CATEGORY_CRITERIA
 }

--- a/src/libs/algolia/fetchAlgolia/fetchAlgolia.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchAlgolia.ts
@@ -3,7 +3,7 @@ import algoliasearch from 'algoliasearch'
 
 import { LocationType } from 'features/search/enums'
 import { Response } from 'features/search/pages/useSearchResults'
-import { SearchState } from 'features/search/types'
+import { PartialSearchState } from 'features/search/types'
 import { SearchParametersQuery } from 'libs/algolia/types'
 import { env } from 'libs/environment'
 import { GeoCoordinates } from 'libs/geolocation'
@@ -48,7 +48,7 @@ const buildSearchParameters = (
     priceRange = null,
     timeRange = null,
     tags = [],
-  }: SearchState,
+  }: PartialSearchState,
   userLocation: GeoCoordinates | null
 ) => ({
   ...buildFacetFilters({ offerCategories, offerTypes, offerIsDuo, tags }),
@@ -65,7 +65,7 @@ const buildSearchParameters = (
 })
 
 export const fetchMultipleAlgolia = (
-  paramsList: SearchState[],
+  paramsList: PartialSearchState[],
   userLocation: GeoCoordinates | null
 ): Readonly<Promise<MultipleQueriesResponse<AlgoliaHit>>> => {
   const queries = paramsList.map((params) => ({
@@ -105,11 +105,11 @@ export const fetchAlgoliaHits = (
   return index.getObjects(objectIds, { attributesToRetrieve })
 }
 
-const buildHitsPerPage = (hitsPerPage: SearchState['hitsPerPage']) =>
+const buildHitsPerPage = (hitsPerPage: PartialSearchState['hitsPerPage']) =>
   hitsPerPage ? { hitsPerPage } : null
 
 const buildGeolocationParameter = (
-  locationFilter: SearchState['locationFilter'],
+  locationFilter: PartialSearchState['locationFilter'],
   userLocation: GeoCoordinates | null
 ): { aroundLatLng: string; aroundRadius: 'all' | number } | undefined => {
   if (locationFilter.locationType === LocationType.VENUE) return

--- a/src/libs/algolia/types.ts
+++ b/src/libs/algolia/types.ts
@@ -1,4 +1,4 @@
-import { SearchState } from 'features/search/types'
+import { PartialSearchState } from 'features/search/types'
 
 /**
  * See Algolia doc on numericFilters and facetFilters
@@ -7,6 +7,6 @@ import { SearchState } from 'features/search/types'
  */
 export type FiltersArray = string[][]
 
-export interface SearchParametersQuery extends SearchState {
+export interface SearchParametersQuery extends PartialSearchState {
   page: number
 }

--- a/src/libs/search/fetch/search.ts
+++ b/src/libs/search/fetch/search.ts
@@ -3,7 +3,7 @@ import { flatten } from 'lodash'
 
 import { OptionalCategoryCriteria } from 'features/search/enums'
 import { Response } from 'features/search/pages/useSearchResults'
-import { SearchState } from 'features/search/types'
+import { PartialSearchState } from 'features/search/types'
 import { SearchParametersQuery } from 'libs/algolia'
 import { GeoCoordinates } from 'libs/geolocation'
 import { SearchHit, VenueHit } from 'libs/search'
@@ -47,7 +47,7 @@ export const fetchObjects = async (
 }
 
 export const fetchMultipleHits = async (
-  paramsList: SearchState[],
+  paramsList: PartialSearchState[],
   userLocation: GeoCoordinates | null,
   isUserUnderage: boolean
 ): Promise<SearchResponse> => {
@@ -84,11 +84,10 @@ export const fetchHits = async (
 }
 
 export const fetchVenueOffers = async (
-  params: SearchState,
+  params: PartialSearchState,
   isUserUnderage: boolean
 ): Promise<SearchResponse> => {
   const options = buildQueryOptions(params, null, isUserUnderage) // no need of geolocation to get venues, yet?
-
   const response = await offersClient.search<AppSearchFields>('', options)
   const { meta } = response.info
 

--- a/src/libs/search/filters/buildFacetFilters.ts
+++ b/src/libs/search/filters/buildFacetFilters.ts
@@ -1,11 +1,13 @@
 import { FilterArray } from '@elastic/app-search-javascript'
 
 import { LocationType } from 'features/search/enums'
-import { SearchState } from 'features/search/types'
+import { PartialSearchState } from 'features/search/types'
 
 import { AppSearchFields, FALSE, TRUE } from './constants'
 
-export const buildFacetFilters = (searchState: SearchState): FilterArray<AppSearchFields> => {
+export const buildFacetFilters = (
+  searchState: PartialSearchState
+): FilterArray<AppSearchFields> => {
   const { offerCategories, offerIsDuo, tags, offerTypes, locationFilter } = searchState
 
   const facetFilters: FilterArray<AppSearchFields> = buildOfferTypesFilter(offerTypes)
@@ -30,7 +32,7 @@ const buildOfferTypesFilter = ({
   isDigital,
   isEvent,
   isThing,
-}: SearchState['offerTypes']): FilterArray<AppSearchFields> => {
+}: PartialSearchState['offerTypes']): FilterArray<AppSearchFields> => {
   if (isDigital) {
     if (!isEvent && !isThing) return [DIGITAL]
     if (!isEvent && isThing) return [THING]

--- a/src/libs/search/filters/buildNumericFilters.ts
+++ b/src/libs/search/filters/buildNumericFilters.ts
@@ -1,13 +1,13 @@
 import { FilterArray, RangeFilter } from '@elastic/app-search-javascript'
 
 import { DATE_FILTER_OPTIONS } from 'features/search/enums'
-import { SearchState } from 'features/search/types'
+import { PartialSearchState } from 'features/search/types'
 import { TIME } from 'libs/search/filters/timeFilters'
 import { NoNullProperties, Range } from 'libs/typesUtils/typeHelpers'
 
 import { AppSearchFields } from './constants'
 
-export const buildNumericFilters = (params: SearchState): FilterArray<AppSearchFields> => {
+export const buildNumericFilters = (params: PartialSearchState): FilterArray<AppSearchFields> => {
   return [
     ...buildOfferPriceRangePredicate(params),
     ...buildDatePredicate(params),
@@ -18,7 +18,9 @@ export const buildNumericFilters = (params: SearchState): FilterArray<AppSearchF
 
 const MAX_PRICE = 30000
 
-const buildOfferPriceRangePredicate = (params: SearchState): FilterArray<AppSearchFields> => {
+const buildOfferPriceRangePredicate = (
+  params: PartialSearchState
+): FilterArray<AppSearchFields> => {
   const { offerIsFree, priceRange } = params
   if (offerIsFree) return [{ [AppSearchFields.prices]: { to: 1 } }] // to is exclusive
   if (!priceRange) return [{ [AppSearchFields.prices]: { to: MAX_PRICE } }]
@@ -29,7 +31,7 @@ const buildOfferPriceRangePredicate = (params: SearchState): FilterArray<AppSear
   return [{ [AppSearchFields.prices]: { from, to } }]
 }
 
-const buildDatePredicate = (params: SearchState): FilterArray<AppSearchFields> => {
+const buildDatePredicate = (params: PartialSearchState): FilterArray<AppSearchFields> => {
   const { date, timeRange } = params
   if (date && timeRange) return buildDateAndTimePredicate({ date, timeRange })
   if (date) return buildDateOnlyPredicate(date)
@@ -37,7 +39,7 @@ const buildDatePredicate = (params: SearchState): FilterArray<AppSearchFields> =
   return []
 }
 
-const buildHomepageDatePredicate = (params: SearchState): FilterArray<AppSearchFields> => {
+const buildHomepageDatePredicate = (params: PartialSearchState): FilterArray<AppSearchFields> => {
   const { beginningDatetime, endingDatetime } = params
   if (!beginningDatetime && !endingDatetime) return []
 
@@ -58,7 +60,7 @@ const buildTimeOnlyPredicate = (timeRange: Range<number>): FilterArray<AppSearch
 const buildDateAndTimePredicate = ({
   date,
   timeRange,
-}: NoNullProperties<Required<Pick<SearchState, 'date' | 'timeRange'>>>): FilterArray<
+}: NoNullProperties<Required<Pick<PartialSearchState, 'date' | 'timeRange'>>>): FilterArray<
   AppSearchFields
 > => {
   let dateFilter
@@ -82,7 +84,7 @@ const buildDateAndTimePredicate = ({
 }
 
 const buildDateOnlyPredicate = (
-  date: Exclude<SearchState['date'], null | undefined>
+  date: Exclude<PartialSearchState['date'], null | undefined>
 ): FilterArray<AppSearchFields> => {
   let from, to
   switch (date.option) {
@@ -114,7 +116,7 @@ const buildDateOnlyPredicate = (
   ]
 }
 
-const buildNewestOffersPredicate = (params: SearchState): FilterArray<AppSearchFields> => {
+const buildNewestOffersPredicate = (params: PartialSearchState): FilterArray<AppSearchFields> => {
   const { offerIsNew } = params
   if (!offerIsNew) return []
 

--- a/src/libs/search/filters/index.ts
+++ b/src/libs/search/filters/index.ts
@@ -1,7 +1,7 @@
 import { SearchOptions } from '@elastic/app-search-javascript'
 
 import { CategoryNameEnum } from 'api/gen'
-import { SearchState } from 'features/search/types'
+import { PartialSearchState } from 'features/search/types'
 import { GeoCoordinates } from 'libs/geolocation'
 import { buildBoosts } from 'libs/search/filters/buildBoosts'
 
@@ -21,7 +21,7 @@ export const underageFilter = {
 }
 
 export const buildQueryOptions = (
-  searchState: SearchState,
+  searchState: PartialSearchState,
   userLocation: GeoCoordinates | null,
   isUserUnderage: boolean,
   page?: number

--- a/src/libs/search/useParseSearchParameters.ts
+++ b/src/libs/search/useParseSearchParameters.ts
@@ -6,16 +6,17 @@ import { SearchState } from 'features/search/types'
 import { useAvailableCategories } from 'features/search/utils/useAvailableCategories'
 import { useGeolocation } from 'libs/geolocation'
 import { parseSearchParameters } from 'libs/search/parseSearchParameters'
-import { filterAvailableCategories } from 'libs/search/utils/filterAvailableCategories'
+import { filterAvailableCategories, getCategoriesFacetFilters } from 'libs/search/utils'
 
 const buildNewSearchParameters = (
   params: SearchParametersFields,
   availableCategories: OptionalCategoryCriteria
 ): SearchParametersFields => {
-  return {
-    ...params,
-    categories: filterAvailableCategories(params.categories || [], availableCategories),
-  }
+  const { categories: categoryLabels = [], ...otherParams } = params
+  // We receive category labels from contentful. We first have to map to facetFilters used for search
+  const facetFilters = categoryLabels.map(getCategoriesFacetFilters)
+  const categories = filterAvailableCategories(facetFilters, availableCategories)
+  return { ...otherParams, categories }
 }
 
 export const useParseSearchParameters = () => {

--- a/src/libs/search/utils/filterAvailableCategories.ts
+++ b/src/libs/search/utils/filterAvailableCategories.ts
@@ -4,8 +4,8 @@ export const filterAvailableCategories = (
   selectedCategories: string[],
   availableCategories: OptionalCategoryCriteria
 ): string[] => {
-  return Object.values(availableCategories)
-    .filter((categoryCriterion) => selectedCategories.includes(categoryCriterion.label))
-    .map((categoryCriterion) => categoryCriterion.facetFilter)
+  const availableFilters = Object.values(availableCategories).map(({ facetFilter }) => facetFilter)
+  return availableFilters
+    .filter((facetFilter) => selectedCategories.includes(facetFilter))
     .sort((a: string, b: string) => a.localeCompare(b))
 }

--- a/src/libs/search/utils/filterAvailableCategories.ts
+++ b/src/libs/search/utils/filterAvailableCategories.ts
@@ -7,4 +7,5 @@ export const filterAvailableCategories = (
   return Object.values(availableCategories)
     .filter((categoryCriterion) => selectedCategories.includes(categoryCriterion.label))
     .map((categoryCriterion) => categoryCriterion.facetFilter)
+    .sort((a: string, b: string) => a.localeCompare(b))
 }

--- a/src/libs/search/utils/getCategoriesFacetFilters.ts
+++ b/src/libs/search/utils/getCategoriesFacetFilters.ts
@@ -1,0 +1,6 @@
+import { CATEGORY_CRITERIA } from 'features/search/enums'
+
+export const getCategoriesFacetFilters = (categoryLabel: string): string => {
+  const category = Object.values(CATEGORY_CRITERIA).find(({ label }) => label === categoryLabel)
+  return category ? category.facetFilter : ''
+}

--- a/src/libs/search/utils/index.ts
+++ b/src/libs/search/utils/index.ts
@@ -1,0 +1,2 @@
+export { filterAvailableCategories } from './filterAvailableCategories'
+export { getCategoriesFacetFilters } from './getCategoriesFacetFilters'

--- a/src/libs/search/utils/tests/filterAvailableCategories.test.ts
+++ b/src/libs/search/utils/tests/filterAvailableCategories.test.ts
@@ -1,0 +1,12 @@
+import { CategoryNameEnum } from 'api/gen'
+import { CATEGORY_CRITERIA } from 'features/search/enums'
+import { filterAvailableCategories } from 'libs/search/utils/filterAvailableCategories'
+
+describe('filterAvailableCategories', () => {
+  it('should sort the categories to reuse cached query', () => {
+    const categories = [CategoryNameEnum.CINEMA, CategoryNameEnum.JEUXVIDEO]
+    const reversed = [CategoryNameEnum.JEUXVIDEO, CategoryNameEnum.CINEMA]
+    expect(filterAvailableCategories(categories, CATEGORY_CRITERIA)).toEqual(categories)
+    expect(filterAvailableCategories(reversed, CATEGORY_CRITERIA)).toEqual(categories)
+  })
+})

--- a/src/libs/search/utils/tests/filterAvailableCategories.test.ts
+++ b/src/libs/search/utils/tests/filterAvailableCategories.test.ts
@@ -1,6 +1,6 @@
 import { CategoryNameEnum } from 'api/gen'
 import { CATEGORY_CRITERIA } from 'features/search/enums'
-import { filterAvailableCategories } from 'libs/search/utils/filterAvailableCategories'
+import { filterAvailableCategories } from 'libs/search/utils'
 
 describe('filterAvailableCategories', () => {
   it('should sort the categories to reuse cached query', () => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10934

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.


## Détails

**Bugs** 🐛

Plusieurs bugs corrigés dans cette PR (depuis master):
- https://github.com/pass-culture/pass-culture-app-native/pull/1687/commits/23d1499a85170b1956f3593951cdb20120b40f17: Quand on clique sur le bouton "Voir plus" d'une playlist de la home:
  - la pagination affiche des pages de `hitsPerPage` configurée dans contentful (donc par exemple par pages de 2)
  - la catégorie choisie ne correspond pas à la catégorie du premier module affichée.
- https://github.com/pass-culture/pass-culture-app-native/pull/1687/commits/529ceb76892091a864c62d09542eba56d334b98c: le filtre par catégories dans la page de recherche ne fonctionnait pas (utilisation des labels au lieu des facetFilters)
- https://github.com/pass-culture/pass-culture-app-native/pull/1687/commits/ef43b149242b32b352c415713357c3a77b147429 utilisation du searchState complet comme clef react-query.

**Performances** 🏃

Meilleure gestion du cache react-query (pour réutiliser les requêtes):
- https://github.com/pass-culture/pass-culture-app-native/pull/1687/commits/92ec787fbfebd4b24539ab935695741b72e5b0fd: suppression de `showResults` => seulement utilisé pour l'UX, pas pour les requêtes donc rien à faire dans le cache.
- https://github.com/pass-culture/pass-culture-app-native/pull/1687/commits/382f1aba9ddaee3bf11d1b24b1dc71284c30ff23: initialisation de `priceRange` plus tôt.
- https://github.com/pass-culture/pass-culture-app-native/pull/1687/commits/2cd69a6fd7b7e8b8337e9581035252281f5926f3: tri par ordre alphabétique des catégories pour utiliser le cache indépendamment de leur ordre de sélection.

**UX** 🎨

- https://github.com/pass-culture/pass-culture-app-native/pull/1687/commits/ec8336122988fb40781f17d72c82dfb122330abc: quand on clique sur "Afficher les résultats", les résultats précédents ne sont pas affichés et on voit directement la liste des résultats corrrespondant aux nouveaux filtres.