### PR TITLE
(PC-11509) Safari mobile - Fix carte tutorial et 18 ans

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
     "react-native-appsflyer": "^6.2.42",
     "react-native-flipper": "^0.98.0",
     "react-native-svg-web": "^1.0.9",
-    "react-native-web": "^0.17.1",
+    "react-native-web": "^0.17.5",
     "react-native-web-linear-gradient": "^1.1.2",
     "react-native-web-lottie": "^1.4.4",
     "react-query-native-devtools": "^3.0.1",

--- a/src/web/utils/navigatorAgent.ts
+++ b/src/web/utils/navigatorAgent.ts
@@ -1,0 +1,13 @@
+import { Platform } from 'react-native'
+
+// https://stackoverflow.com/a/29696509
+export const isSafariMobile = () => {
+    if (Platform.OS !== 'web') {
+        return false
+    }
+    const ua = globalThis.window.navigator.userAgent
+    const iOS = !!ua.match(/iP(ad|hone)/i)
+    const webkit = !!ua.match(/WebKit/i)
+    const iOSSafari = iOS && webkit && !ua.match(/CriOS/i) && !ua.match(/OPiOS/i)
+    return iOSSafari
+}

--- a/web/config/webpack.config.js
+++ b/web/config/webpack.config.js
@@ -399,6 +399,8 @@ module.exports = function (webpackEnv) {
                 /node_modules\/react-native-calendars/,
                 /node_modules\/react-native-swipe-gestures/,
                 /node_modules\/react-native-qrcode-svg/,
+                // these below are only useful in development, edit their package.json main to target src instead of build
+                /node_modules\/react-native-web-swiper\/src/,
               ],
               loader: require.resolve('babel-loader'),
               options: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15774,10 +15774,10 @@ react-native-web-swiper@2.2.1:
   dependencies:
     prop-types "^15.6.2"
 
-react-native-web@^0.17.1:
-  version "0.17.1"
-  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.17.1.tgz#90d473c89dd99b88bc9830b2a9fcdd2fc5f04902"
-  integrity sha512-lUnn+2O8ynQ6/gJKylSxm7DLi2vHw6AujdDV1+LSa8Epe1bYFJNUcJTEhJf0jNYUFGOujzMtuG8Mkz3HdWTkag==
+react-native-web@^0.17.5:
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.17.5.tgz#2c27452b4654fb098c3c412cb04c379add1015a6"
+  integrity sha512-pdieIZi2/YeVTaOuIaeaLC6FMkk8h3pvPNruedH+6cWiE15Oz6BGjJ+5IafdXEyiipb1Y0+QuecW81fa3DVM4g==
   dependencies:
     array-find-index "^1.0.2"
     create-react-class "^15.7.0"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11509

## Description

Sur Safari mobile, le `width`, `height`, `x` et `y` valent tous `0` car `onLayout` n'est pas appelé, ce qui forcément casse l'affichage.

Aussi `swiperRef` n'est jamais défini comme il le faudrait.

https://github.com/reactrondev/react-native-web-swiper/blob/master/src/Swiper.js#L219

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |
