### PR TITLE
(PC-12341) feat(EduConnectErrors): logout user

### DIFF
--- a/src/features/identityCheck/pages/errors/EduConnectErrors.tsx
+++ b/src/features/identityCheck/pages/errors/EduConnectErrors.tsx
@@ -7,6 +7,7 @@ import { UseRouteType } from 'features/navigation/RootNavigator'
 
 export const EduConnectErrors = withEduConnectErrorBoundary(() => {
   const { params } = useRoute<UseRouteType<'EduConnectErrors'>>()
+  params.logoutUrl && fetch(params.logoutUrl)
 
   if (params?.code === 'UserAgeNotValid18YearsOld') {
     throw new EduConnectError(EduConnectErrorMessageEnum.UserAgeNotValid18YearsOld)

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -32,7 +32,7 @@ export type IdentityCheckRootStackParamList = {
   IdentityCheckHonor: undefined
   BeneficiaryRequestSent: undefined
   // Errors
-  EduConnectErrors: { code?: string }
+  EduConnectErrors: { code?: string; logoutUrl?: string }
 }
 
 /**


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12341

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
