### PR TITLE
(PC-11747) fix(GenericAchievementCard): small height viewport with responsive lottie animation

### DIFF
--- a/src/ui/components/achievements/components/GenericAchievementCard.tsx
+++ b/src/ui/components/achievements/components/GenericAchievementCard.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro'
 import LottieView from 'lottie-react-native'
-import React, { FunctionComponent, RefObject, useEffect } from 'react'
+import React, { FunctionComponent, RefObject, useEffect, useMemo } from 'react'
 import { View } from 'react-native'
 import * as Animatable from 'react-native-animatable'
 import Swiper from 'react-native-web-swiper'
@@ -8,6 +8,7 @@ import styled from 'styled-components/native'
 
 import { analytics } from 'libs/analytics'
 import { MonitoringError } from 'libs/monitoring'
+import { useMediaQuery } from 'libs/react-responsive/useMediaQuery'
 import { AnimationObject } from 'ui/animations/type'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
@@ -35,6 +36,7 @@ export type AchievementCardProps = AchievementCardKeyProps & {
   title: string
 }
 
+const SMALL_HEIGHT = 576
 export let didFadeIn = false
 
 export const GenericAchievementCard: FunctionComponent<AchievementCardProps> = (
@@ -43,6 +45,11 @@ export const GenericAchievementCard: FunctionComponent<AchievementCardProps> = (
   const grid = useGrid()
   const animationRef = React.useRef<LottieView>(null)
   const animatedButtonRef = React.useRef<Animatable.View & View>(null)
+
+  const isSmallHeight = useMediaQuery({ maxHeight: SMALL_HEIGHT })
+  const lottieStyle = useMemo(() => (isSmallHeight ? { height: '100%' } : undefined), [
+    isSmallHeight,
+  ])
 
   if (props.index === undefined || props.lastIndex === undefined) {
     throw new MonitoringError(
@@ -96,6 +103,7 @@ Those props are provided by the GenericAchievementCard and must be passed down t
       <Spacer.Flex flex={grid({ sm: 1, default: 2 }, 'height')} />
       <StyledLottieContainer>
         <StyledLottieView
+          style={lottieStyle}
           key={props.activeIndex}
           ref={animationRef}
           source={props.animation}


### PR DESCRIPTION


Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11747

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| Small viewport height | iPhone X viewport height |
| --: | ------: |
|![image](https://user-images.githubusercontent.com/77674046/142012824-768f4ee5-aa92-44ed-83e5-aca1185f61d5.png) | ![image](https://user-images.githubusercontent.com/77674046/142012858-6dbf861e-d52d-4395-b65f-4a1658cef021.png) |

