### PR TITLE
(PC-10598) Fix checkbox included in touchable opacity on setpassword

### DIFF
--- a/src/features/auth/signup/SetEmail/SetEmail.tsx
+++ b/src/features/auth/signup/SetEmail/SetEmail.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro'
 import { useNavigation, useRoute } from '@react-navigation/native'
 import React, { FunctionComponent, useRef, useState } from 'react'
-import { Platform, TextInput as RNTextInput, TouchableOpacity } from 'react-native'
+import { Platform, TextInput as RNTextInput } from 'react-native'
 import styled from 'styled-components/native'
 
 import { SIGNUP_NUMBER_OF_STEPS } from 'features/auth/api'
@@ -32,7 +32,6 @@ if (__DEV__ && env.SIGNUP_RANDOM_EMAIL) {
   INITIAL_EMAIL = `${randomAlphaString()}@${randomAlphaString()}.com`
 }
 
-const IS_NEWSLETTER_CHECKBOX_LABEL = t`Reçois nos recommandations culturelles à proximité de chez toi par e-mail.`
 export const SetEmail: FunctionComponent = () => {
   const [email, setEmail] = useState(INITIAL_EMAIL)
   const [hasError, setHasError] = useState(false)
@@ -105,13 +104,11 @@ export const SetEmail: FunctionComponent = () => {
             />
           </StyledInput>
           <Spacer.Column numberOfSpaces={4} />
-          <StyledCheckBox>
-            <CheckboxInput isChecked={isNewsletterChecked} setIsChecked={setIsNewsletterChecked} />
-            <TouchableOpacity
-              onPress={() => setIsNewsletterChecked(!isNewsletterChecked)}
-              {...testID(IS_NEWSLETTER_CHECKBOX_LABEL)}>
-              <CheckBoxText>{IS_NEWSLETTER_CHECKBOX_LABEL}</CheckBoxText>
-            </TouchableOpacity>
+          <StyledCheckBox onPress={() => setIsNewsletterChecked(!isNewsletterChecked)}>
+            <CheckboxInput isChecked={isNewsletterChecked} />
+            <CheckBoxText>
+              {t`Reçois nos recommandations culturelles à proximité de chez toi par e-mail.`}
+            </CheckBoxText>
           </StyledCheckBox>
           <Spacer.Column numberOfSpaces={6} />
           <ButtonPrimary
@@ -139,7 +136,7 @@ const CheckBoxText = styled(Typo.Body)({
   ...padding(0, 8, 0, 4),
 })
 
-const StyledCheckBox = styled.View({
+const StyledCheckBox = styled.TouchableOpacity({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',

--- a/src/ui/components/inputs/CheckboxInput.tsx
+++ b/src/ui/components/inputs/CheckboxInput.tsx
@@ -7,12 +7,14 @@ import { BorderRadiusEnum } from 'ui/theme/grid'
 
 export type CustomCheckboxProps = {
   isChecked: boolean
-  setIsChecked: (b: boolean) => void
+  setIsChecked?: (b: boolean) => void
 }
 
 export function CheckboxInput({ isChecked, setIsChecked }: CustomCheckboxProps): JSX.Element {
   function setToggleCheckbox() {
-    setIsChecked(!isChecked)
+    if (setIsChecked) {
+      setIsChecked(!isChecked)
+    }
   }
 
   return (


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10598

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*Web - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|  ![image](https://user-images.githubusercontent.com/77674046/134371026-1c4a0166-e860-4fce-8aa1-40b7784fb04e.png)  |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
