### PR TITLE
(PC-11507) OfferHeader - Text ellipsis title color forced to white

### DIFF
--- a/__snapshots__/features/offer/components/__tests__/OfferHeader.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/__tests__/OfferHeader.native.test.tsx.native-snap
@@ -181,6 +181,7 @@ Array [
         numberOfLines={1}
         style={
           Object {
+            "color": "#ffffff",
             "flexShrink": 1,
             "opacity": 0,
             "textAlign": "center",

--- a/__snapshots__/features/offer/components/__tests__/OfferHeader.web.test.tsx.web-snap
+++ b/__snapshots__/features/offer/components/__tests__/OfferHeader.web.test.tsx.web-snap
@@ -101,7 +101,7 @@ Object {
             data-testid="offerHeaderName"
             dir="auto"
             id="animatedComponent"
-            style="flex-shrink: 1; opacity: 0; text-align: center;"
+            style="color: rgb(255, 255, 255); flex-shrink: 1; opacity: 0; text-align: center;"
           >
             <span
               class="css-text-901oao css-textHasAncestor-16my406"
@@ -449,7 +449,7 @@ Object {
           data-testid="offerHeaderName"
           dir="auto"
           id="animatedComponent"
-          style="flex-shrink: 1; opacity: 0; text-align: center;"
+          style="color: rgb(255, 255, 255); flex-shrink: 1; opacity: 0; text-align: center;"
         >
           <span
             class="css-text-901oao css-textHasAncestor-16my406"

--- a/src/features/offer/components/OfferHeader.tsx
+++ b/src/features/offer/components/OfferHeader.tsx
@@ -169,7 +169,8 @@ const Row = styled.View({
   flexDirection: 'row',
   alignItems: 'center',
 })
-const Title = styled(Animated.Text).attrs({ numberOfLines: 1 })({
+const Title = styled(Animated.Text).attrs({ numberOfLines: 1 })(({ theme }) => ({
   flexShrink: 1,
   textAlign: 'center',
-})
+  color: theme.colors.white,
+}))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11507

## Checklist

I have:

- [ ] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         | ![image](https://user-images.githubusercontent.com/77674046/141762443-0fef6052-8ade-41e8-b4d3-505493a778ac.png) |                  |                  |

