### PR TITLE
(PC-11951) fix(FirstTutorial): Fix GenericAchievementCard to fit the bottom button

### DIFF
--- a/__snapshots__/features/eighteenBirthday/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/eighteenBirthday/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -252,6 +252,7 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
                         "flexGrow": 1,
                         "flexShrink": 1,
                         "justifyContent": "flex-end",
+                        "paddingBottom": 40,
                       },
                     ]
                   }
@@ -384,18 +385,6 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
                     </View>
                   </View>
                 </View>
-                <View
-                  flex={1}
-                  style={
-                    Array [
-                      Object {
-                        "flexBasis": 0,
-                        "flexGrow": 1,
-                        "flexShrink": 1,
-                      },
-                    ]
-                  }
-                />
               </View>
             </View>
           </View>

--- a/__snapshots__/features/eighteenBirthday/pages/components/EighteenBirthdayCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/eighteenBirthday/pages/components/EighteenBirthdayCard.native.test.tsx.native-snap
@@ -136,6 +136,7 @@ exports[`<EighteenBirthdayCard /> should render eighteen birthday card 1`] = `
           "flexGrow": 1,
           "flexShrink": 1,
           "justifyContent": "flex-end",
+          "paddingBottom": 40,
         },
       ]
     }
@@ -268,17 +269,5 @@ exports[`<EighteenBirthdayCard /> should render eighteen birthday card 1`] = `
       </View>
     </View>
   </View>
-  <View
-    flex={1}
-    style={
-      Array [
-        Object {
-          "flexBasis": 0,
-          "flexGrow": 1,
-          "flexShrink": 1,
-        },
-      ]
-    }
-  />
 </View>
 `;

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/FirstTutorial.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/FirstTutorial.native.test.tsx.native-snap
@@ -325,6 +325,7 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                         "flexGrow": 1,
                         "flexShrink": 1,
                         "justifyContent": "flex-end",
+                        "paddingBottom": 40,
                       },
                     ]
                   }
@@ -392,18 +393,6 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                     </View>
                   </View>
                 </View>
-                <View
-                  flex={1.5}
-                  style={
-                    Array [
-                      Object {
-                        "flexBasis": 0,
-                        "flexGrow": 1.5,
-                        "flexShrink": 1,
-                      },
-                    ]
-                  }
-                />
               </View>
             </View>
             <View
@@ -550,6 +539,7 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                         "flexGrow": 1,
                         "flexShrink": 1,
                         "justifyContent": "flex-end",
+                        "paddingBottom": 40,
                       },
                     ]
                   }
@@ -572,18 +562,6 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                     />
                   </View>
                 </View>
-                <View
-                  flex={1.5}
-                  style={
-                    Array [
-                      Object {
-                        "flexBasis": 0,
-                        "flexGrow": 1.5,
-                        "flexShrink": 1,
-                      },
-                    ]
-                  }
-                />
               </View>
             </View>
             <View
@@ -730,6 +708,7 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                         "flexGrow": 1,
                         "flexShrink": 1,
                         "justifyContent": "flex-end",
+                        "paddingBottom": 40,
                       },
                     ]
                   }
@@ -752,18 +731,6 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                     />
                   </View>
                 </View>
-                <View
-                  flex={1.5}
-                  style={
-                    Array [
-                      Object {
-                        "flexBasis": 0,
-                        "flexGrow": 1.5,
-                        "flexShrink": 1,
-                      },
-                    ]
-                  }
-                />
               </View>
             </View>
             <View
@@ -910,6 +877,7 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                         "flexGrow": 1,
                         "flexShrink": 1,
                         "justifyContent": "flex-end",
+                        "paddingBottom": 40,
                       },
                     ]
                   }
@@ -932,18 +900,6 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                     />
                   </View>
                 </View>
-                <View
-                  flex={1.5}
-                  style={
-                    Array [
-                      Object {
-                        "flexBasis": 0,
-                        "flexGrow": 1.5,
-                        "flexShrink": 1,
-                      },
-                    ]
-                  }
-                />
               </View>
             </View>
           </View>

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FirstCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FirstCard.native.test.tsx.native-snap
@@ -136,6 +136,7 @@ exports[`FirstCard should render first card 1`] = `
           "flexGrow": 1,
           "flexShrink": 1,
           "justifyContent": "flex-end",
+          "paddingBottom": 40,
         },
       ]
     }
@@ -268,17 +269,5 @@ exports[`FirstCard should render first card 1`] = `
       </View>
     </View>
   </View>
-  <View
-    flex={1}
-    style={
-      Array [
-        Object {
-          "flexBasis": 0,
-          "flexGrow": 1,
-          "flexShrink": 1,
-        },
-      ]
-    }
-  />
 </View>
 `;

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FourthCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FourthCard.native.test.tsx.native-snap
@@ -136,6 +136,7 @@ exports[`FourthCard should render fourth card 1`] = `
           "flexGrow": 1,
           "flexShrink": 1,
           "justifyContent": "flex-end",
+          "paddingBottom": 40,
         },
       ]
     }
@@ -268,17 +269,5 @@ exports[`FourthCard should render fourth card 1`] = `
       </View>
     </View>
   </View>
-  <View
-    flex={1}
-    style={
-      Array [
-        Object {
-          "flexBasis": 0,
-          "flexGrow": 1,
-          "flexShrink": 1,
-        },
-      ]
-    }
-  />
 </View>
 `;

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/SecondCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/SecondCard.native.test.tsx.native-snap
@@ -136,6 +136,7 @@ exports[`SecondCard should render second card 1`] = `
           "flexGrow": 1,
           "flexShrink": 1,
           "justifyContent": "flex-end",
+          "paddingBottom": 40,
         },
       ]
     }
@@ -268,17 +269,5 @@ exports[`SecondCard should render second card 1`] = `
       </View>
     </View>
   </View>
-  <View
-    flex={1}
-    style={
-      Array [
-        Object {
-          "flexBasis": 0,
-          "flexGrow": 1,
-          "flexShrink": 1,
-        },
-      ]
-    }
-  />
 </View>
 `;

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/ThirdCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/ThirdCard.native.test.tsx.native-snap
@@ -136,6 +136,7 @@ exports[`ThirdCard should render third card 1`] = `
           "flexGrow": 1,
           "flexShrink": 1,
           "justifyContent": "flex-end",
+          "paddingBottom": 40,
         },
       ]
     }
@@ -268,17 +269,5 @@ exports[`ThirdCard should render third card 1`] = `
       </View>
     </View>
   </View>
-  <View
-    flex={1}
-    style={
-      Array [
-        Object {
-          "flexBasis": 0,
-          "flexGrow": 1,
-          "flexShrink": 1,
-        },
-      ]
-    }
-  />
 </View>
 `;

--- a/src/ui/components/achievements/components/GenericAchievementCard.tsx
+++ b/src/ui/components/achievements/components/GenericAchievementCard.tsx
@@ -140,13 +140,6 @@ Those props are provided by the GenericAchievementCard and must be passed down t
           </FlexContainer>
         )}
       </BottomButtonsContainer>
-      <Spacer.Flex
-        flex={
-          !props.lastIndex
-            ? grid({ default: 1, sm: 0.5 }, 'height')
-            : grid({ default: 1.5, sm: 2 }, 'height')
-        }
-      />
     </GenericCardContainer>
   )
 }
@@ -159,6 +152,7 @@ const FlexContainer = styled.View<{ marginTop: number }>((props) => ({
 const BottomButtonsContainer = styled.View({
   flex: 1,
   justifyContent: 'flex-end',
+  paddingBottom: getSpacing(10),
 })
 
 const InvisibleButtonHeight = styled.View({


### PR DESCRIPTION


Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-11951

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | iOS | iOS | iOS | 
| --: | --: | --: | --: | 
|<img width="332" alt="Capture d’écran 2021-12-22 à 11 10 49" src="https://user-images.githubusercontent.com/90036171/147077103-ac1d3026-f765-4cde-b8b7-b7af779574e0.png">|<img width="332" alt="Capture d’écran 2021-12-22 à 11 10 57" src="https://user-images.githubusercontent.com/90036171/147076848-856173d5-356f-4a46-aa18-4b478dcb4441.png">|     <img width="331" alt="Capture d’écran 2021-12-22 à 11 11 05" src="https://user-images.githubusercontent.com/90036171/147076880-275b5e79-f63e-476a-bd7f-9cc3b79b9041.png">|<img width="330" alt="Capture d’écran 2021-12-22 à 11 11 12" src="https://user-images.githubusercontent.com/90036171/147076937-8d70838d-4eae-442f-97df-52ec894816b2.png">|




| Chrome |
| --: |
|<img width="1680" alt="Capture d’écran 2021-12-22 à 11 15 50" src="https://user-images.githubusercontent.com/90036171/147076739-03d34904-0c04-479f-809b-53c032aafc7a.png">|



[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
