### PR TITLE
(PC-11702) Nullify user position when geoloc permission is rejected

### DIFF
--- a/src/libs/geolocation/GeolocationWrapper.test.tsx
+++ b/src/libs/geolocation/GeolocationWrapper.test.tsx
@@ -26,7 +26,15 @@ const onSubmit = jest.fn()
 const onAcceptance = jest.fn()
 const onRefusal = jest.fn()
 
+const MOCK_POSITION = { latitude: 90, longitude: 90 }
+
 describe('useGeolocation()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetPositionSuccess()
+  })
+  afterAll(jest.clearAllMocks)
+
   it('should call onSubmit() and onAcceptance() when requestGeolocPermission() returns GRANTED', async () => {
     mockPermissionResult(GeolocPermissionState.GRANTED)
     const { result } = renderGeolocationHook()
@@ -34,6 +42,7 @@ describe('useGeolocation()', () => {
 
     await waitForExpect(() => {
       expect(result.current.permissionState).toEqual(GeolocPermissionState.GRANTED)
+      expect(result.current.position).toBe(MOCK_POSITION)
       expect(onSubmit).toBeCalled()
       expect(onRefusal).not.toBeCalled()
       expect(onAcceptance).toBeCalled()
@@ -47,6 +56,7 @@ describe('useGeolocation()', () => {
 
     await waitForExpect(() => {
       expect(result.current.permissionState).toEqual(GeolocPermissionState.DENIED)
+      expect(result.current.position).toBe(null)
       expect(onSubmit).toBeCalled()
       expect(onRefusal).toBeCalled()
       expect(onAcceptance).not.toBeCalled()
@@ -60,6 +70,7 @@ describe('useGeolocation()', () => {
 
     await waitForExpect(() => {
       expect(result.current.permissionState).toEqual(GeolocPermissionState.NEVER_ASK_AGAIN)
+      expect(result.current.position).toBe(null)
       expect(onSubmit).toBeCalled()
       expect(onRefusal).toBeCalled()
       expect(onAcceptance).not.toBeCalled()
@@ -67,13 +78,13 @@ describe('useGeolocation()', () => {
   })
 
   it('should call onSubmit() and onAcceptance() when requestGeolocPermission() returns NEED_ASK_POSITION_DIRECTLY and position is not null', async () => {
-    mockGetPosition.mockResolvedValue({ latitude: 90, longitude: 90 })
     mockPermissionResult(GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY)
     const { result } = renderGeolocationHook()
     result.current.requestGeolocPermission({ onSubmit, onAcceptance, onRefusal })
 
     await waitForExpect(() => {
       expect(result.current.permissionState).toEqual(GeolocPermissionState.GRANTED)
+      expect(result.current.position).toBe(MOCK_POSITION)
       expect(onSubmit).toBeCalled()
       expect(onRefusal).not.toBeCalled()
       expect(onAcceptance).toBeCalled()
@@ -81,38 +92,50 @@ describe('useGeolocation()', () => {
   })
 
   it('should call onSubmit() and onRefusal() when requestGeolocPermission() returns NEED_ASK_POSITION_DIRECTLY and position is null', async () => {
-    mockGetPosition.mockRejectedValue({
-      type: GeolocPositionError.POSITION_UNAVAILABLE,
-      message: 'error message',
-    } as GeolocationError)
+    mockGetPositionFail()
     mockPermissionResult(GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY)
     const { result } = renderGeolocationHook()
     result.current.requestGeolocPermission({ onSubmit, onAcceptance, onRefusal })
 
     await waitForExpect(() => {
       expect(result.current.permissionState).toEqual(GeolocPermissionState.NEVER_ASK_AGAIN)
+      expect(result.current.position).toBe(null)
       expect(onSubmit).toBeCalled()
       expect(onRefusal).toBeCalled()
       expect(onAcceptance).not.toBeCalled()
     })
   })
 
-  it('should call getPosition() when permission is GRANTED', async () => {
-    mockPermissionResult(GeolocPermissionState.GRANTED)
-    renderGeolocationHook()
-    await waitForExpect(() => {
-      expect(mockGetPosition).toBeCalled()
-    })
-  })
-
-  it('should not call getPosition() when permission is NEVER_ASK_AGAIN', async () => {
-    mockPermissionResult(GeolocPermissionState.NEVER_ASK_AGAIN)
-    renderGeolocationHook()
-    await waitForExpect(() => {
-      expect(mockGetPosition).not.toBeCalled()
-    })
-  })
+  it.each`
+    permission                                          | statement
+    ${GeolocPermissionState.GRANTED}                    | ${'call'}
+    ${GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY} | ${'call'}
+    ${GeolocPermissionState.DENIED}                     | ${'not call'}
+    ${GeolocPermissionState.NEVER_ASK_AGAIN}            | ${'not call'}
+  `(
+    'should $statement getPosition() when permission is $permission',
+    async (params: { permission: GeolocPermissionState; statement: 'call' | 'not call' }) => {
+      const { permission, statement } = params
+      mockPermissionResult(permission)
+      renderGeolocationHook()
+      await waitForExpect(() => {
+        if (statement === 'call') expect(mockGetPosition).toBeCalled()
+        else expect(mockGetPosition).not.toBeCalled()
+      })
+    }
+  )
 })
+
+function mockGetPositionSuccess() {
+  mockGetPosition.mockResolvedValue(MOCK_POSITION)
+}
+
+function mockGetPositionFail() {
+  mockGetPosition.mockRejectedValue({
+    type: GeolocPositionError.POSITION_UNAVAILABLE,
+    message: 'error message',
+  } as GeolocationError)
+}
 
 function renderGeolocationHook() {
   return renderHook(useGeolocation, { wrapper: GeolocationWrapper })

--- a/src/libs/geolocation/GeolocationWrapper.tsx
+++ b/src/libs/geolocation/GeolocationWrapper.tsx
@@ -104,6 +104,13 @@ export const GeolocationWrapper = memo(function GeolocationWrapper({
     setPermissionState(permission)
   }, [])
 
+  useEffect(() => {
+    if (isRejected(permissionState)) {
+      setPosition(null)
+      setPositionError(null)
+    }
+  }, [permissionState])
+
   useAppStateChange(contextualCheckPermission, undefined, [])
 
   function onPressGeolocPermissionModalButton() {
@@ -137,6 +144,12 @@ export function useGeolocation(): IGeolocationContext {
 
 function isGranted(permission: GeolocPermissionState) {
   return permission === GeolocPermissionState.GRANTED
+}
+function isRejected(permission: GeolocPermissionState) {
+  return (
+    permission === GeolocPermissionState.DENIED ||
+    permission === GeolocPermissionState.NEVER_ASK_AGAIN
+  )
 }
 function isNeedAskPosition(permission: GeolocPermissionState) {
   return permission === GeolocPermissionState.NEED_ASK_POSITION_DIRECTLY


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11702

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`
