### PR TITLE
(PC-9623) Stratégie header "unique-id" Web

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "@babel/preset-react": "^7.12.5",
     "@babel/preset-typescript": "^7.13.0",
     "@babel/runtime": "^7.8.4",
+    "@fingerprintjs/fingerprintjs": "^3.3.0",
     "@lingui/cli": "^3.10.2",
     "@lingui/macro": "^3.10.2",
     "@react-native-community/eslint-config": "^2.0.0",

--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { t } from '@lingui/macro'
 import { IdCheckError } from '@pass-culture/id-check'
-import { getUniqueId } from 'react-native-device-info'
 
 import { navigationRef, isNavigationReadyRef } from 'features/navigation/navigationRef'
 import { Headers, FailedToRefreshAccessTokenError } from 'libs/fetch'
 import { decodeAccessToken } from 'libs/jwt'
 import { clearRefreshToken, getRefreshToken } from 'libs/keychain'
 import { eventMonitoring } from 'libs/monitoring'
+import { getUniqueId } from 'libs/react-native-device-info/getUniqueId'
 import { storage } from 'libs/storage'
 
 import Package from '../../package.json'
@@ -70,7 +70,7 @@ export const safeFetch = async (
     ...options,
     headers: {
       ...options.headers,
-      'device-id': getUniqueId(),
+      'device-id': await getUniqueId(),
       'app-version': Package.version,
     },
   }

--- a/src/libs/react-native-device-info/getUniqueId.ts
+++ b/src/libs/react-native-device-info/getUniqueId.ts
@@ -1,0 +1,1 @@
+export { getUniqueId } from 'react-native-device-info'

--- a/src/libs/react-native-device-info/getUniqueId.web.ts
+++ b/src/libs/react-native-device-info/getUniqueId.web.ts
@@ -1,0 +1,13 @@
+import FingerprintJS from '@fingerprintjs/fingerprintjs'
+
+const fpPromise = FingerprintJS.load()
+
+export async function getUniqueId() {
+  try {
+    const fp = await fpPromise
+    const { visitorId } = await fp.get()
+    return visitorId
+  } catch (err) {
+    return ''
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2774,6 +2774,13 @@
     base64-js "^1.2.3"
     xmlbuilder "^14.0.0"
 
+"@fingerprintjs/fingerprintjs@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs/-/fingerprintjs-3.3.0.tgz#d15c2fab8e0d9138bcb8efa1429dd780f93bb945"
+  integrity sha512-2kw2yVrfMKd0YvmYAdNxhGytNhhLvChqNAbBZWMglYVw2J95Jm50ketK5yS1C8SJmqG2nFJgeuWvYXeZEh+b8g==
+  dependencies:
+    tslib "^2.0.1"
+
 "@firebase/analytics-types@0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@firebase/analytics-types/-/analytics-types-0.6.0.tgz#164116ebe8d3b338272acc7f9904cac38556d6cd"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-9623

J’ai créé une PR pour la stratégie avec identifiant navigateur unique (qui sera le même si on passe en incognito ou change de session google par exemple)

Avant de merger celui ci, est-ce que cela pourrait avoir des conséquences ? Par exemple, est-ce que coté back & ops le `device-id` est utilisé quelque part pour autre chose que du logging ?

On peut également imaginer renommer le header en `browser-unique-id`, par exemple.

## Screenshots

| Actuellement | Avec browser fingerprint |
| --: | ------: |
|![image](https://user-images.githubusercontent.com/77674046/141339038-d00880a2-5ab7-404b-92a2-f9bf62e818fa.png) |![image](https://user-images.githubusercontent.com/77674046/141339048-47482b8e-c0dc-4a73-8c23-cd4f31f59903.png)         |


