### PR TITLE
Revert "(PC-10931) Added redirect to home when refreshing succeed"

### DIFF
--- a/src/features/forceUpdate/ForceUpdate.tsx
+++ b/src/features/forceUpdate/ForceUpdate.tsx
@@ -1,12 +1,9 @@
 import { t } from '@lingui/macro'
-import { useFocusEffect, useNavigation } from '@react-navigation/native'
-import React, { useCallback } from 'react'
+import React from 'react'
 import { Platform } from 'react-native'
 import styled from 'styled-components/native'
 
-import { useMustUpdateApp } from 'features/forceUpdate/useMustUpdateApp'
-import { homeNavigateConfig, openExternalUrl } from 'features/navigation/helpers'
-import { UseNavigationType } from 'features/navigation/RootNavigator'
+import { openExternalUrl } from 'features/navigation/helpers'
 import { env } from 'libs/environment'
 import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { Background } from 'ui/svg/Background'
@@ -45,17 +42,6 @@ const buttonText = Platform.select({
 })
 
 export const ForceUpdate = () => {
-  const { navigate } = useNavigation<UseNavigationType>()
-  const mustUpdateApp = useMustUpdateApp()
-
-  useFocusEffect(
-    useCallback(() => {
-      if (!mustUpdateApp) {
-        navigate(homeNavigateConfig.screen, homeNavigateConfig.params)
-      }
-    }, [mustUpdateApp])
-  )
-
   return (
     <Container>
       <Background />


### PR DESCRIPTION
This reverts commit fcf4d810c07a4a2848a520fbbef428182b3dbdb7.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10931

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Written **documentation on Notion** for my feature.
- [ ] Added new reusable components to the AppComponents page and communicate to the team on slack
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).
190
## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | Tablet - [Phone name] | Little - [Phone name] |
| -------------------- | :----------------------: | --------------------: | --------------------: |
|                      |                          |                       |                       |

## Deploy hard

If native code (ios/android) was modified, **after** the PR is merged, on the master branch, upgrade the **app version** (+1 patch):

- if you want an hard deployment of the testing environment, use `yarn trigger:testing:deploy`
