### PR TITLE
(PC-12519) feat(EAC): add tracker on go Back to home from educonnect error

### DIFF
--- a/src/features/cheatcodes/pages/NavigationIdentityCheck/NavigationIdentityCheck.tsx
+++ b/src/features/cheatcodes/pages/NavigationIdentityCheck/NavigationIdentityCheck.tsx
@@ -84,6 +84,10 @@ export function NavigationIdentityCheck(): JSX.Element {
           title={'UserNotWhitelisted Error'}
           onPress={() => trigger(EduConnectErrorMessageEnum.UserNotWhitelisted)}
         />
+        <LinkToComponent
+          title={'Generic Error'}
+          onPress={() => trigger(EduConnectErrorMessageEnum.GenericError)}
+        />
         <Row half>
           <NavigationButton
             title={'Identifie-toi en 2 minutes'}

--- a/src/features/identityCheck/errors/eduConnect/NotEligibleEduConnect.tsx
+++ b/src/features/identityCheck/errors/eduConnect/NotEligibleEduConnect.tsx
@@ -4,6 +4,7 @@ import { TextProps, TextStyle } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import { navigateToHome } from 'features/navigation/helpers'
+import { analytics } from 'libs/analytics'
 import { ScreenErrorProps } from 'libs/monitoring/errors'
 import { Helmet } from 'libs/react-helmet/Helmet'
 import { useMediaQuery } from 'libs/react-responsive/useMediaQuery'
@@ -49,6 +50,7 @@ export const NotEligibleEduConnect = ({
 
   const onAbandon = () => {
     navigateToHome()
+    analytics.logBackToHomeFromEduconnectError({ fromError: message })
     // if we reset too fast, it will rerun the failed query, this as no effect on the UI but that's not desired.
     const beforeResetDelayInMs = 300
     timer.current = globalThis.setTimeout(resetErrorBoundary, beforeResetDelayInMs)

--- a/src/libs/analytics/__mocks__/analytics.ts
+++ b/src/libs/analytics/__mocks__/analytics.ts
@@ -9,6 +9,7 @@ export const analytics: typeof actualAnalytics = {
   setDefaultEventParameters: jest.fn(),
   logAllModulesSeen: jest.fn(),
   logAllTilesSeen: jest.fn(),
+  logBackToHomeFromEduconnectError: jest.fn(),
   logBookingConfirmation: jest.fn(),
   logBookingDetailsScrolledToBottom: jest.fn(),
   logBookingError: jest.fn(),

--- a/src/libs/analytics/analytics.ts
+++ b/src/libs/analytics/analytics.ts
@@ -53,6 +53,8 @@ export const analytics = {
     analyticsProvider.logEvent(AnalyticsEvent.ALL_MODULES_SEEN, { numberOfModules }),
   logAllTilesSeen: (moduleName: string, numberOfTiles: number) =>
     analyticsProvider.logEvent(AnalyticsEvent.ALL_TILES_SEEN, { moduleName, numberOfTiles }),
+  logBackToHomeFromEduconnectError: (params: { fromError: string }) =>
+    analyticsProvider.logEvent(AnalyticsEvent.BACK_TO_HOME_FROM_EDUCONNECT_ERROR, params),
   logConsultHome: (params: { entryId: string }) =>
     analyticsProvider.logEvent(AnalyticsEvent.CONSULT_HOME, params),
   logConsultOffer: (params: {

--- a/src/libs/analytics/events.ts
+++ b/src/libs/analytics/events.ts
@@ -3,6 +3,7 @@ export enum AnalyticsEvent {
   ACCESS_EXTERNAL_OFFER = 'AccessExternalOffer',
   ALL_MODULES_SEEN = 'AllModulesSeen',
   ALL_TILES_SEEN = 'AllTilesSeen',
+  BACK_TO_HOME_FROM_EDUCONNECT_ERROR = 'BackToHomeFromEduconnectError',
   BOOKING_CONFIRMATION = 'BookingConfirmation',
   BOOKING_ERROR = 'BookingError',
   BOOKING_IMPOSSIBLE_IOS = 'BookingImpossibleiOS',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12519

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

<img width="576" alt="Capture d’écran 2021-12-29 à 10 39 23" src="https://user-images.githubusercontent.com/44037911/147648352-5c251735-5b02-45d9-8e67-116efdbd1e38.png">
<img width="576" alt="Capture d’écran 2021-12-29 à 10 40 00" src="https://user-images.githubusercontent.com/44037911/147648354-1b423d9f-52e4-45c0-b05d-fdc3accd1590.png">
<img width="576" alt="Capture d’écran 2021-12-29 à 10 37 41" src="https://user-images.githubusercontent.com/44037911/147648355-7d5216b8-0653-49ec-ae0b-f3828cc9d850.png">
<img width="576" alt="Capture d’écran 2021-12-29 à 10 37 01" src="https://user-images.githubusercontent.com/44037911/147648356-13dcff00-63fb-46cb-915b-d1a5ff6d60ad.png">


<img width="576" alt="Capture d’écran 2021-12-29 à 10 38 44" src="https://user-images.githubusercontent.com/44037911/147648350-82fae57e-da1c-4113-8d09-f31897ef31e1.png">


[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
