### PR TITLE
(PC-12358) fix(setBirthday): use variable translation with nbsp

### DIFF
--- a/src/features/auth/signup/SetBirthday/SetBirthday.tsx
+++ b/src/features/auth/signup/SetBirthday/SetBirthday.tsx
@@ -116,20 +116,20 @@ export const SetBirthday: FunctionComponent<PreValidationSignupStepProps> = (pro
     settings?.enableNativeEacIndividual && settings.enableUnderageGeneralisation
 
   const financialHelpMessage = displayPostGeneralisationMessage
-    ? t`Entre 15 et 18 ans, tu es éligible à une aide financière progressive allant de 20` +
-      '\u00a0' +
-      t`€ à` +
-      '\u00a0' +
-      deposit +
-      '\u00a0' +
-      t`offerte par le Gouvernement.` +
+    ? t({
+        id: 'postGeneralisationFinancialHelpMessage',
+        values: { deposit },
+        message:
+          'Entre 15 et 18 ans, tu es éligible à une aide financière progressive allant de 20\u00a0€ à\u00a0{deposit}\u00a0offerte par le Gouvernement.',
+      }) +
       '\n' +
       '\n'
-    : t`Si tu as 18 ans, tu es éligible à une aide financière de` +
-      '\u00a0' +
-      deposit +
-      '\u00a0' +
-      t`offerte par le Gouvernement.` +
+    : t({
+        id: 'preGeneralisationFinancialHelpMessage',
+        values: { deposit },
+        message:
+          'Si tu as 18 ans, tu es éligible à une aide financière de\u00a0{deposit}\u00a0offerte par le Gouvernement.',
+      }) +
       '\n' +
       '\n'
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -866,10 +866,6 @@ msgstr "Encore un peu de patience... On se donne rendez-vous en janvier 2022 : n
 msgid "Enregistrer"
 msgstr "Enregistrer"
 
-#: src/features/auth/signup/SetBirthday/SetBirthday.tsx
-msgid "Entre 15 et 18 ans, tu es éligible à une aide financière progressive allant de 20"
-msgstr "Entre 15 et 18 ans, tu es éligible à une aide financière progressive allant de 20"
-
 #: src/features/identityCheck/pages/profile/SetAddress.tsx
 msgid "Entre ton adresse"
 msgstr "Entre ton adresse"
@@ -2315,10 +2311,6 @@ msgstr "Seules les sorties et offres physiques seront affichées pour une recher
 msgid "Seules les sorties seront affichées"
 msgstr "Seules les sorties seront affichées"
 
-#: src/features/auth/signup/SetBirthday/SetBirthday.tsx
-msgid "Si tu as 18 ans, tu es éligible à une aide financière de"
-msgstr "Si tu as 18 ans, tu es éligible à une aide financière de"
-
 #: src/ui/components/LayoutExpiredLink.tsx
 msgid "Si tu as besoin d’aide n’hésite pas à :"
 msgstr "Si tu as besoin d’aide n’hésite pas à :"
@@ -3143,11 +3135,6 @@ msgstr "Les {price} ne seront pas recrédités sur ton pass Culture car il est e
 msgid "offerId is undefined"
 msgstr "offerId is undefined"
 
-#: src/features/auth/signup/SetBirthday/SetBirthday.tsx
-#: src/features/auth/signup/SetBirthday/SetBirthday.tsx
-msgid "offerte par le Gouvernement."
-msgstr "offerte par le Gouvernement."
-
 #: src/ui/components/OrSeparator.tsx
 msgid "ou"
 msgstr "ou"
@@ -3163,6 +3150,14 @@ msgstr "page-introuvable"
 #: src/features/identityCheck/atoms/IdentityVerificationText.tsx
 msgid "passeport"
 msgstr "passeport"
+
+#: src/features/auth/signup/SetBirthday/SetBirthday.tsx
+msgid "postGeneralisationFinancialHelpMessage"
+msgstr "Entre 15 et 18 ans, tu es éligible à une aide financière progressive allant de 20 € à {deposit} offerte par le Gouvernement."
+
+#: src/features/auth/signup/SetBirthday/SetBirthday.tsx
+msgid "preGeneralisationFinancialHelpMessage"
+msgstr "Si tu as 18 ans, tu es éligible à une aide financière de {deposit} offerte par le Gouvernement."
 
 #: src/features/bookOffer/components/BookingInformations.tsx
 msgid "prix duo"
@@ -3301,6 +3296,3 @@ msgstr "épuisé"
 msgid "€ viennent d'être crédités sur ton compte pass Culture"
 msgstr "€ viennent d'être crédités sur ton compte pass Culture"
 
-#: src/features/auth/signup/SetBirthday/SetBirthday.tsx
-msgid "€ à"
-msgstr "€ à"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12358

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
