### PR TITLE
build(android): upload universal apk to appcenter

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -116,7 +116,7 @@ apply from: "../../node_modules/react-native-code-push/android/codepush.gradle" 
  * Upload all the APKs to the Play Store and people will download
  * the correct one based on the CPU architecture of their device.
  */
-def enableSeparateBuildPerCPUArchitecture = true
+def enableSeparateBuildPerCPUArchitecture = false
 
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
@@ -180,15 +180,38 @@ android {
         versionName packageJson.version
         buildConfigField "String", "CODEPUSH_KEY", "\"${project.env.get("CODEPUSH_KEY_ANDROID")}\"" // @codepush
         multiDexEnabled true
+        resConfigs "fr" // https://developer.android.com/studio/build/shrink-code#unused-alt-resources
     }
+
+    // When building Android App Bundles, the splits block is ignored.
+    // We keep it for Appcenter as we build apk for it.
     splits {
         abi {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
-            universalApk true  // keep true for AppCenter as it only supports APK format...
+            universalApk false // if we enable splits per abi, we need to set this to true for Appcenter
             include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
     }
+
+    // Instead, use the bundle block to control which types of configuration APKs
+    // you want your app bundle to support. If all configurations are splitted,
+    // it's the same as if we don't include this piece of code, but we leave it for clarity.
+    bundle {
+        language {
+            // This property is set to true by default.
+            enableSplit = true
+        }
+        density {
+            // This property is set to true by default.
+            enableSplit = true
+        }
+        abi {
+            // This property is set to true by default.
+            enableSplit = true
+        }
+    }
+
     signingConfigs {
         config {
             keyAlias keystoreProperties['keyAlias']
@@ -197,6 +220,7 @@ android {
             storePassword keystoreProperties['storePassword']
         }
     }
+
     buildTypes {
         debug {
             if (nativeArchitectures) {
@@ -206,10 +230,21 @@ android {
             }
         }
         release {
+            // Enables code shrinking, obfuscation, and optimization for only
+            // your project's release build type.
             minifyEnabled enableProguardInReleaseBuilds
+
+            // Enables resource shrinking, which is performed by the
+            // Android Gradle plugin.
             shrinkResources true
+
+            // Includes the default ProGuard rules files that are packaged with
+            // the Android Gradle plugin. To learn more, go to the section about
+            // R8 configuration files.
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
             signingConfig signingConfigs.config
+
+            // https://developer.android.com/studio/build/shrink-code#android_gradle_plugin_version_41_or_later
             ndk {
                 debugSymbolLevel "FULL"
             }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -185,7 +185,7 @@ android {
         abi {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
-            universalApk false  // If true, also generate a universal APK
+            universalApk true  // keep true for AppCenter as it only supports APK format...
             include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
     }

--- a/fastlane/.env.production
+++ b/fastlane/.env.production
@@ -11,7 +11,8 @@ APPLE_ACCOUNT_USERNAME='dev.apple@passculture.app'
 
 # Android
 ANDROID_GRADLE_TASK='bundleProductionRelease'
-ANDROID_APK_PATH='android/app/build/outputs/bundle/productionRelease/app-production-release.aab'
+ANDROID_FILE_PATH='android/app/build/outputs/bundle/productionRelease/app-production-release.aab'
+
 # Supply
 SUPPLY_JSON_KEY='fastlane/playStoreServiceAccount.json'
 SUPPLY_TRACK='internal'

--- a/fastlane/.env.staging
+++ b/fastlane/.env.staging
@@ -7,10 +7,9 @@ IOS_SCHEME='PassCulture-Staging'
 IOS_IPA_DIRECTORY='ios/build'
 IOS_IPA_NAME='app-staging.ipa'
 
-
 # Android
 ANDROID_GRADLE_TASK='assembleStagingRelease'
-ANDROID_APK_PATH='android/app/build/outputs/apk/staging/release/app-staging-release.apk'
+ANDROID_FILE_PATH='android/app/build/outputs/apk/staging/release/app-staging-universal-release.apk'
 
 # AppCenter
 APPCENTER_IOS_APP_ID='passculture-staging-ios'

--- a/fastlane/.env.staging
+++ b/fastlane/.env.staging
@@ -9,7 +9,7 @@ IOS_IPA_NAME='app-staging.ipa'
 
 # Android
 ANDROID_GRADLE_TASK='assembleStagingRelease'
-ANDROID_FILE_PATH='android/app/build/outputs/apk/staging/release/app-staging-universal-release.apk'
+ANDROID_FILE_PATH='android/app/build/outputs/apk/staging/release/app-staging-release.apk'
 
 # AppCenter
 APPCENTER_IOS_APP_ID='passculture-staging-ios'

--- a/fastlane/.env.testing
+++ b/fastlane/.env.testing
@@ -7,10 +7,9 @@ IOS_SCHEME='PassCulture-Testing'
 IOS_IPA_DIRECTORY='ios/build'
 IOS_IPA_NAME='app-testing.ipa'
 
-
 # Android
 ANDROID_GRADLE_TASK='assembleApptestingRelease'
-ANDROID_APK_PATH='android/app/build/outputs/apk/apptesting/release/app-apptesting-release.apk'
+ANDROID_FILE_PATH='android/app/build/outputs/apk/apptesting/release/app-apptesting-universal-release.apk'
 
 # AppCenter
 APPCENTER_IOS_APP_ID='passculture-testing-ios'

--- a/fastlane/.env.testing
+++ b/fastlane/.env.testing
@@ -9,7 +9,7 @@ IOS_IPA_NAME='app-testing.ipa'
 
 # Android
 ANDROID_GRADLE_TASK='assembleApptestingRelease'
-ANDROID_FILE_PATH='android/app/build/outputs/apk/apptesting/release/app-apptesting-universal-release.apk'
+ANDROID_FILE_PATH='android/app/build/outputs/apk/apptesting/release/app-apptesting-release.apk'
 
 # AppCenter
 APPCENTER_IOS_APP_ID='passculture-testing-ios'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -90,7 +90,7 @@ platform :android do
       owner_name: ENV['APPCENTER_ORGANISATION'],
       owner_type: "organization",
       app_name: ENV['APPCENTER_ANDROID_APP_ID'],
-      apk: ENV["ANDROID_APK_PATH"],
+      file: ENV["ANDROID_FILE_PATH"],
       release_notes: %x[#{release_notes_command}],
       destinations: ENV['APPCENTER_DISTRIBUTE_GROUPS']
     )


### PR DESCRIPTION
Plusieurs ressources intéressantes:
- https://developer.android.com/studio/build/configure-apk-splits
- https://developer.android.com/guide/app-bundle
- https://developer.android.com/studio/build/shrink-code
- https://infinum.com/the-capsized-eight/optimize-app-delivery-with-android-app-bundles

Il y a plusieurs bonnes pratiques Android qu'on n'avait pas encore mis en place (jusqu'à cette PR: https://github.com/pass-culture/pass-culture-app-native/pull/2207).

Notamment:
- Code shrinking, Obfuscation & Optimisation avec Proguard: `minifyEnabled true`
- Resource shrinking: `shrinkResources true`
- Native crash support: upload des debug symbols pour débugger les crashs: `debugSymbolLevel 'FULL'`

Tout ça est fait dans cette PR: https://github.com/pass-culture/pass-culture-app-native/pull/2207

Le problème: On a maintenant plusieurs builds par architecture:
![image](https://user-images.githubusercontent.com/10118284/145019344-b0a890f6-f709-4c01-a5d3-3f303e7454da.png)

L'ancienne config pour uploader sur AppCenter ne marche plus. Voir [job CircleCi](https://app.circleci.com/pipelines/github/pass-culture/pass-culture-app-native/11093/workflows/0b41c54a-cdb2-4e84-a45f-b863d0752ef2/jobs/29638):
> ERROR [2021-12-06 14:39:00.22]: Couldn't find build file at path 'android/app/build/outputs/apk/apptesting/release/app-apptesting-release.apk'

Quel build choisit-t'on pour AppCenter ?
1. Les builds par architectures sont plus légers (taille divisée par 2) mais ne supportent pas tous les devices ❌
2. On change la commande de build pour créer un bundle AAB comme pour la prod ?

```diff
+ ANDROID_GRADLE_TASK='bundleApptestingRelease'
- ANDROID_GRADLE_TASK='assembleApptestingRelease'
```

Ceci créé bien un bundle AAB `android/app/build/outputs/bundle/apptestingRelease/app-apptesting-release.aab` mais AppCenter ne supporte pas les AAB... ❌

3. On créé un universal APK: `universalApk true` qu'on soumet à AppCenter en testing/staging ✅

🙋‍♂️ Question pertinente: Pourquoi continuer à faire des builds par architecture s'ils ne sont pas utilisés?
> En effet, pour les builds AAB, on utilise la config `bundle`, non `splits`, donc on peut désactiver `enableSeparateBuildPerCPUArchitecture`. Voir 2ème commit


## Autres Modifications

```diff
+      file: ENV["ANDROID_FILE_PATH"],
-      apk: ENV["ANDROID_APK_PATH"],
```

=> `apk` est déprécié depuis la v1.6.0 de fastlane: https://github.com/microsoft/fastlane-plugin-appcenter/releases/tag/v1.6.0. On est en `1.11.1`.

