### PR TITLE
[PC-11420] feat(changeEmail): handle errors according to mocked API responses

### DIFF
--- a/src/features/profile/__mocks__/mutations.ts
+++ b/src/features/profile/__mocks__/mutations.ts
@@ -1,5 +1,11 @@
 import { UseChangeEmailMutationProps } from 'features/profile/mutations'
 
+export enum CHANGE_EMAIL_ERROR_CODE {
+  TOKEN_EXISTS = 'TOKEN_EXISTS',
+  INVALID_PASSWORD = 'INVALID_PASSWORD',
+  INVALID_EMAIL = 'INVALID_EMAIL',
+  EMAIL_UPDATE_ATTEMPTS_LIMIT = 'EMAIL_UPDATE_ATTEMPTS_LIMIT',
+}
 export const useChangeEmailMutation = jest.fn(({ onSuccess }: UseChangeEmailMutationProps) => ({
   mutate: () => onSuccess(),
 }))

--- a/src/features/profile/mutations.ts
+++ b/src/features/profile/mutations.ts
@@ -1,19 +1,33 @@
 import { useMutation } from 'react-query'
 
+export enum CHANGE_EMAIL_ERROR_CODE {
+  TOKEN_EXISTS = 'TOKEN_EXISTS',
+  INVALID_PASSWORD = 'INVALID_PASSWORD',
+  INVALID_EMAIL = 'INVALID_EMAIL',
+  EMAIL_UPDATE_ATTEMPTS_LIMIT = 'EMAIL_UPDATE_ATTEMPTS_LIMIT',
+}
+let mockedErrorCodeIndex = 0
+
 interface ChangeEmailRequest {
   email: string
   password: string
 }
 export interface UseChangeEmailMutationProps {
   onSuccess: () => void
-  onError: (error: unknown) => void
+  onError: (error: { code: CHANGE_EMAIL_ERROR_CODE }) => void
 }
 
 export function useChangeEmailMutation({ onSuccess, onError }: UseChangeEmailMutationProps) {
   return useMutation(
-    // TODO (PC-11573): call the API once available
+    // TODO (PC-11573): call the API once available, and remove `mockedErrorCodeIndex`
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    (body: ChangeEmailRequest) => new Promise((resolve, reject) => setTimeout(reject, 2000)),
+    (body: ChangeEmailRequest) =>
+      new Promise((resolve, reject) =>
+        setTimeout(() => {
+          mockedErrorCodeIndex = (mockedErrorCodeIndex + 1) % 4
+          reject({ code: Object.values(CHANGE_EMAIL_ERROR_CODE)[mockedErrorCodeIndex] })
+        }, 2000)
+      ),
     {
       onSuccess,
       onError,

--- a/src/features/profile/pages/ChangeEmail/ChangeEmail.tsx
+++ b/src/features/profile/pages/ChangeEmail/ChangeEmail.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro'
 import { useNavigation } from '@react-navigation/native'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useRef } from 'react'
 import { Platform, ScrollView, StyleProp, ViewStyle } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -45,6 +45,10 @@ export function ChangeEmail() {
     },
   })
 
+  useEffect(() => {
+    removePasswordError()
+  }, [password])
+
   const scrollRef = useRef<ScrollView | null>(null)
   const [keyboardHeight, setKeyboardHeight] = useState(0)
   const { bottom } = useSafeAreaInsets()
@@ -52,6 +56,10 @@ export function ChangeEmail() {
 
   const disabled =
     !isLongEnough(password) || !!emailErrorMessage || !!passwordErrorMessage || isLoading
+
+  const removePasswordError = () => {
+    setPasswordErrorMessage(null)
+  }
 
   const navigateToProfile = () => navigate(...getTabNavConfig('Profile'))
 

--- a/src/features/profile/pages/ChangeEmail/ChangeEmail.tsx
+++ b/src/features/profile/pages/ChangeEmail/ChangeEmail.tsx
@@ -50,7 +50,8 @@ export function ChangeEmail() {
   const { bottom } = useSafeAreaInsets()
   useForHeightKeyboardEvents(setKeyboardHeight)
 
-  const disabled = !isLongEnough(password) || !!emailErrorMessage || isLoading
+  const disabled =
+    !isLongEnough(password) || !!emailErrorMessage || !!passwordErrorMessage || isLoading
 
   const navigateToProfile = () => navigate(...getTabNavConfig('Profile'))
 

--- a/src/features/profile/pages/ChangeEmail/ChangeEmail.tsx
+++ b/src/features/profile/pages/ChangeEmail/ChangeEmail.tsx
@@ -9,7 +9,7 @@ import styled, { useTheme } from 'styled-components/native'
 import { isLongEnough } from 'features/auth/components/PasswordSecurityRules'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
-import { useChangeEmailMutation } from 'features/profile/mutations'
+import { CHANGE_EMAIL_ERROR_CODE, useChangeEmailMutation } from 'features/profile/mutations'
 import { ChangeEmailDisclaimer } from 'features/profile/pages/ChangeEmail/ChangeEmailDisclaimer'
 import { useValidateEmail } from 'features/profile/pages/ChangeEmail/utils/useValidateEmail'
 import { useSafeState } from 'libs/hooks'
@@ -30,7 +30,7 @@ export function ChangeEmail() {
   const emailErrorMessage = useValidateEmail(email)
   const [passwordErrorMessage, setPasswordErrorMessage] = useSafeState<string | null>(null)
   const { navigate } = useNavigation<UseNavigationType>()
-  const { showSuccessSnackBar } = useSnackBarContext()
+  const { showSuccessSnackBar, showErrorSnackBar } = useSnackBarContext()
 
   const { mutate: changeEmail, isLoading } = useChangeEmailMutation({
     onSuccess: () => {
@@ -40,8 +40,8 @@ export function ChangeEmail() {
       })
       navigateToProfile()
     },
-    onError: () => {
-      setPasswordErrorMessage(t`Mot de passe incorrect`)
+    onError: (error: { code: CHANGE_EMAIL_ERROR_CODE }) => {
+      onEmailChangeError(error.code)
     },
   })
 
@@ -56,6 +56,20 @@ export function ChangeEmail() {
 
   const disabled =
     !isLongEnough(password) || !!emailErrorMessage || !!passwordErrorMessage || isLoading
+
+  const onEmailChangeError = (errorCode: CHANGE_EMAIL_ERROR_CODE) => {
+    switch (errorCode) {
+      case CHANGE_EMAIL_ERROR_CODE.INVALID_PASSWORD:
+        setPasswordErrorMessage(t`Mot de passe incorrect`)
+        break
+      default:
+        showErrorSnackBar({
+          message: t`Une erreur s’est produite pendant la modification de ton e-mail.
+          Réessaie plus tard.`,
+          timeout: SNACK_BAR_TIME_OUT,
+        })
+    }
+  }
 
   const removePasswordError = () => {
     setPasswordErrorMessage(null)

--- a/src/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.native.test.tsx
+++ b/src/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.native.test.tsx
@@ -3,7 +3,11 @@ import { mocked } from 'ts-jest/utils'
 import waitForExpect from 'wait-for-expect'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import { useChangeEmailMutation, UseChangeEmailMutationProps } from 'features/profile/mutations'
+import {
+  CHANGE_EMAIL_ERROR_CODE,
+  useChangeEmailMutation,
+  UseChangeEmailMutationProps,
+} from 'features/profile/mutations'
 import { fireEvent, render } from 'tests/utils'
 import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
 import { ColorsEnum } from 'ui/theme'
@@ -78,11 +82,11 @@ describe('<ChangeEmail/>', () => {
     })
   })
 
-  it('should show error message if the API call is ko', async () => {
+  it('should show error message if the user gave a wrong password', async () => {
     // @ts-ignore we don't use the other properties of UseMutationResult (such as failureCount)
     // eslint-disable-next-line local-rules/independant-mocks
     mockedUseChangeEmailMutation.mockImplementation(({ onError }: UseChangeEmailMutationProps) => ({
-      mutate: () => onError(undefined),
+      mutate: () => onError({ code: CHANGE_EMAIL_ERROR_CODE.INVALID_PASSWORD }),
     }))
 
     const { getByPlaceholderText, getByTestId, queryByText } = render(<ChangeEmail />)

--- a/src/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.native.test.tsx
+++ b/src/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.native.test.tsx
@@ -19,10 +19,11 @@ jest.mock('features/profile/mutations')
 const mockedUseChangeEmailMutation = mocked(useChangeEmailMutation)
 
 const mockShowSuccessSnackBar = jest.fn()
+const mockShowErrorSnackBar = jest.fn()
 jest.mock('ui/components/snackBar/SnackBarContext', () => ({
   useSnackBarContext: () => ({
     showSuccessSnackBar: jest.fn((props: SnackBarHelperSettings) => mockShowSuccessSnackBar(props)),
-    showErrorSnackBar: jest.fn(),
+    showErrorSnackBar: jest.fn((props: SnackBarHelperSettings) => mockShowErrorSnackBar(props)),
   }),
   SNACK_BAR_TIME_OUT: 5000,
 }))
@@ -102,6 +103,40 @@ describe('<ChangeEmail/>', () => {
       expect(navigate).not.toBeCalled()
       const errorMessage = queryByText('Mot de passe incorrect')
       expect(errorMessage).toBeTruthy()
+    })
+
+    // eslint-disable-next-line local-rules/independant-mocks
+    mockedUseChangeEmailMutation.mockImplementation(
+      // @ts-ignore we don't use the other properties of UseMutationResult (such as failureCount)
+      ({ onSuccess }: UseChangeEmailMutationProps) => ({
+        mutate: () => onSuccess(),
+      })
+    )
+  })
+
+  it('should show error message if the API call returns a generic error', async () => {
+    // @ts-ignore we don't use the other properties of UseMutationResult (such as failureCount)
+    // eslint-disable-next-line local-rules/independant-mocks
+    mockedUseChangeEmailMutation.mockImplementation(({ onError }: UseChangeEmailMutationProps) => ({
+      mutate: () => onError({ code: CHANGE_EMAIL_ERROR_CODE.INVALID_EMAIL }),
+    }))
+
+    const { getByPlaceholderText, getByTestId } = render(<ChangeEmail />)
+    const submitButton = getByTestId('Enregistrer')
+    const emailInput = getByPlaceholderText('tonadresse@email.com')
+    const passwordInput = getByPlaceholderText('Ton mot de passe')
+    fireEvent.changeText(emailInput, 'tonadresse@email.com')
+    fireEvent.changeText(passwordInput, 'password>=12')
+
+    fireEvent.press(submitButton)
+
+    await waitForExpect(() => {
+      expect(navigate).not.toBeCalled()
+      expect(mockShowErrorSnackBar).toBeCalledWith({
+        message: `Une erreur s’est produite pendant la modification de ton e-mail.
+Réessaie plus tard.`,
+        timeout: 5000,
+      })
     })
 
     // eslint-disable-next-line local-rules/independant-mocks


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11420

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
| ![image](https://user-images.githubusercontent.com/26742386/140526273-780826d4-4829-4d5b-8bab-cbe47daf397d.png) |         |                 |                  |                  |
