### PR TITLE
(PC-10783) fix(context): reset search and identityCheck context on login

### DIFF
--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -5,7 +5,7 @@ import { useQueryClient } from 'react-query'
 import { api } from 'api/api'
 import { refreshAccessToken } from 'api/apiHelpers'
 import { SigninResponse } from 'api/gen'
-import { useSearch } from 'features/search/pages/SearchWrapper'
+import { useResetContexts } from 'features/auth/useResetContexts'
 import { analytics, LoginRoutineMethod } from 'libs/analytics'
 import { useAppStateChange } from 'libs/appState'
 import { getAccessTokenStatus, getUserIdFromAccesstoken } from 'libs/jwt'
@@ -85,7 +85,7 @@ export const AuthWrapper = memo(function AuthWrapper({ children }: { children: J
 
 export function useLoginRoutine() {
   const { setIsLoggedIn } = useAuthContext()
-  const { dispatch } = useSearch()
+  const resetContexts = useResetContexts()
 
   /**
    * Executes the minimal set of instructions required to proceed to the login
@@ -98,8 +98,7 @@ export function useLoginRoutine() {
     await storage.saveString('access_token', response.accessToken)
     analytics.logLogin({ method })
     setIsLoggedIn(true)
-    // initialise search state to make sure search results correspond to user available categories
-    dispatch({ type: 'INIT' })
+    resetContexts()
   }
 
   return loginRoutine

--- a/src/features/auth/login/Login.native.test.tsx
+++ b/src/features/auth/login/Login.native.test.tsx
@@ -18,6 +18,16 @@ import { Login } from './Login'
 
 jest.mock('react-query')
 jest.mock('features/navigation/helpers')
+const mockSearchDispatch = jest.fn()
+const mockStagedSearchDispatch = jest.fn()
+const mockIdentityCheckDispatch = jest.fn()
+jest.mock('features/search/pages/SearchWrapper', () => ({
+  useSearch: jest.fn(() => ({ dispatch: mockSearchDispatch })),
+  useStagedSearch: jest.fn(() => ({ dispatch: mockStagedSearchDispatch })),
+}))
+jest.mock('features/identityCheck/context/IdentityCheckContextProvider', () => ({
+  useIdentityCheckContext: jest.fn(() => ({ dispatch: mockIdentityCheckDispatch })),
+}))
 
 const mockUsePreviousRoute = usePreviousRoute as jest.Mock
 
@@ -53,6 +63,9 @@ describe('<Login/>', () => {
       expect(BatchUser.editor().setIdentifier).toHaveBeenCalledWith('111')
       expect(analytics.setUserId).toHaveBeenCalledWith(111)
       expect(navigateToHome).toBeCalledTimes(1)
+      expect(mockSearchDispatch).toHaveBeenNthCalledWith(1, { type: 'INIT' })
+      expect(mockStagedSearchDispatch).toHaveBeenNthCalledWith(1, { type: 'INIT' })
+      expect(mockIdentityCheckDispatch).toHaveBeenNthCalledWith(1, { type: 'INIT' })
     })
   })
 

--- a/src/features/auth/useResetContexts.ts
+++ b/src/features/auth/useResetContexts.ts
@@ -1,0 +1,14 @@
+import { useIdentityCheckContext } from 'features/identityCheck/context/IdentityCheckContextProvider'
+import { useSearch, useStagedSearch } from 'features/search/pages/SearchWrapper'
+
+export const useResetContexts = () => {
+  const { dispatch: dispatchSearch } = useSearch()
+  const { dispatch: dispatchStagedSearch } = useStagedSearch()
+  const { dispatch: dispatchIdentityCheck } = useIdentityCheckContext()
+
+  return () => {
+    dispatchSearch({ type: 'INIT' })
+    dispatchStagedSearch({ type: 'INIT' })
+    dispatchIdentityCheck({ type: 'INIT' })
+  }
+}


### PR DESCRIPTION
Link to JIRA tickets:

- https://passculture.atlassian.net/browse/PC-10783
- https://passculture.atlassian.net/browse/PC-12442

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
