### PR TITLE
ci(xcode): update used xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
 
   ios:
     macos:
-      xcode: '13.0.0'
+      xcode: '13.2.1'
 
   gcp:
     docker:


### PR DESCRIPTION
To include the fix of a Log4Shell vulnerability (will be fixed at the upload with Xcode 13.2.1):
https://developer.apple.com/documentation/xcode-release-notes/xcode-13_2_1-release-notes

Confirmed in this post, validated by Apple:
https://developer.apple.com/forums/thread/696785
