### PR TITLE
ci(tests): improve time to run tests on ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,20 @@ commands:
           paths:
             - node_modules
 
+  unit_test_native:
+    description: Unit Tests Native
+    steps:
+      - restore_cache:
+          name: Restore Tests cache
+          keys:
+            - jest-cache-{{ checksum "yarn.lock" }}-{{ arch }}
+      - run: yarn test:unit:ci
+      - save_cache:
+          name: Save Tests cache
+          key: jest-cache-{{ checksum "yarn.lock" }}-{{ arch }}
+          paths:
+            - .jest
+
   install_ruby_modules:
     description: Install Ruby Dependencies
     steps:
@@ -312,9 +326,7 @@ jobs:
     steps:
       - checkout
       - install_node_modules
-      - run:
-          name: Unit Tests Native
-          command: yarn test:unit:ci
+      - unit_test_native
       - sonarcloud-scanner
 
   test-web:

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test:lint": "eslint . --ext .js,.ts,.tsx --cache",
     "test:types": "tsc --noEmit",
     "test:unit": "TZ=UTC JEST=true jest --forceExit",
-    "test:unit:ci": "TZ=UTC yarn test:unit --runInBand --logHeapUsage --forceExit --coverage",
+    "test:unit:ci": "TZ=UTC yarn test:unit --maxWorkers=4 --logHeapUsage --forceExit --coverage",
     "test:unit:web": "TZ=UTC JEST=true jest --config jest.web.config.js --forceExit",
     "test:unit:web:ci": "TZ=UTC yarn test:unit:web --runInBand --logHeapUsage --forceExit",
     "test:unit:full": "TZ=UTC JEST=true jest --collect-coverage",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test:lint": "eslint . --ext .js,.ts,.tsx --cache",
     "test:types": "tsc --noEmit",
     "test:unit": "TZ=UTC JEST=true jest --forceExit",
-    "test:unit:ci": "TZ=UTC yarn test:unit --maxWorkers=4 --logHeapUsage --forceExit --coverage",
+    "test:unit:ci": "TZ=UTC yarn test:unit --maxWorkers=2 --logHeapUsage --forceExit --coverage",
     "test:unit:web": "TZ=UTC JEST=true jest --config jest.web.config.js --forceExit",
     "test:unit:web:ci": "TZ=UTC yarn test:unit:web --runInBand --logHeapUsage --forceExit",
     "test:unit:full": "TZ=UTC JEST=true jest --collect-coverage",


### PR DESCRIPTION
5m30 => moins de 4min

How:
- use CircleCi cache
- increase number of workers to 4.