### PR TITLE
(PC-12391) fix(translation): change space before semi-colon into nbsp

### DIFF
--- a/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -581,7 +581,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                                         ]
                                       }
                                     >
-                                      Clique sur le lien reçu à l'adresse :
+                                      Clique sur le lien reçu à l'adresse :
                                     </Text>
                                     <Text
                                       style={

--- a/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.web.test.tsx.web-snap
@@ -171,7 +171,7 @@ Object {
                                             dir="auto"
                                             style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                                           >
-                                            Clique sur le lien reçu à l'adresse :
+                                            Clique sur le lien reçu à l'adresse :
                                           </div>
                                           <div
                                             class="css-text-901oao"
@@ -489,7 +489,7 @@ Object {
                                           dir="auto"
                                           style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                                         >
-                                          Clique sur le lien reçu à l'adresse :
+                                          Clique sur le lien reçu à l'adresse :
                                         </div>
                                         <div
                                           class="css-text-901oao"

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingImpossible.deprecated.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingImpossible.deprecated.native.test.tsx.native-snap
@@ -71,7 +71,7 @@ exports[`<BookingImpossible /> should render with CTAs when offer is not yet fav
       ]
     }
   >
-    Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !
+    Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !
   </Text>
   <View
     numberOfSpaces={6}

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingImpossible.deprecated.web.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingImpossible.deprecated.web.test.tsx.web-snap
@@ -39,7 +39,7 @@ Object {
           dir="auto"
           style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; padding-right: 24px; padding-left: 24px; text-align: center;"
         >
-          Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !
+          Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !
         </div>
         <div
           class="css-view-1dbjc4n"
@@ -121,7 +121,7 @@ Object {
         dir="auto"
         style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; padding-right: 24px; padding-left: 24px; text-align: center;"
       >
-        Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !
+        Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !
       </div>
       <div
         class="css-view-1dbjc4n"

--- a/__snapshots__/features/bookings/pages/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails.native.test.tsx.native-snap
@@ -619,7 +619,7 @@ exports[`BookingDetails should render correctly 1`] = `
             ]
           }
         >
-          Tu ne peux plus annuler ta réservation : elle devait être annulée avant le 15 mars 2021
+          Tu ne peux plus annuler ta réservation : elle devait être annulée avant le 15 mars 2021
         </Text>
       </View>
       <View

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckStart.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckStart.native.test.tsx.native-snap
@@ -1309,7 +1309,7 @@ Array [
                 Il est important que les informations de ton document soient parfaitement lisibles.
                 
 
-                Nos conseils :
+                Nos conseils :
               </Text>
             </Text>
             <View

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetAddress.native.test.tsx.native-snap
@@ -251,7 +251,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
                 onBlur={[Function]}
                 onChangeText={[Function]}
                 onFocus={[Function]}
-                placeholder="Ex : 34 avenue de l'Opéra"
+                placeholder="Ex : 34 avenue de l'Opéra"
                 placeholderTextColor="#626262"
                 style={
                   Array [

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetCity.native.test.tsx.native-snap
@@ -252,7 +252,7 @@ exports[`<SetCity/> should render correctly 1`] = `
                 onBlur={[Function]}
                 onChangeText={[Function]}
                 onFocus={[Function]}
-                placeholder="Ex : 75017"
+                placeholder="Ex : 75017"
                 placeholderTextColor="#626262"
                 style={
                   Array [

--- a/__snapshots__/features/profile/pages/DeleteProfileSuccess.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfileSuccess.test.tsx.native-snap
@@ -125,7 +125,7 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
           ]
         }
       >
-        Tu as 30 jours pour te rétracter par e-mail à : support@passculture.app
+        Tu as 30 jours pour te rétracter par e-mail à : support@passculture.app
       </Text>
       <View
         numberOfSpaces={4}

--- a/__snapshots__/features/profile/pages/DeleteProfileSuccess.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfileSuccess.test.tsx.web-snap
@@ -166,7 +166,7 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
           }
         }
       >
-        Tu as 30 jours pour te rétracter par e-mail à : support@passculture.app
+        Tu as 30 jours pour te rétracter par e-mail à : support@passculture.app
       </div>
       <div
         className="css-view-1dbjc4n"

--- a/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.native-snap
+++ b/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.native-snap
@@ -167,7 +167,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
           ]
         }
       >
-        Si tu as besoin d’aide n’hésite pas à :
+        Si tu as besoin d’aide n’hésite pas à :
       </Text>
       <View
         numberOfSpaces={2}

--- a/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.web-snap
+++ b/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.web-snap
@@ -204,7 +204,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
           }
         }
       >
-        Si tu as besoin d’aide n’hésite pas à :
+        Si tu as besoin d’aide n’hésite pas à :
       </div>
       <div
         className="css-view-1dbjc4n"

--- a/eslint-custom-rules/nbsp-in-french-translations.js
+++ b/eslint-custom-rules/nbsp-in-french-translations.js
@@ -16,13 +16,13 @@ module.exports = {
   },
   create(context) {
     return {
-      'TaggedTemplateExpression[tag.name="t"] > TemplateLiteral > TemplateElement[value.raw=/\\s+[!?]/]':
+      'TaggedTemplateExpression[tag.name="t"] > TemplateLiteral > TemplateElement[value.raw=/\\s+[!?:]/]':
         (node) => {
           context.report({
             node,
-            message: 'Please use \\u00a0 (nbsp) instead of whitespace before !, ?',
+            message: 'Please use \\u00a0 (nbsp) instead of whitespace before !, ?, :',
             fix: function (fixer) {
-              const textToReplace = node.value.raw.replace(/\s+([!?])/g, '\\u00a0$1')
+              const textToReplace = node.value.raw.replace(/\s+([!?:])/g, '\\u00a0$1')
               return fixer.replaceText(node, `\`${textToReplace}\``)
             },
           })

--- a/eslint-custom-rules/nbsp-in-french-translations.js
+++ b/eslint-custom-rules/nbsp-in-french-translations.js
@@ -23,7 +23,17 @@ module.exports = {
             message: 'Please use \\u00a0 (nbsp) instead of whitespace before !, ?, :',
             fix: function (fixer) {
               const textToReplace = node.value.raw.replace(/\s+([!?:])/g, '\\u00a0$1')
-              return fixer.replaceText(node, `\`${textToReplace}\``)
+
+              // We use range here, because fixer.replaceText(node, textToReplace)
+              // removes the backticks, "${" or "}" around the text.
+              // It's because of the "range" property of the provided TemplateElement
+              // in "node" variable: the range is too wide. So we process it manually,
+              // removing the first character
+              const startRangeIndex = node.range[0] + 1
+              const endRangeIndex = startRangeIndex + node.value.raw.length
+              const range = [startRangeIndex, endRangeIndex]
+
+              return fixer.replaceTextRange(range, textToReplace)
             },
           })
         },

--- a/src/features/auth/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
+++ b/src/features/auth/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
@@ -37,7 +37,7 @@ export const ForgottenPassword: FunctionComponent = () => {
 
   useEffect(() => {
     if (!networkInfo.isConnected) {
-      setErrorMessage(t`Hors connexion : en attente du réseau.`)
+      setErrorMessage(t`Hors connexion\u00a0: en attente du réseau.`)
       setIsDoingReCaptchaChallenge(false)
     } else {
       setErrorMessage(null)
@@ -81,7 +81,7 @@ export const ForgottenPassword: FunctionComponent = () => {
       return
     }
     if (!networkInfo.isConnected) {
-      setErrorMessage(t`Hors connexion : en attente du réseau.`)
+      setErrorMessage(t`Hors connexion\u00a0: en attente du réseau.`)
       return
     }
     setIsDoingReCaptchaChallenge(true)

--- a/src/features/auth/forgottenPassword/ForgottenPassword/tests/ForgottenPassword.native.test.tsx
+++ b/src/features/auth/forgottenPassword/ForgottenPassword/tests/ForgottenPassword.native.test.tsx
@@ -58,7 +58,7 @@ describe('<ForgottenPassword />', () => {
     fireEvent.press(renderAPI.getByText('Valider'))
 
     expect(recaptchaWebviewModal.props.visible).toBeFalsy()
-    expect(renderAPI.queryByText('Hors connexion : en attente du réseau.')).toBeTruthy()
+    expect(renderAPI.queryByText('Hors connexion\u00a0: en attente du réseau.')).toBeTruthy()
     expect(renderAPI.queryByTestId('button-isloading-icon')).toBeFalsy()
   })
 

--- a/src/features/auth/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.tsx
+++ b/src/features/auth/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.tsx
@@ -33,7 +33,7 @@ export const ResetPasswordEmailSent: FunctionComponent<Props> = ({ route }) => {
       />
       <ModalContent>
         <Description>
-          <Typo.Body>{t`Clique sur le lien reçu à l'adresse :`}</Typo.Body>
+          <Typo.Body>{t`Clique sur le lien reçu à l'adresse\u00a0:`}</Typo.Body>
           <Typo.Body>{route.params.email}</Typo.Body>
           <Spacer.Column numberOfSpaces={5} />
           <CenteredText>

--- a/src/features/auth/signup/AcceptCgu/AcceptCgu.native.test.tsx
+++ b/src/features/auth/signup/AcceptCgu/AcceptCgu.native.test.tsx
@@ -79,7 +79,7 @@ describe('<AcceptCgu/>', () => {
     fireEvent.press(renderAPI.getByText('Accepter et s’inscrire'))
 
     expect(recaptchaWebviewModal.props.visible).toBeFalsy()
-    expect(renderAPI.queryByText('Hors connexion : en attente du réseau.')).toBeTruthy()
+    expect(renderAPI.queryByText('Hors connexion\u00a0: en attente du réseau.')).toBeTruthy()
     expect(renderAPI.queryByTestId('button-isloading-icon')).toBeFalsy()
   })
 

--- a/src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
+++ b/src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
@@ -28,7 +28,7 @@ export const AcceptCgu: FC<PreValidationSignupStepProps> = (props) => {
 
   useEffect(() => {
     if (!networkInfo.isConnected) {
-      setErrorMessage(t`Hors connexion : en attente du réseau.`)
+      setErrorMessage(t`Hors connexion\u00a0: en attente du réseau.`)
       setIsDoingReCaptchaChallenge(false)
     } else {
       setErrorMessage(null)
@@ -118,7 +118,7 @@ export const AcceptCgu: FC<PreValidationSignupStepProps> = (props) => {
         <Spacer.Column numberOfSpaces={5} />
         <Paragraphe>
           <Typo.Body>
-            {t`Pour en savoir plus sur la gestion de tes données personnelles et exercer tes droits tu peux :`}
+            {t`Pour en savoir plus sur la gestion de tes données personnelles et exercer tes droits tu peux\u00a0:`}
           </Typo.Body>
         </Paragraphe>
         <ButtonTertiary

--- a/src/features/auth/signup/PhoneValidation/PhoneValidationTooManyAttempts/PhoneValidationTooManyAttempts.tsx
+++ b/src/features/auth/signup/PhoneValidation/PhoneValidationTooManyAttempts/PhoneValidationTooManyAttempts.tsx
@@ -15,7 +15,7 @@ export function PhoneValidationTooManyAttempts() {
   return (
     <GenericInfoPage title={t`Trop de tentatives\u00a0!`} icon={AccountLocked}>
       <StyledBody>
-        {t`Tu as dépassé le nombre d’essais autorisés. L’accès à ton crédit pass Culture a été bloqué. Pour le récupérer tu peux :`}
+        {t`Tu as dépassé le nombre d’essais autorisés. L’accès à ton crédit pass Culture a été bloqué. Pour le récupérer tu peux\u00a0:`}
       </StyledBody>
       <Spacer.Column numberOfSpaces={7} />
       <ButtonTertiaryWhite

--- a/src/features/auth/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSent.tsx
+++ b/src/features/auth/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSent.tsx
@@ -62,14 +62,14 @@ export const SignupConfirmationEmailSent: FunctionComponent<Props> = ({ route })
       />
       <EmailSentModalContent>
         <Description>
-          <Typo.Body>{t`Clique sur le lien reçu à l'adresse :`}</Typo.Body>
+          <Typo.Body>{t`Clique sur le lien reçu à l'adresse\u00a0:`}</Typo.Body>
           <CenteredText>
             <Typo.Body>{route.params.email}</Typo.Body>
           </CenteredText>
           <Spacer.Column numberOfSpaces={5} />
           <CenteredText>
             <Typo.Body>
-              {t`Nous devons vérifier tes informations : l'email peut prendre quelques minutes pour arriver.`}
+              {t`Nous devons vérifier tes informations\u00a0: l'email peut prendre quelques minutes pour arriver.`}
             </Typo.Body>
           </CenteredText>
           <Spacer.Column numberOfSpaces={5} />

--- a/src/features/bookOffer/components/BookingImpossible.tsx
+++ b/src/features/bookOffer/components/BookingImpossible.tsx
@@ -59,7 +59,7 @@ export const BookingImpossible: React.FC = () => {
       <Spacer.Column numberOfSpaces={6} />
       {!favorite ? (
         <Content>
-          {t`Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web\u00a0!`}
+          {t`Mets cette offre en favoris\u00a0: tu recevras une notification avec un lien pour la réserver sur notre application web\u00a0!`}
         </Content>
       ) : (
         <Content>{t`Rends-toi vite sur le site pass Culture afin de la réserver`}</Content>

--- a/src/features/bookings/components/BookingDetailsCancelButton.native.test.tsx
+++ b/src/features/bookings/components/BookingDetailsCancelButton.native.test.tsx
@@ -87,7 +87,7 @@ describe('<BookingDetailsCancelButton />', () => {
     booking.confirmationDate = new Date('2020-11-01T00:00:00Z')
     const { getByText } = renderBookingDetailsCancelButton(booking)
     getByText(
-      'Tu ne peux plus annuler ta réservation : elle devait être annulée avant le 1 novembre 2020'
+      'Tu ne peux plus annuler ta réservation\u00a0: elle devait être annulée avant le\u00a01 novembre 2020'
     )
   })
   it('should block user if cancellation date is over and user is ex beneficiary ', () => {

--- a/src/features/bookings/components/BookingDetailsCancelButton.tsx
+++ b/src/features/bookings/components/BookingDetailsCancelButton.tsx
@@ -75,7 +75,7 @@ export const BookingDetailsCancelButton = (props: BookingDetailsCancelButtonProp
     } else {
       return (
         <CancellationCaption>
-          {t`Tu ne peux plus annuler ta réservation : elle devait être annulée avant le` +
+          {t`Tu ne peux plus annuler ta réservation\u00a0: elle devait être annulée avant le` +
             '\u00a0' +
             formattedConfirmationDate}
         </CancellationCaption>

--- a/src/features/firstTutorial/pages/FirstTutorial/components/SecondCard.native.test.tsx
+++ b/src/features/firstTutorial/pages/FirstTutorial/components/SecondCard.native.test.tsx
@@ -24,7 +24,7 @@ describe('SecondCard', () => {
   })
 
   it.each([
-    [true, 'de 15 à 18 ans : le Gouvernement offre un crédit à dépenser dans l’application.'],
+    [true, 'de 15 à 18 ans\u00a0: le Gouvernement offre un crédit à dépenser dans l’application.'],
     [
       false,
       "dans l'année de tes 18 ans, le Gouvernement offre un crédit de 300€ à dépenser dans l’application.",

--- a/src/features/firstTutorial/pages/FirstTutorial/components/SecondCard.tsx
+++ b/src/features/firstTutorial/pages/FirstTutorial/components/SecondCard.tsx
@@ -80,7 +80,7 @@ export function SecondCard(props: AchievementCardKeyProps) {
   }
 
   let subtitle = t`et si tu as...`
-  let text = t`de 15 à 18 ans : le Gouvernement offre un crédit à dépenser dans l’application.`
+  let text = t`de 15 à 18 ans\u00a0: le Gouvernement offre un crédit à dépenser dans l’application.`
 
   if (!enabledGeneralisation) {
     const deposit = depositAmountsByAge.eighteenYearsOldDeposit.replace(' ', '')

--- a/src/features/identityCheck/components/SomeAdviceBeforeIdentityCheckModal.tsx
+++ b/src/features/identityCheck/components/SomeAdviceBeforeIdentityCheckModal.tsx
@@ -35,7 +35,7 @@ export const SomeAdviceBeforeIdentityCheckModal: FunctionComponent<Props> = ({
       <Typo.Body>
         {t`Il est important que les informations de ton document soient parfaitement lisibles.`}
         {'\n'}
-        {t`Nos conseils :`}
+        {t`Nos conseils\u00a0:`}
       </Typo.Body>
     </Description>
     <Instructions>

--- a/src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
+++ b/src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
@@ -33,7 +33,7 @@ const UserNotWhitelisted: NotEligibleEduConnectErrorData = {
   Icon: Clock,
   title: t`Tu ne fais pas partie de la phase de test`,
   description:
-    t`Encore un peu de patience : en fonction de ton âge, tu pourras compléter ton inscription à la date suivante : ` +
+    t`Encore un peu de patience\u00a0: en fonction de ton âge, tu pourras compléter ton inscription à la date suivante\u00a0: ` +
     '\n\n' +
     t`17 ans, le 10 janvier` +
     '\n' +

--- a/src/features/identityCheck/pages/profile/SetAddress.tsx
+++ b/src/features/identityCheck/pages/profile/SetAddress.tsx
@@ -112,7 +112,7 @@ export const SetAddress = () => {
             onChangeText={onChangeAddress}
             value={query}
             label={label}
-            placeholder={t`Ex : 34 avenue de l'Opéra`}
+            placeholder={t`Ex\u00a0: 34 avenue de l'Opéra`}
             textContentType="addressState"
             RightIcon={() => (query.length > 0 ? <RightIcon /> : null)}
             {...accessibilityAndTestId(t`Entrée pour l'adresse`)}
@@ -131,7 +131,7 @@ export const SetAddress = () => {
                 onPressOption={onAddressSelection}
                 optionKey={address}
                 key={address}
-                {...accessibilityAndTestId(t`Proposition d'adresse ${index + 1} : ${address}`)}
+                {...accessibilityAndTestId(t`Proposition d'adresse ${index + 1}\u00a0: ${address}`)}
               />
             ))}
           </AdressesContainer>

--- a/src/features/identityCheck/pages/profile/SetCity.tsx
+++ b/src/features/identityCheck/pages/profile/SetCity.tsx
@@ -98,7 +98,7 @@ export const SetCity = () => {
             onChangeText={onChangePostalCode}
             value={query}
             label={t`Indique ton code postal et choisis ta ville`}
-            placeholder={t`Ex : 75017`}
+            placeholder={t`Ex\u00a0: 75017`}
             textContentType="postalCode"
             keyboardType="number-pad"
             RightIcon={() => (query.length > 0 ? <RightIcon /> : null)}
@@ -119,7 +119,9 @@ export const SetCity = () => {
                 onPressOption={onPressOption}
                 optionKey={keyExtractor(city)}
                 key={city.name}
-                {...accessibilityAndTestId(t`Proposition de ville ${index + 1} : ${city.name}`)}
+                {...accessibilityAndTestId(
+                  t`Proposition de ville ${index + 1}\u00a0: ${city.name}`
+                )}
               />
             ))}
           </CitiesContainer>

--- a/src/features/identityCheck/pages/profile/__test__/SetAddress.native.test.tsx
+++ b/src/features/identityCheck/pages/profile/__test__/SetAddress.native.test.tsx
@@ -61,7 +61,7 @@ describe('<SetAddress/>', () => {
 
     const { getByText, getByPlaceholderText } = renderSetAddresse()
 
-    const input = getByPlaceholderText("Ex : 34 avenue de l'Opéra")
+    const input = getByPlaceholderText("Ex\u00a0: 34 avenue de l'Opéra")
     fireEvent.changeText(input, QUERY_ADDRESS)
 
     await waitFor(() => {
@@ -82,7 +82,7 @@ describe('<SetAddress/>', () => {
 
     const { getByText, getByPlaceholderText } = renderSetAddresse()
 
-    const input = getByPlaceholderText("Ex : 34 avenue de l'Opéra")
+    const input = getByPlaceholderText("Ex\u00a0: 34 avenue de l'Opéra")
     fireEvent.changeText(input, QUERY_ADDRESS)
 
     await waitFor(() => getByText(mockedSuggestedPlaces.features[1].properties.label))
@@ -105,7 +105,7 @@ describe('<SetAddress/>', () => {
 
     const { getByPlaceholderText } = renderSetAddresse()
 
-    const input = getByPlaceholderText("Ex : 34 avenue de l'Opéra")
+    const input = getByPlaceholderText("Ex\u00a0: 34 avenue de l'Opéra")
     fireEvent.changeText(input, QUERY_ADDRESS)
 
     await waitFor(() => {

--- a/src/features/identityCheck/pages/profile/__test__/SetCity.native.test.tsx
+++ b/src/features/identityCheck/pages/profile/__test__/SetCity.native.test.tsx
@@ -41,7 +41,7 @@ describe('<SetCity/>', () => {
 
     const { getByText, getByPlaceholderText } = renderSetCity()
 
-    const input = getByPlaceholderText('Ex : 75017')
+    const input = getByPlaceholderText('Ex\u00a0: 75017')
     fireEvent.changeText(input, POSTAL_CODE)
 
     await waitFor(() => {
@@ -58,7 +58,7 @@ describe('<SetCity/>', () => {
 
     const { getByText, getByPlaceholderText } = renderSetCity()
 
-    const input = getByPlaceholderText('Ex : 75017')
+    const input = getByPlaceholderText('Ex\u00a0: 75017')
     fireEvent.changeText(input, POSTAL_CODE)
 
     await waitFor(() => {
@@ -75,7 +75,7 @@ describe('<SetCity/>', () => {
 
     const { getByText, getByPlaceholderText } = renderSetCity()
 
-    const input = getByPlaceholderText('Ex : 75017')
+    const input = getByPlaceholderText('Ex\u00a0: 75017')
     fireEvent.changeText(input, POSTAL_CODE)
 
     await waitFor(() => getByText(city.nom))

--- a/src/features/navigation/helpers/openUrl.ts
+++ b/src/features/navigation/helpers/openUrl.ts
@@ -53,7 +53,7 @@ const openExternalUrl = async (
 
 const showAlert = (url: string) => {
   const alertTitle = t`Problème technique ;(`
-  const alertMessage = t`Nous n'arrivons pas à ouvrir ce lien : ${url}`
+  const alertMessage = t`Nous n'arrivons pas à ouvrir ce lien\u00a0: ${url}`
   const alertButtons = undefined
   const alertAndroidOptions = { cancelable: true }
   Alert.alert(alertTitle, alertMessage, alertButtons, alertAndroidOptions)

--- a/src/features/profile/components/BeneficiaryCeilings.tsx
+++ b/src/features/profile/components/BeneficiaryCeilings.tsx
@@ -58,7 +58,7 @@ export function BeneficiaryCeilings(props: BeneficiaryCeilingsProps) {
   return (
     <GreyContainer>
       <Spacer.Column numberOfSpaces={6} />
-      <Title>{t`Tu peux encore dépenser :`}</Title>
+      <Title>{t`Tu peux encore dépenser\u00a0:`}</Title>
       <Spacer.Column numberOfSpaces={5} />
       {!!props.domainsCredit && (
         <CeilingsRow>

--- a/src/features/profile/pages/DeleteProfileSuccess.tsx
+++ b/src/features/profile/pages/DeleteProfileSuccess.tsx
@@ -14,7 +14,7 @@ export function DeleteProfileSuccess() {
       title={t`Compte désactivé`}
       icon={ProfileDeletionLight}
       iconSize={getSpacing(26)}>
-      <StyledBody>{t`Tu as 30 jours pour te rétracter par e-mail à : support@passculture.app`}</StyledBody>
+      <StyledBody>{t`Tu as 30 jours pour te rétracter par e-mail à\u00a0: support@passculture.app`}</StyledBody>
       <Spacer.Column numberOfSpaces={4} />
 
       <StyledBody>{t`Une fois ce délai écoulé, ton compte pass Culture sera définitivement supprimé.`}</StyledBody>

--- a/src/features/search/components/CalendarPicker.web.tsx
+++ b/src/features/search/components/CalendarPicker.web.tsx
@@ -179,7 +179,11 @@ export const CalendarPicker: React.FC<Props> = ({
           adjustsFontSizeToFit={true}
         />
         {isMobileDateInvalid ? (
-          <InputError visible messageId={t`Choisis une date valide :)`} numberOfSpacesTop={1} />
+          <InputError
+            visible
+            messageId={t`Choisis une date valide\u00a0:)`}
+            numberOfSpacesTop={1}
+          />
         ) : (
           <Spacer.Column numberOfSpaces={7} />
         )}

--- a/src/libs/itinerary/useItinerary.native.test.ts
+++ b/src/libs/itinerary/useItinerary.native.test.ts
@@ -41,7 +41,7 @@ describe('useItinerary', () => {
     result.current.navigateTo(address)
     expect(alertMock).toHaveBeenCalledWith(
       "Voir l'itinéraire",
-      "Choisissez l'application pour vous rendre sur le lieu de l'offre :",
+      "Choisissez l'application pour vous rendre sur le lieu de l'offre\u00a0:",
       [
         { text: 'Sygic', onPress: expect.any(Function) },
         { text: 'Waze', onPress: expect.any(Function) },
@@ -67,7 +67,7 @@ describe('useItinerary', () => {
     result.current.navigateTo(address)
     expect(alertMock).toHaveBeenCalledWith(
       "Voir l'itinéraire",
-      "Choisissez l'application pour vous rendre sur le lieu de l'offre :",
+      "Choisissez l'application pour vous rendre sur le lieu de l'offre\u00a0:",
       [
         { text: 'Sygic', onPress: expect.any(Function) },
         { text: 'Waze', onPress: expect.any(Function) },
@@ -124,7 +124,7 @@ describe('useItinerary', () => {
     result.current.navigateTo(address)
     expect(alertMock).toHaveBeenCalledWith(
       "Voir l'itinéraire",
-      "Choisissez l'application pour vous rendre sur le lieu de l'offre :",
+      "Choisissez l'application pour vous rendre sur le lieu de l'offre\u00a0:",
       [
         { text: 'Sygic', onPress: expect.any(Function) },
         { text: 'Waze', onPress: expect.any(Function) },

--- a/src/libs/itinerary/useItinerary.ts
+++ b/src/libs/itinerary/useItinerary.ts
@@ -75,7 +75,7 @@ export const useItinerary = (): UseItineraryResult => {
     if (Platform.OS === 'ios') alertButtons.push({ text: t`Annuler`, style: 'cancel' })
     Alert.alert(
       t`Voir l'itinéraire`,
-      t`Choisissez l'application pour vous rendre sur le lieu de l'offre :`,
+      t`Choisissez l'application pour vous rendre sur le lieu de l'offre\u00a0:`,
       alertButtons,
       { cancelable: true }
     )

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -452,12 +452,12 @@ msgid "Choisis ton statut"
 msgstr "Choisis ton statut"
 
 #: src/features/search/components/CalendarPicker.web.tsx
-msgid "Choisis une date valide :)"
-msgstr "Choisis une date valide :)"
+msgid "Choisis une date valide :)"
+msgstr "Choisis une date valide :)"
 
 #: src/libs/itinerary/useItinerary.ts
-msgid "Choisissez l'application pour vous rendre sur le lieu de l'offre :"
-msgstr "Choisissez l'application pour vous rendre sur le lieu de l'offre :"
+msgid "Choisissez l'application pour vous rendre sur le lieu de l'offre :"
+msgstr "Choisissez l'application pour vous rendre sur le lieu de l'offre :"
 
 #: src/libs/country-picker/CountryPicker.tsx
 msgid "Choix de l'indicatif téléphonique"
@@ -473,8 +473,8 @@ msgstr "Cinéma - Salle de projections"
 
 #: src/features/auth/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.tsx
 #: src/features/auth/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSent.tsx
-msgid "Clique sur le lien reçu à l'adresse :"
-msgstr "Clique sur le lien reçu à l'adresse :"
+msgid "Clique sur le lien reçu à l'adresse :"
+msgstr "Clique sur le lien reçu à l'adresse :"
 
 #: src/ui/components/LayoutExpiredLink.tsx
 msgid "Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien."
@@ -879,8 +879,8 @@ msgid "En voir plus"
 msgstr "En voir plus"
 
 #: src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
-msgid "Encore un peu de patience : en fonction de ton âge, tu pourras compléter ton inscription à la date suivante :"
-msgstr "Encore un peu de patience : en fonction de ton âge, tu pourras compléter ton inscription à la date suivante :"
+msgid "Encore un peu de patience : en fonction de ton âge, tu pourras compléter ton inscription à la date suivante :"
+msgstr "Encore un peu de patience : en fonction de ton âge, tu pourras compléter ton inscription à la date suivante :"
 
 #: src/features/profile/pages/ChangeEmail/ChangeEmail.tsx
 #: src/features/profile/pages/ChangePassword/ChangePassword.tsx
@@ -1039,18 +1039,18 @@ msgstr "Etablissement scolaire - Accueil"
 msgid "Etablissement scolaire - Sélection"
 msgstr "Etablissement scolaire - Sélection"
 
-#: src/features/identityCheck/pages/profile/SetAddress.tsx
-msgid "Ex : 34 avenue de l'Opéra"
-msgstr "Ex : 34 avenue de l'Opéra"
-
-#: src/features/identityCheck/pages/profile/SetCity.tsx
-msgid "Ex : 75017"
-msgstr "Ex : 75017"
-
 #: src/features/bookings/components/NoBookingsView.tsx
 #: src/features/favorites/components/NoFavoritesResult.tsx
 msgid "Explorer les offres"
 msgstr "Explorer les offres"
+
+#: src/features/identityCheck/pages/profile/SetAddress.tsx
+msgid "Ex : 34 avenue de l'Opéra"
+msgstr "Ex : 34 avenue de l'Opéra"
+
+#: src/features/identityCheck/pages/profile/SetCity.tsx
+msgid "Ex : 75017"
+msgstr "Ex : 75017"
 
 #: src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.tsx
 msgid "Faire une nouvelle demande"
@@ -1165,8 +1165,8 @@ msgstr "Historique"
 #: src/features/auth/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
 #: src/features/auth/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
 #: src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
-msgid "Hors connexion : en attente du réseau."
-msgstr "Hors connexion : en attente du réseau."
+msgid "Hors connexion : en attente du réseau."
+msgstr "Hors connexion : en attente du réseau."
 
 #: src/features/offer/pages/OfferDescription.tsx
 msgid "ISBN"
@@ -1589,8 +1589,8 @@ msgid "Mes réservations terminées"
 msgstr "Mes réservations terminées"
 
 #: src/features/bookOffer/components/BookingImpossible.tsx
-msgid "Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !"
-msgstr "Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !"
+msgid "Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !"
+msgstr "Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !"
 
 #: src/features/bookOffer/components/BookingImpossible.tsx
 #: src/features/offer/components/OfferHeader.tsx
@@ -1718,8 +1718,8 @@ msgid "Nombre de tentatives dépassé. Réessaye dans 1 minute."
 msgstr "Nombre de tentatives dépassé. Réessaye dans 1 minute."
 
 #: src/features/identityCheck/components/SomeAdviceBeforeIdentityCheckModal.tsx
-msgid "Nos conseils :"
-msgstr "Nos conseils :"
+msgid "Nos conseils :"
+msgstr "Nos conseils :"
 
 #: src/features/firstTutorial/pages/FirstTutorial/components/FourthCard.tsx
 msgid "Nos nombreux partenaires ajoutent de nouvelles offres quotidiennement. Découvre les dès maintenant !"
@@ -1751,12 +1751,12 @@ msgid "Nous avons eu un problème pour trouver la ville associée à ton code po
 msgstr "Nous avons eu un problème pour trouver la ville associée à ton code postal. Réessaie plus tard."
 
 #: src/features/auth/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSent.tsx
-msgid "Nous devons vérifier tes informations : l'email peut prendre quelques minutes pour arriver."
-msgstr "Nous devons vérifier tes informations : l'email peut prendre quelques minutes pour arriver."
+msgid "Nous devons vérifier tes informations : l'email peut prendre quelques minutes pour arriver."
+msgstr "Nous devons vérifier tes informations : l'email peut prendre quelques minutes pour arriver."
 
 #: src/features/navigation/helpers/openUrl.ts
-msgid "Nous n'arrivons pas à ouvrir ce lien : {url}"
-msgstr "Nous n'arrivons pas à ouvrir ce lien : {url}"
+msgid "Nous n'arrivons pas à ouvrir ce lien : {url}"
+msgstr "Nous n'arrivons pas à ouvrir ce lien : {url}"
 
 #: src/features/identityCheck/pages/identification/IdentityCheckUnavailable.tsx
 msgid "Nous reviendrons vers toi dès que le service sera rétabli."
@@ -1956,8 +1956,8 @@ msgid "Politique de confidentialité."
 msgstr "Politique de confidentialité."
 
 #: src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
-msgid "Pour en savoir plus sur la gestion de tes données personnelles et exercer tes droits tu peux :"
-msgstr "Pour en savoir plus sur la gestion de tes données personnelles et exercer tes droits tu peux :"
+msgid "Pour en savoir plus sur la gestion de tes données personnelles et exercer tes droits tu peux :"
+msgstr "Pour en savoir plus sur la gestion de tes données personnelles et exercer tes droits tu peux :"
 
 #: src/features/profile/pages/ConsentSettings.tsx
 msgid "Pour plus d'informations, nous t'invitons à consulter notre"
@@ -2042,12 +2042,12 @@ msgid "Profite de ton crédit"
 msgstr "Profite de ton crédit"
 
 #: src/features/identityCheck/pages/profile/SetAddress.tsx
-msgid "Proposition d'adresse {0} : {address}"
-msgstr "Proposition d'adresse {0} : {address}"
+msgid "Proposition d'adresse {0} : {address}"
+msgstr "Proposition d'adresse {0} : {address}"
 
 #: src/features/identityCheck/pages/profile/SetCity.tsx
-msgid "Proposition de ville {0} : {1}"
-msgstr "Proposition de ville {0} : {1}"
+msgid "Proposition de ville {0} : {1}"
+msgstr "Proposition de ville {0} : {1}"
 
 #: src/features/favorites/pages/FavoritesSorts.tsx
 msgid "Proximité géographique"
@@ -2348,8 +2348,8 @@ msgid "Seules les sorties seront affichées"
 msgstr "Seules les sorties seront affichées"
 
 #: src/ui/components/LayoutExpiredLink.tsx
-msgid "Si tu as besoin d’aide n’hésite pas à :"
-msgstr "Si tu as besoin d’aide n’hésite pas à :"
+msgid "Si tu as besoin d’aide n’hésite pas à :"
+msgstr "Si tu as besoin d’aide n’hésite pas à :"
 
 #: src/features/auth/signup/underageSignup/SelectSchoolHome.tsx
 msgid "Si tu es élève dans"
@@ -2593,8 +2593,8 @@ msgid "Tu as 18 ans..."
 msgstr "Tu as 18 ans..."
 
 #: src/features/profile/pages/DeleteProfileSuccess.tsx
-msgid "Tu as 30 jours pour te rétracter par e-mail à : support@passculture.app"
-msgstr "Tu as 30 jours pour te rétracter par e-mail à : support@passculture.app"
+msgid "Tu as 30 jours pour te rétracter par e-mail à : support@passculture.app"
+msgstr "Tu as 30 jours pour te rétracter par e-mail à : support@passculture.app"
 
 #: src/features/offer/pages/OfferBody.tsx
 msgid "Tu as déjà signalé cette offre"
@@ -2605,8 +2605,8 @@ msgid "Tu as déjà un compte ?"
 msgstr "Tu as déjà un compte ?"
 
 #: src/features/auth/signup/PhoneValidation/PhoneValidationTooManyAttempts/PhoneValidationTooManyAttempts.tsx
-msgid "Tu as dépassé le nombre d’essais autorisés. L’accès à ton crédit pass Culture a été bloqué. Pour le récupérer tu peux :"
-msgstr "Tu as dépassé le nombre d’essais autorisés. L’accès à ton crédit pass Culture a été bloqué. Pour le récupérer tu peux :"
+msgid "Tu as dépassé le nombre d’essais autorisés. L’accès à ton crédit pass Culture a été bloqué. Pour le récupérer tu peux :"
+msgstr "Tu as dépassé le nombre d’essais autorisés. L’accès à ton crédit pass Culture a été bloqué. Pour le récupérer tu peux :"
 
 #: src/features/auth/signup/PhoneValidation/PhoneValidationTooManySMSSent/PhoneValidationTooManySMSSent.tsx
 msgid "Tu as dépassé le nombre d’essais autorisés. Tu pourras réessayer dans 12 heures !"
@@ -2653,8 +2653,8 @@ msgid "Tu ne fais pas partie de la phase de test"
 msgstr "Tu ne fais pas partie de la phase de test"
 
 #: src/features/bookings/components/BookingDetailsCancelButton.tsx
-msgid "Tu ne peux plus annuler ta réservation : elle devait être annulée avant le"
-msgstr "Tu ne peux plus annuler ta réservation : elle devait être annulée avant le"
+msgid "Tu ne peux plus annuler ta réservation : elle devait être annulée avant le"
+msgstr "Tu ne peux plus annuler ta réservation : elle devait être annulée avant le"
 
 #: src/features/bookings/components/NoBookingsView.tsx
 msgid ""
@@ -2691,8 +2691,8 @@ msgid "Tu peux aussi découvrir les autres activités culturelles sur l'applicat
 msgstr "Tu peux aussi découvrir les autres activités culturelles sur l'application mais leur réservation s'effectuera sur les sites de nos partenaires !"
 
 #: src/features/profile/components/BeneficiaryCeilings.tsx
-msgid "Tu peux encore dépenser :"
-msgstr "Tu peux encore dépenser :"
+msgid "Tu peux encore dépenser :"
+msgstr "Tu peux encore dépenser :"
 
 #: src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.tsx
 msgid "Tu peux faire une nouvelle demande de modification dans ton profil."
@@ -3070,8 +3070,8 @@ msgid "date d'éligibilité"
 msgstr "Patience ! Reviens à partir du {date} pour continuer ta souscription et bénéficier du crédit pass Culture."
 
 #: src/features/firstTutorial/pages/FirstTutorial/components/SecondCard.tsx
-msgid "de 15 à 18 ans : le Gouvernement offre un crédit à dépenser dans l’application."
-msgstr "de 15 à 18 ans : le Gouvernement offre un crédit à dépenser dans l’application."
+msgid "de 15 à 18 ans : le Gouvernement offre un crédit à dépenser dans l’application."
+msgstr "de 15 à 18 ans : le Gouvernement offre un crédit à dépenser dans l’application."
 
 #: src/features/auth/signup/underageSignup/SelectSchoolHome.tsx
 msgid "des académies de Rennes ou de Versailles, tu fais partie de la phase de test du pass Culture 15-17 ans."

--- a/src/ui/components/LayoutExpiredLink.tsx
+++ b/src/ui/components/LayoutExpiredLink.tsx
@@ -36,7 +36,7 @@ export function LayoutExpiredLink({
 
       {!!urlFAQ || !!contactSupport ? (
         <React.Fragment>
-          <StyledBody>{t`Si tu as besoin d’aide n’hésite pas à :`}</StyledBody>
+          <StyledBody>{t`Si tu as besoin d’aide n’hésite pas à\u00a0:`}</StyledBody>
           <Spacer.Column numberOfSpaces={2} />
         </React.Fragment>
       ) : null}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12391

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
