### PR TITLE
(PC-12137) build(nvm): use node installed through NVM at build time

### DIFF
--- a/ios/PassCulture.xcodeproj/project.pbxproj
+++ b/ios/PassCulture.xcodeproj/project.pbxproj
@@ -262,7 +262,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export SENTRY_PROPERTIES=sentry.properties\n../node_modules/@sentry/cli/bin/sentry-cli upload-dsym";
+			shellScript = "export SENTRY_PROPERTIES=sentry.properties\n. ../node_modules/react-native/scripts/find-node.sh # use Node installed via NVM else it looks for global node\n../node_modules/@sentry/cli/bin/sentry-cli upload-dsym\n";
 		};
 		6118FC3F4A398138AE514EB7 /* [CP-User] [RNFB] Core Configuration */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -311,7 +311,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export SENTRY_PROPERTIES=sentry.properties\nexport EXTRA_PACKAGER_ARGS=\"--sourcemap-output $DERIVED_FILE_DIR/main.jsbundle.map\"\nexport NODE_BINARY=node\n../node_modules/@sentry/cli/bin/sentry-cli react-native xcode ../node_modules/react-native/scripts/react-native-xcode.sh\n";
+			shellScript = "export SENTRY_PROPERTIES=sentry.properties\nexport EXTRA_PACKAGER_ARGS=\"--sourcemap-output $DERIVED_FILE_DIR/main.jsbundle.map\"\n. ../node_modules/react-native/scripts/find-node.sh # use Node installed via NVM else it looks for global node\n../node_modules/@sentry/cli/bin/sentry-cli react-native xcode ../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
 		BCA49BE6662C108DF7AE681C /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
https://github.com/pass-culture/pass-culture-app-native/pull/2194

Lorsqu'on build l'app iOS, il y a des scripts qui s'exécute via NodeJS

Avant :
* c'était le NodeJS installé globalement sur la machine (ex: via HomeBrew)

Maintenant :
* NodeJS est fourni par NVM
   1. ça cherche comment NVM a été installé (via le script en CLI ou via HomeBrew)
   2. ça essaie d'utiliser NodeJS fourni par NVM
   3. s'il n'est pas installé (premier lancement, changement de version dans le `.nvmrc` ...) ça l'installe la bonne version de NodeJS via NVM puis ça l'utilise 

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12137

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a