### PR TITLE
(PC-11454) add offer id to openExternalURL log

### DIFF
--- a/src/features/auth/support.services.ts
+++ b/src/features/auth/support.services.ts
@@ -20,21 +20,23 @@ export const contactSupport = {
         '\n' +
         'Bien cordialement,'
     )
-    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}&body=${body}`, false)
+    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}&body=${body}`, {
+      logEvent: false,
+    })
       .then(() => analytics.logMailTo('forChangeEmailExpiredLink'))
       .catch(() =>
         eventMonitoring.captureException(new ContactSupportError('ChangeEmailExpiredLink'))
       )
   },
   forGenericQuestion() {
-    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}`, false)
+    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}`, { logEvent: false })
       .then(() => analytics.logMailTo('forGenericQuestion'))
       .catch(() => eventMonitoring.captureException(new ContactSupportError('GenericQuestion')))
   },
   forSignupConfirmationEmailNotReceived() {
     openUrl(
       'https://aide.passculture.app/fr/articles/5257121-je-n-ai-pas-recu-le-mail-de-confirmation-de-creation-de-compte',
-      false
+      { logEvent: false }
     )
       .then(() => analytics.logMailTo('forSignupConfirmationEmailNotReceived'))
       .catch(() =>
@@ -52,7 +54,9 @@ export const contactSupport = {
         '\n' +
         'Bien cordialement,'
     )
-    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}&body=${body}`, false)
+    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}&body=${body}`, {
+      logEvent: false,
+    })
       .then(() => analytics.logMailTo('forSignupConfirmationExpiredLink'))
       .catch(() =>
         eventMonitoring.captureException(new ContactSupportError('SignupConfirmationExpiredLink'))
@@ -67,7 +71,9 @@ export const contactSupport = {
         '\n' +
         'Bien cordialement,'
     )
-    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}&body=${body}`, false)
+    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}&body=${body}`, {
+      logEvent: false,
+    })
       .then(() => analytics.logMailTo('forResetPasswordEmailNotReceived'))
       .catch(() =>
         eventMonitoring.captureException(new ContactSupportError('ResetPasswordEmailNotReceived'))
@@ -82,7 +88,9 @@ export const contactSupport = {
         '\n' +
         'Bien cordialement,'
     )
-    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}&body=${body}`, false)
+    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}&body=${body}`, {
+      logEvent: false,
+    })
       .then(() => analytics.logMailTo('forResetPasswordExpiredLink'))
       .catch(() =>
         eventMonitoring.captureException(new ContactSupportError('ResetPasswordExpiredLink'))
@@ -101,13 +109,15 @@ export const contactSupport = {
         '\n' +
         'Bien cordialement,'
     )
-    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}&body=${body}`, false)
+    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}&body=${body}`, {
+      logEvent: false,
+    })
       .then(() => analytics.logMailTo('forAccountDeletion'))
       .catch(() => eventMonitoring.captureException(new ContactSupportError('AccountDeletion')))
   },
   forPhoneNumberConfirmation() {
     const subject = encodeURI('Confirmation de numéro de téléphone')
-    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}`, false)
+    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}`, { logEvent: false })
       .then(() => analytics.logMailTo('forPhoneNumberConfirmation'))
       .catch(() =>
         eventMonitoring.captureException(new ContactSupportError('PhoneNumberConfirmation'))

--- a/src/features/auth/support.services.ts
+++ b/src/features/auth/support.services.ts
@@ -21,7 +21,7 @@ export const contactSupport = {
         'Bien cordialement,'
     )
     openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}&body=${body}`, {
-      logEvent: false,
+      shouldLogEvent: false,
     })
       .then(() => analytics.logMailTo('forChangeEmailExpiredLink'))
       .catch(() =>
@@ -29,14 +29,14 @@ export const contactSupport = {
       )
   },
   forGenericQuestion() {
-    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}`, { logEvent: false })
+    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}`, { shouldLogEvent: false })
       .then(() => analytics.logMailTo('forGenericQuestion'))
       .catch(() => eventMonitoring.captureException(new ContactSupportError('GenericQuestion')))
   },
   forSignupConfirmationEmailNotReceived() {
     openUrl(
       'https://aide.passculture.app/fr/articles/5257121-je-n-ai-pas-recu-le-mail-de-confirmation-de-creation-de-compte',
-      { logEvent: false }
+      { shouldLogEvent: false }
     )
       .then(() => analytics.logMailTo('forSignupConfirmationEmailNotReceived'))
       .catch(() =>
@@ -55,7 +55,7 @@ export const contactSupport = {
         'Bien cordialement,'
     )
     openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}&body=${body}`, {
-      logEvent: false,
+      shouldLogEvent: false,
     })
       .then(() => analytics.logMailTo('forSignupConfirmationExpiredLink'))
       .catch(() =>
@@ -72,7 +72,7 @@ export const contactSupport = {
         'Bien cordialement,'
     )
     openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}&body=${body}`, {
-      logEvent: false,
+      shouldLogEvent: false,
     })
       .then(() => analytics.logMailTo('forResetPasswordEmailNotReceived'))
       .catch(() =>
@@ -89,7 +89,7 @@ export const contactSupport = {
         'Bien cordialement,'
     )
     openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}&body=${body}`, {
-      logEvent: false,
+      shouldLogEvent: false,
     })
       .then(() => analytics.logMailTo('forResetPasswordExpiredLink'))
       .catch(() =>
@@ -110,14 +110,14 @@ export const contactSupport = {
         'Bien cordialement,'
     )
     openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}&body=${body}`, {
-      logEvent: false,
+      shouldLogEvent: false,
     })
       .then(() => analytics.logMailTo('forAccountDeletion'))
       .catch(() => eventMonitoring.captureException(new ContactSupportError('AccountDeletion')))
   },
   forPhoneNumberConfirmation() {
     const subject = encodeURI('Confirmation de numéro de téléphone')
-    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}`, { logEvent: false })
+    openUrl(`mailto:${env.SUPPORT_EMAIL_ADDRESS}?subject=${subject}`, { shouldLogEvent: false })
       .then(() => analytics.logMailTo('forPhoneNumberConfirmation'))
       .catch(() =>
         eventMonitoring.captureException(new ContactSupportError('PhoneNumberConfirmation'))

--- a/src/features/bookings/components/BookingDetailsTicketContent.tsx
+++ b/src/features/bookings/components/BookingDetailsTicketContent.tsx
@@ -30,7 +30,7 @@ export const BookingDetailsTicketContent = (props: BookingDetailsTicketContentPr
   const accessExternalOffer = () => {
     if (offer.url) {
       analytics.logAccessExternalOffer(offer.id)
-      openUrl(offer.url)
+      openUrl(offer.url, true, undefined, { offerId: offer.id })
     }
   }
 

--- a/src/features/bookings/components/BookingDetailsTicketContent.tsx
+++ b/src/features/bookings/components/BookingDetailsTicketContent.tsx
@@ -28,7 +28,7 @@ export const BookingDetailsTicketContent = (props: BookingDetailsTicketContentPr
 
   const accessExternalOffer = () => {
     if (offer.url) {
-      openUrl(offer.url, true, undefined, { offerId: offer.id })
+      openUrl(offer.url, { analyticsData: { offerId: offer.id } })
     }
   }
 

--- a/src/features/bookings/components/BookingDetailsTicketContent.tsx
+++ b/src/features/bookings/components/BookingDetailsTicketContent.tsx
@@ -11,7 +11,6 @@ import {
 } from 'features/bookings/components/ThreeShapesTicket.constants'
 import { getBookingProperties } from 'features/bookings/helpers'
 import { openUrl } from 'features/navigation/helpers'
-import { analytics } from 'libs/analytics'
 import { useCategoryId, useSubcategory } from 'libs/subcategories'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ColorsEnum, getSpacing, Typo } from 'ui/theme'
@@ -29,7 +28,6 @@ export const BookingDetailsTicketContent = (props: BookingDetailsTicketContentPr
 
   const accessExternalOffer = () => {
     if (offer.url) {
-      analytics.logAccessExternalOffer(offer.id)
       openUrl(offer.url, true, undefined, { offerId: offer.id })
     }
   }

--- a/src/features/bookings/pages/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails.native.test.tsx
@@ -87,7 +87,9 @@ describe('BookingDetails', () => {
       const offerButton = getByText("Accéder à l'offre")
       fireEvent.press(offerButton)
 
-      expect(mockedOpenUrl).toHaveBeenCalledWith(booking.stock.offer.url)
+      expect(mockedOpenUrl).toHaveBeenCalledWith(booking.stock.offer.url, true, undefined, {
+        offerId: booking.stock.offer.id,
+      })
       expect(analytics.logAccessExternalOffer).toHaveBeenCalledWith(booking.stock.offer.id)
     })
 

--- a/src/features/bookings/pages/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails.native.test.tsx
@@ -87,8 +87,10 @@ describe('BookingDetails', () => {
       const offerButton = getByText("Accéder à l'offre")
       fireEvent.press(offerButton)
 
-      expect(mockedOpenUrl).toHaveBeenCalledWith(booking.stock.offer.url, true, undefined, {
-        offerId: booking.stock.offer.id,
+      expect(mockedOpenUrl).toHaveBeenCalledWith(booking.stock.offer.url, {
+        analyticsData: {
+          offerId: booking.stock.offer.id,
+        },
       })
     })
 

--- a/src/features/bookings/pages/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails.native.test.tsx
@@ -90,7 +90,6 @@ describe('BookingDetails', () => {
       expect(mockedOpenUrl).toHaveBeenCalledWith(booking.stock.offer.url, true, undefined, {
         offerId: booking.stock.offer.id,
       })
-      expect(analytics.logAccessExternalOffer).toHaveBeenCalledWith(booking.stock.offer.id)
     })
 
     it('should display booking qr code if offer is physical', async () => {

--- a/src/features/favorites/atoms/BookingButton.tsx
+++ b/src/features/favorites/atoms/BookingButton.tsx
@@ -6,7 +6,6 @@ import { Credit } from 'features/home/services/useAvailableCredit'
 import { openUrl } from 'features/navigation/helpers'
 import { hasEnoughCredit } from 'features/offer/services/useHasEnoughCredit'
 import { isUserBeneficiary, isUserExBeneficiary } from 'features/profile/utils'
-import { OfferAnalyticsData } from 'libs/analytics/analytics'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ExternalLinkSite } from 'ui/svg/icons/ExternalLinkSite'
 
@@ -87,7 +86,7 @@ const BookExternallyButton = ({
   url ? (
     <ButtonPrimary
       title={t`Réserver`}
-      onPress={() => url && openUrl(url, true, undefined, { offerId })}
+      onPress={() => url && openUrl(url, { analyticsData: { offerId } })}
       icon={ExternalLinkSite}
       buttonHeight="tall"
     />

--- a/src/features/favorites/atoms/BookingButton.tsx
+++ b/src/features/favorites/atoms/BookingButton.tsx
@@ -6,6 +6,7 @@ import { Credit } from 'features/home/services/useAvailableCredit'
 import { openUrl } from 'features/navigation/helpers'
 import { hasEnoughCredit } from 'features/offer/services/useHasEnoughCredit'
 import { isUserBeneficiary, isUserExBeneficiary } from 'features/profile/utils'
+import { OfferAnalyticsData } from 'libs/analytics/analytics'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ExternalLinkSite } from 'ui/svg/icons/ExternalLinkSite'
 
@@ -35,7 +36,9 @@ export const BookingButton: React.FC<Props> = (props) => {
     ) {
       return null
     }
-    return <BookExternallyButton url={props.offer.externalTicketOfficeUrl} />
+    return (
+      <BookExternallyButton url={props.offer.externalTicketOfficeUrl} offerId={props.offer.id} />
+    )
   }
 
   // User is an ex-beneficiary
@@ -49,7 +52,9 @@ export const BookingButton: React.FC<Props> = (props) => {
     if (isFreeOffer) {
       return <BookInAppButton onPress={() => props.onInAppBooking(props.offer)} />
     }
-    return <BookExternallyButton url={props.offer.externalTicketOfficeUrl} />
+    return (
+      <BookExternallyButton url={props.offer.externalTicketOfficeUrl} offerId={props.offer.id} />
+    )
   }
 
   // User is beneficiary
@@ -72,11 +77,17 @@ const BookInAppButton = ({ onPress }: { onPress: () => void }) => (
   <ButtonPrimary title={t`Réserver`} onPress={onPress} buttonHeight="tall" />
 )
 
-const BookExternallyButton = ({ url }: { url: FavoriteOfferResponse['externalTicketOfficeUrl'] }) =>
+const BookExternallyButton = ({
+  url,
+  offerId,
+}: {
+  url: FavoriteOfferResponse['externalTicketOfficeUrl']
+  offerId: FavoriteOfferResponse['id']
+}) =>
   url ? (
     <ButtonPrimary
       title={t`Réserver`}
-      onPress={() => url && openUrl(url)}
+      onPress={() => url && openUrl(url, true, undefined, { offerId })}
       icon={ExternalLinkSite}
       buttonHeight="tall"
     />

--- a/src/features/favorites/atoms/__tests__/BookingButton.test.tsx
+++ b/src/features/favorites/atoms/__tests__/BookingButton.test.tsx
@@ -61,8 +61,6 @@ const user: UserProfileResponse = {
 const onInAppBooking = jest.fn()
 
 describe('<BookingButton />', () => {
-  afterEach(jest.clearAllMocks)
-
   describe('when user is beneficiary', () => {
     // prettier-ignore : do not format the following "table" to keep it readable
     it.each`

--- a/src/features/favorites/atoms/__tests__/BookingButton.test.tsx
+++ b/src/features/favorites/atoms/__tests__/BookingButton.test.tsx
@@ -248,8 +248,10 @@ function favoriteBookingButtonTestRunner({
     fireEvent.press(renderAPI.getByText('Réserver'))
     expect(onInAppBooking).not.toBeCalled()
     expect(renderAPI.queryByText('button-icon-SVG-Mock')).toBeTruthy()
-    expect(mockedOpenUrl).toBeCalledWith(offer.externalTicketOfficeUrl, true, undefined, {
-      offerId: offer.id,
+    expect(mockedOpenUrl).toBeCalledWith(offer.externalTicketOfficeUrl, {
+      analyticsData: {
+        offerId: offer.id,
+      },
     })
     expect(renderAPI.queryByText('Offre réservée')).toBeFalsy()
     expect(renderAPI.queryByText('Offre expirée')).toBeFalsy()

--- a/src/features/favorites/atoms/__tests__/BookingButton.test.tsx
+++ b/src/features/favorites/atoms/__tests__/BookingButton.test.tsx
@@ -60,7 +60,9 @@ const user: UserProfileResponse = {
 } as UserProfileResponse
 const onInAppBooking = jest.fn()
 
-describe('<BookingButtun />', () => {
+describe('<BookingButton />', () => {
+  afterEach(jest.clearAllMocks)
+
   describe('when user is beneficiary', () => {
     // prettier-ignore : do not format the following "table" to keep it readable
     it.each`
@@ -248,7 +250,9 @@ function favoriteBookingButtonTestRunner({
     fireEvent.press(renderAPI.getByText('Réserver'))
     expect(onInAppBooking).not.toBeCalled()
     expect(renderAPI.queryByText('button-icon-SVG-Mock')).toBeTruthy()
-    expect(mockedOpenUrl).toBeCalledWith(offer.externalTicketOfficeUrl)
+    expect(mockedOpenUrl).toBeCalledWith(offer.externalTicketOfficeUrl, true, undefined, {
+      offerId: offer.id,
+    })
     expect(renderAPI.queryByText('Offre réservée')).toBeFalsy()
     expect(renderAPI.queryByText('Offre expirée')).toBeFalsy()
     expect(renderAPI.queryByText('Offre épuisée')).toBeFalsy()

--- a/src/features/navigation/__tests__/helpers.test.ts
+++ b/src/features/navigation/__tests__/helpers.test.ts
@@ -54,7 +54,7 @@ describe('Navigation helpers', () => {
     expect(navigationRef.current?.navigate).toBeCalledWith('PageNotFound', undefined)
   })
 
-  it('should log analytics when logEvent is true', async () => {
+  it('should log analytics when shouldLogEvent is true', async () => {
     openURLSpy.mockResolvedValueOnce(undefined)
     const link = 'https://www.google.com'
 
@@ -69,7 +69,7 @@ describe('Navigation helpers', () => {
     openURLSpy.mockResolvedValueOnce(undefined)
     const link = 'https://www.google.com'
 
-    await openUrl(link, { logEvent: false })
+    await openUrl(link, { shouldLogEvent: false })
 
     await waitForExpect(() => {
       expect(analytics.logOpenExternalUrl).not.toBeCalled()

--- a/src/features/navigation/__tests__/helpers.test.ts
+++ b/src/features/navigation/__tests__/helpers.test.ts
@@ -61,7 +61,7 @@ describe('Navigation helpers', () => {
     await openUrl(link)
 
     await waitForExpect(() => {
-      expect(analytics.logOpenExternalUrl).toBeCalledWith(link)
+      expect(analytics.logOpenExternalUrl).toBeCalledWith(link, {})
     })
   })
 

--- a/src/features/navigation/__tests__/helpers.test.ts
+++ b/src/features/navigation/__tests__/helpers.test.ts
@@ -65,11 +65,11 @@ describe('Navigation helpers', () => {
     })
   })
 
-  it('should not log analytics event when logEvent is false', async () => {
+  it('should not log analytics event when shouldLogEvent is false', async () => {
     openURLSpy.mockResolvedValueOnce(undefined)
     const link = 'https://www.google.com'
 
-    await openUrl(link, false)
+    await openUrl(link, { logEvent: false })
 
     await waitForExpect(() => {
       expect(analytics.logOpenExternalUrl).not.toBeCalled()
@@ -96,7 +96,7 @@ describe('Navigation helpers', () => {
     const link = 'https://www.google.com'
     const fallbackLink = 'https://www.googlefallback.com'
 
-    await openUrl(link, undefined, fallbackLink)
+    await openUrl(link, { fallbackUrl: fallbackLink })
     expect(alertMock).not.toHaveBeenCalled()
   })
 

--- a/src/features/navigation/helpers/openUrl.ts
+++ b/src/features/navigation/helpers/openUrl.ts
@@ -4,6 +4,7 @@ import { Alert, Linking } from 'react-native'
 import { getScreenFromDeeplink } from 'features/deeplinks/getScreenFromDeeplink'
 import { navigationRef } from 'features/navigation/navigationRef'
 import { analytics } from 'libs/analytics'
+import { OfferAnalyticsData } from 'libs/analytics/analytics'
 import { MonitoringError } from 'libs/monitoring'
 
 import { isAppUrl } from './isAppUrl'
@@ -22,11 +23,12 @@ const openAppUrl = (url: string) => {
 const openExternalUrl = async (
   url: string,
   logEvent: boolean | undefined = true,
-  fallbackUrl?: string | undefined
+  fallbackUrl?: string | undefined,
+  analyticsData?: OfferAnalyticsData
 ) => {
   try {
     await Linking.openURL(url)
-    if (logEvent) analytics.logOpenExternalUrl(url)
+    if (logEvent) analytics.logOpenExternalUrl(url, { ...analyticsData })
     return
   } catch (error) {
     new MonitoringError(error.message, 'OpenExternalUrlError')
@@ -35,7 +37,7 @@ const openExternalUrl = async (
   if (fallbackUrl) {
     try {
       await Linking.openURL(fallbackUrl)
-      if (logEvent) analytics.logOpenExternalUrl(fallbackUrl)
+      if (logEvent) analytics.logOpenExternalUrl(fallbackUrl, { ...analyticsData })
       return
     } catch (error) {
       new MonitoringError(error.message, 'OpenExternalUrlError_FallbackUrl')
@@ -55,11 +57,12 @@ const showAlert = (url: string) => {
 export async function openUrl(
   url: string,
   logEvent: boolean | undefined = true,
-  fallbackUrl?: string | undefined
+  fallbackUrl?: string | undefined,
+  analyticsData?: OfferAnalyticsData
 ) {
   if (isAppUrl(url)) {
     return openAppUrl(url)
   }
 
-  openExternalUrl(url, logEvent, fallbackUrl)
+  openExternalUrl(url, logEvent, fallbackUrl, analyticsData)
 }

--- a/src/features/navigation/helpers/openUrl.ts
+++ b/src/features/navigation/helpers/openUrl.ts
@@ -21,18 +21,18 @@ const openAppUrl = (url: string) => {
 }
 
 type paramsProps = {
-  logEvent?: boolean
+  shouldLogEvent?: boolean
   fallbackUrl?: string
   analyticsData?: OfferAnalyticsData
 }
 
 const openExternalUrl = async (
   url: string,
-  { logEvent = true, fallbackUrl, analyticsData }: paramsProps
+  { shouldLogEvent = true, fallbackUrl, analyticsData }: paramsProps
 ) => {
   try {
     await Linking.openURL(url)
-    if (logEvent) analytics.logOpenExternalUrl(url, { ...analyticsData })
+    if (shouldLogEvent) analytics.logOpenExternalUrl(url, { ...analyticsData })
     return
   } catch (error) {
     new MonitoringError(error.message, 'OpenExternalUrlError')
@@ -41,7 +41,7 @@ const openExternalUrl = async (
   if (fallbackUrl) {
     try {
       await Linking.openURL(fallbackUrl)
-      if (logEvent) analytics.logOpenExternalUrl(fallbackUrl, { ...analyticsData })
+      if (shouldLogEvent) analytics.logOpenExternalUrl(fallbackUrl, { ...analyticsData })
       return
     } catch (error) {
       new MonitoringError(error.message, 'OpenExternalUrlError_FallbackUrl')
@@ -60,11 +60,11 @@ const showAlert = (url: string) => {
 
 export async function openUrl(
   url: string,
-  { logEvent = true, fallbackUrl, analyticsData }: paramsProps = {}
+  { shouldLogEvent = true, fallbackUrl, analyticsData }: paramsProps = {}
 ) {
   if (isAppUrl(url)) {
     return openAppUrl(url)
   }
 
-  openExternalUrl(url, { logEvent, fallbackUrl, analyticsData })
+  openExternalUrl(url, { shouldLogEvent, fallbackUrl, analyticsData })
 }

--- a/src/features/navigation/helpers/openUrl.ts
+++ b/src/features/navigation/helpers/openUrl.ts
@@ -20,11 +20,15 @@ const openAppUrl = (url: string) => {
   }
 }
 
+type paramsProps = {
+  logEvent?: boolean
+  fallbackUrl?: string
+  analyticsData?: OfferAnalyticsData
+}
+
 const openExternalUrl = async (
   url: string,
-  logEvent: boolean | undefined = true,
-  fallbackUrl?: string | undefined,
-  analyticsData?: OfferAnalyticsData
+  { logEvent = true, fallbackUrl, analyticsData }: paramsProps
 ) => {
   try {
     await Linking.openURL(url)
@@ -56,13 +60,11 @@ const showAlert = (url: string) => {
 
 export async function openUrl(
   url: string,
-  logEvent: boolean | undefined = true,
-  fallbackUrl?: string | undefined,
-  analyticsData?: OfferAnalyticsData
+  { logEvent = true, fallbackUrl, analyticsData }: paramsProps = {}
 ) {
   if (isAppUrl(url)) {
     return openAppUrl(url)
   }
 
-  openExternalUrl(url, logEvent, fallbackUrl, analyticsData)
+  openExternalUrl(url, { logEvent, fallbackUrl, analyticsData })
 }

--- a/src/libs/analytics/__mocks__/analytics.ts
+++ b/src/libs/analytics/__mocks__/analytics.ts
@@ -7,7 +7,6 @@ export const analytics: typeof actualAnalytics = {
   disableCollection: jest.fn(),
   enableCollection: jest.fn(),
   setDefaultEventParameters: jest.fn(),
-  logAccessExternalOffer: jest.fn(),
   logAllModulesSeen: jest.fn(),
   logAllTilesSeen: jest.fn(),
   logBookingConfirmation: jest.fn(),

--- a/src/libs/analytics/analytics.ts
+++ b/src/libs/analytics/analytics.ts
@@ -15,6 +15,10 @@ const STRING_VALUE_MAX_LENGTH = 100
 type FavoriteSortBy = 'ASCENDING_PRICE' | 'AROUND_ME' | 'RECENTLY_ADDED'
 type OfferIdOrVenueId = { offerId: number } | { venueId: number }
 
+export type OfferAnalyticsData = {
+  offerId?: number
+}
+
 const useInit = () => {
   const { campaignDate } = useUtmParams()
 
@@ -136,9 +140,10 @@ export const analytics = {
   logHasRefusedCookie: () => analyticsProvider.logEvent(AnalyticsEvent.HAS_REFUSED_COOKIE),
   logClickSocialNetwork: (network: string) =>
     analyticsProvider.logEvent(AnalyticsEvent.CLICK_SOCIAL_NETWORK, { network }),
-  logOpenExternalUrl: (url: string) =>
+  logOpenExternalUrl: (url: string, params: OfferAnalyticsData) =>
     analyticsProvider.logEvent(AnalyticsEvent.OPEN_EXTERNAL_URL, {
       url: url.slice(0, STRING_VALUE_MAX_LENGTH),
+      offerId: params.offerId,
     }),
   logMailTo: (
     reason:

--- a/src/libs/analytics/analytics.ts
+++ b/src/libs/analytics/analytics.ts
@@ -180,8 +180,6 @@ export const analytics = {
     analyticsProvider.logEvent(AnalyticsEvent.DISCOVER_OFFERS, { from }),
   logCancelBooking: (offerId: number) =>
     analyticsProvider.logEvent(AnalyticsEvent.CANCEL_BOOKING, { offerId }),
-  logAccessExternalOffer: (offerId: number) =>
-    analyticsProvider.logEvent(AnalyticsEvent.ACCESS_EXTERNAL_OFFER, { offerId }),
   logConfirmBookingCancellation: (offerId: number) =>
     analyticsProvider.logEvent(AnalyticsEvent.CONFIRM_BOOKING_CANCELLATION, { offerId }),
   logVenueContact: (params: { type: keyof VenueContactModel; venueId: number }) =>

--- a/src/ui/components/SocialNetworkCard.tsx
+++ b/src/ui/components/SocialNetworkCard.tsx
@@ -21,7 +21,7 @@ function SocialNetworkCardComponent(props: SocialNetworkCardProps) {
     <TouchableOpacity
       onPress={() => {
         analytics.logClickSocialNetwork(name)
-        openUrl(link, { logEvent: false, fallbackUrl: fallbackLink })
+        openUrl(link, { shouldLogEvent: false, fallbackUrl: fallbackLink })
       }}>
       <Container>
         <NetworkIconBox>

--- a/src/ui/components/SocialNetworkCard.tsx
+++ b/src/ui/components/SocialNetworkCard.tsx
@@ -21,7 +21,7 @@ function SocialNetworkCardComponent(props: SocialNetworkCardProps) {
     <TouchableOpacity
       onPress={() => {
         analytics.logClickSocialNetwork(name)
-        openUrl(link, false, fallbackLink)
+        openUrl(link, { logEvent: false, fallbackUrl: fallbackLink })
       }}>
       <Container>
         <NetworkIconBox>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11454

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

### openExternalURL with no offer

<img width="521" alt="Capture d’écran 2021-11-05 à 11 16 49" src="https://user-images.githubusercontent.com/44037911/140499392-427bc748-ffce-4c3d-ab60-954e5bfbdbd2.png">

### openExternalURL with offer

<img width="521" alt="Capture d’écran 2021-11-05 à 11 05 12" src="https://user-images.githubusercontent.com/44037911/140499458-bdb3f5c4-5447-4897-ba69-9baf37a508a4.png">


