### PR TITLE
(PC-12440) feat(identityCheck): disable steps that are completed

### DIFF
--- a/src/features/identityCheck/atoms/StepButton.tsx
+++ b/src/features/identityCheck/atoms/StepButton.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { StepConfig } from 'features/identityCheck/types'
+import { accessibilityAndTestId } from 'tests/utils'
 import { Validate } from 'ui/svg/icons/Validate'
 import { ColorsEnum, getSpacing, Typo } from 'ui/theme'
 import { ACTIVE_OPACITY } from 'ui/theme/colors'
@@ -19,7 +20,12 @@ export const StepButton = ({ step, state, onPress }: Props) => {
   const { icon: Icon, label } = step
 
   return (
-    <Button activeOpacity={ACTIVE_OPACITY} onPress={onPress} disabled={state === 'disabled'}>
+    <Button
+      activeOpacity={ACTIVE_OPACITY}
+      onPress={onPress}
+      disabled={state !== 'current'}
+      state={state}
+      {...accessibilityAndTestId(label)}>
       <IconContainer>
         <Icon size={getSpacing(10)} />
       </IconContainer>
@@ -28,19 +34,20 @@ export const StepButton = ({ step, state, onPress }: Props) => {
         <Validate
           size={getSpacing(6)}
           color={state === 'completed' ? ColorsEnum.GREEN_LIGHT : ColorsEnum.TRANSPARENT}
+          {...accessibilityAndTestId(state === 'completed' ? 'StepCompleted' : 'StepNotCompleted')}
         />
       </CompletionContainer>
     </Button>
   )
 }
 
-const Button = styled.TouchableOpacity<{ disabled: boolean }>((props) => ({
+const Button = styled.TouchableOpacity<{ disabled: boolean; state: StepButtonState }>((props) => ({
   height: getSpacing(24),
   marginTop: getSpacing(6),
   width: '100%',
   backgroundColor: ColorsEnum.WHITE,
   borderRadius: BorderRadiusEnum.BORDER_RADIUS,
-  opacity: props.disabled ? 0.5 : 1,
+  opacity: props.state === 'disabled' ? 0.5 : 1,
   flexDirection: 'row',
   alignItems: 'center',
 }))

--- a/src/features/identityCheck/atoms/__test__/StepButton.native.test.tsx
+++ b/src/features/identityCheck/atoms/__test__/StepButton.native.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+
+import { StepButton } from 'features/identityCheck/atoms/StepButton'
+import { StepConfig } from 'features/identityCheck/types'
+import { render } from 'tests/utils'
+import { Profile } from 'ui/svg/icons/Profile'
+import { IconInterface } from 'ui/svg/icons/types'
+
+const label = 'Profil'
+const icon: React.FC<IconInterface> = () => <Profile opacity={0.5} />
+const step = { label, icon } as StepConfig
+
+describe('StepButton', () => {
+  describe('button is enabled/disabled', () => {
+    it('should be disabled if step is "completed"', () => {
+      const { getByTestId } = render(<StepButton step={step} state="completed" />)
+      expect(getByTestId(label).props.accessibilityState.disabled).toBe(true)
+    })
+
+    it('should be disabled if step is "disabled"', () => {
+      const { getByTestId } = render(<StepButton step={step} state="disabled" />)
+      expect(getByTestId(label).props.accessibilityState.disabled).toBe(true)
+    })
+
+    it('should be active if step is "current"', () => {
+      const { getByTestId } = render(<StepButton step={step} state="current" />)
+      expect(getByTestId(label).props.accessibilityState.disabled).toBe(false)
+    })
+  })
+
+  it('icon check is present only if step is completed', () => {
+    render(<StepButton step={step} state="completed" />).getByTestId('StepCompleted')
+    render(<StepButton step={step} state="disabled" />).getByTestId('StepNotCompleted')
+    render(<StepButton step={step} state="current" />).getByTestId('StepNotCompleted')
+  })
+})

--- a/src/features/identityCheck/atoms/__test__/StepButton.web.test.tsx
+++ b/src/features/identityCheck/atoms/__test__/StepButton.web.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+
+import { StepButton } from 'features/identityCheck/atoms/StepButton'
+import { StepConfig } from 'features/identityCheck/types'
+import { render } from 'tests/utils/web'
+import { Profile } from 'ui/svg/icons/Profile'
+import { IconInterface } from 'ui/svg/icons/types'
+
+const label = 'Profil'
+const icon: React.FC<IconInterface> = () => <Profile opacity={0.5} />
+const step = { label, icon } as StepConfig
+
+describe('StepButton', () => {
+  describe('button is enabled/disabled', () => {
+    it('should be disabled if step is "completed"', () => {
+      const { getByTestId } = render(<StepButton step={step} state="completed" />)
+      expect(getByTestId(label).getAttribute('aria-disabled')).toBe('true')
+    })
+
+    it('should be disabled if step is "disabled"', () => {
+      const { getByTestId } = render(<StepButton step={step} state="disabled" />)
+      expect(getByTestId(label).getAttribute('aria-disabled')).toBe('true')
+    })
+
+    it('should be active if step is "current"', () => {
+      const { getByTestId } = render(<StepButton step={step} state="current" />)
+      expect(getByTestId(label).getAttribute('aria-disabled')).toBe(null)
+    })
+  })
+
+  describe('icon check is present/absent', () => {
+    it('should be present if step is "completed"', () => {
+      render(<StepButton step={step} state="completed" />).findByTestId('StepCompleted')
+    })
+
+    it('should be absent if step is "disabled"', () => {
+      render(<StepButton step={step} state="disabled" />).findByTestId('StepNotCompleted')
+    })
+
+    it('should be absent if step is "current"', () => {
+      render(<StepButton step={step} state="current" />).findByTestId('StepNotCompleted')
+    })
+  })
+})

--- a/src/features/identityCheck/pages/identification/IdentityCheckWebview.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckWebview.tsx
@@ -44,6 +44,7 @@ export const IdentityCheckWebview: React.FC = () => {
       <Spacer.TopScreen />
       <StyledWebview
         allowsInlineMediaPlayback
+        mediaPlaybackRequiresUserAction={false}
         source={{ uri: identificationUrl }}
         onNavigationStateChange={onNavigationStateChange}
         originWhitelist={ORIGIN_WHITELIST}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12440

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.

## Screenshots

| avant | après |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/10118284/146984286-35a160b4-7b35-48ba-8019-15d1cb92d2df.png) | ![image](https://user-images.githubusercontent.com/10118284/146984171-b4dace71-f070-4962-8c6e-f74c0c62ade0.png) |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
