### PR TITLE
(PC-12360) feat(AppButton): update design for AppButton

### DIFF
--- a/__snapshots__/features/auth/forgottenPassword/ForgottenPassword/tests/ForgottenPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ForgottenPassword/tests/ForgottenPassword.native.test.tsx.native-snap
@@ -84,7 +84,7 @@ exports[`<ForgottenPassword /> should enable validate button when email input is
                         \\"fontFamily\\": \\"Montserrat-Bold\\",
                         \\"fontSize\\": 15,
                         \\"lineHeight\\": 20,
-                        \\"marginLeft\\": 5,
+                        \\"marginLeft\\": 0,
                         \\"maxWidth\\": \\"100%\\",
                       },
                     ]

--- a/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -685,6 +685,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                                       </View>
                                       <Text
                                         adjustsFontSizeToFit={false}
+                                        icon={[Function]}
                                         numberOfLines={1}
                                         style={
                                           Array [
@@ -693,7 +694,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                                               "fontFamily": "Montserrat-Bold",
                                               "fontSize": 15,
                                               "lineHeight": 20,
-                                              "marginLeft": 5,
+                                              "marginLeft": 8,
                                               "maxWidth": "100%",
                                             },
                                           ]
@@ -768,6 +769,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                                     </View>
                                     <Text
                                       adjustsFontSizeToFit={false}
+                                      icon={[Function]}
                                       numberOfLines={1}
                                       style={
                                         Array [
@@ -776,7 +778,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                                             "fontFamily": "Montserrat-Bold",
                                             "fontSize": 15,
                                             "lineHeight": 20,
-                                            "marginLeft": 5,
+                                            "marginLeft": 8,
                                             "maxWidth": "100%",
                                           },
                                         ]

--- a/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.web.test.tsx.web-snap
@@ -221,7 +221,7 @@ Object {
                                             <div
                                               class="css-text-901oao css-textOneLine-vcwn7f"
                                               dir="auto"
-                                              style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                                              style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
                                             >
                                               Consulter l'article d'aide
                                             </div>
@@ -539,7 +539,7 @@ Object {
                                           <div
                                             class="css-text-901oao css-textOneLine-vcwn7f"
                                             dir="auto"
-                                            style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                                            style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
                                           >
                                             Consulter l'article d'aide
                                           </div>

--- a/__snapshots__/features/auth/login/Login.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/login/Login.native.test.tsx.native-snap
@@ -118,7 +118,7 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
                       \\"fontFamily\\": \\"Montserrat-Bold\\",
                       \\"fontSize\\": 15,
                       \\"lineHeight\\": 20,
-                      \\"marginLeft\\": 5,
+                      \\"marginLeft\\": 0,
                       \\"maxWidth\\": \\"100%\\",
                     },
                   ]
@@ -354,7 +354,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                       \\"fontFamily\\": \\"Montserrat-Bold\\",
                       \\"fontSize\\": 15,
                       \\"lineHeight\\": 20,
-                      \\"marginLeft\\": 5,
+                      \\"marginLeft\\": 0,
                       \\"maxWidth\\": \\"100%\\",
                     },
                   ]
@@ -590,7 +590,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                       \\"fontFamily\\": \\"Montserrat-Bold\\",
                       \\"fontSize\\": 15,
                       \\"lineHeight\\": 20,
-                      \\"marginLeft\\": 5,
+                      \\"marginLeft\\": 0,
                       \\"maxWidth\\": \\"100%\\",
                     },
                   ]
@@ -826,7 +826,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                       \\"fontFamily\\": \\"Montserrat-Bold\\",
                       \\"fontSize\\": 15,
                       \\"lineHeight\\": 20,
-                      \\"marginLeft\\": 5,
+                      \\"marginLeft\\": 0,
                       \\"maxWidth\\": \\"100%\\",
                     },
                   ]

--- a/__snapshots__/features/auth/signup/AccountCreated/tests/AccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/AccountCreated/tests/AccountCreated.native.test.tsx.native-snap
@@ -175,7 +175,7 @@ exports[`<AccountCreated /> should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/auth/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
@@ -53,7 +53,7 @@ Array [
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 5,
+              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]
@@ -397,7 +397,7 @@ Array [
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 5,
+              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]
@@ -748,7 +748,7 @@ exports[`SetBirthday Page should render properly 1`] = `
             "fontFamily": "Montserrat-Bold",
             "fontSize": 15,
             "lineHeight": 20,
-            "marginLeft": 5,
+            "marginLeft": 0,
             "maxWidth": "100%",
           },
         ]
@@ -1092,7 +1092,7 @@ exports[`SetBirthday Page should render properly 1`] = `
             "fontFamily": "Montserrat-Bold",
             "fontSize": 15,
             "lineHeight": 20,
-            "marginLeft": 5,
+            "marginLeft": 0,
             "maxWidth": "100%",
           },
         ]

--- a/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.native-snap
@@ -180,7 +180,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.web-snap
+++ b/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.web-snap
@@ -239,7 +239,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
               "fontFamily": "Montserrat-Bold",
               "fontSize": "15px",
               "lineHeight": "20px",
-              "marginLeft": "5px",
+              "marginLeft": "0px",
               "maxWidth": "100%",
             }
           }

--- a/__snapshots__/features/auth/signup/VerifyEligiblity/tests/VerifyEligibility.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/VerifyEligiblity/tests/VerifyEligibility.test.tsx.native-snap
@@ -182,7 +182,7 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -246,6 +246,7 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
         </View>
         <Text
           adjustsFontSizeToFit={false}
+          icon={[Function]}
           numberOfLines={1}
           style={
             Array [
@@ -254,7 +255,7 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/auth/signup/VerifyEligiblity/tests/VerifyEligibility.test.tsx.web-snap
+++ b/__snapshots__/features/auth/signup/VerifyEligiblity/tests/VerifyEligibility.test.tsx.web-snap
@@ -241,7 +241,7 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
               "fontFamily": "Montserrat-Bold",
               "fontSize": "15px",
               "lineHeight": "20px",
-              "marginLeft": "5px",
+              "marginLeft": "0px",
               "maxWidth": "100%",
             }
           }
@@ -331,7 +331,7 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
               "fontFamily": "Montserrat-Bold",
               "fontSize": "15px",
               "lineHeight": "20px",
-              "marginLeft": "5px",
+              "marginLeft": "8px",
               "maxWidth": "100%",
             }
           }

--- a/__snapshots__/features/auth/signup/idCheck/DenyAccessToIdCheck.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/idCheck/DenyAccessToIdCheck.native.test.tsx.native-snap
@@ -382,7 +382,7 @@ exports[`<DenyAccessToIdCheckModal /> should match snapshot 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 5,
+                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx.native-snap
@@ -515,7 +515,7 @@ exports[`<BookingDetails /> should render correctly when user has selected optio
             "fontFamily": "Montserrat-Bold",
             "fontSize": 15,
             "lineHeight": 20,
-            "marginLeft": 5,
+            "marginLeft": 0,
             "maxWidth": "100%",
           },
         ]

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingEventChoices.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingEventChoices.native.test.tsx.native-snap
@@ -570,7 +570,7 @@ exports[`<BookingEventChoices /> should display date step and hour step and duo 
             "fontFamily": "Montserrat-Bold",
             "fontSize": 15,
             "lineHeight": 20,
-            "marginLeft": 5,
+            "marginLeft": 0,
             "maxWidth": "100%",
           },
         ]

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingEventChoices.web.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingEventChoices.web.test.tsx.web-snap
@@ -233,7 +233,7 @@ Object {
           <div
             class="css-text-901oao css-textOneLine-vcwn7f"
             dir="auto"
-            style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+            style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
           >
             Valider ces options
           </div>
@@ -470,7 +470,7 @@ Object {
         <div
           class="css-text-901oao css-textOneLine-vcwn7f"
           dir="auto"
-          style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+          style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
         >
           Valider ces options
         </div>

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingImpossible.deprecated.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingImpossible.deprecated.native.test.tsx.native-snap
@@ -126,7 +126,7 @@ exports[`<BookingImpossible /> should render with CTAs when offer is not yet fav
             "fontFamily": "Montserrat-Bold",
             "fontSize": 15,
             "lineHeight": 20,
-            "marginLeft": 5,
+            "marginLeft": 0,
             "maxWidth": "100%",
           },
         ]
@@ -189,7 +189,7 @@ exports[`<BookingImpossible /> should render with CTAs when offer is not yet fav
             "fontFamily": "Montserrat-Bold",
             "fontSize": 15,
             "lineHeight": 20,
-            "marginLeft": 5,
+            "marginLeft": 0,
             "maxWidth": "100%",
           },
         ]

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingImpossible.deprecated.web.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingImpossible.deprecated.web.test.tsx.web-snap
@@ -55,7 +55,7 @@ Object {
           <div
             class="css-text-901oao css-textOneLine-vcwn7f"
             dir="auto"
-            style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+            style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
           >
             Mettre en favoris
           </div>
@@ -74,7 +74,7 @@ Object {
           <div
             class="css-text-901oao css-textOneLine-vcwn7f"
             dir="auto"
-            style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+            style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
           >
             Retourner à l'offre
           </div>
@@ -137,7 +137,7 @@ Object {
         <div
           class="css-text-901oao css-textOneLine-vcwn7f"
           dir="auto"
-          style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+          style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
         >
           Mettre en favoris
         </div>
@@ -156,7 +156,7 @@ Object {
         <div
           class="css-text-901oao css-textOneLine-vcwn7f"
           dir="auto"
-          style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+          style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
         >
           Retourner à l'offre
         </div>

--- a/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.native-snap
@@ -206,7 +206,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -269,7 +269,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.web-snap
@@ -262,7 +262,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
               "fontFamily": "Montserrat-Bold",
               "fontSize": "15px",
               "lineHeight": "20px",
-              "marginLeft": "5px",
+              "marginLeft": "0px",
               "maxWidth": "100%",
             }
           }
@@ -341,7 +341,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
               "fontFamily": "Montserrat-Bold",
               "fontSize": "15px",
               "lineHeight": "20px",
-              "marginLeft": "5px",
+              "marginLeft": "0px",
               "maxWidth": "100%",
             }
           }

--- a/__snapshots__/features/bookings/pages/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails.native.test.tsx.native-snap
@@ -229,7 +229,7 @@ exports[`BookingDetails should render correctly 1`] = `
                             "fontFamily": "Montserrat-Bold",
                             "fontSize": 15,
                             "lineHeight": 20,
-                            "marginLeft": 5,
+                            "marginLeft": 0,
                             "maxWidth": "100%",
                           },
                         ]
@@ -515,6 +515,7 @@ exports[`BookingDetails should render correctly 1`] = `
             </View>
             <Text
               adjustsFontSizeToFit={false}
+              icon={[Function]}
               numberOfLines={1}
               style={
                 Array [
@@ -523,7 +524,7 @@ exports[`BookingDetails should render correctly 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 5,
+                    "marginLeft": 8,
                     "maxWidth": "100%",
                   },
                 ]
@@ -586,7 +587,7 @@ exports[`BookingDetails should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 5,
+                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]
@@ -988,7 +989,7 @@ exports[`BookingDetails should render correctly 1`] = `
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 5,
+                        "marginLeft": 0,
                         "maxWidth": "100%",
                       },
                     ]
@@ -1051,7 +1052,7 @@ exports[`BookingDetails should render correctly 1`] = `
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 5,
+                        "marginLeft": 0,
                         "maxWidth": "100%",
                       },
                     ]
@@ -1448,7 +1449,7 @@ exports[`BookingDetails should render correctly 1`] = `
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 5,
+                        "marginLeft": 0,
                         "maxWidth": "100%",
                       },
                     ]
@@ -1511,7 +1512,7 @@ exports[`BookingDetails should render correctly 1`] = `
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 5,
+                        "marginLeft": 0,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/eighteenBirthday/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/eighteenBirthday/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -308,7 +308,7 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
                               "fontFamily": "Montserrat-Bold",
                               "fontSize": 15,
                               "lineHeight": 20,
-                              "marginLeft": 5,
+                              "marginLeft": 0,
                               "maxWidth": "100%",
                             },
                           ]
@@ -373,7 +373,7 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
                               "fontFamily": "Montserrat-Bold",
                               "fontSize": 15,
                               "lineHeight": 20,
-                              "marginLeft": 5,
+                              "marginLeft": 0,
                               "maxWidth": "100%",
                             },
                           ]

--- a/__snapshots__/features/eighteenBirthday/pages/components/EighteenBirthdayCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/eighteenBirthday/pages/components/EighteenBirthdayCard.native.test.tsx.native-snap
@@ -192,7 +192,7 @@ exports[`<EighteenBirthdayCard /> should render eighteen birthday card 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -257,7 +257,7 @@ exports[`<EighteenBirthdayCard /> should render eighteen birthday card 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.native.test.tsx.native-snap
@@ -258,7 +258,7 @@ exports[`AsyncErrorBoundary component should render 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.web.test.tsx.web-snap
+++ b/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.web.test.tsx.web-snap
@@ -118,7 +118,7 @@ Object {
               <div
                 class="css-text-901oao css-textOneLine-vcwn7f"
                 dir="auto"
-                style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
               >
                 Réessayer
               </div>
@@ -250,7 +250,7 @@ Object {
             <div
               class="css-text-901oao css-textOneLine-vcwn7f"
               dir="auto"
-              style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+              style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
             >
               Réessayer
             </div>

--- a/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.native-snap
@@ -209,7 +209,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -272,7 +272,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.web-snap
+++ b/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.web-snap
@@ -254,7 +254,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
               "fontFamily": "Montserrat-Bold",
               "fontSize": "15px",
               "lineHeight": "20px",
-              "marginLeft": "5px",
+              "marginLeft": "0px",
               "maxWidth": "100%",
             }
           }
@@ -333,7 +333,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
               "fontFamily": "Montserrat-Bold",
               "fontSize": "15px",
               "lineHeight": "20px",
-              "marginLeft": "5px",
+              "marginLeft": "0px",
               "maxWidth": "100%",
             }
           }

--- a/__snapshots__/features/favorites/pages/__tests__/FavoritesSorts.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/__tests__/FavoritesSorts.native.test.tsx.native-snap
@@ -504,7 +504,7 @@ exports[`FavoritesSorts component should render correctly 1`] = `
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 5,
+              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]

--- a/__snapshots__/features/favorites/pages/__tests__/FavoritesSorts.web.test.tsx.web-snap
+++ b/__snapshots__/features/favorites/pages/__tests__/FavoritesSorts.web.test.tsx.web-snap
@@ -206,7 +206,7 @@ Object {
             <div
               class="css-text-901oao css-textOneLine-vcwn7f"
               dir="auto"
-              style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+              style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
             >
               Valider
             </div>
@@ -417,7 +417,7 @@ Object {
           <div
             class="css-text-901oao css-textOneLine-vcwn7f"
             dir="auto"
-            style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+            style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
           >
             Valider
           </div>

--- a/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicy.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicy.native.test.tsx.native-snap
@@ -341,6 +341,7 @@ exports[`<PrivacyPolicy /> should render privacy policy 1`] = `
             </View>
             <Text
               adjustsFontSizeToFit={false}
+              icon={[Function]}
               numberOfLines={1}
               style={
                 Array [
@@ -349,7 +350,7 @@ exports[`<PrivacyPolicy /> should render privacy policy 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 12,
                     "lineHeight": 20,
-                    "marginLeft": 5,
+                    "marginLeft": 8,
                     "maxWidth": "100%",
                   },
                 ]
@@ -441,7 +442,7 @@ exports[`<PrivacyPolicy /> should render privacy policy 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 5,
+                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]
@@ -505,7 +506,7 @@ exports[`<PrivacyPolicy /> should render privacy policy 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 5,
+                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicyModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicyModal.native.test.tsx.native-snap
@@ -341,6 +341,7 @@ exports[`<PrivacyPolicyModal /> should render correctly 1`] = `
             </View>
             <Text
               adjustsFontSizeToFit={false}
+              icon={[Function]}
               numberOfLines={1}
               style={
                 Array [
@@ -349,7 +350,7 @@ exports[`<PrivacyPolicyModal /> should render correctly 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 12,
                     "lineHeight": 20,
-                    "marginLeft": 5,
+                    "marginLeft": 8,
                     "maxWidth": "100%",
                   },
                 ]
@@ -441,7 +442,7 @@ exports[`<PrivacyPolicyModal /> should render correctly 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 5,
+                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]
@@ -505,7 +506,7 @@ exports[`<PrivacyPolicyModal /> should render correctly 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 5,
+                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/FirstTutorial.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/FirstTutorial.native.test.tsx.native-snap
@@ -100,7 +100,7 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 5,
+                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]
@@ -381,7 +381,7 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                               "fontFamily": "Montserrat-Bold",
                               "fontSize": 15,
                               "lineHeight": 20,
-                              "marginLeft": 5,
+                              "marginLeft": 0,
                               "maxWidth": "100%",
                             },
                           ]

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FirstCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FirstCard.native.test.tsx.native-snap
@@ -192,7 +192,7 @@ exports[`FirstCard should render first card 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -257,7 +257,7 @@ exports[`FirstCard should render first card 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FourthCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FourthCard.native.test.tsx.native-snap
@@ -192,7 +192,7 @@ exports[`FourthCard should render fourth card 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -257,7 +257,7 @@ exports[`FourthCard should render fourth card 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/SecondCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/SecondCard.native.test.tsx.native-snap
@@ -192,7 +192,7 @@ exports[`SecondCard should render second card 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -257,7 +257,7 @@ exports[`SecondCard should render second card 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/ThirdCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/ThirdCard.native.test.tsx.native-snap
@@ -192,7 +192,7 @@ exports[`ThirdCard should render third card 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -257,7 +257,7 @@ exports[`ThirdCard should render third card 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.native-snap
+++ b/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.native-snap
@@ -181,7 +181,7 @@ Pour des questions de performance et de sécurité merci de télécharger la der
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.web-snap
+++ b/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.web-snap
@@ -240,7 +240,7 @@ Pour des questions de performance et de sécurité merci d'actualiser la page po
               "fontFamily": "Montserrat-Bold",
               "fontSize": "15px",
               "lineHeight": "20px",
-              "marginLeft": "5px",
+              "marginLeft": "0px",
               "maxWidth": "100%",
             }
           }

--- a/__snapshots__/features/home/components/tests/NoContentError.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/tests/NoContentError.native.test.tsx.native-snap
@@ -182,6 +182,8 @@ exports[`NoContentError should render correctly 1`] = `
         </View>
         <Text
           adjustsFontSizeToFit={false}
+          icon={[Function]}
+          iconSize={22}
           numberOfLines={1}
           style={
             Array [
@@ -190,7 +192,8 @@ exports[`NoContentError should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 8,
+                "marginRight": 22,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/identityCheck/components/__test__/FastEduconnectConnectionRequestModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/__test__/FastEduconnectConnectionRequestModal.native.test.tsx.native-snap
@@ -349,6 +349,8 @@ exports[`<IdentityCheckEnd/> should render correctly if modal not visible 1`] = 
             </View>
             <Text
               adjustsFontSizeToFit={false}
+              icon={[Function]}
+              iconSize={16}
               numberOfLines={1}
               style={
                 Array [
@@ -357,7 +359,8 @@ exports[`<IdentityCheckEnd/> should render correctly if modal not visible 1`] = 
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 12,
                     "lineHeight": 20,
-                    "marginLeft": 5,
+                    "marginLeft": 8,
+                    "marginRight": 16,
                     "maxWidth": "100%",
                   },
                 ]
@@ -411,7 +414,7 @@ exports[`<IdentityCheckEnd/> should render correctly if modal not visible 1`] = 
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 5,
+                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]
@@ -757,6 +760,7 @@ exports[`<IdentityCheckEnd/> should render correctly if modal not visible 1`] = 
             </View>
             <Text
               adjustsFontSizeToFit={false}
+              icon={[Function]}
               numberOfLines={1}
               style={
                 Array [
@@ -765,7 +769,7 @@ exports[`<IdentityCheckEnd/> should render correctly if modal not visible 1`] = 
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 5,
+                    "marginLeft": 8,
                     "maxWidth": "100%",
                   },
                 ]
@@ -1143,6 +1147,8 @@ exports[`<IdentityCheckEnd/> should render correctly if modal visible 1`] = `
             </View>
             <Text
               adjustsFontSizeToFit={false}
+              icon={[Function]}
+              iconSize={16}
               numberOfLines={1}
               style={
                 Array [
@@ -1151,7 +1157,8 @@ exports[`<IdentityCheckEnd/> should render correctly if modal visible 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 12,
                     "lineHeight": 20,
-                    "marginLeft": 5,
+                    "marginLeft": 8,
+                    "marginRight": 16,
                     "maxWidth": "100%",
                   },
                 ]
@@ -1205,7 +1212,7 @@ exports[`<IdentityCheckEnd/> should render correctly if modal visible 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 5,
+                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]
@@ -1551,6 +1558,7 @@ exports[`<IdentityCheckEnd/> should render correctly if modal visible 1`] = `
             </View>
             <Text
               adjustsFontSizeToFit={false}
+              icon={[Function]}
               numberOfLines={1}
               style={
                 Array [
@@ -1559,7 +1567,7 @@ exports[`<IdentityCheckEnd/> should render correctly if modal visible 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 5,
+                    "marginLeft": 8,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/identityCheck/pages/confirmation/__test__/IdentityCheckHonor.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/__test__/IdentityCheckHonor.native.test.tsx.native-snap
@@ -347,7 +347,7 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 5,
+                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/EduConnectForm.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/EduConnectForm.web.test.tsx.web-snap
@@ -121,7 +121,7 @@ Object {
                     <div
                       class="css-text-901oao css-textOneLine-vcwn7f"
                       dir="auto"
-                      style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                      style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                     >
                       Ouvrir un onglet ÉduConnect
                     </div>
@@ -270,7 +270,7 @@ Object {
                   <div
                     class="css-text-901oao css-textOneLine-vcwn7f"
                     dir="auto"
-                    style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                    style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                   >
                     Ouvrir un onglet ÉduConnect
                   </div>

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckDMS.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckDMS.native.test.tsx.native-snap
@@ -261,98 +261,93 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                 style={
                   Array [
                     Object {
-                      "paddingVertical": 40,
+                      "paddingBottom": 40,
+                      "paddingLeft": 40,
+                      "paddingRight": 40,
+                      "paddingTop": 40,
                     },
                   ]
                 }
               >
                 <View
+                  accessibilityLabel="Je suis de nationalité française"
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  nativeID="animatedComponent"
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "transparent",
+                      "borderRadius": 24,
+                      "borderWidth": 0,
+                      "flexDirection": "row",
+                      "height": 40,
+                      "justifyContent": "center",
+                      "maxWidth": 500,
+                      "opacity": 1,
+                      "paddingBottom": 2,
+                      "paddingLeft": 2,
+                      "paddingRight": 2,
+                      "paddingTop": 2,
+                      "width": "100%",
+                    }
+                  }
+                  testID="Je suis de nationalité française"
+                >
+                  <View
+                    height={32}
+                    testID="button-icon"
+                    width={32}
+                  >
+                    <Text>
+                      button-icon-SVG-Mock
+                    </Text>
+                  </View>
+                  <Text
+                    adjustsFontSizeToFit={false}
+                    icon={[Function]}
+                    numberOfLines={1}
+                    style={
+                      Array [
+                        Object {
+                          "color": "#151515",
+                          "fontFamily": "Montserrat-Bold",
+                          "fontSize": 15,
+                          "lineHeight": 20,
+                          "marginLeft": 8,
+                          "maxWidth": "100%",
+                        },
+                      ]
+                    }
+                    textColor="#151515"
+                  >
+                    Je suis de nationalité française
+                  </Text>
+                </View>
+                <Text
+                  color="#626262"
                   style={
                     Array [
                       Object {
-                        "alignItems": "center",
+                        "color": "#626262",
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 12,
+                        "lineHeight": 16,
+                        "textAlign": "center",
                       },
                     ]
                   }
                 >
-                  <View
-                    accessibilityLabel="Je suis de nationalité française"
-                    accessible={true}
-                    collapsable={false}
-                    focusable={true}
-                    nativeID="animatedComponent"
-                    onClick={[Function]}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 24,
-                        "borderWidth": 0,
-                        "flexDirection": "row",
-                        "height": 40,
-                        "justifyContent": "flex-start",
-                        "maxWidth": 500,
-                        "opacity": 1,
-                        "paddingBottom": 2,
-                        "paddingLeft": 0,
-                        "paddingRight": 0,
-                        "paddingTop": 2,
-                        "width": "100%",
-                      }
-                    }
-                    testID="Je suis de nationalité française"
-                  >
-                    <View
-                      height={32}
-                      testID="button-icon"
-                      width={32}
-                    >
-                      <Text>
-                        button-icon-SVG-Mock
-                      </Text>
-                    </View>
-                    <Text
-                      adjustsFontSizeToFit={false}
-                      numberOfLines={1}
-                      style={
-                        Array [
-                          Object {
-                            "color": "#151515",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
-                            "marginLeft": 5,
-                            "maxWidth": "100%",
-                          },
-                        ]
-                      }
-                      textColor="#151515"
-                    >
-                      Je suis de nationalité française
-                    </Text>
-                  </View>
-                  <Text
-                    color="#626262"
-                    style={
-                      Array [
-                        Object {
-                          "color": "#626262",
-                          "fontFamily": "Montserrat-SemiBold",
-                          "fontSize": 12,
-                          "lineHeight": 16,
-                        },
-                      ]
-                    }
-                  >
-                    Carte d’identité ou passeport.
-                  </Text>
-                </View>
+                  Carte d’identité ou passeport.
+                </Text>
                 <View
                   style={
                     Array [
@@ -645,92 +640,84 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                   </View>
                 </View>
                 <View
+                  accessibilityLabel="Je suis de nationalité étrangère"
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  nativeID="animatedComponent"
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "transparent",
+                      "borderRadius": 24,
+                      "borderWidth": 0,
+                      "flexDirection": "row",
+                      "height": 40,
+                      "justifyContent": "center",
+                      "maxWidth": 500,
+                      "opacity": 1,
+                      "paddingBottom": 2,
+                      "paddingLeft": 2,
+                      "paddingRight": 2,
+                      "paddingTop": 2,
+                      "width": "100%",
+                    }
+                  }
+                  testID="Je suis de nationalité étrangère"
+                >
+                  <View
+                    height={32}
+                    testID="button-icon"
+                    width={32}
+                  >
+                    <Text>
+                      button-icon-SVG-Mock
+                    </Text>
+                  </View>
+                  <Text
+                    adjustsFontSizeToFit={false}
+                    icon={[Function]}
+                    numberOfLines={1}
+                    style={
+                      Array [
+                        Object {
+                          "color": "#151515",
+                          "fontFamily": "Montserrat-Bold",
+                          "fontSize": 15,
+                          "lineHeight": 20,
+                          "marginLeft": 8,
+                          "maxWidth": "100%",
+                        },
+                      ]
+                    }
+                    textColor="#151515"
+                  >
+                    Je suis de nationalité étrangère
+                  </Text>
+                </View>
+                <Text
+                  color="#626262"
                   style={
                     Array [
                       Object {
-                        "alignItems": "center",
+                        "color": "#626262",
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 12,
+                        "lineHeight": 16,
+                        "textAlign": "center",
                       },
                     ]
                   }
                 >
-                  <View
-                    accessibilityLabel="Je suis de nationalité étrangère"
-                    accessible={true}
-                    collapsable={false}
-                    focusable={true}
-                    nativeID="animatedComponent"
-                    onClick={[Function]}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "backgroundColor": "transparent",
-                        "borderRadius": 24,
-                        "borderWidth": 0,
-                        "flexDirection": "row",
-                        "height": 40,
-                        "justifyContent": "flex-start",
-                        "maxWidth": 500,
-                        "opacity": 1,
-                        "paddingBottom": 2,
-                        "paddingLeft": 0,
-                        "paddingRight": 0,
-                        "paddingTop": 2,
-                        "width": "100%",
-                      }
-                    }
-                    testID="Je suis de nationalité étrangère"
-                  >
-                    <View
-                      height={32}
-                      testID="button-icon"
-                      width={32}
-                    >
-                      <Text>
-                        button-icon-SVG-Mock
-                      </Text>
-                    </View>
-                    <Text
-                      adjustsFontSizeToFit={false}
-                      numberOfLines={1}
-                      style={
-                        Array [
-                          Object {
-                            "color": "#151515",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
-                            "marginLeft": 5,
-                            "maxWidth": "100%",
-                          },
-                        ]
-                      }
-                      textColor="#151515"
-                    >
-                      Je suis de nationalité étrangère
-                    </Text>
-                  </View>
-                  <Text
-                    color="#626262"
-                    style={
-                      Array [
-                        Object {
-                          "color": "#626262",
-                          "fontFamily": "Montserrat-SemiBold",
-                          "fontSize": 12,
-                          "lineHeight": 16,
-                        },
-                      ]
-                    }
-                  >
-                    Titre de séjour, carte d'identité ou passeport.
-                  </Text>
-                </View>
+                  Titre de séjour, carte d'identité ou passeport.
+                </Text>
               </View>
               <View
                 customHeight={8}

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnect.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnect.native.test.tsx.native-snap
@@ -320,7 +320,7 @@ exports[`<IdentityCheckEduConnect /> should render correctly 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 5,
+                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckStart.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckStart.native.test.tsx.native-snap
@@ -382,6 +382,8 @@ Array [
                       </View>
                       <Text
                         adjustsFontSizeToFit={false}
+                        icon={[Function]}
+                        iconSize={16}
                         numberOfLines={1}
                         style={
                           Array [
@@ -390,7 +392,8 @@ Array [
                               "fontFamily": "Montserrat-Bold",
                               "fontSize": 12,
                               "lineHeight": 20,
-                              "marginLeft": 5,
+                              "marginLeft": 8,
+                              "marginRight": 16,
                               "maxWidth": "100%",
                             },
                           ]
@@ -747,6 +750,7 @@ Array [
                               </View>
                               <Text
                                 adjustsFontSizeToFit={false}
+                                icon={[Function]}
                                 numberOfLines={1}
                                 style={
                                   Array [
@@ -755,7 +759,7 @@ Array [
                                       "fontFamily": "Montserrat-Bold",
                                       "fontSize": 15,
                                       "lineHeight": 20,
-                                      "marginLeft": 5,
+                                      "marginLeft": 8,
                                       "maxWidth": "100%",
                                     },
                                   ]
@@ -834,6 +838,7 @@ Array [
                               </View>
                               <Text
                                 adjustsFontSizeToFit={false}
+                                icon={[Function]}
                                 numberOfLines={1}
                                 style={
                                   Array [
@@ -842,7 +847,7 @@ Array [
                                       "fontFamily": "Montserrat-Bold",
                                       "fontSize": 15,
                                       "lineHeight": 20,
-                                      "marginLeft": 5,
+                                      "marginLeft": 8,
                                       "maxWidth": "100%",
                                     },
                                   ]
@@ -955,7 +960,7 @@ Array [
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 5,
+                        "marginLeft": 0,
                         "maxWidth": "100%",
                       },
                     ]
@@ -1471,7 +1476,7 @@ Array [
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 5,
+                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckUnavailable.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckUnavailable.native.test.tsx.native-snap
@@ -207,6 +207,7 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
         </View>
         <Text
           adjustsFontSizeToFit={false}
+          icon={[Function]}
           numberOfLines={1}
           style={
             Array [
@@ -215,7 +216,7 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckValidation.native.test.tsx.native-snap
@@ -420,7 +420,7 @@ exports[`<IdentityCheckValidation /> should render IdentityCheckValidation compo
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 5,
+                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetAddress.native.test.tsx.native-snap
@@ -389,7 +389,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 5,
+                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetCity.native.test.tsx.native-snap
@@ -390,7 +390,7 @@ exports[`<SetCity/> should render correctly 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 5,
+                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetName.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetName.native.test.tsx.native-snap
@@ -452,7 +452,7 @@ exports[`<SetName/> should render correctly 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 5,
+                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetSchoolType.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetSchoolType.test.tsx.native-snap
@@ -661,7 +661,7 @@ exports[`<SetSchoolType /> shoud render a list of high school types if profile.s
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 5,
+                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]
@@ -1166,7 +1166,7 @@ exports[`<SetSchoolType /> shoud render a list of middle school types if profile
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 5,
+                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetSchoolType.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetSchoolType.test.tsx.web-snap
@@ -957,7 +957,7 @@ exports[`<SetSchoolType /> shoud render a list of high school types if profile.s
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": "15px",
                     "lineHeight": "20px",
-                    "marginLeft": "5px",
+                    "marginLeft": "0px",
                     "maxWidth": "100%",
                   }
                 }
@@ -1636,7 +1636,7 @@ exports[`<SetSchoolType /> shoud render a list of middle school types if profile
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": "15px",
                     "lineHeight": "20px",
-                    "marginLeft": "5px",
+                    "marginLeft": "0px",
                     "maxWidth": "100%",
                   }
                 }

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/Status.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/Status.test.tsx.native-snap
@@ -816,7 +816,7 @@ exports[`<Status/> should render correctly 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 5,
+                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/Status.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/Status.test.tsx.web-snap
@@ -1168,7 +1168,7 @@ exports[`<Status/> should render correctly 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": "15px",
                     "lineHeight": "20px",
-                    "marginLeft": "5px",
+                    "marginLeft": "0px",
                     "maxWidth": "100%",
                   }
                 }

--- a/__snapshots__/features/offer/components/__tests__/OfferHeader.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/__tests__/OfferHeader.native.test.tsx.native-snap
@@ -769,7 +769,7 @@ Array [
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 5,
+                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]
@@ -830,7 +830,7 @@ Array [
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 5,
+                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/offer/components/__tests__/OfferHeader.web.test.tsx.web-snap
+++ b/__snapshots__/features/offer/components/__tests__/OfferHeader.web.test.tsx.web-snap
@@ -350,7 +350,7 @@ Object {
                   <div
                     class="css-text-901oao css-textOneLine-vcwn7f"
                     dir="auto"
-                    style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                    style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                   >
                     S'inscrire
                   </div>
@@ -369,7 +369,7 @@ Object {
                   <div
                     class="css-text-901oao css-textOneLine-vcwn7f"
                     dir="auto"
-                    style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                    style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                   >
                     Se connecter
                   </div>

--- a/__snapshots__/features/offer/pages/tests/OfferBody.deprecated.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferBody.deprecated.native.test.tsx.native-snap
@@ -886,7 +886,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-Bold",
                                           "fontSize": 15,
                                           "lineHeight": 20,
-                                          "marginLeft": 5,
+                                          "marginLeft": 0,
                                           "maxWidth": "100%",
                                         },
                                       ]
@@ -1893,6 +1893,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                 </View>
                                 <Text
                                   adjustsFontSizeToFit={false}
+                                  icon={[Function]}
                                   numberOfLines={1}
                                   style={
                                     Array [
@@ -1901,7 +1902,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                         "fontFamily": "Montserrat-Bold",
                                         "fontSize": 15,
                                         "lineHeight": 20,
-                                        "marginLeft": 5,
+                                        "marginLeft": 8,
                                         "maxWidth": "100%",
                                       },
                                     ]
@@ -2368,7 +2369,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                                 "fontFamily": "Montserrat-Bold",
                                                 "fontSize": 15,
                                                 "lineHeight": 20,
-                                                "marginLeft": 5,
+                                                "marginLeft": 0,
                                                 "maxWidth": "100%",
                                               },
                                             ]
@@ -3350,7 +3351,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                           "fontFamily": "Montserrat-Bold",
                                           "fontSize": 15,
                                           "lineHeight": 20,
-                                          "marginLeft": 5,
+                                          "marginLeft": 0,
                                           "maxWidth": "100%",
                                         },
                                       ]
@@ -3769,6 +3770,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                 </View>
                                 <Text
                                   adjustsFontSizeToFit={false}
+                                  icon={[Function]}
                                   numberOfLines={1}
                                   style={
                                     Array [
@@ -3777,7 +3779,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                         "fontFamily": "Montserrat-Bold",
                                         "fontSize": 15,
                                         "lineHeight": 20,
-                                        "marginLeft": 5,
+                                        "marginLeft": 8,
                                         "maxWidth": "100%",
                                       },
                                     ]
@@ -4714,6 +4716,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                 </View>
                                 <Text
                                   adjustsFontSizeToFit={false}
+                                  icon={[Function]}
                                   numberOfLines={1}
                                   style={
                                     Array [
@@ -4722,7 +4725,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                         "fontFamily": "Montserrat-Bold",
                                         "fontSize": 15,
                                         "lineHeight": 20,
-                                        "marginLeft": 5,
+                                        "marginLeft": 8,
                                         "maxWidth": "100%",
                                       },
                                     ]
@@ -5189,7 +5192,7 @@ Tous les détails du film sur AlloCiné: http://www.allocine.fr/film/fichefilm_g
                                                 "fontFamily": "Montserrat-Bold",
                                                 "fontSize": 15,
                                                 "lineHeight": 20,
-                                                "marginLeft": 5,
+                                                "marginLeft": 0,
                                                 "maxWidth": "100%",
                                               },
                                             ]

--- a/__snapshots__/features/offer/pages/tests/OfferBody.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferBody.native.test.tsx.native-snap
@@ -571,7 +571,7 @@ exports[`<OfferBody /> should open the report modal upon clicking on 'signaler l
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 5,
+                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]
@@ -942,6 +942,7 @@ exports[`<OfferBody /> should open the report modal upon clicking on 'signaler l
           </View>
           <Text
             adjustsFontSizeToFit={false}
+            icon={[Function]}
             numberOfLines={1}
             style={
               Array [
@@ -950,7 +951,7 @@ exports[`<OfferBody /> should open the report modal upon clicking on 'signaler l
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 5,
+                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]
@@ -1057,6 +1058,7 @@ exports[`<OfferBody /> should open the report modal upon clicking on 'signaler l
           </View>
           <Text
             adjustsFontSizeToFit={false}
+            icon={[Function]}
             numberOfLines={1}
             style={
               Array [
@@ -1065,7 +1067,7 @@ exports[`<OfferBody /> should open the report modal upon clicking on 'signaler l
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 5,
+                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]
@@ -1532,7 +1534,7 @@ exports[`<OfferBody /> should open the report modal upon clicking on 'signaler l
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 5,
+                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/features/profile/components/ProfileBadge.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/ProfileBadge.native.test.tsx.native-snap
@@ -286,7 +286,7 @@ exports[`ProfileBadge should show CTA Icon and CTA message if Icon, Message and 
             "borderWidth": 0,
             "flexDirection": "row",
             "height": 20,
-            "justifyContent": "center",
+            "justifyContent": "flex-start",
             "marginTop": 0,
             "maxWidth": 500,
             "opacity": 1,
@@ -310,6 +310,8 @@ exports[`ProfileBadge should show CTA Icon and CTA message if Icon, Message and 
         </View>
         <Text
           adjustsFontSizeToFit={false}
+          icon={[Function]}
+          iconSize={16}
           numberOfLines={1}
           style={
             Array [
@@ -318,7 +320,8 @@ exports[`ProfileBadge should show CTA Icon and CTA message if Icon, Message and 
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 12,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 8,
+                "marginRight": 16,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/profile/components/ProfileBadge.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/ProfileBadge.native.test.tsx.native-snap
@@ -257,81 +257,71 @@ exports[`ProfileBadge should show CTA Icon and CTA message if Icon, Message and 
       }
     />
     <View
+      accessibilityLabel="Tu peux cliquer ici"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      nativeID="animatedComponent"
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
-        Array [
-          Object {
-            "flexDirection": "row",
-          },
-        ]
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "transparent",
+          "borderRadius": 0,
+          "borderWidth": 0,
+          "flexDirection": "row",
+          "height": 20,
+          "justifyContent": "flex-start",
+          "marginTop": 0,
+          "maxWidth": 500,
+          "opacity": 1,
+          "paddingBottom": 0,
+          "paddingLeft": 0,
+          "paddingRight": 0,
+          "paddingTop": 0,
+          "width": "auto",
+        }
       }
+      testID="call-to-action-button"
     >
       <View
-        accessibilityLabel="Tu peux cliquer ici"
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        nativeID="animatedComponent"
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "alignItems": "center",
-            "backgroundColor": "transparent",
-            "borderRadius": 0,
-            "borderWidth": 0,
-            "flexDirection": "row",
-            "height": 20,
-            "justifyContent": "flex-start",
-            "marginTop": 0,
-            "maxWidth": 500,
-            "opacity": 1,
-            "paddingBottom": 0,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 0,
-            "width": "auto",
-          }
-        }
-        testID="call-to-action-button"
+        height={16}
+        testID="button-icon"
+        width={16}
       >
-        <View
-          height={16}
-          testID="button-icon"
-          width={16}
-        >
-          <Text>
-            button-icon-SVG-Mock
-          </Text>
-        </View>
-        <Text
-          adjustsFontSizeToFit={false}
-          icon={[Function]}
-          iconSize={16}
-          numberOfLines={1}
-          style={
-            Array [
-              Object {
-                "color": "#151515",
-                "fontFamily": "Montserrat-Bold",
-                "fontSize": 12,
-                "lineHeight": 20,
-                "marginLeft": 8,
-                "marginRight": 16,
-                "maxWidth": "100%",
-              },
-            ]
-          }
-          textColor="#151515"
-          textSize={12}
-        >
-          Tu peux cliquer ici
+        <Text>
+          button-icon-SVG-Mock
         </Text>
       </View>
+      <Text
+        adjustsFontSizeToFit={false}
+        icon={[Function]}
+        iconSize={16}
+        numberOfLines={1}
+        style={
+          Array [
+            Object {
+              "color": "#151515",
+              "fontFamily": "Montserrat-Bold",
+              "fontSize": 12,
+              "lineHeight": 20,
+              "marginLeft": 8,
+              "marginRight": 16,
+              "maxWidth": "100%",
+            },
+          ]
+        }
+        textColor="#151515"
+        textSize={12}
+      >
+        Tu peux cliquer ici
+      </Text>
     </View>
   </View>
 </View>

--- a/__snapshots__/features/profile/components/ProfileBadge.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/ProfileBadge.native.test.tsx.native-snap
@@ -23,24 +23,6 @@ exports[`ProfileBadge should not show CTA if no link is provided 1`] = `
     style={
       Array [
         Object {
-          "paddingRight": 16,
-        },
-      ]
-    }
-  >
-    <View
-      height={32}
-      width={32}
-    >
-      <Text>
-        undefined-SVG-Mock
-      </Text>
-    </View>
-  </View>
-  <View
-    style={
-      Array [
-        Object {
           "flexBasis": 0,
           "flexGrow": 1,
           "flexShrink": 1,
@@ -206,24 +188,6 @@ exports[`ProfileBadge should show CTA Icon and CTA message if Icon, Message and 
     style={
       Array [
         Object {
-          "paddingRight": 16,
-        },
-      ]
-    }
-  >
-    <View
-      height={32}
-      width={32}
-    >
-      <Text>
-        undefined-SVG-Mock
-      </Text>
-    </View>
-  </View>
-  <View
-    style={
-      Array [
-        Object {
           "flexBasis": 0,
           "flexGrow": 1,
           "flexShrink": 1,
@@ -273,19 +237,18 @@ exports[`ProfileBadge should show CTA Icon and CTA message if Icon, Message and 
         Object {
           "alignItems": "center",
           "backgroundColor": "transparent",
-          "borderRadius": 0,
+          "borderRadius": 24,
           "borderWidth": 0,
           "flexDirection": "row",
-          "height": 20,
+          "height": "auto",
           "justifyContent": "flex-start",
-          "marginTop": 0,
           "maxWidth": 500,
           "opacity": 1,
-          "paddingBottom": 0,
+          "paddingBottom": 2,
           "paddingLeft": 0,
           "paddingRight": 0,
-          "paddingTop": 0,
-          "width": "auto",
+          "paddingTop": 2,
+          "width": "100%",
         }
       }
       testID="call-to-action-button"
@@ -303,7 +266,7 @@ exports[`ProfileBadge should show CTA Icon and CTA message if Icon, Message and 
         adjustsFontSizeToFit={false}
         icon={[Function]}
         iconSize={16}
-        numberOfLines={1}
+        numberOfLines={2}
         style={
           Array [
             Object {
@@ -346,24 +309,6 @@ exports[`ProfileBadge should show neither CTA Icon nor CTA message if no CTA mes
   }
   testID="profile-badge"
 >
-  <View
-    style={
-      Array [
-        Object {
-          "paddingRight": 16,
-        },
-      ]
-    }
-  >
-    <View
-      height={32}
-      width={32}
-    >
-      <Text>
-        undefined-SVG-Mock
-      </Text>
-    </View>
-  </View>
   <View
     style={
       Array [

--- a/__snapshots__/features/profile/components/ProfileHeader.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/ProfileHeader.native.test.tsx.native-snap
@@ -156,7 +156,7 @@ exports[`ProfileHeader should display the LoggedOutHeader if no user 1`] = `
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 5,
+              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]

--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.native.test.tsx.native-snap
@@ -488,7 +488,7 @@ Array [
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 5,
+                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]
@@ -1101,7 +1101,7 @@ Array [
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 5,
+                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.web.test.tsx.web-snap
@@ -164,7 +164,7 @@ Object {
                 <div
                   class="css-text-901oao css-textOneLine-vcwn7f"
                   dir="auto"
-                  style="color: rgb(98, 98, 98); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                  style="color: rgb(98, 98, 98); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                 >
                   Enregistrer
                 </div>
@@ -396,7 +396,7 @@ Object {
               <div
                 class="css-text-901oao css-textOneLine-vcwn7f"
                 dir="auto"
-                style="color: rgb(98, 98, 98); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                style="color: rgb(98, 98, 98); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
               >
                 Enregistrer
               </div>

--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.native.test.tsx.native-snap
@@ -208,7 +208,7 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -272,6 +272,7 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
         </View>
         <Text
           adjustsFontSizeToFit={false}
+          icon={[Function]}
           numberOfLines={1}
           style={
             Array [
@@ -280,7 +281,7 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]
@@ -514,7 +515,7 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -578,6 +579,7 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
         </View>
         <Text
           adjustsFontSizeToFit={false}
+          icon={[Function]}
           numberOfLines={1}
           style={
             Array [
@@ -586,7 +588,7 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.web.test.tsx.web-snap
@@ -95,7 +95,7 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
               <div
                 class="css-text-901oao css-textOneLine-vcwn7f"
                 dir="auto"
-                style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
               >
                 Faire une nouvelle demande
               </div>
@@ -125,7 +125,7 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
               <div
                 class="css-text-901oao css-textOneLine-vcwn7f"
                 dir="auto"
-                style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
               >
                 Retourner à l'accueil
               </div>
@@ -230,7 +230,7 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
             <div
               class="css-text-901oao css-textOneLine-vcwn7f"
               dir="auto"
-              style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+              style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
             >
               Faire une nouvelle demande
             </div>
@@ -260,7 +260,7 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
             <div
               class="css-text-901oao css-textOneLine-vcwn7f"
               dir="auto"
-              style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+              style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
             >
               Retourner à l'accueil
             </div>
@@ -422,7 +422,7 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
               <div
                 class="css-text-901oao css-textOneLine-vcwn7f"
                 dir="auto"
-                style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
               >
                 Se connecter
               </div>
@@ -452,7 +452,7 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
               <div
                 class="css-text-901oao css-textOneLine-vcwn7f"
                 dir="auto"
-                style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
               >
                 Retourner à l'accueil
               </div>
@@ -557,7 +557,7 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
             <div
               class="css-text-901oao css-textOneLine-vcwn7f"
               dir="auto"
-              style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+              style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
             >
               Se connecter
             </div>
@@ -587,7 +587,7 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
             <div
               class="css-text-901oao css-textOneLine-vcwn7f"
               dir="auto"
-              style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+              style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
             >
               Retourner à l'accueil
             </div>

--- a/__snapshots__/features/profile/pages/ConfirmDeleteProfile.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConfirmDeleteProfile.test.tsx.native-snap
@@ -180,7 +180,7 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -243,7 +243,7 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/profile/pages/ConfirmDeleteProfile.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ConfirmDeleteProfile.test.tsx.web-snap
@@ -239,7 +239,7 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
               "fontFamily": "Montserrat-Bold",
               "fontSize": "15px",
               "lineHeight": "20px",
-              "marginLeft": "5px",
+              "marginLeft": "0px",
               "maxWidth": "100%",
             }
           }
@@ -318,7 +318,7 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
               "fontFamily": "Montserrat-Bold",
               "fontSize": "15px",
               "lineHeight": "20px",
-              "marginLeft": "5px",
+              "marginLeft": "0px",
               "maxWidth": "100%",
             }
           }

--- a/__snapshots__/features/profile/pages/DeleteProfileSuccess.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfileSuccess.test.tsx.native-snap
@@ -206,7 +206,7 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/profile/pages/DeleteProfileSuccess.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfileSuccess.test.tsx.web-snap
@@ -262,7 +262,7 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
               "fontFamily": "Montserrat-Bold",
               "fontSize": "15px",
               "lineHeight": "20px",
-              "marginLeft": "5px",
+              "marginLeft": "0px",
               "maxWidth": "100%",
             }
           }

--- a/__snapshots__/features/profile/pages/PersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/PersonalData.native.test.tsx.native-snap
@@ -203,6 +203,8 @@ Array [
           </View>
           <Text
             adjustsFontSizeToFit={false}
+            icon={[Function]}
+            iconSize={16}
             numberOfLines={1}
             style={
               Array [
@@ -211,7 +213,8 @@ Array [
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 12,
                   "lineHeight": 16,
-                  "marginLeft": 5,
+                  "marginLeft": 8,
+                  "marginRight": 16,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
@@ -3181,7 +3181,7 @@ exports[`SearchFilter component should render correctly 1`] = `
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 5,
+              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]

--- a/__snapshots__/features/venue/pages/__tests__/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/__tests__/Venue.native.test.tsx.native-snap
@@ -1984,6 +1984,7 @@ exports[`<Venue /> should match snapshot 1`] = `
             </View>
             <Text
               adjustsFontSizeToFit={false}
+              icon={[Function]}
               numberOfLines={1}
               style={
                 Array [
@@ -1992,7 +1993,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 5,
+                    "marginLeft": 8,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/venue/pages/__tests__/Venue.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/pages/__tests__/Venue.web.test.tsx.web-snap
@@ -783,7 +783,7 @@ Object {
                   <div
                     class="css-text-901oao css-textOneLine-vcwn7f"
                     dir="auto"
-                    style="color: rgb(21, 21, 21); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                    style="color: rgb(21, 21, 21); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
                   >
                     Voir l'itinéraire
                   </div>
@@ -2245,7 +2245,7 @@ Object {
                 <div
                   class="css-text-901oao css-textOneLine-vcwn7f"
                   dir="auto"
-                  style="color: rgb(21, 21, 21); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                  style="color: rgb(21, 21, 21); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
                 >
                   Voir l'itinéraire
                 </div>

--- a/__snapshots__/features/venue/pages/__tests__/VenueBody.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/__tests__/VenueBody.native.test.tsx.native-snap
@@ -1972,6 +1972,7 @@ exports[`<VenueBody /> should render correctly 1`] = `
           </View>
           <Text
             adjustsFontSizeToFit={false}
+            icon={[Function]}
             numberOfLines={1}
             style={
               Array [
@@ -1980,7 +1981,7 @@ exports[`<VenueBody /> should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 5,
+                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/venue/pages/__tests__/VenueBody.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/pages/__tests__/VenueBody.web.test.tsx.web-snap
@@ -779,7 +779,7 @@ Object {
                 <div
                   class="css-text-901oao css-textOneLine-vcwn7f"
                   dir="auto"
-                  style="color: rgb(21, 21, 21); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                  style="color: rgb(21, 21, 21); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
                 >
                   Voir l'itinéraire
                 </div>
@@ -2071,7 +2071,7 @@ Object {
               <div
                 class="css-text-901oao css-textOneLine-vcwn7f"
                 dir="auto"
-                style="color: rgb(21, 21, 21); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+                style="color: rgb(21, 21, 21); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
               >
                 Voir l'itinéraire
               </div>

--- a/__snapshots__/libs/geolocation/components/__tests__/WhereSection.test.tsx.native-snap
+++ b/__snapshots__/libs/geolocation/components/__tests__/WhereSection.test.tsx.native-snap
@@ -266,6 +266,7 @@ Array [
       </View>
       <Text
         adjustsFontSizeToFit={false}
+        icon={[Function]}
         numberOfLines={1}
         style={
           Array [
@@ -274,7 +275,7 @@ Array [
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 5,
+              "marginLeft": 8,
               "maxWidth": "100%",
             },
           ]

--- a/__snapshots__/libs/geolocation/components/__tests__/WhereSection.test.tsx.web-snap
+++ b/__snapshots__/libs/geolocation/components/__tests__/WhereSection.test.tsx.web-snap
@@ -303,7 +303,7 @@ Array [
             "fontFamily": "Montserrat-Bold",
             "fontSize": "15px",
             "lineHeight": "20px",
-            "marginLeft": "5px",
+            "marginLeft": "8px",
             "maxWidth": "100%",
           }
         }

--- a/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.native-snap
+++ b/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.native-snap
@@ -223,6 +223,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
         </View>
         <Text
           adjustsFontSizeToFit={false}
+          icon={[Function]}
           numberOfLines={1}
           style={
             Array [
@@ -231,7 +232,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]
@@ -285,6 +286,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
         </View>
         <Text
           adjustsFontSizeToFit={false}
+          icon={[Function]}
           numberOfLines={1}
           style={
             Array [
@@ -293,7 +295,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]
@@ -356,7 +358,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -420,6 +422,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
         </View>
         <Text
           adjustsFontSizeToFit={false}
+          icon={[Function]}
           numberOfLines={1}
           style={
             Array [
@@ -428,7 +431,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 5,
+                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.web-snap
+++ b/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.web-snap
@@ -288,7 +288,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
               "fontFamily": "Montserrat-Bold",
               "fontSize": "15px",
               "lineHeight": "20px",
-              "marginLeft": "5px",
+              "marginLeft": "8px",
               "maxWidth": "100%",
             }
           }
@@ -370,7 +370,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
               "fontFamily": "Montserrat-Bold",
               "fontSize": "15px",
               "lineHeight": "20px",
-              "marginLeft": "5px",
+              "marginLeft": "8px",
               "maxWidth": "100%",
             }
           }
@@ -449,7 +449,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
               "fontFamily": "Montserrat-Bold",
               "fontSize": "15px",
               "lineHeight": "20px",
-              "marginLeft": "5px",
+              "marginLeft": "0px",
               "maxWidth": "100%",
             }
           }
@@ -539,7 +539,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
               "fontFamily": "Montserrat-Bold",
               "fontSize": "15px",
               "lineHeight": "20px",
-              "marginLeft": "5px",
+              "marginLeft": "8px",
               "maxWidth": "100%",
             }
           }

--- a/__snapshots__/ui/components/buttons/AppButton.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/buttons/AppButton.native.test.tsx.native-snap
@@ -45,6 +45,7 @@ exports[`AppButton Component * inline property should use inline css style when 
   </View>
   <Text
     adjustsFontSizeToFit={false}
+    icon={[Function]}
     numberOfLines={1}
     style={
       Array [
@@ -53,7 +54,7 @@ exports[`AppButton Component * inline property should use inline css style when 
           "fontFamily": "Montserrat-Bold",
           "fontSize": 15,
           "lineHeight": 20,
-          "marginLeft": 5,
+          "marginLeft": 8,
           "maxWidth": "100%",
         },
       ]

--- a/__snapshots__/ui/components/buttons/AppButton.web.test.tsx.web-snap
+++ b/__snapshots__/ui/components/buttons/AppButton.web.test.tsx.web-snap
@@ -26,7 +26,7 @@ Object {
         <div
           class="css-text-901oao css-textOneLine-vcwn7f"
           dir="auto"
-          style="color: rgb(21, 21, 21); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+          style="color: rgb(21, 21, 21); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
         >
           Testing inline
         </div>
@@ -55,7 +55,7 @@ Object {
       <div
         class="css-text-901oao css-textOneLine-vcwn7f"
         dir="auto"
-        style="color: rgb(21, 21, 21); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 5px; max-width: 100%;"
+        style="color: rgb(21, 21, 21); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
       >
         Testing inline
       </div>

--- a/src/features/identityCheck/atoms/DMSInformation.web.tsx
+++ b/src/features/identityCheck/atoms/DMSInformation.web.tsx
@@ -6,7 +6,7 @@ import { DMSModal } from 'features/identityCheck/components/DMSModal'
 import { analytics } from 'libs/analytics'
 import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
 import { useModal } from 'ui/components/modals/useModal'
-import { DigitalIcon } from 'ui/svg/icons/venueTypes'
+import { ExternalLinkSquare } from 'ui/svg/icons/ExternalLinkSquare'
 import { ColorsEnum, Spacer, Typo } from 'ui/theme'
 
 export const DMSInformation = () => {
@@ -25,7 +25,7 @@ export const DMSInformation = () => {
         <ButtonTertiaryBlack
           title={t`Identification par le site Démarches-Simplifiées`}
           onPress={showDMSModal}
-          icon={DigitalIcon}
+          icon={ExternalLinkSquare}
         />
         <Typo.Caption color={ColorsEnum.GREY_DARK}>{t`Environ 10 jours`}</Typo.Caption>
       </Container>

--- a/src/features/identityCheck/components/DMSModal.tsx
+++ b/src/features/identityCheck/components/DMSModal.tsx
@@ -1,6 +1,5 @@
 import { t } from '@lingui/macro'
 import React, { FunctionComponent } from 'react'
-import styled from 'styled-components/native'
 
 import { openUrl } from 'features/navigation/helpers'
 import { analytics } from 'libs/analytics'

--- a/src/features/identityCheck/components/DMSModal.tsx
+++ b/src/features/identityCheck/components/DMSModal.tsx
@@ -7,7 +7,7 @@ import { env } from 'libs/environment'
 import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
-import { ExternalSite } from 'ui/svg/icons/ExternalSite'
+import { ExternalLinkSquare } from 'ui/svg/icons/ExternalLinkSquare'
 import { ColorsEnum, Spacer, Typo } from 'ui/theme'
 
 interface Props {
@@ -42,7 +42,7 @@ export const DMSModal: FunctionComponent<Props> = ({ visible, hideModal }) => (
     <ButtonTertiaryBlack
       title={t`Je suis de nationalité française`}
       onPress={openDMSFrenchCitizenURL}
-      icon={ExternalSite}
+      icon={ExternalLinkSquare}
       justifyContent="flex-start"
     />
     <Typo.Caption color={ColorsEnum.GREY_DARK}>{t`Carte d’identité ou passeport.`}</Typo.Caption>
@@ -50,7 +50,7 @@ export const DMSModal: FunctionComponent<Props> = ({ visible, hideModal }) => (
     <ButtonTertiaryBlack
       title={t`Je suis de nationalité étrangère`}
       onPress={openDMSForeignCitizenURL}
-      icon={ExternalSite}
+      icon={ExternalLinkSquare}
       justifyContent="flex-start"
     />
     <Typo.Caption color={ColorsEnum.GREY_DARK}>

--- a/src/features/identityCheck/components/DMSModal.tsx
+++ b/src/features/identityCheck/components/DMSModal.tsx
@@ -40,17 +40,19 @@ export const DMSModal: FunctionComponent<Props> = ({ visible, hideModal }) => (
       {t`Tu peux aussi compléter ton dossier sur Démarches simplifiées. Attention le traitement sera plus long\u00a0!`}
     </Typo.Body>
     <Spacer.Column numberOfSpaces={8} />
-    <CustomButtonTertiaryBlack
+    <ButtonTertiaryBlack
       title={t`Je suis de nationalité française`}
       onPress={openDMSFrenchCitizenURL}
       icon={ExternalSite}
+      justifyContent="flex-start"
     />
     <Typo.Caption color={ColorsEnum.GREY_DARK}>{t`Carte d’identité ou passeport.`}</Typo.Caption>
     <Spacer.Column numberOfSpaces={8} />
-    <CustomButtonTertiaryBlack
+    <ButtonTertiaryBlack
       title={t`Je suis de nationalité étrangère`}
       onPress={openDMSForeignCitizenURL}
       icon={ExternalSite}
+      justifyContent="flex-start"
     />
     <Typo.Caption color={ColorsEnum.GREY_DARK}>
       {t`Titre de séjour, carte d'identité, ou passeport.`}
@@ -58,9 +60,3 @@ export const DMSModal: FunctionComponent<Props> = ({ visible, hideModal }) => (
     <Spacer.Column numberOfSpaces={4} />
   </AppModal>
 )
-
-const CustomButtonTertiaryBlack = styled(ButtonTertiaryBlack)({
-  justifyContent: 'flex-start',
-  paddingLeft: 0,
-  paddingRight: 0,
-})

--- a/src/features/identityCheck/pages/identification/IdentityCheckDMS.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckDMS.tsx
@@ -40,29 +40,23 @@ export const IdentityCheckDMS = () => {
             {t`La vérification de ton identité n’a pas pu aboutir. Tu peux créer un dossier sur le site des Démarches Simplifiées afin d’obtenir ton pass Cutlure.`}
           </StyledBody>
           {theme.isMobileViewport ? <Spacer.Flex /> : <Spacer.Column numberOfSpaces={5} />}
-          <ChoicesContainer>
-            <ButtonContainer>
-              <CustomButtonTertiaryBlack
-                title={t`Je suis de nationalité française`}
-                onPress={openDMSFrenchCitizenURL}
-                icon={ExternalSite}
-              />
-              <Typo.Caption color={ColorsEnum.GREY_DARK}>
-                {t`Carte d’identité ou passeport.`}
-              </Typo.Caption>
-            </ButtonContainer>
+          <ButtonContainer>
+            <ButtonTertiaryBlack
+              title={t`Je suis de nationalité française`}
+              onPress={openDMSFrenchCitizenURL}
+              icon={ExternalSite}
+            />
+            <Caption color={ColorsEnum.GREY_DARK}>{t`Carte d’identité ou passeport.`}</Caption>
             <OrSeparator />
-            <ButtonContainer>
-              <CustomButtonTertiaryBlack
-                title={t`Je suis de nationalité étrangère`}
-                onPress={openDMSForeignCitizenURL}
-                icon={ExternalSite}
-              />
-              <Typo.Caption color={ColorsEnum.GREY_DARK}>
-                {t`Titre de séjour, carte d'identité ou passeport.`}
-              </Typo.Caption>
-            </ButtonContainer>
-          </ChoicesContainer>
+            <ButtonTertiaryBlack
+              title={t`Je suis de nationalité étrangère`}
+              onPress={openDMSForeignCitizenURL}
+              icon={ExternalSite}
+            />
+            <Caption color={ColorsEnum.GREY_DARK}>
+              {t`Titre de séjour, carte d'identité ou passeport.`}
+            </Caption>
+          </ButtonContainer>
           <Spacer.BottomScreen />
         </Container>
       }
@@ -71,18 +65,8 @@ export const IdentityCheckDMS = () => {
 }
 
 const Container = styled.View({ height: '100%', alignItems: 'center' })
-const StyledBody = styled(Typo.Body).attrs({
-  color: ColorsEnum.GREY_DARK,
-})({
+const StyledBody = styled(Typo.Body).attrs({ color: ColorsEnum.GREY_DARK })({
   textAlign: 'center',
 })
-const ChoicesContainer = styled.View({ paddingVertical: getSpacing(10) })
-const CustomButtonTertiaryBlack = styled(ButtonTertiaryBlack)({
-  justifyContent: 'flex-start',
-  paddingLeft: 0,
-  paddingRight: 0,
-})
-
-const ButtonContainer = styled.View({
-  alignItems: 'center',
-})
+const ButtonContainer = styled.View({ padding: getSpacing(10) })
+const Caption = styled(Typo.Caption)({ textAlign: 'center' })

--- a/src/features/identityCheck/pages/identification/IdentityCheckDMS.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckDMS.tsx
@@ -46,16 +46,14 @@ export const IdentityCheckDMS = () => {
               onPress={openDMSFrenchCitizenURL}
               icon={ExternalSite}
             />
-            <Caption color={ColorsEnum.GREY_DARK}>{t`Carte d’identité ou passeport.`}</Caption>
+            <Caption>{t`Carte d’identité ou passeport.`}</Caption>
             <OrSeparator />
             <ButtonTertiaryBlack
               title={t`Je suis de nationalité étrangère`}
               onPress={openDMSForeignCitizenURL}
               icon={ExternalSite}
             />
-            <Caption color={ColorsEnum.GREY_DARK}>
-              {t`Titre de séjour, carte d'identité ou passeport.`}
-            </Caption>
+            <Caption>{t`Titre de séjour, carte d'identité ou passeport.`}</Caption>
           </ButtonContainer>
           <Spacer.BottomScreen />
         </Container>
@@ -65,8 +63,6 @@ export const IdentityCheckDMS = () => {
 }
 
 const Container = styled.View({ height: '100%', alignItems: 'center' })
-const StyledBody = styled(Typo.Body).attrs({ color: ColorsEnum.GREY_DARK })({
-  textAlign: 'center',
-})
+const StyledBody = styled(Typo.Body).attrs({ color: ColorsEnum.GREY_DARK })({ textAlign: 'center' })
 const ButtonContainer = styled.View({ padding: getSpacing(10) })
-const Caption = styled(Typo.Caption)({ textAlign: 'center' })
+const Caption = styled(Typo.Caption).attrs({ color: ColorsEnum.GREY_DARK })({ textAlign: 'center' })

--- a/src/features/profile/components/ProfileBadge.tsx
+++ b/src/features/profile/components/ProfileBadge.tsx
@@ -25,14 +25,13 @@ const renderCallToAction = (
   return (
     <React.Fragment>
       <Spacer.Column numberOfSpaces={4} />
-      {/* TODO (LucasBeneston) : Add new button with numberOfLines={2} to ui/components/buttons */}
       <ButtonQuaternaryBlack
-        inline
         icon={callToActionIcon || undefined}
         testId="call-to-action-button"
         onPress={() => handleCallToActionLink(callToActionLink)}
         title={callToActionMessage}
         justifyContent="flex-start"
+        numberOfLines={2}
       />
     </React.Fragment>
   )
@@ -43,7 +42,7 @@ export function ProfileBadge(props: ProfileBadgeProps) {
 
   return (
     <Container testID={props.testID || 'profile-badge'}>
-      {Icon ? (
+      {Icon && !props.callToActionIcon ? (
         <IconContainer>
           <Icon size={getSpacing(8)} color={ColorsEnum.GREY_DARK} />
         </IconContainer>

--- a/src/features/profile/components/ProfileBadge.tsx
+++ b/src/features/profile/components/ProfileBadge.tsx
@@ -25,16 +25,15 @@ const renderCallToAction = (
   return (
     <React.Fragment>
       <Spacer.Column numberOfSpaces={4} />
-      <CallToActionContainer>
-        <ButtonQuaternaryBlack
-          inline
-          icon={callToActionIcon || undefined}
-          testId="call-to-action-button"
-          onPress={() => handleCallToActionLink(callToActionLink)}
-          title={callToActionMessage}
-          justifyContent="flex-start"
-        />
-      </CallToActionContainer>
+      {/* TODO (LucasBeneston) : Add new button with numberOfLines={2} to ui/components/buttons */}
+      <ButtonQuaternaryBlack
+        inline
+        icon={callToActionIcon || undefined}
+        testId="call-to-action-button"
+        onPress={() => handleCallToActionLink(callToActionLink)}
+        title={callToActionMessage}
+        justifyContent="flex-start"
+      />
     </React.Fragment>
   )
 }
@@ -83,8 +82,4 @@ const IconContainer = styled.View({
 
 const TextContainer = styled.View({
   flex: 1,
-})
-
-const CallToActionContainer = styled.View({
-  flexDirection: 'row',
 })

--- a/src/features/profile/components/ProfileBadge.tsx
+++ b/src/features/profile/components/ProfileBadge.tsx
@@ -32,6 +32,7 @@ const renderCallToAction = (
           testId="call-to-action-button"
           onPress={() => handleCallToActionLink(callToActionLink)}
           title={callToActionMessage}
+          justifyContent="flex-start"
         />
       </CallToActionContainer>
     </React.Fragment>

--- a/src/features/profile/utils.ts
+++ b/src/features/profile/utils.ts
@@ -8,7 +8,7 @@ import { Again } from 'ui/svg/icons/Again'
 import { Clock } from 'ui/svg/icons/Clock'
 import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 import { Error } from 'ui/svg/icons/Error'
-import { ExternalSite } from 'ui/svg/icons/ExternalSite'
+import { ExternalLinkSquare } from 'ui/svg/icons/ExternalLinkSquare'
 import { Info } from 'ui/svg/icons/Info'
 import { LegalNotices } from 'ui/svg/icons/LegalNotices'
 import { MagnifyingGlass } from 'ui/svg/icons/MagnifyingGlass'
@@ -59,7 +59,7 @@ export const matchSubscriptionMessageIconToSvg = (
     case 'CLOCK':
       return Clock
     case 'EXTERNAL':
-      return ExternalSite
+      return ExternalLinkSquare
     case 'MAGNIFYING_GLASS':
       return MagnifyingGlass
     case 'ERROR':

--- a/src/ui/components/buttons/AppButton.tsx
+++ b/src/ui/components/buttons/AppButton.tsx
@@ -25,6 +25,7 @@ export interface BaseButtonProps {
   title: string
   fullWidth?: boolean
   justifyContent?: 'center' | 'flex-start'
+  numberOfLines?: number
   style?: StyleProp<ViewStyle>
 }
 
@@ -65,6 +66,7 @@ const _AppButton = <T extends AppButtonProps>({
   textLineHeight,
   adjustsFontSizeToFit,
   justifyContent,
+  numberOfLines,
   style,
 }: Only<T, AppButtonProps>) => {
   const pressHandler = disabled || isLoading ? undefined : onPress
@@ -81,6 +83,7 @@ const _AppButton = <T extends AppButtonProps>({
       inline={inline}
       inlineHeight={inlineHeight ?? 16}
       justifyContent={justifyContent ?? 'center'}
+      numberOfLines={numberOfLines}
       style={style}>
       {isLoading ? (
         <Logo
@@ -104,7 +107,7 @@ const _AppButton = <T extends AppButtonProps>({
             adjustsFontSizeToFit={adjustsFontSizeToFit ?? false}
             icon={Icon}
             iconSize={iconSize}
-            numberOfLines={1}>
+            numberOfLines={numberOfLines ?? 1}>
             {title}
           </Title>
         </Fragment>
@@ -124,6 +127,7 @@ interface StyledTouchableOpacityProps {
   inlineHeight?: number
   fullWidth?: boolean
   justifyContent?: 'center' | 'flex-start'
+  numberOfLines?: number
 }
 
 const StyledTouchableOpacity = styled(TouchableOpacity).attrs(() => ({
@@ -137,15 +141,13 @@ const StyledTouchableOpacity = styled(TouchableOpacity).attrs(() => ({
     inlineHeight,
     fullWidth,
     justifyContent,
+    numberOfLines,
   }) => ({
     flexDirection: 'row',
     justifyContent: justifyContent === 'flex-start' ? 'flex-start' : 'center',
     alignItems: 'center',
     borderRadius: BorderRadiusEnum.BUTTON,
-    paddingBottom: 2,
-    paddingRight: 2,
-    paddingTop: 2,
-    paddingLeft: 2,
+    padding: 2,
     backgroundColor,
     borderColor,
     borderWidth: borderColor ? 2 : 0,
@@ -157,20 +159,13 @@ const StyledTouchableOpacity = styled(TouchableOpacity).attrs(() => ({
           borderWidth: 0,
           borderRadius: 0,
           marginTop: 0,
-          paddingBottom: 0,
-          paddingTop: 0,
-          paddingRight: 0,
-          paddingLeft: 0,
+          padding: 0,
           width: 'auto',
           height: inlineHeight,
         }
       : {}),
-    ...(justifyContent === 'flex-start'
-      ? {
-          paddingRight: 0,
-          paddingLeft: 0,
-        }
-      : {}),
+    ...(justifyContent === 'flex-start' ? { paddingRight: 0, paddingLeft: 0 } : {}),
+    ...(numberOfLines ? { height: 'auto' } : {}),
   })
 )
 

--- a/src/ui/components/buttons/AppButton.tsx
+++ b/src/ui/components/buttons/AppButton.tsx
@@ -24,6 +24,7 @@ export interface BaseButtonProps {
   textSize?: number
   title: string
   fullWidth?: boolean
+  justifyContent?: 'center' | 'flex-start'
   style?: StyleProp<ViewStyle>
 }
 
@@ -63,6 +64,7 @@ const _AppButton = <T extends AppButtonProps>({
   textSize,
   textLineHeight,
   adjustsFontSizeToFit,
+  justifyContent,
   style,
 }: Only<T, AppButtonProps>) => {
   const pressHandler = disabled || isLoading ? undefined : onPress
@@ -78,6 +80,7 @@ const _AppButton = <T extends AppButtonProps>({
       buttonHeight={buttonHeight ?? 'small'}
       inline={inline}
       inlineHeight={inlineHeight ?? 16}
+      justifyContent={justifyContent ?? 'center'}
       style={style}>
       {isLoading ? (
         <Logo
@@ -99,6 +102,8 @@ const _AppButton = <T extends AppButtonProps>({
             textSize={textSize}
             textLineHeight={textLineHeight}
             adjustsFontSizeToFit={adjustsFontSizeToFit ?? false}
+            icon={Icon}
+            iconSize={iconSize}
             numberOfLines={1}>
             {title}
           </Title>
@@ -118,14 +123,23 @@ interface StyledTouchableOpacityProps {
   inline?: boolean
   inlineHeight?: number
   fullWidth?: boolean
+  justifyContent?: 'center' | 'flex-start'
 }
 
 const StyledTouchableOpacity = styled(TouchableOpacity).attrs(() => ({
   activeOpacity: ACTIVE_OPACITY,
 }))<StyledTouchableOpacityProps>(
-  ({ inline, backgroundColor, borderColor, buttonHeight, inlineHeight, fullWidth }) => ({
+  ({
+    inline,
+    backgroundColor,
+    borderColor,
+    buttonHeight,
+    inlineHeight,
+    fullWidth,
+    justifyContent,
+  }) => ({
     flexDirection: 'row',
-    justifyContent: 'center',
+    justifyContent: justifyContent === 'flex-start' ? 'flex-start' : 'center',
     alignItems: 'center',
     borderRadius: BorderRadiusEnum.BUTTON,
     paddingBottom: 2,
@@ -151,6 +165,12 @@ const StyledTouchableOpacity = styled(TouchableOpacity).attrs(() => ({
           height: inlineHeight,
         }
       : {}),
+    ...(justifyContent === 'flex-start'
+      ? {
+          paddingRight: 0,
+          paddingLeft: 0,
+        }
+      : {}),
   })
 )
 
@@ -158,6 +178,8 @@ interface TitleProps {
   textColor?: ColorsEnum
   textSize?: number
   textLineHeight?: string
+  icon?: React.FC<IconInterface>
+  iconSize?: number
 }
 
 const Title = styled(Typo.ButtonText)<TitleProps>((props) => ({
@@ -165,5 +187,6 @@ const Title = styled(Typo.ButtonText)<TitleProps>((props) => ({
   color: props.textColor,
   fontSize: props.textSize,
   lineHeight: props.textLineHeight,
-  marginLeft: 5,
+  marginLeft: props.icon ? getSpacing(2) : 0,
+  marginRight: props.iconSize,
 }))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12360

## But de la PR 
- **AppButton** : Rendre possible l'affichage flex-start avec une props optionelle `justifyContent="flex-start"`.
- **AppButton** : Rendre possible l'affichage du titre sur plusieurs lignes avec une props optionelle `numberOfLines`.
- **AppButton** : Corriger le marginLeft en trop sur tous les boutons qui n'ont pas d'icons.
- **AppButton** : Corriger le cropage de l'affichage de "..." d'un texte trop long dans un bouton, introduit par l'ajout d'un icon. 
- **IdentityCheck + DMS** : Remplacement des icons de redirection externe des pages DMS
- **SubscriptionMessage** : Conditionner l'affichage de `popOverIcon` selon la présence ou non du `callToActionIcon`


## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Added a **screenshot** for UI tickets.

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
| ![Capture d’écran 2021-12-20 à 17 21 14](https://user-images.githubusercontent.com/62059034/146802284-8d7f8d58-f718-46c2-a2c2-a3b65b9bac86.png) <img width="560" alt="Capture d’écran 2021-12-21 à 12 15 46" src="https://user-images.githubusercontent.com/62059034/146921442-7de0757f-4bdb-44d5-b7f4-dff90ecfea9b.png">  <img width="567" alt="Capture d’écran 2021-12-21 à 12 29 02" src="https://user-images.githubusercontent.com/62059034/146922953-a36af5e3-6015-4872-b1dd-a0ed825d57a4.png"> |         |                 |                  

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
