### PR TITLE
(Tech) do not show warning on app init - splashscreen state

### DIFF
--- a/src/libs/splashscreen.tsx
+++ b/src/libs/splashscreen.tsx
@@ -1,8 +1,6 @@
-import { createContext, useCallback, useContext, memo } from 'react'
+import { createContext, useCallback, useContext, memo, useState } from 'react'
 import React from 'react'
 import SplashScreen from 'react-native-splash-screen'
-
-import { useSafeState } from './hooks'
 
 interface SplashScreenContext {
   isSplashScreenHidden: boolean
@@ -18,7 +16,7 @@ export function useSplashScreenContext() {
 export const SplashScreenProvider = memo(function SplashScreenProvider(props: {
   children: JSX.Element
 }) {
-  const [isSplashScreenHidden, setIsSplashScreenHidden] = useSafeState<boolean>(false)
+  const [isSplashScreenHidden, setIsSplashScreenHidden] = useState<boolean>(false)
 
   const hideSplashScreen = useCallback(() => {
     SplashScreen.hide()


### PR DESCRIPTION
## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.

## Warning:

```
 LOG  Warning: Can't call setState on an unmounted component. 
        This is a no-op, but it indicates a memory leak in your application. 
        To fix, cancel all subscriptions and asynchronous tasks in 
        the return function of useEffect().
```