### PR TITLE
(PC-11400) fix(BottomContentPage): tablet and desktop viewport adjustment

### DIFF
--- a/__snapshots__/features/auth/forgottenPassword/ForgottenPassword/tests/ForgottenPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ForgottenPassword/tests/ForgottenPassword.native.test.tsx.native-snap
@@ -5,7 +5,7 @@ exports[`<ForgottenPassword /> should enable validate button when email input is
 - First value
 + Second value
 
-@@ -339,11 +339,11 @@
+@@ -347,11 +347,11 @@
                           },
                         ]
                       }
@@ -18,7 +18,7 @@ exports[`<ForgottenPassword /> should enable validate button when email input is
                 </View>
               </View>
               <View
-@@ -357,22 +357,22 @@
+@@ -365,22 +365,22 @@
                 }
               />
               <View
@@ -43,7 +43,7 @@ exports[`<ForgottenPassword /> should enable validate button when email input is
                     \\"flexDirection\\": \\"row\\",
                     \\"height\\": 40,
                     \\"justifyContent\\": \\"center\\",
-@@ -391,20 +391,20 @@
+@@ -399,20 +399,20 @@
                   adjustsFontSizeToFit={false}
                   numberOfLines={1}
                   style={

--- a/__snapshots__/features/auth/forgottenPassword/ReinitializePassword/tests/ReinitializePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ReinitializePassword/tests/ReinitializePassword.native.test.tsx.native-snap
@@ -5,7 +5,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
 - First value
 + Second value
 
-@@ -294,11 +294,11 @@
+@@ -302,11 +302,11 @@
                         },
                       ]
                     }
@@ -18,7 +18,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                     accessibilityLabel=\\"Basculer l'affichage du mot de passe\\"
                     accessible={true}
                     focusable={true}
-@@ -353,23 +353,23 @@
+@@ -361,23 +361,23 @@
                     ]
                   }
                 >
@@ -46,7 +46,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                           \\"fontSize\\": 12,
                           \\"lineHeight\\": 16,
                           \\"paddingLeft\\": 4,
-@@ -391,23 +391,23 @@
+@@ -399,23 +399,23 @@
                     ]
                   }
                 >
@@ -74,7 +74,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                           \\"fontSize\\": 12,
                           \\"lineHeight\\": 16,
                           \\"paddingLeft\\": 4,
-@@ -429,23 +429,23 @@
+@@ -437,23 +437,23 @@
                     ]
                   }
                 >
@@ -102,7 +102,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                           \\"fontSize\\": 12,
                           \\"lineHeight\\": 16,
                           \\"paddingLeft\\": 4,
-@@ -467,23 +467,23 @@
+@@ -475,23 +475,23 @@
                     ]
                   }
                 >
@@ -130,7 +130,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                           \\"fontSize\\": 12,
                           \\"lineHeight\\": 16,
                           \\"paddingLeft\\": 4,
-@@ -505,23 +505,23 @@
+@@ -513,23 +513,23 @@
                     ]
                   }
                 >

--- a/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -297,18 +297,22 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                       }
                     >
                       <View
+                        height="100%"
                         style={
                           Array [
                             Object {
+                              "bottom": 0,
                               "height": "100%",
                               "left": 0,
                               "position": "absolute",
+                              "right": 0,
                               "top": 0,
                               "width": "100%",
                               "zIndex": -1,
                             },
                           ]
                         }
+                        width="100%"
                       >
                         <View
                           height="100%"
@@ -334,9 +338,14 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                         <View
                           onLayout={[Function]}
                           style={
-                            Object {
-                              "paddingBottom": 0,
-                            }
+                            Array [
+                              Array [
+                                Object {},
+                              ],
+                              Object {
+                                "paddingBottom": 0,
+                              },
+                            ]
                           }
                         >
                           <RCTScrollView
@@ -352,7 +361,6 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                                 "width": "100%",
                               }
                             }
-                            customPaddingBottom={16}
                             keyboardShouldPersistTaps="handled"
                             scrollEnabled={false}
                             style={

--- a/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.web.test.tsx.web-snap
@@ -61,7 +61,7 @@ Object {
                           >
                             <div
                               class="css-view-1dbjc4n"
-                              style="bottom: 0px; left: 0px; position: absolute; right: 0px; top: 0px; z-index: -1;"
+                              style="bottom: 0px; height: 100%; left: 0px; position: absolute; right: 0px; top: 0px; width: 100%; z-index: -1;"
                             >
                               <div
                                 class="css-view-1dbjc4n"
@@ -345,7 +345,7 @@ Object {
                         >
                           <div
                             class="css-view-1dbjc4n"
-                            style="bottom: 0px; left: 0px; position: absolute; right: 0px; top: 0px; z-index: -1;"
+                            style="bottom: 0px; height: 100%; left: 0px; position: absolute; right: 0px; top: 0px; width: 100%; z-index: -1;"
                           >
                             <div
                               class="css-view-1dbjc4n"

--- a/__snapshots__/features/auth/login/Login.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/login/Login.native.test.tsx.native-snap
@@ -5,7 +5,7 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
 - First value
 + Second value
 
-@@ -297,11 +297,11 @@
+@@ -305,11 +305,11 @@
                         },
                       ]
                     }
@@ -18,7 +18,7 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
               </View>
             </View>
             <View
-@@ -416,11 +416,11 @@
+@@ -424,11 +424,11 @@
                     ]
                   }
                   testID=\\"Entrée pour le mot de passe\\"
@@ -31,7 +31,7 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
                   accessibilityLabel=\\"Basculer l'affichage du mot de passe\\"
                   accessible={true}
                   focusable={true}
-@@ -519,22 +519,22 @@
+@@ -527,22 +527,22 @@
               }
             />
             <View
@@ -56,7 +56,7 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
                   \\"flexDirection\\": \\"row\\",
                   \\"height\\": 40,
                   \\"justifyContent\\": \\"center\\",
-@@ -553,20 +553,20 @@
+@@ -561,20 +561,20 @@
                 adjustsFontSizeToFit={false}
                 numberOfLines={1}
                 style={
@@ -86,7 +86,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
 - First value
 + Second value
 
-@@ -179,10 +179,59 @@
+@@ -187,10 +187,59 @@
                   </Text>
                 </View>
               </View>
@@ -146,7 +146,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                 Array [
                   Object {
                     \\"height\\": 28,
-@@ -239,18 +288,18 @@
+@@ -247,18 +296,18 @@
                       },
                     ]
                   }
@@ -167,7 +167,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                         \\"borderWidth\\": 1,
                         \\"flexDirection\\": \\"row\\",
                         \\"height\\": 40,
-@@ -297,11 +346,11 @@
+@@ -305,11 +354,11 @@
                         },
                       ]
                     }
@@ -180,7 +180,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
               </View>
             </View>
             <View
-@@ -350,18 +399,18 @@
+@@ -358,18 +407,18 @@
                     },
                   ]
                 }
@@ -201,7 +201,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                       \\"borderWidth\\": 1,
                       \\"flexDirection\\": \\"row\\",
                       \\"height\\": 40,
-@@ -416,11 +465,11 @@
+@@ -424,11 +473,11 @@
                     ]
                   }
                   testID=\\"Entrée pour le mot de passe\\"
@@ -214,7 +214,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                   accessibilityLabel=\\"Basculer l'affichage du mot de passe\\"
                   accessible={true}
                   focusable={true}
-@@ -519,22 +568,22 @@
+@@ -527,22 +576,22 @@
               }
             />
             <View
@@ -239,7 +239,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                   \\"flexDirection\\": \\"row\\",
                   \\"height\\": 40,
                   \\"justifyContent\\": \\"center\\",
-@@ -553,20 +602,20 @@
+@@ -561,20 +610,20 @@
                 adjustsFontSizeToFit={false}
                 numberOfLines={1}
                 style={
@@ -269,7 +269,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
 - First value
 + Second value
 
-@@ -179,10 +179,59 @@
+@@ -187,10 +187,59 @@
                   </Text>
                 </View>
               </View>
@@ -329,7 +329,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                 Array [
                   Object {
                     \\"height\\": 28,
-@@ -239,18 +288,18 @@
+@@ -247,18 +296,18 @@
                       },
                     ]
                   }
@@ -350,7 +350,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                         \\"borderWidth\\": 1,
                         \\"flexDirection\\": \\"row\\",
                         \\"height\\": 40,
-@@ -297,11 +346,11 @@
+@@ -305,11 +354,11 @@
                         },
                       ]
                     }
@@ -363,7 +363,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
               </View>
             </View>
             <View
-@@ -350,18 +399,18 @@
+@@ -358,18 +407,18 @@
                     },
                   ]
                 }
@@ -384,7 +384,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                       \\"borderWidth\\": 1,
                       \\"flexDirection\\": \\"row\\",
                       \\"height\\": 40,
-@@ -416,11 +465,11 @@
+@@ -424,11 +473,11 @@
                     ]
                   }
                   testID=\\"Entrée pour le mot de passe\\"
@@ -397,7 +397,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                   accessibilityLabel=\\"Basculer l'affichage du mot de passe\\"
                   accessible={true}
                   focusable={true}
-@@ -519,22 +568,22 @@
+@@ -527,22 +576,22 @@
               }
             />
             <View
@@ -422,7 +422,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                   \\"flexDirection\\": \\"row\\",
                   \\"height\\": 40,
                   \\"justifyContent\\": \\"center\\",
-@@ -553,20 +602,20 @@
+@@ -561,20 +610,20 @@
                 adjustsFontSizeToFit={false}
                 numberOfLines={1}
                 style={
@@ -452,7 +452,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
 - First value
 + Second value
 
-@@ -179,10 +179,59 @@
+@@ -187,10 +187,59 @@
                   </Text>
                 </View>
               </View>
@@ -512,7 +512,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                 Array [
                   Object {
                     \\"height\\": 28,
-@@ -239,18 +288,18 @@
+@@ -247,18 +296,18 @@
                       },
                     ]
                   }
@@ -533,7 +533,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                         \\"borderWidth\\": 1,
                         \\"flexDirection\\": \\"row\\",
                         \\"height\\": 40,
-@@ -297,11 +346,11 @@
+@@ -305,11 +354,11 @@
                         },
                       ]
                     }
@@ -546,7 +546,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
               </View>
             </View>
             <View
-@@ -350,18 +399,18 @@
+@@ -358,18 +407,18 @@
                     },
                   ]
                 }
@@ -567,7 +567,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                       \\"borderWidth\\": 1,
                       \\"flexDirection\\": \\"row\\",
                       \\"height\\": 40,
-@@ -416,11 +465,11 @@
+@@ -424,11 +473,11 @@
                     ]
                   }
                   testID=\\"Entrée pour le mot de passe\\"
@@ -580,7 +580,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                   accessibilityLabel=\\"Basculer l'affichage du mot de passe\\"
                   accessible={true}
                   focusable={true}
-@@ -519,22 +568,22 @@
+@@ -527,22 +576,22 @@
               }
             />
             <View
@@ -605,7 +605,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                   \\"flexDirection\\": \\"row\\",
                   \\"height\\": 40,
                   \\"justifyContent\\": \\"center\\",
-@@ -553,20 +602,20 @@
+@@ -561,20 +610,20 @@
                 adjustsFontSizeToFit={false}
                 numberOfLines={1}
                 style={

--- a/__snapshots__/features/auth/signup/AccountCreated/tests/AccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/AccountCreated/tests/AccountCreated.native.test.tsx.native-snap
@@ -14,18 +14,22 @@ exports[`<AccountCreated /> should render correctly 1`] = `
   }
 >
   <View
+    height="100%"
     style={
       Array [
         Object {
+          "bottom": 0,
           "height": "100%",
           "left": 0,
           "position": "absolute",
+          "right": 0,
           "top": 0,
           "width": "100%",
           "zIndex": -1,
         },
       ]
     }
+    width="100%"
   >
     <View
       height="100%"

--- a/__snapshots__/features/auth/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
@@ -12,18 +12,22 @@ Array [
     }
   >
     <View
+      height="100%"
       style={
         Array [
           Object {
+            "bottom": 0,
             "height": "100%",
             "left": 0,
             "position": "absolute",
+            "right": 0,
             "top": 0,
             "width": "100%",
             "zIndex": -1,
           },
         ]
       }
+      width="100%"
     >
       <View
         height="100%"
@@ -49,9 +53,14 @@ Array [
       <View
         onLayout={[Function]}
         style={
-          Object {
-            "paddingBottom": 0,
-          }
+          Array [
+            Array [
+              Object {},
+            ],
+            Object {
+              "paddingBottom": 0,
+            },
+          ]
         }
       >
         <RCTScrollView
@@ -67,7 +76,6 @@ Array [
               "width": "100%",
             }
           }
-          customPaddingBottom={16}
           keyboardShouldPersistTaps="handled"
           scrollEnabled={false}
           style={
@@ -801,18 +809,22 @@ exports[`SetBirthday Page should render properly 1`] = `
   }
 >
   <View
+    height="100%"
     style={
       Array [
         Object {
+          "bottom": 0,
           "height": "100%",
           "left": 0,
           "position": "absolute",
+          "right": 0,
           "top": 0,
           "width": "100%",
           "zIndex": -1,
         },
       ]
     }
+    width="100%"
   >
     <View
       height="100%"
@@ -838,9 +850,14 @@ exports[`SetBirthday Page should render properly 1`] = `
     <View
       onLayout={[Function]}
       style={
-        Object {
-          "paddingBottom": 0,
-        }
+        Array [
+          Array [
+            Object {},
+          ],
+          Object {
+            "paddingBottom": 0,
+          },
+        ]
       }
     >
       <RCTScrollView
@@ -856,7 +873,6 @@ exports[`SetBirthday Page should render properly 1`] = `
             "width": "100%",
           }
         }
-        customPaddingBottom={16}
         keyboardShouldPersistTaps="handled"
         scrollEnabled={false}
         style={

--- a/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.native-snap
@@ -14,18 +14,22 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
   }
 >
   <View
+    height="100%"
     style={
       Array [
         Object {
+          "bottom": 0,
           "height": "100%",
           "left": 0,
           "position": "absolute",
+          "right": 0,
           "top": 0,
           "width": "100%",
           "zIndex": -1,
         },
       ]
     }
+    width="100%"
   >
     <View
       height="100%"

--- a/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.web-snap
@@ -27,10 +27,12 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
     style={
       Object {
         "bottom": "0px",
+        "height": "100%",
         "left": "0px",
         "position": "absolute",
         "right": "0px",
         "top": "0px",
+        "width": "100%",
         "zIndex": -1,
       }
     }

--- a/__snapshots__/features/eighteenBirthday/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/eighteenBirthday/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -3,18 +3,22 @@
 exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
 Array [
   <View
+    height="100%"
     style={
       Array [
         Object {
+          "bottom": 0,
           "height": "100%",
           "left": 0,
           "position": "absolute",
+          "right": 0,
           "top": 0,
           "width": "100%",
           "zIndex": -1,
         },
       ]
     }
+    width="100%"
   >
     <View
       height="100%"

--- a/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.native.test.tsx.native-snap
@@ -14,18 +14,22 @@ exports[`AsyncErrorBoundary component should render 1`] = `
   }
 >
   <View
+    height="100%"
     style={
       Array [
         Object {
+          "bottom": 0,
           "height": "100%",
           "left": 0,
           "position": "absolute",
+          "right": 0,
           "top": 0,
           "width": "100%",
           "zIndex": -1,
         },
       ]
     }
+    width="100%"
   >
     <View
       height="100%"

--- a/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.web.test.tsx.web-snap
+++ b/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.web.test.tsx.web-snap
@@ -11,7 +11,7 @@ Object {
       >
         <div
           class="css-view-1dbjc4n"
-          style="bottom: 0px; left: 0px; position: absolute; right: 0px; top: 0px; z-index: -1;"
+          style="bottom: 0px; height: 100%; left: 0px; position: absolute; right: 0px; top: 0px; width: 100%; z-index: -1;"
         >
           <div
             class="css-view-1dbjc4n"
@@ -143,7 +143,7 @@ Object {
     >
       <div
         class="css-view-1dbjc4n"
-        style="bottom: 0px; left: 0px; position: absolute; right: 0px; top: 0px; z-index: -1;"
+        style="bottom: 0px; height: 100%; left: 0px; position: absolute; right: 0px; top: 0px; width: 100%; z-index: -1;"
       >
         <div
           class="css-view-1dbjc4n"

--- a/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.native-snap
@@ -14,18 +14,22 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
   }
 >
   <View
+    height="100%"
     style={
       Array [
         Object {
+          "bottom": 0,
           "height": "100%",
           "left": 0,
           "position": "absolute",
+          "right": 0,
           "top": 0,
           "width": "100%",
           "zIndex": -1,
         },
       ]
     }
+    width="100%"
   >
     <View
       height="100%"

--- a/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.web-snap
+++ b/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.web-snap
@@ -27,10 +27,12 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
     style={
       Object {
         "bottom": "0px",
+        "height": "100%",
         "left": "0px",
         "position": "absolute",
         "right": "0px",
         "top": "0px",
+        "width": "100%",
         "zIndex": -1,
       }
     }

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/FirstTutorial.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/FirstTutorial.native.test.tsx.native-snap
@@ -3,18 +3,22 @@
 exports[`FirstTutorial page should render first tutorial 1`] = `
 Array [
   <View
+    height="100%"
     style={
       Array [
         Object {
+          "bottom": 0,
           "height": "100%",
           "left": 0,
           "position": "absolute",
+          "right": 0,
           "top": 0,
           "width": "100%",
           "zIndex": -1,
         },
       ]
     }
+    width="100%"
   >
     <View
       height="100%"

--- a/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.native-snap
+++ b/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.native-snap
@@ -14,18 +14,22 @@ exports[`<ForceUpdate/> should match snapshot 1`] = `
   }
 >
   <View
+    height="100%"
     style={
       Array [
         Object {
+          "bottom": 0,
           "height": "100%",
           "left": 0,
           "position": "absolute",
+          "right": 0,
           "top": 0,
           "width": "100%",
           "zIndex": -1,
         },
       ]
     }
+    width="100%"
   >
     <View
       height="100%"

--- a/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.web-snap
+++ b/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.web-snap
@@ -27,10 +27,12 @@ exports[`<ForceUpdate/> should match snapshot 1`] = `
     style={
       Object {
         "bottom": "0px",
+        "height": "100%",
         "left": "0px",
         "position": "absolute",
         "right": "0px",
         "top": "0px",
+        "width": "100%",
         "zIndex": -1,
       }
     }

--- a/__snapshots__/features/identityCheck/pages/__test__/IdentityCheckEnd.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/__test__/IdentityCheckEnd.test.tsx.native-snap
@@ -14,18 +14,22 @@ exports[`<IdentityCheckEnd/> should render correctly 1`] = `
   }
 >
   <View
+    height="100%"
     style={
       Array [
         Object {
+          "bottom": 0,
           "height": "100%",
           "left": 0,
           "position": "absolute",
+          "right": 0,
           "top": 0,
           "width": "100%",
           "zIndex": -1,
         },
       ]
     }
+    width="100%"
   >
     <View
       height="100%"

--- a/__snapshots__/features/identityCheck/pages/__test__/IdentityCheckEnd.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/__test__/IdentityCheckEnd.test.tsx.web-snap
@@ -27,10 +27,12 @@ exports[`<IdentityCheckEnd/> should render correctly 1`] = `
     style={
       Object {
         "bottom": "0px",
+        "height": "100%",
         "left": "0px",
         "position": "absolute",
         "right": "0px",
         "top": "0px",
+        "width": "100%",
         "zIndex": -1,
       }
     }

--- a/__snapshots__/features/maintenance/tests/Maintenance.test.tsx.native-snap
+++ b/__snapshots__/features/maintenance/tests/Maintenance.test.tsx.native-snap
@@ -14,18 +14,22 @@ exports[`<Maintenance /> should match snapshot 1`] = `
   }
 >
   <View
+    height="100%"
     style={
       Array [
         Object {
+          "bottom": 0,
           "height": "100%",
           "left": 0,
           "position": "absolute",
+          "right": 0,
           "top": 0,
           "width": "100%",
           "zIndex": -1,
         },
       ]
     }
+    width="100%"
   >
     <View
       height="100%"

--- a/__snapshots__/features/maintenance/tests/Maintenance.test.tsx.web-snap
+++ b/__snapshots__/features/maintenance/tests/Maintenance.test.tsx.web-snap
@@ -27,10 +27,12 @@ exports[`<Maintenance /> should match snapshot 1`] = `
     style={
       Object {
         "bottom": "0px",
+        "height": "100%",
         "left": "0px",
         "position": "absolute",
         "right": "0px",
         "top": "0px",
+        "width": "100%",
         "zIndex": -1,
       }
     }

--- a/__snapshots__/features/profile/pages/AfterChangeEmailValidationBuffer/__tests__/AfterChangeEmailValidationBuffer.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/AfterChangeEmailValidationBuffer/__tests__/AfterChangeEmailValidationBuffer.native.test.tsx.native-snap
@@ -16,18 +16,22 @@ exports[`<AfterChangeEmailValidationBuffer/> should render correctly 1`] = `
   }
 >
   <View
+    height="100%"
     style={
       Array [
         Object {
+          "bottom": 0,
           "height": "100%",
           "left": 0,
           "position": "absolute",
+          "right": 0,
           "top": 0,
           "width": "100%",
           "zIndex": -1,
         },
       ]
     }
+    width="100%"
   >
     <View
       height="100%"

--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.native.test.tsx.native-snap
@@ -14,18 +14,22 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
   }
 >
   <View
+    height="100%"
     style={
       Array [
         Object {
+          "bottom": 0,
           "height": "100%",
           "left": 0,
           "position": "absolute",
+          "right": 0,
           "top": 0,
           "width": "100%",
           "zIndex": -1,
         },
       ]
     }
+    width="100%"
   >
     <View
       height="100%"

--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.web.test.tsx.web-snap
@@ -11,7 +11,7 @@ Object {
       >
         <div
           class="css-view-1dbjc4n"
-          style="bottom: 0px; left: 0px; position: absolute; right: 0px; top: 0px; z-index: -1;"
+          style="bottom: 0px; height: 100%; left: 0px; position: absolute; right: 0px; top: 0px; width: 100%; z-index: -1;"
         >
           <div
             class="css-view-1dbjc4n"
@@ -181,7 +181,7 @@ Object {
     >
       <div
         class="css-view-1dbjc4n"
-        style="bottom: 0px; left: 0px; position: absolute; right: 0px; top: 0px; z-index: -1;"
+        style="bottom: 0px; height: 100%; left: 0px; position: absolute; right: 0px; top: 0px; width: 100%; z-index: -1;"
       >
         <div
           class="css-view-1dbjc4n"

--- a/__snapshots__/features/profile/pages/ConfirmDeleteProfile.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConfirmDeleteProfile.test.tsx.native-snap
@@ -14,18 +14,22 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
   }
 >
   <View
+    height="100%"
     style={
       Array [
         Object {
+          "bottom": 0,
           "height": "100%",
           "left": 0,
           "position": "absolute",
+          "right": 0,
           "top": 0,
           "width": "100%",
           "zIndex": -1,
         },
       ]
     }
+    width="100%"
   >
     <View
       height="100%"

--- a/__snapshots__/features/profile/pages/ConfirmDeleteProfile.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ConfirmDeleteProfile.test.tsx.web-snap
@@ -27,10 +27,12 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
     style={
       Object {
         "bottom": "0px",
+        "height": "100%",
         "left": "0px",
         "position": "absolute",
         "right": "0px",
         "top": "0px",
+        "width": "100%",
         "zIndex": -1,
       }
     }

--- a/__snapshots__/features/profile/pages/DeleteProfileSuccess.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfileSuccess.test.tsx.native-snap
@@ -14,18 +14,22 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
   }
 >
   <View
+    height="100%"
     style={
       Array [
         Object {
+          "bottom": 0,
           "height": "100%",
           "left": 0,
           "position": "absolute",
+          "right": 0,
           "top": 0,
           "width": "100%",
           "zIndex": -1,
         },
       ]
     }
+    width="100%"
   >
     <View
       height="100%"

--- a/__snapshots__/features/profile/pages/DeleteProfileSuccess.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfileSuccess.test.tsx.web-snap
@@ -27,10 +27,12 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
     style={
       Object {
         "bottom": "0px",
+        "height": "100%",
         "left": "0px",
         "position": "absolute",
         "right": "0px",
         "top": "0px",
+        "width": "100%",
         "zIndex": -1,
       }
     }

--- a/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.native-snap
+++ b/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.native-snap
@@ -14,18 +14,22 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
   }
 >
   <View
+    height="100%"
     style={
       Array [
         Object {
+          "bottom": 0,
           "height": "100%",
           "left": 0,
           "position": "absolute",
+          "right": 0,
           "top": 0,
           "width": "100%",
           "zIndex": -1,
         },
       ]
     }
+    width="100%"
   >
     <View
       height="100%"

--- a/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.web-snap
+++ b/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.web-snap
@@ -27,10 +27,12 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
     style={
       Object {
         "bottom": "0px",
+        "height": "100%",
         "left": "0px",
         "position": "absolute",
         "right": "0px",
         "top": "0px",
+        "width": "100%",
         "zIndex": -1,
       }
     }

--- a/__snapshots__/ui/components/achievements/components/GenericAchievement.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/achievements/components/GenericAchievement.native.test.tsx.native-snap
@@ -3,18 +3,22 @@
 exports[`<GenericAchievement /> should render correctly 1`] = `
 Array [
   <View
+    height="100%"
     style={
       Array [
         Object {
+          "bottom": 0,
           "height": "100%",
           "left": 0,
           "position": "absolute",
+          "right": 0,
           "top": 0,
           "width": "100%",
           "zIndex": -1,
         },
       ]
     }
+    width="100%"
   >
     <View
       height="100%"

--- a/__snapshots__/ui/components/achievements/components/GenericAchievement.web.test.tsx.web-snap
+++ b/__snapshots__/ui/components/achievements/components/GenericAchievement.web.test.tsx.web-snap
@@ -7,7 +7,7 @@ Object {
     <div>
       <div
         class="css-view-1dbjc4n"
-        style="bottom: 0px; left: 0px; position: absolute; right: 0px; top: 0px; z-index: -1;"
+        style="bottom: 0px; height: 100%; left: 0px; position: absolute; right: 0px; top: 0px; width: 100%; z-index: -1;"
       >
         <div
           class="css-view-1dbjc4n"
@@ -89,7 +89,7 @@ Object {
   "container": <div>
     <div
       class="css-view-1dbjc4n"
-      style="bottom: 0px; left: 0px; position: absolute; right: 0px; top: 0px; z-index: -1;"
+      style="bottom: 0px; height: 100%; left: 0px; position: absolute; right: 0px; top: 0px; width: 100%; z-index: -1;"
     >
       <div
         class="css-view-1dbjc4n"

--- a/src/features/home/components/HomeHeader.tsx
+++ b/src/features/home/components/HomeHeader.tsx
@@ -85,10 +85,10 @@ const HeaderBackgroundWrapper = styled.View({
 
 const CheatCodeButtonContainer = styled.TouchableOpacity.attrs({
   activeOpacity: ACTIVE_OPACITY,
-})({
+})(({ theme }) => ({
   position: 'absolute',
   right: getSpacing(2),
-  zIndex: ZIndex.CHEATCODE_BUTTON,
+  zIndex: theme.zIndex.cheatCodeButton,
   border: 1,
   padding: getSpacing(1),
-})
+}))

--- a/src/features/navigation/RootNavigator/Header/Nav.tsx
+++ b/src/features/navigation/RootNavigator/Header/Nav.tsx
@@ -59,7 +59,7 @@ const NavItemsContainer = styled.View<{
   width: '100%',
   maxWidth,
   position: 'absolute',
-  zIndex: theme.zIndexHeaderNav,
+  zIndex: theme.zIndex.headerNav,
   ...(!noShadow
     ? getShadow({
         shadowOffset: { width: 0, height: getSpacing(1 / 4) },

--- a/src/features/navigation/RootNavigator/withWebWrapper.web.tsx
+++ b/src/features/navigation/RootNavigator/withWebWrapper.web.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentType, memo } from 'react'
 import styled from 'styled-components/native'
 
-import { BackgroundPurple } from 'ui/svg/BackgroundPurple'
+import { BackgroundSecondary } from 'ui/svg/BackgroundSecondary'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const withWebWrapper = (Component: ComponentType<any>) => {
@@ -11,7 +11,7 @@ export const withWebWrapper = (Component: ComponentType<any>) => {
         <SiteContainer>
           <Component {...props} />
         </SiteContainer>
-        <BackgroundPurple />
+        <BackgroundSecondary />
       </SiteWrapper>
     )
   })

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -10,7 +10,12 @@ import {
 } from 'react-device-detect'
 import { Platform } from 'react-native'
 
-import { getSpacing, getSpacingString, TAB_BAR_COMP_HEIGHT } from 'ui/theme'
+import {
+  BOTTOM_CONTENT_PAGE_OFFSET_TOP_HEIGHT_DESKTOP_TABLET,
+  getSpacing,
+  getSpacingString,
+  TAB_BAR_COMP_HEIGHT,
+} from 'ui/theme'
 import { ACTIVE_OPACITY, ColorsEnum, UniqueColors } from 'ui/theme/colors'
 import { BorderRadiusEnum, Breakpoints } from 'ui/theme/grid'
 import { ZIndex } from 'ui/theme/layers'
@@ -97,8 +102,23 @@ export interface AppThemeType extends Omit<IdCheckThemeType, 'colors' | 'typogra
     radius: BorderRadiusEnum
     checkbox: BorderRadiusEnum
   }
-  zIndexTabBar: number
-  zIndexHeaderNav: number
+  zIndex: {
+    background: ZIndex
+    cheatCodeButton: ZIndex
+    favoritePastilleContent: ZIndex
+    homeOfferCoverIcons: ZIndex
+    header: ZIndex
+    modalHeader: ZIndex
+    progressbar: ZIndex
+    playlistsButton: ZIndex
+    progressbarIcon: ZIndex
+    tabBar: ZIndex
+    headerNav: ZIndex
+    snackbar: ZIndex
+  }
+  bottomContentPage: {
+    offsetTopHeightDesktopTablet: number
+  }
 }
 
 export const theme: AppThemeType = deepmerge(idCheckTheme, {
@@ -204,6 +224,21 @@ export const theme: AppThemeType = deepmerge(idCheckTheme, {
     radius: BorderRadiusEnum.BORDER_RADIUS,
     checkbox: BorderRadiusEnum.CHECKBOX_RADIUS,
   },
-  zIndexTabBar: ZIndex.TABBAR,
-  zIndexHeaderNav: ZIndex.HEADER_NAV,
+  zIndex: {
+    background: ZIndex.BACKGROUND,
+    cheatCodeButton: ZIndex.CHEAT_CODE_BUTTON,
+    favoritePastilleContent: ZIndex.FAVORITE_PASTILLE_CONTENT,
+    homeOfferCoverIcons: ZIndex.HOME_OFFER_COVER_ICONS,
+    header: ZIndex.HEADER,
+    modalHeader: ZIndex.MODAL_HEADER,
+    progressbar: ZIndex.PROGRESSBAR,
+    playlistsButton: ZIndex.PLAYLIST_BUTTON,
+    progressbarIcon: ZIndex.PROGRESSBAR_ICON,
+    tabBar: ZIndex.TAB_BAR,
+    headerNav: ZIndex.HEADER_NAV,
+    snackbar: ZIndex.SNACKBAR,
+  },
+  bottomContentPage: {
+    offsetTopHeightDesktopTablet: BOTTOM_CONTENT_PAGE_OFFSET_TOP_HEIGHT_DESKTOP_TABLET,
+  },
 })

--- a/src/ui/svg/Background.tsx
+++ b/src/ui/svg/Background.tsx
@@ -1,61 +1,68 @@
 import React, { memo } from 'react'
 import Svg, { Defs, LinearGradient, Stop, Path, G, Mask, Use } from 'react-native-svg'
-import styled from 'styled-components/native'
+import styled, { useTheme } from 'styled-components/native'
 
-import { ZIndex } from 'ui/theme/layers'
+import { svgIdentifier } from 'ui/svg/utils'
 
 export const Background = memo(NotMemoizedBackground)
 
-function NotMemoizedBackground() {
+interface BackgroundProps {
+  width?: string | number
+  height?: string | number
+}
+
+export function NotMemoizedBackground({ width = '100%', height = '100%' }: BackgroundProps) {
   return (
-    <BackgroundContainer>
-      <BackgroundSvg />
+    <BackgroundContainer height={height} width={width}>
+      <BackgroundSvg height={height} width={width} />
     </BackgroundContainer>
   )
 }
 
-const BackgroundContainer = styled.View({
+const BackgroundContainer = styled.View<BackgroundProps>(({ width, height, theme }) => ({
   position: 'absolute',
   top: 0,
   left: 0,
-  width: '100%',
-  height: '100%',
-  zIndex: ZIndex.BACKGROUND,
-})
+  right: 0,
+  bottom: 0,
+  width: width ?? '100%',
+  height: height ?? '100%',
+  zIndex: theme.zIndex.background,
+}))
 
-function BackgroundSvg() {
+function BackgroundSvg({ width = '100%', height = '100%' }: BackgroundProps) {
+  const {
+    colors: { primary, secondary },
+  } = useTheme()
+  const { id: ida, xlinkHref: xlinkHrefa } = svgIdentifier()
+  const { id: idb, fill: fillb } = svgIdentifier()
+  const { id: idc, fill: fillc } = svgIdentifier()
+  const { id: idd, fill: filld } = svgIdentifier()
+  const { id: ide, xlinkHref: xlinkHrefe } = svgIdentifier()
   return (
-    <Svg width="100%" height="100%" viewBox="0 0 375 667" preserveAspectRatio="none">
+    <Svg width={width} height={height} viewBox="0 0 375 667" preserveAspectRatio="none">
       <Defs>
-        <LinearGradient id="bakground__b" x1="65.805%" x2="47.731%" y1="26.588%" y2="116.28%">
-          <Stop offset="0%" stopColor="#EB0055" />
-          <Stop offset="100%" stopColor="#320096" />
+        <LinearGradient id={idb} x1="65.805%" x2="47.731%" y1="26.588%" y2="116.28%">
+          <Stop offset="0%" stopColor={primary} />
+          <Stop offset="100%" stopColor={secondary} />
         </LinearGradient>
-        <LinearGradient id="bakground__d" x1="29.678%" x2="32.571%" y1="71.761%" y2="14.036%">
-          <Stop offset="0%" stopColor="#EB0055" />
-          <Stop offset="100%" stopColor="#320096" />
+        <LinearGradient id={idd} x1="29.678%" x2="32.571%" y1="71.761%" y2="14.036%">
+          <Stop offset="0%" stopColor={primary} />
+          <Stop offset="100%" stopColor={secondary} />
         </LinearGradient>
-        <Path id="bakground__a" d="M0 0h375v667H0z" />
+        <Path id={ida} d="M0 0h375v667H0z" />
         <Path
-          id="bakground__e"
+          id={ide}
           d="M574.848 685.018c44.64 237.462 197.943-58.73 172.765-186.83-25.178-128.1-120.317-395.218-387.196-385.031-266.88 10.187-281.873 242.282-174.83 360.46 107.043 118.179 344.621-26.06 389.26 211.401z"
         />
       </Defs>
       <G fill="none" fillRule="evenodd">
-        <Mask id="bakground__c" fill="#fff">
-          <Use xlinkHref="#bakground__a" />
+        <Mask id={idc} fill="#fff">
+          <Use xlinkHref={xlinkHrefa} />
         </Mask>
-        <Use
-          fill="url(#bakground__b)"
-          transform="matrix(-1 0 0 1 375 0)"
-          xlinkHref="#bakground__a"
-        />
-        <G mask="url(#bakground__c)">
-          <Use
-            fill="url(#bakground__d)"
-            transform="rotate(-150 256.422 462.025)"
-            xlinkHref="#bakground__e"
-          />
+        <Use fill={fillb} transform="matrix(-1 0 0 1 375 0)" xlinkHref={xlinkHrefa} />
+        <G mask={fillc}>
+          <Use fill={filld} transform="rotate(-150 256.422 462.025)" xlinkHref={xlinkHrefe} />
         </G>
       </G>
     </Svg>

--- a/src/ui/svg/Background.web.tsx
+++ b/src/ui/svg/Background.web.tsx
@@ -1,1 +1,0 @@
-export { Background } from '@pass-culture/id-check'

--- a/src/ui/svg/BackgroundSecondary.tsx
+++ b/src/ui/svg/BackgroundSecondary.tsx
@@ -1,12 +1,10 @@
 import React, { memo } from 'react'
 import Svg, { Defs, LinearGradient, Stop, Path, G, Mask, Use } from 'react-native-svg'
-import styled from 'styled-components/native'
+import styled, { useTheme } from 'styled-components/native'
 
 import { svgIdentifier } from 'ui/svg/utils'
-import { ColorsEnum } from 'ui/theme'
-import { ZIndex } from 'ui/theme/layers'
 
-export const BackgroundPurple = memo(NotMemoizedBackground)
+export const BackgroundSecondary = memo(NotMemoizedBackground)
 
 function NotMemoizedBackground() {
   return (
@@ -16,18 +14,19 @@ function NotMemoizedBackground() {
   )
 }
 
-const BackgroundContainer = styled.View({
+const BackgroundContainer = styled.View(({ theme }) => ({
   position: 'absolute',
   top: 0,
   left: 0,
   width: '100%',
   height: '100%',
-  zIndex: ZIndex.BACKGROUND,
-})
+  zIndex: theme.zIndex.background,
+}))
 
 function BackgroundSvg() {
-  const dark = ColorsEnum.BRAND
-  const light = ColorsEnum.BRAND_DARK
+  const {
+    colors: { brand: dark, brandDark: light },
+  } = useTheme()
   const { id, fill } = svgIdentifier()
   const { id: id2, xlinkHref: xlinkHref2 } = svgIdentifier()
   const { id: id3 } = svgIdentifier()

--- a/src/ui/theme/constants.ts
+++ b/src/ui/theme/constants.ts
@@ -1,5 +1,5 @@
 import { getSpacing } from './spacing'
 
 export const TAB_BAR_COMP_HEIGHT = getSpacing(16)
-
+export const BOTTOM_CONTENT_PAGE_OFFSET_TOP_HEIGHT_DESKTOP_TABLET = getSpacing(10)
 export const SECTION_ROW_ICON_SIZE = getSpacing(6)

--- a/src/ui/theme/layers.ts
+++ b/src/ui/theme/layers.ts
@@ -1,6 +1,6 @@
 export enum ZIndex {
   BACKGROUND = -1,
-  CHEATCODE_BUTTON = 1,
+  CHEAT_CODE_BUTTON = 1,
   FAVORITE_PASTILLE_CONTENT = 1,
   HOME_OFFER_COVER_ICONS = 1,
   HEADER = 1,
@@ -8,7 +8,7 @@ export enum ZIndex {
   PROGRESSBAR = 1,
   PLAYLIST_BUTTON = 1,
   PROGRESSBAR_ICON = 2,
-  TABBAR = 2,
+  TAB_BAR = 2,
   HEADER_NAV = 2,
   SNACKBAR = 50,
   // !!! Important !!! Whatever you do, you will never get something above a react-native modal


### PR DESCRIPTION
Also : 

- remove Web specific background exported from `@pass-culture/id-check`
- rename `BackgroundPurple` to `BackgroundSecondary`
- enlarge usage of `theme`

Important :  

- This adjustment will target touch and nontouch device, as long as the viewport width is greater than the mobile one

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11400

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [x] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |![image](https://user-images.githubusercontent.com/77674046/141991933-9789fbaf-2fd3-4dab-aed5-dd1213b2689b.png)| ![image](https://user-images.githubusercontent.com/77674046/141988745-45472e3a-6e3c-4533-bcca-6b06c3dcc6f6.png) |  ![image](https://user-images.githubusercontent.com/77674046/141988599-d635bbef-fb89-4654-844e-244f99877c46.png) | ![image](https://user-images.githubusercontent.com/77674046/141993424-d464106b-51ab-4ab8-802b-fd7fadf24b99.png) |




