### PR TITLE
(PC-9603) use image instead of emoji for flags on the Web

### DIFF
--- a/src/features/auth/signup/PhoneValidation/SetPhoneNumber.tsx
+++ b/src/features/auth/signup/PhoneValidation/SetPhoneNumber.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro'
 import { useNavigation } from '@react-navigation/native'
 import React, { memo, useEffect, useState } from 'react'
-import { Animated } from 'react-native'
+import { Animated, Platform } from 'react-native'
 import CountryPicker, {
   Country,
   CountryCode,
@@ -162,6 +162,7 @@ export const SetPhoneNumber = memo(() => {
           <PhoneNumberInput>
             <CountryPickerPressable onPress={openCountryPickerModal}>
               <CountryPicker
+                withEmoji={Platform.OS !== 'web'}
                 countryCode={countryCode}
                 countryCodes={ALLOWED_COUNTRY_CODES}
                 onSelect={onSelectCountryCode}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-9603

L'option utilise des sources base 64 avec `<img />` .

### Alternative

Avec svgs via https://www.npmjs.com/package/react-world-flags,

```bash
yarn add -D react-world-flags @types/react-world-flags
echo "export { Flag } from '../../../src/ui/components/Flags'" > node_modules/react-native-country-picker-modal/lib/Flag.web.js`
npx patch-package react-native-country-picker-modal
wget -O src/ui/components/Flags.tsx https://raw.githubusercontent.com/xcarpentier/react-native-country-picker-modal/master/src/Flag.tsx
```

Puis utiliser les svg `Flag`, depuis `src/ui/components/Flags`:

```diff
+ import RWFlag from 'react-world-flags'
- <EmojiFlag {...{ countryCode, flagSize }} />
+ <RNWFlag code={countryCode} height={flagSize} />
```




## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [x] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [x] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [x] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         | ![image](https://user-images.githubusercontent.com/77674046/138675193-6e87a986-29a9-4da5-a965-160e2776fc1b.png)  |  ![image](https://user-images.githubusercontent.com/77674046/138675249-5e036bf2-77cc-4b70-945f-7deda0da0598.png)                   |
