### PR TITLE
(PC-12428) fix(translations): merge translation with nbsp and variable

### DIFF
--- a/src/features/auth/signup/SetBirthday/SetBirthday.tsx
+++ b/src/features/auth/signup/SetBirthday/SetBirthday.tsx
@@ -102,7 +102,7 @@ export const SetBirthday: FunctionComponent<PreValidationSignupStepProps> = (pro
       return (
         <InputError
           visible
-          messageId={t`Tu dois avoir` + '\u00a0' + youngestAge + '\u00a0' + t`ans pour t'inscrire`}
+          messageId={t`Tu dois avoir\u00a0${youngestAge}\u00a0ans pour t'inscrire`}
           numberOfSpacesTop={5}
         />
       )

--- a/src/features/auth/signup/underageSignup/SelectSchool.tsx
+++ b/src/features/auth/signup/underageSignup/SelectSchool.tsx
@@ -64,7 +64,7 @@ export const SelectSchool = withEduConnectErrorBoundary(() => {
         {Object.keys(eligibleSchools).map((academy) => (
           <React.Fragment key={academy}>
             <Divider />
-            <AccordionItem title={t`Académie de` + '\u00a0' + academy}>
+            <AccordionItem title={t`Académie de\u00a0${academy}`}>
               {eligibleSchools[academy].map((item) => renderItem(item, academy))}
             </AccordionItem>
           </React.Fragment>

--- a/src/features/bookings/components/BookingDetailsCancelButton.tsx
+++ b/src/features/bookings/components/BookingDetailsCancelButton.tsx
@@ -57,7 +57,7 @@ export const BookingDetailsCancelButton = (props: BookingDetailsCancelButtonProp
           {renderButton}
           <Spacer.Column numberOfSpaces={4} />
           <CancellationCaption>
-            {t`La réservation est annulable jusqu'au` + '\u00a0' + formattedConfirmationDate}
+            {t`La réservation est annulable jusqu'au\u00a0${formattedConfirmationDate}`}
           </CancellationCaption>
         </React.Fragment>
       )
@@ -75,9 +75,7 @@ export const BookingDetailsCancelButton = (props: BookingDetailsCancelButtonProp
     } else {
       return (
         <CancellationCaption>
-          {t`Tu ne peux plus annuler ta réservation\u00a0: elle devait être annulée avant le` +
-            '\u00a0' +
-            formattedConfirmationDate}
+          {t`Tu ne peux plus annuler ta réservation\u00a0: elle devait être annulée avant le\u00a0${formattedConfirmationDate}`}
         </CancellationCaption>
       )
     }

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -92,8 +92,8 @@ msgid "Abandonner la vérification"
 msgstr "Abandonner la vérification"
 
 #: src/features/auth/signup/underageSignup/SelectSchool.tsx
-msgid "Académie de"
-msgstr "Académie de"
+msgid "Académie de {academy}"
+msgstr "Académie de {academy}"
 
 #: src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
 msgid "Accepter et s’inscrire"
@@ -1330,8 +1330,8 @@ msgid "La réservation a bien été archivée. Tu pourras la retrouver dans tes 
 msgstr "La réservation a bien été archivée. Tu pourras la retrouver dans tes réservations terminées"
 
 #: src/features/bookings/components/BookingDetailsCancelButton.tsx
-msgid "La réservation est annulable jusqu'au"
-msgstr "La réservation est annulable jusqu'au"
+msgid "La réservation est annulable jusqu'au {formattedConfirmationDate}"
+msgstr "La réservation est annulable jusqu'au {formattedConfirmationDate}"
 
 #: src/features/identityCheck/pages/identification/IdentityCheckDMS.tsx
 msgid "La vérification de ton identité n’a pas pu aboutir. Tu peux créer un dossier sur le site des Démarches Simplifiées afin d’obtenir ton pass Cutlure."
@@ -2528,8 +2528,8 @@ msgid "Tu as jusqu’à la veille de tes 18 ans pour profiter de ton budget. Dé
 msgstr "Tu as jusqu’à la veille de tes 18 ans pour profiter de ton budget. Découvre dès maintenant les offres culturelles autour de chez toi !"
 
 #: src/features/auth/signup/SetBirthday/SetBirthday.tsx
-msgid "Tu dois avoir"
-msgstr "Tu dois avoir"
+msgid "Tu dois avoir {youngestAge} ans pour t'inscrire"
+msgstr "Tu dois avoir {youngestAge} ans pour t'inscrire"
 
 #: src/features/bookings/pages/BookingDetails.tsx
 msgid "Tu dois présenter ta carte d’identité et ce code de 6 caractères pour profiter de ta réservation ! N’oublie pas que tu n’as pas le droit de le revendre ou le céder."
@@ -2560,8 +2560,8 @@ msgid "Tu ne fais pas partie de la phase de test"
 msgstr "Tu ne fais pas partie de la phase de test"
 
 #: src/features/bookings/components/BookingDetailsCancelButton.tsx
-msgid "Tu ne peux plus annuler ta réservation : elle devait être annulée avant le"
-msgstr "Tu ne peux plus annuler ta réservation : elle devait être annulée avant le"
+msgid "Tu ne peux plus annuler ta réservation : elle devait être annulée avant le {formattedConfirmationDate}"
+msgstr "Tu ne peux plus annuler ta réservation : elle devait être annulée avant le {formattedConfirmationDate}"
 
 #: src/features/bookings/components/NoBookingsView.tsx
 msgid ""
@@ -2913,10 +2913,6 @@ msgstr "À activer avant le {date}"
 #: src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
 msgid "ainsi que notre"
 msgstr "ainsi que notre"
-
-#: src/features/auth/signup/SetBirthday/SetBirthday.tsx
-msgid "ans pour t'inscrire"
-msgstr "ans pour t'inscrire"
 
 #: src/features/offer/pages/OfferDescription.tsx
 msgid "auteur"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12428

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
