### PR TITLE
(PC-12427) fix(translations): replace space before € with nbsp

### DIFF
--- a/__snapshots__/features/auth/signup/idCheck/DenyAccessToIdCheck.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/idCheck/DenyAccessToIdCheck.native.test.tsx.native-snap
@@ -326,7 +326,7 @@ exports[`<DenyAccessToIdCheckModal /> should match snapshot 1`] = `
                   ]
                 }
               >
-                Vous êtes actuellement très nombreux à vouloir effectuer votre demande des 300€. Tu recevras une alerte par mail pour commencer ta demande des 300€ dès que le service sera de nouveau disponible !
+                Vous êtes actuellement très nombreux à vouloir effectuer votre demande des 300 €. Tu recevras une alerte par mail pour commencer ta demande des 300 € dès que le service sera de nouveau disponible !
               </Text>
             </Text>
             <View

--- a/__snapshots__/features/bookOffer/components/__tests__/BookDuoChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookDuoChoice.native.test.tsx.native-snap
@@ -156,7 +156,7 @@ Array [
             }
             testID="DuoChoice1-price"
           >
-            20€
+            20 €
           </Text>
         </View>
       </View>
@@ -268,7 +268,7 @@ Array [
             }
             testID="DuoChoice2-price"
           >
-            40€
+            40 €
           </Text>
         </View>
       </View>

--- a/__snapshots__/features/bookOffer/components/__tests__/BookDuoChoice.web.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookDuoChoice.web.test.tsx.web-snap
@@ -73,7 +73,7 @@ Object {
                 dir="auto"
                 style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
               >
-                20€
+                20 €
               </div>
             </div>
           </div>
@@ -119,7 +119,7 @@ Object {
                 dir="auto"
                 style="color: rgb(21, 21, 21); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
               >
-                40€
+                40 €
               </div>
             </div>
           </div>
@@ -196,7 +196,7 @@ Object {
               dir="auto"
               style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
             >
-              20€
+              20 €
             </div>
           </div>
         </div>
@@ -242,7 +242,7 @@ Object {
               dir="auto"
               style="color: rgb(21, 21, 21); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
             >
-              40€
+              40 €
             </div>
           </div>
         </div>

--- a/__snapshots__/features/bookOffer/components/__tests__/BookHourChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookHourChoice.native.test.tsx.native-snap
@@ -262,7 +262,7 @@ Array [
             }
             testID="HourChoice148409-price"
           >
-            24€
+            24 €
           </Text>
         </View>
       </View>

--- a/__snapshots__/features/bookOffer/components/__tests__/BookHourChoice.web.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookHourChoice.web.test.tsx.web-snap
@@ -95,7 +95,7 @@ Object {
                 dir="auto"
                 style="color: rgb(21, 21, 21); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
               >
-                24€
+                24 €
               </div>
             </div>
           </div>
@@ -194,7 +194,7 @@ Object {
               dir="auto"
               style="color: rgb(21, 21, 21); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
             >
-              24€
+              24 €
             </div>
           </div>
         </div>

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx.native-snap
@@ -366,7 +366,7 @@ exports[`<BookingDetails /> should render correctly when user has selected optio
         ]
       }
     >
-      20 €
+      20 €
     </Text>
     <View
       numberOfSpaces={2}
@@ -540,7 +540,7 @@ exports[`<BookingDetails /> should render correctly when user has selected optio
       ]
     }
   >
-    20 € seront déduits de ton crédit pass Culture
+    20 € seront déduits de ton crédit pass Culture
   </Text>
 </View>
 `;
@@ -911,7 +911,7 @@ exports[`<BookingDetails /> should render disable CTA when user is underage and 
         ]
       }
     >
-      20 €
+      20 €
     </Text>
     <View
       numberOfSpaces={2}
@@ -1085,7 +1085,7 @@ exports[`<BookingDetails /> should render disable CTA when user is underage and 
       ]
     }
   >
-    20 € seront déduits de ton crédit pass Culture
+    20 € seront déduits de ton crédit pass Culture
   </Text>
 </View>
 `;

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingInformations.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingInformations.test.tsx.native-snap
@@ -115,7 +115,7 @@ Array [
         ]
       }
     >
-      0,22 €
+      0,22 €
     </Text>
     <View
       numberOfSpaces={2}
@@ -717,7 +717,7 @@ Array [
         ]
       }
     >
-      0,22 €
+      0,22 €
     </Text>
     <View
       numberOfSpaces={2}
@@ -1018,7 +1018,7 @@ Array [
         ]
       }
     >
-      0,11 €
+      0,11 €
     </Text>
     <View
       numberOfSpaces={2}
@@ -1465,7 +1465,7 @@ Array [
         ]
       }
     >
-      0,22 €
+      0,22 €
     </Text>
     <View
       numberOfSpaces={2}
@@ -1490,7 +1490,7 @@ Array [
         ]
       }
     >
-      (0,11 € x 2 places)
+      (0,11 € x 2 places)
     </Text>
   </View>,
 ]

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingInformations.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingInformations.test.tsx.web-snap
@@ -125,7 +125,7 @@ Array [
         }
       }
     >
-      0,22 €
+      0,22 €
     </div>
     <div
       className="css-view-1dbjc4n"
@@ -761,7 +761,7 @@ Array [
         }
       }
     >
-      0,22 €
+      0,22 €
     </div>
     <div
       className="css-view-1dbjc4n"
@@ -1079,7 +1079,7 @@ Array [
         }
       }
     >
-      0,11 €
+      0,11 €
     </div>
     <div
       className="css-view-1dbjc4n"
@@ -1550,7 +1550,7 @@ Array [
         }
       }
     >
-      0,22 €
+      0,22 €
     </div>
     <div
       className="css-view-1dbjc4n"
@@ -1572,7 +1572,7 @@ Array [
         }
       }
     >
-      (0,11 € x 2 places)
+      (0,11 € x 2 places)
     </div>
   </div>,
 ]

--- a/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.native-snap
@@ -125,7 +125,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
           ]
         }
       >
-        Il te reste encore 20 € à dépenser sur le pass !
+        Il te reste encore 20 € à dépenser sur le pass !
       </Text>
       <View
         numberOfSpaces={4}

--- a/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.web-snap
@@ -166,7 +166,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
           }
         }
       >
-        Il te reste encore 20 € à dépenser sur le pass !
+        Il te reste encore 20 € à dépenser sur le pass !
       </div>
       <div
         className="css-view-1dbjc4n"

--- a/__snapshots__/features/eighteenBirthday/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/eighteenBirthday/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -230,7 +230,7 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
                     ]
                   }
                 >
-                  Tu pourras bénéficier des 300€ offerts par le Gouvernement dès que tu auras vérifié ton identité
+                  Tu pourras bénéficier des 300 € offerts par le Gouvernement dès que tu auras vérifié ton identité
                 </Text>
                 <View
                   flex={2}

--- a/__snapshots__/features/eighteenBirthday/pages/components/EighteenBirthdayCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/eighteenBirthday/pages/components/EighteenBirthdayCard.native.test.tsx.native-snap
@@ -114,7 +114,7 @@ exports[`<EighteenBirthdayCard /> should render eighteen birthday card 1`] = `
       ]
     }
   >
-    Tu pourras bénéficier des 300€ offerts par le Gouvernement dès que tu auras vérifié ton identité
+    Tu pourras bénéficier des 300 € offerts par le Gouvernement dès que tu auras vérifié ton identité
   </Text>
   <View
     flex={2}

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/FirstTutorial.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/FirstTutorial.native.test.tsx.native-snap
@@ -528,7 +528,7 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                     ]
                   }
                 >
-                  dans l'année de tes 18 ans, le Gouvernement offre un crédit de 300€ à dépenser dans l’application.
+                  dans l'année de tes 18 ans, le Gouvernement offre un crédit de 300 € à dépenser dans l’application.
                 </Text>
                 <View
                   flex={2}

--- a/__snapshots__/features/home/components/tests/OffersModule.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/tests/OffersModule.native.test.tsx.native-snap
@@ -389,7 +389,7 @@ exports[`OffersModule component should render correctly - with black title 1`] =
                 }
                 testID="priceIsDuo"
               >
-                28 €
+                28 €
               </Text>
             </View>
           </View>
@@ -591,7 +591,7 @@ exports[`OffersModule component should render correctly - with black title 1`] =
                 }
                 testID="priceIsDuo"
               >
-                23 €
+                23 €
               </Text>
             </View>
           </View>
@@ -809,7 +809,7 @@ exports[`OffersModule component should render correctly - with black title 1`] =
                 }
                 testID="priceIsDuo"
               >
-                34 € - Duo
+                34 € - Duo
               </Text>
             </View>
           </View>
@@ -1013,7 +1013,7 @@ exports[`OffersModule component should render correctly - with black title 1`] =
                 }
                 testID="priceIsDuo"
               >
-                28 €
+                28 €
               </Text>
             </View>
           </View>

--- a/__snapshots__/features/offer/components/__tests__/OfferIconCaptions.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/__tests__/OfferIconCaptions.native.test.tsx.native-snap
@@ -134,7 +134,7 @@ exports[`<OfferIconCaptions /> should match snapshot 1`] = `
       }
       testID="caption-iconPrice"
     >
-      28 €
+      28 €
     </Text>
   </View>
   <View

--- a/__snapshots__/features/offer/components/__tests__/OfferIconCaptions.web.test.tsx.web-snap
+++ b/__snapshots__/features/offer/components/__tests__/OfferIconCaptions.web.test.tsx.web-snap
@@ -71,7 +71,7 @@ Object {
             dir="auto"
             style="color: rgb(21, 21, 21); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
           >
-            28 €
+            28 €
           </div>
         </div>
         <div
@@ -148,7 +148,7 @@ Object {
           dir="auto"
           style="color: rgb(21, 21, 21); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
         >
-          28 €
+          28 €
         </div>
       </div>
       <div

--- a/__snapshots__/features/offer/pages/tests/OfferBody.deprecated.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferBody.deprecated.native.test.tsx.native-snap
@@ -720,7 +720,7 @@ exports[`<OfferBody /> should match snapshot for digital offer 1`] = `
                                 }
                                 testID="caption-iconPrice"
                               >
-                                5 €
+                                5 €
                               </Text>
                             </View>
                             <View
@@ -3185,7 +3185,7 @@ exports[`<OfferBody /> should match snapshot for physical offer 1`] = `
                                 }
                                 testID="caption-iconPrice"
                               >
-                                5 € / place
+                                5 € / place
                               </Text>
                             </View>
                             <View

--- a/__snapshots__/features/offer/pages/tests/OfferBody.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferBody.native.test.tsx.native-snap
@@ -472,7 +472,7 @@ exports[`<OfferBody /> should open the report modal upon clicking on 'signaler l
           }
           testID="caption-iconPrice"
         >
-          Dès 24 € / place
+          Dès 24 € / place
         </Text>
       </View>
       <View

--- a/__snapshots__/features/profile/components/CreditCeiling.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/CreditCeiling.native.test.tsx.native-snap
@@ -110,7 +110,7 @@ exports[`CreditCeiling should render properly 1`] = `
       ]
     }
   >
-    155 €
+    155 €
   </Text>
   <View>
     <Text

--- a/__snapshots__/features/profile/components/CreditCeiling.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/components/CreditCeiling.web.test.tsx.web-snap
@@ -46,7 +46,7 @@ Object {
           dir="auto"
           style="color: rgb(50, 0, 150); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
         >
-          155 €
+          155 €
         </div>
         <div
           class="css-view-1dbjc4n"
@@ -104,7 +104,7 @@ Object {
         dir="auto"
         style="color: rgb(50, 0, 150); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
       >
-        155 €
+        155 €
       </div>
       <div
         class="css-view-1dbjc4n"

--- a/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
@@ -1794,7 +1794,7 @@ exports[`SearchFilter component should render correctly 1`] = `
               ]
             }
           >
-            0 € - 300 €
+            0 € - 300 €
           </Text>
           <View
             numberOfSpaces={4}

--- a/eslint-custom-rules/nbsp-in-french-translations.js
+++ b/eslint-custom-rules/nbsp-in-french-translations.js
@@ -17,13 +17,13 @@ module.exports = {
   create(context) {
     return {
       // For t`textToTranslate !`
-      'TaggedTemplateExpression[tag.name="t"] > TemplateLiteral > TemplateElement[value.raw=/\\s+[!?:»]/]':
+      'TaggedTemplateExpression[tag.name="t"] > TemplateLiteral > TemplateElement[value.raw=/\\s+[!?:»€]/]':
         (node) => {
           context.report({
             node,
-            message: 'Please use \\u00a0 (nbsp) instead of whitespace before !, ?, :, »',
+            message: 'Please use \\u00a0 (nbsp) instead of whitespace before !, ?, :, », €',
             fix: function (fixer) {
-              const textToReplace = node.value.raw.replace(/\s+([!?:»])/g, '\\u00a0$1')
+              const textToReplace = node.value.raw.replace(/\s+([!?:»€])/g, '\\u00a0$1')
               const range = getReplaceRange(node)
 
               return fixer.replaceTextRange(range, textToReplace)
@@ -45,14 +45,14 @@ module.exports = {
         },
 
       // For t({ message: 'textToTranslate !'})
-      'CallExpression[callee.name="t"] > ObjectExpression > Property[key.name="message"][value.raw=/\\s+[!?:»]/]':
+      'CallExpression[callee.name="t"] > ObjectExpression > Property[key.name="message"][value.raw=/\\s+[!?:»€]/]':
         (node) => {
           context.report({
             node,
-            message: 'Please use \\u00a0 (nbsp) instead of whitespace before !, ?, :, »',
+            message: 'Please use \\u00a0 (nbsp) instead of whitespace before !, ?, :, », €',
             fix: function (fixer) {
               const textToReplace =
-                'message: ' + node.value.raw.replace(/\s+([!?:»])/g, '\\u00a0$1')
+                'message: ' + node.value.raw.replace(/\s+([!?:»€])/g, '\\u00a0$1')
 
               return fixer.replaceText(node, textToReplace)
             },

--- a/eslint-custom-rules/nbsp-in-french-translations.js
+++ b/eslint-custom-rules/nbsp-in-french-translations.js
@@ -16,6 +16,7 @@ module.exports = {
   },
   create(context) {
     return {
+      // For t`textToTranslate !`
       'TaggedTemplateExpression[tag.name="t"] > TemplateLiteral > TemplateElement[value.raw=/\\s+[!?:»]/]':
         (node) => {
           context.report({
@@ -39,6 +40,33 @@ module.exports = {
               const range = getReplaceRange(node)
 
               return fixer.replaceTextRange(range, textToReplace)
+            },
+          })
+        },
+
+      // For t({ message: 'textToTranslate !'})
+      'CallExpression[callee.name="t"] > ObjectExpression > Property[key.name="message"][value.raw=/\\s+[!?:»]/]':
+        (node) => {
+          context.report({
+            node,
+            message: 'Please use \\u00a0 (nbsp) instead of whitespace before !, ?, :, »',
+            fix: function (fixer) {
+              const textToReplace =
+                'message: ' + node.value.raw.replace(/\s+([!?:»])/g, '\\u00a0$1')
+
+              return fixer.replaceText(node, textToReplace)
+            },
+          })
+        },
+      'CallExpression[callee.name="t"] > ObjectExpression > Property[key.name="message"][value.raw=/«\\s+/]':
+        (node) => {
+          context.report({
+            node,
+            message: 'Please use \\u00a0 (nbsp) instead of whitespace after «',
+            fix: function (fixer) {
+              const textToReplace = 'message: ' + node.value.raw.replace(/(«)\s+/g, '$1\\u00a0')
+
+              return fixer.replaceText(node, textToReplace)
             },
           })
         },

--- a/src/features/auth/signup/idCheck/DenyAccessToIdCheck.tsx
+++ b/src/features/auth/signup/idCheck/DenyAccessToIdCheck.tsx
@@ -40,7 +40,7 @@ export const DenyAccessToIdCheckModal = (props: DenyAccessToIdCheckModalProps) =
         <Spacer.Column numberOfSpaces={getSpacing(2)} />
         <Paragraphe>
           <Typo.Body color={ColorsEnum.GREY_DARK}>
-            {t`Vous êtes actuellement très nombreux à vouloir effectuer votre demande des 300€. Tu recevras une alerte par mail pour commencer ta demande des 300€ dès que le service sera de nouveau disponible\u00a0!`}
+            {t`Vous êtes actuellement très nombreux à vouloir effectuer votre demande des 300\u00a0€. Tu recevras une alerte par mail pour commencer ta demande des 300\u00a0€ dès que le service sera de nouveau disponible\u00a0!`}
           </Typo.Body>
         </Paragraphe>
         <Spacer.Column numberOfSpaces={getSpacing(2)} />

--- a/src/features/bookOffer/components/__tests__/BookHourChoice.native.test.tsx
+++ b/src/features/bookOffer/components/__tests__/BookHourChoice.native.test.tsx
@@ -105,7 +105,7 @@ describe('BookHourChoice', () => {
     const firstPrice = page.getByTestId('HourChoice148409-price')
 
     expect(firstHour.props.children).toBe('20h00')
-    expect(firstPrice.props.children).toBe('24€')
+    expect(firstPrice.props.children).toBe('24\u00a0€')
 
     const secondHour = page.getByTestId('HourChoice148411-hour')
     const secondPrice = page.getByTestId('HourChoice148411-price')

--- a/src/features/bookOffer/components/__tests__/BookHourChoice.web.test.tsx
+++ b/src/features/bookOffer/components/__tests__/BookHourChoice.web.test.tsx
@@ -105,7 +105,7 @@ describe('BookHourChoice', () => {
     const firstPrice = page.getByTestId('HourChoice148409-price')
 
     expect(firstHour.textContent).toBe('20h00')
-    expect(firstPrice.textContent).toBe('24€')
+    expect(firstPrice.textContent).toBe('24\u00a0€')
 
     const secondHour = page.getByTestId('HourChoice148411-hour')
     const secondPrice = page.getByTestId('HourChoice148411-price')

--- a/src/features/bookOffer/pages/BookingConfirmation.tsx
+++ b/src/features/bookOffer/pages/BookingConfirmation.tsx
@@ -54,7 +54,7 @@ export function BookingConfirmation() {
         {t({
           id: 'credit left to spend',
           values: { credit: formatToFrenchDecimal(amountLeft) },
-          message: 'Il te reste encore {credit} à dépenser sur le pass !',
+          message: 'Il te reste encore {credit} à dépenser sur le pass\u00a0!',
         })}
       </StyledBody>
       <Spacer.Column numberOfSpaces={4} />

--- a/src/features/bookings/components/BookingDetailsCancelButton.tsx
+++ b/src/features/bookings/components/BookingDetailsCancelButton.tsx
@@ -68,7 +68,7 @@ export const BookingDetailsCancelButton = (props: BookingDetailsCancelButtonProp
             id: 'not cancellable because expired for ex beneficiary',
             values: { date: formattedConfirmationDate },
             message:
-              'Ton crédit est expiré.\nTu ne peux plus annuler ta réservation : elle devait être annulée avant le {date}',
+              'Ton crédit est expiré.\nTu ne peux plus annuler ta réservation\u00a0: elle devait être annulée avant le {date}',
           })}
         </CancellationCaption>
       )

--- a/src/features/bookings/components/CancelBookingModal.native.test.tsx
+++ b/src/features/bookings/components/CancelBookingModal.native.test.tsx
@@ -82,7 +82,7 @@ describe('<CancelBookingModal />', () => {
     const { getByText } = render(
       <CancelBookingModal visible dismissModal={mockDismissModal} booking={booking} />
     )
-    getByText('19 € seront recrédités sur ton pass Culture.')
+    getByText('19\u00a0€ seront recrédités sur ton pass Culture.')
   })
 
   it('should display refund rule if user is ex beneficiary and offer is not free', () => {
@@ -92,7 +92,7 @@ describe('<CancelBookingModal />', () => {
       <CancelBookingModal visible dismissModal={mockDismissModal} booking={booking} />
     )
 
-    getByText('Les 19 € ne seront pas recrédités sur ton pass Culture car il est expiré.')
+    getByText('Les 19\u00a0€ ne seront pas recrédités sur ton pass Culture car il est expiré.')
   })
 
   it('should navigate to bookings and show error snackbar if cancel booking request fails', async () => {

--- a/src/features/home/pages/tests/Home.native.test.tsx
+++ b/src/features/home/pages/tests/Home.native.test.tsx
@@ -56,7 +56,7 @@ describe('Home component', () => {
 
   it('should show the available credit to the user - remaining', () => {
     const { getByText } = render(<Home />)
-    getByText('Tu as 496 € sur ton pass')
+    getByText('Tu as 496\u00a0€ sur ton pass')
   })
 
   it('should show the available credit to the user - expired', () => {
@@ -64,7 +64,7 @@ describe('Home component', () => {
     mockUserProfileInfo!.depositExpirationDate = new Date('2020-02-16T17:16:04.735235')
     const { queryByText, getByText } = render(<Home />)
     expect(getByText('Ton crédit est expiré')).toBeTruthy()
-    expect(queryByText('Tu as 496 € sur ton pass')).toBeFalsy()
+    expect(queryByText('Tu as 496\u00a0€ sur ton pass')).toBeFalsy()
   })
 
   it('should show the available credit to the user - not logged in', () => {

--- a/src/features/identityCheck/pages/confirmation/UnderageAccountCreated.tsx
+++ b/src/features/identityCheck/pages/confirmation/UnderageAccountCreated.tsx
@@ -24,7 +24,7 @@ export function UnderageAccountCreated() {
   return (
     <GenericInfoPageWhite animation={TutorialPassLogo} title={t`Bonne nouvelle\u00a0!`}>
       <StyledSubtitle>
-        {maxPrice + '\u00a0' + t`€ viennent d'être crédités sur ton compte pass Culture`}
+        {t`${maxPrice}\u00a0€ viennent d'être crédités sur ton compte pass Culture`}
       </StyledSubtitle>
 
       <Spacer.Column numberOfSpaces={4} />

--- a/src/features/identityCheck/pages/confirmation/UnderageAccountCreated.tsx
+++ b/src/features/identityCheck/pages/confirmation/UnderageAccountCreated.tsx
@@ -10,6 +10,7 @@ import {
 } from 'features/auth/signup/underageSignup/notificationPagesStyles'
 import { navigateToHome } from 'features/navigation/helpers'
 import { useMaxPrice } from 'features/search/utils/useMaxPrice'
+import { formatPriceInEuroToDisplayPrice } from 'libs/parsers'
 import TutorialPassLogo from 'ui/animations/tutorial_pass_logo.json'
 import { ProgressBar } from 'ui/components/bars/ProgressBar'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
@@ -36,7 +37,7 @@ export function UnderageAccountCreated() {
           iconSize={20}
           isAnimated
         />
-        <Amount color={UniqueColors.BRAND}>{maxPrice + '€'}</Amount>
+        <Amount color={UniqueColors.BRAND}>{formatPriceInEuroToDisplayPrice(maxPrice)}</Amount>
       </ProgressBarContainer>
       <Spacer.Column numberOfSpaces={4} />
       <Text>{text}</Text>

--- a/src/features/offer/components/__tests__/OfferIconCaptions.native.test.tsx
+++ b/src/features/offer/components/__tests__/OfferIconCaptions.native.test.tsx
@@ -138,17 +138,17 @@ describe('<OfferIconCaptions />', () => {
 
   it.each`
     stocks                      | isDuo    | isBeneficiary | expectedDisplayedPrice
-    ${sevenEurosBookableStocks} | ${false} | ${true}       | ${'7 €'}
-    ${sevenEurosBookableStocks} | ${true}  | ${true}       | ${'7 € / place'}
-    ${sevenEurosBookableStocks} | ${true}  | ${false}      | ${'7 €'}
+    ${sevenEurosBookableStocks} | ${false} | ${true}       | ${'7\u00a0€'}
+    ${sevenEurosBookableStocks} | ${true}  | ${true}       | ${'7\u00a0€ / place'}
+    ${sevenEurosBookableStocks} | ${true}  | ${false}      | ${'7\u00a0€'}
     ${freeBookableStocks}       | ${false} | ${true}       | ${'Gratuit'}
     ${freeBookableStocks}       | ${true}  | ${true}       | ${'Gratuit'}
     ${freeBookableStocks}       | ${true}  | ${false}      | ${'Gratuit'}
     ${noPrice}                  | ${false} | ${true}       | ${''}
     ${noPrice}                  | ${true}  | ${true}       | ${''}
     ${noPrice}                  | ${true}  | ${false}      | ${''}
-    ${severalStocks}            | ${true}  | ${false}      | ${'7 €'}
-    ${noBookableStocks}         | ${true}  | ${false}      | ${'Dès 7 €'}
+    ${severalStocks}            | ${true}  | ${false}      | ${'7\u00a0€'}
+    ${noBookableStocks}         | ${true}  | ${false}      | ${'Dès 7\u00a0€'}
   `('should show right price', async ({ stocks, isDuo, isBeneficiary, expectedDisplayedPrice }) => {
     const component = await renderOfferIconCaptions({ isDuo, stocks, isBeneficiary })
     await waitForExpect(() => {

--- a/src/features/offer/components/__tests__/OfferIconCaptions.web.test.tsx
+++ b/src/features/offer/components/__tests__/OfferIconCaptions.web.test.tsx
@@ -138,17 +138,17 @@ describe('<OfferIconCaptions />', () => {
 
   it.each`
     stocks                      | isDuo    | isBeneficiary | expectedDisplayedPrice
-    ${sevenEurosBookableStocks} | ${false} | ${true}       | ${'7 €'}
-    ${sevenEurosBookableStocks} | ${true}  | ${true}       | ${'7 € / place'}
-    ${sevenEurosBookableStocks} | ${true}  | ${false}      | ${'7 €'}
+    ${sevenEurosBookableStocks} | ${false} | ${true}       | ${'7\u00a0€'}
+    ${sevenEurosBookableStocks} | ${true}  | ${true}       | ${'7\u00a0€ / place'}
+    ${sevenEurosBookableStocks} | ${true}  | ${false}      | ${'7\u00a0€'}
     ${freeBookableStocks}       | ${false} | ${true}       | ${'Gratuit'}
     ${freeBookableStocks}       | ${true}  | ${true}       | ${'Gratuit'}
     ${freeBookableStocks}       | ${true}  | ${false}      | ${'Gratuit'}
     ${noPrice}                  | ${false} | ${true}       | ${''}
     ${noPrice}                  | ${true}  | ${true}       | ${''}
     ${noPrice}                  | ${true}  | ${false}      | ${''}
-    ${severalStocks}            | ${true}  | ${false}      | ${'7 €'}
-    ${noBookableStocks}         | ${true}  | ${false}      | ${'Dès 7 €'}
+    ${severalStocks}            | ${true}  | ${false}      | ${'7\u00a0€'}
+    ${noBookableStocks}         | ${true}  | ${false}      | ${'Dès 7\u00a0€'}
   `('should show right price', async ({ stocks, isDuo, isBeneficiary, expectedDisplayedPrice }) => {
     const component = await renderOfferIconCaptions({ isDuo, stocks, isBeneficiary })
     await waitForExpect(() => {

--- a/src/features/profile/components/CreditCeiling.tsx
+++ b/src/features/profile/components/CreditCeiling.tsx
@@ -3,6 +3,7 @@ import { View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { ExpenseDomain } from 'api/gen/api'
+import { formatPriceInEuroToDisplayPrice } from 'libs/parsers'
 import { Logo } from 'ui/svg/icons/Logo'
 import { OfferDigital } from 'ui/svg/icons/OfferDigital'
 import { OfferOutings } from 'ui/svg/icons/OfferOutings'
@@ -69,7 +70,7 @@ export function CreditCeiling(props: CreditCeilingProps) {
   if (!ceilingConfig || props.initial <= 0) {
     return null
   }
-  const amountLabel = `${props.amount} €`
+  const amountLabel = formatPriceInEuroToDisplayPrice(props.amount)
   const progress = Number((props.amount / props.initial).toFixed(2))
   const color = props.amount === 0 ? ColorsEnum.GREY_DARK : ceilingConfig.color
 

--- a/src/features/profile/components/SubscriptionMessageBadge.tsx
+++ b/src/features/profile/components/SubscriptionMessageBadge.tsx
@@ -21,7 +21,7 @@ const formatDateToLastUpdatedAtMessage = (lastUpdatedDate: Date | undefined) =>
           day: formatToSlashedFrenchDate(new Date(lastUpdatedDate).toISOString()),
           hour: formatToHour(new Date(lastUpdatedDate)),
         },
-        message: 'Dossier mis à jour le : {day} à {hour}',
+        message: 'Dossier mis à jour le\u00a0: {day} à {hour}',
       })
     : undefined
 

--- a/src/features/profile/components/YoungerBadge.tsx
+++ b/src/features/profile/components/YoungerBadge.tsx
@@ -10,7 +10,7 @@ export function YoungerBadge(props: { eligibilityStartDatetime: Date }) {
     id: "date d'éligibilité",
     values: { date: formatToSlashedFrenchDate(props.eligibilityStartDatetime.toISOString()) },
     message:
-      'Patience ! Reviens à partir du {date} pour continuer ton inscription et bénéficier du crédit pass Culture.',
+      'Patience\u00a0! Reviens à partir du {date} pour continuer ton inscription et bénéficier du crédit pass Culture.',
   })
 
   return <ProfileBadge popOverIcon={Clock} message={information} testID={'younger-badge'} />

--- a/src/features/recreditBirthdayNotification/pages/components/__test__/RecreditBirthdayNotification.test.tsx
+++ b/src/features/recreditBirthdayNotification/pages/components/__test__/RecreditBirthdayNotification.test.tsx
@@ -41,7 +41,7 @@ describe('<RecreditBirthdayNotification />', () => {
     })
 
     const recreditText = getByText(
-      "Pour tes 15 ans, le Gouvernement vient d'ajouter 50 € à ton crédit. Tu disposes maintenant de :"
+      "Pour tes 15 ans, le Gouvernement vient d'ajouter 50\u00a0€ à ton crédit. Tu disposes maintenant de :"
     )
 
     expect(recreditText).toBeTruthy()

--- a/src/features/search/sections/Price.tsx
+++ b/src/features/search/sections/Price.tsx
@@ -5,10 +5,9 @@ import { useStagedSearch } from 'features/search/pages/SearchWrapper'
 import { SectionTitle } from 'features/search/sections/titles'
 import { useLogFilterOnce } from 'features/search/utils/useLogFilterOnce'
 import { useMaxPrice } from 'features/search/utils/useMaxPrice'
+import { formatPriceInEuroToDisplayPrice } from 'libs/parsers'
 import { Range } from 'libs/typesUtils/typeHelpers'
 import { Slider } from 'ui/components/inputs/Slider'
-
-const formatEuro = (price: number) => `${price} €`
 
 export const Price: React.FC = () => {
   const logUseFilter = useLogFilterOnce(SectionTitle.Price)
@@ -33,7 +32,7 @@ export const Price: React.FC = () => {
         showValues={true}
         values={values}
         max={maxPrice}
-        formatValues={formatEuro}
+        formatValues={formatPriceInEuroToDisplayPrice}
         onValuesChangeFinish={onValuesChangeFinish}
       />
     </CenteredSection>

--- a/src/features/search/sections/tests/Price.native.test.tsx
+++ b/src/features/search/sections/tests/Price.native.test.tsx
@@ -25,9 +25,9 @@ describe('Price component', () => {
     mockedUseMaxPrice.mockImplementation(() => 300)
   })
   it('should render initial price range correctly', () => {
-    expect(render(<Price />).queryByText('0 € - 300 €')).toBeTruthy()
+    expect(render(<Price />).queryByText('0\u00a0€ - 300\u00a0€')).toBeTruthy()
     mockSearchState = { ...initialSearchState, priceRange: [20, 200] }
-    expect(render(<Price />).queryByText('20 € - 200 €')).toBeTruthy()
+    expect(render(<Price />).queryByText('20\u00a0€ - 200\u00a0€')).toBeTruthy()
   })
   it('should dispatch PRICE_RANGE onPress', () => {
     const { getByTestId } = render(<Price />)
@@ -95,12 +95,12 @@ describe('Price component for underage', () => {
   })
 
   it('should render initial price correctly', () => {
-    expect(render(<Price />).queryByText(`0 € - ${maxPrice} €`)).toBeTruthy()
+    expect(render(<Price />).queryByText(`0\u00a0€ - ${maxPrice}\u00a0€`)).toBeTruthy()
   })
 
   it('should render the price correctly when the max price is changed', () => {
     mockSearchState = { ...initialSearchState, priceRange: [0, 49] }
-    expect(render(<Price />).queryByText(`0 € - 49 €`)).toBeTruthy()
+    expect(render(<Price />).queryByText(`0\u00a0€ - 49\u00a0€`)).toBeTruthy()
   })
 
   it('should NOT have the indicator when the price range is untouched', () => {

--- a/src/libs/parsers/getDisplayPrice.ts
+++ b/src/libs/parsers/getDisplayPrice.ts
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro'
 
-import { CENTS_IN_EURO } from 'libs/parsers/pricesConversion'
+import { CENTS_IN_EURO, convertEuroToCents } from 'libs/parsers/pricesConversion'
 
 const EURO_SYMBOL = '€'
 
@@ -16,11 +16,14 @@ export const formatToFrenchDecimal = (priceInCents: number) => {
   return t`${fixed.toString().replace('.', ',')}\u00a0${EURO_SYMBOL}`
 }
 
+export const formatPriceInEuroToDisplayPrice = (priceInEuro: number) =>
+  formatToFrenchDecimal(convertEuroToCents(priceInEuro))
+
 const getPricePerPlace = (prices: number[]): string => {
   const uniquePrices = Array.from(new Set(prices.filter((p) => p > 0)))
   if (uniquePrices.length === 1) return `${formatToFrenchDecimal(uniquePrices[0])}`
   const sortedPrices = uniquePrices.sort((a, b) => a - b)
-  return `Dès ${formatToFrenchDecimal(sortedPrices[0])}`
+  return t`Dès ${formatToFrenchDecimal(sortedPrices[0])}`
 }
 
 export const getDisplayPrice = (prices: number[] | undefined): string => {

--- a/src/libs/parsers/getDisplayPrice.ts
+++ b/src/libs/parsers/getDisplayPrice.ts
@@ -13,7 +13,7 @@ export const formatToFrenchDecimal = (priceInCents: number) => {
   const euros = priceInCents / CENTS_IN_EURO
   // we show 2 decimals if price is not round. Ex: 21,50 €
   const fixed = euros === Math.floor(euros) ? euros : euros.toFixed(2)
-  return `${fixed.toString().replace('.', ',')} ${EURO_SYMBOL}`
+  return t`${fixed.toString().replace('.', ',')}\u00a0${EURO_SYMBOL}`
 }
 
 const getPricePerPlace = (prices: number[]): string => {

--- a/src/libs/parsers/tests/getDisplayPrice.test.ts
+++ b/src/libs/parsers/tests/getDisplayPrice.test.ts
@@ -12,14 +12,14 @@ describe('getDisplayPrice', () => {
     ${[]}                | ${''}
     ${[0]}               | ${'Gratuit'}
     ${[0, 700]}          | ${'Gratuit'}
-    ${[100]}             | ${'1 €'}
-    ${[200]}             | ${'2 €'}
-    ${[345]}             | ${'3,45 €'}
-    ${[350]}             | ${'3,50 €'}
-    ${[560, 300]}        | ${'Dès 3 €'}
-    ${[200, 1000, 3000]} | ${'Dès 2 €'}
-    ${[-300, 560]}       | ${'5,60 €'}
-    ${[800, 800]}        | ${'8 €'}
+    ${[100]}             | ${'1\u00a0€'}
+    ${[200]}             | ${'2\u00a0€'}
+    ${[345]}             | ${'3,45\u00a0€'}
+    ${[350]}             | ${'3,50\u00a0€'}
+    ${[560, 300]}        | ${'Dès 3\u00a0€'}
+    ${[200, 1000, 3000]} | ${'Dès 2\u00a0€'}
+    ${[-300, 560]}       | ${'5,60\u00a0€'}
+    ${[800, 800]}        | ${'8\u00a0€'}
   `('getDisplayPrice($prices) \t= $expected', ({ prices, expected }) => {
     expect(getDisplayPrice(prices)).toBe(expected)
   })
@@ -30,13 +30,13 @@ describe('getDisplayPrice', () => {
     ${[]}                | ${''}
     ${[0]}               | ${'Gratuit'}
     ${[0, 700]}          | ${'Gratuit'}
-    ${[100]}             | ${'1 € / place'}
-    ${[200]}             | ${'2 € / place'}
-    ${[345]}             | ${'3,45 € / place'}
-    ${[200, 1000, 3000]} | ${'Dès 2 € / place'}
-    ${[560, 300]}        | ${'Dès 3 € / place'}
-    ${[-300, 560]}       | ${'5,60 € / place'}
-    ${[800, 800]}        | ${'8 € / place'}
+    ${[100]}             | ${'1\u00a0€ / place'}
+    ${[200]}             | ${'2\u00a0€ / place'}
+    ${[345]}             | ${'3,45\u00a0€ / place'}
+    ${[200, 1000, 3000]} | ${'Dès 2\u00a0€ / place'}
+    ${[560, 300]}        | ${'Dès 3\u00a0€ / place'}
+    ${[-300, 560]}       | ${'5,60\u00a0€ / place'}
+    ${[800, 800]}        | ${'8\u00a0€ / place'}
   `('getDisplayPriceWithDuoMention($prices) \t= $expected', ({ prices, expected }) => {
     expect(getDisplayPriceWithDuoMention(prices)).toBe(expected)
   })
@@ -48,9 +48,9 @@ describe('getFavoriteDisplayPrice', () => {
     ${undefined} | ${undefined} | ${''}
     ${null}      | ${null}      | ${''}
     ${0}         | ${null}      | ${'Gratuit'}
-    ${1000}      | ${null}      | ${'10 €'}
-    ${null}      | ${0}         | ${'Dès 0 €'}
-    ${null}      | ${1000}      | ${'Dès 10 €'}
+    ${1000}      | ${null}      | ${'10\u00a0€'}
+    ${null}      | ${0}         | ${'Dès 0\u00a0€'}
+    ${null}      | ${1000}      | ${'Dès 10\u00a0€'}
   `(
     'getFavoriteDisplayPrice({ price: $price, startPrice: $startPrice }) \t= $expected',
     ({ price, startPrice, expected }) => {
@@ -67,19 +67,19 @@ describe('getFavoriteDisplayPrice', () => {
 describe('formatToFrenchDecimal()', () => {
   it.each`
     priceInCents | expected
-    ${0}         | ${'0 €'}
-    ${500}       | ${'5 €'}
-    ${-500}      | ${'-5 €'}
-    ${1050}      | ${'10,50 €'}
-    ${-1050}     | ${'-10,50 €'}
-    ${1110}      | ${'11,10 €'}
-    ${-1110}     | ${'-11,10 €'}
-    ${1190}      | ${'11,90 €'}
-    ${-1190}     | ${'-11,90 €'}
-    ${1199}      | ${'11,99 €'}
-    ${-1199}     | ${'-11,99 €'}
-    ${1199.6}    | ${'12,00 €'}
-    ${-1199.6}   | ${'-12,00 €'}
+    ${0}         | ${'0\u00a0€'}
+    ${500}       | ${'5\u00a0€'}
+    ${-500}      | ${'-5\u00a0€'}
+    ${1050}      | ${'10,50\u00a0€'}
+    ${-1050}     | ${'-10,50\u00a0€'}
+    ${1110}      | ${'11,10\u00a0€'}
+    ${-1110}     | ${'-11,10\u00a0€'}
+    ${1190}      | ${'11,90\u00a0€'}
+    ${-1190}     | ${'-11,90\u00a0€'}
+    ${1199}      | ${'11,99\u00a0€'}
+    ${-1199}     | ${'-11,99\u00a0€'}
+    ${1199.6}    | ${'12,00\u00a0€'}
+    ${-1199.6}   | ${'-12,00\u00a0€'}
   `('formatToFrenchDecimal($priceInCents) \t= $expected', ({ priceInCents, expected }) => {
     expect(formatToFrenchDecimal(priceInCents)).toBe(expected)
   })

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -748,6 +748,10 @@ msgstr "Dossier déposé, nous avons bien reçu ton dossier et sommes en train d
 msgid "Duo"
 msgstr "Duo"
 
+#: src/libs/parsers/getDisplayPrice.ts
+msgid "Dès {0}"
+msgstr "Dès {0}"
+
 #: src/features/profile/pages/Profile.tsx
 #: src/features/profile/pages/Profile.tsx
 msgid "Déconnexion"
@@ -2861,8 +2865,8 @@ msgid "Vous êtes actuellement très nombreux à vouloir créer un compte, notre
 msgstr "Vous êtes actuellement très nombreux à vouloir créer un compte, notre service rencontre quelques difficultés."
 
 #: src/features/auth/signup/idCheck/DenyAccessToIdCheck.tsx
-msgid "Vous êtes actuellement très nombreux à vouloir effectuer votre demande des 300€. Tu recevras une alerte par mail pour commencer ta demande des 300€ dès que le service sera de nouveau disponible !"
-msgstr "Vous êtes actuellement très nombreux à vouloir effectuer votre demande des 300€. Tu recevras une alerte par mail pour commencer ta demande des 300€ dès que le service sera de nouveau disponible !"
+msgid "Vous êtes actuellement très nombreux à vouloir effectuer votre demande des 300 €. Tu recevras une alerte par mail pour commencer ta demande des 300 € dès que le service sera de nouveau disponible !"
+msgstr "Vous êtes actuellement très nombreux à vouloir effectuer votre demande des 300 €. Tu recevras une alerte par mail pour commencer ta demande des 300 € dès que le service sera de nouveau disponible !"
 
 #: src/features/navigation/RootNavigator/identityCheckRoutes.ts
 msgid "Vérification d'identité"
@@ -3184,9 +3188,17 @@ msgstr "À retirer avant le {dateLimit}"
 msgid "{0, plural, one {Réservation terminée} other {Réservations terminées}}"
 msgstr "{0, plural, one {Réservation terminée} other {Réservations terminées}}"
 
+#: src/libs/parsers/getDisplayPrice.ts
+msgid "{0} {EURO_SYMBOL}"
+msgstr "{0} {EURO_SYMBOL}"
+
 #: src/features/bookings/pages/EndedBookings.tsx
 msgid "{endedBookingsCount, plural, one {# réservation terminée} other {# réservations terminées}}"
 msgstr "{endedBookingsCount, plural, one {# réservation terminée} other {# réservations terminées}}"
+
+#: src/features/identityCheck/pages/confirmation/UnderageAccountCreated.tsx
+msgid "{maxPrice} € viennent d'être crédités sur ton compte pass Culture"
+msgstr "{maxPrice} € viennent d'être crédités sur ton compte pass Culture"
 
 #: src/features/favorites/atoms/NumberOfResults.tsx
 msgid "{nbFavorites, plural, one {# favori} other {# favoris}}"
@@ -3227,7 +3239,3 @@ msgstr "à portée de main !"
 #: src/features/bookOffer/atoms/HourChoice.tsx
 msgid "épuisé"
 msgstr "épuisé"
-
-#: src/features/identityCheck/pages/confirmation/UnderageAccountCreated.tsx
-msgid "€ viennent d'être crédités sur ton compte pass Culture"
-msgstr "€ viennent d'être crédités sur ton compte pass Culture"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12427

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
