### PR TITLE
(PC-12359) fix(translations): change space to non-breaking before exclamation

### DIFF
--- a/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -496,7 +496,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                                         ]
                                       }
                                     >
-                                      E-mail envoyé !
+                                      E-mail envoyé !
                                     </Text>
                                   </View>
                                   <View
@@ -628,7 +628,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                                           ]
                                         }
                                       >
-                                        L'e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams !
+                                        L'e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams !
                                       </Text>
                                     </Text>
                                     <View

--- a/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.web.test.tsx.web-snap
@@ -130,7 +130,7 @@ Object {
                                             dir="auto"
                                             style="color: rgb(21, 21, 21); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                                           >
-                                            E-mail envoyé !
+                                            E-mail envoyé !
                                           </div>
                                         </div>
                                         <div
@@ -193,7 +193,7 @@ Object {
                                               class="css-text-901oao css-textHasAncestor-16my406"
                                               style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                                             >
-                                              L'e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams !
+                                              L'e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams !
                                             </span>
                                           </div>
                                           <div
@@ -448,7 +448,7 @@ Object {
                                           dir="auto"
                                           style="color: rgb(21, 21, 21); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                                         >
-                                          E-mail envoyé !
+                                          E-mail envoyé !
                                         </div>
                                       </div>
                                       <div
@@ -511,7 +511,7 @@ Object {
                                             class="css-text-901oao css-textHasAncestor-16my406"
                                             style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                                           >
-                                            L'e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams !
+                                            L'e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams !
                                           </span>
                                         </div>
                                         <div

--- a/__snapshots__/features/auth/signup/AccountCreated/tests/AccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/AccountCreated/tests/AccountCreated.native.test.tsx.native-snap
@@ -94,7 +94,7 @@ exports[`<AccountCreated /> should render correctly 1`] = `
           ]
         }
       >
-        Ton compte a été activé !
+        Ton compte a été activé !
       </Text>
       <View
         numberOfSpaces={5}
@@ -120,7 +120,7 @@ exports[`<AccountCreated /> should render correctly 1`] = `
           ]
         }
       >
-        Aide-nous à en savoir plus sur tes pratiques culturelles ! Ta sélection n'aura pas d'impact sur les offres proposées.
+        Aide-nous à en savoir plus sur tes pratiques culturelles ! Ta sélection n'aura pas d'impact sur les offres proposées.
       </Text>
       <View
         numberOfSpaces={15}
@@ -133,7 +133,7 @@ exports[`<AccountCreated /> should render correctly 1`] = `
         }
       />
       <View
-        accessibilityLabel="On y va !"
+        accessibilityLabel="On y va !"
         accessible={true}
         collapsable={false}
         focusable={true}
@@ -163,7 +163,7 @@ exports[`<AccountCreated /> should render correctly 1`] = `
             "width": "100%",
           }
         }
-        testID="On y va !"
+        testID="On y va !"
       >
         <Text
           adjustsFontSizeToFit={false}
@@ -182,7 +182,7 @@ exports[`<AccountCreated /> should render correctly 1`] = `
           }
           textColor="#eb0055"
         >
-          On y va !
+          On y va !
         </Text>
       </View>
       <View

--- a/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.native-snap
@@ -99,7 +99,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
           ]
         }
       >
-        C'est pour bientôt !
+        C'est pour bientôt !
       </Text>
       <View
         numberOfSpaces={5}

--- a/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.web-snap
+++ b/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.web-snap
@@ -143,7 +143,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
           }
         }
       >
-        C'est pour bientôt !
+        C'est pour bientôt !
       </div>
       <div
         className="css-view-1dbjc4n"

--- a/__snapshots__/features/auth/signup/idCheck/DenyAccessToIdCheck.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/idCheck/DenyAccessToIdCheck.native.test.tsx.native-snap
@@ -197,7 +197,7 @@ exports[`<DenyAccessToIdCheckModal /> should match snapshot 1`] = `
             ]
           }
         >
-          Oups !
+          Oups !
         </Text>
       </View>
       <View
@@ -326,7 +326,7 @@ exports[`<DenyAccessToIdCheckModal /> should match snapshot 1`] = `
                   ]
                 }
               >
-                Vous êtes actuellement très nombreux à vouloir effectuer votre demande des 300€. Tu recevras une alerte par mail pour commencer ta demande des 300€ dès que le service sera de nouveau disponible !
+                Vous êtes actuellement très nombreux à vouloir effectuer votre demande des 300€. Tu recevras une alerte par mail pour commencer ta demande des 300€ dès que le service sera de nouveau disponible !
               </Text>
             </Text>
             <View

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingImpossible.deprecated.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingImpossible.deprecated.native.test.tsx.native-snap
@@ -71,7 +71,7 @@ exports[`<BookingImpossible /> should render with CTAs when offer is not yet fav
       ]
     }
   >
-    Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !
+    Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !
   </Text>
   <View
     numberOfSpaces={6}

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingImpossible.deprecated.web.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingImpossible.deprecated.web.test.tsx.web-snap
@@ -39,7 +39,7 @@ Object {
           dir="auto"
           style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; padding-right: 24px; padding-left: 24px; text-align: center;"
         >
-          Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !
+          Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !
         </div>
         <div
           class="css-view-1dbjc4n"
@@ -121,7 +121,7 @@ Object {
         dir="auto"
         style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; padding-right: 24px; padding-left: 24px; text-align: center;"
       >
-        Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !
+        Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !
       </div>
       <div
         class="css-view-1dbjc4n"

--- a/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.native-snap
@@ -99,7 +99,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
           ]
         }
       >
-        Réservation confirmée !
+        Réservation confirmée !
       </Text>
       <View
         numberOfSpaces={5}

--- a/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.web-snap
@@ -143,7 +143,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
           }
         }
       >
-        Réservation confirmée !
+        Réservation confirmée !
       </div>
       <div
         className="css-view-1dbjc4n"

--- a/__snapshots__/features/bookings/pages/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails.native.test.tsx.native-snap
@@ -285,7 +285,7 @@ exports[`BookingDetails should render correctly 1`] = `
             ]
           }
         >
-          Ce code à 6 caractères est ta preuve d’achat ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder.
+          Ce code à 6 caractères est ta preuve d’achat ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder.
         </Text>
         <View
           numberOfSpaces={8}

--- a/__snapshots__/features/eighteenBirthday/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/eighteenBirthday/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -186,7 +186,7 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
                     ]
                   }
                 >
-                  Bonne nouvelle !
+                  Bonne nouvelle !
                 </Text>
                 <Text
                   fontSize={24}

--- a/__snapshots__/features/eighteenBirthday/pages/components/EighteenBirthdayCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/eighteenBirthday/pages/components/EighteenBirthdayCard.native.test.tsx.native-snap
@@ -70,7 +70,7 @@ exports[`<EighteenBirthdayCard /> should render eighteen birthday card 1`] = `
       ]
     }
   >
-    Bonne nouvelle !
+    Bonne nouvelle !
   </Text>
   <Text
     fontSize={24}

--- a/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.native.test.tsx.native-snap
@@ -126,7 +126,7 @@ exports[`AsyncErrorBoundary component should render 1`] = `
       ]
     }
   >
-    Oups !
+    Oups !
   </Text>
   <View
     numberOfSpaces={4}

--- a/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.web.test.tsx.web-snap
+++ b/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.web.test.tsx.web-snap
@@ -68,7 +68,7 @@ Object {
           dir="auto"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Black; font-size: 24px; font-weight: 900; line-height: 36px;"
         >
-          Oups !
+          Oups !
         </div>
         <div
           class="css-view-1dbjc4n"
@@ -200,7 +200,7 @@ Object {
         dir="auto"
         style="color: rgb(255, 255, 255); font-family: Montserrat-Black; font-size: 24px; font-weight: 900; line-height: 36px;"
       >
-        Oups !
+        Oups !
       </div>
       <div
         class="css-view-1dbjc4n"

--- a/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.native-snap
@@ -97,7 +97,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
         ]
       }
     >
-      Connecte-toi pour profiter de cette fonctionnalité !
+      Connecte-toi pour profiter de cette fonctionnalité !
     </Text>
     <View
       numberOfSpaces={4}
@@ -140,7 +140,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
             ]
           }
         >
-          Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil !
+          Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil !
         </Text>
       </Text>
     </View>

--- a/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.web-snap
+++ b/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.web-snap
@@ -118,7 +118,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
         }
       }
     >
-      Connecte-toi pour profiter de cette fonctionnalité !
+      Connecte-toi pour profiter de cette fonctionnalité !
     </div>
     <div
       className="css-view-1dbjc4n"
@@ -156,7 +156,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
             }
           }
         >
-          Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil !
+          Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil !
         </span>
       </div>
     </div>

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/FirstTutorial.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/FirstTutorial.native.test.tsx.native-snap
@@ -684,7 +684,7 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                     ]
                   }
                 >
-                  à portée de main !
+                  à portée de main !
                 </Text>
                 <View
                   flex={0.5}
@@ -892,7 +892,7 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                     ]
                   }
                 >
-                  Nos nombreux partenaires ajoutent de nouvelles offres quotidiennement. Découvre les dès maintenant !
+                  Nos nombreux partenaires ajoutent de nouvelles offres quotidiennement. Découvre les dès maintenant !
                 </Text>
                 <View
                   flex={2}

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FourthCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FourthCard.native.test.tsx.native-snap
@@ -115,7 +115,7 @@ exports[`FourthCard should render fourth card 1`] = `
       ]
     }
   >
-    Nos nombreux partenaires ajoutent de nouvelles offres quotidiennement. Découvre les dès maintenant !
+    Nos nombreux partenaires ajoutent de nouvelles offres quotidiennement. Découvre les dès maintenant !
   </Text>
   <View
     flex={2}

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/ThirdCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/ThirdCard.native.test.tsx.native-snap
@@ -88,7 +88,7 @@ exports[`ThirdCard should render third card 1`] = `
       ]
     }
   >
-    à portée de main !
+    à portée de main !
   </Text>
   <View
     flex={0.5}

--- a/__snapshots__/features/home/components/tests/NoContentError.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/tests/NoContentError.native.test.tsx.native-snap
@@ -99,7 +99,7 @@ exports[`NoContentError should render correctly 1`] = `
           ]
         }
       >
-        Oups !
+        Oups !
       </Text>
       <View
         numberOfSpaces={5}

--- a/__snapshots__/features/home/pages/tests/Home.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/tests/Home.native.test.tsx.native-snap
@@ -121,7 +121,7 @@ exports[`Home component should render correctly without login modal 1`] = `
                 ]
               }
             >
-              Bienvenue !
+              Bienvenue !
             </Text>
             <View
               numberOfSpaces={2}

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/EduConnectForm.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/EduConnectForm.web.test.tsx.web-snap
@@ -99,7 +99,7 @@ Object {
                       dir="auto"
                       style="color: rgb(98, 98, 98); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
                     >
-                      Pour procéder à ton identification, nous allons te demander de te connecter à ÉduConnect. Muni toi de ton identifiant et de ton mot de passe ÉduConnect. Dès que tu as bien complété le parcours, reviens sur ce site pour terminer ton inscription et découvrir toutes les offres du pass Culture !
+                      Pour procéder à ton identification, nous allons te demander de te connecter à ÉduConnect. Muni toi de ton identifiant et de ton mot de passe ÉduConnect. Dès que tu as bien complété le parcours, reviens sur ce site pour terminer ton inscription et découvrir toutes les offres du pass Culture !
                     </div>
                     <div
                       class="css-view-1dbjc4n"
@@ -248,7 +248,7 @@ Object {
                     dir="auto"
                     style="color: rgb(98, 98, 98); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
                   >
-                    Pour procéder à ton identification, nous allons te demander de te connecter à ÉduConnect. Muni toi de ton identifiant et de ton mot de passe ÉduConnect. Dès que tu as bien complété le parcours, reviens sur ce site pour terminer ton inscription et découvrir toutes les offres du pass Culture !
+                    Pour procéder à ton identification, nous allons te demander de te connecter à ÉduConnect. Muni toi de ton identifiant et de ton mot de passe ÉduConnect. Dès que tu as bien complété le parcours, reviens sur ce site pour terminer ton inscription et découvrir toutes les offres du pass Culture !
                   </div>
                   <div
                     class="css-view-1dbjc4n"

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEnd.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEnd.native.test.tsx.native-snap
@@ -99,7 +99,7 @@ exports[`<IdentityCheckEnd/> should render correctly 1`] = `
           ]
         }
       >
-        Ta pièce d’identité a bien été transmise !
+        Ta pièce d’identité a bien été transmise !
       </Text>
       <View
         numberOfSpaces={5}

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckStart.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckStart.native.test.tsx.native-snap
@@ -691,7 +691,7 @@ Array [
                                 ]
                               }
                             >
-                              Tu peux aussi compléter ton dossier sur Démarches simplifiées. Attention le traitement sera plus long !
+                              Tu peux aussi compléter ton dossier sur Démarches simplifiées. Attention le traitement sera plus long !
                             </Text>
                             <View
                               numberOfSpaces={8}

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckUnavailable.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckUnavailable.native.test.tsx.native-snap
@@ -99,7 +99,7 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
           ]
         }
       >
-        Victime de notre succès !
+        Victime de notre succès !
       </Text>
       <View
         numberOfSpaces={5}

--- a/__snapshots__/features/maintenance/tests/Maintenance.test.tsx.native-snap
+++ b/__snapshots__/features/maintenance/tests/Maintenance.test.tsx.native-snap
@@ -306,7 +306,7 @@ exports[`<Maintenance /> should match snapshot with default message 1`] = `
           ]
         }
       >
-        L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !
+        L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !
       </Text>
       <View
         numberOfSpaces={24}

--- a/__snapshots__/features/maintenance/tests/Maintenance.test.tsx.web-snap
+++ b/__snapshots__/features/maintenance/tests/Maintenance.test.tsx.web-snap
@@ -381,7 +381,7 @@ exports[`<Maintenance /> should match snapshot with default message 1`] = `
           }
         }
       >
-        L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !
+        L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !
       </div>
       <div
         className="css-view-1dbjc4n"

--- a/__snapshots__/features/offer/components/__tests__/OfferHeader.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/__tests__/OfferHeader.native.test.tsx.native-snap
@@ -725,7 +725,7 @@ Array [
                   ]
                 }
               >
-                Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil !
+                Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil !
               </Text>
             </Text>
             <View

--- a/__snapshots__/features/offer/components/__tests__/OfferHeader.web.test.tsx.web-snap
+++ b/__snapshots__/features/offer/components/__tests__/OfferHeader.web.test.tsx.web-snap
@@ -337,7 +337,7 @@ Object {
                     class="css-text-901oao css-textHasAncestor-16my406"
                     style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                   >
-                    Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil !
+                    Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil !
                   </span>
                 </div>
                 <div

--- a/__snapshots__/features/offer/pages/tests/OfferBody.deprecated.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferBody.deprecated.native.test.tsx.native-snap
@@ -3119,7 +3119,7 @@ exports[`<OfferBody /> should match snapshot for physical offer 1`] = `
                                 }
                                 testID="caption-iconDuo"
                               >
-                                À deux !
+                                À deux !
                               </Text>
                             </View>
                             <View

--- a/__snapshots__/features/offer/pages/tests/OfferBody.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferBody.native.test.tsx.native-snap
@@ -407,7 +407,7 @@ exports[`<OfferBody /> should open the report modal upon clicking on 'signaler l
           }
           testID="caption-iconDuo"
         >
-          À deux !
+          À deux !
         </Text>
       </View>
       <View

--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.native.test.tsx.native-snap
@@ -99,7 +99,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
           ]
         }
       >
-        Oups !
+        Oups !
       </Text>
       <View
         numberOfSpaces={5}
@@ -125,7 +125,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly 1`] = `
           ]
         }
       >
-        Le lien est expiré !
+        Le lien est expiré !
       </Text>
       <Text
         color="#ffffff"
@@ -405,7 +405,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly when logged out 1`] 
           ]
         }
       >
-        Oups !
+        Oups !
       </Text>
       <View
         numberOfSpaces={5}
@@ -431,7 +431,7 @@ exports[`<ChangeEmailExpiredLink /> should render correctly when logged out 1`] 
           ]
         }
       >
-        Le lien est expiré !
+        Le lien est expiré !
       </Text>
       <Text
         color="#ffffff"

--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.web.test.tsx.web-snap
@@ -55,7 +55,7 @@ Object {
               dir="auto"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
             >
-              Oups !
+              Oups !
             </div>
             <div
               class="css-view-1dbjc4n"
@@ -66,7 +66,7 @@ Object {
               dir="auto"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
             >
-              Le lien est expiré !
+              Le lien est expiré !
             </div>
             <div
               class="css-text-901oao"
@@ -190,7 +190,7 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
             dir="auto"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
           >
-            Oups !
+            Oups !
           </div>
           <div
             class="css-view-1dbjc4n"
@@ -201,7 +201,7 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
             dir="auto"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
           >
-            Le lien est expiré !
+            Le lien est expiré !
           </div>
           <div
             class="css-text-901oao"
@@ -382,7 +382,7 @@ Object {
               dir="auto"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
             >
-              Oups !
+              Oups !
             </div>
             <div
               class="css-view-1dbjc4n"
@@ -393,7 +393,7 @@ Object {
               dir="auto"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
             >
-              Le lien est expiré !
+              Le lien est expiré !
             </div>
             <div
               class="css-text-901oao"
@@ -517,7 +517,7 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
             dir="auto"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
           >
-            Oups !
+            Oups !
           </div>
           <div
             class="css-view-1dbjc4n"
@@ -528,7 +528,7 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
             dir="auto"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
           >
-            Le lien est expiré !
+            Le lien est expiré !
           </div>
           <div
             class="css-text-901oao"

--- a/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.native-snap
+++ b/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.native-snap
@@ -99,7 +99,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
           ]
         }
       >
-        Oups !
+        Oups !
       </Text>
       <View
         numberOfSpaces={5}
@@ -125,7 +125,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
           ]
         }
       >
-        Le lien est expiré !
+        Le lien est expiré !
       </Text>
       <Text
         color="#ffffff"

--- a/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.web-snap
+++ b/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.web-snap
@@ -143,7 +143,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
           }
         }
       >
-        Oups !
+        Oups !
       </div>
       <div
         className="css-view-1dbjc4n"
@@ -166,7 +166,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
           }
         }
       >
-        Le lien est expiré !
+        Le lien est expiré !
       </div>
       <div
         className="css-text-901oao"

--- a/src/features/_marketingAndCommunication/components/DeeplinksGeneratorForm.tsx
+++ b/src/features/_marketingAndCommunication/components/DeeplinksGeneratorForm.tsx
@@ -219,7 +219,7 @@ export const DeeplinksGeneratorForm = ({ onCreate }: Props) => {
       <BottomContainer>
         <Banner color={ColorsEnum.ERROR}>
           <Warning color={ColorsEnum.ERROR} size={getSpacing(3.5)} />
-          {t`Seulement les "ids" disposent de validation !`}
+          {t`Seulement les "ids" disposent de validation\u00a0!`}
         </Banner>
         <ButtonPrimary title={t`Générer le lien`} disabled={disabled} onPress={onPress} />
       </BottomContainer>

--- a/src/features/auth/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
+++ b/src/features/auth/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
@@ -131,7 +131,7 @@ export const ForgottenPassword: FunctionComponent = () => {
       <ModalContent>
         <CenteredText>
           <Typo.Body>
-            {t`Saisis ton adresse e-mail pour recevoir un lien qui te permettra de réinitialiser ton mot de passe !`}
+            {t`Saisis ton adresse e-mail pour recevoir un lien qui te permettra de réinitialiser ton mot de passe\u00a0!`}
           </Typo.Body>
         </CenteredText>
         <Spacer.Column numberOfSpaces={4} />

--- a/src/features/auth/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
+++ b/src/features/auth/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
@@ -48,7 +48,7 @@ export const ReinitializePassword = () => {
 
   const { mutate: resetPassword, isLoading } = useResetPasswordMutation(() => {
     showSuccessSnackBar({
-      message: t`Ton mot de passe a été modifié !`,
+      message: t`Ton mot de passe a été modifié\u00a0!`,
       timeout: SNACK_BAR_TIME_OUT,
     })
     analytics.logHasChangedPassword('resetPassword')

--- a/src/features/auth/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.tsx
+++ b/src/features/auth/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.tsx
@@ -23,7 +23,7 @@ export const ResetPasswordEmailSent: FunctionComponent<Props> = ({ route }) => {
   return (
     <BottomContentPage>
       <ModalHeader
-        title={t`E-mail envoyé !`}
+        title={t`E-mail envoyé\u00a0!`}
         leftIconAccessibilityLabel={t`Revenir en arrière`}
         leftIcon={ArrowPrevious}
         onLeftIconPress={goBack}
@@ -38,7 +38,7 @@ export const ResetPasswordEmailSent: FunctionComponent<Props> = ({ route }) => {
           <Spacer.Column numberOfSpaces={5} />
           <CenteredText>
             <Typo.Body>
-              {t`L'e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams !`}
+              {t`L'e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams\u00a0!`}
             </Typo.Body>
           </CenteredText>
           <Spacer.Column numberOfSpaces={5} />

--- a/src/features/auth/login/Login.tsx
+++ b/src/features/auth/login/Login.tsx
@@ -128,7 +128,7 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
   return (
     <BottomContentPage>
       <ModalHeader
-        title={t`Connecte-toi !`}
+        title={t`Connecte-toi\u00a0!`}
         leftIconAccessibilityLabel={t`Revenir en arrière`}
         leftIcon={ArrowPrevious}
         onLeftIconPress={goBack}

--- a/src/features/auth/signup/AccountCreated/AccountCreated.tsx
+++ b/src/features/auth/signup/AccountCreated/AccountCreated.tsx
@@ -33,14 +33,16 @@ export function AccountCreated() {
   }, [user?.id])
 
   return (
-    <GenericInfoPage title={t`Ton compte a été activé !`} animation={IlluminatedSmileyAnimation}>
+    <GenericInfoPage
+      title={t`Ton compte a été activé\u00a0!`}
+      animation={IlluminatedSmileyAnimation}>
       {!!shouldNavigateToCulturalSurvey && (
         <StyledBody>
-          {t`Aide-nous à en savoir plus sur tes pratiques culturelles ! Ta sélection n'aura pas d'impact sur les offres proposées.`}
+          {t`Aide-nous à en savoir plus sur tes pratiques culturelles\u00a0! Ta sélection n'aura pas d'impact sur les offres proposées.`}
         </StyledBody>
       )}
       <Spacer.Column numberOfSpaces={15} />
-      <ButtonPrimaryWhite title={t`On y va !`} onPress={onPress} />
+      <ButtonPrimaryWhite title={t`On y va\u00a0!`} onPress={onPress} />
     </GenericInfoPage>
   )
 }

--- a/src/features/auth/signup/AccountCreated/tests/AccountCreated.native.test.tsx
+++ b/src/features/auth/signup/AccountCreated/tests/AccountCreated.native.test.tsx
@@ -29,7 +29,7 @@ describe('<AccountCreated />', () => {
   it('should redirect to cultural survey page WHEN "On y va !" button is clicked', async () => {
     const renderAPI = render(<AccountCreated />)
 
-    fireEvent.press(await renderAPI.findByText('On y va !'))
+    fireEvent.press(await renderAPI.findByText('On y va\u00a0!'))
 
     expect(navigateToHome).not.toBeCalledTimes(1)
     expect(navigate).toBeCalledTimes(1)
@@ -43,7 +43,7 @@ describe('<AccountCreated />', () => {
     } as UseQueryResult<UserProfileResponse>)
     const renderAPI = render(<AccountCreated />)
 
-    fireEvent.press(await renderAPI.findByText('On y va !'))
+    fireEvent.press(await renderAPI.findByText('On y va\u00a0!'))
 
     expect(navigateToHome).toBeCalledTimes(1)
     expect(navigate).not.toBeCalledWith('CulturalSurvey')
@@ -56,7 +56,7 @@ describe('<AccountCreated />', () => {
     } as UseQueryResult<UserProfileResponse>)
     const renderAPI = render(<AccountCreated />)
 
-    fireEvent.press(await renderAPI.findByText('On y va !'))
+    fireEvent.press(await renderAPI.findByText('On y va\u00a0!'))
 
     expect(navigateToHome).toBeCalledTimes(1)
     expect(navigate).not.toBeCalledWith('CulturalSurvey')

--- a/src/features/auth/signup/PhoneValidation/PhoneValidationTooManyAttempts/PhoneValidationTooManyAttempts.tsx
+++ b/src/features/auth/signup/PhoneValidation/PhoneValidationTooManyAttempts/PhoneValidationTooManyAttempts.tsx
@@ -13,7 +13,7 @@ import { ColorsEnum, Spacer, Typo } from 'ui/theme'
 
 export function PhoneValidationTooManyAttempts() {
   return (
-    <GenericInfoPage title={t`Trop de tentatives !`} icon={AccountLocked}>
+    <GenericInfoPage title={t`Trop de tentatives\u00a0!`} icon={AccountLocked}>
       <StyledBody>
         {t`Tu as dépassé le nombre d’essais autorisés. L’accès à ton crédit pass Culture a été bloqué. Pour le récupérer tu peux :`}
       </StyledBody>

--- a/src/features/auth/signup/PhoneValidation/PhoneValidationTooManySMSSent/PhoneValidationTooManySMSSent.tsx
+++ b/src/features/auth/signup/PhoneValidation/PhoneValidationTooManySMSSent/PhoneValidationTooManySMSSent.tsx
@@ -10,9 +10,9 @@ import { ColorsEnum, Spacer, Typo } from 'ui/theme'
 
 export function PhoneValidationTooManySMSSent() {
   return (
-    <GenericInfoPage title={t`Trop de tentatives !`} icon={AccountLocked}>
+    <GenericInfoPage title={t`Trop de tentatives\u00a0!`} icon={AccountLocked}>
       <StyledBody>
-        {t`Tu as dépassé le nombre d’essais autorisés. Tu pourras réessayer dans 12 heures !`}
+        {t`Tu as dépassé le nombre d’essais autorisés. Tu pourras réessayer dans 12 heures\u00a0!`}
       </StyledBody>
 
       <Spacer.Column numberOfSpaces={22} />

--- a/src/features/auth/signup/VerifyEligiblity/NotYetUnderageEligibility.tsx
+++ b/src/features/auth/signup/VerifyEligiblity/NotYetUnderageEligibility.tsx
@@ -15,7 +15,10 @@ type Props = StackScreenProps<RootStackParamList, 'NotYetUnderageEligibility'>
 
 export const NotYetUnderageEligibility: FunctionComponent<Props> = (props) => {
   return (
-    <GenericInfoPage title={t`C'est pour bientôt ! `} icon={Calendar} iconSize={getSpacing(30)}>
+    <GenericInfoPage
+      title={t`C'est pour bientôt\u00a0! `}
+      icon={Calendar}
+      iconSize={getSpacing(30)}>
       <StyledBody>
         {t({
           id: 'reviens a partir du',

--- a/src/features/auth/signup/idCheck/DenyAccessToIdCheck.tsx
+++ b/src/features/auth/signup/idCheck/DenyAccessToIdCheck.tsx
@@ -28,7 +28,7 @@ export const DenyAccessToIdCheckModal = (props: DenyAccessToIdCheckModalProps) =
   return (
     <AppModal
       visible={props.visible}
-      title={t`Oups !`}
+      title={t`Oups\u00a0!`}
       leftIconAccessibilityLabel={undefined}
       leftIcon={undefined}
       onLeftIconPress={undefined}
@@ -40,7 +40,7 @@ export const DenyAccessToIdCheckModal = (props: DenyAccessToIdCheckModalProps) =
         <Spacer.Column numberOfSpaces={getSpacing(2)} />
         <Paragraphe>
           <Typo.Body color={ColorsEnum.GREY_DARK}>
-            {t`Vous êtes actuellement très nombreux à vouloir effectuer votre demande des 300€. Tu recevras une alerte par mail pour commencer ta demande des 300€ dès que le service sera de nouveau disponible !`}
+            {t`Vous êtes actuellement très nombreux à vouloir effectuer votre demande des 300€. Tu recevras une alerte par mail pour commencer ta demande des 300€ dès que le service sera de nouveau disponible\u00a0!`}
           </Typo.Body>
         </Paragraphe>
         <Spacer.Column numberOfSpaces={getSpacing(2)} />

--- a/src/features/auth/signup/underageSignup/UnderageAccountCreated.tsx
+++ b/src/features/auth/signup/underageSignup/UnderageAccountCreated.tsx
@@ -19,10 +19,10 @@ import { ColorsEnum, Spacer } from 'ui/theme'
 
 export function UnderageAccountCreated() {
   const maxPrice = useMaxPrice()
-  const text = t`Tu as jusqu’à la veille de tes 18 ans pour profiter de ton budget. Découvre dès maintenant les offres culturelles autour de chez toi !`
+  const text = t`Tu as jusqu’à la veille de tes 18 ans pour profiter de ton budget. Découvre dès maintenant les offres culturelles autour de chez toi\u00a0!`
 
   return (
-    <GenericInfoPageWhite animation={TutorialPassLogo} title={t`Bonne nouvelle !`}>
+    <GenericInfoPageWhite animation={TutorialPassLogo} title={t`Bonne nouvelle\u00a0!`}>
       <StyledSubtitle>
         {maxPrice + '\u00a0' + t`€ viennent d'être crédités sur ton compte pass Culture`}
       </StyledSubtitle>

--- a/src/features/bookOffer/components/BookingDetails.tsx
+++ b/src/features/bookOffer/components/BookingDetails.tsx
@@ -27,9 +27,9 @@ interface Props {
 }
 
 const errorCodeToMessage: Record<string, string> = {
-  INSUFFICIENT_CREDIT: t`Attention, ton crédit est insuffisant pour pouvoir réserver cette offre !`,
-  ALREADY_BOOKED: t`Attention, il est impossible de réserver plusieurs fois la même offre !`,
-  STOCK_NOT_BOOKABLE: t`Oups, cette offre n’est plus disponible !`,
+  INSUFFICIENT_CREDIT: t`Attention, ton crédit est insuffisant pour pouvoir réserver cette offre\u00a0!`,
+  ALREADY_BOOKED: t`Attention, il est impossible de réserver plusieurs fois la même offre\u00a0!`,
+  STOCK_NOT_BOOKABLE: t`Oups, cette offre n’est plus disponible\u00a0!`,
 }
 
 export const BookingDetails: React.FC<Props> = ({ stocks }) => {

--- a/src/features/bookOffer/components/BookingImpossible.tsx
+++ b/src/features/bookOffer/components/BookingImpossible.tsx
@@ -59,7 +59,7 @@ export const BookingImpossible: React.FC = () => {
       <Spacer.Column numberOfSpaces={6} />
       {!favorite ? (
         <Content>
-          {t`Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !`}
+          {t`Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web\u00a0!`}
         </Content>
       ) : (
         <Content>{t`Rends-toi vite sur le site pass Culture afin de la réserver`}</Content>

--- a/src/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx
+++ b/src/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx
@@ -137,9 +137,9 @@ describe('<BookingDetails />', () => {
   it.each`
     code                     | message
     ${undefined}             | ${'En raison d’une erreur technique, l’offre n’a pas pu être réservée'}
-    ${'INSUFFICIENT_CREDIT'} | ${'Attention, ton crédit est insuffisant pour pouvoir réserver cette offre !'}
-    ${'ALREADY_BOOKED'}      | ${'Attention, il est impossible de réserver plusieurs fois la même offre !'}
-    ${'STOCK_NOT_BOOKABLE'}  | ${'Oups, cette offre n’est plus disponible !'}
+    ${'INSUFFICIENT_CREDIT'} | ${'Attention, ton crédit est insuffisant pour pouvoir réserver cette offre\u00a0!'}
+    ${'ALREADY_BOOKED'}      | ${'Attention, il est impossible de réserver plusieurs fois la même offre\u00a0!'}
+    ${'STOCK_NOT_BOOKABLE'}  | ${'Oups, cette offre n’est plus disponible\u00a0!'}
   `(
     'should show the error snackbar with message="$message" for errorCode="$code" if booking an offer fails',
     async ({ code, message }: { code: string | undefined; message: string }) => {

--- a/src/features/bookOffer/pages/BookingConfirmation.tsx
+++ b/src/features/bookOffer/pages/BookingConfirmation.tsx
@@ -47,7 +47,7 @@ export function BookingConfirmation() {
 
   return (
     <GenericInfoPage
-      title={t`Réservation confirmée !`}
+      title={t`Réservation confirmée\u00a0!`}
       icon={TicketBooked}
       iconSize={getSpacing(65)}>
       <StyledBody>

--- a/src/features/bookings/pages/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails.native.test.tsx
@@ -117,7 +117,7 @@ describe('BookingDetails', () => {
       const { getByText } = renderBookingDetails(booking)
 
       getByText(
-        'Ce code à 6 caractères est ta preuve d’achat ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder.'
+        'Ce code à 6 caractères est ta preuve d’achat\u00a0! N’oublie pas que tu n’as pas le droit de le revendre ou le céder.'
       )
     })
     it('should display rules for a digital offer with activation code', () => {
@@ -131,7 +131,7 @@ describe('BookingDetails', () => {
       const { getByText } = renderBookingDetails(booking)
 
       getByText(
-        'Ce code est ta preuve d’achat, il te permet d’accéder à ton offre ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder.'
+        'Ce code est ta preuve d’achat, il te permet d’accéder à ton offre\u00a0! N’oublie pas que tu n’as pas le droit de le revendre ou le céder.'
       )
     })
 
@@ -147,7 +147,7 @@ describe('BookingDetails', () => {
       const { getByText } = renderBookingDetails(booking)
 
       getByText(
-        'Tu dois présenter ta carte d’identité et ce code de 6 caractères pour profiter de ta réservation ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder.'
+        'Tu dois présenter ta carte d’identité et ce code de 6 caractères pour profiter de ta réservation\u00a0! N’oublie pas que tu n’as pas le droit de le revendre ou le céder.'
       )
     })
   })
@@ -207,7 +207,7 @@ describe('BookingDetails', () => {
   describe('booking not found', () => {
     it('should render ScreenError BookingNotFound when booking is not found', () => {
       const renderAPI = renderBookingDetails(undefined)
-      expect(renderAPI.queryByText('Réservation introuvable !')).toBeTruthy()
+      expect(renderAPI.queryByText('Réservation introuvable\u00a0!')).toBeTruthy()
       expect(
         renderAPI.queryByText(
           `Désolé, nous ne retrouvons pas ta réservation. Peut-être a-t-elle été annulée. N'hésite pas à retrouver la liste de tes réservations terminées et annulées pour t'en assurer.`

--- a/src/features/bookings/pages/BookingDetails.tsx
+++ b/src/features/bookings/pages/BookingDetails.tsx
@@ -41,11 +41,11 @@ const getOfferRules = (
 ): string => {
   const { hasActivationCode, isDigital, isPhysical, isEvent } = properties
   if (hasActivationCode && activationCodeFeatureEnabled)
-    return t`Ce code est ta preuve d’achat, il te permet d’accéder à ton offre ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder.`
+    return t`Ce code est ta preuve d’achat, il te permet d’accéder à ton offre\u00a0! N’oublie pas que tu n’as pas le droit de le revendre ou le céder.`
   if (isDigital)
-    return t`Ce code à 6 caractères est ta preuve d’achat ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder.`
+    return t`Ce code à 6 caractères est ta preuve d’achat\u00a0! N’oublie pas que tu n’as pas le droit de le revendre ou le céder.`
   if (isPhysical || isEvent)
-    return t`Tu dois présenter ta carte d’identité et ce code de 6 caractères pour profiter de ta réservation ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder.`
+    return t`Tu dois présenter ta carte d’identité et ce code de 6 caractères pour profiter de ta réservation\u00a0! N’oublie pas que tu n’as pas le droit de le revendre ou le céder.`
   return ''
 }
 

--- a/src/features/bookings/pages/BookingNotFound.tsx
+++ b/src/features/bookings/pages/BookingNotFound.tsx
@@ -31,7 +31,7 @@ export const BookingNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
         <title>{t`Réservation introuvable | Pass Culture`}</title>
       </Helmet>
       <GenericInfoPage
-        title={t`Réservation introuvable !`}
+        title={t`Réservation introuvable\u00a0!`}
         icon={NoBookings}
         iconSize={getSpacing(40)}>
         <StyledBody>{t`Désolé, nous ne retrouvons pas ta réservation. Peut-être a-t-elle été annulée. N'hésite pas à retrouver la liste de tes réservations terminées et annulées pour t'en assurer.`}</StyledBody>

--- a/src/features/eighteenBirthday/pages/components/EighteenBirthdayCard.tsx
+++ b/src/features/eighteenBirthday/pages/components/EighteenBirthdayCard.tsx
@@ -30,7 +30,7 @@ export function EighteenBirthdayCard(props: AchievementCardKeyProps) {
         message:
           'Tu pourras bénéficier des {deposit} offerts par le Ministère de la Culture dès que tu auras vérifié ton identité',
       })}
-      title={t`Bonne nouvelle !`}
+      title={t`Bonne nouvelle\u00a0!`}
       swiperRef={props.swiperRef}
       name={props.name}
       index={props.index}

--- a/src/features/errors/pages/AsyncErrorBoundary.tsx
+++ b/src/features/errors/pages/AsyncErrorBoundary.tsx
@@ -62,7 +62,7 @@ export const AsyncErrorBoundaryWithoutNavigation = ({
       <BrokenConnection color={ColorsEnum.WHITE} />
       <Spacer.Column numberOfSpaces={2} />
 
-      <Typo.Title1 color={ColorsEnum.WHITE}>{t`Oups !`}</Typo.Title1>
+      <Typo.Title1 color={ColorsEnum.WHITE}>{t`Oups\u00a0!`}</Typo.Title1>
       <Spacer.Column numberOfSpaces={4} />
 
       <Row>

--- a/src/features/errors/pages/tests/AsyncErrorBoundary.native.test.tsx
+++ b/src/features/errors/pages/tests/AsyncErrorBoundary.native.test.tsx
@@ -50,7 +50,7 @@ describe('Usage of AsyncErrorBoundary as fallback in ErrorBoundary', () => {
     // TODO (PC-6360) : console error displayed in DEV mode even if caught by ErrorBoundary
     const { getByText } = renderErrorBoundary()
 
-    expect(getByText('Oups !')).toBeTruthy()
+    expect(getByText('Oups\u00a0!')).toBeTruthy()
   })
 })
 

--- a/src/features/favorites/components/NoFavoritesResult.tsx
+++ b/src/features/favorites/components/NoFavoritesResult.tsx
@@ -18,7 +18,7 @@ export const NoFavoritesResult = () => {
         <EmptyFavorites size={197} color={ColorsEnum.GREY_MEDIUM} />
       </IconContainer>
       <Explanation color={ColorsEnum.GREY_DARK}>
-        {t`Retrouve toutes tes offres en un clin d'oeil en les ajoutant à tes favoris !`}
+        {t`Retrouve toutes tes offres en un clin d'oeil en les ajoutant à tes favoris\u00a0!`}
       </Explanation>
       <Spacer.Column numberOfSpaces={6} />
       <ButtonContainer>

--- a/src/features/favorites/components/NotConnectedFavorites.tsx
+++ b/src/features/favorites/components/NotConnectedFavorites.tsx
@@ -21,14 +21,14 @@ export const NotConnectedFavorites = () => {
 
       <CenteredContainer>
         <TypoTitle4 color={ColorsEnum.WHITE}>
-          {t`Connecte-toi pour profiter de cette fonctionnalité !`}
+          {t`Connecte-toi pour profiter de cette fonctionnalité\u00a0!`}
         </TypoTitle4>
         <Spacer.Column numberOfSpaces={4} />
 
         <TextContainer>
           <CenteredText>
             <Typo.Body color={ColorsEnum.WHITE}>
-              {t`Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil !`}
+              {t`Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil\u00a0!`}
             </Typo.Body>
           </CenteredText>
         </TextContainer>

--- a/src/features/favorites/components/__tests__/NoFavoritesResult.test.tsx
+++ b/src/features/favorites/components/__tests__/NoFavoritesResult.test.tsx
@@ -28,7 +28,7 @@ jest.mock('features/favorites/pages/FavoritesWrapper', () => ({
 describe('NoFavoritesResult component', () => {
   it('should show the message', () => {
     const text = render(<NoFavoritesResult />).getByText(
-      `Retrouve toutes tes offres en un clin d'oeil en les ajoutant à tes favoris !`
+      `Retrouve toutes tes offres en un clin d'oeil en les ajoutant à tes favoris\u00a0!`
     )
     expect(text).toBeTruthy()
   })

--- a/src/features/favorites/pages/__tests__/Favorites.native.test.tsx
+++ b/src/features/favorites/pages/__tests__/Favorites.native.test.tsx
@@ -30,7 +30,7 @@ describe('Favorites component', () => {
 
   it('should show non connected page when not logged in', () => {
     const { getByText } = renderFavorites({ isLoggedIn: false })
-    expect(getByText('Connecte-toi pour profiter de cette fonctionnalité !')).toBeTruthy()
+    expect(getByText('Connecte-toi pour profiter de cette fonctionnalité\u00a0!')).toBeTruthy()
   })
 
   it('should show loading when not logged in', () => {

--- a/src/features/firstTutorial/pages/FirstTutorial/components/FourthCard.tsx
+++ b/src/features/firstTutorial/pages/FirstTutorial/components/FourthCard.tsx
@@ -33,7 +33,7 @@ export function FourthCard(props: AchievementCardKeyProps) {
       buttonText={t`Découvrir`}
       pauseAnimationOnRenderAtFrame={62}
       subTitle={t`quotidiennes`}
-      text={t`Nos nombreux partenaires ajoutent de nouvelles offres quotidiennement. Découvre les dès maintenant !`}
+      text={t`Nos nombreux partenaires ajoutent de nouvelles offres quotidiennement. Découvre les dès maintenant\u00a0!`}
       title={t`Des nouveautés`}
       swiperRef={props.swiperRef}
       name={props.name}

--- a/src/features/firstTutorial/pages/FirstTutorial/components/ThirdCard.tsx
+++ b/src/features/firstTutorial/pages/FirstTutorial/components/ThirdCard.tsx
@@ -29,7 +29,7 @@ export function ThirdCard(props: AchievementCardKeyProps) {
       buttonCallback={onGeolocationButtonPress}
       buttonText={t`Activer la géolocalisation`}
       pauseAnimationOnRenderAtFrame={62}
-      subTitle={t`à portée de main !`}
+      subTitle={t`à portée de main\u00a0!`}
       text={t`Active la géolocalisation pour découvrir toutes les offres existantes autour de toi.`}
       title={t`Toute la culture`}
       swiperRef={props.swiperRef}

--- a/src/features/home/components/HomeHeader.tsx
+++ b/src/features/home/components/HomeHeader.tsx
@@ -27,7 +27,7 @@ export const HomeHeader: FunctionComponent = function () {
         values: { name: userInfos?.firstName },
         message: 'Bonjour {name}',
       })
-    : t`Bienvenue !`
+    : t`Bienvenue\u00a0!`
 
   let subtitle = t`Toute la culture à portée de main`
   if (userInfos?.isBeneficiary && availableCredit) {

--- a/src/features/home/components/NoContentError.tsx
+++ b/src/features/home/components/NoContentError.tsx
@@ -19,7 +19,7 @@ export const NoContentError = () => {
   }
 
   return (
-    <GenericInfoPage title={t`Oups !`} icon={BrokenConnection} iconSize={200}>
+    <GenericInfoPage title={t`Oups\u00a0!`} icon={BrokenConnection} iconSize={200}>
       <BodyText>{t`Une erreur s’est produite pendant le chargement de nos recommandations.`}</BodyText>
       <Spacer.Column numberOfSpaces={4} />
       <SearchButton

--- a/src/features/home/pages/tests/Home.native.test.tsx
+++ b/src/features/home/pages/tests/Home.native.test.tsx
@@ -59,8 +59,8 @@ describe('Home component', () => {
 
   it('should have a welcome message', async () => {
     const { getByText } = await homeRenderer({ isLoggedIn: false })
-    const welcomeText = getByText('Bienvenue !')
-    expect(welcomeText.props.children).toBe('Bienvenue !')
+    const welcomeText = getByText('Bienvenue\u00a0!')
+    expect(welcomeText.props.children).toBe('Bienvenue\u00a0!')
   })
 
   it('should have a personalized welcome message when user is logged in', async () => {

--- a/src/features/identityCheck/atoms/IdentityVerificationText.web.tsx
+++ b/src/features/identityCheck/atoms/IdentityVerificationText.web.tsx
@@ -9,7 +9,7 @@ export const IdentityVerificationText = () => (
     <Title>{t`Vérifie ton identité sur ton smartphone`}</Title>
     <Spacer.Column numberOfSpaces={6} />
     <Body>
-      {t`Gagne du temps en vérifiant ton identité directement sur ton smartphone ! Sinon tu peux passer par le site Démarches-Simplifiées mais le traitement sera plus long.`}
+      {t`Gagne du temps en vérifiant ton identité directement sur ton smartphone\u00a0! Sinon tu peux passer par le site Démarches-Simplifiées mais le traitement sera plus long.`}
     </Body>
     <Spacer.Column numberOfSpaces={2} />
     <Body>

--- a/src/features/identityCheck/components/DMSModal.tsx
+++ b/src/features/identityCheck/components/DMSModal.tsx
@@ -37,7 +37,7 @@ export const DMSModal: FunctionComponent<Props> = ({ visible, hideModal }) => (
     rightIcon={undefined}
     onRightIconPress={undefined}>
     <Typo.Body color={ColorsEnum.GREY_DARK}>
-      {t`Tu peux aussi compléter ton dossier sur Démarches simplifiées. Attention le traitement sera plus long !`}
+      {t`Tu peux aussi compléter ton dossier sur Démarches simplifiées. Attention le traitement sera plus long\u00a0!`}
     </Typo.Body>
     <Spacer.Column numberOfSpaces={8} />
     <CustomButtonTertiaryBlack

--- a/src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
+++ b/src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
@@ -45,7 +45,7 @@ const OutOfTestPhase: NotEligibleEduConnectErrorData = {
 
 const UserAgeNotValid: NotEligibleEduConnectErrorData = {
   Icon: InfoFraud,
-  title: t`Oh non !`,
+  title: t`Oh non\u00a0!`,
   description:
     t`La date de naissance enregistrée dans ÉduConnect semble indiquer que tu n'as pas l'âge requis pour obtenir l'aide du Gouvernement.` +
     '\n\n' +
@@ -58,7 +58,7 @@ const getInvalidInformation = (
   onPrimaryButtonPress: () => Promise<void>
 ): NotEligibleEduConnectErrorData => ({
   Icon: InfoFraud,
-  title: t`Oh non !`,
+  title: t`Oh non\u00a0!`,
   description:
     t`Il semblerait que les informations que tu nous as communiquées ne soient pas correctes.` +
     '\n\n' +
@@ -86,7 +86,7 @@ const getUserTypeNotStudent = (
 
 const GenericError: NotEligibleEduConnectErrorData = {
   Icon: MaintenanceCone,
-  title: t`Oups !`,
+  title: t`Oups\u00a0!`,
   description: t`Une erreur s'est produite pendant le chargement`,
   titleAlignment: 'center',
   descriptionAlignment: 'center',

--- a/src/features/identityCheck/pages/Stepper.tsx
+++ b/src/features/identityCheck/pages/Stepper.tsx
@@ -72,7 +72,7 @@ export const IdentityCheckStepper = () => {
           <Spacer.TopScreen />
           {theme.isDesktopViewport ? <Spacer.Column numberOfSpaces={2} /> : <Spacer.Flex />}
 
-          <Title>{t`C’est très rapide !`}</Title>
+          <Title>{t`C’est très rapide\u00a0!`}</Title>
           <Spacer.Column numberOfSpaces={2} />
 
           <StyledBody>{t`Voici les 3 étapes que tu vas devoir suivre.`}</StyledBody>

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.tsx
@@ -34,19 +34,19 @@ export function BeneficiaryRequestSent() {
 
   let inTheMeantime = ''
   if (shouldNavigateToCulturalSurvey) {
-    inTheMeantime = t`En attendant, aide-nous à en savoir plus sur tes pratiques culturelles !`
+    inTheMeantime = t`En attendant, aide-nous à en savoir plus sur tes pratiques culturelles\u00a0!`
   } else if (settings?.enableIdCheckRetention) {
-    inTheMeantime = t`En attendant, tu peux découvrir l'application !`
+    inTheMeantime = t`En attendant, tu peux découvrir l'application\u00a0!`
   }
 
   const message = inTheMeantime.length ? `${body} ${inTheMeantime}` : body
 
   return (
-    <GenericInfoPage title={t`Demande envoyée !`} icon={RequestSent} iconSize={getSpacing(42)}>
+    <GenericInfoPage title={t`Demande envoyée\u00a0!`} icon={RequestSent} iconSize={getSpacing(42)}>
       <StyledBody>{t`Nous étudions ton dossier...`}</StyledBody>
       <StyledBody>{message}</StyledBody>
       <Spacer.Column numberOfSpaces={15} />
-      <ButtonPrimaryWhite title={t`On y va !`} onPress={onPress} />
+      <ButtonPrimaryWhite title={t`On y va\u00a0!`} onPress={onPress} />
     </GenericInfoPage>
   )
 }

--- a/src/features/identityCheck/pages/confirmation/__test__/BeneficiaryRequestSent.test.tsx
+++ b/src/features/identityCheck/pages/confirmation/__test__/BeneficiaryRequestSent.test.tsx
@@ -28,7 +28,7 @@ describe('<BeneficiaryRequestSent />', () => {
   it('should redirect to cultural survey page WHEN "On y va !" button is clicked', () => {
     const { getByText } = render(<BeneficiaryRequestSent />)
 
-    fireEvent.press(getByText('On y va !'))
+    fireEvent.press(getByText('On y va\u00a0!'))
 
     expect(navigateToHome).not.toBeCalled()
     expect(navigate).toBeCalledTimes(1)
@@ -41,7 +41,7 @@ describe('<BeneficiaryRequestSent />', () => {
     } as UseQueryResult<UserProfileResponse>)
     const { getByText } = render(<BeneficiaryRequestSent />)
 
-    fireEvent.press(getByText('On y va !'))
+    fireEvent.press(getByText('On y va\u00a0!'))
 
     expect(navigateToHome).toBeCalledTimes(1)
     expect(navigate).not.toBeCalledWith('CulturalSurvey')
@@ -53,7 +53,7 @@ describe('<BeneficiaryRequestSent />', () => {
     } as UseQueryResult<UserProfileResponse>)
     const { getByText } = render(<BeneficiaryRequestSent />)
 
-    fireEvent.press(getByText('On y va !'))
+    fireEvent.press(getByText('On y va\u00a0!'))
 
     expect(navigateToHome).toBeCalledTimes(1)
     expect(navigate).not.toBeCalledWith('CulturalSurvey')
@@ -71,7 +71,7 @@ describe('<BeneficiaryRequestSent />', () => {
 
     const { getByText } = render(<BeneficiaryRequestSent />)
     getByText(
-      "Tu recevras une réponse par e-mail sous 5 jours ouvrés. En attendant, tu peux découvrir l'application !"
+      "Tu recevras une réponse par e-mail sous 5 jours ouvrés. En attendant, tu peux découvrir l'application\u00a0!"
     )
   })
 
@@ -85,7 +85,7 @@ describe('<BeneficiaryRequestSent />', () => {
     } as UseQueryResult<UserProfileResponse>)
     const { getByText } = render(<BeneficiaryRequestSent />)
     getByText(
-      'Tu recevras une réponse par e-mail sous 5 jours ouvrés. En attendant, aide-nous à en savoir plus sur tes pratiques culturelles !'
+      'Tu recevras une réponse par e-mail sous 5 jours ouvrés. En attendant, aide-nous à en savoir plus sur tes pratiques culturelles\u00a0!'
     )
   })
 })

--- a/src/features/identityCheck/pages/identification/IdentityCheckEduConnectForm.web.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckEduConnectForm.web.tsx
@@ -68,7 +68,7 @@ export const IdentityCheckEduConnectForm = () => {
             <Spacer.Column numberOfSpaces={4} />
 
             <JustifiedText color={ColorsEnum.GREY_DARK}>
-              {t`Pour procéder à ton identification, nous allons te demander de te connecter à ÉduConnect. Muni toi de ton identifiant et de ton mot de passe ÉduConnect. Dès que tu as bien complété le parcours, reviens sur ce site pour terminer ton inscription et découvrir toutes les offres du pass Culture !`}
+              {t`Pour procéder à ton identification, nous allons te demander de te connecter à ÉduConnect. Muni toi de ton identifiant et de ton mot de passe ÉduConnect. Dès que tu as bien complété le parcours, reviens sur ce site pour terminer ton inscription et découvrir toutes les offres du pass Culture\u00a0!`}
             </JustifiedText>
 
             <Spacer.Column numberOfSpaces={8} />

--- a/src/features/identityCheck/pages/identification/IdentityCheckEnd.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckEnd.tsx
@@ -16,7 +16,7 @@ export const IdentityCheckEnd = () => {
 
   return (
     <GenericInfoPage
-      title={t`Ta pièce d’identité a bien été transmise !`}
+      title={t`Ta pièce d’identité a bien été transmise\u00a0!`}
       icon={EmailSent}
       iconSize={getSpacing(42)}
     />

--- a/src/features/identityCheck/pages/identification/IdentityCheckPending.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckPending.tsx
@@ -11,7 +11,7 @@ import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
 export function IdentityCheckPending() {
   return (
     <GenericInfoPage
-      title={t`Oups !`}
+      title={t`Oups\u00a0!`}
       icon={({ color }) => <IdCardError size={getSpacing(36)} color={color} />}>
       <StyledBody>{t`Il y a déjà une demande de crédit pass Culture en cours sur ton compte.`}</StyledBody>
       <Spacer.Column numberOfSpaces={5} />

--- a/src/features/identityCheck/pages/identification/IdentityCheckUnavailable.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckUnavailable.tsx
@@ -18,7 +18,7 @@ export function IdentityCheckUnavailable() {
   const { params } = useRoute<UseRouteType<'IdentityCheckUnavailable'>>()
   return (
     <GenericInfoPage
-      title={t`Victime de notre succès !`}
+      title={t`Victime de notre succès\u00a0!`}
       icon={({ color }) => <HappyFace size={getSpacing(30)} color={color} />}>
       <StyledBody>{t`Vous êtes actuellement très nombreux à vouloir créer un compte, notre service rencontre quelques difficultés.`}</StyledBody>
       <Spacer.Column numberOfSpaces={5} />

--- a/src/features/maintenance/Maintenance.tsx
+++ b/src/features/maintenance/Maintenance.tsx
@@ -26,7 +26,7 @@ export const Maintenance: React.FC<MaintenanceProps> = (props) => {
         <StyledBody>
           {props.message
             ? props.message
-            : t`L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !`}
+            : t`L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement\u00a0!`}
         </StyledBody>
         <Spacer.Column numberOfSpaces={24} />
         <LogoPassCulture />

--- a/src/features/navigation/PageNotFound.tsx
+++ b/src/features/navigation/PageNotFound.tsx
@@ -11,7 +11,7 @@ import { ColorsEnum, Spacer, Typo, getSpacing } from 'ui/theme'
 export const PageNotFound: React.FC = () => {
   return (
     <GenericInfoPage
-      title={t`Page introuvable !`}
+      title={t`Page introuvable\u00a0!`}
       icon={PageNotFoundIcon}
       iconSize={getSpacing(40)}>
       <StyledBody>{t`Il est possible que cette page soit désactivée ou n'existe pas.`}</StyledBody>

--- a/src/features/navigation/RootNavigator/routes.ts
+++ b/src/features/navigation/RootNavigator/routes.ts
@@ -144,7 +144,7 @@ export const routes: Route[] = [
     name: 'AccountCreated',
     component: AccountCreated,
     path: 'creation-compte/confirmation',
-    options: { title: t`Compte créé !` },
+    options: { title: t`Compte créé\u00a0!` },
   },
   {
     name: 'AfterChangeEmailValidationBuffer',
@@ -399,7 +399,7 @@ export const routes: Route[] = [
     name: 'UnderageAccountCreated',
     component: UnderageAccountCreated,
     path: 'creation-compte/confirmation-15-17',
-    options: { title: t`Compte 15-17 créé !` },
+    options: { title: t`Compte 15-17 créé\u00a0!` },
   },
   {
     name: 'Venue',

--- a/src/features/offer/components/OfferIconCaptions.tsx
+++ b/src/features/offer/components/OfferIconCaptions.tsx
@@ -36,7 +36,7 @@ export const OfferIconCaptions: React.FC<Props> = ({ isDuo, stocks, categoryId, 
       {!!showDuo && (
         <React.Fragment>
           <Separator />
-          <IconWithCaption testID="iconDuo" Icon={Duo} caption={t`À deux !`} />
+          <IconWithCaption testID="iconDuo" Icon={Duo} caption={t`À deux\u00a0!`} />
         </React.Fragment>
       )}
       <Separator />

--- a/src/features/offer/components/SignUpSignInChoiceOfferModal.tsx
+++ b/src/features/offer/components/SignUpSignInChoiceOfferModal.tsx
@@ -44,7 +44,7 @@ export const SignUpSignInChoiceOfferModal: FunctionComponent<Props> = ({
       onRightIconPress={dismissModal}>
       <Description>
         <Typo.Body>
-          {t`Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil !`}
+          {t`Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil\u00a0!`}
         </Typo.Body>
       </Description>
 

--- a/src/features/offer/components/__tests__/OfferHeader.native.test.tsx
+++ b/src/features/offer/components/__tests__/OfferHeader.native.test.tsx
@@ -104,7 +104,7 @@ describe('<OfferHeader />', () => {
     const url = getOfferUrl(116656)
     const message =
       'Retrouve "Sous les étoiles de Paris - VF" chez "PATHE BEAUGRENELLE" sur le pass Culture'
-    const title = "Je t'invite à découvrir une super offre sur le pass Culture !"
+    const title = "Je t'invite à découvrir une super offre sur le pass Culture\u00a0!"
 
     expect(share).toHaveBeenCalledWith(
       { message, title, url },
@@ -123,7 +123,7 @@ describe('<OfferHeader />', () => {
     const messageWithUrl =
       'Retrouve "Sous les étoiles de Paris - VF" chez "PATHE BEAUGRENELLE" sur le pass Culture\n\n' +
       url
-    const title = "Je t'invite à découvrir une super offre sur le pass Culture !"
+    const title = "Je t'invite à découvrir une super offre sur le pass Culture\u00a0!"
 
     expect(share).toHaveBeenCalledWith(
       { message: messageWithUrl, title, url },

--- a/src/features/offer/components/__tests__/OfferIconCaptions.native.test.tsx
+++ b/src/features/offer/components/__tests__/OfferIconCaptions.native.test.tsx
@@ -121,9 +121,9 @@ describe('<OfferIconCaptions />', () => {
       })
       await waitForExpect(() => {
         if (show === 'show') {
-          expect(component.queryByText(/À deux !/)).toBeTruthy()
+          expect(component.queryByText(/À deux\u00a0!/)).toBeTruthy()
         } else {
-          expect(component.queryByText(/À deux !/)).toBeNull()
+          expect(component.queryByText(/À deux\u00a0!!/)).toBeNull()
         }
       })
     }

--- a/src/features/offer/pages/OfferNotFound.tsx
+++ b/src/features/offer/pages/OfferNotFound.tsx
@@ -28,7 +28,7 @@ export const OfferNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
       <Helmet>
         <title>{t`Offre introuvable | Pass Culture`}</title>
       </Helmet>
-      <GenericInfoPage title={t`Offre introuvable !`} icon={NoOffer} iconSize={getSpacing(40)}>
+      <GenericInfoPage title={t`Offre introuvable\u00a0!`} icon={NoOffer} iconSize={getSpacing(40)}>
         <StyledBody>{t`Il est possible que cette offre soit désactivée ou n'existe pas.`}</StyledBody>
         <Spacer.Column numberOfSpaces={12} />
         <ButtonPrimaryWhite title={t`Retourner à l'accueil`} onPress={onPress} />

--- a/src/features/offer/services/useShareOffer.ts
+++ b/src/features/offer/services/useShareOffer.ts
@@ -29,7 +29,7 @@ async function shareOffer(offer: OfferResponse) {
 
   // url share content param is only for iOs, so we add url in message for android
   const completeMessage = Platform.OS === 'ios' ? message : message.concat(`\n\n${url}`)
-  const title = t`Je t'invite à découvrir une super offre sur le pass Culture !`
+  const title = t`Je t'invite à découvrir une super offre sur le pass Culture\u00a0!`
   const shareContent = {
     message: completeMessage,
     url, // iOS only

--- a/src/features/profile/components/ExBeneficiaryHeader.test.tsx
+++ b/src/features/profile/components/ExBeneficiaryHeader.test.tsx
@@ -13,10 +13,10 @@ describe('ExBeneficiaryHeader', () => {
     getByText('Rosa Bonheur')
     getByText('crédit expiré le 25/12/2020')
     getByText('Mon crédit est expiré, que faire ?')
-    getByText('Ton crédit pass Culture est arrivé à expiration mais l’aventure continue !')
+    getByText('Ton crédit pass Culture est arrivé à expiration mais l’aventure continue\u00a0!')
     getByText('Tu peux toujours réserver les offres gratuites exclusives au pass Culture.')
     getByText(
-      "Tu peux aussi découvrir les autres activités culturelles sur l'application mais leur réservation s'effectuera sur les sites de nos partenaires !"
+      "Tu peux aussi découvrir les autres activités culturelles sur l'application mais leur réservation s'effectuera sur les sites de nos partenaires\u00a0!"
     )
   })
 })

--- a/src/features/profile/components/ExBeneficiaryHeader.tsx
+++ b/src/features/profile/components/ExBeneficiaryHeader.tsx
@@ -47,14 +47,14 @@ export function ExBeneficiaryHeader(props: ExBeneficiaryHeaderProps) {
           titleStyle={accordionStyle.title}
           bodyStyle={accordionStyle.body}>
           <Description>
-            {t`Ton crédit pass Culture est arrivé à expiration mais l’aventure continue !`}
+            {t`Ton crédit pass Culture est arrivé à expiration mais l’aventure continue\u00a0!`}
           </Description>
           <Spacer.Column numberOfSpaces={5} />
           <Description>
             {t`Tu peux toujours réserver les offres gratuites exclusives au pass Culture.`}
           </Description>
           <Description>
-            {t`Tu peux aussi découvrir les autres activités culturelles sur l'application mais leur réservation s'effectuera sur les sites de nos partenaires !`}
+            {t`Tu peux aussi découvrir les autres activités culturelles sur l'application mais leur réservation s'effectuera sur les sites de nos partenaires\u00a0!`}
           </Description>
         </AccordionItem>
         <Spacer.Column numberOfSpaces={2} />

--- a/src/features/profile/components/IdCheckProcessingBadge.tsx
+++ b/src/features/profile/components/IdCheckProcessingBadge.tsx
@@ -47,7 +47,7 @@ export function IdCheckProcessingBadge(props: IdCheckProcessingBadgeProps) {
         callToActionLink={props.subscriptionMessage?.callToAction?.callToActionLink}
         message={
           props.subscriptionMessage?.userMessage ||
-          t`Dossier déposé, nous avons bien reçu ton dossier et sommes en train de l’analyser !`
+          t`Dossier déposé, nous avons bien reçu ton dossier et sommes en train de l’analyser\u00a0!`
         }
       />
     </React.Fragment>

--- a/src/features/profile/pages/ChangeEmail/ChangeEmail.tsx
+++ b/src/features/profile/pages/ChangeEmail/ChangeEmail.tsx
@@ -44,7 +44,7 @@ export function ChangeEmail() {
     {
       onSuccess: () => {
         showSuccessSnackBar({
-          message: t`E-mail envoyé ! Tu as 24h pour activer ta nouvelle adresse. Si tu ne le trouves pas, pense à vérifier tes spams.`,
+          message: t`E-mail envoyé\u00a0! Tu as 24h pour activer ta nouvelle adresse. Si tu ne le trouves pas, pense à vérifier tes spams.`,
           timeout: SNACK_BAR_TIME_OUT,
         })
         navigateToProfile()

--- a/src/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.native.test.tsx
+++ b/src/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.native.test.tsx
@@ -136,7 +136,7 @@ describe('<ChangeEmail/>', () => {
       expect(navigate).toBeCalledWith('TabNavigator', { screen: 'Profile' })
       expect(mockShowSuccessSnackBar).toBeCalledWith({
         message:
-          'E-mail envoyé ! Tu as 24h pour activer ta nouvelle adresse. Si tu ne le trouves pas, pense à vérifier tes spams.',
+          'E-mail envoyé\u00a0! Tu as 24h pour activer ta nouvelle adresse. Si tu ne le trouves pas, pense à vérifier tes spams.',
         timeout: 5000,
       })
       expect(analytics.logSaveNewMail).toBeCalled()

--- a/src/features/recreditBirthdayNotification/pages/components/RecreditBirthdayNotification.tsx
+++ b/src/features/recreditBirthdayNotification/pages/components/RecreditBirthdayNotification.tsx
@@ -64,7 +64,7 @@ export const RecreditBirthdayNotification = () => {
   }, [animationRef])
 
   return (
-    <GenericInfoPageWhite animation={TutorialPassLogo} title={t`Bonne nouvelle !`}>
+    <GenericInfoPageWhite animation={TutorialPassLogo} title={t`Bonne nouvelle\u00a0!`}>
       <StyledSubtitle>
         {t({
           id: 'birthday notification text',

--- a/src/features/search/atoms/NoSearchResult.tsx
+++ b/src/features/search/atoms/NoSearchResult.tsx
@@ -32,7 +32,7 @@ export const NoSearchResult: React.FC = () => {
     <Container>
       <Spacer.Flex />
       <NoOffer size={156} />
-      <MainTitle>{t`Oups !`}</MainTitle>
+      <MainTitle>{t`Oups\u00a0!`}</MainTitle>
       <DescriptionErrorTextContainer>
         <DescriptionErrorText>{errorMessage}</DescriptionErrorText>
       </DescriptionErrorTextContainer>

--- a/src/features/venue/pages/VenueNotFound.tsx
+++ b/src/features/venue/pages/VenueNotFound.tsx
@@ -29,7 +29,7 @@ export const VenueNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
         <title>{t`Lieu introuvable | Pass Culture`}</title>
         <meta name="robots" content="noindex" />
       </Helmet>
-      <GenericInfoPage title={t`Lieu introuvable !`} icon={NoOffer} iconSize={getSpacing(40)}>
+      <GenericInfoPage title={t`Lieu introuvable\u00a0!`} icon={NoOffer} iconSize={getSpacing(40)}>
         <StyledBody>{t`Il est possible que ce lieu soit désactivé ou n'existe pas.`}</StyledBody>
         <Spacer.Column numberOfSpaces={12} />
         <ButtonPrimaryWhite title={t`Retourner à l'accueil`} onPress={onPress} />

--- a/src/libs/firestore/__tests__/maintenance.native.test.ts
+++ b/src/libs/firestore/__tests__/maintenance.native.test.ts
@@ -112,7 +112,7 @@ describe('[method] maintenanceStatus', () => {
       expect(mockedCallBack).toHaveBeenCalledWith({
         status: 'ON',
         message:
-          'L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !',
+          'L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement\u00a0!',
       })
     })
   })

--- a/src/libs/firestore/maintenance.ts
+++ b/src/libs/firestore/maintenance.ts
@@ -45,7 +45,7 @@ export const maintenanceStatusListener = (onMaintenanceChange: OnMaintenanceChan
         const message =
           typeof rawMessage === 'string'
             ? rawMessage
-            : t`L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !`
+            : t`L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement\u00a0!`
 
         const maintenance: Maintenance = maintenanceIsOn
           ? {

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -551,6 +551,10 @@ msgstr "Connecte-toi"
 msgid "Connecte-toi !"
 msgstr "Connecte-toi !"
 
+#: src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.tsx
+msgid "Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de modification."
+msgstr "Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de modification."
+
 #: src/features/offer/components/SignUpSignInChoiceOfferModal.tsx
 msgid "Connecte-toi pour profiter de cette fonctionnalité"
 msgstr "Connecte-toi pour profiter de cette fonctionnalité"
@@ -771,10 +775,6 @@ msgstr "Désactiver la géolocalisation"
 #: src/features/bookings/pages/BookingNotFound.tsx
 msgid "Désolé, nous ne retrouvons pas ta réservation. Peut-être a-t-elle été annulée. N'hésite pas à retrouver la liste de tes réservations terminées et annulées pour t'en assurer."
 msgstr "Désolé, nous ne retrouvons pas ta réservation. Peut-être a-t-elle été annulée. N'hésite pas à retrouver la liste de tes réservations terminées et annulées pour t'en assurer."
-
-#: src/features/auth/signup/useBeneficiaryValidationNavigation.ts
-msgid "Désolé, tu as effectué trop de tentatives. Essaye de nouveau dans 12 heures."
-msgstr "Désolé, tu as effectué trop de tentatives. Essaye de nouveau dans 12 heures."
 
 #: src/features/navigation/RootNavigator/routes.ts
 msgid "Détails de l'offre"
@@ -1000,6 +1000,10 @@ msgstr "Environ 10 jours"
 msgid "Environ 3 heures"
 msgstr "Environ 3 heures"
 
+#: src/features/navigation/RootNavigator/identityCheckRoutes.ts
+msgid "Erreur"
+msgstr "Erreur"
+
 #: src/features/auth/login/Login.tsx
 msgid "Erreur réseau. Tu peux réessayer une fois la connexion réétablie."
 msgstr "Erreur réseau. Tu peux réessayer une fois la connexion réétablie."
@@ -1028,6 +1032,10 @@ msgstr "Ex : 75017"
 #: src/features/favorites/components/NoFavoritesResult.tsx
 msgid "Explorer les offres"
 msgstr "Explorer les offres"
+
+#: src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.tsx
+msgid "Faire une nouvelle demande"
+msgstr "Faire une nouvelle demande"
 
 #: src/features/auth/signup/underageSignup/SelectSchoolHome.tsx
 msgid "Fais-tu partie de la phase de test ?"
@@ -1507,6 +1515,7 @@ msgid "Localisation"
 msgstr "Localisation"
 
 #: src/features/maintenance/Maintenance.tsx
+#: src/libs/firestore/maintenance.ts
 msgid "L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !"
 msgstr "L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !"
 
@@ -1818,6 +1827,7 @@ msgstr "On y va !"
 #: src/features/auth/signup/idCheck/DenyAccessToIdCheck.tsx
 #: src/features/errors/pages/AsyncErrorBoundary.tsx
 #: src/features/home/components/NoContentError.tsx
+#: src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
 #: src/features/identityCheck/pages/identification/IdentityCheckPending.tsx
 #: src/features/search/atoms/NoSearchResult.tsx
 #: src/ui/components/LayoutExpiredLink.tsx
@@ -2110,7 +2120,9 @@ msgstr "Refuser"
 msgid "Rends-toi vite sur le site pass Culture afin de la réserver"
 msgstr "Rends-toi vite sur le site pass Culture afin de la réserver"
 
-#: src/ui/components/LayoutExpiredLink.tsx
+#: src/features/auth/forgottenPassword/ResetPasswordExpiredLink/ResetPasswordExpiredLink.tsx
+#: src/features/auth/signup/SignupConfirmationExpiredLink/SignupConfirmationExpiredLink.tsx
+#: src/ui/components/__tests__/LayoutExpiredLink.test.tsx
 msgid "Renvoyer l'email"
 msgstr "Renvoyer l'email"
 
@@ -2295,6 +2307,7 @@ msgstr "Salle de projections"
 #: src/features/auth/login/Login.tsx
 #: src/features/favorites/components/NotConnectedFavorites.tsx
 #: src/features/offer/components/SignUpSignInChoiceOfferModal.tsx
+#: src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.tsx
 msgid "Se connecter"
 msgstr "Se connecter"
 
@@ -2322,10 +2335,6 @@ msgstr "Si tu as 18 ans, tu es éligible à une aide financière de"
 #: src/ui/components/LayoutExpiredLink.tsx
 msgid "Si tu as besoin d’aide n’hésite pas à :"
 msgstr "Si tu as besoin d’aide n’hésite pas à :"
-
-#: src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.tsx
-msgid "Si tu as besoin d’aide, n’hésite pas à contacter le support."
-msgstr "Si tu as besoin d’aide, n’hésite pas à contacter le support."
 
 #: src/features/auth/signup/underageSignup/SelectSchoolHome.tsx
 msgid "Si tu es élève dans"
@@ -2436,6 +2445,10 @@ msgstr "Titre, artiste, lieu..."
 #: src/features/profile/pages/AfterChangeEmailValidationBuffer/AfterChangeEmailValidationBuffer.tsx
 msgid "Ton adresse e-mail a été modifiée. Tu peux te reconnecter avec ta nouvelle adresse e-mail."
 msgstr "Ton adresse e-mail a été modifiée. Tu peux te reconnecter avec ta nouvelle adresse e-mail."
+
+#: src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.tsx
+msgid "Ton adresse e-mail n’a pas été modifiée. Le lien que tu reçois par e-mail expire 24h après sa réception."
+msgstr "Ton adresse e-mail n’a pas été modifiée. Le lien que tu reçois par e-mail expire 24h après sa réception."
 
 #: src/features/auth/signup/AccountCreated/AccountCreated.tsx
 msgid "Ton compte a été activé !"
@@ -2662,6 +2675,10 @@ msgstr "Tu peux aussi découvrir les autres activités culturelles sur l'applica
 msgid "Tu peux encore dépenser :"
 msgstr "Tu peux encore dépenser :"
 
+#: src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.tsx
+msgid "Tu peux faire une nouvelle demande de modification dans ton profil."
+msgstr "Tu peux faire une nouvelle demande de modification dans ton profil."
+
 #: src/features/identityCheck/pages/identification/IdentityCheckUnavailable.tsx
 msgid ""
 "Tu peux nous transmettre ton dossier via la plateforme Démarches Simplifiées.\n"
@@ -2673,10 +2690,6 @@ msgstr ""
 #: src/features/bookOffer/pages/BookingConfirmation.tsx
 msgid "Tu peux retrouver toutes les informations concernant ta réservation sur l’application"
 msgstr "Tu peux retrouver toutes les informations concernant ta réservation sur l’application"
-
-#: src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.tsx
-msgid "Tu peux te connecter sur ton profil pour recommencer le parcours de changement d’e-mail."
-msgstr "Tu peux te connecter sur ton profil pour recommencer le parcours de changement d’e-mail."
 
 #: src/features/profile/components/ExBeneficiaryHeader.tsx
 msgid "Tu peux toujours réserver les offres gratuites exclusives au pass Culture."
@@ -2758,6 +2771,10 @@ msgstr "Une erreur est survenue"
 #: src/features/identityCheck/api.ts
 msgid "Une erreur est survenue lors de la mise à jour de votre profil"
 msgstr "Une erreur est survenue lors de la mise à jour de votre profil"
+
+#: src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
+msgid "Une erreur s'est produite pendant le chargement"
+msgstr "Une erreur s'est produite pendant le chargement"
 
 #: src/features/errors/pages/AsyncErrorBoundary.tsx
 msgid "Une erreur s'est produite pendant le chargement."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -183,8 +183,8 @@ msgid "Aide financière 18 ans"
 msgstr "Aide financière 18 ans"
 
 #: src/features/auth/signup/AccountCreated/AccountCreated.tsx
-msgid "Aide-nous à en savoir plus sur tes pratiques culturelles ! Ta sélection n'aura pas d'impact sur les offres proposées."
-msgstr "Aide-nous à en savoir plus sur tes pratiques culturelles ! Ta sélection n'aura pas d'impact sur les offres proposées."
+msgid "Aide-nous à en savoir plus sur tes pratiques culturelles ! Ta sélection n'aura pas d'impact sur les offres proposées."
+msgstr "Aide-nous à en savoir plus sur tes pratiques culturelles ! Ta sélection n'aura pas d'impact sur les offres proposées."
 
 #: src/features/profile/pages/Profile.tsx
 msgid "Aides"
@@ -225,12 +225,12 @@ msgid "Attention tu n'as que 3 tentatives."
 msgstr "Attention tu n'as que 3 tentatives."
 
 #: src/features/bookOffer/components/BookingDetails.tsx
-msgid "Attention, il est impossible de réserver plusieurs fois la même offre !"
-msgstr "Attention, il est impossible de réserver plusieurs fois la même offre !"
+msgid "Attention, il est impossible de réserver plusieurs fois la même offre !"
+msgstr "Attention, il est impossible de réserver plusieurs fois la même offre !"
 
 #: src/features/bookOffer/components/BookingDetails.tsx
-msgid "Attention, ton crédit est insuffisant pour pouvoir réserver cette offre !"
-msgstr "Attention, ton crédit est insuffisant pour pouvoir réserver cette offre !"
+msgid "Attention, ton crédit est insuffisant pour pouvoir réserver cette offre !"
+msgstr "Attention, ton crédit est insuffisant pour pouvoir réserver cette offre !"
 
 #: src/features/search/pages/SuggestedPlaces.tsx
 msgid "Aucun lieu ne correspond à ta recherche"
@@ -321,22 +321,22 @@ msgid "Bien que l'ensemble du catalogue soit vérifié par nos soins, il n'est p
 msgstr "Bien que l'ensemble du catalogue soit vérifié par nos soins, il n'est pas impossible que certaines offres ne respectent pas les CGU."
 
 #: src/features/home/components/HomeHeader.tsx
-msgid "Bienvenue !"
-msgstr "Bienvenue !"
+msgid "Bienvenue !"
+msgstr "Bienvenue !"
 
 #: src/features/auth/signup/underageSignup/UnderageAccountCreated.tsx
 #: src/features/eighteenBirthday/pages/components/EighteenBirthdayCard.tsx
 #: src/features/recreditBirthdayNotification/pages/components/RecreditBirthdayNotification.tsx
-msgid "Bonne nouvelle !"
-msgstr "Bonne nouvelle !"
+msgid "Bonne nouvelle !"
+msgstr "Bonne nouvelle !"
 
 #: src/features/navigation/RootNavigator/routes.ts
 msgid "C'est pour bientôt"
 msgstr "C'est pour bientôt"
 
 #: src/features/auth/signup/VerifyEligiblity/NotYetUnderageEligibility.tsx
-msgid "C'est pour bientôt !"
-msgstr "C'est pour bientôt !"
+msgid "C'est pour bientôt !"
+msgstr "C'est pour bientôt !"
 
 #: src/features/auth/signup/SignupForm.tsx
 msgid "CGU & Données"
@@ -357,16 +357,16 @@ msgid "Catégories"
 msgstr "Catégories"
 
 #: src/features/bookings/pages/BookingDetails.tsx
-msgid "Ce code est ta preuve d’achat, il te permet d’accéder à ton offre ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder."
-msgstr "Ce code est ta preuve d’achat, il te permet d’accéder à ton offre ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder."
+msgid "Ce code est ta preuve d’achat, il te permet d’accéder à ton offre ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder."
+msgstr "Ce code est ta preuve d’achat, il te permet d’accéder à ton offre ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder."
 
 #: src/features/identityCheck/pages/profile/SetCity.tsx
 msgid "Ce code postal est introuvable. Réessaye un autre code postal ou renseigne un arrondissement (ex: 75001)."
 msgstr "Ce code postal est introuvable. Réessaye un autre code postal ou renseigne un arrondissement (ex: 75001)."
 
 #: src/features/bookings/pages/BookingDetails.tsx
-msgid "Ce code à 6 caractères est ta preuve d’achat ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder."
-msgstr "Ce code à 6 caractères est ta preuve d’achat ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder."
+msgid "Ce code à 6 caractères est ta preuve d’achat ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder."
+msgstr "Ce code à 6 caractères est ta preuve d’achat ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder."
 
 #: src/features/auth/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.tsx
 msgid "Ce lien de validation n'est plus valide"
@@ -485,12 +485,12 @@ msgid "Composants"
 msgstr "Composants"
 
 #: src/features/navigation/RootNavigator/routes.ts
-msgid "Compte 15-17 créé !"
-msgstr "Compte 15-17 créé !"
+msgid "Compte 15-17 créé !"
+msgstr "Compte 15-17 créé !"
 
 #: src/features/navigation/RootNavigator/routes.ts
-msgid "Compte créé !"
-msgstr "Compte créé !"
+msgid "Compte créé !"
+msgstr "Compte créé !"
 
 #: src/features/profile/pages/DeleteProfileSuccess.tsx
 msgid "Compte désactivé"
@@ -547,10 +547,6 @@ msgstr "Confirmer le mot de passe"
 msgid "Connecte-toi"
 msgstr "Connecte-toi"
 
-#: src/features/auth/login/Login.tsx
-msgid "Connecte-toi !"
-msgstr "Connecte-toi !"
-
 #: src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.tsx
 msgid "Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de modification."
 msgstr "Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de modification."
@@ -560,8 +556,12 @@ msgid "Connecte-toi pour profiter de cette fonctionnalité"
 msgstr "Connecte-toi pour profiter de cette fonctionnalité"
 
 #: src/features/favorites/components/NotConnectedFavorites.tsx
-msgid "Connecte-toi pour profiter de cette fonctionnalité !"
-msgstr "Connecte-toi pour profiter de cette fonctionnalité !"
+msgid "Connecte-toi pour profiter de cette fonctionnalité !"
+msgstr "Connecte-toi pour profiter de cette fonctionnalité !"
+
+#: src/features/auth/login/Login.tsx
+msgid "Connecte-toi !"
+msgstr "Connecte-toi !"
 
 #: src/features/navigation/RootNavigator/routes.ts
 msgid "Connexion"
@@ -669,8 +669,8 @@ msgid "C’est quoi ÉduConnect ?"
 msgstr "C’est quoi ÉduConnect ?"
 
 #: src/features/identityCheck/pages/Stepper.tsx
-msgid "C’est très rapide !"
-msgstr "C’est très rapide !"
+msgid "C’est très rapide !"
+msgstr "C’est très rapide !"
 
 #: src/features/identityCheck/pages/profile/SetSchoolType.tsx
 msgid "Dans quel type d'établissement ?"
@@ -706,8 +706,8 @@ msgid "Demande en attente"
 msgstr "Demande en attente"
 
 #: src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.tsx
-msgid "Demande envoyée !"
-msgstr "Demande envoyée !"
+msgid "Demande envoyée !"
+msgstr "Demande envoyée !"
 
 #: src/features/bookings/helpers.ts
 msgid "Dernier jour pour retirer"
@@ -738,8 +738,8 @@ msgid "Données personnelles"
 msgstr "Données personnelles"
 
 #: src/features/profile/components/IdCheckProcessingBadge.tsx
-msgid "Dossier déposé, nous avons bien reçu ton dossier et sommes en train de l’analyser !"
-msgstr "Dossier déposé, nous avons bien reçu ton dossier et sommes en train de l’analyser !"
+msgid "Dossier déposé, nous avons bien reçu ton dossier et sommes en train de l’analyser !"
+msgstr "Dossier déposé, nous avons bien reçu ton dossier et sommes en train de l’analyser !"
 
 #: src/features/bookOffer/components/BookDuoChoice.tsx
 #: src/features/bookOffer/components/BookDuoChoice.tsx
@@ -794,12 +794,12 @@ msgid "E-mail"
 msgstr "E-mail"
 
 #: src/features/auth/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.tsx
-msgid "E-mail envoyé !"
-msgstr "E-mail envoyé !"
+msgid "E-mail envoyé !"
+msgstr "E-mail envoyé !"
 
 #: src/features/profile/pages/ChangeEmail/ChangeEmail.tsx
-msgid "E-mail envoyé ! Tu as 24h pour activer ta nouvelle adresse. Si tu ne le trouves pas, pense à vérifier tes spams."
-msgstr "E-mail envoyé ! Tu as 24h pour activer ta nouvelle adresse. Si tu ne le trouves pas, pense à vérifier tes spams."
+msgid "E-mail envoyé ! Tu as 24h pour activer ta nouvelle adresse. Si tu ne le trouves pas, pense à vérifier tes spams."
+msgstr "E-mail envoyé ! Tu as 24h pour activer ta nouvelle adresse. Si tu ne le trouves pas, pense à vérifier tes spams."
 
 #: src/features/auth/login/Login.tsx
 msgid "E-mail ou mot de passe incorrect."
@@ -830,12 +830,12 @@ msgid "Email modification mot de passe expiré"
 msgstr "Email modification mot de passe expiré"
 
 #: src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.tsx
-msgid "En attendant, aide-nous à en savoir plus sur tes pratiques culturelles !"
-msgstr "En attendant, aide-nous à en savoir plus sur tes pratiques culturelles !"
+msgid "En attendant, aide-nous à en savoir plus sur tes pratiques culturelles !"
+msgstr "En attendant, aide-nous à en savoir plus sur tes pratiques culturelles !"
 
 #: src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.tsx
-msgid "En attendant, tu peux découvrir l'application !"
-msgstr "En attendant, tu peux découvrir l'application !"
+msgid "En attendant, tu peux découvrir l'application !"
+msgstr "En attendant, tu peux découvrir l'application !"
 
 #: src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
 msgid "En attendant, tu peux tout de même découvrir l'application mais sans pouvoir réserver les offres."
@@ -1092,8 +1092,8 @@ msgid "Format du lien incorrect"
 msgstr "Format du lien incorrect"
 
 #: src/features/identityCheck/atoms/IdentityVerificationText.web.tsx
-msgid "Gagne du temps en vérifiant ton identité directement sur ton smartphone ! Sinon tu peux passer par le site Démarches-Simplifiées mais le traitement sera plus long."
-msgstr "Gagne du temps en vérifiant ton identité directement sur ton smartphone ! Sinon tu peux passer par le site Démarches-Simplifiées mais le traitement sera plus long."
+msgid "Gagne du temps en vérifiant ton identité directement sur ton smartphone ! Sinon tu peux passer par le site Démarches-Simplifiées mais le traitement sera plus long."
+msgstr "Gagne du temps en vérifiant ton identité directement sur ton smartphone ! Sinon tu peux passer par le site Démarches-Simplifiées mais le traitement sera plus long."
 
 #: src/libs/parsers/venueType.ts
 msgid "Galeries d’art"
@@ -1310,8 +1310,8 @@ msgid "Je suis de nationalité étrangère"
 msgstr "Je suis de nationalité étrangère"
 
 #: src/features/offer/services/useShareOffer.ts
-msgid "Je t'invite à découvrir une super offre sur le pass Culture !"
-msgstr "Je t'invite à découvrir une super offre sur le pass Culture !"
+msgid "Je t'invite à découvrir une super offre sur le pass Culture !"
+msgstr "Je t'invite à découvrir une super offre sur le pass Culture !"
 
 #: src/features/profile/pages/NotificationSettings.tsx
 msgid "Je veux recevoir les recommandations personnalisées et meilleures offres du pass Culture."
@@ -1351,8 +1351,8 @@ msgid "L'application pass Culture utilise des traceurs susceptibles de réaliser
 msgstr "L'application pass Culture utilise des traceurs susceptibles de réaliser des statistiques sur ta navigation. Ceci permet d'améliorer la qualité et la sureté de ton expérience. Pour ces besoins, les analyses réalisées sont strictement anonymes et ne comportent aucune donnée personnelle."
 
 #: src/features/auth/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.tsx
-msgid "L'e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams !"
-msgstr "L'e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams !"
+msgid "L'e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams !"
+msgstr "L'e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams !"
 
 #: src/features/profile/pages/ChangeEmail/utils/useValidateEmail.ts
 msgid "L'e-mail saisi est identique à votre e-mail actuel"
@@ -1415,8 +1415,8 @@ msgid "Le but du pass Culture est de renforcer tes pratiques culturelles, mais a
 msgstr "Le but du pass Culture est de renforcer tes pratiques culturelles, mais aussi d'en créer de nouvelles."
 
 #: src/ui/components/LayoutExpiredLink.tsx
-msgid "Le lien est expiré !"
-msgstr "Le lien est expiré !"
+msgid "Le lien est expiré !"
+msgstr "Le lien est expiré !"
 
 #: src/features/deeplinks/useDeeplinkUrlHandler.ts
 msgid "Le lien est incorrect"
@@ -1502,12 +1502,12 @@ msgid "Lieu"
 msgstr "Lieu"
 
 #: src/features/venue/pages/VenueNotFound.tsx
-msgid "Lieu introuvable !"
-msgstr "Lieu introuvable !"
-
-#: src/features/venue/pages/VenueNotFound.tsx
 msgid "Lieu introuvable | Pass Culture"
 msgstr "Lieu introuvable | Pass Culture"
+
+#: src/features/venue/pages/VenueNotFound.tsx
+msgid "Lieu introuvable !"
+msgstr "Lieu introuvable !"
 
 #: src/features/search/pages/LocationFilter.tsx
 #: src/features/search/sections/titles.ts
@@ -1516,8 +1516,8 @@ msgstr "Localisation"
 
 #: src/features/maintenance/Maintenance.tsx
 #: src/libs/firestore/maintenance.ts
-msgid "L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !"
-msgstr "L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !"
+msgid "L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !"
+msgstr "L’application est actuellement en maintenance, mais sera à nouveau en ligne rapidement !"
 
 #: src/ui/components/inputs/DateInput.tsx
 #: src/ui/components/inputs/DateInput.web.test.tsx
@@ -1574,8 +1574,8 @@ msgid "Mes réservations terminées"
 msgstr "Mes réservations terminées"
 
 #: src/features/bookOffer/components/BookingImpossible.tsx
-msgid "Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !"
-msgstr "Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !"
+msgid "Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !"
+msgstr "Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !"
 
 #: src/features/bookOffer/components/BookingImpossible.tsx
 #: src/features/offer/components/OfferHeader.tsx
@@ -1707,8 +1707,8 @@ msgid "Nos conseils :"
 msgstr "Nos conseils :"
 
 #: src/features/firstTutorial/pages/FirstTutorial/components/FourthCard.tsx
-msgid "Nos nombreux partenaires ajoutent de nouvelles offres quotidiennement. Découvre les dès maintenant !"
-msgstr "Nos nombreux partenaires ajoutent de nouvelles offres quotidiennement. Découvre les dès maintenant !"
+msgid "Nos nombreux partenaires ajoutent de nouvelles offres quotidiennement. Découvre les dès maintenant !"
+msgstr "Nos nombreux partenaires ajoutent de nouvelles offres quotidiennement. Découvre les dès maintenant !"
 
 #: src/features/navigation/RootNavigator/routes.ts
 msgid "Notices légales"
@@ -1783,12 +1783,12 @@ msgid "Offre expirée"
 msgstr "Offre expirée"
 
 #: src/features/offer/pages/OfferNotFound.tsx
-msgid "Offre introuvable !"
-msgstr "Offre introuvable !"
-
-#: src/features/offer/pages/OfferNotFound.tsx
 msgid "Offre introuvable | Pass Culture"
 msgstr "Offre introuvable | Pass Culture"
+
+#: src/features/offer/pages/OfferNotFound.tsx
+msgid "Offre introuvable !"
+msgstr "Offre introuvable !"
 
 #: src/features/search/sections/OfferType.tsx
 #: src/libs/parsers/venueType.ts
@@ -1816,13 +1816,17 @@ msgstr "Offres"
 
 #: src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
 #: src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
-msgid "Oh non !"
-msgstr "Oh non !"
+msgid "Oh non !"
+msgstr "Oh non !"
 
 #: src/features/auth/signup/AccountCreated/AccountCreated.tsx
 #: src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.tsx
-msgid "On y va !"
-msgstr "On y va !"
+msgid "On y va !"
+msgstr "On y va !"
+
+#: src/features/bookOffer/components/BookingDetails.tsx
+msgid "Oups, cette offre n’est plus disponible !"
+msgstr "Oups, cette offre n’est plus disponible !"
 
 #: src/features/auth/signup/idCheck/DenyAccessToIdCheck.tsx
 #: src/features/errors/pages/AsyncErrorBoundary.tsx
@@ -1831,12 +1835,8 @@ msgstr "On y va !"
 #: src/features/identityCheck/pages/identification/IdentityCheckPending.tsx
 #: src/features/search/atoms/NoSearchResult.tsx
 #: src/ui/components/LayoutExpiredLink.tsx
-msgid "Oups !"
-msgstr "Oups !"
-
-#: src/features/bookOffer/components/BookingDetails.tsx
-msgid "Oups, cette offre n’est plus disponible !"
-msgstr "Oups, cette offre n’est plus disponible !"
+msgid "Oups !"
+msgstr "Oups !"
 
 #: src/libs/country-picker/CountryPicker.tsx
 msgid "Ouvrir la modale de choix de l'indicatif téléphonique"
@@ -1859,8 +1859,8 @@ msgid "Page introuvable"
 msgstr "Page introuvable"
 
 #: src/features/navigation/PageNotFound.tsx
-msgid "Page introuvable !"
-msgstr "Page introuvable !"
+msgid "Page introuvable !"
+msgstr "Page introuvable !"
 
 #: src/features/_marketingAndCommunication/components/DeeplinksGeneratorForm.tsx
 msgid "Pages"
@@ -1949,8 +1949,8 @@ msgid "Pour plus d'informations, nous t'invitons à consulter notre"
 msgstr "Pour plus d'informations, nous t'invitons à consulter notre"
 
 #: src/features/identityCheck/pages/identification/IdentityCheckEduConnectForm.web.tsx
-msgid "Pour procéder à ton identification, nous allons te demander de te connecter à ÉduConnect. Muni toi de ton identifiant et de ton mot de passe ÉduConnect. Dès que tu as bien complété le parcours, reviens sur ce site pour terminer ton inscription et découvrir toutes les offres du pass Culture !"
-msgstr "Pour procéder à ton identification, nous allons te demander de te connecter à ÉduConnect. Muni toi de ton identifiant et de ton mot de passe ÉduConnect. Dès que tu as bien complété le parcours, reviens sur ce site pour terminer ton inscription et découvrir toutes les offres du pass Culture !"
+msgid "Pour procéder à ton identification, nous allons te demander de te connecter à ÉduConnect. Muni toi de ton identifiant et de ton mot de passe ÉduConnect. Dès que tu as bien complété le parcours, reviens sur ce site pour terminer ton inscription et découvrir toutes les offres du pass Culture !"
+msgstr "Pour procéder à ton identification, nous allons te demander de te connecter à ÉduConnect. Muni toi de ton identifiant et de ton mot de passe ÉduConnect. Dès que tu as bien complété le parcours, reviens sur ce site pour terminer ton inscription et découvrir toutes les offres du pass Culture !"
 
 #: src/features/auth/signup/PhoneValidation/SetPhoneNumber.tsx
 msgid "Pour sécuriser l'accès à ton pass nous avons besoin de valider ton numéro."
@@ -2173,8 +2173,8 @@ msgid "Retrouve toutes les offres autour de chez toi en activant les données de
 msgstr "Retrouve toutes les offres autour de chez toi en activant les données de localisation."
 
 #: src/features/favorites/components/NoFavoritesResult.tsx
-msgid "Retrouve toutes tes offres en un clin d'oeil en les ajoutant à tes favoris !"
-msgstr "Retrouve toutes tes offres en un clin d'oeil en les ajoutant à tes favoris !"
+msgid "Retrouve toutes tes offres en un clin d'oeil en les ajoutant à tes favoris !"
+msgstr "Retrouve toutes tes offres en un clin d'oeil en les ajoutant à tes favoris !"
 
 #: src/features/auth/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
 #: src/features/auth/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.tsx
@@ -2247,16 +2247,16 @@ msgid "Réservation annulée"
 msgstr "Réservation annulée"
 
 #: src/features/bookOffer/pages/BookingConfirmation.tsx
-msgid "Réservation confirmée !"
-msgstr "Réservation confirmée !"
-
-#: src/features/bookings/pages/BookingNotFound.tsx
-msgid "Réservation introuvable !"
-msgstr "Réservation introuvable !"
+msgid "Réservation confirmée !"
+msgstr "Réservation confirmée !"
 
 #: src/features/bookings/pages/BookingNotFound.tsx
 msgid "Réservation introuvable | Pass Culture"
 msgstr "Réservation introuvable | Pass Culture"
+
+#: src/features/bookings/pages/BookingNotFound.tsx
+msgid "Réservation introuvable !"
+msgstr "Réservation introuvable !"
 
 #: src/features/navigation/TabBar/routes.ts
 #: src/features/navigation/TabBar/routes.ts
@@ -2293,8 +2293,8 @@ msgid "Saisis ta nouvelle adresse e-mail et ton mot de passe. Tu vas recevoir un
 msgstr "Saisis ta nouvelle adresse e-mail et ton mot de passe. Tu vas recevoir un e-mail sur ta nouvelle adresse avec un lien de confirmation valable 24h. Tu ne peux modifier ton adresse e-mail qu'une fois par jour."
 
 #: src/features/auth/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
-msgid "Saisis ton adresse e-mail pour recevoir un lien qui te permettra de réinitialiser ton mot de passe !"
-msgstr "Saisis ton adresse e-mail pour recevoir un lien qui te permettra de réinitialiser ton mot de passe !"
+msgid "Saisis ton adresse e-mail pour recevoir un lien qui te permettra de réinitialiser ton mot de passe !"
+msgstr "Saisis ton adresse e-mail pour recevoir un lien qui te permettra de réinitialiser ton mot de passe !"
 
 #: src/libs/parsers/venueType.ts
 msgid "Salle de concerts"
@@ -2312,8 +2312,8 @@ msgid "Se connecter"
 msgstr "Se connecter"
 
 #: src/features/_marketingAndCommunication/components/DeeplinksGeneratorForm.tsx
-msgid "Seulement les \"ids\" disposent de validation !"
-msgstr "Seulement les \"ids\" disposent de validation !"
+msgid "Seulement les \"ids\" disposent de validation !"
+msgstr "Seulement les \"ids\" disposent de validation !"
 
 #: src/features/search/sections/Location.tsx
 msgid "Seules les sorties et offres physiques seront affichées"
@@ -2419,8 +2419,8 @@ msgid "Ta date de naissance"
 msgstr "Ta date de naissance"
 
 #: src/features/identityCheck/pages/identification/IdentityCheckEnd.tsx
-msgid "Ta pièce d’identité a bien été transmise !"
-msgstr "Ta pièce d’identité a bien été transmise !"
+msgid "Ta pièce d’identité a bien été transmise !"
+msgstr "Ta pièce d’identité a bien été transmise !"
 
 #: src/features/bookings/components/BookingDetailsCancelButton.tsx
 msgid "Terminer"
@@ -2451,21 +2451,21 @@ msgid "Ton adresse e-mail n’a pas été modifiée. Le lien que tu reçois par 
 msgstr "Ton adresse e-mail n’a pas été modifiée. Le lien que tu reçois par e-mail expire 24h après sa réception."
 
 #: src/features/auth/signup/AccountCreated/AccountCreated.tsx
-msgid "Ton compte a été activé !"
-msgstr "Ton compte a été activé !"
+msgid "Ton compte a été activé !"
+msgstr "Ton compte a été activé !"
 
 #: src/features/favorites/components/NotConnectedFavorites.tsx
 #: src/features/offer/components/SignUpSignInChoiceOfferModal.tsx
-msgid "Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil !"
-msgstr "Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil !"
+msgid "Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil !"
+msgstr "Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil !"
 
 #: src/features/home/components/HomeHeader.tsx
 msgid "Ton crédit est expiré"
 msgstr "Ton crédit est expiré"
 
 #: src/features/profile/components/ExBeneficiaryHeader.tsx
-msgid "Ton crédit pass Culture est arrivé à expiration mais l’aventure continue !"
-msgstr "Ton crédit pass Culture est arrivé à expiration mais l’aventure continue !"
+msgid "Ton crédit pass Culture est arrivé à expiration mais l’aventure continue !"
+msgstr "Ton crédit pass Culture est arrivé à expiration mais l’aventure continue !"
 
 #: src/features/offer/components/ReportOfferDescription.tsx
 msgid "Ton identité restera anonyme auprès des acteurs culturels."
@@ -2484,8 +2484,8 @@ msgid "Ton mot de passe"
 msgstr "Ton mot de passe"
 
 #: src/features/auth/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
-msgid "Ton mot de passe a été modifié !"
-msgstr "Ton mot de passe a été modifié !"
+msgid "Ton mot de passe a été modifié !"
+msgstr "Ton mot de passe a été modifié !"
 
 #: src/features/profile/pages/ChangePassword/ChangePassword.tsx
 msgid "Ton mot de passe actuel"
@@ -2566,8 +2566,8 @@ msgstr "Trop de favoris enregistrés. Supprime des favoris pour en ajouter de no
 
 #: src/features/auth/signup/PhoneValidation/PhoneValidationTooManyAttempts/PhoneValidationTooManyAttempts.tsx
 #: src/features/auth/signup/PhoneValidation/PhoneValidationTooManySMSSent/PhoneValidationTooManySMSSent.tsx
-msgid "Trop de tentatives !"
-msgstr "Trop de tentatives !"
+msgid "Trop de tentatives !"
+msgstr "Trop de tentatives !"
 
 #: src/features/eighteenBirthday/pages/components/EighteenBirthdayCard.tsx
 msgid "Tu as 18 ans..."
@@ -2590,24 +2590,24 @@ msgid "Tu as dépassé le nombre d’essais autorisés. L’accès à ton crédi
 msgstr "Tu as dépassé le nombre d’essais autorisés. L’accès à ton crédit pass Culture a été bloqué. Pour le récupérer tu peux :"
 
 #: src/features/auth/signup/PhoneValidation/PhoneValidationTooManySMSSent/PhoneValidationTooManySMSSent.tsx
-msgid "Tu as dépassé le nombre d’essais autorisés. Tu pourras réessayer dans 12 heures !"
-msgstr "Tu as dépassé le nombre d’essais autorisés. Tu pourras réessayer dans 12 heures !"
+msgid "Tu as dépassé le nombre d’essais autorisés. Tu pourras réessayer dans 12 heures !"
+msgstr "Tu as dépassé le nombre d’essais autorisés. Tu pourras réessayer dans 12 heures !"
 
 #: src/features/recreditBirthdayNotification/pages/components/RecreditBirthdayNotification.tsx
 msgid "Tu as jusqu’à la veille de tes 18 ans pour profiter de ton budget."
 msgstr "Tu as jusqu’à la veille de tes 18 ans pour profiter de ton budget."
 
 #: src/features/auth/signup/underageSignup/UnderageAccountCreated.tsx
-msgid "Tu as jusqu’à la veille de tes 18 ans pour profiter de ton budget. Découvre dès maintenant les offres culturelles autour de chez toi !"
-msgstr "Tu as jusqu’à la veille de tes 18 ans pour profiter de ton budget. Découvre dès maintenant les offres culturelles autour de chez toi !"
+msgid "Tu as jusqu’à la veille de tes 18 ans pour profiter de ton budget. Découvre dès maintenant les offres culturelles autour de chez toi !"
+msgstr "Tu as jusqu’à la veille de tes 18 ans pour profiter de ton budget. Découvre dès maintenant les offres culturelles autour de chez toi !"
 
 #: src/features/auth/signup/SetBirthday/SetBirthday.tsx
 msgid "Tu dois avoir"
 msgstr "Tu dois avoir"
 
 #: src/features/bookings/pages/BookingDetails.tsx
-msgid "Tu dois présenter ta carte d’identité et ce code de 6 caractères pour profiter de ta réservation ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder."
-msgstr "Tu dois présenter ta carte d’identité et ce code de 6 caractères pour profiter de ta réservation ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder."
+msgid "Tu dois présenter ta carte d’identité et ce code de 6 caractères pour profiter de ta réservation ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder."
+msgstr "Tu dois présenter ta carte d’identité et ce code de 6 caractères pour profiter de ta réservation ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder."
 
 #: src/features/profile/pages/NotificationSettings.tsx
 msgid "Tu dois être connecté pour activer les notifications et rester informé des actualités du pass Culture"
@@ -2664,12 +2664,12 @@ msgid "Tu peux activer ou désactiver cette fonctionnalité dans les paramètres
 msgstr "Tu peux activer ou désactiver cette fonctionnalité dans les paramètres de ton appareil."
 
 #: src/features/identityCheck/components/DMSModal.tsx
-msgid "Tu peux aussi compléter ton dossier sur Démarches simplifiées. Attention le traitement sera plus long !"
-msgstr "Tu peux aussi compléter ton dossier sur Démarches simplifiées. Attention le traitement sera plus long !"
+msgid "Tu peux aussi compléter ton dossier sur Démarches simplifiées. Attention le traitement sera plus long !"
+msgstr "Tu peux aussi compléter ton dossier sur Démarches simplifiées. Attention le traitement sera plus long !"
 
 #: src/features/profile/components/ExBeneficiaryHeader.tsx
-msgid "Tu peux aussi découvrir les autres activités culturelles sur l'application mais leur réservation s'effectuera sur les sites de nos partenaires !"
-msgstr "Tu peux aussi découvrir les autres activités culturelles sur l'application mais leur réservation s'effectuera sur les sites de nos partenaires !"
+msgid "Tu peux aussi découvrir les autres activités culturelles sur l'application mais leur réservation s'effectuera sur les sites de nos partenaires !"
+msgstr "Tu peux aussi découvrir les autres activités culturelles sur l'application mais leur réservation s'effectuera sur les sites de nos partenaires !"
 
 #: src/features/profile/components/BeneficiaryCeilings.tsx
 msgid "Tu peux encore dépenser :"
@@ -2879,8 +2879,8 @@ msgid "Veux-tu abandonner la vérification d'identité ?"
 msgstr "Veux-tu abandonner la vérification d'identité ?"
 
 #: src/features/identityCheck/pages/identification/IdentityCheckUnavailable.tsx
-msgid "Victime de notre succès !"
-msgstr "Victime de notre succès !"
+msgid "Victime de notre succès !"
+msgstr "Victime de notre succès !"
 
 #: src/features/identityCheck/pages/Stepper.tsx
 msgid "Voici les 3 étapes que tu vas devoir suivre."
@@ -2933,8 +2933,8 @@ msgid "Vous êtes actuellement très nombreux à vouloir créer un compte, notre
 msgstr "Vous êtes actuellement très nombreux à vouloir créer un compte, notre service rencontre quelques difficultés."
 
 #: src/features/auth/signup/idCheck/DenyAccessToIdCheck.tsx
-msgid "Vous êtes actuellement très nombreux à vouloir effectuer votre demande des 300€. Tu recevras une alerte par mail pour commencer ta demande des 300€ dès que le service sera de nouveau disponible !"
-msgstr "Vous êtes actuellement très nombreux à vouloir effectuer votre demande des 300€. Tu recevras une alerte par mail pour commencer ta demande des 300€ dès que le service sera de nouveau disponible !"
+msgid "Vous êtes actuellement très nombreux à vouloir effectuer votre demande des 300€. Tu recevras une alerte par mail pour commencer ta demande des 300€ dès que le service sera de nouveau disponible !"
+msgstr "Vous êtes actuellement très nombreux à vouloir effectuer votre demande des 300€. Tu recevras une alerte par mail pour commencer ta demande des 300€ dès que le service sera de nouveau disponible !"
 
 #: src/features/navigation/RootNavigator/identityCheckRoutes.ts
 msgid "Vérification d'identité"
@@ -3295,8 +3295,8 @@ msgid "À activer"
 msgstr "À activer"
 
 #: src/features/offer/components/OfferIconCaptions.tsx
-msgid "À deux !"
-msgstr "À deux !"
+msgid "À deux !"
+msgstr "À deux !"
 
 #: src/features/auth/signup/underageSignup/SelectSchool.tsx
 msgid "Établissements partenaires"
@@ -3307,8 +3307,8 @@ msgid "à dépenser dans l'application"
 msgstr "à dépenser dans l'application"
 
 #: src/features/firstTutorial/pages/FirstTutorial/components/ThirdCard.tsx
-msgid "à portée de main !"
-msgstr "à portée de main !"
+msgid "à portée de main !"
+msgstr "à portée de main !"
 
 #: src/features/bookOffer/atoms/HourChoice.tsx
 msgid "épuisé"

--- a/src/ui/components/LayoutExpiredLink.tsx
+++ b/src/ui/components/LayoutExpiredLink.tsx
@@ -27,8 +27,8 @@ export function LayoutExpiredLink({
   customBodyText,
 }: Props) {
   return (
-    <GenericInfoPage title={t`Oups !`} icon={SadFace}>
-      <StyledBody>{t`Le lien est expiré !`}</StyledBody>
+    <GenericInfoPage title={t`Oups\u00a0!`} icon={SadFace}>
+      <StyledBody>{t`Le lien est expiré\u00a0!`}</StyledBody>
       <StyledBody>
         {customBodyText || t`Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien.`}
       </StyledBody>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12359

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
