### PR TITLE
(Tech) remove warning for NextBeneficiaryStep

### DIFF
--- a/src/features/auth/signup/NextBeneficiaryStep/tests/NextBeneficiaryStep.native.test.tsx
+++ b/src/features/auth/signup/NextBeneficiaryStep/tests/NextBeneficiaryStep.native.test.tsx
@@ -1,14 +1,20 @@
 import React from 'react'
 
 import { NextBeneficiaryStep } from 'features/auth/signup/NextBeneficiaryStep'
-import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { render, superFlushWithAct } from 'tests/utils'
+import { render } from 'tests/utils'
+
+jest.mock('features/auth/settings')
+
+const mockData: unknown = null
+jest.mock('features/home/api', () => ({
+  useUserProfileInfo: jest.fn(() => ({
+    refetch: jest.fn(() => Promise.resolve({ data: mockData })),
+  })),
+}))
 
 describe('<NextBeneficiaryStep />', () => {
-  it('should show a loading page on init', async () => {
-    // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-    const renderAPI = render(reactQueryProviderHOC(<NextBeneficiaryStep />))
-    await superFlushWithAct()
+  it('should show a loading page on init', () => {
+    const renderAPI = render(<NextBeneficiaryStep />)
     expect(renderAPI.getByTestId('Loading-Animation')).toBeTruthy()
   })
 })


### PR DESCRIPTION
Remove warning:

```
 ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Warning: An update to NextBeneficiaryStep inside a test was not wrapped in act(...).

    When testing, code that causes React state updates should be wrapped into act(...):

    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */

    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
        at NextBeneficiaryStep (/home/circleci/pass-culture/src/features/auth/signup/NextBeneficiaryStep/NextBeneficiaryStep.tsx:8:62)
        at QueryClientProvider (/home/circleci/pass-culture/node_modules/react-query/lib/react/QueryClientProvider.js:41:22)
        at I18nProvider (/home/circleci/pass-culture/node_modules/@lingui/react/cjs/react.development.js:46:19)
        at LinguiProvider (/home/circleci/pass-culture/src/tests/utils.tsx:77:37)".

       6 | 
       7 | export function NextBeneficiaryStep() {
    >  8 |   const { error, navigateToNextBeneficiaryValidationStep } = useBeneficiaryValidationNavigation()
         |                                                              ^
       9 |   useFocusEffect(navigateToNextBeneficiaryValidationStep)
      10 | 
      11 |   if (error) {

      at NextBeneficiaryStep (src/features/auth/signup/NextBeneficiaryStep/NextBeneficiaryStep.tsx:8:62)
      at QueryClientProvider (node_modules/react-query/lib/react/QueryClientProvider.js:41:22)
      at I18nProvider (node_modules/@lingui/react/cjs/react.development.js:46:19)
      at LinguiProvider (src/tests/utils.tsx:77:37)".
      at BufferedConsole.error (node_modules/@jest/console/build/BufferedConsole.js:161:10)
      at printWarning (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:68:30)
      at error (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:44:5)
      at warnIfNotCurrentlyActingUpdatesInDEV (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15034:9)
      at dispatchAction (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:7129:9)
      at node_modules/react-query/lib/react/useBaseQuery.js:69:9
      at node_modules/react-query/lib/core/notifyManager.js:62:18
      at NotifyManager.notifyFn (node_modules/react-query/lib/core/notifyManager.js:15:7)
      at node_modules/react-query/lib/core/notifyManager.js:77:20
          at Array.forEach (<anonymous>)


  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Warning: An update to NextBeneficiaryStep inside a test was not wrapped in act(...).

    When testing, code that causes React state updates should be wrapped into act(...):

    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */

    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
        at NextBeneficiaryStep (/home/circleci/pass-culture/src/features/auth/signup/NextBeneficiaryStep/NextBeneficiaryStep.tsx:8:62)
        at QueryClientProvider (/home/circleci/pass-culture/node_modules/react-query/lib/react/QueryClientProvider.js:41:22)
        at I18nProvider (/home/circleci/pass-culture/node_modules/@lingui/react/cjs/react.development.js:46:19)
        at LinguiProvider (/home/circleci/pass-culture/src/tests/utils.tsx:77:37)".

       6 | 
       7 | export function NextBeneficiaryStep() {
    >  8 |   const { error, navigateToNextBeneficiaryValidationStep } = useBeneficiaryValidationNavigation()
         |                                                              ^
       9 |   useFocusEffect(navigateToNextBeneficiaryValidationStep)
      10 | 
      11 |   if (error) {

      at NextBeneficiaryStep (src/features/auth/signup/NextBeneficiaryStep/NextBeneficiaryStep.tsx:8:62)
      at QueryClientProvider (node_modules/react-query/lib/react/QueryClientProvider.js:41:22)
      at I18nProvider (node_modules/@lingui/react/cjs/react.development.js:46:19)
      at LinguiProvider (src/tests/utils.tsx:77:37)".
      at BufferedConsole.error (node_modules/@jest/console/build/BufferedConsole.js:161:10)
      at printWarning (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:68:30)
      at error (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:44:5)
      at warnIfNotCurrentlyActingUpdatesInDEV (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15034:9)
      at dispatchAction (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:7129:9)
      at node_modules/react-query/lib/react/useBaseQuery.js:69:9
      at node_modules/react-query/lib/core/notifyManager.js:62:18
      at NotifyManager.notifyFn (node_modules/react-query/lib/core/notifyManager.js:15:7)
      at node_modules/react-query/lib/core/notifyManager.js:77:20
          at Array.forEach (<anonymous>)


  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Warning: An update to NextBeneficiaryStep inside a test was not wrapped in act(...).

    When testing, code that causes React state updates should be wrapped into act(...):

    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */

    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
        at NextBeneficiaryStep (/home/circleci/pass-culture/src/features/auth/signup/NextBeneficiaryStep/NextBeneficiaryStep.tsx:8:62)
        at QueryClientProvider (/home/circleci/pass-culture/node_modules/react-query/lib/react/QueryClientProvider.js:41:22)
        at I18nProvider (/home/circleci/pass-culture/node_modules/@lingui/react/cjs/react.development.js:46:19)
        at LinguiProvider (/home/circleci/pass-culture/src/tests/utils.tsx:77:37)".

       6 | 
       7 | export function NextBeneficiaryStep() {
    >  8 |   const { error, navigateToNextBeneficiaryValidationStep } = useBeneficiaryValidationNavigation()
         |                                                              ^
       9 |   useFocusEffect(navigateToNextBeneficiaryValidationStep)
      10 | 
      11 |   if (error) {

      at NextBeneficiaryStep (src/features/auth/signup/NextBeneficiaryStep/NextBeneficiaryStep.tsx:8:62)
      at QueryClientProvider (node_modules/react-query/lib/react/QueryClientProvider.js:41:22)
      at I18nProvider (node_modules/@lingui/react/cjs/react.development.js:46:19)
      at LinguiProvider (src/tests/utils.tsx:77:37)".
      at BufferedConsole.error (node_modules/@jest/console/build/BufferedConsole.js:161:10)
      at printWarning (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:68:30)
      at error (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:44:5)
      at warnIfNotCurrentlyActingUpdatesInDEV (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15034:9)
      at dispatchAction (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:7129:9)
      at node_modules/react-query/lib/react/useBaseQuery.js:69:9
      at node_modules/react-query/lib/core/notifyManager.js:62:18
      at NotifyManager.notifyFn (node_modules/react-query/lib/core/notifyManager.js:15:7)
      at node_modules/react-query/lib/core/notifyManager.js:77:20
          at Array.forEach (<anonymous>)

 PASS  src/features/auth/signup/NextBeneficiaryStep/tests/NextBeneficiaryStep.native.test.tsx (1403 MB heap size)
  ● Console

    console.error
      Warning: An update to NextBeneficiaryStep inside a test was not wrapped in act(...).
      
      When testing, code that causes React state updates should be wrapped into act(...):
      
      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */
      
      This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
          at NextBeneficiaryStep (/home/circleci/pass-culture/src/features/auth/signup/NextBeneficiaryStep/NextBeneficiaryStep.tsx:8:62)
          at QueryClientProvider (/home/circleci/pass-culture/node_modules/react-query/lib/react/QueryClientProvider.js:41:22)
          at I18nProvider (/home/circleci/pass-culture/node_modules/@lingui/react/cjs/react.development.js:46:19)
          at LinguiProvider (/home/circleci/pass-culture/src/tests/utils.tsx:77:37)

      at printWarning (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:68:30)
      at error (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:44:5)
      at warnIfNotCurrentlyActingUpdatesInDEV (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15034:9)
      at dispatchAction (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:7129:9)
      at node_modules/react-query/lib/react/useBaseQuery.js:69:9
      at node_modules/react-query/lib/core/notifyManager.js:62:18
      at NotifyManager.notifyFn (node_modules/react-query/lib/core/notifyManager.js:15:7)
      at node_modules/react-query/lib/core/notifyManager.js:77:20

    console.error
      Warning: An update to NextBeneficiaryStep inside a test was not wrapped in act(...).
      
      When testing, code that causes React state updates should be wrapped into act(...):
      
      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */
      
      This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
          at NextBeneficiaryStep (/home/circleci/pass-culture/src/features/auth/signup/NextBeneficiaryStep/NextBeneficiaryStep.tsx:8:62)
          at QueryClientProvider (/home/circleci/pass-culture/node_modules/react-query/lib/react/QueryClientProvider.js:41:22)
          at I18nProvider (/home/circleci/pass-culture/node_modules/@lingui/react/cjs/react.development.js:46:19)
          at LinguiProvider (/home/circleci/pass-culture/src/tests/utils.tsx:77:37)

      at printWarning (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:68:30)
      at error (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:44:5)
      at warnIfNotCurrentlyActingUpdatesInDEV (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15034:9)
      at dispatchAction (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:7129:9)
      at node_modules/react-query/lib/react/useBaseQuery.js:69:9
      at node_modules/react-query/lib/core/notifyManager.js:62:18
      at NotifyManager.notifyFn (node_modules/react-query/lib/core/notifyManager.js:15:7)
      at node_modules/react-query/lib/core/notifyManager.js:77:20

    console.error
      Warning: An update to NextBeneficiaryStep inside a test was not wrapped in act(...).
      
      When testing, code that causes React state updates should be wrapped into act(...):
      
      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */
      
      This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
          at NextBeneficiaryStep (/home/circleci/pass-culture/src/features/auth/signup/NextBeneficiaryStep/NextBeneficiaryStep.tsx:8:62)
          at QueryClientProvider (/home/circleci/pass-culture/node_modules/react-query/lib/react/QueryClientProvider.js:41:22)
          at I18nProvider (/home/circleci/pass-culture/node_modules/@lingui/react/cjs/react.development.js:46:19)
          at LinguiProvider (/home/circleci/pass-culture/src/tests/utils.tsx:77:37)

      at printWarning (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:68:30)
      at error (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:44:5)
      at warnIfNotCurrentlyActingUpdatesInDEV (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15034:9)
      at dispatchAction (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:7129:9)
      at node_modules/react-query/lib/react/useBaseQuery.js:69:9
      at node_modules/react-query/lib/core/notifyManager.js:62:18
      at NotifyManager.notifyFn (node_modules/react-query/lib/core/notifyManager.js:15:7)
      at node_modules/react-query/lib/core/notifyManager.js:77:20

    console.error
      Warning: An update to NextBeneficiaryStep inside a test was not wrapped in act(...).
      
      When testing, code that causes React state updates should be wrapped into act(...):
      
      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */
      
      This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
          at NextBeneficiaryStep (/home/circleci/pass-culture/src/features/auth/signup/NextBeneficiaryStep/NextBeneficiaryStep.tsx:8:62)
          at QueryClientProvider (/home/circleci/pass-culture/node_modules/react-query/lib/react/QueryClientProvider.js:41:22)
          at I18nProvider (/home/circleci/pass-culture/node_modules/@lingui/react/cjs/react.development.js:46:19)
          at LinguiProvider (/home/circleci/pass-culture/src/tests/utils.tsx:77:37)

      at printWarning (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:68:30)
      at error (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:44:5)
      at warnIfNotCurrentlyActingUpdatesInDEV (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15034:9)
      at dispatchAction (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:7129:9)
      at node_modules/react-query/lib/react/useBaseQuery.js:69:9
      at node_modules/react-query/lib/core/notifyManager.js:62:18
      at NotifyManager.notifyFn (node_modules/react-query/lib/core/notifyManager.js:15:7)
      at node_modules/react-query/lib/core/notifyManager.js:77:20
```