### PR TITLE
(PC-11104) Fix openExternalUrl() on some androids by not relying on canOpenURL()

### DIFF
--- a/src/features/auth/signup/AcceptCgu.native.test.tsx
+++ b/src/features/auth/signup/AcceptCgu.native.test.tsx
@@ -65,8 +65,6 @@ describe('AcceptCgu Page', () => {
 
   it('should redirect to the "CGU" page', async () => {
     simulateConnectedNetwork()
-    // eslint-disable-next-line local-rules/independant-mocks
-    jest.spyOn(Linking, 'canOpenURL').mockResolvedValue(true)
 
     const { getByTestId } = renderAcceptCGU()
 
@@ -80,8 +78,6 @@ describe('AcceptCgu Page', () => {
 
   it('should redirect to the "Politique de confidentialité" page', async () => {
     simulateConnectedNetwork()
-    // eslint-disable-next-line local-rules/independant-mocks
-    jest.spyOn(Linking, 'canOpenURL').mockResolvedValue(true)
 
     const { getByTestId } = renderAcceptCGU()
 

--- a/src/libs/itinerary/useItinerary.ts
+++ b/src/libs/itinerary/useItinerary.ts
@@ -1,10 +1,11 @@
 import { t } from '@lingui/macro'
 import { useEffect, useState } from 'react'
-import { Alert, AlertButton, Linking, Platform } from 'react-native'
+import { Alert, AlertButton, Platform } from 'react-native'
 import LN from 'react-native-launch-navigator'
 import { AppEnum } from 'react-native-launch-navigator/enum'
 
 import { Coordinates } from 'api/gen'
+import { openExternalUrl } from 'features/navigation/helpers'
 import { getOpenStreetMapUrl } from 'libs/parsers/getOpenStreetMapUrl'
 import { snakeCaseToUppercaseFirstLetter } from 'libs/parsers/snakeCaseToUppercaseFirstLetter'
 import { useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
@@ -33,8 +34,8 @@ export const useItinerary = () => {
     }
   }
   const navigateWithOpenStreetMap = (coordinates: Required<Coordinates>) => {
-    const openStreetMapUrl = getOpenStreetMapUrl(coordinates)
-    if (Linking.canOpenURL(openStreetMapUrl)) Linking.openURL(openStreetMapUrl)
+    const url = getOpenStreetMapUrl(coordinates)
+    openExternalUrl(url)
   }
   const navigateToWithApp = async (
     coordinates: Required<Coordinates>,

--- a/src/ui/components/contact/helpers.ts
+++ b/src/ui/components/contact/helpers.ts
@@ -1,4 +1,6 @@
-import { Linking, Platform } from 'react-native'
+import { Platform } from 'react-native'
+
+import { openExternalUrl } from 'features/navigation/helpers'
 
 export const isValidFrenchPhoneNumber = (phonenumber: string) => {
   const metropolitanFranceReg = new RegExp(/^(?:(?:\+|00)33|0)\s*[1-9](?:[\s.-]*\d{2}){4}$/)
@@ -20,11 +22,11 @@ export const isValidFrenchPhoneNumber = (phonenumber: string) => {
 }
 
 export async function openPhoneNumber(phone: string) {
-  const phoneNumber = Platform.OS === 'android' ? `tel:${phone}` : `telprompt:${phone}`
-  if (await Linking.canOpenURL(phoneNumber)) Linking.openURL(phoneNumber)
+  const url = Platform.OS === 'android' ? `tel:${phone}` : `telprompt:${phone}`
+  await openExternalUrl(url)
 }
 
 export async function openMail(mail: string) {
-  const mailTo = `mailto:${mail}`
-  if (await Linking.canOpenURL(mailTo)) Linking.openURL(mailTo)
+  const url = `mailto:${mail}`
+  await openExternalUrl(url)
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11104

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices.
- [ ] Written **unit tests** for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** for any added TODO/FIXME \
       (for tech tasks, give the best context about the TODO resolution: what/who/when).

## Screenshots

| \*iOS - [Phone name] | \*Android - [Phone name] | 
| -------------------- | :----------------------: | 
|                      |                          | 