### PR TITLE
(PC-12192) fix(countryPicker): Make more room to country picker on desktop

### DIFF
--- a/src/features/auth/signup/PhoneValidation/SetPhoneNumber.tsx
+++ b/src/features/auth/signup/PhoneValidation/SetPhoneNumber.tsx
@@ -195,13 +195,22 @@ const InputContainer = styled.View({
   maxWidth: getSpacing(90),
 })
 
+const PICKER_WIDTH_DESKTOP = 30 // in %
+const PICKER_WIDTH_MOBILE = 35 // in %
+const INPUT_WIDTH_DESKTOP = 100 - PICKER_WIDTH_DESKTOP // in %
+const INPUT_WIDTH_MOBILE = 100 - PICKER_WIDTH_MOBILE // in %
+
 const StyledCountryPicker = styled(CountryPicker)(({ theme }) => ({
-  width: theme.isDesktopViewport ? '25%' : '35%',
+  width: theme.isDesktopViewport ? `${PICKER_WIDTH_DESKTOP}%` : `${PICKER_WIDTH_MOBILE}%`,
 }))
 
 const StyledTextInput = styled(TextInput).attrs((props) => {
   const { theme } = props
-  return { containerStyle: { width: theme.isDesktopViewport ? '75%' : '65%' } }
+  return {
+    containerStyle: {
+      width: theme.isDesktopViewport ? `${INPUT_WIDTH_DESKTOP}%` : `${INPUT_WIDTH_MOBILE}%`,
+    },
+  }
 })({})
 
 /**


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12192

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
