### PR TITLE
(PC-12096) fix(home): header isnt removed when scrolling to first child

### DIFF
--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -100,6 +100,7 @@ export const Home: FunctionComponent = () => {
           ListHeaderComponent={ListHeaderComponent}
           initialNumToRender={5}
           onEndReachedThreshold={0.5}
+          removeClippedSubviews={false}
         />
       </HomeBodyLoadingContainer>
       <Spacer.Column numberOfSpaces={6} />


### PR DESCRIPTION
because removeClippedSubviews is true by default on Android
https://reactnative.dev/docs/flatlist#removeclippedsubviews
so when the user scrolls to the first child, the header isnt focused anymore (even if we still see it), so it is not rendered anymore

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12096

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [x] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2) : https://www.notion.so/passcultureapp/53bc28f61ee647c69133311cd1a2c7a1?v=714d970fdfb24ef19101aeffb66d7632&p=a118a51ae23c40b0b8a7d3344582fded
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| Avant | Après |
| -----: | ------: |
| ![Capture2](https://user-images.githubusercontent.com/26742386/146418808-972ded17-8cdd-46af-ba93-0fbcbc06e57f.gif) | ![Capture](https://user-images.githubusercontent.com/26742386/146419161-c47f832c-234f-4e69-b2f5-d3b27c5ce464.gif) |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
