### PR TITLE
(PC-12103) fix(codepush): fix crash on android when no codepush

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -175,6 +175,7 @@ android {
         resValue "string", "WEBAPP_NATIVE_REDIRECTION_DOMAIN", project.env.get("WEBAPP_NATIVE_REDIRECTION_DOMAIN")
         resValue "string", "WEBAPP_V2_DOMAIN", project.env.get("WEBAPP_V2_DOMAIN")
         resValue "string", "EMAIL_PROVIDER_CUSTOM_DOMAIN", project.env.get("EMAIL_PROVIDER_CUSTOM_DOMAIN")
+        resValue "string", "CODE_PUSH_APK_BUILD_TIME", String.format("\"%d\"", System.currentTimeMillis())
         versionCode (packageJson.build as Integer)
         versionName packageJson.version
         buildConfigField "String", "CODEPUSH_KEY", "\"${project.env.get("CODEPUSH_KEY_ANDROID")}\"" // @codepush


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12103

Error:

```
java.lang.RuntimeException: 
  at android.app.ActivityThread.handleBindApplication (ActivityThread.java:7218)
  at android.app.ActivityThread.access$2200 (ActivityThread.java:296)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2208)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loop (Looper.java:213)
  at android.app.ActivityThread.main (ActivityThread.java:8178)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:513)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1101)
Caused by: com.microsoft.codepush.react.CodePushUnknownException: 
  at com.microsoft.codepush.react.CodePush.getBinaryResourcesModifiedTime (CodePush.java:207)
  at com.microsoft.codepush.react.CodePush.isPackageBundleLatest (CodePush.java:349)
  at com.microsoft.codepush.react.CodePush.getJSBundleFileInternal (CodePush.java:270)
  at com.microsoft.codepush.react.CodePush.getJSBundleFile (CodePush.java:246)
  at com.microsoft.codepush.react.CodePush.getJSBundleFile (CodePush.java:238)
  at com.passculture.MainApplication$1.getJSBundleFile (MainApplication.java:35)
  at com.facebook.react.ReactNativeHost.createReactInstanceManager (ReactNativeHost.java:83)
  at com.facebook.react.ReactNativeHost.getReactInstanceManager (ReactNativeHost.java:39)
  at com.passculture.MainApplication.onCreate (MainApplication.java:62)
  at android.app.Instrumentation.callApplicationOnCreate (Instrumentation.java:1195)
  at android.app.ActivityThread.handleBindApplication (ActivityThread.java:7202)
Caused by: android.content.res.Resources$NotFoundException: 
  at android.content.res.Resources.getText (Resources.java:413)
  at android.content.res.Resources.getString (Resources.java:509)
  at com.microsoft.codepush.react.CodePush.getBinaryResourcesModifiedTime (CodePush.java:204)
```

Solution taken from [here](https://github.com/microsoft/react-native-code-push/issues/1961#issuecomment-710698621)

## Explication

The line that crashes:

```java
int codePushApkBuildTimeId = this.mContext.getResources().getIdentifier(CodePushConstants.CODE_PUSH_APK_BUILD_TIME_KEY, "string", packageName);
String codePushApkBuildTime = this.mContext.getResources().getString(codePushApkBuildTimeId).replaceAll("\"","");
```

If no codepush yet, `CODE_PUSH_APK_BUILD_TIME_KEY` is undefined.

In `CodePushConstants.java`, it is defined from `CODE_PUSH_APK_BUILD_TIME`:

```java
    public static final String CODE_PUSH_APK_BUILD_TIME_KEY = "CODE_PUSH_APK_BUILD_TIME";
``` 

By adding it to our `BuildConfig`, this variable is now defined as "now" (`System.currentTimeMillis()`)

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.

Impact:

![image](https://user-images.githubusercontent.com/10118284/144651340-aa17a223-8602-4774-9446-871da98e69c5.png)


[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
