### PR TITLE
(PC-12412) fix(IdentityCheckValidation): replace idcheck validation page with custom one

### DIFF
--- a/src/features/identityCheck/pages/identification/IdentityCheckValidation.web.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckValidation.web.tsx
@@ -1,0 +1,81 @@
+import { t } from '@lingui/macro'
+import { useRoute } from '@react-navigation/native'
+import moment from 'moment'
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { CenteredTitle } from 'features/identityCheck/atoms/CenteredTitle'
+import { PageWithHeader } from 'features/identityCheck/components/layout/PageWithHeader'
+import { useIdentityCheckContext } from 'features/identityCheck/context/IdentityCheckContextProvider'
+import { IdentityCheckStep } from 'features/identityCheck/types'
+import { useIdentityCheckNavigation } from 'features/identityCheck/useIdentityCheckNavigation'
+import { UseRouteType } from 'features/navigation/RootNavigator'
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { ColorsEnum, Spacer, Typo } from 'ui/theme'
+
+export const IdentityCheckValidation = () => {
+  const { params } = useRoute<UseRouteType<'IdentityCheckValidation'>>()
+
+  const { dispatch, identification } = useIdentityCheckContext()
+  dispatch({
+    type: 'SET_IDENTIFICATION',
+    payload: {
+      firstName: params.firstName ?? null,
+      lastName: params.lastName ?? null,
+      birthDate: params.dateOfBirth ?? null,
+    },
+  })
+
+  const { navigateToNextScreen } = useIdentityCheckNavigation()
+
+  const birthDate = identification.birthDate
+    ? moment(identification.birthDate, 'YYYY-MM-DD').format('DD/MM/YYYY')
+    : ''
+
+  const navigateToNextEduConnectStep = async () => {
+    dispatch({ type: 'SET_STEP', payload: IdentityCheckStep.CONFIRMATION })
+    navigateToNextScreen()
+  }
+
+  return (
+    <PageWithHeader
+      title={t`Mon identité`}
+      fixedTopChildren={
+        <CenteredTitle title={t`Les informations extraites sont-elles correctes\u00a0?`} />
+      }
+      scrollChildren={
+        <BodyContainer>
+          <Typo.Body color={ColorsEnum.GREY_DARK}>{t`Ton prénom`}</Typo.Body>
+          <Spacer.Column numberOfSpaces={2} />
+          <Typo.Title3 testID="validation-first-name">{identification.firstName}</Typo.Title3>
+          <Spacer.Column numberOfSpaces={5} />
+          <Typo.Body color={ColorsEnum.GREY_DARK}>{t`Ton nom de famille`}</Typo.Body>
+          <Spacer.Column numberOfSpaces={2} />
+          <Typo.Title3 testID="validation-name">{identification.lastName}</Typo.Title3>
+          <Spacer.Column numberOfSpaces={5} />
+          <Typo.Body color={ColorsEnum.GREY_DARK}>{t`Ta date de naissance`}</Typo.Body>
+          <Spacer.Column numberOfSpaces={2} />
+          <Typo.Title3 testID="validation-birth-date">{birthDate}</Typo.Title3>
+        </BodyContainer>
+      }
+      fixedBottomChildren={
+        <React.Fragment>
+          <StyledButtonPrimary
+            title={t`Valider mes informations`}
+            onPress={navigateToNextEduConnectStep}
+          />
+        </React.Fragment>
+      }
+    />
+  )
+}
+
+const StyledButtonPrimary = styled(ButtonPrimary)({
+  width: '100%',
+})
+
+const BodyContainer = styled.View({
+  alignItems: 'center',
+  justifyContent: 'center',
+  flex: 1,
+})

--- a/src/features/navigation/RootNavigator/routes.ts
+++ b/src/features/navigation/RootNavigator/routes.ts
@@ -40,6 +40,7 @@ import { FavoritesSorts } from 'features/favorites/pages/FavoritesSorts'
 import { CulturalSurvey } from 'features/firstLogin/CulturalSurvey'
 import { FirstTutorial } from 'features/firstTutorial/pages/FirstTutorial/FirstTutorial'
 import { EduConnectErrors } from 'features/identityCheck/pages/errors/EduConnectErrors'
+import { IdentityCheckValidation } from 'features/identityCheck/pages/identification/IdentityCheckValidation'
 import { PageNotFound } from 'features/navigation/PageNotFound'
 import { identityCheckRoutes } from 'features/navigation/RootNavigator/identityCheckRoutes'
 import { screenParamsParser } from 'features/navigation/screenParamsUtils'
@@ -72,6 +73,11 @@ const importedIdCheckRoutes = idCheckRoutes.map((route) => {
     // This route is hardcoded in the backend
     // https://github.com/pass-culture/pass-culture-main/blob/master/api/src/pcapi/routes/saml/educonnect.py#L28
     return { ...route, component: EduConnectErrors }
+  }
+  if (route.name === 'Validation') {
+    // This route is hardcoded in the backend
+    // https://github.com/pass-culture/pass-culture-main/blob/master/api/src/pcapi/routes/saml/educonnect.py#L28
+    return { ...route, component: IdentityCheckValidation }
   }
   return route
 })

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -25,7 +25,7 @@ export type IdentityCheckRootStackParamList = {
   IdentityCheckUnavailable: { withDMS?: boolean }
   IdentityCheckEduConnect: undefined
   IdentityCheckEduConnectForm: undefined
-  IdentityCheckValidation: undefined
+  IdentityCheckValidation: { firstName?: string; lastName?: string; dateOfBirth?: string }
   IdentityCheckPending: undefined
   IdentityCheckDMS: undefined
   // Confirmation


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12412

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
