### PR TITLE
PC-11790 fix(OfferHeader): Title on two lignes and fixed Safari title too long

### DIFF
--- a/__snapshots__/features/offer/components/__tests__/OfferHeader.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/__tests__/OfferHeader.native.test.tsx.native-snap
@@ -178,7 +178,7 @@ Array [
         }
       />
       <Text
-        numberOfLines={1}
+        numberOfLines={2}
         style={
           Object {
             "color": "#ffffff",

--- a/__snapshots__/features/offer/components/__tests__/OfferHeader.web.test.tsx.web-snap
+++ b/__snapshots__/features/offer/components/__tests__/OfferHeader.web.test.tsx.web-snap
@@ -97,11 +97,11 @@ Object {
             style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
           />
           <div
-            class="css-text-901oao css-textOneLine-vcwn7f"
+            class="css-text-901oao css-textMultiLine-cens5h"
             data-testid="offerHeaderName"
             dir="auto"
             id="animatedComponent"
-            style="color: rgb(255, 255, 255); flex-shrink: 1; opacity: 0; text-align: center;"
+            style="color: rgb(255, 255, 255); flex-shrink: 1; opacity: 0; text-align: center; white-space: pre-wrap;"
           >
             <span
               class="css-text-901oao css-textHasAncestor-16my406"
@@ -445,11 +445,11 @@ Object {
           style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
         />
         <div
-          class="css-text-901oao css-textOneLine-vcwn7f"
+          class="css-text-901oao css-textMultiLine-cens5h"
           data-testid="offerHeaderName"
           dir="auto"
           id="animatedComponent"
-          style="color: rgb(255, 255, 255); flex-shrink: 1; opacity: 0; text-align: center;"
+          style="color: rgb(255, 255, 255); flex-shrink: 1; opacity: 0; text-align: center; white-space: pre-wrap;"
         >
           <span
             class="css-text-901oao css-textHasAncestor-16my406"

--- a/src/features/offer/components/OfferHeader.tsx
+++ b/src/features/offer/components/OfferHeader.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro'
 import { useRoute } from '@react-navigation/native'
 import React, { useRef } from 'react'
-import { Animated } from 'react-native'
+import { Animated, Platform } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled from 'styled-components/native'
 
@@ -169,8 +169,9 @@ const Row = styled.View({
   flexDirection: 'row',
   alignItems: 'center',
 })
-const Title = styled(Animated.Text).attrs({ numberOfLines: 1 })(({ theme }) => ({
+const Title = styled(Animated.Text).attrs({ numberOfLines: 2 })(({ theme }) => ({
   flexShrink: 1,
   textAlign: 'center',
   color: theme.colors.white,
+  ...(Platform.OS === 'web' ? { whiteSpace: 'pre-wrap' } : {}),
 }))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11790

- Use two lines for `title` in `<OfferHeader />`
- Fix `text-overflow: ellipsis` by adding a `whiteSpace: 'pre-wrap'` on the WEB

## Checklist

I have:

- [x] Made sure the title of my PR follows the convention `[PC-XXXXX] <summary>`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| Desktop - Safari | Android | Mobile - Safari | Desktop - Chrome | Mobile - Chrome | 
| --: | ------: | --------------: | ---------------: | ---------------: | 
| ![image](https://user-images.githubusercontent.com/77674046/141776617-2aa3d210-614f-4d38-93d0-2da3fb3a48f8.png) | ![image](https://user-images.githubusercontent.com/77674046/141777722-7586c43c-ae5b-4141-8db6-198a2b2af3b2.png)          | ![image](https://user-images.githubusercontent.com/77674046/141776006-782b8d93-1e1f-414a-9aaa-c9375f15bbbc.png) | ![image](https://user-images.githubusercontent.com/77674046/141775659-63ec7abe-14ec-44f2-9053-5929192ed5ce.png) | ![image](https://user-images.githubusercontent.com/77674046/141776075-91d0d7bd-b85c-4ea0-a8d5-65352b717b79.png) |





