### PR TITLE
(PC-12306) fix(searchbox): Stage query in state when typing it

### DIFF
--- a/src/features/search/components/SearchBox.tsx
+++ b/src/features/search/components/SearchBox.tsx
@@ -44,8 +44,13 @@ const RightIcon: React.FC<{ currentValue: string; onPress: () => void }> = (prop
 export const SearchBox: React.FC = () => {
   const { navigate } = useNavigation<UseNavigationType>()
   const { searchState, dispatch } = useSearch()
-  const { searchState: stagedSearchState } = useStagedSearch()
-  const [query, setQuery] = useState<string>('')
+  const { searchState: stagedSearchState, dispatch: stagedDispatch } = useStagedSearch()
+  const [query, _setQuery] = useState<string>('')
+
+  function setQuery(value: string) {
+    stagedDispatch({ type: 'SET_QUERY', payload: value })
+    _setQuery(value)
+  }
 
   useFocusEffect(
     useCallback(() => {
@@ -71,7 +76,7 @@ export const SearchBox: React.FC = () => {
     const { locationFilter, offerCategories } = stagedSearchState
     const query = event.nativeEvent.text
     navigate(
-      ...getTabNavConfig('Search', { query, showResults: true, locationFilter, offerCategories })
+      ...getTabNavConfig('Search', { showResults: true, query, locationFilter, offerCategories })
     )
     analytics.logSearchQuery(query)
   }

--- a/src/features/search/components/__tests__/SearchBox.test.tsx
+++ b/src/features/search/components/__tests__/SearchBox.test.tsx
@@ -23,13 +23,24 @@ const mockStagedSearchState: SearchState = {
 }
 
 const mockDispatch = jest.fn()
+const mockStagedDispatch = jest.fn()
 jest.mock('features/search/pages/SearchWrapper', () => ({
   useSearch: () => ({ searchState: mockSearchState, dispatch: mockDispatch }),
-  useStagedSearch: () => ({ searchState: mockStagedSearchState }),
+  useStagedSearch: () => ({ searchState: mockStagedSearchState, dispatch: mockStagedDispatch }),
 }))
 jest.mock('libs/analytics')
 
 describe('SearchBox component', () => {
+  it('should call mockStagedDispatch() when typing', () => {
+    const { getByPlaceholderText } = render(<SearchBox />)
+    const searchInput = getByPlaceholderText('Titre, artiste, lieu...')
+    expect(mockStagedDispatch).toBeCalledWith({ type: 'SET_QUERY', payload: '' })
+    fireEvent.changeText(searchInput, 'Ma')
+    expect(mockStagedDispatch).toBeCalledWith({ type: 'SET_QUERY', payload: 'Ma' })
+    fireEvent.changeText(searchInput, 'Mama')
+    expect(mockStagedDispatch).toBeCalledWith({ type: 'SET_QUERY', payload: 'Mama' })
+  })
+
   it('should call logSearchQuery on submit', () => {
     const { getByPlaceholderText } = render(<SearchBox />)
     const searchInput = getByPlaceholderText('Titre, artiste, lieu...')


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12306

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
