### PR TITLE
(PC-11070) Tweak react-native-web Image component to support css transformation (Offer/Venue)

### DIFF
--- a/patches/react-native-web+0.17.1.patch
+++ b/patches/react-native-web+0.17.1.patch
@@ -1,0 +1,65 @@
+diff --git a/node_modules/react-native-web/dist/cjs/exports/Image/index.js b/node_modules/react-native-web/dist/cjs/exports/Image/index.js
+index 945174e..559ad3e 100644
+--- a/node_modules/react-native-web/dist/cjs/exports/Image/index.js
++++ b/node_modules/react-native-web/dist/cjs/exports/Image/index.js
+@@ -188,6 +188,7 @@ var Image = /*#__PURE__*/React.forwardRef(function (props, ref) {
+       pointerEvents = props.pointerEvents,
+       source = props.source,
+       style = props.style,
++      transform = props.transform,
+       rest = _objectWithoutPropertiesLoose(props, ["accessibilityLabel", "blurRadius", "defaultSource", "draggable", "onError", "onLayout", "onLoad", "onLoadEnd", "onLoadStart", "pointerEvents", "source", "style"]);
+
+   if (process.env.NODE_ENV !== 'production') {
+@@ -326,7 +327,8 @@ var Image = /*#__PURE__*/React.forwardRef(function (props, ref) {
+   }), /*#__PURE__*/React.createElement(_View.default, {
+     style: [styles.image, resizeModeStyles[resizeMode], {
+       backgroundImage: backgroundImage,
+-      filter: filter
++      filter: filter,
++      transform: transform
+     }, backgroundSize != null && {
+       backgroundSize: backgroundSize
+     }],
+diff --git a/node_modules/react-native-web/dist/exports/Image/index.js b/node_modules/react-native-web/dist/exports/Image/index.js
+index 5c25ebf..b9ab20d 100644
+--- a/node_modules/react-native-web/dist/exports/Image/index.js
++++ b/node_modules/react-native-web/dist/exports/Image/index.js
+@@ -175,6 +175,7 @@ var Image = /*#__PURE__*/React.forwardRef(function (props, ref) {
+       pointerEvents = props.pointerEvents,
+       source = props.source,
+       style = props.style,
++      transform = props.transform,
+       rest = _objectWithoutPropertiesLoose(props, ["accessibilityLabel", "blurRadius", "defaultSource", "draggable", "onError", "onLayout", "onLoad", "onLoadEnd", "onLoadStart", "pointerEvents", "source", "style"]);
+
+   if (process.env.NODE_ENV !== 'production') {
+@@ -312,7 +313,8 @@ var Image = /*#__PURE__*/React.forwardRef(function (props, ref) {
+   }), /*#__PURE__*/React.createElement(View, {
+     style: [styles.image, resizeModeStyles[resizeMode], {
+       backgroundImage: backgroundImage,
+-      filter: filter
++      filter: filter,
++      transform: transform
+     }, backgroundSize != null && {
+       backgroundSize: backgroundSize
+     }],
+diff --git a/node_modules/react-native-web/src/exports/Image/index.js b/node_modules/react-native-web/src/exports/Image/index.js
+index 7cbde9f..324efeb 100644
+--- a/node_modules/react-native-web/src/exports/Image/index.js
++++ b/node_modules/react-native-web/src/exports/Image/index.js
+@@ -157,6 +157,7 @@ const Image: React.AbstractComponent<ImageProps, React.ElementRef<typeof View>>
+       pointerEvents,
+       source,
+       style,
++      transform,
+       ...rest
+     } = props;
+
+@@ -290,7 +291,7 @@ const Image: React.AbstractComponent<ImageProps, React.ElementRef<typeof View>>
+           style={[
+             styles.image,
+             resizeModeStyles[resizeMode],
+-            { backgroundImage, filter },
++            { backgroundImage, filter, transform },
+             backgroundSize != null && { backgroundSize }
+           ]}
+           suppressHydrationWarning={true}

--- a/src/ui/components/hero/HeroHeader.tsx
+++ b/src/ui/components/hero/HeroHeader.tsx
@@ -41,6 +41,8 @@ export const HeroHeader: React.FC<Props> = (props) => {
             blurRadius={Platform.OS === 'android' ? 5 : 20}
             resizeMode="cover"
             source={{ uri: props.imageUrl }}
+            // @ts-ignore TODO: remove when https://github.com/necolas/react-native-web/issues/2139 is fixed
+            {...(Platform.OS === 'web' ? { transform: 'scale(1.1)' } : {})}
           />
         ) : (
           backgroundImage


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11070

Added tweak of react-native-web `Image` component until https://github.com/necolas/react-native-web/issues/2139 is resolved.

- `props.transform` : apply transform to `<img />` styles.

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*Web - [avant] | \*Web - [Après] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
| ![image](https://user-images.githubusercontent.com/77674046/134939303-78fd2d31-a957-44f8-ac9b-702f18091acc.png) | ![image](https://user-images.githubusercontent.com/77674046/134939173-06c8f1f3-9c34-4f9c-b777-804efa4ffde1.png) |                       |                       |





## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
