### PR TITLE
(PC-12453) fix(phone): button was a bit cropped

### DIFF
--- a/src/features/auth/signup/PhoneValidation/SetPhoneValidationCode.tsx
+++ b/src/features/auth/signup/PhoneValidation/SetPhoneValidationCode.tsx
@@ -256,7 +256,7 @@ export const SetPhoneValidationCode = memo(function SetPhoneValidationCodeCompon
             <Typo.Body>{t`Tu n'as pas reçu le sms\u00a0?`}</Typo.Body>
             {/* force button to wrap on small screen, otherwise timer will "unwrap" when timer is under 10 seconds */}
             {appContentWidth <= 320 ? <Break /> : null}
-            <ButtonTertiary
+            <RetryButton
               title={getRetryButtonTitle()}
               testId={'Réessayer'}
               onPress={requestSendPhoneValidationCode}
@@ -334,4 +334,8 @@ const HelpRow = styled.View({
   width: '100%',
   flexWrap: 'wrap',
   alignItems: 'center',
+})
+
+const RetryButton = styled(ButtonTertiary)({
+  height: '100%',
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12453

Le `y` du bouton `Réessayer` était coupé

Reviewer, tu peux utiliser la branche `PC-12453-fix-cropped-button-easy-test` si tu veux tester

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the ~~relevant real~~ / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

iOS
|avant|après|
|:--|:--|
|![image](https://user-images.githubusercontent.com/95220086/147077955-38ad15ca-be54-4c44-be46-f0d6c71b5f78.png)|![image](https://user-images.githubusercontent.com/95220086/147078074-5d819d70-d57b-4d94-856e-54ff5d252859.png)|


Firefox Desktop (le problème n'était pas présent, donc il n'y a pas de changement)
|avant|après|
|:--|:--|
|![image](https://user-images.githubusercontent.com/95220086/147077883-ac6905bd-7ede-4bfc-9ed3-6215b76cc551.png)|![image](https://user-images.githubusercontent.com/95220086/147078262-b7ed4960-a483-4bbb-b9a2-0e4578d24f0f.png)|


[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
