### PR TITLE
(PC-11100) Safari fix : ask for geoloc when app starts

### DIFF
--- a/src/libs/geolocation/checkGeolocPermission.web.ts
+++ b/src/libs/geolocation/checkGeolocPermission.web.ts
@@ -1,12 +1,24 @@
 import { GeolocPermissionState } from './enums'
 
+// Note : `navigator.permissions` is not yet supported for Safari desktop and mobile :
+// https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API#browser_compatibility
 export async function checkGeolocPermission(): Promise<GeolocPermissionState> {
-  const { state } = await navigator.permissions.query({ name: 'geolocation' })
-  if (state === 'granted') {
-    return GeolocPermissionState.GRANTED
+  if (navigator.permissions) {
+    const { state } = await navigator.permissions.query({ name: 'geolocation' })
+    if (state === 'granted') {
+      return GeolocPermissionState.GRANTED
+    }
+    if (state === 'prompt') {
+      return GeolocPermissionState.DENIED
+    }
+    return GeolocPermissionState.NEVER_ASK_AGAIN
   }
-  if (state === 'prompt') {
-    return GeolocPermissionState.DENIED
-  }
-  return GeolocPermissionState.NEVER_ASK_AGAIN
+  // With the current implementation of useGeolocation(), when `navigation.permissions`
+  // is undefined, the user will be asked for geolocation permission when the app starts
+  return new Promise((resolve) => {
+    navigator.geolocation.getCurrentPosition(
+      () => resolve(GeolocPermissionState.GRANTED),
+      () => resolve(GeolocPermissionState.NEVER_ASK_AGAIN)
+    )
+  })
 }

--- a/src/libs/geolocation/requestGeolocPermission.web.test.ts
+++ b/src/libs/geolocation/requestGeolocPermission.web.test.ts
@@ -3,56 +3,94 @@ import { MockedFunction } from 'ts-jest/dist/utils/testing'
 import { GeolocPermissionState } from './enums'
 import { requestGeolocPermission } from './requestGeolocPermission.web'
 
-const mockQuery = navigator.permissions.query as MockedFunction<typeof navigator.permissions.query>
+let mockQuery = navigator.permissions.query as MockedFunction<typeof navigator.permissions.query>
 const mockGetCurrentPosition = navigator.geolocation.getCurrentPosition as MockedFunction<
   typeof navigator.geolocation.getCurrentPosition
 >
 
+const initialNavigatorPermissions = { ...navigator.permissions }
+function resetNavigatorPermissions() {
+  // @ts-expect-error : `permissions` is a read-only property
+  global.navigator.permissions = initialNavigatorPermissions
+  mockQuery = initialNavigatorPermissions.query as MockedFunction<
+    typeof navigator.permissions.query
+  >
+}
+function mockNavigatorPermissionsUndefined() {
+  // @ts-expect-error : `permissions` is a read-only property
+  global.navigator.permissions = undefined
+}
+
 describe('requestGeolocPermission web', () => {
-  afterEach(jest.clearAllMocks)
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
 
   it('should return GRANTED if web permission is "granted"', async () => {
     mockQuery.mockResolvedValueOnce({ state: 'granted' } as PermissionStatus)
     const state = await requestGeolocPermission()
+    expect(mockQuery).toBeCalledTimes(1)
     expect(state).toEqual(GeolocPermissionState.GRANTED)
   })
 
   it('should return NEVER_ASK_AGAIN if web permission is "denied"', async () => {
     mockQuery.mockResolvedValueOnce({ state: 'denied' } as PermissionStatus)
     const state = await requestGeolocPermission()
+    expect(mockQuery).toBeCalledTimes(1)
     expect(state).toEqual(GeolocPermissionState.NEVER_ASK_AGAIN)
   })
 
   it('should return GRANTED if web permission is "prompt" and getCurrentPosition() executes its successCallback', async () => {
     mockQuery.mockResolvedValueOnce({ state: 'prompt' } as PermissionStatus)
-    mockGetCurrentPosition.mockImplementationOnce((successCallback) =>
-      Promise.resolve(
-        successCallback({ coords: { latitude: 48.85, longitude: 2.29 } } as GeolocationPosition)
-      )
-    )
+    mockGetCurrentPositionSuccess()
     const state = await requestGeolocPermission()
+    expect(mockQuery).toBeCalledTimes(1)
     expect(state).toEqual(GeolocPermissionState.GRANTED)
+  })
+
+  it('should return GRANTED if navigator.permissions is undefined and getCurrentPosition() executes its successCallback', async () => {
+    mockNavigatorPermissionsUndefined()
+    mockGetCurrentPositionSuccess()
+    const state = await requestGeolocPermission()
+    expect(mockQuery).not.toBeCalled()
+    expect(state).toEqual(GeolocPermissionState.GRANTED)
+    resetNavigatorPermissions()
   })
 
   it('should return NEVER_ASK_AGAIN if web permission is "prompt" and getCurrentPosition() executes its errorCallback', async () => {
     mockQuery.mockResolvedValueOnce({ state: 'prompt' } as PermissionStatus)
-    mockGetCurrentPosition.mockImplementationOnce((_successCallback, errorCallback) => {
-      if (!errorCallback) return Promise.resolve(undefined)
-      return Promise.resolve(
-        errorCallback({
-          code: GeolocationPositionError.POSITION_UNAVAILABLE,
-          message: '',
-        } as GeolocationPositionError)
-      )
-    })
+    mockGetCurrentPositionError()
     const state = await requestGeolocPermission()
+    expect(mockQuery).toBeCalledTimes(1)
     expect(state).toEqual(GeolocPermissionState.NEVER_ASK_AGAIN)
   })
 
-  it('should return NEVER_ASK_AGAIN if web permission is something else', async () => {
-    // @ts-expect-error : we purposely return an "impossible value" for the sake of the test
-    mockQuery.mockResolvedValueOnce({ state: 'something else' })
+  it('should return NEVER_ASK_AGAIN if navigator.permissions is undefined and getCurrentPosition() executes its errorCallback', async () => {
+    mockNavigatorPermissionsUndefined()
+    mockGetCurrentPositionError()
     const state = await requestGeolocPermission()
+    expect(mockQuery).not.toBeCalled()
     expect(state).toEqual(GeolocPermissionState.NEVER_ASK_AGAIN)
+    resetNavigatorPermissions()
   })
 })
+
+function mockGetCurrentPositionSuccess() {
+  mockGetCurrentPosition.mockImplementationOnce((successCallback) =>
+    Promise.resolve(
+      successCallback({ coords: { latitude: 48.85, longitude: 2.29 } } as GeolocationPosition)
+    )
+  )
+}
+
+function mockGetCurrentPositionError() {
+  mockGetCurrentPosition.mockImplementationOnce((_successCallback, errorCallback) => {
+    if (!errorCallback) return Promise.resolve(undefined)
+    return Promise.resolve(
+      errorCallback({
+        code: GeolocationPositionError.POSITION_UNAVAILABLE,
+        message: '',
+      } as GeolocationPositionError)
+    )
+  })
+}

--- a/src/libs/geolocation/requestGeolocPermission.web.ts
+++ b/src/libs/geolocation/requestGeolocPermission.web.ts
@@ -1,20 +1,21 @@
 import { GeolocPermissionState } from './enums'
 
+// Note : `navigator.permissions` is not yet supported for Safari desktop and mobile :
+// https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API#browser_compatibility
 export async function requestGeolocPermission(): Promise<GeolocPermissionState> {
-  const { state } = await navigator.permissions.query({ name: 'geolocation' })
-  if (state === 'granted') {
-    return GeolocPermissionState.GRANTED
+  if (navigator.permissions) {
+    const { state } = await navigator.permissions.query({ name: 'geolocation' })
+    if (state === 'granted') {
+      return GeolocPermissionState.GRANTED
+    }
+    if (state === 'denied') {
+      return GeolocPermissionState.NEVER_ASK_AGAIN
+    }
   }
-  if (state === 'denied') {
-    return GeolocPermissionState.NEVER_ASK_AGAIN
-  }
-  if (state === 'prompt') {
-    return new Promise((resolve) => {
-      navigator.geolocation.getCurrentPosition(
-        () => resolve(GeolocPermissionState.GRANTED),
-        () => resolve(GeolocPermissionState.NEVER_ASK_AGAIN)
-      )
-    })
-  }
-  return GeolocPermissionState.NEVER_ASK_AGAIN
+  return new Promise((resolve) => {
+    navigator.geolocation.getCurrentPosition(
+      () => resolve(GeolocPermissionState.GRANTED),
+      () => resolve(GeolocPermissionState.NEVER_ASK_AGAIN)
+    )
+  })
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11100

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |
