### PR TITLE
ci(standards): add automated check on PR title

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,6 @@ Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX
 
 I have:
 
-- [ ] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
 - [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
 - [ ] Written **unit tests** native (and web when implementation is different) for my feature.
 - [ ] Added a **screenshot** for UI tickets.

--- a/.github/pr-title-checker.test.ts
+++ b/.github/pr-title-checker.test.ts
@@ -1,0 +1,29 @@
+// See https://github.com/Slashgear/action-check-pr-title/blob/main/src/run.js#L17
+
+const REGEX = new RegExp(
+  /(\(?\[?PC-[0-9]+\)?\]? )?(build|ci|docs|feat|fix|perf|refactor|test)\(\w+\): \w+/i
+)
+
+const invalidPullRequestTitles: string[] = [
+  '[PC-1234] tech(home): Add color to button', // invalid type
+  '[PC-1234] Add color to button', // no scope nor type
+  '[PC-1234] feat: Add color to button', // No scope
+  'feat: Add color to button [PC-1234]', // jira ticket at the end
+]
+
+const validPullRequestTitles: string[] = [
+  '[PC-1234] feat(home): Add color to button',
+  '(PC-1234) feat(home): Add color to button',
+  'PC-1234 feat(home): Add color to button',
+  'feat(home): Add color to button', // jira ticket is optionel, although better to have it
+]
+
+describe('pr-title-checker', () => {
+  it.each(invalidPullRequestTitles)('should not allow invalid PR titles: "%s"', (title) => {
+    expect(REGEX.test(title)).toBeFalsy()
+  })
+
+  it.each(validPullRequestTitles)('should allow valid PR titles: "%s"', (title) => {
+    expect(REGEX.test(title)).toBeTruthy()
+  })
+})

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,0 +1,20 @@
+name: Check PR title format
+
+on:
+  pull_request:
+    branches: [master]
+    types:
+      - opened
+      - edited
+      - synchronize
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Slashgear/action-check-pr-title@v3.0.0
+        with:
+          regexp: '(\(?\[?PC-[0-9]+\)?\]? )?(build|ci|docs|feat|fix|perf|refactor|test)\(\w+\): \w+'

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ In the `doc/` folder you will find the `dev standards` the team members follow:
 - [error and crash management](./doc/standards/errorManagement.md).
 - [variable naming](./doc/standards/naming.md).
 - [testing strategy](./doc/standards/testStrategy.md).
+- [PR title format](./doc/standards/pr-title.md).
 
 <details>
   <summary>To add a dev standard</summary>

--- a/doc/standards/pr-title.md
+++ b/doc/standards/pr-title.md
@@ -1,0 +1,39 @@
+## PR title format 🤖
+
+### Why
+
+- To have consistent PR titles
+- To have consistent commit messages on master
+
+##### About squashing the PR commits
+
+If we squash the PR when we merge it, the PR title becomes the commit message on master.
+As a result, we just need to enforce consistency on the title of the PR to have consistent commit message on master.
+
+The commits of the PR won't be on master, but are still useful for PR readliness and for future reference.
+
+### Key points
+
+- The agreed upon format for the PR title is:
+
+```
+<jira> <type>(<scope>): <short summary>
+  │       │      |             │
+  │       │      |             └─⫸ PR Summary: short summary of the Jira ticket title in English. Present tense.
+  │       │      |                  Not capitalized. No period at the end.
+  │       │      |
+  │       │      └─⫸ PR Scope: Hierarchical scope. Not capitalized, but snakeCase. For instance:
+  │       │           app, core, themeProvider... > identityCheck, eac, booking, search... > useSelectPlaylist...
+  │       │
+  │       └─⫸ PR Type: build, ci, docs, feat, fix, perf, refactor or test.
+  |            See https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type
+  │
+  └─⫸ Jira ticket number: [PC-1234], (PC-1234) or PC-1234.
+```
+
+- Github action to ensure that the PR title is in the right format: [pr-title-checker.yml](../../.github/workflows/pr-title-checker.yml)
+- Test of the regex used in the github action: [pr-title-checker.test.ts](../../.github/pr-title-checker.test.ts)
+
+### Resources
+
+See [ADR](https://www.notion.so/passcultureapp/V-rification-des-titres-de-PR-automatique-4c75df3be25a4417a70a86a37dc14960)


### PR DESCRIPTION
In this PR:

- added github action to check on PR title
- Remove line from PR template (now automatic).
- added test to verify regex.

#### PR title format

⚠  Make sure every PR title follows the following format:

```
<jira> <type>(<scope>): <short summary>
  │       │      |             │
  │       │      |             └─⫸ PR Summary: short summary of the Jira ticket title in English. Present tense.
  │       │      |                  Not capitalized. No period at the end.
  │       │      |
  │       │      └─⫸ PR Scope: Hierarchical scope. Not capitalized, but snakeCase. For instance:
  │       │           app, core, themeProvider... > identityCheck, eac, booking, search... > useSelectPlaylist...
  │       │
  │       └─⫸ PR Type: build, ci, docs, feat, fix, perf, refactor or test.
  |            See https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type
  │
  └─⫸ Jira ticket number: [PC-1234], (PC-1234) or PC-1234.
```

[PC-1234]: https://passculture.atlassian.net/browse/PC-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ