### PR TITLE
(PC-10886) Added BeneficiaryValidationStep.BeneficiaryInformation as a valid nextStep to enter idCheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@elastic/app-search-javascript": "^7.13.1",
     "@lingui/core": "^3.10.4",
     "@lingui/react": "^3.10.2",
-    "@pass-culture/id-check": "^2.5.4",
+    "@pass-culture/id-check": "^2.6.0",
     "@pass-culture/react-native-profiling": "1.0.19",
     "@ptomasroos/react-native-multi-slider": "^2.2.2",
     "@react-native-async-storage/async-storage": "^1.15.5",

--- a/src/features/auth/signup/useBeneficiaryValidationNavigation.test.ts
+++ b/src/features/auth/signup/useBeneficiaryValidationNavigation.test.ts
@@ -78,6 +78,16 @@ describe('useBeneficiaryValidationNavigation', () => {
     expect(navigate).toBeCalledWith('IdCheckV2')
   })
 
+  it('should navigate to IdCheck if prefetched next step is beneficiary-information and email is not null', () => {
+    const { result } = renderHook(useBeneficiaryValidationNavigation)
+    result.current.navigateToNextBeneficiaryValidationStep({
+      email: 'christophe.dupont@gmail.com',
+      nextBeneficiaryValidationStep: BeneficiaryValidationStep.BeneficiaryInformation,
+    })
+
+    expect(navigate).toBeCalledWith('IdCheckV2')
+  })
+
   it('should navigate to IdCheck if prefetched next step is id-check and email is not null', () => {
     const { result } = renderHook(useBeneficiaryValidationNavigation)
     result.current.navigateToNextBeneficiaryValidationStep({

--- a/src/features/auth/signup/useBeneficiaryValidationNavigation.ts
+++ b/src/features/auth/signup/useBeneficiaryValidationNavigation.ts
@@ -47,13 +47,16 @@ export const useBeneficiaryValidationNavigation = () => {
   function navigateToNextStep(nextStep: PrefetchedInfo['nextBeneficiaryValidationStep']) {
     if (nextStep === BeneficiaryValidationStep.PhoneValidation && settings?.enablePhoneValidation) {
       navigate('SetPhoneNumber')
-    } else if (nextStep === BeneficiaryValidationStep.IdCheck) {
+    } else if (
+      nextStep === BeneficiaryValidationStep.IdCheck ||
+      nextStep === BeneficiaryValidationStep.BeneficiaryInformation
+    ) {
       if (settings?.allowIdCheckRegistration) {
         try {
           analytics.logIdCheck('Profile')
           navigateToIdCheck()
         } catch (err) {
-          eventMonitoring.captureException(err, { isEligible: true })
+          eventMonitoring.captureException(err, { isEligible: true, nextStep })
           showErrorSnackBar({
             message: t`Désolé, tu as effectué trop de tentatives. Essaye de nouveau dans 12 heures.`,
             timeout: SNACK_BAR_TIME_OUT,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3429,10 +3429,10 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
-"@pass-culture/id-check@^2.5.4":
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/@pass-culture/id-check/-/id-check-2.5.4.tgz#b0e5b936d8e52618383f79b75fffc4bee4a02484"
-  integrity sha512-SgDfqe9J6bMJMzeIdqP/XO41xmdOAXRgvW+qLrVlHgwe9WUzi0i820g55X5yNF8hdtbgpSgEg5GqQ+EypKDzeA==
+"@pass-culture/id-check@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@pass-culture/id-check/-/id-check-2.6.0.tgz#a61d6941c3fb3482d9b12e74fc842fe202f1db2b"
+  integrity sha512-OQ783IfsAfGi8FNQ9AnGIxT9qPo6GqYD6grSOfNG4OKTPXQKjeCAmBdkomB4Rwu6NpS9hh9RdhcfT5RjqSbbiQ==
   dependencies:
     deepmerge "^4.2.2"
     lodash "^4.17.21"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10886

- (PC-10886) Upgrade `@pass-culture/id-check` to `v2.6.0` (added `initialStep`) [(PR)](https://github.com/pass-culture/id-check-front/pull/227)
- (PC-10886) Added `BeneficiaryValidationStep.BeneficiaryInformation` as a valid `nextStep` to enter id-check

### Todo

We should update our `api.ts` first and rebase here in order to fix `ci/circleci: test-lint-and-types` GitHub check

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
