### PR TITLE
(PC-11509) Using resize-observer-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,6 +269,7 @@
     "react-native-web-linear-gradient": "^1.1.2",
     "react-native-web-lottie": "^1.4.4",
     "react-query-native-devtools": "^3.0.1",
+    "resize-observer-polyfill": "^1.5.1",
     "resolve": "^1.20.0",
     "resolve-url-loader": "^3.1.2",
     "sass-loader": "^11.0.1",

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -27,6 +27,7 @@ import { theme } from 'theme'
 import { LoadingPage } from 'ui/components/LoadingPage'
 import { SnackBarProvider } from 'ui/components/snackBar/SnackBarContext'
 import { ServiceWorkerProvider } from 'web/useServiceWorker'
+import 'resize-observer-polyfill/dist/ResizeObserver.global'
 
 export function App() {
   useStartBatchNotification()

--- a/yarn.lock
+++ b/yarn.lock
@@ -16529,6 +16529,11 @@ reselect@^4.0.0:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
   integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11509

This will fix tutorial and birthday cards on safar mobile ios 10 

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Safari | Mobile - Safari | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         | ![image](https://user-images.githubusercontent.com/77674046/140486197-a1a09796-45b9-4614-a5c0-f137e83d1b8a.png) | ![image](https://user-images.githubusercontent.com/77674046/140486417-7bc5ca43-4b66-4c83-ac37-d962cf8af2d5.png)  |                  |

