### PR TITLE
(PC-12415) fix(translations): replace space before » and after « with nbsp

### DIFF
--- a/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.native-snap
+++ b/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.native-snap
@@ -141,7 +141,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
           ]
         }
       >
-        Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien.
+        Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien.
       </Text>
       <View
         numberOfSpaces={6}

--- a/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.native-snap
+++ b/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.native-snap
@@ -141,7 +141,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
           ]
         }
       >
-        Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien.
+        Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien.
       </Text>
       <View
         numberOfSpaces={6}

--- a/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.web-snap
+++ b/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.web-snap
@@ -181,7 +181,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
           }
         }
       >
-        Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien.
+        Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien.
       </div>
       <div
         className="css-view-1dbjc4n"

--- a/eslint-custom-rules/nbsp-in-french-translations.js
+++ b/eslint-custom-rules/nbsp-in-french-translations.js
@@ -37,6 +37,27 @@ module.exports = {
             },
           })
         },
+      'TaggedTemplateExpression[tag.name="t"] > TemplateLiteral > TemplateElement[value.raw=/«\\s+/]':
+        (node) => {
+          context.report({
+            node,
+            message: 'Please use \\u00a0 (nbsp) instead of whitespace after «',
+            fix: function (fixer) {
+              const textToReplace = node.value.raw.replace(/(«)\s+/g, '$1\\u00a0')
+
+              // We use range here, because fixer.replaceText(node, textToReplace)
+              // removes the backticks, "${" or "}" around the text.
+              // It's because of the "range" property of the provided TemplateElement
+              // in "node" variable: the range is too wide. So we process it manually,
+              // removing the first character
+              const startRangeIndex = node.range[0] + 1
+              const endRangeIndex = startRangeIndex + node.value.raw.length
+              const range = [startRangeIndex, endRangeIndex]
+
+              return fixer.replaceTextRange(range, textToReplace)
+            },
+          })
+        },
     }
   },
 }

--- a/eslint-custom-rules/nbsp-in-french-translations.js
+++ b/eslint-custom-rules/nbsp-in-french-translations.js
@@ -16,13 +16,13 @@ module.exports = {
   },
   create(context) {
     return {
-      'TaggedTemplateExpression[tag.name="t"] > TemplateLiteral > TemplateElement[value.raw=/\\s+[!?:]/]':
+      'TaggedTemplateExpression[tag.name="t"] > TemplateLiteral > TemplateElement[value.raw=/\\s+[!?:»]/]':
         (node) => {
           context.report({
             node,
-            message: 'Please use \\u00a0 (nbsp) instead of whitespace before !, ?, :',
+            message: 'Please use \\u00a0 (nbsp) instead of whitespace before !, ?, :, »',
             fix: function (fixer) {
-              const textToReplace = node.value.raw.replace(/\s+([!?:])/g, '\\u00a0$1')
+              const textToReplace = node.value.raw.replace(/\s+([!?:»])/g, '\\u00a0$1')
 
               // We use range here, because fixer.replaceText(node, textToReplace)
               // removes the backticks, "${" or "}" around the text.

--- a/eslint-custom-rules/nbsp-in-french-translations.js
+++ b/eslint-custom-rules/nbsp-in-french-translations.js
@@ -23,15 +23,7 @@ module.exports = {
             message: 'Please use \\u00a0 (nbsp) instead of whitespace before !, ?, :, »',
             fix: function (fixer) {
               const textToReplace = node.value.raw.replace(/\s+([!?:»])/g, '\\u00a0$1')
-
-              // We use range here, because fixer.replaceText(node, textToReplace)
-              // removes the backticks, "${" or "}" around the text.
-              // It's because of the "range" property of the provided TemplateElement
-              // in "node" variable: the range is too wide. So we process it manually,
-              // removing the first character
-              const startRangeIndex = node.range[0] + 1
-              const endRangeIndex = startRangeIndex + node.value.raw.length
-              const range = [startRangeIndex, endRangeIndex]
+              const range = getReplaceRange(node)
 
               return fixer.replaceTextRange(range, textToReplace)
             },
@@ -44,15 +36,7 @@ module.exports = {
             message: 'Please use \\u00a0 (nbsp) instead of whitespace after «',
             fix: function (fixer) {
               const textToReplace = node.value.raw.replace(/(«)\s+/g, '$1\\u00a0')
-
-              // We use range here, because fixer.replaceText(node, textToReplace)
-              // removes the backticks, "${" or "}" around the text.
-              // It's because of the "range" property of the provided TemplateElement
-              // in "node" variable: the range is too wide. So we process it manually,
-              // removing the first character
-              const startRangeIndex = node.range[0] + 1
-              const endRangeIndex = startRangeIndex + node.value.raw.length
-              const range = [startRangeIndex, endRangeIndex]
+              const range = getReplaceRange(node)
 
               return fixer.replaceTextRange(range, textToReplace)
             },
@@ -60,4 +44,15 @@ module.exports = {
         },
     }
   },
+}
+
+function getReplaceRange(node) {
+  // We use range here, because fixer.replaceText(node, textToReplace)
+  // removes the backticks, "${" or "}" around the text.
+  // It's because of the "range" property of the provided TemplateElement
+  // in "node" variable: the range is too wide. So we process it manually,
+  // removing the first character
+  const startRangeIndex = node.range[0] + 1
+  const endRangeIndex = startRangeIndex + node.value.raw.length
+  return [startRangeIndex, endRangeIndex]
 }

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -477,8 +477,8 @@ msgid "Clique sur le lien reçu à l'adresse :"
 msgstr "Clique sur le lien reçu à l'adresse :"
 
 #: src/ui/components/LayoutExpiredLink.tsx
-msgid "Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien."
-msgstr "Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien."
+msgid "Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien."
+msgstr "Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien."
 
 #: src/features/navigation/RootNavigator/identityCheckRoutes.ts
 msgid "Code postal - Formulaire"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -477,8 +477,8 @@ msgid "Clique sur le lien reçu à l'adresse :"
 msgstr "Clique sur le lien reçu à l'adresse :"
 
 #: src/ui/components/LayoutExpiredLink.tsx
-msgid "Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien."
-msgstr "Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien."
+msgid "Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien."
+msgstr "Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien."
 
 #: src/features/navigation/RootNavigator/identityCheckRoutes.ts
 msgid "Code postal - Formulaire"

--- a/src/ui/components/LayoutExpiredLink.tsx
+++ b/src/ui/components/LayoutExpiredLink.tsx
@@ -30,7 +30,8 @@ export function LayoutExpiredLink({
     <GenericInfoPage title={t`Oups\u00a0!`} icon={SadFace}>
       <StyledBody>{t`Le lien est expiré\u00a0!`}</StyledBody>
       <StyledBody>
-        {customBodyText || t`Clique sur « Renvoyer l’e-mail\u00a0» pour recevoir un nouveau lien.`}
+        {customBodyText ||
+          t`Clique sur «\u00a0Renvoyer l’e-mail\u00a0» pour recevoir un nouveau lien.`}
       </StyledBody>
       <Spacer.Column numberOfSpaces={6} />
 

--- a/src/ui/components/LayoutExpiredLink.tsx
+++ b/src/ui/components/LayoutExpiredLink.tsx
@@ -30,7 +30,7 @@ export function LayoutExpiredLink({
     <GenericInfoPage title={t`Oups\u00a0!`} icon={SadFace}>
       <StyledBody>{t`Le lien est expiré\u00a0!`}</StyledBody>
       <StyledBody>
-        {customBodyText || t`Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien.`}
+        {customBodyText || t`Clique sur « Renvoyer l’e-mail\u00a0» pour recevoir un nouveau lien.`}
       </StyledBody>
       <Spacer.Column numberOfSpaces={6} />
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12415

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
