### PR TITLE
[PC-11596] Fix SearchFilter on reset to reinitialize with the correct…

### DIFF
--- a/src/features/search/atoms/Buttons/ReinitializeFilters.tsx
+++ b/src/features/search/atoms/Buttons/ReinitializeFilters.tsx
@@ -4,6 +4,7 @@ import { TouchableOpacity } from 'react-native'
 
 import { useFunctionOnce } from 'features/offer/services/useFunctionOnce'
 import { useStagedSearch } from 'features/search/pages/SearchWrapper'
+import { useMaxPrice } from 'features/search/utils/useMaxPrice'
 import { analytics } from 'libs/analytics'
 import { accessibilityAndTestId } from 'tests/utils'
 import { ColorsEnum, Typo } from 'ui/theme'
@@ -14,9 +15,15 @@ export const ReinitializeFilters = () => {
   const logReinitializeFilters = useFunctionOnce(() => {
     analytics.logReinitializeFilters()
   })
-
+  const maxPrice = useMaxPrice()
   const reinitializeFilters = () => {
     dispatch({ type: 'INIT' })
+    dispatch({
+      type: 'SET_STATE',
+      payload: {
+        priceRange: [0, maxPrice],
+      },
+    })
     logReinitializeFilters()
   }
 


### PR DESCRIPTION
… max price filter

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11596

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-11596] [EAC] Recherche - Maintenir le cap à la hauteur du crédit quand les filtres sont réinitialisés `.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |


[PC-11596]: https://passculture.atlassian.net/browse/PC-11596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ