### PR TITLE
[UX - Analytics] Uniformise transition to Offer details page

### DIFF
--- a/src/features/bookings/components/EndedBookingItem.native.test.tsx
+++ b/src/features/bookings/components/EndedBookingItem.native.test.tsx
@@ -2,12 +2,15 @@ import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 import { BookingCancellationReasons } from 'api/gen'
+import { analytics } from 'libs/analytics'
 import { fireEvent, render } from 'tests/utils'
 
 import { bookingsSnap } from '../api/bookingsSnap'
 
 import { EndedBookingItem } from './EndedBookingItem'
 import { Booking } from './types'
+
+jest.mock('react-query')
 
 describe('EndedBookingItem', () => {
   it('should display offer title', () => {
@@ -59,6 +62,10 @@ describe('EndedBookingItem', () => {
 
     expect(navigate).toHaveBeenCalledWith('Offer', {
       id: 147874,
+      from: 'endedbookings',
+    })
+    expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {
+      offerId: 147874,
       from: 'endedbookings',
     })
   })

--- a/src/features/bookings/components/EndedBookingItem.tsx
+++ b/src/features/bookings/components/EndedBookingItem.tsx
@@ -2,10 +2,13 @@ import { t } from '@lingui/macro'
 import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 import { TouchableOpacity } from 'react-native'
+import { useQueryClient } from 'react-query'
 import styled from 'styled-components/native'
 
 import { BookingCancellationReasons } from 'api/gen'
+import { mergeOfferData } from 'features/home/atoms/OfferTile'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
+import { analytics } from 'libs/analytics'
 import { formatToSlashedFrenchDate } from 'libs/dates'
 import { useCategoryId } from 'libs/subcategories'
 import { InputRule } from 'ui/components/inputs/rules/InputRule'
@@ -20,19 +23,31 @@ export const EndedBookingItem = ({ booking }: BookingItemProps) => {
   const { navigate } = useNavigation<UseNavigationType>()
   const { cancellationDate, cancellationReason, dateUsed, stock } = booking
   const categoryId = useCategoryId(stock.offer.subcategoryId)
+  const queryClient = useQueryClient()
 
   const endedBookingReason = getEndedBookingReason(cancellationReason, dateUsed)
   const endedBookingDateLabel = getEndedBookingDateLabel(cancellationDate, dateUsed)
 
+  function handlePressOffer() {
+    const { offer } = stock
+    if (!offer.id) return
+    // We pre-populate the query-cache with the data from the search result for a smooth transition
+    queryClient.setQueryData(
+      ['offer', offer.id],
+      mergeOfferData({
+        ...offer,
+        categoryId,
+        thumbUrl: offer.image?.url,
+        name: offer.name,
+        offerId: offer.id,
+      })
+    )
+    analytics.logConsultOffer({ offerId: offer.id, from: 'endedbookings' })
+    navigate('Offer', { id: stock.offer.id, from: 'endedbookings' })
+  }
+
   return (
-    <TouchableOpacity
-      onPress={() =>
-        navigate('Offer', {
-          id: stock.offer.id,
-          from: 'endedbookings',
-        })
-      }
-      testID="EndedBookingItem">
+    <TouchableOpacity onPress={handlePressOffer} testID="EndedBookingItem">
       <ItemContainer>
         <EndedBookingTicket image={stock.offer.image?.url} categoryId={categoryId} />
         <Spacer.Row numberOfSpaces={4} />

--- a/src/features/bookings/components/EndedBookingItem.web.test.tsx
+++ b/src/features/bookings/components/EndedBookingItem.web.test.tsx
@@ -2,12 +2,15 @@ import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 import { BookingCancellationReasons } from 'api/gen'
+import { analytics } from 'libs/analytics'
 import { fireEvent, render } from 'tests/utils/web'
 
 import { bookingsSnap } from '../api/bookingsSnap'
 
 import { EndedBookingItem } from './EndedBookingItem'
 import { Booking } from './types'
+
+jest.mock('react-query')
 
 describe('EndedBookingItem', () => {
   it('should display offer title', () => {
@@ -59,6 +62,10 @@ describe('EndedBookingItem', () => {
 
     expect(navigate).toHaveBeenCalledWith('Offer', {
       id: 147874,
+      from: 'endedbookings',
+    })
+    expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {
+      offerId: 147874,
       from: 'endedbookings',
     })
   })

--- a/src/features/bookings/pages/BookingDetails.tsx
+++ b/src/features/bookings/pages/BookingDetails.tsx
@@ -3,6 +3,7 @@ import { useNavigation, useRoute } from '@react-navigation/native'
 import React from 'react'
 import { useWindowDimensions } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
+import { useQueryClient } from 'react-query'
 import styled from 'styled-components/native'
 
 import { useAppSettings } from 'features/auth/settings'
@@ -15,6 +16,7 @@ import { BookingPropertiesSection } from 'features/bookings/components/BookingPr
 import { CancelBookingModal } from 'features/bookings/components/CancelBookingModal'
 import { ThreeShapesTicket } from 'features/bookings/components/ThreeShapesTicket'
 import { BookingProperties, getBookingProperties } from 'features/bookings/helpers'
+import { mergeOfferData } from 'features/home/atoms/OfferTile'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator'
 import { useFunctionOnce } from 'features/offer/services/useFunctionOnce'
 import { analytics, isCloseToBottom } from 'libs/analytics'
@@ -50,6 +52,7 @@ export function BookingDetails() {
   const { params } = useRoute<UseRouteType<'BookingDetails'>>()
   const { navigate } = useNavigation<UseNavigationType>()
   const booking = useOngoingOrEndedBooking(params.id)
+  const queryClient = useQueryClient()
   const { visible: cancelModalVisible, showModal: showCancelModal, hideModal } = useModal(false)
   const {
     visible: archiveModalVisible,
@@ -94,11 +97,18 @@ export function BookingDetails() {
   }
 
   const navigateToOffer = () => {
+    queryClient.setQueryData(
+      ['offer', offer.id],
+      mergeOfferData({
+        ...offer,
+        categoryId: mapping[offer.subcategoryId].categoryId,
+        thumbUrl: offer.image?.url,
+        name: offer.name,
+        offerId: offer.id,
+      })
+    )
     analytics.logConsultOffer({ offerId: offer.id, from: 'bookings' })
-    navigate('Offer', {
-      id: offer.id,
-      from: 'bookingdetails',
-    })
+    navigate('Offer', { id: offer.id, from: 'bookingdetails' })
   }
 
   return (

--- a/src/features/bookings/pages/EndedBookings.test.tsx
+++ b/src/features/bookings/pages/EndedBookings.test.tsx
@@ -9,6 +9,8 @@ import { bookingsSnap } from '../api/bookingsSnap'
 
 import { EndedBookings } from './EndedBookings'
 
+jest.mock('react-query')
+
 describe('EndedBookings', () => {
   afterEach(jest.restoreAllMocks)
 

--- a/src/features/favorites/atoms/Favorite.tsx
+++ b/src/features/favorites/atoms/Favorite.tsx
@@ -12,6 +12,7 @@ import { mergeOfferData } from 'features/home/atoms/OfferTile'
 import { Credit } from 'features/home/services/useAvailableCredit'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { OfferImage } from 'features/search/atoms/OfferImage'
+import { analytics } from 'libs/analytics'
 import { useDistance } from 'libs/geolocation/hooks/useDistance'
 import { formatToFrenchDate, getFavoriteDisplayPrice } from 'libs/parsers'
 import { useSearchGroupLabel, useSubcategory } from 'libs/subcategories'
@@ -35,7 +36,7 @@ export const Favorite: React.FC<Props> = (props) => {
   const [height, setHeight] = useState<number | undefined>(undefined)
   const animatedOpacity = useRef(new Animated.Value(1)).current
   const animatedCollapse = useRef(new Animated.Value(1)).current
-  const navigation = useNavigation<UseNavigationType>()
+  const { navigate } = useNavigation<UseNavigationType>()
   const queryClient = useQueryClient()
   const distanceToOffer = useDistance({
     lat: offer.coordinates?.latitude,
@@ -81,10 +82,8 @@ export const Favorite: React.FC<Props> = (props) => {
         offerId: offer.id,
       })
     )
-    navigation.navigate('Offer', {
-      id: offer.id,
-      from: 'favorites',
-    })
+    analytics.logConsultOffer({ offerId: offer.id, from: 'favorites' })
+    navigate('Offer', { id: offer.id, from: 'favorites' })
   }
 
   function onRemove() {


### PR DESCRIPTION
## Details

The goal of this PR is to make sure we have the same behaviour when we go to the page OfferDetails:
 - analytics event `ConsultOffer` triggered
 - no blank page => pre-caching the offer response (image, name, etc...)
