### PR TITLE
(PC-11727) build(IdentityCheck): fix build on web

### DIFF
--- a/src/features/identityCheck/pages/identification/IdentityCheckWebview.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckWebview.tsx
@@ -1,6 +1,6 @@
 import { useRoute } from '@react-navigation/native'
 import React from 'react'
-import WebView from 'react-native-webview'
+import { WebView } from 'react-native-webview'
 import styled from 'styled-components/native'
 
 import { UseRouteType } from 'features/navigation/RootNavigator'

--- a/src/features/identityCheck/pages/identification/IdentityCheckWebview.web.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckWebview.web.tsx
@@ -1,0 +1,16 @@
+import { t } from '@lingui/macro'
+import React from 'react'
+
+import { GenericInfoPage } from 'ui/components/GenericInfoPage'
+import { Error } from 'ui/svg/icons/Error'
+import { getSpacing } from 'ui/theme'
+
+export const IdentityCheckWebview: React.FC = () => {
+  return (
+    <GenericInfoPage
+      title={t`Cet écran n'est pas accessible depuis le web`}
+      icon={Error}
+      iconSize={getSpacing(42)}
+    />
+  )
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11727

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).

```
➜  pass-culture-app-native git:(master) ✗ yarn build
yarn run v1.22.10
$ node web/scripts/build.js
Creating an optimized production build...
(node:45850) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
Failed to compile.

./node_modules/react-native-webview/lib/WebView.js
SyntaxError: /Users/agarcia/passculture/pass-culture-app-native/node_modules/react-native-webview/lib/WebView.js: Support for the experimental syntax 'jsx' isn't currently enabled (7:37):

   5 | // implementation which is produced by Expo SDK 37.0.0.1 implementation, with
   6 | // similar interface than the native ones have.
>  7 | var WebView = function () { return (<View style={{
     |                                     ^
   8 |     alignSelf: 'flex-start',
   9 |     borderColor: 'rgb(255, 0, 0)',
  10 |     borderWidth: 1

Add @babel/preset-react (https://git.io/JfeDR) to the 'presets' section of your Babel config to enable transformation.
If you want to leave it as-is, add @babel/plugin-syntax-jsx (https://git.io/vb4yA) to the 'plugins' section to enable parsing.


error Command failed with exit code 1.
```

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md

![image](https://user-images.githubusercontent.com/10118284/142620995-16dc0b34-7ce8-41b9-a91e-ecfd91260b02.png)
