### PR TITLE
(PC-11379) Use safe function to get web geoloc error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,14 +64,14 @@ module.exports = {
       {
         object: 'window',
         property: 'GeolocationPositionError',
-        message: 'Use BrowserGeolocPositionError instead to support legacy browsers.',
+        message: 'Use getWebGeolocErrorFromCode() to support legacy browsers.',
       },
     ],
     'no-restricted-globals': [
       'error',
       {
         name: 'GeolocationPositionError',
-        message: 'Use BrowserGeolocPositionError instead to support legacy browsers.',
+        message: 'Use getWebGeolocErrorFromCode() to support legacy browsers.',
       },
     ],
     strict: ['error', 'global'],

--- a/src/libs/geolocation/getPosition.web.ts
+++ b/src/libs/geolocation/getPosition.web.ts
@@ -9,14 +9,24 @@ const GET_POSITION_SETTINGS = {
   maximumAge: 10000,
 }
 
-// @ts-expect-error: older versions of Safari and Firefox use the non-standard name of `PositionError`:
+// @ts-expect-error: older versions of Safari and Firefox may use the non-standard name of `PositionError`:
 // eslint-disable-next-line no-restricted-properties
-export const BrowserGeolocPositionError = window.GeolocationPositionError || window.PositionError
+const BrowserGeolocPositionError = window.GeolocationPositionError || window.PositionError
 
-const ERROR_MAPPING: Record<string, GeolocPositionError> = {
-  [BrowserGeolocPositionError.PERMISSION_DENIED]: GeolocPositionError.PERMISSION_DENIED,
-  [BrowserGeolocPositionError.POSITION_UNAVAILABLE]: GeolocPositionError.POSITION_UNAVAILABLE,
-  [BrowserGeolocPositionError.TIMEOUT]: GeolocPositionError.TIMEOUT,
+export function getWebGeolocErrorFromCode(errorCode: number): GeolocPositionError {
+  // !!! Important : verify if an actual error API is available on legacy browsers.
+  // Example : error API does not exist on the latest supported version of Safari on iPhone 5.
+  if (BrowserGeolocPositionError) {
+    // errorCode == 1
+    if (errorCode === BrowserGeolocPositionError.PERMISSION_DENIED)
+      return GeolocPositionError.PERMISSION_DENIED
+    // errorCode == 2
+    if (errorCode === BrowserGeolocPositionError.POSITION_UNAVAILABLE)
+      return GeolocPositionError.POSITION_UNAVAILABLE
+    // errorCode == 3
+    if (errorCode === BrowserGeolocPositionError.TIMEOUT) return GeolocPositionError.TIMEOUT
+  }
+  return GeolocPositionError.POSITION_UNAVAILABLE
 }
 
 export const getPosition = (
@@ -32,20 +42,20 @@ export const getPosition = (
       })
     },
     ({ code }) => {
-      const type = ERROR_MAPPING[code]
-      switch (type) {
+      const errorType = getWebGeolocErrorFromCode(code)
+      switch (errorType) {
         case GeolocPositionError.PERMISSION_DENIED:
           setPositionError(null)
           setPosition(null)
           break
         case GeolocPositionError.POSITION_UNAVAILABLE:
           // Location provider not available
-          setPositionError({ type, message: GEOLOCATION_USER_ERROR_MESSAGE[type] })
+          setPositionError({ type: errorType, message: GEOLOCATION_USER_ERROR_MESSAGE[errorType] })
           break
         case GeolocPositionError.TIMEOUT:
           // Location request timed out
           // TODO: we could implement a retry pattern
-          setPositionError({ type, message: GEOLOCATION_USER_ERROR_MESSAGE[type] })
+          setPositionError({ type: errorType, message: GEOLOCATION_USER_ERROR_MESSAGE[errorType] })
           setPosition(null)
           break
       }

--- a/src/libs/geolocation/requestGeolocPermission.web.test.ts
+++ b/src/libs/geolocation/requestGeolocPermission.web.test.ts
@@ -1,7 +1,5 @@
 import { MockedFunction } from 'ts-jest/dist/utils/testing'
 
-import { BrowserGeolocPositionError } from 'libs/geolocation/getPosition.web'
-
 import { GeolocPermissionState } from './enums'
 import { requestGeolocPermission } from './requestGeolocPermission.web'
 
@@ -90,10 +88,7 @@ function mockGetCurrentPositionError() {
     if (!errorCallback) return Promise.resolve(undefined)
     return Promise.resolve(
       // @ts-expect-error: object passed as param matches the type GeolocationPositioError
-      errorCallback({
-        code: BrowserGeolocPositionError.POSITION_UNAVAILABLE,
-        message: '',
-      })
+      errorCallback({ code: 1, message: '' })
     )
   })
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11379

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.