### PR TITLE
(PC-11943) ci(Webapp): vider le caching GCP après un déploiment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,15 @@ commands:
           set +eo pipefail
           gsutil rsync -r ./build gs://<< parameters.bucket_name >>
           true
+  invalidate-cache:
+    description: Invalidate Cache
+    parameters:
+      url_map_name:
+        type: string
+    steps:
+      - run:
+          name: Invalidate cache
+          command: gcloud compute url-maps invalidate-cdn-cache << parameters.url_map_name >> --path "/*"
 
 jobs:
   checkout-and-install-deps:
@@ -523,6 +532,8 @@ jobs:
           env: testing
       - push-to-bucket:
           bucket_name: passculture-metier-ehp-testing-decliweb
+      - invalidate-cache:
+          url_map_name: testing-decliweb-url-map
 
   deploy-web-staging:
     docker:
@@ -543,6 +554,8 @@ jobs:
           env: staging
       - push-to-bucket:
           bucket_name: passculture-metier-ehp-staging-decliweb
+      - invalidate-cache:
+          url_map_name: staging-decliweb-url-map
 
   deploy-web-integration:
     docker:
@@ -562,6 +575,8 @@ jobs:
           env: integration
       - push-to-bucket:
           bucket_name: passculture-metier-ehp-integration-decliweb
+      - invalidate-cache:
+          url_map_name: integration-decliweb-url-map
 
   deploy-web-prod:
     docker:
@@ -582,6 +597,8 @@ jobs:
           env: production
       - push-to-bucket:
           bucket_name: passculture-metier-prod-production-decliweb
+      - invalidate-cache:
+          url_map_name: production-decliweb-url-map
 
 workflows:
   version: 2.1


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11943

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
