### PR TITLE
(PC-12074) fix(SmartBanner): disable react-smartbanner on the Web temporary

### DIFF
--- a/src/features/smartBanner/SmartBanner.web.tsx
+++ b/src/features/smartBanner/SmartBanner.web.tsx
@@ -1,29 +1,31 @@
-import { t } from '@lingui/macro'
-import React from 'react'
-
-import ReactSmartBanner from 'libs/react-smartbanner'
-
-import { author } from '../../../package.json'
-
-const price = {
-  ios: t`GRATUIT`,
-  android: t`GRATUIT`,
-}
-const storeText = {
-  ios: t`Sur l'App Store`,
-  android: t`Sur Google Play`,
-}
-
-const buttonText = t`Voir`
-
-export const SmartBanner = () => (
-  <ReactSmartBanner
-    button={buttonText}
-    daysHidden={15}
-    daysReminder={90}
-    position="top"
-    price={price}
-    storeText={storeText}
-    title={author.name}
-  />
-)
+// TODO: code was commented so we can release webapp v2 and have more time later for testing this.
+// import { t } from '@lingui/macro'
+// import React from 'react'
+//
+// import ReactSmartBanner from 'libs/react-smartbanner'
+//
+// import { author } from '../../../package.json'
+//
+// const price = {
+//   ios: t`GRATUIT`,
+//   android: t`GRATUIT`,
+// }
+// const storeText = {
+//   ios: t`Sur l'App Store`,
+//   android: t`Sur Google Play`,
+// }
+//
+// const buttonText = t`Voir`
+//
+// export const SmartBanner = () => (
+//   <ReactSmartBanner
+//     button={buttonText}
+//     daysHidden={15}
+//     daysReminder={90}
+//     position="top"
+//     price={price}
+//     storeText={storeText}
+//     title={author.name}
+//   />
+// )
+export const SmartBanner = () => null

--- a/src/features/smartBanner/tests/SmartBanner.web.test.tsx
+++ b/src/features/smartBanner/tests/SmartBanner.web.test.tsx
@@ -4,7 +4,7 @@ import { render } from 'tests/utils/web'
 
 import { SmartBanner } from '../SmartBanner'
 
-describe('SmartBanner page', () => {
+describe.skip('SmartBanner page', () => {
   it('should render a smart banner', () => {
     const smartBanner = render(<SmartBanner />)
     expect(smartBanner.container.firstChild).not.toBeNull()


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12074

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
