### PR TITLE
(PC-12412) fix(Web): restore webpack alias for react-native-web-lottie

### DIFF
--- a/web/config/webpack.config.js
+++ b/web/config/webpack.config.js
@@ -302,6 +302,9 @@ module.exports = function (webpackEnv) {
         'react-native-svg': 'react-native-svg-web',
         'react-native-linear-gradient': 'react-native-web-linear-gradient',
 
+        // still required by @pass-culture/id-check
+        'lottie-react-native': 'react-native-web-lottie',
+
         // Those libs are mocked until we implement web specific solutions
         'react-native-email-link': path.join(paths.appSrc, 'libs/react-native-email-link'),
         'react-native-permissions': path.join(paths.appSrc, 'libs/react-native-permissions'),


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12412

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
