### PR TITLE
(PC-10546) App Native - Decli Web - Page Profile - Pas d'espace après "300€" sur la bannière

### DIFF
--- a/src/ui/components/ModuleBanner/ModuleBanner.tsx
+++ b/src/ui/components/ModuleBanner/ModuleBanner.tsx
@@ -26,7 +26,7 @@ export function ModuleBanner(props: ModuleBannerProps) {
             <IconContainer>{props.leftIcon}</IconContainer>
             <TextContainer>
               <Typo.ButtonText color={ColorsEnum.WHITE} testID="module-title">
-                {props.title}
+                <TitleContainer>{props.title}</TitleContainer>
               </Typo.ButtonText>
               <Typo.Body color={ColorsEnum.WHITE}>{props.subTitle}</Typo.Body>
             </TextContainer>
@@ -68,4 +68,8 @@ const IconContainer = styled.View({
   justifyContent: 'center',
   alignItems: 'center',
   textAlign: 'left',
+})
+
+const TitleContainer = styled.Text({
+  marginRight: 5,
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10546

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-10546]  App Native - Decli Web - Page Profile - Pas d'espace après "300€" sur la bannière`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*Chrome - [Desktop] | \*Chrome - [Small] |
| -------------------- | :----------------------: |
|<img width="1920" alt="Schermata 2021-09-27 alle 17 19 04" src="https://user-images.githubusercontent.com/90036171/134938153-a6addaed-af6b-490f-80c2-09939ca4a412.png">|<img width="500" alt="Schermata 2021-09-27 alle 17 19 13" src="https://user-images.githubusercontent.com/90036171/134938194-4ea7dbe1-4593-4755-a803-99e4b2e76dd9.png">|



## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`


[PC-10546]: https://passculture.atlassian.net/browse/PC-10546