### PR TITLE
(Tech) using educonnect/erreur instead of educonnect/errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@elastic/app-search-javascript": "^7.13.1",
     "@lingui/core": "^3.10.4",
     "@lingui/react": "^3.10.2",
-    "@pass-culture/id-check": "2.10.9",
+    "@pass-culture/id-check": "2.10.10",
     "@pass-culture/react-native-profiling": "1.0.19",
     "@ptomasroos/react-native-multi-slider": "^2.2.2",
     "@react-native-async-storage/async-storage": "^1.15.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3429,10 +3429,10 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
-"@pass-culture/id-check@2.10.9":
-  version "2.10.9"
-  resolved "https://registry.yarnpkg.com/@pass-culture/id-check/-/id-check-2.10.9.tgz#b293129a2806fc3871decb8785f17d3956fd2fe5"
-  integrity sha512-f5XCclsWV3Etp5Z+v0XaXC5EcvqCaqkQiPxJ4Gn7ZWCsL8XgBub1G158ZDpvbbP+2JUgkmQ1psK3bm43IJm9Wg==
+"@pass-culture/id-check@2.10.10":
+  version "2.10.10"
+  resolved "https://registry.yarnpkg.com/@pass-culture/id-check/-/id-check-2.10.10.tgz#12b87165297f1a92793358c17463db0e0c72b7ca"
+  integrity sha512-TiaLFZI/AC+ZxjSmGK/AVe9eXicLoPyanDr5wtyokmQfcFRYVEZjD4+x15C74OHd0mwqsbKXijXNxbQJzkTG4Q==
   dependencies:
     deepmerge "^4.2.2"
     lodash "^4.17.21"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |
