### PR TITLE
fix(ubbleWebview): add NSMicrophoneUsageDescription

### DIFF
--- a/ios/PassCulture/Info.plist
+++ b/ios/PassCulture/Info.plist
@@ -90,6 +90,8 @@
 	<string>Cette application a besoin de ta géolocalisation pour te montrer des offres proche de toi.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Cette application a besoin de ta géolocalisation pour te montrer des offres proche de toi.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Cette application peut vérifier ton identité avec de l'audio</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Montserrat-Bold.ttf</string>


### PR DESCRIPTION
Le problème : Le parcours Ubble ne démarre pas car il est mal supporté sur les versions inférieures d'iOS14.5

![Capture d’écran 2021-12-22 à 14 55 48](https://user-images.githubusercontent.com/62059034/147103764-94741440-1b6e-4019-824e-13832c3d50ef.png)

Le fix : Selon Ubble, il faut ajouter la permission Microphone dans `Info.plist`
```
<key>NSMicrophoneUsageDescription</key>
<string>Video and Audio Recording</string>