### PR TITLE
(PC-11686) fix(booking): Display 0€ when price is 0

### DIFF
--- a/__snapshots__/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx.native-snap
@@ -523,5 +523,23 @@ exports[`<BookingDetails /> should render correctly when user has selected optio
       Confirmer la réservation
     </Text>
   </View>
+  <Text
+    color="#626262"
+    style={
+      Array [
+        Object {
+          "color": "#626262",
+          "fontFamily": "Montserrat-SemiBold",
+          "fontSize": 12,
+          "lineHeight": 16,
+          "marginBottom": -4,
+          "marginTop": 4,
+          "textAlign": "center",
+        },
+      ]
+    }
+  >
+    20 € seront déduits de ton crédit pass Culture
+  </Text>
 </View>
 `;

--- a/src/features/bookOffer/components/BookingDetails.tsx
+++ b/src/features/bookOffer/components/BookingDetails.tsx
@@ -85,14 +85,14 @@ export const BookingDetails: React.FC<Props> = ({ stocks }) => {
 
   if (!selectedStock || typeof quantity !== 'number') return <React.Fragment />
 
-  const price =
-    selectedStock.price > 0 ? formatToFrenchDecimal(quantity * selectedStock.price) : undefined
+  const priceInCents = quantity * selectedStock.price
+  const formattedPriceWithEuro = formatToFrenchDecimal(priceInCents)
 
   const onPressBookOffer = () => mutate({ quantity, stockId: selectedStock.id })
 
   const deductedAmount = t({
     id: 'montant déduit',
-    values: { price },
+    values: { price: formattedPriceWithEuro },
     message: '{price} seront déduits de ton crédit pass Culture',
   })
 
@@ -112,7 +112,7 @@ export const BookingDetails: React.FC<Props> = ({ stocks }) => {
       <Spacer.Column numberOfSpaces={6} />
 
       <ButtonPrimary title={t`Confirmer la réservation`} onPress={onPressBookOffer} />
-      {!price && <Caption>{deductedAmount}</Caption>}
+      {!!formattedPriceWithEuro && <Caption>{deductedAmount}</Caption>}
     </Container>
   )
 }

--- a/src/libs/parsers/getDisplayPrice.ts
+++ b/src/libs/parsers/getDisplayPrice.ts
@@ -4,8 +4,13 @@ import { CENTS_IN_EURO } from 'libs/parsers/pricesConversion'
 
 const EURO_SYMBOL = '€'
 
-export const formatToFrenchDecimal = (cents: number) => {
-  const euros = cents / CENTS_IN_EURO
+/**
+ * Takes a price in cents (ex: 5.5€ = 550 cents) and returns a string with the
+ * price in euros in the French format, ex: "5,50 €"
+ * @param {number} priceInCents
+ */
+export const formatToFrenchDecimal = (priceInCents: number) => {
+  const euros = priceInCents / CENTS_IN_EURO
   // we show 2 decimals if price is not round. Ex: 21,50 €
   const fixed = euros === Math.floor(euros) ? euros : euros.toFixed(2)
   return `${fixed.toString().replace('.', ',')} ${EURO_SYMBOL}`

--- a/src/libs/parsers/tests/getDisplayPrice.test.ts
+++ b/src/libs/parsers/tests/getDisplayPrice.test.ts
@@ -2,6 +2,7 @@ import {
   getDisplayPrice,
   getDisplayPriceWithDuoMention,
   getFavoriteDisplayPrice,
+  formatToFrenchDecimal,
 } from '../getDisplayPrice'
 
 describe('getDisplayPrice', () => {
@@ -61,4 +62,25 @@ describe('getFavoriteDisplayPrice', () => {
       ).toBe(expected)
     }
   )
+})
+
+describe('formatToFrenchDecimal()', () => {
+  it.each`
+    priceInCents | expected
+    ${0}         | ${'0 €'}
+    ${500}       | ${'5 €'}
+    ${-500}      | ${'-5 €'}
+    ${1050}      | ${'10,50 €'}
+    ${-1050}     | ${'-10,50 €'}
+    ${1110}      | ${'11,10 €'}
+    ${-1110}     | ${'-11,10 €'}
+    ${1190}      | ${'11,90 €'}
+    ${-1190}     | ${'-11,90 €'}
+    ${1199}      | ${'11,99 €'}
+    ${-1199}     | ${'-11,99 €'}
+    ${1199.6}    | ${'12,00 €'}
+    ${-1199.6}   | ${'-12,00 €'}
+  `('formatToFrenchDecimal($priceInCents) \t= $expected', ({ priceInCents, expected }) => {
+    expect(formatToFrenchDecimal(priceInCents)).toBe(expected)
+  })
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11686

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
