### PR TITLE
[Tech] Performance improvement for AppSearch

### DIFF
--- a/__snapshots__/features/home/components/tests/OffersModule.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/tests/OffersModule.native.test.tsx.native-snap
@@ -54,7 +54,6 @@ Array [
           "offer": Object {
             "category": "MUSIQUE",
             "dates": Array [],
-            "description": "Bel astre voyageur, hôte qui nous arrives, Des profondeurs du ciel et qu'on n'attendait pas, Où vas-tu ? Quel dessein pousse vers nous tes pas ? Toi qui vogues au large en cette mer sans rives",
             "isDigital": false,
             "isDuo": false,
             "name": "Mensch ! Où sont les Hommes ?",
@@ -73,7 +72,6 @@ Array [
           "offer": Object {
             "category": "MUSIQUE",
             "dates": Array [],
-            "description": "D'un coup d'épée, Frappé par un héros, tomber la pointe au coeur! Oui, je disais cela!... Le destin est railleur!... Et voila que je suis tué, par un laquais, d'un coup de bûche! C'est très bien. J'aurai tout manqué, même ma mort.",
             "isDigital": false,
             "isDuo": false,
             "name": "I want something more",
@@ -94,7 +92,6 @@ Array [
             "dates": Array [
               1605643200,
             ],
-            "description": null,
             "isDigital": false,
             "isDuo": true,
             "name": "Un lit sous une rivière",
@@ -113,7 +110,6 @@ Array [
           "offer": Object {
             "category": "MUSIQUE",
             "dates": Array [],
-            "description": "D'un coup d'épée, Frappé par un héros, tomber la pointe au coeur! Oui, je disais cela!... Le destin est railleur!... Et voila que je suis tué, par un laquais, d'un coup de bûche! C'est très bien. J'aurai tout manqué, même ma mort.",
             "isDigital": false,
             "isDuo": false,
             "name": "I want something more",

--- a/__snapshots__/features/venue/components/__tests__/VenueOffers.test.tsx.native-snap
+++ b/__snapshots__/features/venue/components/__tests__/VenueOffers.test.tsx.native-snap
@@ -53,9 +53,9 @@ Array [
     data={
       Array [
         Object {
-          "coordinates": Object {
-            "latitude": 47.8898,
-            "longitude": -2.83593,
+          "_geoloc": Object {
+            "lat": 47.8898,
+            "lng": -2.83593,
           },
           "objectID": "223342",
           "offer": Object {
@@ -65,7 +65,6 @@ Array [
               1629485100,
               1629657900,
             ],
-            "description": "Après une série de crimes inexpliqués, un père retrouve son fils disparu depuis 10 ans. Titane : Métal hautement résistant à la chaleur et à la corrosion, donnant des alliages très durs.",
             "isDigital": false,
             "isDuo": true,
             "name": "Titane - VF",
@@ -78,9 +77,9 @@ Array [
           },
         },
         Object {
-          "coordinates": Object {
-            "latitude": 47.8898,
-            "longitude": -2.83593,
+          "_geoloc": Object {
+            "lat": 47.8898,
+            "lng": -2.83593,
           },
           "objectID": "223338",
           "offer": Object {
@@ -90,7 +89,6 @@ Array [
               1629485100,
               1629657900,
             ],
-            "description": "2012. Les quartiers Nord de Marseille détiennent un triste record : la zone au taux de criminalité le plus élevé de France. Poussée par sa hiérarchie, la BAC Nord, brigade de terrain, cherche sans cesse à améliorer ses résultats.",
             "isDigital": false,
             "isDuo": true,
             "name": "Bac Nord - VF",
@@ -103,9 +101,9 @@ Array [
           },
         },
         Object {
-          "coordinates": Object {
-            "latitude": 47.8898,
-            "longitude": -2.83593,
+          "_geoloc": Object {
+            "lat": 47.8898,
+            "lng": -2.83593,
           },
           "objectID": "223339",
           "offer": Object {
@@ -115,7 +113,6 @@ Array [
               1629485100,
               1629657900,
             ],
-            "description": "Natasha Romanoff, alias Black Widow, voit resurgir la part la plus sombre de son passé pour faire face à une redoutable conspiration liée à sa vie d’autrefois.",
             "isDigital": false,
             "isDuo": true,
             "name": "Black Widow - VF",

--- a/__snapshots__/features/venue/pages/__tests__/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/__tests__/Venue.native.test.tsx.native-snap
@@ -674,9 +674,9 @@ exports[`<Venue /> should match snapshot 1`] = `
         data={
           Array [
             Object {
-              "coordinates": Object {
-                "latitude": 47.8898,
-                "longitude": -2.83593,
+              "_geoloc": Object {
+                "lat": 47.8898,
+                "lng": -2.83593,
               },
               "objectID": "223342",
               "offer": Object {
@@ -686,7 +686,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                   1629485100,
                   1629657900,
                 ],
-                "description": "Après une série de crimes inexpliqués, un père retrouve son fils disparu depuis 10 ans. Titane : Métal hautement résistant à la chaleur et à la corrosion, donnant des alliages très durs.",
                 "isDigital": false,
                 "isDuo": true,
                 "name": "Titane - VF",
@@ -699,9 +698,9 @@ exports[`<Venue /> should match snapshot 1`] = `
               },
             },
             Object {
-              "coordinates": Object {
-                "latitude": 47.8898,
-                "longitude": -2.83593,
+              "_geoloc": Object {
+                "lat": 47.8898,
+                "lng": -2.83593,
               },
               "objectID": "223338",
               "offer": Object {
@@ -711,7 +710,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                   1629485100,
                   1629657900,
                 ],
-                "description": "2012. Les quartiers Nord de Marseille détiennent un triste record : la zone au taux de criminalité le plus élevé de France. Poussée par sa hiérarchie, la BAC Nord, brigade de terrain, cherche sans cesse à améliorer ses résultats.",
                 "isDigital": false,
                 "isDuo": true,
                 "name": "Bac Nord - VF",
@@ -724,9 +722,9 @@ exports[`<Venue /> should match snapshot 1`] = `
               },
             },
             Object {
-              "coordinates": Object {
-                "latitude": 47.8898,
-                "longitude": -2.83593,
+              "_geoloc": Object {
+                "lat": 47.8898,
+                "lng": -2.83593,
               },
               "objectID": "223339",
               "offer": Object {
@@ -736,7 +734,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                   1629485100,
                   1629657900,
                 ],
-                "description": "Natasha Romanoff, alias Black Widow, voit resurgir la part la plus sombre de son passé pour faire face à une redoutable conspiration liée à sa vie d’autrefois.",
                 "isDigital": false,
                 "isDuo": true,
                 "name": "Black Widow - VF",

--- a/__snapshots__/features/venue/pages/__tests__/VenueBody.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/__tests__/VenueBody.native.test.tsx.native-snap
@@ -664,9 +664,9 @@ exports[`<VenueBody /> should render correctly 1`] = `
       data={
         Array [
           Object {
-            "coordinates": Object {
-              "latitude": 47.8898,
-              "longitude": -2.83593,
+            "_geoloc": Object {
+              "lat": 47.8898,
+              "lng": -2.83593,
             },
             "objectID": "223342",
             "offer": Object {
@@ -676,7 +676,6 @@ exports[`<VenueBody /> should render correctly 1`] = `
                 1629485100,
                 1629657900,
               ],
-              "description": "Après une série de crimes inexpliqués, un père retrouve son fils disparu depuis 10 ans. Titane : Métal hautement résistant à la chaleur et à la corrosion, donnant des alliages très durs.",
               "isDigital": false,
               "isDuo": true,
               "name": "Titane - VF",
@@ -689,9 +688,9 @@ exports[`<VenueBody /> should render correctly 1`] = `
             },
           },
           Object {
-            "coordinates": Object {
-              "latitude": 47.8898,
-              "longitude": -2.83593,
+            "_geoloc": Object {
+              "lat": 47.8898,
+              "lng": -2.83593,
             },
             "objectID": "223338",
             "offer": Object {
@@ -701,7 +700,6 @@ exports[`<VenueBody /> should render correctly 1`] = `
                 1629485100,
                 1629657900,
               ],
-              "description": "2012. Les quartiers Nord de Marseille détiennent un triste record : la zone au taux de criminalité le plus élevé de France. Poussée par sa hiérarchie, la BAC Nord, brigade de terrain, cherche sans cesse à améliorer ses résultats.",
               "isDigital": false,
               "isDuo": true,
               "name": "Bac Nord - VF",
@@ -714,9 +712,9 @@ exports[`<VenueBody /> should render correctly 1`] = `
             },
           },
           Object {
-            "coordinates": Object {
-              "latitude": 47.8898,
-              "longitude": -2.83593,
+            "_geoloc": Object {
+              "lat": 47.8898,
+              "lng": -2.83593,
             },
             "objectID": "223339",
             "offer": Object {
@@ -726,7 +724,6 @@ exports[`<VenueBody /> should render correctly 1`] = `
                 1629485100,
                 1629657900,
               ],
-              "description": "Natasha Romanoff, alias Black Widow, voit resurgir la part la plus sombre de son passé pour faire face à une redoutable conspiration liée à sa vie d’autrefois.",
               "isDigital": false,
               "isDuo": true,
               "name": "Black Widow - VF",

--- a/src/features/favorites/atoms/Favorite.tsx
+++ b/src/features/favorites/atoms/Favorite.tsx
@@ -76,7 +76,6 @@ export const Favorite: React.FC<Props> = (props) => {
         ...offer,
         category: parseCategory(offer.category.name),
         categoryName: offer.category.name,
-        description: '',
         thumbUrl: offer.image?.url,
         name: offer.name,
         offerId: offer.id,

--- a/src/features/home/atoms/OfferTile.tsx
+++ b/src/features/home/atoms/OfferTile.tsx
@@ -19,7 +19,6 @@ import { BorderRadiusEnum } from 'ui/theme/grid'
 interface OfferTileProps {
   category: string
   categoryName: CategoryNameEnum | null | undefined
-  description?: string | null
   distance?: string
   date?: string
   name?: string
@@ -34,14 +33,14 @@ interface OfferTileProps {
 
 type PartialOffer = Pick<
   OfferTileProps,
-  'category' | 'categoryName' | 'description' | 'thumbUrl' | 'isDuo' | 'name' | 'offerId'
+  'category' | 'categoryName' | 'thumbUrl' | 'isDuo' | 'name' | 'offerId'
 >
 
 export const mergeOfferData = (offer: PartialOffer) => (
   prevData: OfferAdaptedResponse | undefined
 ): OfferAdaptedResponse => ({
   fullAddress: null,
-  description: offer.description,
+  description: '',
   image: offer.thumbUrl ? { url: offer.thumbUrl } : undefined,
   isDuo: offer.isDuo || false,
   name: offer.name || '',

--- a/src/features/home/atoms/tests/OfferTile.native.test.tsx
+++ b/src/features/home/atoms/tests/OfferTile.native.test.tsx
@@ -14,7 +14,6 @@ const offerId = 116656
 const props = {
   category: offer.category || '',
   categoryName: offer.category,
-  description: offer.description || '',
   expenseDomains: [],
   distance: '1,2km',
   date: 'Dès le 12 mars 2020',
@@ -69,7 +68,7 @@ describe('OfferTile component', () => {
     expect(query!.state.data).toStrictEqual({
       accessibility: {},
       category: { label: 'MUSIQUE', name: 'MUSIQUE' },
-      description: offer.description,
+      description: '',
       expenseDomains: [],
       fullAddress: null,
       id: offerId,

--- a/src/features/home/atoms/tests/OfferTile.web.test.tsx
+++ b/src/features/home/atoms/tests/OfferTile.web.test.tsx
@@ -14,7 +14,6 @@ const offerId = 116656
 const props = {
   category: offer.category || '',
   categoryName: offer.category,
-  description: offer.description || '',
   expenseDomains: [],
   distance: '1,2km',
   date: 'Dès le 12 mars 2020',
@@ -69,7 +68,7 @@ describe('OfferTile component', () => {
     expect(query!.state.data).toStrictEqual({
       accessibility: {},
       category: { label: 'MUSIQUE', name: 'MUSIQUE' },
-      description: offer.description,
+      description: '',
       expenseDomains: [],
       fullAddress: null,
       id: offerId,

--- a/src/features/home/components/OffersModule.tsx
+++ b/src/features/home/components/OffersModule.tsx
@@ -47,7 +47,6 @@ export const OffersModule = (props: OffersModuleProps) => {
           category={parseCategory(item.offer.category)}
           categoryName={item.offer.category}
           offerId={+item.objectID}
-          description={item.offer.description || ''}
           distance={formatDistance(item._geoloc, position)}
           name={item.offer.name}
           date={formatDates(timestampsInMillis)}

--- a/src/features/home/components/RecommendationModule.tsx
+++ b/src/features/home/components/RecommendationModule.tsx
@@ -44,7 +44,6 @@ export const RecommendationModule = (props: RecommendationModuleProps) => {
             category={parseCategory(hit.offer.category)}
             categoryName={hit.offer.category}
             offerId={+hit.objectID}
-            description={hit.offer.description || ''}
             distance={formatDistance(hit._geoloc, position)}
             name={hit.offer.name}
             date={formatDates(timestampsInMillis)}

--- a/src/features/search/atoms/Hit.tsx
+++ b/src/features/search/atoms/Hit.tsx
@@ -40,7 +40,6 @@ export const Hit: React.FC<Props> = ({ hit, query }) => {
         ...offer,
         category: parseCategory(offer.category),
         categoryName: offer.category,
-        description: offer.description || '',
         thumbUrl: offer.thumbUrl,
         isDuo: offer.isDuo,
         name: offer.name,

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -10,7 +10,7 @@ export interface SelectedDate {
   selectedDate: Date
 }
 
-type LocationFilter =
+export type LocationFilter =
   | { locationType: LocationType.EVERYWHERE }
   | { locationType: LocationType.AROUND_ME; aroundRadius: number | null }
   | { locationType: LocationType.PLACE; place: SuggestedPlace; aroundRadius: number }

--- a/src/features/venue/atoms/VenueOfferTile.tsx
+++ b/src/features/venue/atoms/VenueOfferTile.tsx
@@ -14,10 +14,9 @@ import { OfferCaption } from 'ui/components/OfferCaption'
 import { LENGTH_L, RATIO_HOME_IMAGE } from 'ui/theme'
 import { BorderRadiusEnum, MARGIN_DP } from 'ui/theme/grid'
 
-interface OfferTileProps {
+interface VenueOfferTileProps {
   category: string
   categoryName: CategoryNameEnum | null | undefined
-  description?: string | null
   date?: string
   name?: string
   isDuo?: boolean
@@ -29,15 +28,15 @@ interface OfferTileProps {
 }
 
 type PartialOffer = Pick<
-  OfferTileProps,
-  'category' | 'categoryName' | 'description' | 'thumbUrl' | 'isDuo' | 'name' | 'offerId'
+  VenueOfferTileProps,
+  'category' | 'categoryName' | 'thumbUrl' | 'isDuo' | 'name' | 'offerId'
 >
 
 export const mergeOfferData = (offer: PartialOffer) => (
   prevData: OfferAdaptedResponse | undefined
 ): OfferAdaptedResponse => ({
   fullAddress: null,
-  description: offer.description,
+  description: '',
   image: offer.thumbUrl ? { url: offer.thumbUrl } : undefined,
   isDuo: offer.isDuo || false,
   name: offer.name || '',
@@ -64,7 +63,7 @@ export const mergeOfferData = (offer: PartialOffer) => (
     - Remove rowHeight
   */
 
-export const VenueOfferTile = (props: OfferTileProps) => {
+export const VenueOfferTile = (props: VenueOfferTileProps) => {
   const navigation = useNavigation<UseNavigationType>()
   const { isBeneficiary, venueId, ...offer } = props
   const queryClient = useQueryClient()

--- a/src/features/venue/atoms/__tests__/VenueOfferTile.native.test.tsx
+++ b/src/features/venue/atoms/__tests__/VenueOfferTile.native.test.tsx
@@ -15,7 +15,6 @@ const venueId = 34
 const props = {
   category: offer.category || '',
   categoryName: offer.category,
-  description: offer.description || '',
   expenseDomains: [],
   date: 'Dès le 12 mars 2020',
   name: offer.name,
@@ -68,7 +67,7 @@ describe('VenueOfferTile component', () => {
     expect(query!.state.data).toStrictEqual({
       accessibility: {},
       category: { label: 'MUSIQUE', name: 'MUSIQUE' },
-      description: offer.description,
+      description: '',
       expenseDomains: [],
       fullAddress: null,
       id: offerId,

--- a/src/features/venue/atoms/__tests__/VenueOfferTile.web.test.tsx
+++ b/src/features/venue/atoms/__tests__/VenueOfferTile.web.test.tsx
@@ -15,7 +15,6 @@ const venueId = 34
 const props = {
   category: offer.category || '',
   categoryName: offer.category,
-  description: offer.description || '',
   expenseDomains: [],
   date: 'Dès le 12 mars 2020',
   name: offer.name,
@@ -68,7 +67,7 @@ describe('VenueOfferTile component', () => {
     expect(query!.state.data).toStrictEqual({
       accessibility: {},
       category: { label: 'MUSIQUE', name: 'MUSIQUE' },
-      description: offer.description,
+      description: '',
       expenseDomains: [],
       fullAddress: null,
       id: offerId,

--- a/src/features/venue/components/VenueOffers.tsx
+++ b/src/features/venue/components/VenueOffers.tsx
@@ -45,7 +45,6 @@ export const VenueOffers: React.FC<Props> = ({ venueId }) => {
           category={parseCategory(item.offer.category)}
           categoryName={item.offer.category}
           offerId={+item.objectID}
-          description={item.offer.description || ''}
           name={item.offer.name}
           date={formatDates(timestampsInMillis)}
           isDuo={item.offer.isDuo}
@@ -67,7 +66,6 @@ export const VenueOffers: React.FC<Props> = ({ venueId }) => {
   }, [params])
 
   const onPressSeeMore = useCallback(() => {
-    // TODO(antoinewg) add search params with category filter
     analytics.logVenueSeeMoreClicked(venueId)
     dispatch({ type: 'SET_STATE', payload: params })
     stagedDispatch({ type: 'SET_STATE', payload: params })

--- a/src/features/venue/components/__tests__/VenueOffers.test.tsx
+++ b/src/features/venue/components/__tests__/VenueOffers.test.tsx
@@ -5,7 +5,7 @@ import { mocked } from 'ts-jest/utils'
 
 import { initialSearchState } from 'features/search/pages/reducer'
 import { useVenueOffers } from 'features/venue/api/useVenueOffers'
-import { VenueOffersWithOneOfferResponseSnap } from 'features/venue/fixtures/venueOffersResponseSnap'
+import { VenueOffersResponseSnap } from 'features/venue/fixtures/venueOffersResponseSnap'
 import { venueResponseSnap } from 'features/venue/fixtures/venueResponseSnap'
 import { AlgoliaHit } from 'libs/algolia'
 import { analytics } from 'libs/analytics'
@@ -38,15 +38,15 @@ describe('<VenueOffers />', () => {
     expect(renderAPI).toMatchSnapshot()
   })
 
-  it('should display "En voir plus" button if hits is more than hits.length', () => {
+  it('should display "En voir plus" button if nbHits is more than hits.length', () => {
     const { queryByText } = render(<VenueOffers venueId={venueId} />)
     expect(queryByText('En voir plus')).toBeTruthy()
   })
 
-  it(`should doesn't display "En voir plus" button if hits is less than hits.length`, () => {
-    mockUseVenueOffers.mockReturnValueOnce(({
-      data: { hits: VenueOffersWithOneOfferResponseSnap, nbHits: 3 },
-    } as unknown) as UseQueryResult<{ hits: AlgoliaHit[]; nbHits: number }, unknown>)
+  it(`should not display "En voir plus" button if nbHits is same as hits.length`, () => {
+    mockUseVenueOffers.mockReturnValueOnce({
+      data: { hits: VenueOffersResponseSnap, nbHits: VenueOffersResponseSnap.length },
+    } as UseQueryResult<{ hits: AlgoliaHit[]; nbHits: number }, unknown>)
 
     const { queryByText } = render(<VenueOffers venueId={venueId} />)
     expect(queryByText('En voir plus')).toBeFalsy()

--- a/src/features/venue/fixtures/venueOffersResponseSnap.ts
+++ b/src/features/venue/fixtures/venueOffersResponseSnap.ts
@@ -1,11 +1,12 @@
-export const VenueOffersWithOneOfferResponseSnap = {
-  coordinates: { latitude: 47.8898, longitude: -2.83593 },
+import { CategoryNameEnum } from 'api/gen'
+import { SearchHit } from 'libs/search'
+
+export const VenueOffersWithOneOfferResponseSnap: SearchHit = {
+  _geoloc: { lat: 47.8898, lng: -2.83593 },
   objectID: '223337',
   offer: {
-    category: 'CINEMA',
+    category: CategoryNameEnum.CINEMA,
     dates: [1629312300, 1629485100, 1629657900],
-    description:
-      'Après une série de crimes inexpliqués, un père retrouve son fils disparu depuis 10 ans. Titane : Métal hautement résistant à la chaleur et à la corrosion, donnant des alliages très durs.',
     isDigital: false,
     isDuo: true,
     name: 'Titane - VF',
@@ -15,15 +16,13 @@ export const VenueOffersWithOneOfferResponseSnap = {
   },
 }
 
-export const VenueOffersResponseSnap = [
+export const VenueOffersResponseSnap: SearchHit[] = [
   {
-    coordinates: { latitude: 47.8898, longitude: -2.83593 },
+    _geoloc: { lat: 47.8898, lng: -2.83593 },
     objectID: '223342',
     offer: {
-      category: 'CINEMA',
+      category: CategoryNameEnum.CINEMA,
       dates: [1629312300, 1629485100, 1629657900],
-      description:
-        'Après une série de crimes inexpliqués, un père retrouve son fils disparu depuis 10 ans. Titane : Métal hautement résistant à la chaleur et à la corrosion, donnant des alliages très durs.',
       isDigital: false,
       isDuo: true,
       name: 'Titane - VF',
@@ -33,13 +32,11 @@ export const VenueOffersResponseSnap = [
     },
   },
   {
-    coordinates: { latitude: 47.8898, longitude: -2.83593 },
+    _geoloc: { lat: 47.8898, lng: -2.83593 },
     objectID: '223338',
     offer: {
-      category: 'CINEMA',
+      category: CategoryNameEnum.CINEMA,
       dates: [1629312300, 1629485100, 1629657900],
-      description:
-        '2012. Les quartiers Nord de Marseille détiennent un triste record : la zone au taux de criminalité le plus élevé de France. Poussée par sa hiérarchie, la BAC Nord, brigade de terrain, cherche sans cesse à améliorer ses résultats.',
       isDigital: false,
       isDuo: true,
       name: 'Bac Nord - VF',
@@ -49,13 +46,11 @@ export const VenueOffersResponseSnap = [
     },
   },
   {
-    coordinates: { latitude: 47.8898, longitude: -2.83593 },
+    _geoloc: { lat: 47.8898, lng: -2.83593 },
     objectID: '223339',
     offer: {
-      category: 'CINEMA',
+      category: CategoryNameEnum.CINEMA,
       dates: [1629312300, 1629485100, 1629657900],
-      description:
-        'Natasha Romanoff, alias Black Widow, voit resurgir la part la plus sombre de son passé pour faire face à une redoutable conspiration liée à sa vie d’autrefois.',
       isDigital: false,
       isDuo: true,
       name: 'Black Widow - VF',

--- a/src/libs/algolia/algolia.d.ts
+++ b/src/libs/algolia/algolia.d.ts
@@ -3,7 +3,6 @@ import { CategoryNameEnum } from 'api/gen'
 interface Offer {
   category: CategoryNameEnum | null
   dates?: number[]
-  description?: string | null
   isDigital?: boolean
   isDuo?: boolean
   name?: string

--- a/src/libs/algolia/mockedResponses/mockedAlgoliaResponse.ts
+++ b/src/libs/algolia/mockedResponses/mockedAlgoliaResponse.ts
@@ -10,8 +10,6 @@ export const mockedAlgoliaResponse: SearchResponse<AlgoliaHit> = {
       offer: {
         category: CategoryNameEnum.MUSIQUE,
         dates: [],
-        description:
-          "Bel astre voyageur, hôte qui nous arrives, Des profondeurs du ciel et qu'on n'attendait pas, Où vas-tu ? Quel dessein pousse vers nous tes pas ? Toi qui vogues au large en cette mer sans rives",
         isDigital: false,
         isDuo: false,
         name: 'Mensch ! Où sont les Hommes ?',
@@ -26,8 +24,6 @@ export const mockedAlgoliaResponse: SearchResponse<AlgoliaHit> = {
       offer: {
         category: CategoryNameEnum.MUSIQUE,
         dates: [],
-        description:
-          "D'un coup d'épée, Frappé par un héros, tomber la pointe au coeur! Oui, je disais cela!... Le destin est railleur!... Et voila que je suis tué, par un laquais, d'un coup de bûche! C'est très bien. J'aurai tout manqué, même ma mort.",
         isDigital: false,
         isDuo: false,
         name: 'I want something more',
@@ -42,7 +38,6 @@ export const mockedAlgoliaResponse: SearchResponse<AlgoliaHit> = {
       offer: {
         category: CategoryNameEnum.MUSIQUE,
         dates: [1605643200.0],
-        description: null,
         isDigital: false,
         isDuo: true,
         name: 'Un lit sous une rivière',
@@ -57,8 +52,6 @@ export const mockedAlgoliaResponse: SearchResponse<AlgoliaHit> = {
       offer: {
         category: CategoryNameEnum.MUSIQUE,
         dates: [],
-        description:
-          "D'un coup d'épée, Frappé par un héros, tomber la pointe au coeur! Oui, je disais cela!... Le destin est railleur!... Et voila que je suis tué, par un laquais, d'un coup de bûche! C'est très bien. J'aurai tout manqué, même ma mort.",
         isDigital: false,
         isDuo: false,
         name: 'I want something more',
@@ -85,8 +78,6 @@ export const physicalAlgoliaOffer: AlgoliaHit = {
   offer: {
     category: CategoryNameEnum.SPECTACLE,
     dates: [1612465203, 1612551603, 1612638003],
-    description:
-      'Le regard drôle et décalé de sept circassiennes de haut vol sur leur Finlande natale.\n\nIl y a dix ans, un groupe de copines, soudées par des années communes de formation en cirque, exilées et éloignées, décide de raconter en un spectacle leur Finlande natale. Mad in Finland est né lors du festival costarmoricain Tant qu’il y aura des Mouettes, nourri par le bonheur des sept acrobates de se retrouver. Depuis, la Finlande a élu une femme Premier ministre, les extrêmes ont gagné du terrain, Nokia – fierté nationale – n’est plus la marque de téléphone le plus vendu. Mais les sept sœurs de piste ont toujours la joie communicative, l’autodérision, la tendresse et l’énergie pour partager leur pays : la nuit polaire, les championnats en tout genre, le saut à ski, les forêts grouillantes de bûcherons, la passion finlandaise pour le sauna… Trapèzes, fil, tissu, rola bola, main à main et musique en direct composent ce récit en V.O. joyeux et généreux.',
     isDigital: false,
     isDuo: true,
     name: 'Mad in Finland',
@@ -102,8 +93,6 @@ export const digitalAlgoliaOffer: AlgoliaHit = {
   offer: {
     category: CategoryNameEnum.FILM,
     dates: [],
-    description:
-      'Depuis, cinq ans, dans le cerveau de Bahia, tout bugge. Mobilité, élocution, coordination, en gros, « c’est la merde ». Du coup Bahia est obligée de faire équipe avec Simone. Ensemble, elles découvrent les joies du handicap ! Le parcours du combattant face à l’administration, les rendez-vous systématiquement ratés pour cause de retards intempestifs, les « dates » au 5ème sans ascenseur, et la merveilleuse ville de Paris où rien n’est fait, ou presque pour l’accessibilité des personnes « à mobilité réduite ». Heureusement, Bahia est épaulée par Tom, son coloc, et son très séduisant kiné…',
     isDigital: true,
     isDuo: false,
     name: 'Web série : Simone et moi',

--- a/src/libs/search/filters/buildBoosts.ts
+++ b/src/libs/search/filters/buildBoosts.ts
@@ -1,33 +1,32 @@
-import { Boosts } from '@elastic/app-search-javascript'
+import { Boosts, ProximityBoost } from '@elastic/app-search-javascript'
 
+import { LocationFilter } from 'features/search/types'
 import { GeoCoordinates } from 'libs/geolocation'
 
 import { AppSearchFields, AppSearchVenuesFields } from './constants'
 
+const getProximityBoost = (userLocation: GeoCoordinates): ProximityBoost => ({
+  type: 'proximity',
+  function: 'exponential',
+  center: `${userLocation.latitude},${userLocation.longitude}`,
+  factor: 10,
+})
+
+const isSearchFilteredAroundUserPosition = (locationFilter: LocationFilter): boolean =>
+  'aroundRadius' in locationFilter && typeof locationFilter['aroundRadius'] === 'number'
+
 export const buildBoosts = (
-  userLocation: GeoCoordinates | null
+  userLocation: GeoCoordinates | null,
+  locationFilter: LocationFilter
 ): Boosts<AppSearchFields> | undefined => {
-  if (!userLocation) return
-  return {
-    [AppSearchFields.venue_position]: {
-      type: 'proximity',
-      function: 'exponential',
-      center: `${userLocation.latitude},${userLocation.longitude}`,
-      factor: 10,
-    },
-  }
+  if (!userLocation || !isSearchFilteredAroundUserPosition(locationFilter)) return
+  return { [AppSearchFields.venue_position]: getProximityBoost(userLocation) }
 }
 
 export const buildBoostsVenues = (
-  userLocation: GeoCoordinates | null
+  userLocation: GeoCoordinates | null,
+  locationFilter: LocationFilter
 ): Boosts<AppSearchVenuesFields> | undefined => {
-  if (!userLocation) return
-  return {
-    [AppSearchVenuesFields.position]: {
-      type: 'proximity',
-      function: 'exponential',
-      center: `${userLocation.latitude},${userLocation.longitude}`,
-      factor: 10,
-    },
-  }
+  if (!userLocation || !isSearchFilteredAroundUserPosition(locationFilter)) return
+  return { [AppSearchVenuesFields.position]: getProximityBoost(userLocation) }
 }

--- a/src/libs/search/filters/buildQueryOptions.ts
+++ b/src/libs/search/filters/buildQueryOptions.ts
@@ -49,7 +49,7 @@ export const buildQueryOptions = (
     sort: SORT_OPTIONS,
   }
 
-  const boosts = buildBoosts(userLocation)
+  const boosts = buildBoosts(userLocation, searchState.locationFilter)
   if (boosts) {
     queryOptions['boosts'] = boosts
   }

--- a/src/libs/search/filters/buildVenuesQueryOptions.ts
+++ b/src/libs/search/filters/buildVenuesQueryOptions.ts
@@ -36,7 +36,7 @@ export const buildVenuesQueryOptions = (
     group: { field: AppSearchVenuesFields.id },
   }
 
-  const boosts = buildBoostsVenues(userLocation)
+  const boosts = buildBoostsVenues(userLocation, locationFilter)
   if (boosts) {
     queryOptions['boosts'] = boosts
   }

--- a/src/libs/search/filters/constants.ts
+++ b/src/libs/search/filters/constants.ts
@@ -57,7 +57,6 @@ export enum AppSearchVenuesFields {
 export const RESULT_FIELDS: ResultFields<AppSearchFields> = {
   [AppSearchFields.category]: { raw: {} },
   [AppSearchFields.dates]: { raw: {} },
-  [AppSearchFields.description]: { raw: {} },
   [AppSearchFields.id]: { raw: {} },
   [AppSearchFields.is_digital]: { raw: {} },
   [AppSearchFields.is_duo]: { raw: {} },

--- a/src/libs/search/filters/tests/buildBoosts.test.ts
+++ b/src/libs/search/filters/tests/buildBoosts.test.ts
@@ -1,23 +1,81 @@
-import { AppSearchFields } from 'libs/search/filters/constants'
+import { LocationType } from 'features/search/enums'
+import { LocationFilter } from 'features/search/types'
+import { SuggestedPlace } from 'libs/place'
+import { AppSearchFields, AppSearchVenuesFields } from 'libs/search/filters/constants'
 
-import { buildBoosts } from '../buildBoosts'
+import { buildBoosts, buildBoostsVenues } from '../buildBoosts'
+
+const Kourou: SuggestedPlace = {
+  label: 'Kourou',
+  info: 'Guyane',
+  geolocation: { longitude: -52.669736, latitude: 5.16186 },
+}
+
+const filterEverywhere: LocationFilter = { locationType: LocationType.EVERYWHERE }
+const filterAroundUser: LocationFilter = { locationType: LocationType.AROUND_ME, aroundRadius: 20 }
+const filterPlace: LocationFilter = {
+  locationType: LocationType.PLACE,
+  place: Kourou,
+  aroundRadius: 20,
+}
+const filterVenue: LocationFilter = {
+  locationType: LocationType.VENUE,
+  venue: { ...Kourou, venueId: 4 },
+}
+
+const userLocation = { latitude: 48.8557, longitude: 2.3469 }
+const expectedBoost = {
+  [AppSearchFields.venue_position]: {
+    type: 'proximity',
+    function: 'exponential',
+    center: `48.8557,2.3469`,
+    factor: 10,
+  },
+}
+
+const venueBoost = {
+  [AppSearchVenuesFields.position]: {
+    type: 'proximity',
+    function: 'exponential',
+    center: `48.8557,2.3469`,
+    factor: 10,
+  },
+}
 
 describe('buildBoosts', () => {
-  describe('proximity boost', () => {
-    it('should not add a proximity boost if no position', () => {
-      expect(buildBoosts(null)).toBeUndefined()
-    })
+  it('should not add a proximity boost if no position', () => {
+    expect(buildBoosts(null, filterEverywhere)).toBeUndefined()
+    expect(buildBoosts(null, filterAroundUser)).toBeUndefined()
+    expect(buildBoosts(null, filterPlace)).toBeUndefined()
+    expect(buildBoosts(null, filterVenue)).toBeUndefined()
+  })
 
-    it("should add a proximity boost centered around the user's position", () => {
-      const boosts = buildBoosts({ latitude: 48.8557, longitude: 2.3469 })
-      expect(boosts).toStrictEqual({
-        [AppSearchFields.venue_position]: {
-          type: 'proximity',
-          function: 'exponential',
-          center: `48.8557,2.3469`,
-          factor: 10,
-        },
-      })
-    })
+  it('should not add a proximity boost if no geolocation filter is applied beforehand', () => {
+    expect(buildBoosts(userLocation, filterEverywhere)).toBeUndefined()
+    expect(buildBoosts(userLocation, filterVenue)).toBeUndefined()
+  })
+
+  it("should add a proximity boost centered around the user's position if the search is filtered geographically", () => {
+    expect(buildBoosts(userLocation, filterAroundUser)).toStrictEqual(expectedBoost)
+    expect(buildBoosts(userLocation, filterPlace)).toStrictEqual(expectedBoost)
+  })
+})
+
+describe('buildBoostsVenues', () => {
+  it('should not add a proximity boost if no position', () => {
+    expect(buildBoostsVenues(null, filterEverywhere)).toBeUndefined()
+    expect(buildBoostsVenues(null, filterAroundUser)).toBeUndefined()
+    expect(buildBoostsVenues(null, filterPlace)).toBeUndefined()
+    expect(buildBoostsVenues(null, filterVenue)).toBeUndefined()
+  })
+
+  it('should not add a proximity boost if no geolocation filter is applied beforehand', () => {
+    expect(buildBoostsVenues(userLocation, filterEverywhere)).toBeUndefined()
+    expect(buildBoostsVenues(userLocation, filterVenue)).toBeUndefined()
+  })
+
+  it("should add a proximity boost centered around the user's position if the search is filtered geographically", () => {
+    expect(buildBoostsVenues(userLocation, filterAroundUser)).toStrictEqual(venueBoost)
+    expect(buildBoostsVenues(userLocation, filterPlace)).toStrictEqual(venueBoost)
   })
 })

--- a/src/libs/search/utils/buildAlgoliaHit.ts
+++ b/src/libs/search/utils/buildAlgoliaHit.ts
@@ -26,7 +26,6 @@ export const buildAlgoliaHit = (searchHit: ResultItem<AppSearchFields>): Algolia
     offer: {
       category: searchHit.getRaw(AppSearchFields.category) as CategoryNameEnum,
       dates,
-      description: searchHit.getRaw(AppSearchFields.description) as string,
       isDigital: +searchHit.getRaw(AppSearchFields.is_digital) === TRUE,
       isDuo: +searchHit.getRaw(AppSearchFields.is_duo) === TRUE,
       name: searchHit.getRaw(AppSearchFields.name) as string,

--- a/src/types/@elastic/app-search-javascript/index.d.ts
+++ b/src/types/@elastic/app-search-javascript/index.d.ts
@@ -132,7 +132,7 @@ export type Sort<FieldsEnum> = SortOption<FieldsEnum> | Array<SortOption<FieldsE
  *
  * https://swiftype.com/documentation/app-search/api/search/boosts#value-boosts
  */
-interface ValueBooost {
+interface ValueBoost {
   type: 'value'
   /** The value to exact match on. Use an array to match on multiple values. */
   value: number | string
@@ -147,7 +147,7 @@ interface ValueBooost {
  *
  * https://swiftype.com/documentation/app-search/api/search/boosts#functional-boosts
  */
-interface FunctionalBooost {
+interface FunctionalBoost {
   type: 'functional'
   /** Type of function to calculate the boost value */
   function: 'linear' | 'exponential' | 'logarithmic'
@@ -162,7 +162,7 @@ interface FunctionalBooost {
  *
  * https://swiftype.com/documentation/app-search/api/search/boosts#proximity-boosts
  */
-interface ProximityBooost {
+export interface ProximityBoost {
   type: 'proximity'
   /** The mode of the distribution */
   center: string
@@ -178,7 +178,7 @@ interface ProximityBooost {
  * https://swiftype.com/documentation/app-search/api/search/boosts
  */
 export type Boosts<FieldsEnum> = FieldsEnum extends string
-  ? Partial<Record<FieldsEnum, ValueBooost | FunctionalBooost | ProximityBooost>>
+  ? Partial<Record<FieldsEnum, ValueBoost | FunctionalBoost | ProximityBoost>>
   : never
 
 export interface SearchOptions<FieldsEnum> {


### PR DESCRIPTION
### Details

-  https://github.com/pass-culture/pass-culture-app-native/pull/1716/commits/ae212996d1ac65c40d240de0b249dccb74bc1e5e: on n'utilise pas le champ `description` qui provient d'Algolia/AppSearch. Par conséquent, on peut l'enlever des champs récupérés. Impact léger et principalement sur les données transférées  via l'appel réseau. Ça permet aussi de se préparer au moment éventuel où le champ description ne sera plus indexé sur AppSearch.

- https://github.com/pass-culture/pass-culture-app-native/pull/1716/commits/251a3617dc48b2200713f5774b1f7180603e11a5 : Impact conséquent sur les temps de requêtes à ElasticSearch. Par exemple pour les playlist non géolocalisées de la home, on appliquait un boost par proximité si l'utilisateur avec sa geoloc activée. Ceci entraine un calcul de la distance entre l'utilisateur et chacune des offres en bases afin de lui afficher en premier les offres proches de lui (très gros calcul).