### PR TITLE
fix(identityCheck): Update design for Declaration and AddressOption

### DIFF
--- a/__snapshots__/features/identityCheck/pages/confirmation/__test__/IdentityCheckHonor.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/__test__/IdentityCheckHonor.test.tsx.native-snap
@@ -202,7 +202,7 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
                       "flexBasis": 0,
                       "flexGrow": 1,
                       "flexShrink": 1,
-                      "maxWidth": 352,
+                      "maxWidth": 500,
                     },
                   ]
                 }

--- a/__snapshots__/features/identityCheck/pages/confirmation/__test__/IdentityCheckHonor.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/__test__/IdentityCheckHonor.test.tsx.web-snap
@@ -284,7 +284,7 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
                     "flexBasis": "0px",
                     "flexGrow": 1,
                     "flexShrink": 1,
-                    "maxWidth": "352px",
+                    "maxWidth": "500px",
                     "msFlexAlign": "center",
                     "msFlexNegative": 1,
                     "msFlexPositive": 1,

--- a/src/features/identityCheck/atoms/AddressOption.tsx
+++ b/src/features/identityCheck/atoms/AddressOption.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 export const AddressOption = ({ optionKey, label, onPressOption, selected }: Props) => {
   return (
-    <React.Fragment>
+    <Container>
       <StyledTouchableOpacity
         onPress={() => onPressOption(optionKey)}
         activeOpacity={ACTIVE_OPACITY}>
@@ -29,9 +29,13 @@ export const AddressOption = ({ optionKey, label, onPressOption, selected }: Pro
         </TextContainer>
       </StyledTouchableOpacity>
       <Separator />
-    </React.Fragment>
+    </Container>
   )
 }
+
+const Container = styled.View({
+  paddingHorizontal: getSpacing(4),
+})
 
 const StyledTouchableOpacity = styled.TouchableOpacity(({ theme }) => ({
   flexDirection: 'column',

--- a/src/features/identityCheck/atoms/Declaration.tsx
+++ b/src/features/identityCheck/atoms/Declaration.tsx
@@ -21,7 +21,7 @@ export const Declaration = ({ text, description }: { text: string; description: 
   )
 }
 
-const CenteredContainer = styled.View({ flex: 1, alignItems: 'center', maxWidth: getSpacing(88) })
+const CenteredContainer = styled.View({ flex: 1, alignItems: 'center', maxWidth: getSpacing(125) })
 const CenteredText = styled(Typo.Body)({ textAlign: 'center' })
 const CenteredDescription = styled(Typo.Caption)({ textAlign: 'center' })
 const QuoteContainer = styled.View<{ reversed?: boolean }>(({ reversed = false }) => ({


### PR DESCRIPTION
Objectifs : 
* Avoir les villes / adresses qui s'affiche dans l'axe du code postal ou de l'adresse => Plus facile à lire 
* Centrer la page Honor sur décli-web

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Added a **screenshot** for UI tickets.

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
| <img width="429" alt="Capture d’écran 2021-11-30 à 12 02 42" src="https://user-images.githubusercontent.com/62059034/144035894-eab1141e-13c5-447b-973c-c7cb401efb2e.png">    |         |     <img width="1792" alt="Capture d’écran 2021-11-30 à 11 54 22" src="https://user-images.githubusercontent.com/62059034/144035943-125337a9-0d84-4913-9324-752a592c148e.png">    |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md