### PR TITLE
(PC-11780) feat(NotYetUnderageEligibility): handle different eligibility ages

### DIFF
--- a/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.native-snap
@@ -125,7 +125,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
           ]
         }
       >
-        Reviens à partir du 01 Décembre pour poursuivre ton inscription et bénéficier des offres du pass Culture.
+        Reviens à partir du 01 décembre pour poursuivre ton inscription et bénéficier des offres du pass Culture.
       </Text>
       <View
         numberOfSpaces={30}

--- a/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.web-snap
+++ b/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.web-snap
@@ -166,7 +166,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
           }
         }
       >
-        Reviens à partir du 01 Décembre pour poursuivre ton inscription et bénéficier des offres du pass Culture.
+        Reviens à partir du 01 décembre pour poursuivre ton inscription et bénéficier des offres du pass Culture.
       </div>
       <div
         className="css-view-1dbjc4n"

--- a/src/libs/dates.test.ts
+++ b/src/libs/dates.test.ts
@@ -16,8 +16,8 @@ describe('currentTimestamp()', () => {
 })
 describe('formatToReadableFrenchDate()', () => {
   it('should return formated translated and readable date', () => {
-    expect(formatToReadableFrenchDate(new Date('2019-12-01T00:00:00Z'))).toEqual('01 Décembre')
-    expect(formatToReadableFrenchDate(new Date('2019-03-12T00:00:00Z'))).toEqual('12 Mars')
+    expect(formatToReadableFrenchDate(new Date('2019-12-01T00:00:00Z'))).toEqual('01 décembre')
+    expect(formatToReadableFrenchDate(new Date('2019-03-12T00:00:00Z'))).toEqual('12 mars')
   })
 })
 

--- a/src/libs/dates.ts
+++ b/src/libs/dates.ts
@@ -63,6 +63,6 @@ export const formatToSlashedFrenchDate = (ISODate: string) => {
 export const formatToReadableFrenchDate = (date: Date) => {
   const monthOrder = date.getMonth()
   const day = ('0' + date.getDate()).slice(-2)
-  const month = monthNames[monthOrder]
+  const month = monthNames[monthOrder].toLowerCase()
   return `${day} ${month}`
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11780

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
