### PR TITLE
(PC-11769) Centrer le CTA sur la page Notification

### DIFF
--- a/src/features/profile/pages/NotificationSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings.tsx
@@ -201,7 +201,7 @@ export function NotificationSettings() {
         )}
         <Spacer.Flex flex={1} />
         {!!isLoggedIn && (
-          <ButtonPrimary
+          <StyledButtonPrimary
             title={t`Enregistrer`}
             isLoading={isUpdating}
             disabled={!state.emailTouched && !state.pushTouched}
@@ -219,6 +219,10 @@ export function NotificationSettings() {
     </React.Fragment>
   )
 }
+
+const StyledButtonPrimary = styled(ButtonPrimary)({
+  alignSelf: 'center',
+})
 
 const Line = styled.View({
   paddingVertical: getSpacing(4),


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11769

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         | ![image](https://user-images.githubusercontent.com/77674046/141434124-c6ed1ba0-c7a3-4c31-a855-98bab7a234a9.png) | ![image](https://user-images.githubusercontent.com/77674046/141434136-6efcdc98-8131-43e7-9259-12b8599dce94.png)|                  |


