### PR TITLE
(PC-11752) WebApp v2 - Path /home remplacé par /accueil

### DIFF
--- a/src/features/navigation/RootNavigator/linking/__tests__/getScreenPath.test.ts
+++ b/src/features/navigation/RootNavigator/linking/__tests__/getScreenPath.test.ts
@@ -3,7 +3,7 @@ import { getScreenPath } from '../getScreenPath'
 describe('getScreenPath()', () => {
   it.each`
     screen             | params                                             | expectedPath
-    ${'TabNavigator'}  | ${{ screen: 'Home', params: { entryId: '1234' } }} | ${'/home?entryId=1234'}
+    ${'TabNavigator'}  | ${{ screen: 'Home', params: { entryId: '1234' } }} | ${'/accueil?entryId=1234'}
     ${'TabNavigator'}  | ${{ screen: 'Profile' }}                           | ${'/profil'}
     ${'Offer'}         | ${{ id: 666, from: 'offer' }}                      | ${'/offre/666?from=offer'}
     ${'UnknownScreen'} | ${undefined}                                       | ${'/UnknownScreen'}

--- a/src/features/navigation/RootNavigator/linking/__tests__/getStateFromPath.test.ts
+++ b/src/features/navigation/RootNavigator/linking/__tests__/getStateFromPath.test.ts
@@ -8,8 +8,8 @@ import { storeUtmParams } from 'libs/utm'
 jest.mock('libs/utm', () => ({ storeUtmParams: jest.fn() }))
 
 describe('getStateFromPath()', () => {
-  it('should return state for path home?entryId=666', async () => {
-    const state = customGetStateFromPath('home?entryId=666', linking.config)
+  it('should return state for path accueil?entryId=666', async () => {
+    const state = customGetStateFromPath('accueil?entryId=666', linking.config)
     const expectedState = {
       routes: [
         { name: 'TabNavigator', state: { routes: [{ name: 'Home', params: { entryId: '666' } }] } },

--- a/src/features/navigation/TabBar/routes.ts
+++ b/src/features/navigation/TabBar/routes.ts
@@ -21,7 +21,7 @@ export const routes: TabRoute[] = [
   {
     name: 'Home',
     component: Home,
-    pathConfig: { path: 'home', deeplinkPaths: ['accueil'], parse: screenParamsParser['Home'] },
+    pathConfig: { path: 'accueil', deeplinkPaths: ['home'], parse: screenParamsParser['Home'] },
   },
   {
     name: 'Search',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11752

## Description

Depuis la dernière mise en production, le `ForceUpdate` est affiché pour tout nos utilisateurs ayant une version inférieur à la version v1.158.1.

Dans cette version, la home supporte déjà `/home` et `/accueil`. Ce changement sera donc transparent pour la communication et les utilisateurs au niveau du partage du lien.

Cela permet également :
 
- En Web: de rediriger sur `/accueil` plutôt que `/home` 

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |
