### PR TITLE
(PC-10559) fix category booking details label

### DIFF
--- a/src/features/bookOffer/components/BookingDetails.tsx
+++ b/src/features/bookOffer/components/BookingDetails.tsx
@@ -50,7 +50,7 @@ export const BookingDetails: React.FC<Props> = ({ stocks }) => {
             af_offer_id: offer.id,
             af_booking_id: selectedStock.id,
             af_price: selectedStock.price,
-            af_category: offer.category.label,
+            ...(offer.category?.label ? { af_category: offer.category.label } : {}),
           })
         navigate('BookingConfirmation', { offerId, bookingId })
       }


### PR DESCRIPTION
Lorsque nous réservons depuis la page favoris, nous voyons un bandeau rouge snack bar avec l'erreur : 

```
TypeError: Cannot read properties of undefined (reading 'label')
    at onSuccess (BookingDetails.tsx:53)
    at Object.onSuccess (useBookOfferMutation.ts:19)
    at mutation.js:86
BookingDetails.tsx:61 TypeError: Cannot read properties of undefined (reading 'label')
    at onSuccess (BookingDetails.tsx:53)
    at Object.onSuccess (useBookOfferMutation.ts:19)
    at mutation.js:86
```

Pourtant la réservation est un succès.

Ça casse ici exactement : https://github.com/pass-culture/pass-culture-app-native/blob/master/src/features/bookOffer/components/BookingDetails.tsx#L53

N'ayant pas suivi le sujet des bookings, j'ai juste ignoré le category label de l'analytics si pas disponible.

Related to : https://passculture.atlassian.net/browse/PC-10559
## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |
