### PR TITLE
[PC-10972] Allow ProfileBadge to show no icon

### DIFF
--- a/__snapshots__/features/profile/components/ProfileBadge.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/ProfileBadge.native.test.tsx.native-snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProfileBadge should render component correctly if icon is provided 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#f5f5f5",
+        "borderRadius": 6,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "paddingBottom": 16,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 16,
+      },
+    ]
+  }
+  testID="profile-badge"
+>
+  <View
+    style={
+      Array [
+        Object {
+          "paddingRight": 16,
+        },
+      ]
+    }
+  >
+    <View
+      height={48}
+      width={48}
+    >
+      <Text>
+        undefined-SVG-Mock
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+        },
+      ]
+    }
+  >
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#151515",
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 12,
+            "lineHeight": 16,
+          },
+        ]
+      }
+    >
+      Tu as déposé ton dossier. Bravo
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`ProfileBadge should render component correctly if no icon is provided 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#f5f5f5",
+        "borderRadius": 6,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "paddingBottom": 16,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 16,
+      },
+    ]
+  }
+  testID="profile-badge"
+>
+  <View
+    style={
+      Array [
+        Object {
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+        },
+      ]
+    }
+  >
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#151515",
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 12,
+            "lineHeight": 16,
+          },
+        ]
+      }
+    >
+      Tu as déposé ton dossier. Bravo
+    </Text>
+  </View>
+</View>
+`;

--- a/src/features/cheatcodes/pages/AppComponents/AppComponents.tsx
+++ b/src/features/cheatcodes/pages/AppComponents/AppComponents.tsx
@@ -14,6 +14,7 @@ import { ThreeShapesTicket } from 'features/bookings/components/ThreeShapesTicke
 import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { BeneficiaryCeilings } from 'features/profile/components/BeneficiaryCeilings'
+import { IdCheckProcessingBadge } from 'features/profile/components/IdCheckProcessingBadge'
 import { NonBeneficiaryHeader } from 'features/profile/components/NonBeneficiaryHeader'
 import { SelectionLabel } from 'features/search/atoms/SelectionLabel'
 import { CATEGORY_CRITERIA } from 'features/search/enums'
@@ -812,6 +813,12 @@ export const AppComponents: FunctionComponent = () => {
             <Spacer.Column numberOfSpaces={2} />
             <Button title="+1 an" onPress={() => setYear((year) => year - 1)} />
           </AlignedText>
+        </View>
+        <Text>Sans icône et long texte</Text>
+        <View>
+          <IdCheckProcessingBadge
+            message={`Ceci est un très long message pour montrer que le texte est adaptatif est que ça ne posera aucun problème. Je suis sûr qu'on peut le rendre encore un peu plus long sans difficulté si on se creuse un peu les méninges`}
+          />
         </View>
 
         <Spacer.Column numberOfSpaces={4} />

--- a/src/features/profile/components/IdCheckProcessingBadge.tsx
+++ b/src/features/profile/components/IdCheckProcessingBadge.tsx
@@ -1,14 +1,22 @@
 import { t } from '@lingui/macro'
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 
 import { ProfileBadge } from 'features/profile/components/ProfileBadge'
-import { Clock } from 'ui/svg/icons/Clock'
+import { IconInterface } from 'ui/svg/icons/types'
 
-export function IdCheckProcessingBadge() {
+type IdCheckProcessingBadgeProps = {
+  icon?: FunctionComponent<IconInterface>
+  message?: string
+}
+
+export function IdCheckProcessingBadge(props: IdCheckProcessingBadgeProps) {
   return (
     <ProfileBadge
-      icon={Clock}
-      message={t`Dossier déposé, nous avons bien reçu ton dossier et sommes en train de l’analyser !`}
+      icon={props.icon}
+      message={
+        props.message ||
+        t`Dossier déposé, nous avons bien reçu ton dossier et sommes en train de l’analyser !`
+      }
     />
   )
 }

--- a/src/features/profile/components/NonBeneficiaryHeader.tsx
+++ b/src/features/profile/components/NonBeneficiaryHeader.tsx
@@ -10,6 +10,7 @@ import { YoungerBadge } from 'features/profile/components/YoungerBadge'
 import { formatToSlashedFrenchDate } from 'libs/dates'
 import SvgPageHeader from 'ui/components/headers/SvgPageHeader'
 import { ModuleBanner } from 'ui/components/ModuleBanner'
+import { Clock } from 'ui/svg/icons/Clock'
 import { ThumbUp } from 'ui/svg/icons/ThumbUp'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
@@ -72,7 +73,7 @@ function NonBeneficiaryHeaderComponent(props: PropsWithChildren<NonBeneficiaryHe
     } else {
       body = (
         <BodyContainer testID="body-container-18-idcheck-completed">
-          <IdCheckProcessingBadge />
+          <IdCheckProcessingBadge icon={Clock} />
         </BodyContainer>
       )
     }

--- a/src/features/profile/components/ProfileBadge.native.test.tsx
+++ b/src/features/profile/components/ProfileBadge.native.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import { ProfileBadge } from 'features/profile/components/ProfileBadge'
+import { render } from 'tests/utils'
+import { Clock } from 'ui/svg/icons/Clock'
+
+describe('ProfileBadge', () => {
+  it('should render component correctly if no icon is provided', () => {
+    const myComponent = render(<ProfileBadge message={'Tu as déposé ton dossier. Bravo'} />)
+    expect(myComponent).toMatchSnapshot()
+  })
+  it('should render component correctly if icon is provided', () => {
+    const myComponent = render(
+      <ProfileBadge message={'Tu as déposé ton dossier. Bravo'} icon={Clock} />
+    )
+    expect(myComponent).toMatchSnapshot()
+  })
+})

--- a/src/features/profile/components/ProfileBadge.tsx
+++ b/src/features/profile/components/ProfileBadge.tsx
@@ -6,16 +6,19 @@ import { ColorsEnum, getSpacing, Typo } from 'ui/theme'
 
 interface ProfileBadgeProps {
   message: string
-  icon: FunctionComponent<IconInterface>
+  icon?: FunctionComponent<IconInterface>
+  testID?: string
 }
 
 export function ProfileBadge(props: ProfileBadgeProps) {
   const Icon = props.icon
   return (
-    <Container testID="younger-badge">
-      <IconContainer>
-        <Icon size={48} />
-      </IconContainer>
+    <Container testID={props.testID || 'profile-badge'}>
+      {Icon ? (
+        <IconContainer>
+          <Icon size={48} />
+        </IconContainer>
+      ) : null}
       <TextContainer>
         <Typo.Caption>{props.message}</Typo.Caption>
       </TextContainer>
@@ -33,10 +36,9 @@ const Container = styled.View({
 })
 
 const IconContainer = styled.View({
-  flex: 0.1,
-  minWidth: 48,
-  maxWidth: 48,
+  paddingRight: getSpacing(4),
 })
+
 const TextContainer = styled.View({
-  flex: 0.85,
+  flex: 1,
 })

--- a/src/features/profile/components/YoungerBadge.tsx
+++ b/src/features/profile/components/YoungerBadge.tsx
@@ -16,5 +16,5 @@ export function YoungerBadge() {
     '\u00a0' +
     t`offerts à dépenser sur l’application.`
 
-  return <ProfileBadge icon={Clock} message={information} />
+  return <ProfileBadge icon={Clock} message={information} testID={'younger-badge'} />
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10972

## Checklist

I have:

- [X] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [X] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|<img width="357" alt="Capture d’écran 2021-10-05 à 11 53 36" src="https://user-images.githubusercontent.com/44037911/136001938-e2f8d2da-53fb-40d5-8bb5-2d6a2dea86e6.png">  |       <img width="338" alt="Capture d’écran 2021-10-05 à 15 07 56" src="https://user-images.githubusercontent.com/44037911/136028978-173ad48b-8fbd-405f-a511-cb4e856fb90b.png">  |                 |          <img width="495" alt="Capture d’écran 2021-10-05 à 11 58 36" src="https://user-images.githubusercontent.com/44037911/136002142-a20cb967-f86d-403a-a477-565553dcac6b.png">        |                  |
