### PR TITLE
[PC-11249] Perfs - Certains jeunes n'arrivent pas à charger l'application

### DIFF
--- a/src/libs/jwt.ts
+++ b/src/libs/jwt.ts
@@ -29,7 +29,8 @@ export const getUserIdFromAccesstoken = (accessToken: string) => {
 
 type AccessTokenStatus = 'valid' | 'expired' | 'unknown'
 
-export const getAccessTokenStatus = (accessToken: string): AccessTokenStatus => {
+export const getAccessTokenStatus = (accessToken: string | null): AccessTokenStatus => {
+  if (!accessToken) return 'unknown'
   const tokenContent = decodeAccessToken(accessToken)
   if (!tokenContent?.exp) return 'unknown'
   return tokenContent.exp * 1000 > Date.now() ? 'valid' : 'expired'

--- a/src/libs/jwt.ts
+++ b/src/libs/jwt.ts
@@ -2,7 +2,7 @@ import jwtDecode from 'jwt-decode'
 
 interface AccessToken {
   exp: number
-  fresh: false
+  fresh: number
   iat: number
   sub: string
   jti: string
@@ -25,4 +25,12 @@ export const getUserIdFromAccesstoken = (accessToken: string) => {
   const tokenContent = decodeAccessToken(accessToken)
 
   return tokenContent?.user_claims?.user_id ?? null
+}
+
+type AccessTokenStatus = 'valid' | 'expired' | 'unknown'
+
+export const getAccessTokenStatus = (accessToken: string): AccessTokenStatus => {
+  const tokenContent = decodeAccessToken(accessToken)
+  if (!tokenContent?.exp) return 'unknown'
+  return tokenContent.exp * 1000 > Date.now() ? 'valid' : 'expired'
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11249

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).

## Détails

When the user opens the application after 15minutes of inactivity (an access token is valid for 15mins by default), the apps:

- considers the user as `logged in`
- hence make calls to backend as logged in. This fails with error code 401:
![image](https://user-images.githubusercontent.com/10118284/139831105-d6d00673-7247-4f8c-8c7d-ec1eab85c5f6.png)

Note: We have a retry mechanism on the app so the user doesn't actually see the error message.
But it's better to refresh the token before any call fi we know it's expired => that's what we do in this PR.

Note 2: I don't think the impact on the number of crash is significant. The cause is probably elsewhere.