### PR TITLE
(PC-12196) feat(privacy): Consent settings page does not automatically enable tracking

### DIFF
--- a/src/features/profile/pages/ConsentSettings.tsx
+++ b/src/features/profile/pages/ConsentSettings.tsx
@@ -31,13 +31,7 @@ export const ConsentSettings: FunctionComponent<Props> = ({ route }) => {
 
   useEffect(() => {
     storage.readObject('has_accepted_cookie').then((hasAcceptedCookie) => {
-      if (hasAcceptedCookie === null) {
-        // default user choice is true
-        storage.saveObject('has_accepted_cookie', true)
-        setIsTrackingSwitchActive(true)
-      } else {
-        setIsTrackingSwitchActive(Boolean(hasAcceptedCookie))
-      }
+      setIsTrackingSwitchActive(Boolean(hasAcceptedCookie))
     })
   }, [])
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12196

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
