### PR TITLE
fix(Tech) LayoutExpired: use EmailFilled icon

### DIFF
--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.native.test.tsx.native-snap
@@ -207,9 +207,9 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
         testID="Contacter le support"
       >
         <View
-          height={28}
+          height={20}
           testID="button-icon"
-          width={28}
+          width={20}
         >
           <Text>
             button-icon-SVG-Mock
@@ -338,9 +338,9 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
         testID="Retourner à l'accueil"
       >
         <View
-          height={17}
+          height={20}
           testID="button-icon"
-          width={17}
+          width={20}
         >
           <Text>
             button-icon-SVG-Mock

--- a/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.native-snap
+++ b/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.native-snap
@@ -267,9 +267,9 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
         testID="Contacter le support"
       >
         <View
-          height={28}
+          height={20}
           testID="button-icon"
-          width={28}
+          width={20}
         >
           <Text>
             button-icon-SVG-Mock
@@ -398,9 +398,9 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
         testID="Retourner à l'accueil"
       >
         <View
-          height={17}
+          height={20}
           testID="button-icon"
-          width={17}
+          width={20}
         >
           <Text>
             button-icon-SVG-Mock

--- a/src/ui/components/LayoutExpiredLink.tsx
+++ b/src/ui/components/LayoutExpiredLink.tsx
@@ -3,14 +3,16 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { navigateToHome, openUrl } from 'features/navigation/helpers'
+import { accessibilityAndTestId } from 'tests/utils'
 import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { ButtonTertiaryWhite } from 'ui/components/buttons/ButtonTertiaryWhite'
 import { GenericInfoPage } from 'ui/components/GenericInfoPage'
-import { Email } from 'ui/svg/icons/Email'
+import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 import { ExternalSite } from 'ui/svg/icons/ExternalSite'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
 import { SadFace } from 'ui/svg/icons/SadFace'
-import { ColorsEnum, Spacer, Typo } from 'ui/theme'
+import { IconInterface } from 'ui/svg/icons/types'
+import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
 
 type Props = {
   onResendEmail: () => void
@@ -50,7 +52,7 @@ export function LayoutExpiredLink({
         <ButtonTertiaryWhite
           title={t`Contacter le support`}
           onPress={contactSupport}
-          icon={Email}
+          icon={EmailFilledIcon}
         />
       )}
 
@@ -64,7 +66,7 @@ export function LayoutExpiredLink({
       <ButtonTertiaryWhite
         title={t`Retourner à l'accueil`}
         onPress={navigateToHome}
-        icon={PlainArrowPrevious}
+        icon={PlainArrowPreviousIcon}
       />
     </GenericInfoPage>
   )
@@ -75,3 +77,15 @@ const StyledBody = styled(Typo.Body).attrs({
 })({
   textAlign: 'center',
 })
+
+const EmailFilledIcon: React.FC<IconInterface> = ({ color }) => (
+  <EmailFilled {...accessibilityAndTestId('button-icon')} color={color} size={getSpacing(5)} />
+)
+
+const PlainArrowPreviousIcon: React.FC<IconInterface> = ({ color }) => (
+  <PlainArrowPrevious
+    {...accessibilityAndTestId('button-icon')}
+    color={color}
+    size={getSpacing(5)}
+  />
+)


### PR DESCRIPTION
## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Added a **screenshot** for UI tickets.

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
| Avant : <img width="380" alt="Capture d’écran 2021-11-04 à 16 55 28" src="https://user-images.githubusercontent.com/62059034/140373781-4637ff2b-733f-4e4c-a63e-737d2b72411f.png">  Après: <img width="380" alt="Capture d’écran 2021-11-04 à 14 37 55" src="https://user-images.githubusercontent.com/62059034/140373528-6369c0f3-09d7-4ae1-bd7f-5e095ffeaed9.png">    |         |                 |                  |                  |
