### PR TITLE
(PC-11022) call setParams right after parsing to have correct  analytics when app is already open

### DIFF
--- a/src/libs/analytics/analytics.ts
+++ b/src/libs/analytics/analytics.ts
@@ -16,23 +16,17 @@ type FavoriteSortBy = 'ASCENDING_PRICE' | 'AROUND_ME' | 'RECENTLY_ADDED'
 type OfferIdOrVenueId = { offerId: number } | { venueId: number }
 
 const useInit = () => {
-  const { campaign, source, medium, campaignDate } = useUtmParams()
+  const { campaignDate } = useUtmParams()
 
   useEffect(() => {
-    // When we start the application, we set utm params as default
+    // If the user has clicked on marketing link 48h ago, we want to remove the marketing params
     const ago48Hours = new Date()
     ago48Hours.setDate(ago48Hours.getDate() - 2)
 
-    if (campaignDate && campaignDate > ago48Hours) {
-      analytics.setDefaultEventParameters({
-        traffic_campaign: campaign || '',
-        traffic_source: source || '',
-        traffic_medium: medium || '',
-      })
-    } else {
+    if (campaignDate && campaignDate < ago48Hours) {
       analytics.setDefaultEventParameters(undefined)
     }
-  }, [campaign, source, medium, campaignDate])
+  }, [campaignDate])
 }
 
 export const analytics = {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11022

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |
