### PR TITLE
(PC-12044) fix(mobileDatePicker): Disable choice for past dates

### DIFF
--- a/src/features/bookOffer/components/Calendar/Calendar.utils.ts
+++ b/src/features/bookOffer/components/Calendar/Calendar.utils.ts
@@ -31,21 +31,20 @@ export const monthNamesShort = [
 export const dayNames = ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi']
 export const dayNamesShort = ['D', 'L', 'M', 'M', 'J', 'V', 'S']
 
-const EARLIEST_YEAR_AVAILABLE = new Date().getFullYear() - 50
-export const YEAR_LIST = Array.from(new Array(100)).map(
-  (item, index) => EARLIEST_YEAR_AVAILABLE + index
-)
+export function getYears(startYear: number, numberOfYears: number) {
+  return range(startYear, startYear + numberOfYears, 1)
+}
 
 /**
  * Returns a list of dates such as [1, 2, ..., 31].
  * Example :
  * ```ts
- * getListOfDatesInMonth(1, 2009) // february 2009 --> [1, 2, 3, ..., 27, 28]
+ * getDatesInMonth(1, 2009) // february 2009 --> [1, 2, 3, ..., 27, 28]
  * ```
  * @param monthIndex Integer value representing the month, beginning with 0 for January to 11 for December
  * @param year Integer value representing the year
  */
-export function getListOfDatesInMonth(monthIndex: number, year: number) {
+export function getDatesInMonth(monthIndex: number, year: number) {
   const nextMonthIndex = monthIndex + 1
   const nbOfDaysInMonth = new Date(year, nextMonthIndex, 0).getDate()
   return range(1, nbOfDaysInMonth + 1)

--- a/src/features/bookOffer/components/__tests__/Calendar.utils.test.ts
+++ b/src/features/bookOffer/components/__tests__/Calendar.utils.test.ts
@@ -1,9 +1,9 @@
 import range from 'lodash/range'
 import timezoneMock, { TimeZone } from 'timezone-mock'
 
-import { getListOfDatesInMonth } from 'features/bookOffer/components/Calendar/Calendar.utils'
+import { getDatesInMonth } from 'features/bookOffer/components/Calendar/Calendar.utils'
 
-describe('getListOfDatesInMonth()', () => {
+describe('getDatesInMonth()', () => {
   it.each`
     timezone
     ${'Australia/Adelaide'}
@@ -13,10 +13,10 @@ describe('getListOfDatesInMonth()', () => {
     'should return a list [1, 2, ..., N] for some specified month and year with timezone $timezone',
     ({ timezone }: { timezone: TimeZone }) => {
       timezoneMock.register(timezone)
-      expect(getListOfDatesInMonth(9, 2021)).toEqual(range(1, 31 + 1)) // october 2021 has 31 days
-      expect(getListOfDatesInMonth(10, 2021)).toEqual(range(1, 30 + 1)) // november 2021 has 30 days
-      expect(getListOfDatesInMonth(1, 2009)).toEqual(range(1, 28 + 1)) // february 2009 has 28 days
-      expect(getListOfDatesInMonth(1, 2008)).toEqual(range(1, 29 + 1)) // february 2008 has 29 days
+      expect(getDatesInMonth(9, 2021)).toEqual(range(1, 31 + 1)) // october 2021 has 31 days
+      expect(getDatesInMonth(10, 2021)).toEqual(range(1, 30 + 1)) // november 2021 has 30 days
+      expect(getDatesInMonth(1, 2009)).toEqual(range(1, 28 + 1)) // february 2009 has 28 days
+      expect(getDatesInMonth(1, 2008)).toEqual(range(1, 29 + 1)) // february 2008 has 29 days
     }
   )
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12044

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
