### PR TITLE
[PC-10839][FIX] App Native - Decli Web - Regler les fonts sur Firefox (ex: Page d'erreur 404)

### DIFF
--- a/__snapshots__/features/eighteenBirthday/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/eighteenBirthday/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -198,6 +198,7 @@ Array [
                           "color": "#151515",
                           "fontFamily": "Montserrat-ExtraBoldItalic",
                           "fontSize": 28,
+                          "fontWeight": "800",
                           "lineHeight": 34,
                         },
                         Object {

--- a/__snapshots__/features/eighteenBirthday/pages/components/EighteenBirthdayCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/eighteenBirthday/pages/components/EighteenBirthdayCard.native.test.tsx.native-snap
@@ -61,6 +61,7 @@ exports[`<EighteenBirthdayCard /> should render eighteen birthday card 1`] = `
           "color": "#151515",
           "fontFamily": "Montserrat-ExtraBoldItalic",
           "fontSize": 28,
+          "fontWeight": "800",
           "lineHeight": 34,
         },
         Object {

--- a/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.native.test.tsx.native-snap
@@ -113,6 +113,7 @@ exports[`AsyncErrorBoundary component should render 1`] = `
           "color": "#ffffff",
           "fontFamily": "Montserrat-ExtraBoldItalic",
           "fontSize": 28,
+          "fontWeight": "800",
           "lineHeight": 34,
         },
       ]

--- a/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.web.test.tsx.web-snap
+++ b/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.web.test.tsx.web-snap
@@ -66,7 +66,7 @@ Object {
         <div
           class="css-text-901oao"
           dir="auto"
-          style="color: rgb(255, 255, 255); font-family: Montserrat-ExtraBoldItalic; font-size: 24px; line-height: 34px;"
+          style="color: rgb(255, 255, 255); font-family: Montserrat-ExtraBoldItalic; font-size: 24px; font-weight: 800; line-height: 34px;"
         >
           Oups !
         </div>
@@ -198,7 +198,7 @@ Object {
       <div
         class="css-text-901oao"
         dir="auto"
-        style="color: rgb(255, 255, 255); font-family: Montserrat-ExtraBoldItalic; font-size: 24px; line-height: 34px;"
+        style="color: rgb(255, 255, 255); font-family: Montserrat-ExtraBoldItalic; font-size: 24px; font-weight: 800; line-height: 34px;"
       >
         Oups !
       </div>

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/FirstTutorial.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/FirstTutorial.native.test.tsx.native-snap
@@ -269,6 +269,7 @@ Array [
                           "color": "#151515",
                           "fontFamily": "Montserrat-ExtraBoldItalic",
                           "fontSize": 28,
+                          "fontWeight": "800",
                           "lineHeight": 34,
                         },
                         Object {
@@ -492,6 +493,7 @@ Array [
                           "color": "#151515",
                           "fontFamily": "Montserrat-ExtraBoldItalic",
                           "fontSize": 28,
+                          "fontWeight": "800",
                           "lineHeight": 34,
                         },
                         Object {
@@ -670,6 +672,7 @@ Array [
                           "color": "#151515",
                           "fontFamily": "Montserrat-ExtraBoldItalic",
                           "fontSize": 28,
+                          "fontWeight": "800",
                           "lineHeight": 34,
                         },
                         Object {
@@ -848,6 +851,7 @@ Array [
                           "color": "#151515",
                           "fontFamily": "Montserrat-ExtraBoldItalic",
                           "fontSize": 28,
+                          "fontWeight": "800",
                           "lineHeight": 34,
                         },
                         Object {

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FirstCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FirstCard.native.test.tsx.native-snap
@@ -61,6 +61,7 @@ exports[`FirstCard should render first card 1`] = `
           "color": "#151515",
           "fontFamily": "Montserrat-ExtraBoldItalic",
           "fontSize": 28,
+          "fontWeight": "800",
           "lineHeight": 34,
         },
         Object {

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FourthCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FourthCard.native.test.tsx.native-snap
@@ -61,6 +61,7 @@ exports[`FourthCard should render fourth card 1`] = `
           "color": "#151515",
           "fontFamily": "Montserrat-ExtraBoldItalic",
           "fontSize": 28,
+          "fontWeight": "800",
           "lineHeight": 34,
         },
         Object {

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/SecondCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/SecondCard.native.test.tsx.native-snap
@@ -61,6 +61,7 @@ exports[`SecondCard should render second card 1`] = `
           "color": "#151515",
           "fontFamily": "Montserrat-ExtraBoldItalic",
           "fontSize": 28,
+          "fontWeight": "800",
           "lineHeight": 34,
         },
         Object {

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/ThirdCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/ThirdCard.native.test.tsx.native-snap
@@ -61,6 +61,7 @@ exports[`ThirdCard should render third card 1`] = `
           "color": "#151515",
           "fontFamily": "Montserrat-ExtraBoldItalic",
           "fontSize": 28,
+          "fontWeight": "800",
           "lineHeight": 34,
         },
         Object {

--- a/__snapshots__/features/home/pages/tests/Home.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/tests/Home.native.test.tsx.native-snap
@@ -116,6 +116,7 @@ exports[`Home component should render correctly without login modal 1`] = `
                     "color": "#ffffff",
                     "fontFamily": "Montserrat-ExtraBoldItalic",
                     "fontSize": 28,
+                    "fontWeight": "800",
                     "lineHeight": 34,
                   },
                   Object {

--- a/public/index.html
+++ b/public/index.html
@@ -94,6 +94,17 @@
     <!-- See usage of `window.grecaptcha` in ReCaptcha.web.tsx -->
     <script src="https://www.google.com/recaptcha/api.js?hl=fr" async defer></script>
     <style type="text/css">
+        @font-face {
+            font-family: 'Montserrat-ExtraBoldItalic';
+            font-style: normal;
+            font-weight: 800;
+            font-display: swap;
+            src: url(https://fonts.gstatic.com/s/montserrat/v18/JTUPjIg1_i6t8kCHKm459WxZbgjz_PZwjimrqw.woff2)
+            format('woff2');
+            unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+            U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+        }
+
       @font-face {
         font-family: 'Montserrat-MediumItalic';
         font-style: normal;
@@ -141,6 +152,17 @@
         font-weight: 600;
         font-display: swap;
         src: url(https://fonts.gstatic.com/s/montserrat/v15/JTURjIg1_i6t8kCHKm45_bZF3gnD_g.woff2)
+          format('woff2');
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+          U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+      }
+
+      @font-face {
+        font-family: 'Montserrat-ExtraBoldItalic';
+        font-style: normal;
+        font-weight: 500;
+        font-display: swap;
+        src: url(https://fonts.gstatic.com/s/montserrat/v15/JTUPjIg1_i6t8kCHKm459WxZbgjz8fZwjimrq1Q_.woff2)
           format('woff2');
         unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
           U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;

--- a/src/ui/theme/typography.tsx
+++ b/src/ui/theme/typography.tsx
@@ -34,6 +34,7 @@ const StyledTitle1 = styled(ColoredText)<{ fontSize: number }>((props) => ({
   fontFamily: 'Montserrat-ExtraBoldItalic',
   fontSize: props.fontSize,
   lineHeight: getSpacingString(8.5),
+  fontWeight: 800,
 }))
 
 const Title2: React.FC<TextProps> = (props) => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10839

Test with the URL : http://localhost:3000/first-tutorial?shouldCloseAppOnBackAction=true

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-10839] App Native - Decli Web - Regler les fonts sur Firefox (ex: Page d'erreur 404)`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*Chrome - [Desktop] | \*Firefox - [Desktop] | Safari - [Desktop] |
| -------------------- | :----------------------: | --------------------: |
|<img width="1920" alt="Schermata 2021-09-21 alle 11 59 58" src="https://user-images.githubusercontent.com/90036171/134151900-ff4fda0d-6924-4102-a94c-8527c0bce580.png">|<img width="1920" alt="Schermata 2021-09-21 alle 12 00 13" src="https://user-images.githubusercontent.com/90036171/134151941-40a7789c-8fc8-4bc1-ade3-0196f3ad51b1.png">|<img width="1920" alt="Schermata 2021-09-21 alle 12 00 27" src="https://user-images.githubusercontent.com/90036171/134151995-fb9a5e53-9fc6-488f-a717-a46d8895e9e0.png">|

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`


[PC-10839]: https://passculture.atlassian.net/browse/PC-10839