### PR TITLE
docs(Sentry): add auth-token generation instruction

### DIFF
--- a/doc/standards/sentry.md
+++ b/doc/standards/sentry.md
@@ -22,6 +22,8 @@ project = application-native
 token=<token>
 ```
 
+> Click [here](https://sentry.internal-passculture.app/settings/account/api/auth-tokens/) to generate your own auth `<token>`, use the following scope permissions: `event:read`, `event:admin`, `member:read`, `org:read`, `project:read`, `project:releases`, `team:read`, `project:write`, `org:integrations`
+
 ### 📦 Create the source maps locally
 
 #### Android


### PR DESCRIPTION
Learn how to generate your sentry auth token. This is mandatory if you are building for iOS.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](../doc/standards/pr-title.md) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" : `https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a`
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots
Added:
![image](https://user-images.githubusercontent.com/77674046/142176808-fde4af61-fbbb-4293-b100-4ceef18cb03c.png)
