### PR TITLE
(PC-10213) Investigation du crash de l'app au démarrage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,8 +81,8 @@ const App: FunctionComponent = function () {
       <ThemeProvider theme={theme}>
         <SafeAreaProvider>
           <QueryClientProvider client={queryClient}>
-            <AuthWrapper>
-              <ErrorBoundary FallbackComponent={AsyncErrorBoundaryWithoutNavigation}>
+            <ErrorBoundary FallbackComponent={AsyncErrorBoundaryWithoutNavigation}>
+              <AuthWrapper>
                 <GeolocationWrapper>
                   <FavoritesWrapper>
                     <SearchWrapper>
@@ -100,8 +100,8 @@ const App: FunctionComponent = function () {
                     </SearchWrapper>
                   </FavoritesWrapper>
                 </GeolocationWrapper>
-              </ErrorBoundary>
-            </AuthWrapper>
+              </AuthWrapper>
+            </ErrorBoundary>
           </QueryClientProvider>
         </SafeAreaProvider>
       </ThemeProvider>

--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -20,12 +20,10 @@ export function navigateToLogin() {
 }
 
 export async function getAuthenticationHeaders(options?: RequestInit): Promise<Headers> {
+  if (options && options.credentials === 'omit') return {}
+
   const accessToken = await storage.readString('access_token')
-  const shouldAuthenticate = accessToken && (!options || options.credentials !== 'omit')
-  if (shouldAuthenticate) {
-    return { Authorization: `Bearer ${accessToken}` }
-  }
-  return {}
+  return accessToken ? { Authorization: `Bearer ${accessToken}` } : {}
 }
 
 // HOT FIX waiting for a better strategy

--- a/src/libs/jwt.ts
+++ b/src/libs/jwt.ts
@@ -2,7 +2,7 @@ import jwtDecode from 'jwt-decode'
 
 interface AccessToken {
   exp: number
-  fresh: number
+  fresh: boolean
   iat: number
   sub: string
   jti: string


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-10213

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).

## Details

Quand le token est expiré et que l'appel à `refresh_token` échoue, la traceback est: 

(exactement comme cette [évènement Sentry](https://sentry.internal-passculture.app/organizations/sentry/issues/35/events/e3c08ce032b0429a85fb0f960ca857e0/?project=6&query=is%3Aunresolved))

```
 WARN  undefined
 ERROR  Unspecified error

This error is located at:
    in SearchWrapper (at App.tsx:89)
    in FavoritesWrapper (at App.tsx:88)
    in GeolocationWrapper (at App.tsx:87)
    in ErrorBoundary (at App.tsx:86)
    in AuthWrapper (at App.tsx:85)
    in QueryClientProvider (at App.tsx:84)
    in RNCSafeAreaProvider (at SafeAreaContext.tsx:74)
    in SafeAreaProvider (at App.tsx:83)
    in ThemeProvider (at ThemeProvider.tsx:21)
    in ThemeProvider (at App.tsx:82)
    in ABTestingProvider (at App.tsx:81)
    in App (at renderApplication.js:47)
    in RCTView (at View.js:34)
    in View (at AppContainer.js:107)
    in RCTView (at View.js:34)
    in View (at AppContainer.js:134)
    in AppContainer (at renderApplication.js:40), js engine: hermes
 LOG  Warning: Can't call setState on an unmounted component. 
        This is a no-op, but it indicates a memory leak in your application. 
        To fix, cancel all subscriptions and asynchronous tasks in 
        the return function of useEffect().
 LOG  Warning: Can't call setState on an unmounted component. 
        This is a no-op, but it indicates a memory leak in your application. 
        To fix, cancel all subscriptions and asynchronous tasks in 
        the return function of useEffect().
 LOG  Warning: Can't call setState on an unmounted component. 
        This is a no-op, but it indicates a memory leak in your application. 
        To fix, cancel all subscriptions and asynchronous tasks in 
        the return function of useEffect().
```


Le problème est double:

1. on utilise mal `Promise.reject`: la fonction navigateToLogin était pas appelé
2. on utilise `Promise.reject(undefined)` essentiellement sans catcher l'erreur (d'où l'erreur sentry)

![image](https://user-images.githubusercontent.com/10118284/139843462-f08e3dc4-73f7-44c0-a17a-f3ee160a68cd.png)
