### PR TITLE
(PC-12365) fix(translations): replace space with nbsp before question mark

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     'local-rules/independant-mocks': ['error'],
     'local-rules/no-string-check-before-component': ['error'],
     'local-rules/no-react-query-provider-hoc': ['error'],
+    'local-rules/nbsp-in-french-translations': ['error'],
     '@typescript-eslint/ban-ts-comment': [
       2, // error
       {

--- a/__snapshots__/features/auth/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
@@ -13,7 +13,7 @@ Array [
     }
   >
     <View
-      accessibilityLabel="Pourquoi ?"
+      accessibilityLabel="Pourquoi ?"
       accessible={true}
       focusable={true}
       onClick={[Function]}
@@ -41,7 +41,7 @@ Array [
           "width": "100%",
         }
       }
-      testID="Pourquoi ?"
+      testID="Pourquoi ?"
     >
       <Text
         adjustsFontSizeToFit={false}
@@ -60,7 +60,7 @@ Array [
         }
         textColor="#eb0055"
       >
-        Pourquoi ?
+        Pourquoi ?
       </Text>
     </View>
     <View
@@ -708,7 +708,7 @@ exports[`SetBirthday Page should render properly 1`] = `
   }
 >
   <View
-    accessibilityLabel="Pourquoi ?"
+    accessibilityLabel="Pourquoi ?"
     accessible={true}
     focusable={true}
     onClick={[Function]}
@@ -736,7 +736,7 @@ exports[`SetBirthday Page should render properly 1`] = `
         "width": "100%",
       }
     }
-    testID="Pourquoi ?"
+    testID="Pourquoi ?"
   >
     <Text
       adjustsFontSizeToFit={false}
@@ -755,7 +755,7 @@ exports[`SetBirthday Page should render properly 1`] = `
       }
       textColor="#eb0055"
     >
-      Pourquoi ?
+      Pourquoi ?
     </Text>
   </View>
   <View

--- a/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.native-snap
+++ b/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.native-snap
@@ -125,7 +125,7 @@ exports[`<ForceUpdate/> should match snapshot 1`] = `
           ]
         }
       >
-        Le pass Culture ne semble plus à jour sur ton téléphone !
+        Le pass Culture ne semble plus à jour sur ton téléphone !
 Pour des questions de performance et de sécurité merci de télécharger la dernière version disponible.
       </Text>
       <View

--- a/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.web-snap
+++ b/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.web-snap
@@ -166,7 +166,7 @@ exports[`<ForceUpdate/> should match snapshot 1`] = `
           }
         }
       >
-        Le pass Culture de ton navigateur ne semble plus à jour !
+        Le pass Culture de ton navigateur ne semble plus à jour !
 Pour des questions de performance et de sécurité merci d'actualiser la page pour obtenir la dernière version disponible.
       </div>
       <div

--- a/__snapshots__/features/identityCheck/components/__test__/FastEduconnectConnectionRequestModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/__test__/FastEduconnectConnectionRequestModal.native.test.tsx.native-snap
@@ -304,7 +304,7 @@ exports[`<IdentityCheckEnd/> should render correctly if modal not visible 1`] = 
             Tu peux vérifier ton identité en moins de 2 minutes en utilisant ton compte ÉduConnect. Si tu n'as pas d'identifiants ÉduConnect rapproche toi de ton établissement.
           </Text>
           <View
-            accessibilityLabel="C’est quoi ÉduConnect ?"
+            accessibilityLabel="C’est quoi ÉduConnect ?"
             accessible={true}
             collapsable={false}
             focusable={true}
@@ -335,7 +335,7 @@ exports[`<IdentityCheckEnd/> should render correctly if modal not visible 1`] = 
                 "width": "100%",
               }
             }
-            testID="C’est quoi ÉduConnect ?"
+            testID="C’est quoi ÉduConnect ?"
           >
             <View
               fill="#151515"
@@ -365,7 +365,7 @@ exports[`<IdentityCheckEnd/> should render correctly if modal not visible 1`] = 
               textColor="#151515"
               textSize={12}
             >
-              C’est quoi ÉduConnect ?
+              C’est quoi ÉduConnect ?
             </Text>
           </View>
           <View
@@ -1098,7 +1098,7 @@ exports[`<IdentityCheckEnd/> should render correctly if modal visible 1`] = `
             Tu peux vérifier ton identité en moins de 2 minutes en utilisant ton compte ÉduConnect. Si tu n'as pas d'identifiants ÉduConnect rapproche toi de ton établissement.
           </Text>
           <View
-            accessibilityLabel="C’est quoi ÉduConnect ?"
+            accessibilityLabel="C’est quoi ÉduConnect ?"
             accessible={true}
             collapsable={false}
             focusable={true}
@@ -1129,7 +1129,7 @@ exports[`<IdentityCheckEnd/> should render correctly if modal visible 1`] = `
                 "width": "100%",
               }
             }
-            testID="C’est quoi ÉduConnect ?"
+            testID="C’est quoi ÉduConnect ?"
           >
             <View
               fill="#151515"
@@ -1159,7 +1159,7 @@ exports[`<IdentityCheckEnd/> should render correctly if modal visible 1`] = `
               textColor="#151515"
               textSize={12}
             >
-              C’est quoi ÉduConnect ?
+              C’est quoi ÉduConnect ?
             </Text>
           </View>
           <View

--- a/__snapshots__/features/identityCheck/pages/confirmation/__test__/IdentityCheckHonor.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/__test__/IdentityCheckHonor.native.test.tsx.native-snap
@@ -187,7 +187,7 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
                     ]
                   }
                 >
-                  Les informations que tu as renseignées sont-elles correctes ?
+                  Les informations que tu as renseignées sont-elles correctes ?
                 </Text>
               </View>
               <View

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckValidation.native.test.tsx.native-snap
@@ -178,7 +178,7 @@ exports[`<IdentityCheckValidation /> should render IdentityCheckValidation compo
                   ]
                 }
               >
-                Les informations extraites sont-elles correctes ?
+                Les informations extraites sont-elles correctes ?
               </Text>
             </View>
           </View>

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetAddress.native.test.tsx.native-snap
@@ -178,7 +178,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
                   ]
                 }
               >
-                Quelle est ton adresse ?
+                Quelle est ton adresse ?
               </Text>
             </View>
             <View

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetCity.native.test.tsx.native-snap
@@ -178,7 +178,7 @@ exports[`<SetCity/> should render correctly 1`] = `
                   ]
                 }
               >
-                Dans quelle ville résides-tu ?
+                Dans quelle ville résides-tu ?
               </Text>
             </View>
             <View

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetName.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetName.native.test.tsx.native-snap
@@ -178,7 +178,7 @@ exports[`<SetName/> should render correctly 1`] = `
                   ]
                 }
               >
-                Comment t'appelles-tu ?
+                Comment t'appelles-tu ?
               </Text>
             </View>
             <View

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetSchoolType.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetSchoolType.test.tsx.native-snap
@@ -178,7 +178,7 @@ exports[`<SetSchoolType /> shoud render a list of high school types if profile.s
                   ]
                 }
               >
-                Dans quel type d'établissement ?
+                Dans quel type d'établissement ?
               </Text>
             </View>
             <View
@@ -895,7 +895,7 @@ exports[`<SetSchoolType /> shoud render a list of middle school types if profile
                   ]
                 }
               >
-                Dans quel type d'établissement ?
+                Dans quel type d'établissement ?
               </Text>
             </View>
             <View

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetSchoolType.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetSchoolType.test.tsx.web-snap
@@ -225,7 +225,7 @@ exports[`<SetSchoolType /> shoud render a list of high school types if profile.s
                   }
                 }
               >
-                Dans quel type d'établissement ?
+                Dans quel type d'établissement ?
               </div>
             </div>
             <div
@@ -1232,7 +1232,7 @@ exports[`<SetSchoolType /> shoud render a list of middle school types if profile
                   }
                 }
               >
-                Dans quel type d'établissement ?
+                Dans quel type d'établissement ?
               </div>
             </div>
             <div

--- a/__snapshots__/features/offer/pages/tests/OfferBody.deprecated.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferBody.deprecated.native.test.tsx.native-snap
@@ -959,7 +959,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                 ]
                               }
                             >
-                              Quand ?
+                              Quand ?
                             </Text>
                             <Text
                               style={
@@ -3423,7 +3423,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                 ]
                               }
                             >
-                              Quand ?
+                              Quand ?
                             </Text>
                             <Text
                               style={
@@ -3483,7 +3483,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                 ]
                               }
                             >
-                              Où ?
+                              Où ?
                             </Text>
                             <View
                               numberOfSpaces={4}

--- a/__snapshots__/features/offer/pages/tests/OfferBody.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferBody.native.test.tsx.native-snap
@@ -644,7 +644,7 @@ exports[`<OfferBody /> should open the report modal upon clicking on 'signaler l
           ]
         }
       >
-        Quand ?
+        Quand ?
       </Text>
       <Text
         style={
@@ -704,7 +704,7 @@ exports[`<OfferBody /> should open the report modal upon clicking on 'signaler l
           ]
         }
       >
-        Où ?
+        Où ?
       </Text>
       <View
         numberOfSpaces={4}

--- a/__snapshots__/features/profile/components/ProfileHeader.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/ProfileHeader.native.test.tsx.native-snap
@@ -198,7 +198,7 @@ exports[`ProfileHeader should display the LoggedOutHeader if no user 1`] = `
           ]
         }
       >
-        Tu as déjà un compte ? 
+        Tu as déjà un compte ? 
       </Text>
       <View
         accessibilityLabel="Connecte-toi"

--- a/__snapshots__/features/profile/pages/ConfirmDeleteProfile.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConfirmDeleteProfile.test.tsx.native-snap
@@ -99,7 +99,7 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
           ]
         }
       >
-        Es-tu sûr de vouloir supprimer ton compte ?
+        Es-tu sûr de vouloir supprimer ton compte ?
       </Text>
       <View
         numberOfSpaces={5}

--- a/__snapshots__/features/profile/pages/ConfirmDeleteProfile.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ConfirmDeleteProfile.test.tsx.web-snap
@@ -143,7 +143,7 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
           }
         }
       >
-        Es-tu sûr de vouloir supprimer ton compte ?
+        Es-tu sûr de vouloir supprimer ton compte ?
       </div>
       <div
         className="css-view-1dbjc4n"

--- a/__snapshots__/features/venue/pages/__tests__/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/__tests__/Venue.native.test.tsx.native-snap
@@ -1852,7 +1852,7 @@ exports[`<Venue /> should match snapshot 1`] = `
             ]
           }
         >
-          Où ?
+          Où ?
         </Text>
         <View
           numberOfSpaces={4}

--- a/__snapshots__/features/venue/pages/__tests__/Venue.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/pages/__tests__/Venue.web.test.tsx.web-snap
@@ -723,7 +723,7 @@ Object {
                 dir="auto"
                 style="color: rgb(21, 21, 21); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
               >
-                Où ?
+                Où ?
               </div>
               <div
                 class="css-view-1dbjc4n"
@@ -2185,7 +2185,7 @@ Object {
               dir="auto"
               style="color: rgb(21, 21, 21); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
             >
-              Où ?
+              Où ?
             </div>
             <div
               class="css-view-1dbjc4n"

--- a/__snapshots__/features/venue/pages/__tests__/VenueBody.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/__tests__/VenueBody.native.test.tsx.native-snap
@@ -1840,7 +1840,7 @@ exports[`<VenueBody /> should render correctly 1`] = `
           ]
         }
       >
-        Où ?
+        Où ?
       </Text>
       <View
         numberOfSpaces={4}

--- a/__snapshots__/features/venue/pages/__tests__/VenueBody.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/pages/__tests__/VenueBody.web.test.tsx.web-snap
@@ -719,7 +719,7 @@ Object {
               dir="auto"
               style="color: rgb(21, 21, 21); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
             >
-              Où ?
+              Où ?
             </div>
             <div
               class="css-view-1dbjc4n"
@@ -2011,7 +2011,7 @@ Object {
             dir="auto"
             style="color: rgb(21, 21, 21); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
           >
-            Où ?
+            Où ?
           </div>
           <div
             class="css-view-1dbjc4n"

--- a/__snapshots__/libs/geolocation/components/__tests__/WhereSection.test.tsx.native-snap
+++ b/__snapshots__/libs/geolocation/components/__tests__/WhereSection.test.tsx.native-snap
@@ -24,7 +24,7 @@ Array [
       ]
     }
   >
-    Où ?
+    Où ?
   </Text>,
   <View
     numberOfSpaces={4}

--- a/__snapshots__/libs/geolocation/components/__tests__/WhereSection.test.tsx.web-snap
+++ b/__snapshots__/libs/geolocation/components/__tests__/WhereSection.test.tsx.web-snap
@@ -22,7 +22,7 @@ Array [
       }
     }
   >
-    Où ?
+    Où ?
   </div>,
   <div
     className="css-view-1dbjc4n"

--- a/eslint-custom-rules/nbsp-in-french-translations.js
+++ b/eslint-custom-rules/nbsp-in-french-translations.js
@@ -1,5 +1,5 @@
 /**
- * This rule aims to spot miss-use of a space instead of a non-breaking space (nbsp) with code \u00a0
+ * This rule aims to spot misuses of a space instead of a non-breaking space (nbsp) with code \u00a0
  * before some characters in French translations, such as ! ? : ; € » or after «
  *
  * Ex: "Bienvenue !" should be "Bienvenue\u00a0!"

--- a/eslint-custom-rules/nbsp-in-french-translations.js
+++ b/eslint-custom-rules/nbsp-in-french-translations.js
@@ -16,26 +16,14 @@ module.exports = {
   },
   create(context) {
     return {
-      'TaggedTemplateExpression[tag.name="t"] > TemplateLiteral > TemplateElement[value.raw=/ !/]':
+      'TaggedTemplateExpression[tag.name="t"] > TemplateLiteral > TemplateElement[value.raw=/\\s+[!?]/]':
         (node) => {
           context.report({
             node,
             message:
               'Please use \\u00a0 (nbsp) instead of whitespace before !, ?, :, ;, €, » and after «',
             fix: function (fixer) {
-              const textToReplace = node.value.raw.replace(/ !/g, '\\u00a0!')
-              return fixer.replaceText(node, `\`${textToReplace}\``)
-            },
-          })
-        },
-      'TaggedTemplateExpression[tag.name="t"] > TemplateLiteral > TemplateElement[value.raw=/ \\?/]':
-        (node) => {
-          context.report({
-            node,
-            message:
-              'Please use \\u00a0 (nbsp) instead of whitespace before !, ?, :, ;, €, » and after «',
-            fix: function (fixer) {
-              const textToReplace = node.value.raw.replace(/ \?/g, '\\u00a0?')
+              const textToReplace = node.value.raw.replace(/\s+([!?])/g, '\\u00a0$1')
               return fixer.replaceText(node, `\`${textToReplace}\``)
             },
           })

--- a/eslint-custom-rules/nbsp-in-french-translations.js
+++ b/eslint-custom-rules/nbsp-in-french-translations.js
@@ -20,8 +20,7 @@ module.exports = {
         (node) => {
           context.report({
             node,
-            message:
-              'Please use \\u00a0 (nbsp) instead of whitespace before !, ?, :, ;, €, » and after «',
+            message: 'Please use \\u00a0 (nbsp) instead of whitespace before !, ?',
             fix: function (fixer) {
               const textToReplace = node.value.raw.replace(/\s+([!?])/g, '\\u00a0$1')
               return fixer.replaceText(node, `\`${textToReplace}\``)

--- a/eslint-custom-rules/nbsp-in-french-translations.js
+++ b/eslint-custom-rules/nbsp-in-french-translations.js
@@ -1,0 +1,45 @@
+/**
+ * This rule aims to spot miss-use of a space instead of a non-breaking space (nbsp) with code \u00a0
+ * before some characters in French translations, such as ! ? : ; € » or after «
+ *
+ * Ex: "Bienvenue !" should be "Bienvenue\u00a0!"
+ */
+
+module.exports = {
+  name: 'nbsp-in-french-translations',
+  meta: {
+    docs: {
+      description:
+        'force the use of non-breaking space before some characters in French translations',
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      'TaggedTemplateExpression[tag.name="t"] > TemplateLiteral > TemplateElement[value.raw=/ !/]':
+        (node) => {
+          context.report({
+            node,
+            message:
+              'Please use \\u00a0 (nbsp) instead of whitespace before !, ?, :, ;, €, » and after «',
+            fix: function (fixer) {
+              const textToReplace = node.value.raw.replace(/ !/g, '\\u00a0!')
+              return fixer.replaceText(node, `\`${textToReplace}\``)
+            },
+          })
+        },
+      'TaggedTemplateExpression[tag.name="t"] > TemplateLiteral > TemplateElement[value.raw=/ \\?/]':
+        (node) => {
+          context.report({
+            node,
+            message:
+              'Please use \\u00a0 (nbsp) instead of whitespace before !, ?, :, ;, €, » and after «',
+            fix: function (fixer) {
+              const textToReplace = node.value.raw.replace(/ \?/g, '\\u00a0?')
+              return fixer.replaceText(node, `\`${textToReplace}\``)
+            },
+          })
+        },
+    }
+  },
+}

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -2,10 +2,12 @@ const noAllowConsole = require('./eslint-custom-rules/no-allow-console')
 const noStringCheckBeforeComponent = require('./eslint-custom-rules/no-string-check-before-component')
 const independantMocks = require('./eslint-custom-rules/independant-mocks')
 const noReactQueryProviderHOC = require('./eslint-custom-rules/no-react-query-provider-hoc')
+const nbspInFrenchTranslations = require('./eslint-custom-rules/nbsp-in-french-translations')
 
 module.exports = {
   'no-allow-console': noAllowConsole,
   'no-string-check-before-component': noStringCheckBeforeComponent,
   'independant-mocks': independantMocks,
   'no-react-query-provider-hoc': noReactQueryProviderHOC,
+  'nbsp-in-french-translations': nbspInFrenchTranslations,
 }

--- a/src/features/_marketingAndCommunication/components/DeeplinksGeneratorForm.tsx
+++ b/src/features/_marketingAndCommunication/components/DeeplinksGeneratorForm.tsx
@@ -175,7 +175,7 @@ export const DeeplinksGeneratorForm = ({ onCreate }: Props) => {
   return (
     <React.Fragment>
       <Container>
-        <TitleContainer>{t`Besoin d'un lien ?`}</TitleContainer>
+        <TitleContainer>{t`Besoin d'un lien\u00a0?`}</TitleContainer>
         <Spacer.Column numberOfSpaces={6} />
         <AccordionItem title={t`Pages`} defaultOpen>
           {Object.keys(SCREENS_CONFIG).map((key) =>

--- a/src/features/_marketingAndCommunication/pages/DeeplinksGenerator.tsx
+++ b/src/features/_marketingAndCommunication/pages/DeeplinksGenerator.tsx
@@ -67,7 +67,7 @@ export const DeeplinksGenerator = () => {
         </Right>
       </Row>
       <Spacer.Column numberOfSpaces={4} />
-      <PageHeader title={t`Envie de tout envie de lien ?`} />
+      <PageHeader title={t`Envie de tout envie de lien\u00a0?`} />
     </React.Fragment>
   )
 }

--- a/src/features/auth/components/QuitSignupModal.native.test.tsx
+++ b/src/features/auth/components/QuitSignupModal.native.test.tsx
@@ -19,14 +19,14 @@ describe('QuitSignupModal', () => {
   it('should not display the modal when visible is false', () => {
     const { queryByText } = renderQuitSignupModal(false)
 
-    const title = queryByText("Veux-tu abandonner l'inscription ?")
+    const title = queryByText("Veux-tu abandonner l'inscription\u00a0?")
     expect(title).toBeFalsy()
   })
 
   it('should display the modal when visible is true', () => {
     const { queryByText } = renderQuitSignupModal(true)
 
-    const button = queryByText("Veux-tu abandonner l'inscription ?")
+    const button = queryByText("Veux-tu abandonner l'inscription\u00a0?")
     expect(button).toBeTruthy()
   })
 

--- a/src/features/auth/components/QuitSignupModal.tsx
+++ b/src/features/auth/components/QuitSignupModal.tsx
@@ -31,7 +31,7 @@ export const QuitSignupModal: FunctionComponent<Props> = ({
     navigateToHome()
   }
 
-  const title = t`Veux-tu abandonner l'inscription ?`
+  const title = t`Veux-tu abandonner l'inscription\u00a0?`
   const description = t`Les informations que tu as renseignées ne seront pas enregistrées.`
 
   return (

--- a/src/features/auth/login/Login.tsx
+++ b/src/features/auth/login/Login.tsx
@@ -157,7 +157,7 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
       <Spacer.Column numberOfSpaces={7} />
       <ForgottenPasswordContainer>
         <TouchableOpacity onPress={onForgottenPasswordClick}>
-          <Typo.ButtonText>{t`Mot de passe oublié ?`}</Typo.ButtonText>
+          <Typo.ButtonText>{t`Mot de passe oublié\u00a0?`}</Typo.ButtonText>
         </TouchableOpacity>
       </ForgottenPasswordContainer>
       <Spacer.Column numberOfSpaces={8} />

--- a/src/features/auth/signup/PhoneValidation/SetPhoneValidationCode.tsx
+++ b/src/features/auth/signup/PhoneValidation/SetPhoneValidationCode.tsx
@@ -253,7 +253,7 @@ export const SetPhoneValidationCode = memo(function SetPhoneValidationCodeCompon
           />
           <Spacer.Column numberOfSpaces={4} />
           <HelpRow>
-            <Typo.Body>{t`Tu n'as pas reçu le sms ?`}</Typo.Body>
+            <Typo.Body>{t`Tu n'as pas reçu le sms\u00a0?`}</Typo.Body>
             {/* force button to wrap on small screen, otherwise timer will "unwrap" when timer is under 10 seconds */}
             {appContentWidth <= 320 ? <Break /> : null}
             <ButtonTertiary

--- a/src/features/auth/signup/SetBirthday/SetBirthday.native.test.tsx
+++ b/src/features/auth/signup/SetBirthday/SetBirthday.native.test.tsx
@@ -54,7 +54,7 @@ describe('SetBirthday Page', () => {
 
   it('should show the correct deposit amount', async () => {
     const component = render(<SetBirthday {...props} />)
-    fireEvent.press(component.getByTestId('Pourquoi ?'))
+    fireEvent.press(component.getByTestId('Pourquoi\u00a0?'))
     expect(component.queryByText(/une aide financière de/)).toBeTruthy()
     expect(component.queryByText(new RegExp('300' + '\u00a0' + '€'))).toBeTruthy()
   })
@@ -73,7 +73,7 @@ describe('SetBirthday Page', () => {
         } as UseQueryResult<SettingsResponse, unknown>)
     )
     const component = render(<SetBirthday {...props} />)
-    fireEvent.press(component.getByTestId('Pourquoi ?'))
+    fireEvent.press(component.getByTestId('Pourquoi\u00a0?'))
     expect(component.queryByText(/une aide financière progressive allant de/)).toBeTruthy()
 
     expect(component.queryByText(new RegExp('20' + '\u00a0' + '€'))).toBeTruthy()
@@ -123,7 +123,7 @@ describe('SetBirthday Page', () => {
   it('should display a information modal when clicking "Pourquoi" link', () => {
     const { getByTestId, toJSON } = render(<SetBirthday {...props} />)
 
-    const whyBirthdayLink = getByTestId('Pourquoi ?')
+    const whyBirthdayLink = getByTestId('Pourquoi\u00a0?')
     fireEvent.press(whyBirthdayLink)
 
     const birthdayModal = getByTestId('modal-birthday-information')
@@ -135,7 +135,7 @@ describe('SetBirthday Page', () => {
     it('should log ConsultModalWhyAnniversary when clicking "Pourquoi" link', () => {
       const { getByTestId } = render(<SetBirthday {...props} />)
 
-      const whyBirthdayLink = getByTestId('Pourquoi ?')
+      const whyBirthdayLink = getByTestId('Pourquoi\u00a0?')
       fireEvent.press(whyBirthdayLink)
 
       expect(analytics.logConsultWhyAnniversary).toHaveBeenCalledTimes(1)

--- a/src/features/auth/signup/SetBirthday/SetBirthday.tsx
+++ b/src/features/auth/signup/SetBirthday/SetBirthday.tsx
@@ -144,7 +144,7 @@ export const SetBirthday: FunctionComponent<PreValidationSignupStepProps> = (pro
   return (
     <React.Fragment>
       <InnerContainer>
-        <ButtonTertiary title={t`Pourquoi ?`} onPress={onPressWhy} />
+        <ButtonTertiary title={t`Pourquoi\u00a0?`} onPress={onPressWhy} />
         <Spacer.Column numberOfSpaces={8} />
         <DateInputContainer>
           <DateInput

--- a/src/features/auth/signup/SignupForm.native.test.tsx
+++ b/src/features/auth/signup/SignupForm.native.test.tsx
@@ -68,7 +68,7 @@ describe('<SignupForm />', () => {
   it('should open quit signup modal when preventCancellation route param is false', () => {
     const { getByTestId, getByText } = render(<SignupForm {...defaultProps} />)
     fireEvent.press(getByTestId('rightIcon'))
-    getByText("Veux-tu abandonner l'inscription ?")
+    getByText("Veux-tu abandonner l'inscription\u00a0?")
   })
 
   it('should not open quit signup modal when preventCancellation route param is true', () => {

--- a/src/features/auth/signup/underageSignup/SelectSchool.tsx
+++ b/src/features/auth/signup/underageSignup/SelectSchool.tsx
@@ -60,7 +60,7 @@ export const SelectSchool: React.FC = () => {
       <Spacer.TopScreen />
       <Spacer.Column numberOfSpaces={18} />
       <Container>
-        <TitleContainer>{t`Vois-tu ton établissement ?`}</TitleContainer>
+        <TitleContainer>{t`Vois-tu ton établissement\u00a0?`}</TitleContainer>
         <Spacer.Column numberOfSpaces={6} />
         {Object.keys(eligibleSchools).map((academy) => (
           <React.Fragment key={academy}>

--- a/src/features/auth/signup/underageSignup/SelectSchoolHome.tsx
+++ b/src/features/auth/signup/underageSignup/SelectSchoolHome.tsx
@@ -30,7 +30,7 @@ export const SelectSchoolHome: React.FC = () => {
         <StyledLottieView ref={animation} source={StarAnimation} loop={false} />
       </StyledLottieContainer>
       <Spacer.Flex flex={0.5} />
-      <TitleContainer>{t`Fais-tu partie de la phase de test ?`}</TitleContainer>
+      <TitleContainer>{t`Fais-tu partie de la phase de test\u00a0?`}</TitleContainer>
       <BodyContainer>
         {t`Si tu es élève dans` + '\u00a0'}
         <Strong>{t`l'un des 21 établissements de test`}</Strong>

--- a/src/features/bookings/components/NoBookingsView.tsx
+++ b/src/features/bookings/components/NoBookingsView.tsx
@@ -18,7 +18,7 @@ export function NoBookingsView() {
       <Explanation color={ColorsEnum.GREY_DARK}>
         {t`Tu n’as pas de réservations en cours.
       Découvre les offres disponibles 
-      sans attendre !`}
+      sans attendre\u00a0!`}
       </Explanation>
       <Spacer.Column numberOfSpaces={8} />
       <ButtonContainer>

--- a/src/features/deeplinks/pages/DeeplinkImporter.tsx
+++ b/src/features/deeplinks/pages/DeeplinkImporter.tsx
@@ -46,7 +46,7 @@ export const DeeplinkImporter: FunctionComponent = () => {
       />
       <ModalContent>
         <StyledInput>
-          <Typo.Body>{t`Un lien ne fonctionne pas ?`}</Typo.Body>
+          <Typo.Body>{t`Un lien ne fonctionne pas\u00a0?`}</Typo.Body>
           <Spacer.Column numberOfSpaces={2} />
           <TextInput
             autoFocus={true}

--- a/src/features/forceUpdate/ForceUpdate.tsx
+++ b/src/features/forceUpdate/ForceUpdate.tsx
@@ -31,9 +31,9 @@ const title = Platform.select({
 })
 
 const description = Platform.select({
-  default: t`Le pass Culture ne semble plus à jour sur ton téléphone !
+  default: t`Le pass Culture ne semble plus à jour sur ton téléphone\u00a0!
                 Pour des questions de performance et de sécurité merci de télécharger la dernière version disponible.`,
-  web: t`Le pass Culture de ton navigateur ne semble plus à jour !
+  web: t`Le pass Culture de ton navigateur ne semble plus à jour\u00a0!
                 Pour des questions de performance et de sécurité merci d'actualiser la page pour obtenir la dernière version disponible.`,
 })
 

--- a/src/features/identityCheck/atoms/DMSInformation.web.tsx
+++ b/src/features/identityCheck/atoms/DMSInformation.web.tsx
@@ -20,7 +20,7 @@ export const DMSInformation = () => {
   return (
     <React.Fragment>
       <Container>
-        <Typo.Body color={ColorsEnum.GREY_DARK}>{t`Tu n'as pas de smartphone ?`}</Typo.Body>
+        <Typo.Body color={ColorsEnum.GREY_DARK}>{t`Tu n'as pas de smartphone\u00a0?`}</Typo.Body>
         <Spacer.Column numberOfSpaces={4} />
         <ButtonTertiaryBlack
           title={t`Identification par le site Démarches-Simplifiées`}

--- a/src/features/identityCheck/components/FastEduconnectConnectionRequestModal.tsx
+++ b/src/features/identityCheck/components/FastEduconnectConnectionRequestModal.tsx
@@ -44,7 +44,7 @@ export const FastEduconnectConnectionRequestModal: React.FC<
       <TextQuestion
         onPress={() => openUrl(env.FAQ_LINK_EDUCONNECT_URL)}
         icon={(props) => <InfoPlain {...props} size={getSpacing(5)} />}
-        title={t`C’est quoi ÉduConnect ?`}
+        title={t`C’est quoi ÉduConnect\u00a0?`}
       />
 
       <ButtonPrimary

--- a/src/features/identityCheck/components/QuitIdentityCheckModal.tsx
+++ b/src/features/identityCheck/components/QuitIdentityCheckModal.tsx
@@ -19,7 +19,7 @@ interface Props {
   testIdSuffix?: string
 }
 
-const title = t`Veux-tu abandonner la vérification d'identité ?`
+const title = t`Veux-tu abandonner la vérification d'identité\u00a0?`
 const description = t`Les informations que tu as renseignées ne seront pas enregistrées.`
 
 export const QuitIdentityCheckModal: FunctionComponent<Props> = ({

--- a/src/features/identityCheck/components/__test__/QuitIdentityCheckModal.native.test.tsx
+++ b/src/features/identityCheck/components/__test__/QuitIdentityCheckModal.native.test.tsx
@@ -18,14 +18,14 @@ describe('<QuitIdentityCheckModal/>', () => {
   it('should not display the modal when visible is false', () => {
     const { queryByText } = renderQuitIdentityCheckModal(false)
 
-    const title = queryByText("Veux-tu abandonner la vérification d'identité ?")
+    const title = queryByText("Veux-tu abandonner la vérification d'identité\u00a0?")
     expect(title).toBeFalsy()
   })
 
   it('should display the modal when visible is true', () => {
     const { queryByText } = renderQuitIdentityCheckModal(true)
 
-    const title = queryByText("Veux-tu abandonner la vérification d'identité ?")
+    const title = queryByText("Veux-tu abandonner la vérification d'identité\u00a0?")
     expect(title).toBeTruthy()
   })
 

--- a/src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
+++ b/src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
@@ -73,7 +73,7 @@ const getUserTypeNotStudent = (
   onPrimaryButtonPress: () => void
 ): NotEligibleEduConnectErrorData => ({
   Icon: InfoFraud,
-  title: t`Qui est-ce ?`,
+  title: t`Qui est-ce\u00a0?`,
   description:
     t`Les informations provenant d'ÉduConnect indiquent que vous êtes le représentant légal d'un jeune scolarisé.` +
     '\n\n' +

--- a/src/features/identityCheck/pages/confirmation/IdentityCheckHonor.tsx
+++ b/src/features/identityCheck/pages/confirmation/IdentityCheckHonor.tsx
@@ -36,7 +36,9 @@ export const IdentityCheckHonor = () => {
       title={t`Confirmation`}
       fixedTopChildren={
         <Container>
-          <CenteredTitle title={t`Les informations que tu as renseignées sont-elles correctes ?`} />
+          <CenteredTitle
+            title={t`Les informations que tu as renseignées sont-elles correctes\u00a0?`}
+          />
           {theme.isMobileViewport ? <Spacer.Flex /> : <Spacer.Column numberOfSpaces={10} />}
           <Declaration
             text={t`Je déclare que l'ensemble des informations que j’ai renseignées sont correctes.`}

--- a/src/features/identityCheck/pages/identification/IdentityCheckValidation.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckValidation.tsx
@@ -28,7 +28,7 @@ export const IdentityCheckValidation = () => {
     <PageWithHeader
       title={t`Mon identité`}
       fixedTopChildren={
-        <CenteredTitle title={t`Les informations extraites sont-elles correctes ?`} />
+        <CenteredTitle title={t`Les informations extraites sont-elles correctes\u00a0?`} />
       }
       scrollChildren={
         <BodyContainer>

--- a/src/features/identityCheck/pages/profile/SetAddress.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.tsx
@@ -105,7 +105,7 @@ export const SetAddress = () => {
       title={t`Profil`}
       fixedTopChildren={
         <React.Fragment>
-          <CenteredTitle title={t`Quelle est ton adresse ?`} />
+          <CenteredTitle title={t`Quelle est ton adresse\u00a0?`} />
           <Spacer.Column numberOfSpaces={5} />
           <TextInput
             autoFocus

--- a/src/features/identityCheck/pages/profile/SetCity.tsx
+++ b/src/features/identityCheck/pages/profile/SetCity.tsx
@@ -91,7 +91,7 @@ export const SetCity = () => {
       title={t`Profil`}
       fixedTopChildren={
         <React.Fragment>
-          <CenteredTitle title={t`Dans quelle ville résides-tu ?`} />
+          <CenteredTitle title={t`Dans quelle ville résides-tu\u00a0?`} />
           <Spacer.Column numberOfSpaces={5} />
           <TextInput
             autoFocus

--- a/src/features/identityCheck/pages/profile/SetName.tsx
+++ b/src/features/identityCheck/pages/profile/SetName.tsx
@@ -33,7 +33,7 @@ export const SetName = () => {
       title={t`Profil`}
       fixedTopChildren={
         <React.Fragment>
-          <CenteredTitle title={t`Comment t'appelles-tu ?`} />
+          <CenteredTitle title={t`Comment t'appelles-tu\u00a0?`} />
           <Spacer.Column numberOfSpaces={5} />
         </React.Fragment>
       }

--- a/src/features/identityCheck/pages/profile/SetSchoolType.tsx
+++ b/src/features/identityCheck/pages/profile/SetSchoolType.tsx
@@ -42,7 +42,7 @@ export const SetSchoolType = () => {
       title={t`Profil`}
       fixedTopChildren={
         <React.Fragment>
-          <CenteredTitle title={t`Dans quel type d'établissement ?`} />
+          <CenteredTitle title={t`Dans quel type d'établissement\u00a0?`} />
           <Spacer.Column numberOfSpaces={5} />
         </React.Fragment>
       }

--- a/src/features/offer/components/useReportOfferModalContent.tsx
+++ b/src/features/offer/components/useReportOfferModalContent.tsx
@@ -40,7 +40,7 @@ export const useReportOfferModalContent = (props: Props) => {
           leftIconAccessibilityLabel: t`Revenir à l'étape précédente`,
           leftIcon: ArrowPrevious,
           onLeftIconPress: () => props.setReportStep(ReportSteps.REPORT_OFFER_DESCRIPTION),
-          title: t`Pourquoi signales-tu` + '\n' + t`cette offre ?`,
+          title: t`Pourquoi signales-tu` + '\n' + t`cette offre\u00a0?`,
         }
       case ReportSteps.REPORT_OFFER_OTHER_REASON:
         return {
@@ -50,7 +50,7 @@ export const useReportOfferModalContent = (props: Props) => {
           leftIconAccessibilityLabel: t`Revenir à l'étape précédente`,
           leftIcon: ArrowPrevious,
           onLeftIconPress: () => props.setReportStep(ReportSteps.REPORT_OFFER_REASON),
-          title: t`Pourquoi signales-tu` + '\n' + t`cette offre ?`,
+          title: t`Pourquoi signales-tu` + '\n' + t`cette offre\u00a0?`,
         }
       default:
         return {

--- a/src/features/offer/pages/OfferBody.tsx
+++ b/src/features/offer/pages/OfferBody.tsx
@@ -113,7 +113,7 @@ export const OfferBody: FunctionComponent<Props> = ({ offerId, onScroll }) => {
       <Spacer.Column numberOfSpaces={4} />
 
       <SectionWithDivider visible={shouldDisplayWhenBlock} margin={true}>
-        <SectionTitle>{t`Quand ?`}</SectionTitle>
+        <SectionTitle>{t`Quand\u00a0?`}</SectionTitle>
         <SectionBody>{formattedDate}</SectionBody>
       </SectionWithDivider>
 

--- a/src/features/profile/components/BeneficiaryCeilings.native.test.tsx
+++ b/src/features/profile/components/BeneficiaryCeilings.native.test.tsx
@@ -29,7 +29,7 @@ describe('BeneficiaryCeilings', () => {
     expect(progressBars.length).toBe(3)
 
     const ceilingQuestion = getByText(
-      'Pourquoi les biens physiques et numériques sont-ils limités ?'
+      'Pourquoi les biens physiques et numériques sont-ils limités\u00a0?'
     )
     expect(ceilingQuestion).toBeTruthy()
   })
@@ -42,7 +42,7 @@ describe('BeneficiaryCeilings', () => {
     const progressBars = getAllByTestId('progress-bar')
     expect(progressBars.length).toBe(2)
 
-    const ceilingQuestion = getByText('Pourquoi les biens numériques sont-ils limités ?')
+    const ceilingQuestion = getByText('Pourquoi les biens numériques sont-ils limités\u00a0?')
     expect(ceilingQuestion).toBeTruthy()
   })
 
@@ -57,7 +57,7 @@ describe('BeneficiaryCeilings', () => {
     const progressBars = getAllByTestId('progress-bar')
     expect(progressBars.length).toBe(1)
 
-    const ceilingQuestion = queryByText('Pourquoi les biens numériques sont-ils limités ?')
+    const ceilingQuestion = queryByText('Pourquoi les biens numériques sont-ils limités\u00a0?')
     expect(ceilingQuestion).toBe(null)
   })
 })

--- a/src/features/profile/components/BeneficiaryCeilings.tsx
+++ b/src/features/profile/components/BeneficiaryCeilings.tsx
@@ -24,8 +24,8 @@ type CeilingsDescriptionProps = {
 const EXPENSE_DOMAIN_ORDER = [ExpenseDomain.Digital, ExpenseDomain.Physical, ExpenseDomain.All]
 
 const ceilingsDescriptionTitle = {
-  physicalAndDigital: t`Pourquoi les biens physiques et numériques sont-ils limités ?`,
-  digital: t`Pourquoi les biens numériques sont-ils limités ?`,
+  physicalAndDigital: t`Pourquoi les biens physiques et numériques sont-ils limités\u00a0?`,
+  digital: t`Pourquoi les biens numériques sont-ils limités\u00a0?`,
 }
 
 const ceilingsDescription = {

--- a/src/features/profile/components/ExBeneficiaryHeader.test.tsx
+++ b/src/features/profile/components/ExBeneficiaryHeader.test.tsx
@@ -12,7 +12,7 @@ describe('ExBeneficiaryHeader', () => {
 
     getByText('Rosa Bonheur')
     getByText('crédit expiré le 25/12/2020')
-    getByText('Mon crédit est expiré, que faire ?')
+    getByText('Mon crédit est expiré, que faire\u00a0?')
     getByText('Ton crédit pass Culture est arrivé à expiration mais l’aventure continue\u00a0!')
     getByText('Tu peux toujours réserver les offres gratuites exclusives au pass Culture.')
     getByText(

--- a/src/features/profile/components/ExBeneficiaryHeader.tsx
+++ b/src/features/profile/components/ExBeneficiaryHeader.tsx
@@ -43,7 +43,7 @@ export function ExBeneficiaryHeader(props: ExBeneficiaryHeaderProps) {
       <Spacer.Column numberOfSpaces={6} />
       <DescriptionContainer>
         <AccordionItem
-          title={<Typo.ButtonText>{t`Mon crédit est expiré, que faire ?`}</Typo.ButtonText>}
+          title={<Typo.ButtonText>{t`Mon crédit est expiré, que faire\u00a0?`}</Typo.ButtonText>}
           titleStyle={accordionStyle.title}
           bodyStyle={accordionStyle.body}>
           <Description>

--- a/src/features/profile/components/LoggedOutHeader.tsx
+++ b/src/features/profile/components/LoggedOutHeader.tsx
@@ -36,7 +36,9 @@ export function LoggedOutHeader() {
         />
         <Spacer.Column numberOfSpaces={5} />
         <LoginCta>
-          <Typo.Body color={ColorsEnum.WHITE}>{t`Tu as déjà un compte ?` + '\u00a0'}</Typo.Body>
+          <Typo.Body color={ColorsEnum.WHITE}>
+            {t`Tu as déjà un compte\u00a0?` + '\u00a0'}
+          </Typo.Body>
           <TouchableOpacity
             onPress={() => navigate('Login', { preventCancellation: true })}
             {...accessibilityAndTestId(t`Connecte-toi`)}>

--- a/src/features/profile/pages/ConfirmDeleteProfile.tsx
+++ b/src/features/profile/pages/ConfirmDeleteProfile.tsx
@@ -41,7 +41,7 @@ export function ConfirmDeleteProfile() {
 
   return (
     <GenericInfoPage
-      title={t`Es-tu sûr de vouloir supprimer ton compte ?`}
+      title={t`Es-tu sûr de vouloir supprimer ton compte\u00a0?`}
       icon={Error}
       iconSize={getSpacing(25)}>
       <StyledBody>{t`Cela entraînera l'annulation de l'ensemble de tes réservations en cours, ainsi que la suppression définitive de ton crédit pass Culture si tu en bénéficies.`}</StyledBody>

--- a/src/features/profile/pages/Profile.native.test.tsx
+++ b/src/features/profile/pages/Profile.native.test.tsx
@@ -174,7 +174,7 @@ describe('Profile component', () => {
     it('should navigate when the how-it-works row is clicked', async () => {
       const { getByTestId } = await renderProfile()
 
-      const row = getByTestId('Comment ça marche ?')
+      const row = getByTestId('Comment ça marche\u00a0?')
       fireEvent.press(row)
 
       expect(mockNavigate).toBeCalledWith('FirstTutorial', { shouldCloseAppOnBackAction: false })
@@ -192,7 +192,7 @@ describe('Profile component', () => {
     it('should navigate when the how-import-deeplink row is clicked', async () => {
       const { getByTestId } = await renderProfile()
 
-      const row = getByTestId('Problèmes pour ouvrir un lien ?')
+      const row = getByTestId('Problèmes pour ouvrir un lien\u00a0?')
       fireEvent.press(row)
 
       expect(mockNavigate).toBeCalledWith('DeeplinkImporter')

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -163,7 +163,7 @@ export const Profile: React.FC = () => {
         </ProfileSection>
         <ProfileSection title={t`Aides`}>
           <Row
-            title={t`Comment ça marche ?`}
+            title={t`Comment ça marche\u00a0?`}
             type="navigable"
             onPress={() => navigate('FirstTutorial', { shouldCloseAppOnBackAction: false })}
             icon={LifeBuoy}
@@ -178,7 +178,7 @@ export const Profile: React.FC = () => {
           />
           {Platform.OS !== 'web' && (
             <Row
-              title={t`Problèmes pour ouvrir un lien ?`}
+              title={t`Problèmes pour ouvrir un lien\u00a0?`}
               type="navigable"
               onPress={() => navigate('DeeplinkImporter')}
               icon={LifeBuoy}

--- a/src/libs/geolocation/components/WhereSection.tsx
+++ b/src/libs/geolocation/components/WhereSection.tsx
@@ -71,7 +71,7 @@ export const WhereSection: React.FC<Props> = ({
   return (
     <React.Fragment>
       <Spacer.Column numberOfSpaces={6} />
-      <Typo.Title4>{t`Où ?`}</Typo.Title4>
+      <Typo.Title4>{t`Où\u00a0?`}</Typo.Title4>
       {showVenueBanner ? (
         <React.Fragment>
           <Spacer.Column numberOfSpaces={4} />

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1428,18 +1428,18 @@ msgstr "Le pass Culture"
 
 #: src/features/forceUpdate/ForceUpdate.tsx
 msgid ""
-"Le pass Culture de ton navigateur ne semble plus à jour !\n"
+"Le pass Culture de ton navigateur ne semble plus à jour !\n"
 "Pour des questions de performance et de sécurité merci d'actualiser la page pour obtenir la dernière version disponible."
 msgstr ""
-"Le pass Culture de ton navigateur ne semble plus à jour !\n"
+"Le pass Culture de ton navigateur ne semble plus à jour !\n"
 "Pour des questions de performance et de sécurité merci d'actualiser la page pour obtenir la dernière version disponible."
 
 #: src/features/forceUpdate/ForceUpdate.tsx
 msgid ""
-"Le pass Culture ne semble plus à jour sur ton téléphone !\n"
+"Le pass Culture ne semble plus à jour sur ton téléphone !\n"
 "Pour des questions de performance et de sécurité merci de télécharger la dernière version disponible."
 msgstr ""
-"Le pass Culture ne semble plus à jour sur ton téléphone !\n"
+"Le pass Culture ne semble plus à jour sur ton téléphone !\n"
 "Pour des questions de performance et de sécurité merci de télécharger la dernière version disponible."
 
 #: src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
@@ -2633,11 +2633,11 @@ msgstr "Tu ne peux plus annuler ta réservation : elle devait être annulée ava
 msgid ""
 "Tu n’as pas de réservations en cours.\n"
 "Découvre les offres disponibles \n"
-"sans attendre !"
+"sans attendre !"
 msgstr ""
 "Tu n’as pas de réservations en cours.\n"
 "Découvre les offres disponibles \n"
-"sans attendre !"
+"sans attendre !"
 
 #: src/libs/geolocation/components/GeolocationActivationModal.tsx
 msgid "Tu peux activer ou désactiver cette fonctionnalité dans Autorisations > Localisation."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -305,8 +305,8 @@ msgid "Basculer l'affichage du mot de passe"
 msgstr "Basculer l'affichage du mot de passe"
 
 #: src/features/_marketingAndCommunication/components/DeeplinksGeneratorForm.tsx
-msgid "Besoin d'un lien ?"
-msgstr "Besoin d'un lien ?"
+msgid "Besoin d'un lien ?"
+msgstr "Besoin d'un lien ?"
 
 #: src/libs/parsers/venueType.ts
 msgid "Bibliothèque / médiathèque"
@@ -473,12 +473,12 @@ msgid "Commencer la vérification"
 msgstr "Commencer la vérification"
 
 #: src/features/identityCheck/pages/profile/SetName.tsx
-msgid "Comment t'appelles-tu ?"
-msgstr "Comment t'appelles-tu ?"
+msgid "Comment t'appelles-tu ?"
+msgstr "Comment t'appelles-tu ?"
 
 #: src/features/profile/pages/Profile.tsx
-msgid "Comment ça marche ?"
-msgstr "Comment ça marche ?"
+msgid "Comment ça marche ?"
+msgstr "Comment ça marche ?"
 
 #: src/features/cheatcodes/pages/CheatMenu/CheatMenu.tsx
 msgid "Composants"
@@ -665,20 +665,20 @@ msgid "Culture scientifique"
 msgstr "Culture scientifique"
 
 #: src/features/identityCheck/components/FastEduconnectConnectionRequestModal.tsx
-msgid "C’est quoi ÉduConnect ?"
-msgstr "C’est quoi ÉduConnect ?"
+msgid "C’est quoi ÉduConnect ?"
+msgstr "C’est quoi ÉduConnect ?"
 
 #: src/features/identityCheck/pages/Stepper.tsx
 msgid "C’est très rapide !"
 msgstr "C’est très rapide !"
 
 #: src/features/identityCheck/pages/profile/SetSchoolType.tsx
-msgid "Dans quel type d'établissement ?"
-msgstr "Dans quel type d'établissement ?"
+msgid "Dans quel type d'établissement ?"
+msgstr "Dans quel type d'établissement ?"
 
 #: src/features/identityCheck/pages/profile/SetCity.tsx
-msgid "Dans quelle ville résides-tu ?"
-msgstr "Dans quelle ville résides-tu ?"
+msgid "Dans quelle ville résides-tu ?"
+msgstr "Dans quelle ville résides-tu ?"
 
 #: src/features/bookOffer/components/BookDateChoice.tsx
 #: src/features/search/sections/titles.ts
@@ -985,8 +985,8 @@ msgid "Entrée pour le prénom"
 msgstr "Entrée pour le prénom"
 
 #: src/features/_marketingAndCommunication/pages/DeeplinksGenerator.tsx
-msgid "Envie de tout envie de lien ?"
-msgstr "Envie de tout envie de lien ?"
+msgid "Envie de tout envie de lien ?"
+msgstr "Envie de tout envie de lien ?"
 
 #: src/features/identityCheck/atoms/DMSInformation.web.tsx
 msgid "Environ 10 jours"
@@ -1005,8 +1005,8 @@ msgid "Erreur réseau. Tu peux réessayer une fois la connexion réétablie."
 msgstr "Erreur réseau. Tu peux réessayer une fois la connexion réétablie."
 
 #: src/features/profile/pages/ConfirmDeleteProfile.tsx
-msgid "Es-tu sûr de vouloir supprimer ton compte ?"
-msgstr "Es-tu sûr de vouloir supprimer ton compte ?"
+msgid "Es-tu sûr de vouloir supprimer ton compte ?"
+msgstr "Es-tu sûr de vouloir supprimer ton compte ?"
 
 #: src/features/navigation/RootNavigator/routes.ts
 msgid "Etablissement scolaire - Accueil"
@@ -1034,8 +1034,8 @@ msgid "Faire une nouvelle demande"
 msgstr "Faire une nouvelle demande"
 
 #: src/features/auth/signup/underageSignup/SelectSchoolHome.tsx
-msgid "Fais-tu partie de la phase de test ?"
-msgstr "Fais-tu partie de la phase de test ?"
+msgid "Fais-tu partie de la phase de test ?"
+msgstr "Fais-tu partie de la phase de test ?"
 
 #: src/features/navigation/TabBar/routes.ts
 #: src/features/navigation/TabBar/routes.ts
@@ -1460,8 +1460,8 @@ msgid "Les conditions générales d'utilisation de l'App Store iOS ne permettent
 msgstr "Les conditions générales d'utilisation de l'App Store iOS ne permettent pas de réserver cette offre sur l'application."
 
 #: src/features/identityCheck/pages/identification/IdentityCheckValidation.tsx
-msgid "Les informations extraites sont-elles correctes ?"
-msgstr "Les informations extraites sont-elles correctes ?"
+msgid "Les informations extraites sont-elles correctes ?"
+msgstr "Les informations extraites sont-elles correctes ?"
 
 #: src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
 msgid "Les informations provenant d'ÉduConnect indiquent que vous êtes le représentant légal d'un jeune scolarisé."
@@ -1473,8 +1473,8 @@ msgid "Les informations que tu as renseignées ne seront pas enregistrées."
 msgstr "Les informations que tu as renseignées ne seront pas enregistrées."
 
 #: src/features/identityCheck/pages/confirmation/IdentityCheckHonor.tsx
-msgid "Les informations que tu as renseignées sont-elles correctes ?"
-msgstr "Les informations que tu as renseignées sont-elles correctes ?"
+msgid "Les informations que tu as renseignées sont-elles correctes ?"
+msgstr "Les informations que tu as renseignées sont-elles correctes ?"
 
 #: src/libs/geolocation/enums.ts
 msgid "Les réglages de ton téléphone ne nous permettent pas d’utiliser la géolocalisation"
@@ -1610,8 +1610,8 @@ msgid "Modifier mon e-mail"
 msgstr "Modifier mon e-mail"
 
 #: src/features/profile/components/ExBeneficiaryHeader.tsx
-msgid "Mon crédit est expiré, que faire ?"
-msgstr "Mon crédit est expiré, que faire ?"
+msgid "Mon crédit est expiré, que faire ?"
+msgstr "Mon crédit est expiré, que faire ?"
 
 #: src/features/identityCheck/pages/identification/IdentityCheckEduConnectForm.web.tsx
 #: src/features/identityCheck/pages/identification/IdentityCheckValidation.tsx
@@ -1646,8 +1646,8 @@ msgid "Mot de passe oublié"
 msgstr "Mot de passe oublié"
 
 #: src/features/auth/login/Login.tsx
-msgid "Mot de passe oublié ?"
-msgstr "Mot de passe oublié ?"
+msgid "Mot de passe oublié ?"
+msgstr "Mot de passe oublié ?"
 
 #: src/libs/parsers/venueType.ts
 msgid "Musique - Disquaire"
@@ -1847,8 +1847,8 @@ msgid "Où"
 msgstr "Où"
 
 #: src/libs/geolocation/components/WhereSection.tsx
-msgid "Où ?"
-msgstr "Où ?"
+msgid "Où ?"
+msgstr "Où ?"
 
 #: src/features/navigation/RootNavigator/routes.ts
 msgid "Page introuvable"
@@ -1956,17 +1956,13 @@ msgstr "Pour sécuriser l'accès à ton pass nous avons besoin de valider ton nu
 msgid "Pour t'identifier, nous allons te demander de te connecter à ÉduConnect. Pense bien à avoir ton identifiant et ton mot de passe pour continuer. Si tu ne les as pas, contacte ton établissement pour les récupérer."
 msgstr "Pour t'identifier, nous allons te demander de te connecter à ÉduConnect. Pense bien à avoir ton identifiant et ton mot de passe pour continuer. Si tu ne les as pas, contacte ton établissement pour les récupérer."
 
-#: src/features/auth/signup/SetBirthday/SetBirthday.tsx
-msgid "Pourquoi ?"
-msgstr "Pourquoi ?"
+#: src/features/profile/components/BeneficiaryCeilings.tsx
+msgid "Pourquoi les biens numériques sont-ils limités ?"
+msgstr "Pourquoi les biens numériques sont-ils limités ?"
 
 #: src/features/profile/components/BeneficiaryCeilings.tsx
-msgid "Pourquoi les biens numériques sont-ils limités ?"
-msgstr "Pourquoi les biens numériques sont-ils limités ?"
-
-#: src/features/profile/components/BeneficiaryCeilings.tsx
-msgid "Pourquoi les biens physiques et numériques sont-ils limités ?"
-msgstr "Pourquoi les biens physiques et numériques sont-ils limités ?"
+msgid "Pourquoi les biens physiques et numériques sont-ils limités ?"
+msgstr "Pourquoi les biens physiques et numériques sont-ils limités ?"
 
 #: src/features/auth/signup/SetBirthday/SetBirthday.tsx
 msgid "Pourquoi saisir ma date de naissance ?"
@@ -1976,6 +1972,10 @@ msgstr "Pourquoi saisir ma date de naissance ?"
 #: src/features/offer/components/useReportOfferModalContent.tsx
 msgid "Pourquoi signales-tu"
 msgstr "Pourquoi signales-tu"
+
+#: src/features/auth/signup/SetBirthday/SetBirthday.tsx
+msgid "Pourquoi ?"
+msgstr "Pourquoi ?"
 
 #: src/libs/parsers/venueType.ts
 msgid "Pratique artistiques"
@@ -2002,8 +2002,8 @@ msgid "Problème technique ;("
 msgstr "Problème technique ;("
 
 #: src/features/profile/pages/Profile.tsx
-msgid "Problèmes pour ouvrir un lien ?"
-msgstr "Problèmes pour ouvrir un lien ?"
+msgid "Problèmes pour ouvrir un lien ?"
+msgstr "Problèmes pour ouvrir un lien ?"
 
 #: src/features/identityCheck/pages/profile/SetAddress.tsx
 #: src/features/identityCheck/pages/profile/SetCity.tsx
@@ -2039,12 +2039,12 @@ msgid "Prénom et nom"
 msgstr "Prénom et nom"
 
 #: src/features/offer/pages/OfferBody.tsx
-msgid "Quand ?"
-msgstr "Quand ?"
+msgid "Quand ?"
+msgstr "Quand ?"
 
 #: src/features/identityCheck/pages/profile/SetAddress.tsx
-msgid "Quelle est ton adresse ?"
-msgstr "Quelle est ton adresse ?"
+msgid "Quelle est ton adresse ?"
+msgstr "Quelle est ton adresse ?"
 
 #: src/features/identityCheck/components/SomeAdviceBeforeIdentityCheckModal.tsx
 msgid "Quelques conseils"
@@ -2059,8 +2059,8 @@ msgid "Questions fréquentes"
 msgstr "Questions fréquentes"
 
 #: src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
-msgid "Qui est-ce ?"
-msgstr "Qui est-ce ?"
+msgid "Qui est-ce ?"
+msgstr "Qui est-ce ?"
 
 #: src/features/search/sections/titles.ts
 msgid "Rayon"
@@ -2574,8 +2574,8 @@ msgid "Tu as déjà signalé cette offre"
 msgstr "Tu as déjà signalé cette offre"
 
 #: src/features/profile/components/LoggedOutHeader.tsx
-msgid "Tu as déjà un compte ?"
-msgstr "Tu as déjà un compte ?"
+msgid "Tu as déjà un compte ?"
+msgstr "Tu as déjà un compte ?"
 
 #: src/features/auth/signup/PhoneValidation/PhoneValidationTooManyAttempts/PhoneValidationTooManyAttempts.tsx
 msgid "Tu as dépassé le nombre d’essais autorisés. L’accès à ton crédit pass Culture a été bloqué. Pour le récupérer tu peux :"
@@ -2614,12 +2614,12 @@ msgid "Tu es sur le point d'archiver"
 msgstr "Tu es sur le point d'archiver"
 
 #: src/features/identityCheck/atoms/DMSInformation.web.tsx
-msgid "Tu n'as pas de smartphone ?"
-msgstr "Tu n'as pas de smartphone ?"
+msgid "Tu n'as pas de smartphone ?"
+msgstr "Tu n'as pas de smartphone ?"
 
 #: src/features/auth/signup/PhoneValidation/SetPhoneValidationCode.tsx
-msgid "Tu n'as pas reçu le sms ?"
-msgstr "Tu n'as pas reçu le sms ?"
+msgid "Tu n'as pas reçu le sms ?"
+msgstr "Tu n'as pas reçu le sms ?"
 
 #: src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
 msgid "Tu ne fais pas partie de la phase de test"
@@ -2736,8 +2736,8 @@ msgid "Téléphone - Formulaire"
 msgstr "Téléphone - Formulaire"
 
 #: src/features/deeplinks/pages/DeeplinkImporter.tsx
-msgid "Un lien ne fonctionne pas ?"
-msgstr "Un lien ne fonctionne pas ?"
+msgid "Un lien ne fonctionne pas ?"
+msgstr "Un lien ne fonctionne pas ?"
 
 #: src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
 #: src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
@@ -2863,12 +2863,12 @@ msgid "Version"
 msgstr "Version"
 
 #: src/features/auth/components/QuitSignupModal.tsx
-msgid "Veux-tu abandonner l'inscription ?"
-msgstr "Veux-tu abandonner l'inscription ?"
+msgid "Veux-tu abandonner l'inscription ?"
+msgstr "Veux-tu abandonner l'inscription ?"
 
 #: src/features/identityCheck/components/QuitIdentityCheckModal.tsx
-msgid "Veux-tu abandonner la vérification d'identité ?"
-msgstr "Veux-tu abandonner la vérification d'identité ?"
+msgid "Veux-tu abandonner la vérification d'identité ?"
+msgstr "Veux-tu abandonner la vérification d'identité ?"
 
 #: src/features/identityCheck/pages/identification/IdentityCheckUnavailable.tsx
 msgid "Victime de notre succès !"
@@ -2909,8 +2909,8 @@ msgid "Voir toutes les offres"
 msgstr "Voir toutes les offres"
 
 #: src/features/auth/signup/underageSignup/SelectSchool.tsx
-msgid "Vois-tu ton établissement ?"
-msgstr "Vois-tu ton établissement ?"
+msgid "Vois-tu ton établissement ?"
+msgstr "Vois-tu ton établissement ?"
 
 #: src/features/_marketingAndCommunication/components/DeeplinksResult.tsx
 msgid "Votre lien"
@@ -3002,8 +3002,8 @@ msgstr "carte d'identité"
 
 #: src/features/offer/components/useReportOfferModalContent.tsx
 #: src/features/offer/components/useReportOfferModalContent.tsx
-msgid "cette offre ?"
-msgstr "cette offre ?"
+msgid "cette offre ?"
+msgstr "cette offre ?"
 
 #: src/features/profile/components/ExBeneficiaryHeader.tsx
 msgid "credit expired on date"
@@ -3312,4 +3312,3 @@ msgstr "épuisé"
 #: src/features/auth/signup/underageSignup/UnderageAccountCreated.tsx
 msgid "€ viennent d'être crédités sur ton compte pass Culture"
 msgstr "€ viennent d'être crédités sur ton compte pass Culture"
-


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12365

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
