### PR TITLE
(PC-11303) ReCaptcha Web viewport height under 440px css fix

### DIFF
--- a/src/libs/recaptcha/ReCaptcha.web.tsx
+++ b/src/libs/recaptcha/ReCaptcha.web.tsx
@@ -10,6 +10,16 @@ type Props = {
   isVisible: boolean
 }
 
+// This will move up and reduce recaptcha challenge when viewport height is lower than 440px
+const css = `
+   @media only screen and (max-height : 440px) {
+      div[style*="transition: visibility"] > div[style*="position: fixed"] + div[style*="position: absolute"] {
+          transform: scale(0.75);
+          transform-origin: 50% 0%;
+      }
+   }
+`
+
 export function ReCaptcha(props: Props) {
   const reCaptchaContainerRef = useRef<HTMLDivElement>(null)
 
@@ -78,5 +88,10 @@ export function ReCaptcha(props: Props) {
     }
   }, [props.isVisible])
 
-  return <div id="recaptcha-container" ref={reCaptchaContainerRef} />
+  return (
+    <React.Fragment>
+      <style type="text/css">{css}</style>
+      <div id="recaptcha-container" ref={reCaptchaContainerRef} />
+    </React.Fragment>
+  )
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11303

It is not easy to add markup in the injected HTML, the selector is strict enough (height) to be used as a diry workaround until a proper solution can be found.

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`

## Screenshots

| iOS | Android | Mobile - Chrome | Mobile - Chrome (viewport  height< 440px) | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         | ![image](https://user-images.githubusercontent.com/77674046/138871937-2e4d28e2-5584-4c81-b86d-3424e0abe30a.png) | ![image](https://user-images.githubusercontent.com/77674046/138871919-d3597f20-e738-41f8-b897-dbe0ca56e42b.png) |                  |




