### PR TITLE
(PC-12378) feat(signup): show maintenance page on stepper if nextSubscriptionStep is maintenance

### DIFF
--- a/doc/development/localApi.md
+++ b/doc/development/localApi.md
@@ -24,7 +24,7 @@ To launch the web application, run `yarn start:web:testing`.
 
 #### Mobile app
 
-To make the mmobile app request the backend, you either need to rebuild the application, OR you can change [this line](https://github.com/pass-culture/pass-culture-app-native/blob/masteer/src/api/api.ts#L7):
+To make the mobile app request the backend, you either need to rebuild the application, OR you can change [this line](https://github.com/pass-culture/pass-culture-app-native/blob/master/src/api/api.ts#L7):
 
 ```diff
 +   basePath: 'http://localhost',

--- a/src/features/identityCheck/pages/Stepper.tsx
+++ b/src/features/identityCheck/pages/Stepper.tsx
@@ -3,8 +3,7 @@ import { useNavigation } from '@react-navigation/native'
 import React, { useEffect } from 'react'
 import styled, { useTheme } from 'styled-components/native'
 
-import { IdentityCheckMethod } from 'api/gen'
-import { useNextSubscriptionStep } from 'features/auth/signup/nextSubscriptionStep'
+import { IdentityCheckMethod, MaintenancePageType, SubscriptionStep } from 'api/gen'
 import { StepButton } from 'features/identityCheck/atoms/StepButton'
 import { FastEduconnectConnectionRequestModal } from 'features/identityCheck/components/FastEduconnectConnectionRequestModal'
 import { QuitIdentityCheckModal } from 'features/identityCheck/components/QuitIdentityCheckModal'
@@ -26,8 +25,7 @@ export const IdentityCheckStepper = () => {
   const steps = useIdentityCheckSteps()
   const getStepState = useGetStepState()
   const context = useIdentityCheckContext()
-  const { data: subscription } = useNextSubscriptionStep()
-  useSetCurrentSubscriptionStep()
+  const { subscription } = useSetCurrentSubscriptionStep()
 
   const { visible, showModal, hideModal } = useModal(false)
   const {
@@ -40,6 +38,14 @@ export const IdentityCheckStepper = () => {
     if (context.step === null && steps[0])
       context.dispatch({ type: 'SET_STEP', payload: steps[0].name })
   }, [steps.length])
+
+  useEffect(() => {
+    if (subscription?.nextSubscriptionStep === SubscriptionStep.Maintenance) {
+      navigate('IdentityCheckUnavailable', {
+        withDMS: subscription?.maintenancePageType === MaintenancePageType.WithDms,
+      })
+    }
+  }, [subscription])
 
   function showQuitIdentityCheckModal() {
     if (context.step) analytics.logQuitIdentityCheck(context.step)

--- a/src/features/identityCheck/useSetCurrentSubscriptionStep.ts
+++ b/src/features/identityCheck/useSetCurrentSubscriptionStep.ts
@@ -1,32 +1,40 @@
 import { useFocusEffect } from '@react-navigation/native'
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 
-import { SubscriptionStep } from 'api/gen'
+import { NextSubscriptionStepResponse, SubscriptionStep } from 'api/gen'
 import { useNextSubscriptionStep } from 'features/auth/signup/nextSubscriptionStep'
 import { useIdentityCheckContext } from 'features/identityCheck/context/IdentityCheckContextProvider'
 import { IdentityCheckStep } from 'features/identityCheck/types'
 import { eventMonitoring } from 'libs/monitoring'
 
-const getIdentityCheckStep = (subscriptionStep: SubscriptionStep | null): IdentityCheckStep => {
+const getIdentityCheckStep = (
+  subscriptionStep: SubscriptionStep | null
+): IdentityCheckStep | null => {
   if (subscriptionStep === SubscriptionStep.ProfileCompletion) return IdentityCheckStep.PROFILE
   if (subscriptionStep === SubscriptionStep.IdentityCheck) return IdentityCheckStep.IDENTIFICATION
-  return IdentityCheckStep.CONFIRMATION
+  if (subscriptionStep === SubscriptionStep.HonorStatement) return IdentityCheckStep.CONFIRMATION
+  return null
 }
 
 export const useSetCurrentSubscriptionStep = () => {
   const context = useIdentityCheckContext()
   const { refetch } = useNextSubscriptionStep()
+  const [subscription, setSubscription] = useState<NextSubscriptionStepResponse | undefined>()
 
   useFocusEffect(
     useCallback(() => {
       refetch()
         .then(({ data: subscription }) => {
-          const step = getIdentityCheckStep(subscription?.nextSubscriptionStep || null)
-          context.dispatch({ type: 'SET_STEP', payload: step })
+          setSubscription(subscription)
+          const nextStep = subscription?.nextSubscriptionStep
+          const step = getIdentityCheckStep(nextStep || null)
+          if (step) context.dispatch({ type: 'SET_STEP', payload: step })
         })
         .catch(() => {
           eventMonitoring.captureException(new Error('Error fetching subscription'))
         })
     }, [])
   )
+
+  return { subscription }
 }

--- a/src/features/navigation/RootNavigator/identityCheckRoutes.ts
+++ b/src/features/navigation/RootNavigator/identityCheckRoutes.ts
@@ -158,7 +158,7 @@ export const identityCheckRoutes: GenericRoute<IdentityCheckRootStackParamList>[
     name: 'UnderageAccountCreated',
     component: UnderageAccountCreated,
     path: 'creation-compte/confirmation-15-17',
-    options: { title: t`Compte 15-17 créé !` },
+    options: { title: t`Compte 15-17 créé\u00a0!` },
     secure: true,
   },
   // Errors


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12378

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
