### PR TITLE
:bug: (PC-11315) Add unit tests for password reset

### DIFF
--- a/src/features/auth/components/PasswordSecurityRules.native.test.tsx
+++ b/src/features/auth/components/PasswordSecurityRules.native.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 
-import { PasswordSecurityRules } from 'features/auth/components/PasswordSecurityRules'
+import {
+  isPasswordCorrect,
+  PasswordSecurityRules,
+} from 'features/auth/components/PasswordSecurityRules'
 import { render } from 'tests/utils'
 
 describe('<PasswordSecurityRules />', () => {
@@ -55,5 +58,49 @@ describe('<PasswordSecurityRules />', () => {
     const validateEveryRule = render(<PasswordSecurityRules password={'ABCDefgh1234!!!!'} />)
     const checkIcons = validateEveryRule.getAllByTestId('rule-icon-check')
     expect(checkIcons.length).toBe(5)
+  })
+  it('should unvalidate the following invalid passwords', () => {
+    const invalidPasswords = [
+      't00::5H0rt@',
+      'n0upper_c4s3^letter',
+      'NO-LOWER_CASE.L3TT3R',
+      'MIXED.case-WITHOUT_digits',
+      'MIXEDcaseWITHOUTSP3C14lchars',
+    ]
+    invalidPasswords.forEach((password) => {
+      expect(isPasswordCorrect(password)).not.toBe(true)
+    })
+  })
+  it('should validate the following valid passwords', () => {
+    const validPasswords = [
+      '-v4l1dP455sw0rd',
+      '&v4l1dP455sw0rd',
+      '?v4l1dP455sw0rd',
+      '~v4l1dP455sw0rd',
+      '#v4l1dP455sw0rd',
+      '|v4l1dP455sw0rd',
+      '^v4l1dP455sw0rd',
+      '@v4l1dP455sw0rd',
+      '=v4l1dP455sw0rd',
+      '+v4l1dP455sw0rd',
+      '$v4l1dP455sw0rd',
+      '<v4l1dP455sw0rd',
+      '>v4l1dP455sw0rd',
+      '%v4l1dP455sw0rd',
+      '*v4l1dP455sw0rd',
+      '!v4l1dP455sw0rd',
+      ':v4l1dP455sw0rd',
+      ';v4l1dP455sw0rd',
+      ',v4l1dP455sw0rd',
+      '.v4l1dP455sw0rd',
+      '{v4l1dP455sw0rd',
+      '}v4l1dP455sw0rd',
+      '(v4l1dP455sw0rd',
+      ')v4l1dP455sw0rd',
+      '\\v4l1dP455sw0rd',
+    ]
+    validPasswords.forEach((password) => {
+      expect(isPasswordCorrect(password)).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11315

The backend is going to update its regex to include the front-end special characters

backend regex : https://github.com/pass-culture/pass-culture-api/blob/134ce23d8c54194f311a673ba85ef6cdbf489366/src/pcapi/domain/password.py#L83

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |
