### PR TITLE
feat(AlgoliaError): stop sending algolia errors to sentry

### DIFF
--- a/src/libs/algolia/fetchAlgolia/AlgoliaError.ts
+++ b/src/libs/algolia/fetchAlgolia/AlgoliaError.ts
@@ -1,15 +1,4 @@
-import { eventMonitoring } from 'libs/monitoring'
-
-// https://www.algolia.com/doc/api-client/methods/advanced/#error-handling
-class AlgoliaError extends Error {
-  name = 'AlgoliaError'
-
-  constructor(error: Error) {
-    super(error.message)
-    this.name = error.name
-  }
-}
-
-export const captureAlgoliaError = (error: unknown): void => {
-  eventMonitoring.captureException(new AlgoliaError(error as Error))
+export const captureAlgoliaError = (_error: unknown): void => {
+  // We actually don't send the error to sentry, because there are too many
+  // eventMonitoring.captureException(new AlgoliaError(error as Error))
 }


### PR DESCRIPTION
Too many errors due to Algolia on Sentry. To prevent the flood we stop sending them.

![image](https://user-images.githubusercontent.com/10118284/144451150-9f9b9bbd-4c65-40d7-8f3b-cfe5c389ddcb.png)