### PR TITLE
(PC-12252) feat(maintenance): custom message in maintenance mode

### DIFF
--- a/__snapshots__/features/maintenance/tests/Maintenance.test.tsx.native-snap
+++ b/__snapshots__/features/maintenance/tests/Maintenance.test.tsx.native-snap
@@ -1,6 +1,177 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Maintenance /> should match snapshot 1`] = `
+exports[`<Maintenance /> should match snapshot with custom message 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+      },
+    ]
+  }
+>
+  <View
+    height="100%"
+    style={
+      Array [
+        Object {
+          "bottom": 0,
+          "height": "100%",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "width": "100%",
+          "zIndex": -1,
+        },
+      ]
+    }
+    width="100%"
+  >
+    <View
+      height="100%"
+      width="100%"
+    >
+      <Text>
+        undefined-SVG-Mock
+      </Text>
+    </View>
+  </View>
+  <RCTScrollView
+    bounces={false}
+    contentContainerStyle={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "column",
+        "flexGrow": 1,
+        "justifyContent": "center",
+        "maxWidth": 360,
+        "paddingHorizontal": 16,
+      }
+    }
+  >
+    <View>
+      <View
+        numberOfSpaces={18}
+        style={
+          Array [
+            Object {
+              "height": 72,
+            },
+          ]
+        }
+      />
+      <View
+        height={124}
+        width={197}
+      >
+        <Text>
+          undefined-SVG-Mock
+        </Text>
+      </View>
+      <View
+        numberOfSpaces={9}
+        style={
+          Array [
+            Object {
+              "height": 36,
+            },
+          ]
+        }
+      />
+      <Text
+        color="#ffffff"
+        fontSize={24}
+        style={
+          Array [
+            Object {
+              "color": "#ffffff",
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 24,
+              "lineHeight": 28,
+            },
+            Object {
+              "textAlign": "center",
+            },
+          ]
+        }
+      >
+        Maintenance en cours
+      </Text>
+      <View
+        numberOfSpaces={5}
+        style={
+          Array [
+            Object {
+              "height": 20,
+            },
+          ]
+        }
+      />
+      <View
+        numberOfSpaces={6}
+        style={
+          Array [
+            Object {
+              "height": 24,
+            },
+          ]
+        }
+      />
+      <Text
+        color="#ffffff"
+        style={
+          Array [
+            Object {
+              "color": "#ffffff",
+              "fontFamily": "Montserrat-Regular",
+              "fontSize": 15,
+              "lineHeight": 20,
+              "textAlign": "center",
+            },
+          ]
+        }
+      >
+        C'est tout cassé ! Reviens plus tard
+      </Text>
+      <View
+        numberOfSpaces={24}
+        style={
+          Array [
+            Object {
+              "height": 96,
+            },
+          ]
+        }
+      />
+      <View
+        height={36}
+        width={107}
+      >
+        <Text>
+          undefined-SVG-Mock
+        </Text>
+      </View>
+      <View
+        customHeight={8}
+        enable={true}
+        style={
+          Array [
+            Object {
+              "height": 8,
+            },
+          ]
+        }
+      />
+    </View>
+  </RCTScrollView>
+</View>
+`;
+
+exports[`<Maintenance /> should match snapshot with default message 1`] = `
 <View
   style={
     Array [

--- a/__snapshots__/features/maintenance/tests/Maintenance.test.tsx.web-snap
+++ b/__snapshots__/features/maintenance/tests/Maintenance.test.tsx.web-snap
@@ -1,6 +1,213 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Maintenance /> should match snapshot 1`] = `
+exports[`<Maintenance /> should match snapshot with custom message 1`] = `
+<div
+  className="css-view-1dbjc4n"
+  style={
+    Object {
+      "WebkitAlignItems": "center",
+      "WebkitBoxAlign": "center",
+      "WebkitBoxFlex": 1,
+      "WebkitFlexBasis": "0px",
+      "WebkitFlexGrow": 1,
+      "WebkitFlexShrink": 1,
+      "alignItems": "center",
+      "flexBasis": "0px",
+      "flexGrow": 1,
+      "flexShrink": 1,
+      "msFlexAlign": "center",
+      "msFlexNegative": 1,
+      "msFlexPositive": 1,
+      "msFlexPreferredSize": "0px",
+    }
+  }
+>
+  <div
+    className="css-view-1dbjc4n"
+    style={
+      Object {
+        "bottom": "0px",
+        "height": "100%",
+        "left": "0px",
+        "position": "absolute",
+        "right": "0px",
+        "top": "0px",
+        "width": "100%",
+        "zIndex": -1,
+      }
+    }
+  >
+    <div
+      className="css-view-1dbjc4n"
+    >
+      <div
+        className="css-text-901oao"
+        dir="auto"
+      >
+        undefined-SVG-Mock
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-view-1dbjc4n"
+    onScroll={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    onWheel={[Function]}
+    style={
+      Object {
+        "WebkitBoxDirection": "normal",
+        "WebkitBoxFlex": 1,
+        "WebkitBoxOrient": "vertical",
+        "WebkitFlexDirection": "column",
+        "WebkitFlexGrow": 1,
+        "WebkitFlexShrink": 1,
+        "WebkitOverflowScrolling": "touch",
+        "WebkitTransform": "translateZ(0px)",
+        "flexDirection": "column",
+        "flexGrow": 1,
+        "flexShrink": 1,
+        "msFlexDirection": "column",
+        "msFlexNegative": 1,
+        "msFlexPositive": 1,
+        "overflowX": "hidden",
+        "overflowY": "auto",
+        "transform": "translateZ(0px)",
+      }
+    }
+  >
+    <div
+      className="css-view-1dbjc4n"
+      style={
+        Object {
+          "WebkitAlignItems": "center",
+          "WebkitBoxAlign": "center",
+          "WebkitBoxDirection": "normal",
+          "WebkitBoxFlex": 1,
+          "WebkitBoxOrient": "vertical",
+          "WebkitBoxPack": "center",
+          "WebkitFlexDirection": "column",
+          "WebkitFlexGrow": 1,
+          "WebkitJustifyContent": "center",
+          "alignItems": "center",
+          "flexDirection": "column",
+          "flexGrow": 1,
+          "justifyContent": "center",
+          "maxWidth": "360px",
+          "msFlexAlign": "center",
+          "msFlexDirection": "column",
+          "msFlexPack": "center",
+          "msFlexPositive": 1,
+          "paddingLeft": "16px",
+          "paddingRight": "16px",
+        }
+      }
+    >
+      <div
+        className="css-view-1dbjc4n"
+        style={
+          Object {
+            "height": "72px",
+          }
+        }
+      />
+      <div
+        className="css-view-1dbjc4n"
+      >
+        <div
+          className="css-text-901oao"
+          dir="auto"
+        >
+          undefined-SVG-Mock
+        </div>
+      </div>
+      <div
+        className="css-view-1dbjc4n"
+        style={
+          Object {
+            "height": "36px",
+          }
+        }
+      />
+      <div
+        className="css-text-901oao"
+        dir="auto"
+        style={
+          Object {
+            "color": "rgba(255,255,255,1.00)",
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": "22px",
+            "lineHeight": "28px",
+            "textAlign": "center",
+          }
+        }
+      >
+        Maintenance en cours
+      </div>
+      <div
+        className="css-view-1dbjc4n"
+        style={
+          Object {
+            "height": "20px",
+          }
+        }
+      />
+      <div
+        className="css-view-1dbjc4n"
+        style={
+          Object {
+            "height": "24px",
+          }
+        }
+      />
+      <div
+        className="css-text-901oao"
+        dir="auto"
+        style={
+          Object {
+            "color": "rgba(255,255,255,1.00)",
+            "fontFamily": "Montserrat-Regular",
+            "fontSize": "15px",
+            "lineHeight": "20px",
+            "textAlign": "center",
+          }
+        }
+      >
+        C'est tout cassé ! Reviens plus tard
+      </div>
+      <div
+        className="css-view-1dbjc4n"
+        style={
+          Object {
+            "height": "96px",
+          }
+        }
+      />
+      <div
+        className="css-view-1dbjc4n"
+      >
+        <div
+          className="css-text-901oao"
+          dir="auto"
+        >
+          undefined-SVG-Mock
+        </div>
+      </div>
+      <div
+        className="css-view-1dbjc4n"
+        style={
+          Object {
+            "height": "8px",
+          }
+        }
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Maintenance /> should match snapshot with default message 1`] = `
 <div
   className="css-view-1dbjc4n"
   style={

--- a/src/features/cheatcodes/pages/Navigation/Navigation.tsx
+++ b/src/features/cheatcodes/pages/Navigation/Navigation.tsx
@@ -260,7 +260,13 @@ export function Navigation(): JSX.Element {
         <Row half>
           <NavigationButton
             title={`Maintenance Page`}
-            onPress={() => setScreenError(new ScreenError('Test maintenance page', Maintenance))}
+            onPress={() =>
+              setScreenError(
+                new ScreenError('Test maintenance page', () => (
+                  <Maintenance message="Some maintenance message that is set in Firestore" />
+                ))
+              )
+            }
           />
         </Row>
         <Row half>

--- a/src/features/errors/pages/ScreenErrorProvider.tsx
+++ b/src/features/errors/pages/ScreenErrorProvider.tsx
@@ -3,18 +3,19 @@ import React from 'react'
 import { ForceUpdate } from 'features/forceUpdate/ForceUpdate'
 import { useMustUpdateApp } from 'features/forceUpdate/useMustUpdateApp'
 import { MaintenanceErrorPage } from 'features/maintenance/MaintenanceErrorPage'
-import { useIsUnderMaintenance } from 'features/maintenance/useMaintenance'
+import { useMaintenance } from 'features/maintenance/useMaintenance'
+import { MAINTENANCE } from 'libs/firestore/maintenance'
 import { ScreenError } from 'libs/monitoring/errors'
 
 export const ScreenErrorProvider = ({ children }: { children?: JSX.Element | JSX.Element[] }) => {
-  const isUnderMaintenance = useIsUnderMaintenance()
+  const { status } = useMaintenance()
   const mustUpdateApp = useMustUpdateApp()
 
   if (mustUpdateApp) {
     throw new ScreenError('Must update app', ForceUpdate)
   }
 
-  if (isUnderMaintenance) {
+  if (status === MAINTENANCE.ON) {
     throw new ScreenError('Under maintenance', MaintenanceErrorPage)
   }
 

--- a/src/features/maintenance/Maintenance.tsx
+++ b/src/features/maintenance/Maintenance.tsx
@@ -8,7 +8,11 @@ import { LogoPassCulture as LogoPassCultureOriginal } from 'ui/svg/icons/LogoPas
 import { MaintenanceCone } from 'ui/svg/icons/MaintenanceCone'
 import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
 
-export const Maintenance = () => {
+type MaintenanceProps = {
+  message?: string
+}
+
+export const Maintenance: React.FC<MaintenanceProps> = (props) => {
   return (
     <React.Fragment>
       <Helmet>
@@ -19,7 +23,11 @@ export const Maintenance = () => {
         icon={MaintenanceCone}
         iconSize={getSpacing(40)}>
         <Spacer.Column numberOfSpaces={6} />
-        <StyledBody>{t`L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !`}</StyledBody>
+        <StyledBody>
+          {props.message
+            ? props.message
+            : t`L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !`}
+        </StyledBody>
         <Spacer.Column numberOfSpaces={24} />
         <LogoPassCulture />
       </GenericInfoPage>

--- a/src/features/maintenance/MaintenanceErrorPage.tsx
+++ b/src/features/maintenance/MaintenanceErrorPage.tsx
@@ -1,22 +1,23 @@
 import React, { useEffect } from 'react'
 
 import { Maintenance } from 'features/maintenance/Maintenance'
-import { useIsUnderMaintenance } from 'features/maintenance/useMaintenance'
+import { useMaintenance } from 'features/maintenance/useMaintenance'
+import { MAINTENANCE } from 'libs/firestore/maintenance'
 
 type Props = {
   resetErrorBoundary: () => void
 }
 
 export const MaintenanceErrorPage = ({ resetErrorBoundary }: Props) => {
-  const isUnderMaintenance = useIsUnderMaintenance()
+  const { status, message } = useMaintenance()
   // This first hook will be like a componentWillUnmount
   useEffect(() => resetErrorBoundary, [])
   // This one is for when feature flip switch back to off later
   useEffect(() => {
     // it must be false and not undefined (which means not fetched)
-    if (isUnderMaintenance === false) {
+    if (status === MAINTENANCE.OFF) {
       resetErrorBoundary()
     }
-  }, [isUnderMaintenance])
-  return <Maintenance />
+  }, [status])
+  return <Maintenance message={message} />
 }

--- a/src/features/maintenance/tests/Maintenance.test.tsx
+++ b/src/features/maintenance/tests/Maintenance.test.tsx
@@ -5,8 +5,15 @@ import { render } from 'tests/utils'
 import { Maintenance } from '../Maintenance'
 
 describe('<Maintenance />', () => {
-  it('should match snapshot', async () => {
-    const renderForceUpdate = await render(<Maintenance />)
-    expect(renderForceUpdate).toMatchSnapshot()
+  it('should match snapshot with default message', async () => {
+    const maintenancePage = await render(<Maintenance />)
+    expect(maintenancePage).toMatchSnapshot()
+  })
+
+  it('should match snapshot with custom message', async () => {
+    const maintenancePage = await render(
+      <Maintenance message="C'est tout cassé ! Reviens plus tard" />
+    )
+    expect(maintenancePage).toMatchSnapshot()
   })
 })

--- a/src/features/maintenance/useMaintenance.tsx
+++ b/src/features/maintenance/useMaintenance.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useState } from 'react'
 
-import { maintenanceStatusListener } from 'libs/firestore/maintenance'
+import { MAINTENANCE, Maintenance, maintenanceStatusListener } from 'libs/firestore/maintenance'
 
-export const useIsUnderMaintenance = () => {
-  const [maintenance, setMaintenance] = useState<boolean | undefined>()
+export const useMaintenance = (): Maintenance => {
+  const [maintenance, setMaintenance] = useState<Maintenance>({
+    status: MAINTENANCE.UNKNOWN,
+    message: undefined,
+  })
   useEffect(() => {
     const subscriber = maintenanceStatusListener(setMaintenance)
 

--- a/src/libs/firestore/__tests__/maintenance.native.test.ts
+++ b/src/libs/firestore/__tests__/maintenance.native.test.ts
@@ -7,17 +7,21 @@ jest.mock('@react-native-firebase/firestore')
 describe('[method] maintenanceStatus', () => {
   let onNext: (input: FirebaseFirestoreTypes.DocumentSnapshot) => void
 
-  firestore()
-    .collection('maintenance')
-    .doc('testing')
-    // @ts-expect-error is a mock
-    .onSnapshot.mockImplementationOnce((localOnNext) => {
-      onNext = localOnNext
-    })
   const mockedCallBack = jest.fn()
+
+  beforeEach(() => {
+    firestore()
+      .collection('maintenance')
+      .doc('testing')
+      // @ts-expect-error is a mock
+      .onSnapshot.mockImplementationOnce((localOnNext) => {
+        onNext = localOnNext
+      })
+  })
 
   it('should set up listener to the maintenance feature flag', () => {
     maintenanceStatusListener(mockedCallBack)
+
     expect(firestore().collection).toHaveBeenCalledWith('maintenance')
     expect(firestore().collection('maintenance').doc).toHaveBeenCalledWith('testing')
     expect(firestore().collection('maintenance').doc('testing').onSnapshot).toHaveBeenCalledWith(
@@ -27,6 +31,8 @@ describe('[method] maintenanceStatus', () => {
   })
 
   it('should set up listener with given callback', () => {
+    maintenanceStatusListener(mockedCallBack)
+
     const get = jest.fn().mockReturnValue('getReturn')
     // @ts-expect-error is an incomplete mock
     const docSnapshot: FirebaseFirestoreTypes.DocumentSnapshot = { get }

--- a/src/libs/firestore/__tests__/maintenance.native.test.ts
+++ b/src/libs/firestore/__tests__/maintenance.native.test.ts
@@ -30,14 +30,90 @@ describe('[method] maintenanceStatus', () => {
     )
   })
 
-  it('should set up listener with given callback', () => {
-    maintenanceStatusListener(mockedCallBack)
-
-    const get = jest.fn().mockReturnValue('getReturn')
+  it('should set message when maintenance is on', () => {
     // @ts-expect-error is an incomplete mock
-    const docSnapshot: FirebaseFirestoreTypes.DocumentSnapshot = { get }
+    const docSnapshot: FirebaseFirestoreTypes.DocumentSnapshot = {
+      data: jest.fn().mockReturnValueOnce({
+        maintenanceIsOn: true,
+        message: 'Some maintenance message',
+      }),
+    }
+
+    maintenanceStatusListener(mockedCallBack)
     onNext(docSnapshot)
-    expect(get).toHaveBeenCalledWith('maintenanceIsOn')
-    expect(mockedCallBack).toHaveBeenCalledWith('getReturn')
+
+    expect(mockedCallBack).toHaveBeenCalledWith({
+      status: 'ON',
+      message: 'Some maintenance message',
+    })
+  })
+
+  it('should ignore the message when maintenance is off', () => {
+    // @ts-expect-error is an incomplete mock
+    const docSnapshot: FirebaseFirestoreTypes.DocumentSnapshot = {
+      data: jest.fn().mockReturnValueOnce({
+        maintenanceIsOn: false,
+        message: 'Some maintenance message',
+      }),
+    }
+
+    maintenanceStatusListener(mockedCallBack)
+    onNext(docSnapshot)
+
+    expect(mockedCallBack).toHaveBeenCalledWith({
+      status: 'OFF',
+      message: undefined,
+    })
+  })
+
+  describe('when something goes wrong in firebase', () => {
+    describe('should ignore the data', () => {
+      it('when data is wrong', () => {
+        // @ts-expect-error is an incomplete mock
+        const docSnapshot: FirebaseFirestoreTypes.DocumentSnapshot = {
+          data: jest.fn().mockReturnValueOnce(undefined),
+        }
+
+        maintenanceStatusListener(mockedCallBack)
+        onNext(docSnapshot)
+
+        expect(mockedCallBack).not.toBeCalled()
+      })
+
+      it('when maintenanceIsOn is wrong', () => {
+        // @ts-expect-error is an incomplete mock
+        const docSnapshot: FirebaseFirestoreTypes.DocumentSnapshot = {
+          data: jest.fn().mockReturnValueOnce({
+            maintenanceIsOn: 'something that is not a boolean',
+            message: 'Some maintenance message',
+          }),
+        }
+
+        maintenanceStatusListener(mockedCallBack)
+        onNext(docSnapshot)
+
+        expect(mockedCallBack).not.toBeCalled()
+      })
+    })
+
+    it('should use default message when message is wrong', () => {
+      // @ts-expect-error is an incomplete mock
+      const docSnapshot: FirebaseFirestoreTypes.DocumentSnapshot = {
+        data: jest.fn().mockReturnValueOnce({
+          maintenanceIsOn: true,
+          message: 42,
+        }),
+      }
+
+      maintenanceStatusListener(mockedCallBack)
+      onNext(docSnapshot)
+
+      // expect(mockedCallBack).not.toBeCalled()
+      expect(mockedCallBack).toHaveBeenCalledWith({
+        status: 'ON',
+        message:
+          'L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !',
+      })
+    })
   })
 })

--- a/src/libs/firestore/maintenance.ts
+++ b/src/libs/firestore/maintenance.ts
@@ -1,15 +1,63 @@
+import { t } from '@lingui/macro'
+
 import { env } from 'libs/environment'
 import { firestoreRemoteStore } from 'libs/firestore/client'
 import { RemoteStoreCollections, RemoteStoreDocuments } from 'libs/firestore/types'
 import { MonitoringError } from 'libs/monitoring'
 
-export const maintenanceStatusListener = (onValueChange: (maintenanceStatus: boolean) => void) =>
+export enum MAINTENANCE {
+  UNKNOWN = 'UNKNOWN',
+  OFF = 'OFF',
+  ON = 'ON',
+}
+
+export type Maintenance =
+  | {
+      status: MAINTENANCE.UNKNOWN
+      message: undefined
+    }
+  | {
+      status: MAINTENANCE.OFF
+      message: undefined
+    }
+  | {
+      status: MAINTENANCE.ON
+      message: string
+    }
+
+type OnMaintenanceChange = (maintenance: Maintenance) => void
+
+type Unsubscribe = () => void
+
+export const maintenanceStatusListener = (onMaintenanceChange: OnMaintenanceChange): Unsubscribe =>
   firestoreRemoteStore
     .collection(RemoteStoreCollections.MAINTENANCE)
     .doc(env.ENV)
     .onSnapshot(
       (docSnapshot) => {
-        onValueChange(docSnapshot.get(RemoteStoreDocuments.MAINTENANCE_IS_ON))
+        const data = docSnapshot.data()
+
+        const maintenanceIsOn = data?.[RemoteStoreDocuments.MAINTENANCE_IS_ON]
+        const rawMessage = data?.[RemoteStoreDocuments.MAINTENANCE_MESSAGE]
+
+        if (typeof maintenanceIsOn !== 'boolean') return
+
+        const message =
+          typeof rawMessage === 'string'
+            ? rawMessage
+            : t`L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !`
+
+        const maintenance: Maintenance = maintenanceIsOn
+          ? {
+              status: MAINTENANCE.ON,
+              message,
+            }
+          : {
+              status: MAINTENANCE.OFF,
+              message: undefined,
+            }
+
+        onMaintenanceChange(maintenance)
       },
       (error) => {
         new MonitoringError(error.message, 'firestore_not_available')

--- a/src/libs/firestore/types.ts
+++ b/src/libs/firestore/types.ts
@@ -9,5 +9,6 @@ export enum RemoteStoreCollections {
 export enum RemoteStoreDocuments {
   LOAD_PERCENT = 'load_percent',
   MAINTENANCE_IS_ON = 'maintenanceIsOn',
+  MAINTENANCE_MESSAGE = 'message',
   MINIMAL_BUILD_NUMBER = 'minimalBuildNumber',
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12252

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
    - [x] web
    - [x] iOS virtual
    - [ ] Android virtual (:warning: l'app ne démarre pas, je ne sais pas pourquoi)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Made sure translations file is up to date (`yarn translations:extract`) :warning: comment gérer la traduction d'un message externe ?

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari | Desktop Firefox
| --: | ------: | --------------: | ---------------: | ---------------: |--:
|  ![image](https://user-images.githubusercontent.com/95220086/146036021-6939bdda-539b-44b4-9456-22810606a3ac.png)   |         |                 |                  |                  |![image](https://user-images.githubusercontent.com/95220086/146036496-bf2c91ce-f116-4015-9203-1ec83d70980e.png)


[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a


J'aurais bien aimé pouvoir ajouter des tests sur `useMaintenance` mais je ne sais pas encore tester les hooks

En Draft parce que le dernier commit ne devra pas etre mergé, mais permet de tester en local