### PR TITLE
(Tech) Fix async error boundary width button

### DIFF
--- a/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.native.test.tsx.native-snap
@@ -202,6 +202,7 @@ exports[`AsyncErrorBoundary component should render 1`] = `
             "flexBasis": 0,
             "flexGrow": 1,
             "flexShrink": 1,
+            "maxWidth": 176,
             "minWidth": 120,
           },
         ]

--- a/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.web.test.tsx.web-snap
+++ b/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.web.test.tsx.web-snap
@@ -106,7 +106,7 @@ Object {
         >
           <div
             class="css-view-1dbjc4n"
-            style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1; min-width: 120px;"
+            style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1; max-width: 176px; min-width: 120px;"
           >
             <div
               aria-label="Réessayer"
@@ -238,7 +238,7 @@ Object {
       >
         <div
           class="css-view-1dbjc4n"
-          style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1; min-width: 120px;"
+          style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1; max-width: 176px; min-width: 120px;"
         >
           <div
             aria-label="Réessayer"

--- a/src/features/errors/pages/AsyncErrorBoundary.tsx
+++ b/src/features/errors/pages/AsyncErrorBoundary.tsx
@@ -120,7 +120,11 @@ const Container = styled.View({
 
 const Row = styled.View({ flexDirection: 'row' })
 
-const ButtonContainer = styled.View({ flex: 1, minWidth: getSpacing(30) })
+const ButtonContainer = styled.View({
+  flex: 1,
+  minWidth: getSpacing(30),
+  maxWidth: getSpacing(44),
+})
 const TextContainer = styled.View({ maxWidth: getSpacing(88) })
 
 const CenteredText = styled.Text({


### PR DESCRIPTION
## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Added a **screenshot** for UI tickets.

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
| <img width="378" alt="Capture d’écran 2021-10-27 à 18 31 23" src="https://user-images.githubusercontent.com/62059034/139109115-987e4312-e39b-48c8-b272-987eeaf7f04a.png"> |         |                 |  ![Capture d’écran 2021-10-27 à 18 37 25](https://user-images.githubusercontent.com/62059034/139109133-10f89c37-26e5-4ab6-8dc4-88ff5d65bb6d.png) |                  |
