### PR TITLE
(PC-11781) feat(EduConnect): map not eligible error to error pages

### DIFF
--- a/src/features/cheatcodes/pages/NavigationIdentityCheck/NavigationIdentityCheck.tsx
+++ b/src/features/cheatcodes/pages/NavigationIdentityCheck/NavigationIdentityCheck.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components/native'
 
 import { FastEduconnectConnectionRequestModal } from 'features/identityCheck/components/FastEduconnectConnectionRequestModal'
 import { NotEligibleEduConnect } from 'features/identityCheck/errors/eduConnect/NotEligibleEduConnect'
+import { NotEligibleEduConnectErrorMessageEnum } from 'features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData'
 import {
   RootScreenNames,
   RootStackParamList,
@@ -61,36 +62,39 @@ export function NavigationIdentityCheck(): JSX.Element {
         />
         <Row half>
           <NavigationButton
-            title={'Ineligible Educonnect Error'}
-            onPress={() => {
-              setScreenError(new ScreenError('UserAgeNotValidEduConnect', NotEligibleEduConnect))
-            }}
-          />
-        </Row>
-        <Row half>
-          <NavigationButton
-            title={'InvalidAgeFromEduConnect Error'}
+            title={'UserAgeNotValid Educonnect Error'}
             onPress={() => {
               setScreenError(
-                new ScreenError('InvalidAgeFromEduConnectEduConnect', NotEligibleEduConnect)
+                new ScreenError(
+                  NotEligibleEduConnectErrorMessageEnum.UserAgeNotValid,
+                  NotEligibleEduConnect
+                )
               )
             }}
           />
         </Row>
         <Row half>
           <NavigationButton
-            title={'Invalid information EduConnect Error'}
+            title={'UserAgeNotValid18YearsOld Error'}
             onPress={() => {
-              setScreenError(new ScreenError('InvalidInformationEduConnect', NotEligibleEduConnect))
+              setScreenError(
+                new ScreenError(
+                  NotEligibleEduConnectErrorMessageEnum.UserAgeNotValid18YearsOld,
+                  NotEligibleEduConnect
+                )
+              )
             }}
           />
         </Row>
         <Row half>
           <NavigationButton
-            title={'LegalRepresentative Error'}
+            title={'UserTypeNotStudent Error'}
             onPress={() => {
               setScreenError(
-                new ScreenError('LegalRepresentativeEduConnect', NotEligibleEduConnect)
+                new ScreenError(
+                  NotEligibleEduConnectErrorMessageEnum.UserTypeNotStudent,
+                  NotEligibleEduConnect
+                )
               )
             }}
           />

--- a/src/features/cheatcodes/pages/NavigationIdentityCheck/NavigationIdentityCheck.tsx
+++ b/src/features/cheatcodes/pages/NavigationIdentityCheck/NavigationIdentityCheck.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/native'
 
 import { FastEduconnectConnectionRequestModal } from 'features/identityCheck/components/FastEduconnectConnectionRequestModal'
 import { NotEligibleEduConnect } from 'features/identityCheck/errors/eduConnect/NotEligibleEduConnect'
-import { NotEligibleEduConnectErrorMessageEnum } from 'features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData'
+import { EduConnectErrorMessageEnum } from 'features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData'
 import {
   RootScreenNames,
   RootStackParamList,
@@ -65,10 +65,7 @@ export function NavigationIdentityCheck(): JSX.Element {
             title={'UserAgeNotValid Educonnect Error'}
             onPress={() => {
               setScreenError(
-                new ScreenError(
-                  NotEligibleEduConnectErrorMessageEnum.UserAgeNotValid,
-                  NotEligibleEduConnect
-                )
+                new ScreenError(EduConnectErrorMessageEnum.UserAgeNotValid, NotEligibleEduConnect)
               )
             }}
           />
@@ -79,7 +76,7 @@ export function NavigationIdentityCheck(): JSX.Element {
             onPress={() => {
               setScreenError(
                 new ScreenError(
-                  NotEligibleEduConnectErrorMessageEnum.UserAgeNotValid18YearsOld,
+                  EduConnectErrorMessageEnum.UserAgeNotValid18YearsOld,
                   NotEligibleEduConnect
                 )
               )
@@ -92,7 +89,7 @@ export function NavigationIdentityCheck(): JSX.Element {
             onPress={() => {
               setScreenError(
                 new ScreenError(
-                  NotEligibleEduConnectErrorMessageEnum.UserTypeNotStudent,
+                  EduConnectErrorMessageEnum.UserTypeNotStudent,
                   NotEligibleEduConnect
                 )
               )

--- a/src/features/identityCheck/errors/eduConnect/EduConnectErrorBoundary.tsx
+++ b/src/features/identityCheck/errors/eduConnect/EduConnectErrorBoundary.tsx
@@ -5,7 +5,7 @@ import { AsyncErrorBoundary } from 'features/errors'
 import { NotEligibleEduConnect } from 'features/identityCheck/errors/eduConnect/NotEligibleEduConnect'
 import { eventMonitoring } from 'libs/monitoring'
 
-import { EduConnectError, EduConnectErrors } from './types'
+import { EduConnectError } from './types'
 
 export interface EduConnectFallbackProps extends FallbackProps {
   error: EduConnectError | Error
@@ -25,10 +25,7 @@ export const EduConnectErrorBoundary = memo(function EduConnectErrorBoundary({
   }, [error, errorMonitoring])
 
   const EduConnectErrorPage = useMemo(
-    () =>
-      error instanceof EduConnectError && !!EduConnectErrors[error.errorCode]
-        ? NotEligibleEduConnect
-        : AsyncErrorBoundary,
+    () => (error instanceof EduConnectError ? NotEligibleEduConnect : AsyncErrorBoundary),
     [error]
   )
 

--- a/src/features/identityCheck/errors/eduConnect/EduConnectErrorBoundary.tsx
+++ b/src/features/identityCheck/errors/eduConnect/EduConnectErrorBoundary.tsx
@@ -1,0 +1,36 @@
+import React, { memo, useEffect, useMemo } from 'react'
+import { FallbackProps } from 'react-error-boundary'
+
+import { AsyncErrorBoundary } from 'features/errors'
+import { NotEligibleEduConnect } from 'features/identityCheck/errors/eduConnect/NotEligibleEduConnect'
+import { eventMonitoring } from 'libs/monitoring'
+
+import { EduConnectError, EduConnectErrors } from './types'
+
+export interface EduConnectFallbackProps extends FallbackProps {
+  error: EduConnectError | Error
+  resetErrorBoundary: (...args: Array<unknown>) => void
+}
+
+export const EduConnectErrorBoundary = memo(function EduConnectErrorBoundary({
+  error,
+  resetErrorBoundary,
+}: EduConnectFallbackProps) {
+  const errorMonitoring = eventMonitoring
+
+  useEffect(() => {
+    if (error) {
+      errorMonitoring.captureException(error)
+    }
+  }, [error, errorMonitoring])
+
+  const EduConnectErrorPage = useMemo(
+    () =>
+      error instanceof EduConnectError && !!EduConnectErrors[error.errorCode]
+        ? NotEligibleEduConnect
+        : AsyncErrorBoundary,
+    [error]
+  )
+
+  return <EduConnectErrorPage error={error} resetErrorBoundary={resetErrorBoundary} />
+})

--- a/src/features/identityCheck/errors/eduConnect/types.ts
+++ b/src/features/identityCheck/errors/eduConnect/types.ts
@@ -1,0 +1,42 @@
+/* eslint-disable max-classes-per-file */
+import { ComponentType } from 'react'
+
+/*
+ * Here all errors returned by edu connect or pass culture api
+ */
+export enum EduConnectErrors {
+  'not-eligible' = 'not-eligible',
+}
+
+export type EduConnectErrorCode = keyof EduConnectErrors
+
+export class EduConnectError extends Error {
+  public errorCode: EduConnectErrors
+
+  public initialError: Error | undefined
+
+  constructor(errorCode: EduConnectErrors, messageOrInitialError?: Error | string) {
+    super(errorCode)
+    this.errorCode = errorCode
+    if (messageOrInitialError) {
+      if (typeof messageOrInitialError === 'string') {
+        this.message = messageOrInitialError
+      } else {
+        this.stack = messageOrInitialError.stack
+        this.message = messageOrInitialError.message
+        this.initialError = messageOrInitialError
+      }
+    }
+  }
+}
+
+EduConnectError.prototype.name = 'EduConnectError'
+
+export interface EduConnectErrorProps {
+  error: EduConnectError | Error
+}
+
+export type EduConnectErrorPage = Record<
+  EduConnectErrors,
+  ComponentType<EduConnectErrorProps | undefined>
+>

--- a/src/features/identityCheck/errors/eduConnect/types.ts
+++ b/src/features/identityCheck/errors/eduConnect/types.ts
@@ -1,23 +1,12 @@
-/* eslint-disable max-classes-per-file */
-import { ComponentType } from 'react'
-
 /*
  * Here all errors returned by edu connect or pass culture api
  */
-export enum EduConnectErrors {
-  'not-eligible' = 'not-eligible',
-}
-
-export type EduConnectErrorCode = keyof EduConnectErrors
 
 export class EduConnectError extends Error {
-  public errorCode: EduConnectErrors
-
   public initialError: Error | undefined
 
-  constructor(errorCode: EduConnectErrors, messageOrInitialError?: Error | string) {
-    super(errorCode)
-    this.errorCode = errorCode
+  constructor(messageOrInitialError?: Error | string) {
+    super()
     if (messageOrInitialError) {
       if (typeof messageOrInitialError === 'string') {
         this.message = messageOrInitialError
@@ -31,12 +20,3 @@ export class EduConnectError extends Error {
 }
 
 EduConnectError.prototype.name = 'EduConnectError'
-
-export interface EduConnectErrorProps {
-  error: EduConnectError | Error
-}
-
-export type EduConnectErrorPage = Record<
-  EduConnectErrors,
-  ComponentType<EduConnectErrorProps | undefined>
->

--- a/src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
+++ b/src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
@@ -17,7 +17,7 @@ type NotEligibleEduConnectErrorData = {
   tertiaryButtonVisible?: boolean
   onPrimaryButtonPress?: () => void
 }
-const UserAgeNotValid: NotEligibleEduConnectErrorData = {
+const NonExistentError: NotEligibleEduConnectErrorData = {
   Icon: Clock,
   title: t`Tu ne fais pas partie de la phase de test`,
   description:
@@ -30,7 +30,7 @@ const UserAgeNotValid: NotEligibleEduConnectErrorData = {
   descriptionAlignment: 'left',
 }
 
-const InvalidAgeFromEduConnect: NotEligibleEduConnectErrorData = {
+const UserAgeNotValid: NotEligibleEduConnectErrorData = {
   Icon: InfoFraud,
   title: t`Oh non !`,
   description:
@@ -56,7 +56,7 @@ const getInvalidInformation = (
   onPrimaryButtonPress,
 })
 
-const LegalRepresentative: NotEligibleEduConnectErrorData = {
+const UserTypeNotStudent: NotEligibleEduConnectErrorData = {
   Icon: InfoFraud,
   title: t`Qui est-ce ?`,
   description:
@@ -71,27 +71,25 @@ const LegalRepresentative: NotEligibleEduConnectErrorData = {
   },
 }
 type NotEligibleEduConnectErrorMessage =
-  | 'UserAlreadyBeneficiaryEduConnect'
-  | 'InvalidAgeFromEduConnectEduConnect'
-  | 'UserAgeNotValidEduConnect'
-  | 'InvalidInformationEduConnect'
-  | 'LegalRepresentativeEduConnect'
+  | 'UserAgeNotValid18YearsOld'
+  | 'UserAgeNotValid'
+  | 'UserTypeNotStudent'
 
 export function useNotEligibleEduConnectErrorData(
   message: NotEligibleEduConnectErrorMessage | string
 ) {
   const { navigateToNextBeneficiaryValidationStep } = useBeneficiaryValidationNavigation()
   switch (message) {
-    case 'InvalidAgeFromEduConnectEduConnect':
-      return InvalidAgeFromEduConnect
-
-    case 'InvalidInformationEduConnect':
+    case 'UserAgeNotValid18YearsOld':
       return getInvalidInformation(navigateToNextBeneficiaryValidationStep)
 
-    case 'LegalRepresentativeEduConnect':
-      return LegalRepresentative
+    case 'UserAgeNotValid':
+      return UserAgeNotValid
+
+    case 'UserTypeNotStudent':
+      return UserTypeNotStudent
 
     default:
-      return UserAgeNotValid
+      return NonExistentError
   }
 }

--- a/src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
+++ b/src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
@@ -7,6 +7,12 @@ import { Clock } from 'ui/svg/icons/Clock'
 import { InfoFraud } from 'ui/svg/icons/InfoFraud'
 import { IconInterface } from 'ui/svg/icons/types'
 
+export enum EduConnectErrorMessageEnum {
+  UserAgeNotValid18YearsOld = 'UserAgeNotValid18YearsOld',
+  UserAgeNotValid = 'UserAgeNotValid',
+  UserTypeNotStudent = 'UserTypeNotStudent',
+}
+
 type NotEligibleEduConnectErrorData = {
   Icon: FunctionComponent<IconInterface>
   title: string
@@ -17,7 +23,9 @@ type NotEligibleEduConnectErrorData = {
   tertiaryButtonVisible?: boolean
   onPrimaryButtonPress?: () => void
 }
-const NonExistentError: NotEligibleEduConnectErrorData = {
+
+//(Yorick) TODO : cette page n'a pas lieu d'exister, on fallback vers une erreur générique
+const OutOfTestPhase: NotEligibleEduConnectErrorData = {
   Icon: Clock,
   title: t`Tu ne fais pas partie de la phase de test`,
   description:
@@ -70,26 +78,20 @@ const UserTypeNotStudent: NotEligibleEduConnectErrorData = {
     //(Wendy) TODO: Dans le prochain Ticket ajouter une navigation pour revenir à l'action précédente
   },
 }
-type NotEligibleEduConnectErrorMessage =
-  | 'UserAgeNotValid18YearsOld'
-  | 'UserAgeNotValid'
-  | 'UserTypeNotStudent'
 
-export function useNotEligibleEduConnectErrorData(
-  message: NotEligibleEduConnectErrorMessage | string
-) {
+export function useNotEligibleEduConnectErrorData(message: EduConnectErrorMessageEnum | string) {
   const { navigateToNextBeneficiaryValidationStep } = useBeneficiaryValidationNavigation()
   switch (message) {
-    case 'UserAgeNotValid18YearsOld':
+    case EduConnectErrorMessageEnum.UserAgeNotValid18YearsOld:
       return getInvalidInformation(navigateToNextBeneficiaryValidationStep)
 
-    case 'UserAgeNotValid':
+    case EduConnectErrorMessageEnum.UserAgeNotValid:
       return UserAgeNotValid
 
-    case 'UserTypeNotStudent':
+    case EduConnectErrorMessageEnum.UserTypeNotStudent:
       return UserTypeNotStudent
 
     default:
-      return NonExistentError
+      return OutOfTestPhase
   }
 }

--- a/src/libs/eduConnectClient.ts
+++ b/src/libs/eduConnectClient.ts
@@ -1,5 +1,3 @@
-import { EduConnectErrors, EduConnectError } from '@pass-culture/id-check'
-
 import { api } from 'api/api'
 import { refreshAccessToken } from 'api/apiHelpers'
 import { env } from 'libs/environment'
@@ -16,7 +14,7 @@ export const eduConnectClient = {
     const tokenContent = decodeAccessToken(accessToken ?? '')
     if (!tokenContent) {
       eventMonitoring.captureMessage('eduConnectClient failed to decodeAccessToken')
-      return Promise.reject(new EduConnectError(EduConnectErrors.unavailable))
+      return Promise.reject(new Error())
     }
     if (tokenContent.exp * 1000 <= new Date().getTime()) {
       try {
@@ -26,7 +24,7 @@ export const eduConnectClient = {
         eventMonitoring.captureException(error, {
           message: 'eduConnectClient failed to refreshAccessToken',
         })
-        return Promise.reject(new EduConnectError(EduConnectErrors.unavailable, error as Error))
+        return Promise.reject(new Error('eduConnectClient failed to refreshAccessToken'))
       }
     }
     return accessToken


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11781

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
