### PR TITLE
(PC-11988) fix(identityCheckEduConnect): Fix icon spacing

### DIFF
--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnect.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnect.native.test.tsx.native-snap
@@ -177,9 +177,19 @@ exports[`<IdentityCheckEduConnect /> should render correctly 1`] = `
                 }
               >
                 <View
+                  numberOfSpaces={10}
+                  style={
+                    Array [
+                      Object {
+                        "height": 40,
+                      },
+                    ]
+                  }
+                />
+                <View
                   fill="none"
-                  height={150.4}
-                  width={235}
+                  height={115.2}
+                  width={180}
                 >
                   <Text>
                     undefined-SVG-Mock

--- a/src/features/identityCheck/pages/identification/IdentityCheckEduConnect.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckEduConnect.tsx
@@ -15,10 +15,11 @@ export const IdentityCheckEduConnect = () => {
       scrollChildren={
         <React.Fragment>
           <Center>
+            <Spacer.Column numberOfSpaces={10} />
             <BicolorIdCardWithMagnifyingClass
               color={ColorsEnum.SECONDARY}
               color2={ColorsEnum.PRIMARY}
-              size={getSpacing(47)}
+              size={getSpacing(36)}
             />
           </Center>
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11988

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|<img width="386" alt="Schermata 2021-12-02 alle 09 51 39" src="https://user-images.githubusercontent.com/90036171/144389892-b3b1c090-8df7-45ff-8030-2cd9b0c64cfc.png">|<img width="338" alt="Schermata 2021-12-02 alle 09 49 08" src="https://user-images.githubusercontent.com/90036171/144390074-c5899658-7ca2-493d-95e2-c80b2a0681d8.png">| |<img width="1920" alt="Schermata 2021-12-02 alle 09 49 17" src="https://user-images.githubusercontent.com/90036171/144389951-3132d398-bec0-49f6-bace-fca2ce6558d6.png">|                  |




[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
