### PR TITLE
(Tech) clean sentry from geoloc related logs

### DIFF
--- a/src/libs/geolocation/getPosition.ts
+++ b/src/libs/geolocation/getPosition.ts
@@ -4,8 +4,6 @@ import AgonTukGeolocation, {
   PositionError as AgonTukPositionError,
 } from 'react-native-geolocation-service'
 
-import { MonitoringError, MonitoringMessage } from 'libs/monitoring'
-
 import { GEOLOCATION_USER_ERROR_MESSAGE, GeolocPositionError } from './enums'
 import { GeolocationError, GeoCoordinates } from './types'
 
@@ -38,7 +36,7 @@ export const getPosition = (
         latitude: position.coords.latitude,
       })
     },
-    ({ code, message }) => {
+    ({ code }) => {
       const type = ERROR_MAPPING[code]
       switch (type) {
         case GeolocPositionError.PERMISSION_DENIED:
@@ -49,31 +47,26 @@ export const getPosition = (
           // Location provider not available
           // or old iPhones (5s, 6s confirmed) only : global localisation setting is off with message "Location service is turned off"
           setPositionError({ type, message: GEOLOCATION_USER_ERROR_MESSAGE[type] })
-          new MonitoringMessage('PositionError_PositionUnavailable' + message)
           break
         case GeolocPositionError.TIMEOUT:
           // Location request timed out
           // TODO: we could implement a retry pattern
           setPositionError({ type, message: GEOLOCATION_USER_ERROR_MESSAGE[type] })
           setPosition(null)
-          new MonitoringError(message, 'PositionError_Timeout')
           break
         case GeolocPositionError.PLAY_SERVICE_NOT_AVAILABLE:
           setPositionError({ type, message: GEOLOCATION_USER_ERROR_MESSAGE[type] })
           setPosition(null)
-          new MonitoringMessage('PositionError_PlayServiceNotAvailable' + message)
           break
         case GeolocPositionError.SETTINGS_NOT_SATISFIED:
           // Android only : location service is disabled or location mode is not appropriate for the current request
           setPositionError({ type, message: GEOLOCATION_USER_ERROR_MESSAGE[type] })
           setPosition(null)
-          new MonitoringMessage('PositionError_SettingsNotSatisfied' + message)
           break
         case GeolocPositionError.INTERNAL_ERROR:
           /// Android only : library crashed for some reason or getCurrentActivity() returned null
           setPositionError({ type, message: GEOLOCATION_USER_ERROR_MESSAGE[type] })
           setPosition(null)
-          new MonitoringError(message, 'PositionError_InternalError')
           break
       }
     },

--- a/src/libs/geolocation/getPosition.web.ts
+++ b/src/libs/geolocation/getPosition.web.ts
@@ -1,7 +1,5 @@
 import { Dispatch, SetStateAction } from 'react'
 
-import { MonitoringError, MonitoringMessage } from 'libs/monitoring'
-
 import { GEOLOCATION_USER_ERROR_MESSAGE, GeolocPositionError } from './enums'
 import { GeolocationError, GeoCoordinates } from './types'
 
@@ -29,7 +27,7 @@ export const getPosition = (
         latitude: position.coords.latitude,
       })
     },
-    ({ code, message }) => {
+    ({ code }) => {
       const type = ERROR_MAPPING[code]
       switch (type) {
         case GeolocPositionError.PERMISSION_DENIED:
@@ -39,14 +37,12 @@ export const getPosition = (
         case GeolocPositionError.POSITION_UNAVAILABLE:
           // Location provider not available
           setPositionError({ type, message: GEOLOCATION_USER_ERROR_MESSAGE[type] })
-          new MonitoringMessage('PositionError_PositionUnavailable' + message)
           break
         case GeolocPositionError.TIMEOUT:
           // Location request timed out
           // TODO: we could implement a retry pattern
           setPositionError({ type, message: GEOLOCATION_USER_ERROR_MESSAGE[type] })
           setPosition(null)
-          new MonitoringError(message, 'PositionError_Timeout')
           break
       }
     },


### PR DESCRIPTION
Beaucoup de logs sur les erreurs lié à la position. On a eu l'information, si on veut l'analyser, on peut.
On va éviter de flooder sentry avec ces messages maintenant.

![image](https://user-images.githubusercontent.com/10118284/135425268-1d8c25d7-0be0-43b9-93fc-bb10dc33b6a7.png)
