### PR TITLE
[PC-11314] Fixing alert showing even when opening valid fallback link

### DIFF
--- a/src/features/navigation/__tests__/helpers.test.ts
+++ b/src/features/navigation/__tests__/helpers.test.ts
@@ -74,6 +74,19 @@ describe('Navigation helpers', () => {
     await openUrl(link)
     expect(alertMock).toHaveBeenCalled()
   })
+  it('should not display alert when Linking.openURL throws but fallbackUrl is valid', async () => {
+    // Last in first out, it will fail then succeed.
+    jest.spyOn(Linking, 'openURL').mockResolvedValueOnce(undefined)
+    jest
+      .spyOn(Linking, 'openURL')
+      .mockImplementationOnce(() => Promise.reject(new Error('Did not open correctly')))
+    const alertMock = jest.spyOn(Alert, 'alert')
+    const link = 'https://www.google.com'
+    const fallbackLink = 'https://www.googlefallback.com'
+
+    await openUrl(link, undefined, fallbackLink)
+    expect(alertMock).not.toHaveBeenCalled()
+  })
 
   describe('[Method] navigateToBooking', () => {
     it('should navigate to BookingDetails', async () => {

--- a/src/features/navigation/helpers.ts
+++ b/src/features/navigation/helpers.ts
@@ -39,7 +39,6 @@ const openExternalUrl = async (
     return
   } catch (error) {
     new MonitoringError(error.message, 'OpenExternalUrlError')
-    showAlert(url)
   }
 
   if (fallbackUrl) {
@@ -49,9 +48,9 @@ const openExternalUrl = async (
       return
     } catch (error) {
       new MonitoringError(error.message, 'OpenExternalUrlError_FallbackUrl')
-      showAlert(url)
     }
   }
+  showAlert(url)
 }
 
 const showAlert = (url: string) => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11314

Bug introduced in https://github.com/pass-culture/pass-culture-app-native/pull/1811

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |
