### PR TITLE
(PC-11901) fix(signup): make sure status is in context before patchProfile

### DIFF
--- a/src/features/identityCheck/pages/profile/Status.tsx
+++ b/src/features/identityCheck/pages/profile/Status.tsx
@@ -29,7 +29,7 @@ export const Status = () => {
 
   const onPressContinue = async () => {
     if (!selectedStatus) return
-    dispatch({ type: 'SET_STATUS', payload: selectedStatus })
+    await dispatch({ type: 'SET_STATUS', payload: selectedStatus })
     navigateToNextScreen()
   }
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11901

**Desciption du bug**: le call à /subscription/profile plantait si on sélectionnait un statut autre que lycéen ou collégien


## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
