### PR TITLE
build(ios): fix podfile to avoid changes in the podfile lock

### DIFF
--- a/ios/PassCulture.xcodeproj/project.pbxproj
+++ b/ios/PassCulture.xcodeproj/project.pbxproj
@@ -254,6 +254,20 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		260533F25B7E4D4284853996 /* Upload Debug Symbols to Sentry */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Upload Debug Symbols to Sentry";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export SENTRY_PROPERTIES=sentry.properties\n../node_modules/@sentry/cli/bin/sentry-cli upload-dsym";
+		};
 		6118FC3F4A398138AE514EB7 /* [CP-User] [RNFB] Core Configuration */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -363,20 +377,6 @@
 			shellPath = /bin/sh;
 			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../node_modules/react-native/scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
 			showEnvVarsInLog = 0;
-		};
-		260533F25B7E4D4284853996 /* Upload Debug Symbols to Sentry */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			name = "Upload Debug Symbols to Sentry";
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			shellPath = /bin/sh;
-			shellScript = "export SENTRY_PROPERTIES=sentry.properties\n../node_modules/@sentry/cli/bin/sentry-cli upload-dsym";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -892,14 +892,14 @@ SPEC CHECKSUMS:
   CodePush: 69186fd1143f7e5e5c6f65383cf14f4927e28213
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: e686045572151edef46010a6f819ade377dfeb4b
-  FBReactNativeSpec: 1f1e38b79ec675f63489c885fa9c63a50511b8d9
+  FBReactNativeSpec: b30928116374479d80d407d74915cc3d0ff13635
   Firebase: bc9325d5ee2041524bac78a5213d0e530c651309
   FirebaseABTesting: 981336dd14d84787e33466e4247f77ec2343f8d9
   FirebaseAnalytics: 52768800c2add1d84b751420cb4caaf8195f2c41
   FirebaseCore: f4804c1d3f4bbbefc88904d15653038f2c99ddf7
   FirebaseCoreDiagnostics: fe77f42da6329d6d83d21fd9d621a6b704413bfc
   FirebaseDynamicLinks: e3fd315f43196811df8eac95803f10ff47c3b026
-  FirebaseFirestore: c2301e9c84582c2b6d4dfcd8b5e17ef9fd2576e7
+  FirebaseFirestore: 0f0d98ab906dbf65c82d070dd1a0c53da48d74dd
   FirebaseInstallations: 2563cb18a723ef9c6ef18318a49519b75dce613c
   FirebasePerformance: a1a23adbc53917d7654c349d355371d5239cc340
   FirebaseRemoteConfig: 34300dd83055c06e2768d0932dd8fb2c1575745f

--- a/patches/react-native+0.64.2.patch
+++ b/patches/react-native+0.64.2.patch
@@ -83,3 +83,31 @@ index 2ef8cf8..236c52f 100755
 +#if [[ -d $HOMEBREW_M1_BIN && ! $PATH =~ $HOMEBREW_M1_BIN ]]; then
 +#  export PATH="$HOMEBREW_M1_BIN:$PATH"
 +#fi
+diff --git a/node_modules/react-native/scripts/react_native_pods.rb b/node_modules/react-native/scripts/react_native_pods.rb
+index db9a34a..ce694c4 100644
+--- a/node_modules/react-native/scripts/react_native_pods.rb
++++ b/node_modules/react-native/scripts/react_native_pods.rb
+@@ -165,7 +165,7 @@ def use_react_native_codegen!(spec, options={})
+   return if ENV['DISABLE_CODEGEN'] == '1'
+ 
+   # The path to react-native (e.g. react_native_path)
+-  prefix = options[:path] ||= File.join(__dir__, "..")
++  prefix = options[:path] ||= "../../node_modules/react-native"
+ 
+   # The path to JavaScript files
+   srcs_dir = options[:srcs_dir] ||= File.join(prefix, "Libraries")
+@@ -208,12 +208,12 @@ def use_react_native_codegen!(spec, options={})
+     :name => 'Generate Specs',
+     :input_files => [srcs_dir],
+     :output_files => ["$(DERIVED_FILE_DIR)/codegen-#{codegen_modules_library_name}.log"].concat(generated_files),
+-    :script => "set -o pipefail\n\nbash -l -c '#{env_vars} CODEGEN_MODULES_LIBRARY_NAME=#{codegen_modules_library_name} #{File.join(__dir__, "generate-specs.sh")}' 2>&1 | tee \"${SCRIPT_OUTPUT_FILE_0}\"",
++    :script => "set -o pipefail\n\nbash -l -c '#{env_vars} CODEGEN_MODULES_LIBRARY_NAME=#{codegen_modules_library_name} ../../node_modules/react-native/scripts/generate-specs.sh' 2>&1 | tee \"${SCRIPT_OUTPUT_FILE_0}\"",
+     :execution_position => :before_compile,
+     :show_env_vars_in_log => true
+   }
+ 
+-  spec.prepare_command = "#{mkdir_command} && touch #{generated_files.reduce() { |str, file| str + " " + file }}"
++  spec.prepare_command = "cd ../.. && #{mkdir_command} && touch #{generated_files.reduce() { |str, file| str + " " + file }}"
+ end
+ 
+ # Local method for the Xcode 12.5 fix


### PR DESCRIPTION
From this issue, on react-native 0.64 (still there on 0.64.2 we use): https://github.com/facebook/react-native/issues/31193

The pod depends on the path of the node_module, which is user specific: every dev generates a new key. The PR replaces it by a relative path, which is not user-specific anymore