### PR TITLE
(Tech) use appSearch for venues no matter the flag

### DIFF
--- a/src/features/home/pages/useHomeVenueModules.ts
+++ b/src/features/home/pages/useHomeVenueModules.ts
@@ -6,7 +6,6 @@ import { useGeolocation } from 'libs/geolocation'
 import { QueryKeys } from 'libs/queryKeys'
 import { VenueHit } from 'libs/search'
 import { fetchMultipleVenues } from 'libs/search/fetch/search'
-import { useAppSearchBackend } from 'libs/search/fetch/useAppSearchBackend'
 
 export type HomeVenuesModuleResponse = {
   [moduleId: string]: {
@@ -20,7 +19,6 @@ export const useHomeVenueModules = (
 ): HomeVenuesModuleResponse => {
   const { position } = useGeolocation()
   const homeVenuesModules: HomeVenuesModuleResponse = {}
-  const { enabled, isAppSearchBackend } = useAppSearchBackend()
 
   const queries = useQueries(
     venuesModules.map(({ search, moduleId }) => {
@@ -32,7 +30,6 @@ export const useHomeVenueModules = (
       return {
         queryKey: [QueryKeys.HOME_VENUES_MODULE, moduleId],
         queryFn: fetchModule,
-        enabled: enabled && isAppSearchBackend,
         notifyOnChangeProps: ['data'],
       }
     })

--- a/src/features/search/api/useVenues.ts
+++ b/src/features/search/api/useVenues.ts
@@ -2,17 +2,12 @@ import { useQuery } from 'react-query'
 
 import { QueryKeys } from 'libs/queryKeys'
 import { fetchVenues } from 'libs/search/fetch/search'
-import { useAppSearchBackend } from 'libs/search/fetch/useAppSearchBackend'
 import { SuggestedVenue } from 'libs/venue'
 
 const STALE_TIME_VENUES = 5 * 60 * 1000
 
-export const useVenues = (query: string) => {
-  const { enabled, isAppSearchBackend } = useAppSearchBackend()
-
-  return useQuery<SuggestedVenue[]>([QueryKeys.VENUES, query], () => fetchVenues(query), {
+export const useVenues = (query: string) =>
+  useQuery<SuggestedVenue[]>([QueryKeys.VENUES, query], () => fetchVenues(query), {
     staleTime: STALE_TIME_VENUES,
-    // TODO(antoinewg) remove condition once migration to AppSearch is complete
-    enabled: query.length > 0 && enabled && isAppSearchBackend,
+    enabled: query.length > 0,
   })
-}


### PR DESCRIPTION
### Détails

Tant que les performances d'AppSearch ne sont pas suffisantes, on va continuer à utiliser le flag `useAppSearch` pour les offres.
Étant donné que les lieux n'ont pas ce problèmes de perfs/pertinence et qu'ils ne sont que sur AppSearch, on ne les fait plus dépendre de ce flag.