### PR TITLE
(PC-9254) Réduction du nombre de requêtes - Favoris

### DIFF
--- a/__snapshots__/features/favorites/pages/__tests__/Favorites.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/__tests__/Favorites.native.test.tsx.native-snap
@@ -81,7 +81,6 @@ exports[`Favorites component should render correctly 1`] = `
           "withComponent": [Function],
         }
       }
-      ListFooterComponent={<Styled(View) />}
       ListHeaderComponent={<NumberOfResultsPlaceholder />}
       contentContainerStyle={
         Object {
@@ -3883,19 +3882,6 @@ exports[`Favorites component should render correctly 1`] = `
             }
           }
         />
-        <View
-          onLayout={[Function]}
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "height": 0,
-                },
-              ]
-            }
-          />
-        </View>
       </View>
     </RCTScrollView>
   </View>

--- a/src/features/favorites/atoms/BicolorFavoriteCount.tsx
+++ b/src/features/favorites/atoms/BicolorFavoriteCount.tsx
@@ -24,23 +24,7 @@ export const BicolorFavoriteCount: React.FC<BicolorIconInterface> = ({
 }) => {
   const { isLoggedIn } = useAuthContext()
   const { data } = useFavorites()
-  const scaleAnimation = useRef(new Animated.Value(1))
-  useEffect(() => {
-    if (data?.nbFavorites) {
-      Animated.sequence([
-        Animated.timing(scaleAnimation.current, {
-          toValue: 1.2,
-          duration: 200,
-          useNativeDriver: false,
-        }),
-        Animated.timing(scaleAnimation.current, {
-          toValue: 1,
-          duration: 200,
-          useNativeDriver: false,
-        }),
-      ]).start()
-    }
-  }, [data?.nbFavorites])
+  const scale = useScaleFavoritesAnimation(data?.nbFavorites)
 
   if (!isLoggedIn || !data) {
     return <BicolorFavorite size={size} color={color} color2={color2} thin={thin} testID={testID} />
@@ -56,7 +40,7 @@ export const BicolorFavoriteCount: React.FC<BicolorIconInterface> = ({
         testID={testID}
       />
       <CountPositionContainer>
-        <Animated.View style={{ transform: [{ scale: scaleAnimation.current }] }}>
+        <Animated.View style={{ transform: [{ scale }] }}>
           <CountContainer>
             <Pastille color={thin ? ColorsEnum.GREY_DARK : undefined} />
             {hasTooMany ? (
@@ -109,3 +93,26 @@ const Count = styled(Typo.Caption).attrs({
   paddingRight,
   bottom: 1,
 }))
+
+const useScaleFavoritesAnimation = (nbFavorites?: number) => {
+  const scaleAnimation = useRef(new Animated.Value(1))
+
+  useEffect(() => {
+    if (typeof nbFavorites === 'number') {
+      Animated.sequence([
+        Animated.timing(scaleAnimation.current, {
+          toValue: 1.2,
+          duration: 200,
+          useNativeDriver: false,
+        }),
+        Animated.timing(scaleAnimation.current, {
+          toValue: 1,
+          duration: 200,
+          useNativeDriver: false,
+        }),
+      ]).start()
+    }
+  }, [nbFavorites])
+
+  return scaleAnimation.current
+}

--- a/src/features/favorites/components/FavoritesResults.tsx
+++ b/src/features/favorites/components/FavoritesResults.tsx
@@ -49,6 +49,7 @@ export const FavoritesResults: React.FC = React.memo(function FavoritesResults()
   const favoritesState = useFavoritesState()
   const { position } = useGeolocation()
   const { data, isLoading } = useFavorites()
+
   const sortedFavorites = useMemo(() => {
     if (!data) {
       return undefined
@@ -68,9 +69,7 @@ export const FavoritesResults: React.FC = React.memo(function FavoritesResults()
 
   const renderItem = useCallback(
     ({ item: favorite }: { item: FavoriteResponse }) => {
-      if (!user || !credit) {
-        return <HitPlaceholder />
-      }
+      if (!user || !credit) return <HitPlaceholder />
       return (
         <Favorite credit={credit} favorite={favorite} user={user} onInAppBooking={setOfferToBook} />
       )
@@ -84,8 +83,8 @@ export const FavoritesResults: React.FC = React.memo(function FavoritesResults()
   )
   const ListEmptyComponent = useMemo(() => <NoFavoritesResult />, [])
   const ListFooterComponent = useMemo(
-    () => <Footer hasFavorites={sortedFavorites ? sortedFavorites.length > 0 : false} />,
-    [sortedFavorites]
+    () => (sortedFavorites?.length ? <Spacer.Column numberOfSpaces={52} /> : null),
+    [sortedFavorites?.length]
   )
 
   if (isLoading || !data) return <FavoritesResultsPlaceHolder />
@@ -131,10 +130,6 @@ const contentContainerStyle = {
 }
 const Container = styled.View({ height: '100%' })
 
-const Footer = styled.View<{ hasFavorites?: boolean }>(({ hasFavorites = false }) => ({
-  height: hasFavorites ? getSpacing(52) : 0,
-}))
-
 const Separator = styled.View({
   height: 2,
   backgroundColor: ColorsEnum.GREY_LIGHT,
@@ -155,7 +150,6 @@ const FAVORITE_LIST_PLACEHOLDER = Array.from({ length: 20 }).map((_, index) => (
 const FavoritesResultsPlaceHolder = () => {
   const renderItem = useCallback(() => <HitPlaceholder />, [])
   const ListHeaderComponent = useMemo(() => <NumberOfResultsPlaceholder />, [])
-  const ListFooterComponent = useMemo(() => <Footer />, [])
 
   return (
     <React.Fragment>
@@ -166,7 +160,6 @@ const FavoritesResultsPlaceHolder = () => {
           contentContainerStyle={contentContainerStyle}
           ListHeaderComponent={ListHeaderComponent}
           ItemSeparatorComponent={Separator}
-          ListFooterComponent={ListFooterComponent}
           scrollEnabled={false}
         />
       </Container>

--- a/src/features/favorites/pages/Favorites.tsx
+++ b/src/features/favorites/pages/Favorites.tsx
@@ -1,32 +1,18 @@
 import { t } from '@lingui/macro'
-import { useFocusEffect } from '@react-navigation/native'
 import React from 'react'
 import styled from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/AuthContext'
 import { FavoritesResults } from 'features/favorites/components/FavoritesResults'
 import { NotConnectedFavorites } from 'features/favorites/components/NotConnectedFavorites'
-import { useFavorites } from 'features/favorites/pages/useFavorites'
 import SvgPageHeader from 'ui/components/headers/SvgPageHeader'
 import { useKeyboardAdjust } from 'ui/components/keyboard/useKeyboardAdjust'
 
-const useFetchResults = () => {
-  const { refetch, dataUpdatedAt, isFetching } = useFavorites()
-
-  function refetchDebounce() {
-    const debounceDelayMs = 100
-    const isOldData = new Date().getTime() - dataUpdatedAt > debounceDelayMs
-    if (isOldData && !isFetching) {
-      refetch()
-    }
-  }
-
-  useFocusEffect(refetchDebounce)
-}
-
-export const FavoritesScreen: React.FC = () => {
+export const Favorites: React.FC = () => {
   useKeyboardAdjust()
-  useFetchResults()
+  const { isLoggedIn } = useAuthContext()
+
+  if (!isLoggedIn) return <NotConnectedFavorites />
 
   return (
     <Container>
@@ -34,14 +20,6 @@ export const FavoritesScreen: React.FC = () => {
       <FavoritesResults />
     </Container>
   )
-}
-
-export const Favorites: React.FC = () => {
-  const { isLoggedIn } = useAuthContext()
-  if (!isLoggedIn) {
-    return <NotConnectedFavorites />
-  }
-  return <FavoritesScreen />
 }
 
 const Container = styled.View({ flex: 1 })

--- a/src/features/favorites/pages/__tests__/useFavorites.test.tsx
+++ b/src/features/favorites/pages/__tests__/useFavorites.test.tsx
@@ -326,102 +326,15 @@ describe('useFavorite hook', () => {
       isLoggedIn: true,
       setIsLoggedIn: jest.fn(),
     })
-    const { result, waitFor } = renderHook(
-      () =>
-        useFavorite({
-          offerId: favorite.offer.id,
-        }),
-      {
-        wrapper: (props) =>
-          // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-          reactQueryProviderHOC(
-            <FavoritesWrapper>
-              <View>{props.children}</View>
-            </FavoritesWrapper>
-          ),
-      }
-    )
-    await superFlushWithAct()
-    await waitFor(() => {
-      expect(result.current).toEqual({
-        ...favorite,
-        offer: {
-          ...favorite.offer,
-          date: favorite.offer.date?.toISOString(),
-        },
-      })
+    const { result, waitFor } = renderHook(() => useFavorite({ offerId: favorite.offer.id }), {
+      wrapper: (props) =>
+        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+        reactQueryProviderHOC(
+          <FavoritesWrapper>
+            <View>{props.children}</View>
+          </FavoritesWrapper>
+        ),
     })
-  })
-
-  it('should get favorite from id', async () => {
-    const favorite = paginatedFavoritesResponseSnap.favorites[0]
-    const favoriteId = favorite.id
-    simulateBackend({
-      id: favorite.offer.id,
-      hasAddFavoriteError: false,
-      hasRemoveFavoriteError: false,
-    })
-    // eslint-disable-next-line local-rules/independant-mocks
-    mockUseAuthContext.mockReturnValue({
-      isLoggedIn: true,
-      setIsLoggedIn: jest.fn(),
-    })
-    const { result, waitFor } = renderHook(
-      () =>
-        useFavorite({
-          id: favoriteId,
-        }),
-      {
-        wrapper: (props) =>
-          // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-          reactQueryProviderHOC(
-            <FavoritesWrapper>
-              <View>{props.children}</View>
-            </FavoritesWrapper>
-          ),
-      }
-    )
-    await superFlushWithAct()
-    await waitFor(() => {
-      expect(result.current).toEqual({
-        ...favorite,
-        offer: {
-          ...favorite.offer,
-          date: favorite.offer.date?.toISOString(),
-        },
-      })
-    })
-  })
-
-  it('should get favorite from id and offer id', async () => {
-    const favorite = paginatedFavoritesResponseSnap.favorites[0]
-    const favoriteId = favorite.id
-    simulateBackend({
-      id: favorite.offer.id,
-      hasAddFavoriteError: false,
-      hasRemoveFavoriteError: false,
-    })
-    // eslint-disable-next-line local-rules/independant-mocks
-    mockUseAuthContext.mockReturnValue({
-      isLoggedIn: true,
-      setIsLoggedIn: jest.fn(),
-    })
-    const { result, waitFor } = renderHook(
-      () =>
-        useFavorite({
-          id: favoriteId,
-          offerId: favorite.offer.id,
-        }),
-      {
-        wrapper: (props) =>
-          // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-          reactQueryProviderHOC(
-            <FavoritesWrapper>
-              <View>{props.children}</View>
-            </FavoritesWrapper>
-          ),
-      }
-    )
     await superFlushWithAct()
     await waitFor(() => {
       expect(result.current).toEqual({
@@ -446,124 +359,18 @@ describe('useFavorite hook', () => {
       isLoggedIn: true,
       setIsLoggedIn: jest.fn(),
     })
-    const { result, waitFor } = renderHook(
-      () =>
-        useFavorite({
-          offerId: 99999,
-        }),
-      {
-        wrapper: (props) =>
-          // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-          reactQueryProviderHOC(
-            <FavoritesWrapper>
-              <View>{props.children}</View>
-            </FavoritesWrapper>
-          ),
-      }
-    )
+    const { result, waitFor } = renderHook(() => useFavorite({ offerId: 99999 }), {
+      wrapper: (props) =>
+        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+        reactQueryProviderHOC(
+          <FavoritesWrapper>
+            <View>{props.children}</View>
+          </FavoritesWrapper>
+        ),
+    })
     await superFlushWithAct()
     await waitFor(() => {
       expect(result.current).toEqual(undefined)
-    })
-  })
-
-  it('should not get favorite from id', async () => {
-    const favorite = paginatedFavoritesResponseSnap.favorites[0]
-    simulateBackend({
-      id: favorite.offer.id,
-      hasAddFavoriteError: false,
-      hasRemoveFavoriteError: false,
-    })
-    // eslint-disable-next-line local-rules/independant-mocks
-    mockUseAuthContext.mockReturnValue({
-      isLoggedIn: true,
-      setIsLoggedIn: jest.fn(),
-    })
-    const { result, waitFor } = renderHook(
-      () =>
-        useFavorite({
-          id: 99999,
-        }),
-      {
-        wrapper: (props) =>
-          // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-          reactQueryProviderHOC(
-            <FavoritesWrapper>
-              <View>{props.children}</View>
-            </FavoritesWrapper>
-          ),
-      }
-    )
-    await superFlushWithAct()
-    await waitFor(() => {
-      expect(result.current).toEqual(undefined)
-    })
-  })
-
-  it('should not get favorite from id and offer id', async () => {
-    const favorite = paginatedFavoritesResponseSnap.favorites[0]
-    simulateBackend({
-      id: favorite.offer.id,
-      hasAddFavoriteError: false,
-      hasRemoveFavoriteError: false,
-    })
-    // eslint-disable-next-line local-rules/independant-mocks
-    mockUseAuthContext.mockReturnValue({
-      isLoggedIn: true,
-      setIsLoggedIn: jest.fn(),
-    })
-    const { result, waitFor } = renderHook(
-      () =>
-        useFavorite({
-          id: 99999,
-          offerId: 99999,
-        }),
-      {
-        wrapper: (props) =>
-          // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-          reactQueryProviderHOC(
-            <FavoritesWrapper>
-              <View>{props.children}</View>
-            </FavoritesWrapper>
-          ),
-      }
-    )
-    await superFlushWithAct()
-    await waitFor(() => {
-      expect(result.current).toEqual(undefined)
-    })
-  })
-
-  it('should not get favorite when not logged in', async () => {
-    const favorite = paginatedFavoritesResponseSnap.favorites[0]
-    simulateBackend({
-      id: favorite.offer.id,
-      hasAddFavoriteError: false,
-      hasRemoveFavoriteError: false,
-    })
-    // eslint-disable-next-line local-rules/independant-mocks
-    mockUseAuthContext.mockReturnValue({
-      isLoggedIn: false,
-      setIsLoggedIn: jest.fn(),
-    })
-    const { result, waitFor } = renderHook(
-      () =>
-        useFavorite({
-          id: favorite.id,
-        }),
-      {
-        wrapper: (props) =>
-          // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-          reactQueryProviderHOC(
-            <FavoritesWrapper>
-              <View>{props.children}</View>
-            </FavoritesWrapper>
-          ),
-      }
-    )
-    await superFlushWithAct()
-    await waitFor(() => {
-      expect(result.current).toEqual(null)
     })
   })
 })

--- a/src/features/favorites/pages/__tests__/useFavorites.test.tsx
+++ b/src/features/favorites/pages/__tests__/useFavorites.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-hooks'
 import { rest } from 'msw'
 import * as React from 'react'
 import { View } from 'react-native'
+import waitForExpect from 'wait-for-expect'
 
 import { FavoriteResponse, OfferResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/AuthContext'
@@ -123,45 +124,31 @@ describe('useAddFavorite hook', () => {
       setIsLoggedIn: jest.fn(),
     }))
     const onSuccess = jest.fn()
-    const onMutate = jest.fn()
     const onError = jest.fn()
-    const onSettled = jest.fn()
-    const { result, waitFor } = renderHook(
-      () =>
-        useAddFavorite({
-          onSuccess,
-          onMutate,
-          onError,
-          onSettled,
-        }),
-      {
-        wrapper: (props) =>
-          // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-          reactQueryProviderHOC(
-            <FavoritesWrapper>
-              <View>{props.children}</View>
-            </FavoritesWrapper>
-          ),
-      }
-    )
+    const { result } = renderHook(() => useAddFavorite({ onSuccess, onError }), {
+      wrapper: (props) =>
+        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+        reactQueryProviderHOC(
+          <FavoritesWrapper>
+            <View>{props.children}</View>
+          </FavoritesWrapper>
+        ),
+    })
 
     expect(result.current.isLoading).toBeFalsy()
     result.current.mutate({ offerId })
     await superFlushWithAct()
-    await waitFor(() => {
-      expect(onMutate).toBeCalledWith({ offerId })
-    })
 
-    await superFlushWithAct()
-    expect(onSuccess).toBeCalledWith({
-      ...addFavoriteJsonResponseSnap,
-      offer: {
-        ...addFavoriteJsonResponseSnap.offer,
-        date: addFavoriteJsonResponseSnap.offer.date?.toISOString(),
-      },
+    waitForExpect(() => {
+      expect(onSuccess).toBeCalledWith({
+        ...addFavoriteJsonResponseSnap,
+        offer: {
+          ...addFavoriteJsonResponseSnap.offer,
+          date: addFavoriteJsonResponseSnap.offer.date?.toISOString(),
+        },
+      })
+      expect(onError).not.toBeCalled()
     })
-    expect(onError).not.toBeCalled()
-    expect(onSettled).toBeCalled()
   })
 
   it('should fail to add favorite', async () => {
@@ -175,39 +162,25 @@ describe('useAddFavorite hook', () => {
       setIsLoggedIn: jest.fn(),
     }))
     const onSuccess = jest.fn()
-    const onMutate = jest.fn()
     const onError = jest.fn()
-    const onSettled = jest.fn()
-    const { result, waitFor } = renderHook(
-      () =>
-        useAddFavorite({
-          onSuccess,
-          onMutate,
-          onError,
-          onSettled,
-        }),
-      {
-        wrapper: (props) =>
-          // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-          reactQueryProviderHOC(
-            <FavoritesWrapper>
-              <View>{props.children}</View>
-            </FavoritesWrapper>
-          ),
-      }
-    )
+    const { result } = renderHook(() => useAddFavorite({ onSuccess, onError }), {
+      wrapper: (props) =>
+        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+        reactQueryProviderHOC(
+          <FavoritesWrapper>
+            <View>{props.children}</View>
+          </FavoritesWrapper>
+        ),
+    })
 
     expect(result.current.isLoading).toBeFalsy()
     result.current.mutate({ offerId })
     await superFlushWithAct()
-    await waitFor(() => {
-      expect(onMutate).toBeCalledWith({ offerId })
-    })
 
-    await superFlushWithAct()
-    expect(onSuccess).not.toBeCalled()
-    expect(onError).toBeCalled()
-    expect(onSettled).toBeCalled()
+    waitForExpect(() => {
+      expect(onSuccess).not.toBeCalled()
+      expect(onError).toBeCalled()
+    })
   })
 })
 
@@ -226,40 +199,24 @@ describe('useRemoveFavorite hook', () => {
       isLoggedIn: true,
       setIsLoggedIn: jest.fn(),
     }))
-    const onSuccess = jest.fn()
-    const onMutate = jest.fn()
     const onError = jest.fn()
-    const onSettled = jest.fn()
-    const { result, waitFor } = renderHook(
-      () =>
-        useRemoveFavorite({
-          onSuccess,
-          onMutate,
-          onError,
-          onSettled,
-        }),
-      {
-        wrapper: (props) =>
-          // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-          reactQueryProviderHOC(
-            <FavoritesWrapper>
-              <View>{props.children}</View>
-            </FavoritesWrapper>
-          ),
-      }
-    )
+    const { result } = renderHook(() => useRemoveFavorite({ onError }), {
+      wrapper: (props) =>
+        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+        reactQueryProviderHOC(
+          <FavoritesWrapper>
+            <View>{props.children}</View>
+          </FavoritesWrapper>
+        ),
+    })
 
     expect(result.current.isLoading).toBeFalsy()
     result.current.mutate(favoriteId)
     await superFlushWithAct()
-    await waitFor(() => {
-      expect(onMutate).toBeCalledWith(favoriteId)
-    })
 
-    await superFlushWithAct()
-    expect(onSuccess).toBeCalled()
-    expect(onError).not.toBeCalled()
-    expect(onSettled).toBeCalled()
+    waitForExpect(() => {
+      expect(onError).not.toBeCalled()
+    })
   })
 
   it('should fail to remove favorite', async () => {
@@ -274,40 +231,24 @@ describe('useRemoveFavorite hook', () => {
       isLoggedIn: true,
       setIsLoggedIn: jest.fn(),
     }))
-    const onSuccess = jest.fn()
-    const onMutate = jest.fn()
     const onError = jest.fn()
-    const onSettled = jest.fn()
-    const { result, waitFor } = renderHook(
-      () =>
-        useRemoveFavorite({
-          onSuccess,
-          onMutate,
-          onError,
-          onSettled,
-        }),
-      {
-        wrapper: (props) =>
-          // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-          reactQueryProviderHOC(
-            <FavoritesWrapper>
-              <View>{props.children}</View>
-            </FavoritesWrapper>
-          ),
-      }
-    )
+    const { result } = renderHook(() => useRemoveFavorite({ onError }), {
+      wrapper: (props) =>
+        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+        reactQueryProviderHOC(
+          <FavoritesWrapper>
+            <View>{props.children}</View>
+          </FavoritesWrapper>
+        ),
+    })
 
     expect(result.current.isLoading).toBeFalsy()
     result.current.mutate(favoriteId)
     await superFlushWithAct()
-    await waitFor(() => {
-      expect(onMutate).toBeCalledWith(favoriteId)
-    })
 
-    await superFlushWithAct()
-    expect(onSuccess).not.toBeCalled()
-    expect(onError).toBeCalled()
-    expect(onSettled).toBeCalled()
+    waitForExpect(() => {
+      expect(onError).toBeCalled()
+    })
   })
 })
 
@@ -326,7 +267,7 @@ describe('useFavorite hook', () => {
       isLoggedIn: true,
       setIsLoggedIn: jest.fn(),
     })
-    const { result, waitFor } = renderHook(() => useFavorite({ offerId: favorite.offer.id }), {
+    const { result } = renderHook(() => useFavorite({ offerId: favorite.offer.id }), {
       wrapper: (props) =>
         // eslint-disable-next-line local-rules/no-react-query-provider-hoc
         reactQueryProviderHOC(
@@ -336,7 +277,8 @@ describe('useFavorite hook', () => {
         ),
     })
     await superFlushWithAct()
-    await waitFor(() => {
+
+    waitForExpect(() => {
       expect(result.current).toEqual({
         ...favorite,
         offer: {
@@ -359,7 +301,7 @@ describe('useFavorite hook', () => {
       isLoggedIn: true,
       setIsLoggedIn: jest.fn(),
     })
-    const { result, waitFor } = renderHook(() => useFavorite({ offerId: 99999 }), {
+    const { result } = renderHook(() => useFavorite({ offerId: 99999 }), {
       wrapper: (props) =>
         // eslint-disable-next-line local-rules/no-react-query-provider-hoc
         reactQueryProviderHOC(
@@ -369,7 +311,7 @@ describe('useFavorite hook', () => {
         ),
     })
     await superFlushWithAct()
-    await waitFor(() => {
+    waitForExpect(() => {
       expect(result.current).toEqual(undefined)
     })
   })

--- a/src/features/favorites/pages/useFavorites.ts
+++ b/src/features/favorites/pages/useFavorites.ts
@@ -142,13 +142,16 @@ export function useAddFavorite({ onSuccess, onError, onMutate, onSettled }: AddF
   })
 }
 
+// arbitrary. We have to make sure we invalidate the cache when adding/removing favorites. See above
+const STALE_TIME_FAVORITES = 5 * 60 * 1000
+
 export function useFavorites() {
   const { isLoggedIn } = useAuthContext()
 
   return useQuery<PaginatedFavoritesResponse>(
     QueryKeys.FAVORITES,
     () => api.getnativev1mefavorites(),
-    { enabled: isLoggedIn }
+    { enabled: isLoggedIn, staleTime: STALE_TIME_FAVORITES }
   )
 }
 

--- a/src/features/favorites/pages/useFavorites.ts
+++ b/src/features/favorites/pages/useFavorites.ts
@@ -148,26 +148,13 @@ export function useFavorites() {
   return useQuery<PaginatedFavoritesResponse>(
     QueryKeys.FAVORITES,
     () => api.getnativev1mefavorites(),
-    {
-      enabled: isLoggedIn,
-    }
+    { enabled: isLoggedIn }
   )
 }
 
-export function useFavorite({ offerId, id }: { offerId?: number; id?: number }) {
+export function useFavorite({ offerId }: { offerId?: number }): FavoriteResponse | undefined {
   const { data } = useFavorites()
-  if (!data) {
-    return null
-  }
 
-  return data.favorites.find((favorite) => {
-    if (
-      (offerId && id && favorite.offer.id === offerId && favorite.id === id) ||
-      (!id && favorite.offer.id === offerId) ||
-      (!offerId && favorite.id === id)
-    ) {
-      return true
-    }
-    return false
-  })
+  if (typeof offerId !== 'number') return
+  return data?.favorites.find((favorite) => favorite.offer.id === offerId)
 }

--- a/src/features/offer/pages/OfferBody.tsx
+++ b/src/features/offer/pages/OfferBody.tsx
@@ -1,22 +1,19 @@
 import { t } from '@lingui/macro'
 import React, { FunctionComponent, useRef, useState } from 'react'
 import { ScrollView } from 'react-native'
-import { useQuery } from 'react-query'
 import styled from 'styled-components/native'
 
-import { api } from 'api/api'
-import { CategoryType, ReportedOffer, UserReportedOffersResponse } from 'api/gen'
-import { useAuthContext } from 'features/auth/AuthContext'
+import { CategoryType, ReportedOffer } from 'api/gen'
 import { useUserProfileInfo } from 'features/home/api'
 import { useAvailableCredit } from 'features/home/services/useAvailableCredit'
 import { LocationCaption } from 'features/offer/atoms/LocationCaption'
 import { ReportOfferModal } from 'features/offer/components/ReportOfferModal'
+import { useReportedOffers } from 'features/offer/services/useReportedOffers'
 import { isUserBeneficiary, isUserExBeneficiary } from 'features/profile/utils'
 import { analytics } from 'libs/analytics'
 import { WhereSection } from 'libs/geolocation/components/WhereSection'
 import { formatDatePeriod } from 'libs/parsers'
 import { highlightLinks } from 'libs/parsers/highlightLinks'
-import { QueryKeys } from 'libs/queryKeys'
 import { AccessibilityBlock } from 'ui/components/accessibility/AccessibilityBlock'
 import { AccordionItem } from 'ui/components/AccordionItem'
 import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
@@ -30,13 +27,14 @@ import { OfferIconCaptions, OfferPartialDescription } from '../components'
 
 import { useTrackOfferSeenDuration } from './useTrackOfferSeenDuration'
 
-export const OfferBody: FunctionComponent<{
+interface Props {
   offerId: number
   onScroll: () => void
-}> = ({ offerId, onScroll }) => {
+}
+
+export const OfferBody: FunctionComponent<Props> = ({ offerId, onScroll }) => {
   const { data: offerResponse } = useOffer({ offerId })
   const credit = useAvailableCredit()
-  const { isLoggedIn } = useAuthContext()
   const { data: user } = useUserProfileInfo()
   const scrollViewRef = useRef<ScrollView | null>(null)
 
@@ -46,16 +44,10 @@ export const OfferBody: FunctionComponent<{
 
   useTrackOfferSeenDuration(offerId)
 
-  const { data } = useQuery<UserReportedOffersResponse>(
-    QueryKeys.REPORTED_OFFERS,
-    () => api.getnativev1offersreports(),
-    { enabled: isLoggedIn, retry: true }
+  const { data: reportedOffersResponse } = useReportedOffers()
+  const isOfferAlreadyReported = reportedOffersResponse?.reportedOffers?.find(
+    (reportedOffer: ReportedOffer) => reportedOffer.offerId === offerId
   )
-
-  const reportedOffers = data?.reportedOffers
-  const isOfferAlreadyReported = reportedOffers?.find((reportedOffer: ReportedOffer) => {
-    return reportedOffer.offerId === offerId
-  })
 
   if (!offerResponse) return <React.Fragment></React.Fragment>
   const { accessibility, category, venue } = offerResponse

--- a/src/features/offer/services/useReportedOffers.ts
+++ b/src/features/offer/services/useReportedOffers.ts
@@ -1,0 +1,18 @@
+import { useQuery } from 'react-query'
+
+import { api } from 'api/api'
+import { UserReportedOffersResponse } from 'api/gen'
+import { useAuthContext } from 'features/auth/AuthContext'
+import { QueryKeys } from 'libs/queryKeys'
+
+const STALE_TIME_REPORTED_OFFERS = 5 * 60 * 1000
+
+export const useReportedOffers = () => {
+  const { isLoggedIn } = useAuthContext()
+
+  return useQuery<UserReportedOffersResponse>(
+    QueryKeys.REPORTED_OFFERS,
+    () => api.getnativev1offersreports(),
+    { enabled: isLoggedIn, staleTime: STALE_TIME_REPORTED_OFFERS, retry: true }
+  )
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-9254

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [x] Written **unit tests** for my feature.

## Détails

Chemin:
- chargement de l'application (en étant connecté)
- visite de la page des favoris
- visite d'une page de détail d'une offre favoris
- visite de la recherche
- ajout en favoris d'une offre
- visite de la page des favoris
- suppression d'une offre favoris

Voici  toutes les requêtes sur ce chemin utilisateurs effectuées à `/me/favorites` (POST/GET/DELETE inclus):

#### Avant

![image](https://user-images.githubusercontent.com/10118284/134227032-8e016787-299a-482f-8bb2-e18601170cf4.png)


#### Après
![image](https://user-images.githubusercontent.com/10118284/134226566-38b0fb7d-03ae-4c86-ba85-0cf16683b830.png)

=> Au total sur ce chemin, on évite 6 requêtes inutiles.