### PR TITLE
(PC-11793) fix(BatchSDK): Safari is not yet supported, this commit will disable BatchSDK on Safari

### DIFF
--- a/src/libs/react-native-batch.web.ts
+++ b/src/libs/react-native-batch.web.ts
@@ -1,9 +1,14 @@
 import { getBatchSDK } from 'libs/batch/batch-sdk'
 import { env } from 'libs/environment'
+import { isSafari } from 'web/utils'
 
 /* eslint-disable no-console */
 export const Batch = {
   start() {
+    // TODO: remove this condition when BatchSDK will support Safari, see also service-worker.ts#L83
+    if (isSafari()) {
+      return
+    }
     getBatchSDK()
     /* Initiate Batch SDK opt-in UI configuration (native prompt) */
     let batchSDKUIConfig

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -14,6 +14,8 @@ import { precacheAndRoute, createHandlerBoundToURL } from 'workbox-precaching'
 import { registerRoute } from 'workbox-routing'
 import { StaleWhileRevalidate } from 'workbox-strategies'
 
+import { isSafari } from 'web/utils'
+
 declare const self: ServiceWorkerGlobalScope
 
 clientsClaim()
@@ -77,5 +79,8 @@ self.addEventListener('message', (event) => {
   }
 })
 
-// This is for web push notifications with batch
-self.importScripts(process.env.PUBLIC_URL + '/batchsdk-shared-worker.js')
+// TODO: remove this condition when BatchSDK will support Safari, see also react-native-batch.web.ts#L9
+if (!isSafari()) {
+  // This is for web push notifications with batch
+  self.importScripts(process.env.PUBLIC_URL + '/batchsdk-shared-worker.js')
+}

--- a/src/web/utils/index.ts
+++ b/src/web/utils/index.ts
@@ -1,0 +1,3 @@
+export function isSafari() {
+  return false
+}

--- a/src/web/utils/index.web.ts
+++ b/src/web/utils/index.web.ts
@@ -1,0 +1,12 @@
+/**
+ * This will work with any version of Safari across all devices: Mac, iPhone, iPod, iPad.
+ * Taken from https://stackoverflow.com/a/31732310/2127277
+ */
+export function isSafari() {
+  const { navigator } = globalThis
+  return (
+    navigator?.vendor?.includes('Apple') &&
+    !navigator?.userAgent?.includes('CriOS') &&
+    !navigator?.userAgent?.includes('FxiOS')
+  )
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11793

Testé sur MacOS et iPhone, le fix exclus l'initialisation de batch sdk safari, n'étant toujours pas supporté.

>  Concernant le push web Safari, il n'est pas (encore) supporté par Batch.
Nos équipes travaillent déjà sur ce sujet, les développements sont en cours et la sortie de ce nouveau canal aura lieu très prochainement.

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |
