### PR TITLE
(PC-12535) refactor(icons): replace back icons in headers

### DIFF
--- a/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.native.test.tsx.native-snap
@@ -85,8 +85,8 @@ exports[`AsyncErrorBoundary component should render 1`] = `
     testID="backArrow"
   >
     <View
-      height={40}
-      width={40}
+      height={28}
+      width={28}
     >
       <Text>
         undefined-SVG-Mock

--- a/__snapshots__/features/favorites/pages/__tests__/FavoritesSorts.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/__tests__/FavoritesSorts.native.test.tsx.native-snap
@@ -392,9 +392,9 @@ exports[`FavoritesSorts component should render correctly 1`] = `
           testID="Revenir en arrière"
         >
           <View
-            height={32}
+            height={24}
             testID="icon-back"
-            width={32}
+            width={24}
           >
             <Text>
               icon-back-SVG-Mock

--- a/__snapshots__/features/offer/pages/tests/OfferDescription.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferDescription.native.test.tsx.native-snap
@@ -659,9 +659,9 @@ Tous les détails du film sur AlloCiné:
                                 testID="Revenir en arrière"
                               >
                                 <View
-                                  height={32}
+                                  height={24}
                                   testID="icon-back"
-                                  width={32}
+                                  width={24}
                                 >
                                   <Text>
                                     icon-back-SVG-Mock

--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.native.test.tsx.native-snap
@@ -594,9 +594,9 @@ Array [
           testID="Revenir en arrière"
         >
           <View
-            height={32}
+            height={24}
             testID="icon-back"
-            width={32}
+            width={24}
           >
             <Text>
               icon-back-SVG-Mock
@@ -1207,9 +1207,9 @@ Array [
           testID="Revenir en arrière"
         >
           <View
-            height={32}
+            height={24}
             testID="icon-back"
-            width={32}
+            width={24}
           >
             <Text>
               icon-back-SVG-Mock

--- a/__snapshots__/features/profile/pages/PersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/PersonalData.native.test.tsx.native-snap
@@ -378,9 +378,9 @@ Array [
           testID="Revenir en arrière"
         >
           <View
-            height={32}
+            height={24}
             testID="icon-back"
-            width={32}
+            width={24}
           >
             <Text>
               icon-back-SVG-Mock

--- a/__snapshots__/features/search/pages/__tests__/Categories.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/__tests__/Categories.test.tsx.native-snap
@@ -1232,9 +1232,9 @@ exports[`Categories component should render correctly 1`] = `
           testID="Revenir en arrière"
         >
           <View
-            height={32}
+            height={24}
             testID="icon-back"
-            width={32}
+            width={24}
           >
             <Text>
               icon-back-SVG-Mock

--- a/__snapshots__/features/search/pages/__tests__/LocationFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/__tests__/LocationFilter.native.test.tsx.native-snap
@@ -585,9 +585,9 @@ exports[`LocationFilter component should render correctly 1`] = `
           testID="Revenir en arrière"
         >
           <View
-            height={32}
+            height={24}
             testID="icon-back"
-            width={32}
+            width={24}
           >
             <Text>
               icon-back-SVG-Mock

--- a/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
@@ -3038,9 +3038,9 @@ exports[`SearchFilter component should render correctly 1`] = `
           testID="Revenir en arrière"
         >
           <View
-            height={32}
+            height={24}
             testID="icon-back"
-            width={32}
+            width={24}
           >
             <Text>
               icon-back-SVG-Mock

--- a/src/features/bookOffer/services/__tests__/useModalContent.test.tsx
+++ b/src/features/bookOffer/services/__tests__/useModalContent.test.tsx
@@ -132,7 +132,7 @@ describe('useModalContent', () => {
 
     expect((result.current.children as any).type.name).toBe('BookingDetails')
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(result.current.leftIcon!.name).toBe('ArrowPreviousDeprecated')
+    expect(result.current.leftIcon!.name).toBe('ArrowPrevious')
     expect(result.current.onLeftIconPress).not.toBeUndefined()
     expect(result.current.title).toBe('Détails de la réservation')
   })

--- a/src/features/bookOffer/services/useModalContent.tsx
+++ b/src/features/bookOffer/services/useModalContent.tsx
@@ -8,7 +8,7 @@ import { BookingEventChoices } from 'features/bookOffer/components/BookingEventC
 import { getOfferPrice } from 'features/offer/services/getOfferPrice'
 import { useSubcategoriesMapping } from 'libs/subcategories'
 import { ModalLeftIconProps } from 'ui/components/modals/types'
-import { ArrowPreviousDeprecated as ArrowPrevious } from 'ui/svg/icons/ArrowPrevious_deprecated'
+import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 
 import { BookingImpossible } from '../components/BookingImpossible'
 import { useBooking, useBookingOffer } from '../pages/BookingOfferWrapper'

--- a/src/features/cheatcodes/pages/AppComponents/Icons.tsx
+++ b/src/features/cheatcodes/pages/AppComponents/Icons.tsx
@@ -145,7 +145,7 @@ export const Icons: FunctionComponent = () => {
       <Icon name="EditPen" component={EditPen} isNew />
       <Icon name="Email" component={Email} isNew />
       <Icon name="EmailDeprecated" component={EmailDeprecated} />
-      <Icon name="EmailFilled" component={EmailFilled} />
+      <Icon name="EmailFilled" component={EmailFilled} isNew />
       <Icon name="Error" component={Error} isNew />
       <Icon name="ExternalSite" component={ExternalSite} isNew />
       <Icon name="ExternalSiteFilled" component={ExternalSiteFilled} isNew />

--- a/src/features/errors/pages/AsyncErrorBoundary.tsx
+++ b/src/features/errors/pages/AsyncErrorBoundary.tsx
@@ -11,7 +11,7 @@ import { ScreenError } from 'libs/monitoring/errors'
 import { AppButton } from 'ui/components/buttons/AppButton'
 import { Background } from 'ui/svg/Background'
 import { BrokenConnection } from 'ui/svg/BrokenConnection'
-import { ArrowPreviousDeprecated as ArrowPrevious } from 'ui/svg/icons/ArrowPrevious_deprecated'
+import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
@@ -105,7 +105,7 @@ export const AsyncErrorBoundary = (props: AsyncFallbackProps) => {
       header={
         !!canGoBack() && (
           <HeaderContainer onPress={goBack} top={top + getSpacing(3.5)} testID="backArrow">
-            <ArrowPrevious color={ColorsEnum.WHITE} size={getSpacing(10)} />
+            <ArrowPrevious color={ColorsEnum.WHITE} size={getSpacing(7)} />
           </HeaderContainer>
         )
       }

--- a/src/features/offer/components/__mocks__/useReportOfferModalContent.tsx
+++ b/src/features/offer/components/__mocks__/useReportOfferModalContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Text } from 'react-native'
 
-import { ArrowPreviousDeprecated as ArrowPrevious } from 'ui/svg/icons/ArrowPrevious_deprecated'
+import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 
 export const useReportOfferModalContent = () => {
   const childrenProps = {

--- a/src/features/offer/components/useReportOfferModalContent.tsx
+++ b/src/features/offer/components/useReportOfferModalContent.tsx
@@ -5,7 +5,7 @@ import { ReportOfferDescription } from 'features/offer/components/ReportOfferDes
 import { ReportOfferOtherReason } from 'features/offer/components/ReportOfferOtherReason'
 import { ReportOfferReason } from 'features/offer/components/ReportOfferReason'
 import { ModalLeftIconProps } from 'ui/components/modals/types'
-import { ArrowPreviousDeprecated as ArrowPrevious } from 'ui/svg/icons/ArrowPrevious_deprecated'
+import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 
 export enum ReportSteps {
   REPORT_OFFER_DESCRIPTION = 0,

--- a/src/ui/components/headers/PageHeader.tsx
+++ b/src/ui/components/headers/PageHeader.tsx
@@ -7,7 +7,7 @@ import { homeNavConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { accessibilityAndTestId } from 'tests/utils'
 import { useElementWidth } from 'ui/hooks/useElementWidth'
-import { ArrowPreviousDeprecated as ArrowPrevious } from 'ui/svg/icons/ArrowPrevious_deprecated'
+import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
 import { ACTIVE_OPACITY } from 'ui/theme/colors'
 
@@ -28,7 +28,7 @@ const HeaderIconBack: React.FC<HeaderIconProps> = ({ onGoBack }) => {
       activeOpacity={ACTIVE_OPACITY}
       onPress={onGoBack || goBack}
       {...accessibilityAndTestId(t`Revenir en arrière`)}>
-      <ArrowPrevious color={ColorsEnum.WHITE} testID="icon-back" />
+      <ArrowPrevious color={ColorsEnum.WHITE} size={24} testID="icon-back" />
     </TouchableOpacity>
   )
 }

--- a/src/ui/components/modals/ModalHeader.native.test.tsx
+++ b/src/ui/components/modals/ModalHeader.native.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { fireEvent, render } from 'tests/utils'
-import { ArrowPreviousDeprecated as ArrowPrevious } from 'ui/svg/icons/ArrowPrevious_deprecated'
+import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { Close } from 'ui/svg/icons/Close'
 
 import { ModalHeader } from './ModalHeader'

--- a/src/ui/components/modals/ModalHeader.web.test.tsx
+++ b/src/ui/components/modals/ModalHeader.web.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { fireEvent, render } from 'tests/utils/web'
-import { ArrowPreviousDeprecated as ArrowPrevious } from 'ui/svg/icons/ArrowPrevious_deprecated'
+import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { Close } from 'ui/svg/icons/Close'
 
 import { ModalHeader } from './ModalHeader'


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12535

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

<img width="326" alt="Capture d’écran 2021-12-29 à 11 21 03" src="https://user-images.githubusercontent.com/44037911/147654447-abe03e83-4f99-44e6-a104-b705fbc5c892.png">
<img width="326" alt="Capture d’écran 2021-12-29 à 11 25 32" src="https://user-images.githubusercontent.com/44037911/147654454-bd01e1c2-58c8-4dfc-90b5-bbed41acfb06.png">
<img width="326" alt="Capture d’écran 2021-12-29 à 11 41 37" src="https://user-images.githubusercontent.com/44037911/147654458-10b5b06f-496a-4b40-bdef-54f983af4fdb.png">
<img width="326" alt="Capture d’écran 2021-12-29 à 11 31 07" src="https://user-images.githubusercontent.com/44037911/147654462-e28d45f7-de75-40f1-b7c9-9ab1403c91d8.png">
<img width="326" alt="Capture d’écran 2021-12-29 à 11 48 08" src="https://user-images.githubusercontent.com/44037911/147654473-d2f48f8f-d7ab-4569-84b0-ea92e6b284e6.png">

