### PR TITLE
(PC-11721) fix(dynamicLink): encode links in a long dynamic link

### DIFF
--- a/src/features/deeplinks/utils.test.ts
+++ b/src/features/deeplinks/utils.test.ts
@@ -30,9 +30,10 @@ describe('Formatting deeplink url', () => {
   describe('generateLongFirebaseDynamicLink', () => {
     it('should return a format long firebase dynamic link', () => {
       const fullWebAppUrlWithParams = 'https://web.example.com/offre/1'
+      const encodedFullWebAppUrlWithParams = 'https%3A%2F%2Fweb.example.com%2Foffre%2F1'
       const dynamicLink = generateLongFirebaseDynamicLink(fullWebAppUrlWithParams)
       expect(dynamicLink).toEqual(
-        `${FIREBASE_DYNAMIC_LINK_URL}/?link=${fullWebAppUrlWithParams}&${getLongDynamicLinkURI()}`
+        `${FIREBASE_DYNAMIC_LINK_URL}/?link=${encodedFullWebAppUrlWithParams}&${getLongDynamicLinkURI()}`
       )
     })
   })
@@ -40,6 +41,7 @@ describe('Formatting deeplink url', () => {
   describe('generateLongFirebaseDynamicLink with extra FDL params', () => {
     it('should return a format long firebase dynamic link', () => {
       const fullWebAppUrlWithParams = 'https://web.example.com/set-email'
+      const encodedFullWebAppUrlWithParams = 'https%3A%2F%2Fweb.example.com%2Fset-email'
       const ofl = `https://${env.WEBAPP_V2_DOMAIN}/set-email`
       const amv = '10160005'
       const extraParams = {
@@ -48,7 +50,7 @@ describe('Formatting deeplink url', () => {
       }
       const dynamicLink = generateLongFirebaseDynamicLink(fullWebAppUrlWithParams, extraParams)
       expect(dynamicLink).toEqual(
-        `${FIREBASE_DYNAMIC_LINK_URL}/?link=${fullWebAppUrlWithParams}&${getLongDynamicLinkURI()}&ofl=https://webapp-v2.example.com/set-email&amv=10160005`
+        `${FIREBASE_DYNAMIC_LINK_URL}/?link=${encodedFullWebAppUrlWithParams}&${getLongDynamicLinkURI()}&ofl=https://webapp-v2.example.com/set-email&amv=10160005`
       )
     })
   })

--- a/src/features/deeplinks/utils.ts
+++ b/src/features/deeplinks/utils.ts
@@ -35,7 +35,9 @@ export function generateLongFirebaseDynamicLink(
       })
     }
   }
-  return `${FIREBASE_DYNAMIC_LINK_URL}/?link=${deepLink}&${getLongDynamicLinkURI()}${params}`
+  return `${FIREBASE_DYNAMIC_LINK_URL}/?link=${encodeURIComponent(
+    deepLink
+  )}&${getLongDynamicLinkURI()}${params}`
 }
 
 export const isUniversalLink = (url: string) => url.startsWith(WEBAPP_NATIVE_REDIRECTION_URL)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11721

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](../doc/standards/pr-title.md) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.

But :
au lieu de générer :
`https://passcultureapptesting.page.link/?link=https://app.testing.passculture.team/offre/3197?utm_campaign=rap_hiphop&utm_medium=email&utm_source=jeuconcours&apn=app.passculture.testing&isi=1557887412&ibi=app.passculture.test&efr=1&ofl=https://web.passculture.app/accueil/details/BR6Q`
, on génère (sera mieux parsé):
`https://passcultureapptesting.page.link/?link=https%3A%2F%2Fapp.testing.passculture.team%2Foffre%2F3197%3Futm_campaign%3Drap_hiphop%26utm_medium%3Demail%26utm_source%3Djeuconcours&apn=app.passculture.testing&isi=1557887412&ibi=app.passculture.test&efr=1&ofl=https://web.passculture.app/accueil/details/BR6Q`