### PR TITLE
(PC-8471) feat(offer): hide see more button when description is small

### DIFF
--- a/__snapshots__/features/offer/pages/tests/OfferBody.deprecated.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferBody.deprecated.native.test.tsx.native-snap
@@ -775,6 +775,7 @@ exports[`<OfferBody /> should match snapshot for digital offer 1`] = `
                             />
                             <Text
                               numberOfLines={8}
+                              onTextLayout={[Function]}
                               style={
                                 Array [
                                   Object {
@@ -3296,6 +3297,7 @@ exports[`<OfferBody /> should match snapshot for physical offer 1`] = `
                             />
                             <Text
                               numberOfLines={8}
+                              onTextLayout={[Function]}
                               style={
                                 Array [
                                   Object {

--- a/src/features/offer/components/OfferPartialDescription.tsx
+++ b/src/features/offer/components/OfferPartialDescription.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from 'react'
-import { Platform } from 'react-native'
-import styled, { useTheme } from 'styled-components/native'
+import React from 'react'
+import styled from 'styled-components/native'
 
 import { highlightLinks } from 'libs/parsers/highlightLinks'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
@@ -9,36 +8,11 @@ import { useOffer } from '../api/useOffer'
 import { OfferSeeMore } from '../atoms/OfferSeeMore'
 import { getContentFromOffer } from '../pages/OfferDescription'
 
+import { useShouldDisplaySeeMoreButton } from './useShouldDisplaySeeMoreButton'
+
 interface Props {
   id: number
   description?: string
-}
-
-export const useShouldDisplaySeeMoreButton = (
-  maxTheoricalDisplayedDescriptionLines: number,
-  contentOfferDescription: ReturnType<typeof getContentFromOffer>
-): {
-  shouldDisplaySeeMoreButton: boolean
-  maxDisplayedDescriptionLines?: number
-  setLinesDisplayed: (linesDisplayed: number) => void
-} => {
-  const theme = useTheme()
-  const shouldTruncateDescription = !(Platform.OS === 'web' && theme.isDesktopViewport === true)
-  const maxDisplayedDescriptionLines = shouldTruncateDescription
-    ? maxTheoricalDisplayedDescriptionLines
-    : undefined
-  const [isLongerThanMaximumLines, setIsLongerThanMaximumLines] =
-    useState(shouldTruncateDescription)
-  const setLinesDisplayed = (linesDisplayed: number): void => {
-    if (typeof maxDisplayedDescriptionLines === 'undefined') return
-
-    setIsLongerThanMaximumLines(linesDisplayed >= maxDisplayedDescriptionLines)
-  }
-  const shouldDisplaySeeMoreButton = shouldTruncateDescription
-    ? contentOfferDescription.length > 0 && isLongerThanMaximumLines
-    : contentOfferDescription.filter(({ key }) => key !== 'description').length > 0
-
-  return { shouldDisplaySeeMoreButton, maxDisplayedDescriptionLines, setLinesDisplayed }
 }
 
 export const OfferPartialDescription: React.FC<Props> = ({ id, description = '' }) => {

--- a/src/features/offer/components/OfferPartialDescription.tsx
+++ b/src/features/offer/components/OfferPartialDescription.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { Platform } from 'react-native'
 import styled from 'styled-components/native'
 
 import { highlightLinks } from 'libs/parsers/highlightLinks'
@@ -18,6 +19,20 @@ export const OfferPartialDescription: React.FC<Props> = ({ id, description = '' 
   const { extraData = {}, image } = offerResponse || {}
   const contentOfferDescription = getContentFromOffer(extraData, description, image?.credit)
 
+  const shouldDisplaySeeMoreButtonOnThisPlatform = Platform.OS !== 'web'
+  const maxDisplayedDescriptionLines = shouldDisplaySeeMoreButtonOnThisPlatform ? 8 : undefined
+  const [isLongerThanMaximumLines, setIsLongerThanMaximumLines] = useState(
+    shouldDisplaySeeMoreButtonOnThisPlatform
+  )
+  const setLinesDisplayed = (linesDisplayed: number): void => {
+    if (typeof maxDisplayedDescriptionLines === 'undefined') return
+
+    setIsLongerThanMaximumLines(linesDisplayed >= maxDisplayedDescriptionLines)
+  }
+  const shouldDisplaySeeMoreButton = shouldDisplaySeeMoreButtonOnThisPlatform
+    ? contentOfferDescription.length > 0 && isLongerThanMaximumLines
+    : contentOfferDescription.filter(({ key }) => key !== 'description').length > 0
+
   if (contentOfferDescription.length === 0) return null
 
   return (
@@ -25,13 +40,18 @@ export const OfferPartialDescription: React.FC<Props> = ({ id, description = '' 
       <Spacer.Column numberOfSpaces={4} />
       {!!description && (
         <React.Fragment>
-          <TypoDescription testID="offerPartialDescriptionBody" numberOfLines={8}>
+          <TypoDescription
+            testID="offerPartialDescriptionBody"
+            numberOfLines={maxDisplayedDescriptionLines}
+            onTextLayout={({ nativeEvent }) => {
+              setLinesDisplayed(nativeEvent.lines.length)
+            }}>
             {highlightLinks(description)}
           </TypoDescription>
           <Spacer.Column numberOfSpaces={2} />
         </React.Fragment>
       )}
-      {contentOfferDescription.length > 0 && (
+      {!!shouldDisplaySeeMoreButton && (
         <OfferSeeMoreContainer testID="offerSeeMoreContainer" description={description}>
           <OfferSeeMore id={id} longWording={!description} />
         </OfferSeeMoreContainer>

--- a/src/features/offer/components/OfferPartialDescription.tsx
+++ b/src/features/offer/components/OfferPartialDescription.tsx
@@ -23,20 +23,18 @@ export const useShouldDisplaySeeMoreButton = (
   setLinesDisplayed: (linesDisplayed: number) => void
 } => {
   const theme = useTheme()
-  const shouldDisplaySeeMoreButtonOnThisPlatform =
-    Platform.OS !== 'web' || theme.isDesktopViewport === false
-  const maxDisplayedDescriptionLines = shouldDisplaySeeMoreButtonOnThisPlatform
+  const shouldTruncateDescription = !(Platform.OS === 'web' && theme.isDesktopViewport === true)
+  const maxDisplayedDescriptionLines = shouldTruncateDescription
     ? maxTheoricalDisplayedDescriptionLines
     : undefined
-  const [isLongerThanMaximumLines, setIsLongerThanMaximumLines] = useState(
-    shouldDisplaySeeMoreButtonOnThisPlatform
-  )
+  const [isLongerThanMaximumLines, setIsLongerThanMaximumLines] =
+    useState(shouldTruncateDescription)
   const setLinesDisplayed = (linesDisplayed: number): void => {
     if (typeof maxDisplayedDescriptionLines === 'undefined') return
 
     setIsLongerThanMaximumLines(linesDisplayed >= maxDisplayedDescriptionLines)
   }
-  const shouldDisplaySeeMoreButton = shouldDisplaySeeMoreButtonOnThisPlatform
+  const shouldDisplaySeeMoreButton = shouldTruncateDescription
     ? contentOfferDescription.length > 0 && isLongerThanMaximumLines
     : contentOfferDescription.filter(({ key }) => key !== 'description').length > 0
 

--- a/src/features/offer/components/__tests__/OfferPartialDescription.native.test.tsx
+++ b/src/features/offer/components/__tests__/OfferPartialDescription.native.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient } from 'react-query'
 
 import { offerResponseSnap } from 'features/offer/api/snaps/offerResponseSnap'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { render } from 'tests/utils'
+import { act, render } from 'tests/utils'
 
 import { OfferPartialDescription } from '../OfferPartialDescription'
 
@@ -63,9 +63,23 @@ describe('OfferPartialDescription', () => {
       expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
     })
     describe('should be rendered', () => {
-      it('when there is description on the description page', () => {
-        const { queryByTestId } = renderOfferDescription({
+      it('when the description is ellipsed', () => {
+        const lines = [
+          { text: "Ce n'est pas le besoin d'argent où les " },
+          { text: 'vieillards peuvent appréhender de tomber ' },
+          { text: 'un jour qui les rend avares, car il y en a de ' },
+          { text: "tels qui ont de si grands fonds, qu'ils ne " },
+          { text: 'peuvent guère avoir cette inquiétude : et ' },
+          { text: "d'ailleurs comment pourraient-ils craindre " },
+          { text: 'de manquer dans leur caducité des ' },
+          {
+            text: "commodités de la vie, puisqu'ils s'en privent eux-mêmes volontairement pour satisfaire à leur avarice ?",
+          },
+        ]
+        const description = lines.map(({ text }) => text).join(' ')
+        const { getByTestId, queryByTestId } = renderOfferDescription({
           ...defaultParams,
+          description,
           setup: (queryClient) => {
             queryClient.setQueryData(['offer', offerId], {
               image: {},
@@ -73,6 +87,12 @@ describe('OfferPartialDescription', () => {
             })
           },
         })
+        const descriptionComponent = getByTestId('offerPartialDescriptionBody')
+
+        act(() => {
+          descriptionComponent.props.onTextLayout({ nativeEvent: { lines } })
+        })
+
         expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
       })
       it('when there is image on the description page', () => {
@@ -107,6 +127,29 @@ describe('OfferPartialDescription', () => {
         description: undefined,
         setup: setupWithNoDataInDescriptionPage,
       })
+      expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
+    })
+    it("shouldn't be rendered when the description is small enough to be fully readable", () => {
+      const lines = [
+        { text: 'Combattant sans risque, vous devez agir ' },
+        { text: 'sans précaution. En effet, pour vous autres ' },
+        { text: 'hommes, les défaites ne sont que des ' },
+        { text: 'succès de moins. Dans cette partie si ' },
+        { text: 'inégale, notre fortune est de ne pas perdre, ' },
+        { text: 'et votre malheur de ne pas gagner.' },
+      ]
+      const description = lines.map(({ text }) => text).join(' ')
+      const { getByTestId, queryByTestId } = renderOfferDescription({
+        ...defaultParams,
+        description,
+        setup: setupWithNoDataInDescriptionPage,
+      })
+      const descriptionComponent = getByTestId('offerPartialDescriptionBody')
+
+      act(() => {
+        descriptionComponent.props.onTextLayout({ nativeEvent: { lines } })
+      })
+
       expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
     })
   })

--- a/src/features/offer/components/__tests__/OfferPartialDescription.native.test.tsx
+++ b/src/features/offer/components/__tests__/OfferPartialDescription.native.test.tsx
@@ -7,53 +7,112 @@ import { render } from 'tests/utils'
 
 import { OfferPartialDescription } from '../OfferPartialDescription'
 
-const description =
+const defaultDescription =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua: https://google.com'
+const offerId = 123
+type Setup = (queryClient: QueryClient) => void
+const defaultSetup: Setup = (queryClient) => {
+  queryClient.removeQueries()
+  queryClient.setQueryData(['offer', offerId], offerResponseSnap)
+}
+type Params = {
+  description?: string
+  setup: Setup
+}
+const defaultParams: Params = {
+  description: defaultDescription,
+  setup: defaultSetup,
+}
 
 describe('OfferPartialDescription', () => {
-  it('centers CTA when provided description is empty', async () => {
-    const { getByTestId } = await renderOfferDescription('')
+  it('centers CTA when provided description is empty', () => {
+    const { getByTestId } = renderOfferDescription({
+      ...defaultParams,
+      description: '',
+    })
     const offerSeeMoreContainer = getByTestId('offerSeeMoreContainer')
     expect(offerSeeMoreContainer.props.style[0].alignSelf).toBe('center')
   })
-  it('places CTA on flex-end when provided a description', async () => {
-    const { getByTestId } = await renderOfferDescription(description)
+  it('places CTA on flex-end when provided a description', () => {
+    const { getByTestId } = renderOfferDescription(defaultParams)
     const offerSeeMoreContainer = getByTestId('offerSeeMoreContainer')
     expect(offerSeeMoreContainer.props.style[0].alignSelf).toBe('flex-end')
   })
-  it('renders externalLinks if http(s) url are present in the description', async () => {
-    const { queryByTestId } = await renderOfferDescription(description)
+  it('renders externalLinks if http(s) url are present in the description', () => {
+    const { queryByTestId } = renderOfferDescription(defaultParams)
     expect(queryByTestId('externalSiteIcon')).toBeTruthy()
   })
-  it("shouldn't render an empty line and a spacer when description is undefined", async () => {
-    const { queryByTestId } = await renderOfferDescription(undefined)
+  it("shouldn't render an empty line and a spacer when description is empty", () => {
+    const { queryByTestId } = renderOfferDescription({
+      ...defaultParams,
+      description: undefined,
+    })
     expect(queryByTestId('offerPartialDescriptionBody')).toBeFalsy()
   })
-  it("shouldn't render the SeeMore button if no content is on description page", async () => {
-    const { queryByTestId } = render(
-      // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-      reactQueryProviderHOC(
-        <OfferPartialDescription id={offerId} description={undefined} />,
-        (queryClient: QueryClient) => {
-          queryClient.setQueryData(['offer', offerId], {
-            ...offerResponseSnap,
-            image: {},
-            extraData: {},
-          })
-        }
-      )
-    )
-    expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
+  describe('SeeMore button', () => {
+    const setupWithNoDataInDescriptionPage: Setup = (queryClient) => {
+      queryClient.setQueryData(['offer', offerId], {
+        ...offerResponseSnap,
+        image: {},
+        extraData: {},
+      })
+    }
+
+    it('should be rendered when there is some content on the description page', () => {
+      const { queryByTestId } = renderOfferDescription(defaultParams)
+      expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
+    })
+    describe('should be rendered', () => {
+      it('when there is description on the description page', () => {
+        const { queryByTestId } = renderOfferDescription({
+          ...defaultParams,
+          setup: (queryClient) => {
+            queryClient.setQueryData(['offer', offerId], {
+              image: {},
+              extraData: {},
+            })
+          },
+        })
+        expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
+      })
+      it('when there is image on the description page', () => {
+        const { queryByTestId } = renderOfferDescription({
+          ...defaultParams,
+          description: undefined,
+          setup: (queryClient) => {
+            queryClient.setQueryData(['offer', offerId], {
+              image: offerResponseSnap.image,
+              extraData: {},
+            })
+          },
+        })
+        expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
+      })
+      it('when there is extraData on the description page', () => {
+        const { queryByTestId } = renderOfferDescription({
+          ...defaultParams,
+          description: undefined,
+          setup: (queryClient) => {
+            queryClient.setQueryData(['offer', offerId], {
+              image: {},
+              extraData: { author: 'John Lang' },
+            })
+          },
+        })
+        expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
+      })
+    })
+    it("shouldn't be rendered when there is no content on the description page", () => {
+      const { queryByTestId } = renderOfferDescription({
+        description: undefined,
+        setup: setupWithNoDataInDescriptionPage,
+      })
+      expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
+    })
   })
 })
 
-const offerId = 123
-const renderOfferDescription = async (description?: string) => {
-  const setup = (queryClient: QueryClient) => {
-    queryClient.removeQueries()
-    queryClient.setQueryData(['offer', offerId], offerResponseSnap)
-  }
-
+const renderOfferDescription = ({ description, setup }: Params) => {
   const wrapper = render(
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
     reactQueryProviderHOC(<OfferPartialDescription id={offerId} description={description} />, setup)

--- a/src/features/offer/components/__tests__/OfferPartialDescription.web.test.tsx
+++ b/src/features/offer/components/__tests__/OfferPartialDescription.web.test.tsx
@@ -67,18 +67,6 @@ describe('OfferPartialDescription', () => {
       expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
     })
     describe('should be rendered', () => {
-      it('when there is description on the description page', () => {
-        const { queryByTestId } = renderOfferDescription({
-          ...defaultParams,
-          setup: (queryClient) => {
-            queryClient.setQueryData(['offer', offerId], {
-              image: {},
-              extraData: {},
-            })
-          },
-        })
-        expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
-      })
       it('when there is image on the description page', () => {
         const { queryByTestId } = renderOfferDescription({
           ...defaultParams,
@@ -106,12 +94,26 @@ describe('OfferPartialDescription', () => {
         expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
       })
     })
-    it("shouldn't be rendered when there is no content on the description page", () => {
-      const { queryByTestId } = renderOfferDescription({
-        description: undefined,
-        setup: setupWithNoDataInDescriptionPage,
+    describe("shouldn't be rendered", () => {
+      it('when there is no content on the description page', () => {
+        const { queryByTestId } = renderOfferDescription({
+          description: undefined,
+          setup: setupWithNoDataInDescriptionPage,
+        })
+        expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
       })
-      expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
+      it('when there is only description on the description page', () => {
+        const { queryByTestId } = renderOfferDescription({
+          ...defaultParams,
+          setup: (queryClient) => {
+            queryClient.setQueryData(['offer', offerId], {
+              image: {},
+              extraData: {},
+            })
+          },
+        })
+        expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
+      })
     })
   })
 })

--- a/src/features/offer/components/__tests__/OfferPartialDescription.web.test.tsx
+++ b/src/features/offer/components/__tests__/OfferPartialDescription.web.test.tsx
@@ -7,57 +7,116 @@ import { render } from 'tests/utils/web'
 
 import { OfferPartialDescription } from '../OfferPartialDescription'
 
-const description =
+const defaultDescription =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua: https://google.com'
+const offerId = 123
+type Setup = (queryClient: QueryClient) => void
+const defaultSetup: Setup = (queryClient) => {
+  queryClient.removeQueries()
+  queryClient.setQueryData(['offer', offerId], offerResponseSnap)
+}
+type Params = {
+  description?: string
+  setup: Setup
+}
+const defaultParams: Params = {
+  description: defaultDescription,
+  setup: defaultSetup,
+}
 
 describe('OfferPartialDescription', () => {
-  it('centers CTA when provided description is empty', async () => {
-    const { getByTestId } = await renderOfferDescription('')
+  it('centers CTA when provided description is empty', () => {
+    const { getByTestId } = renderOfferDescription({
+      ...defaultParams,
+      description: '',
+    })
     const offerSeeMoreContainer = getByTestId('offerSeeMoreContainer')
     // @ts-expect-error FIXME see how to fix typing
     const { 'align-self': alignSelf } = offerSeeMoreContainer.style
     expect(alignSelf).toBe('center')
   })
-  it('places CTA on flex-end when provided a description', async () => {
-    const { getByTestId } = await renderOfferDescription(description)
+  it('places CTA on flex-end when provided a description', () => {
+    const { getByTestId } = renderOfferDescription(defaultParams)
     const offerSeeMoreContainer = getByTestId('offerSeeMoreContainer')
     // @ts-expect-error FIXME see how to fix typing
     const { 'align-self': alignSelf } = offerSeeMoreContainer.style
     expect(alignSelf).toBe('flex-end')
   })
-  it('renders externalLinks if http(s) url are present in the description', async () => {
-    const { queryByTestId } = await renderOfferDescription(description)
+  it('renders externalLinks if http(s) url are present in the description', () => {
+    const { queryByTestId } = renderOfferDescription(defaultParams)
     expect(queryByTestId('externalSiteIcon')).toBeTruthy()
   })
-  it("shouldn't render an empty line and a spacer when description is undefined", async () => {
-    const { queryByTestId } = await renderOfferDescription(undefined)
+  it("shouldn't render an empty line and a spacer when description is empty", () => {
+    const { queryByTestId } = renderOfferDescription({
+      ...defaultParams,
+      description: undefined,
+    })
     expect(queryByTestId('offerPartialDescriptionBody')).toBeFalsy()
   })
-  it("shouldn't render the SeeMore button if no content is on description page", async () => {
-    const { queryByTestId } = render(
-      // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-      reactQueryProviderHOC(
-        <OfferPartialDescription id={offerId} description={undefined} />,
-        (queryClient: QueryClient) => {
-          queryClient.setQueryData(['offer', offerId], {
-            ...offerResponseSnap,
-            image: {},
-            extraData: {},
-          })
-        }
-      )
-    )
-    expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
+  describe('SeeMore button', () => {
+    const setupWithNoDataInDescriptionPage: Setup = (queryClient) => {
+      queryClient.setQueryData(['offer', offerId], {
+        ...offerResponseSnap,
+        image: {},
+        extraData: {},
+      })
+    }
+
+    it('should be rendered when there is some content on the description page', () => {
+      const { queryByTestId } = renderOfferDescription(defaultParams)
+      expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
+    })
+    describe('should be rendered', () => {
+      it('when there is description on the description page', () => {
+        const { queryByTestId } = renderOfferDescription({
+          ...defaultParams,
+          setup: (queryClient) => {
+            queryClient.setQueryData(['offer', offerId], {
+              image: {},
+              extraData: {},
+            })
+          },
+        })
+        expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
+      })
+      it('when there is image on the description page', () => {
+        const { queryByTestId } = renderOfferDescription({
+          ...defaultParams,
+          description: undefined,
+          setup: (queryClient) => {
+            queryClient.setQueryData(['offer', offerId], {
+              image: offerResponseSnap.image,
+              extraData: {},
+            })
+          },
+        })
+        expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
+      })
+      it('when there is extraData on the description page', () => {
+        const { queryByTestId } = renderOfferDescription({
+          ...defaultParams,
+          description: undefined,
+          setup: (queryClient) => {
+            queryClient.setQueryData(['offer', offerId], {
+              image: {},
+              extraData: { author: 'John Lang' },
+            })
+          },
+        })
+        expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
+      })
+    })
+    it("shouldn't be rendered when there is no content on the description page", () => {
+      const { queryByTestId } = renderOfferDescription({
+        description: undefined,
+        setup: setupWithNoDataInDescriptionPage,
+      })
+      expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
+    })
   })
 })
 
-const offerId = 123
-const renderOfferDescription = async (description?: string) => {
-  const setup = (queryClient: QueryClient) => {
-    queryClient.removeQueries()
-    queryClient.setQueryData(['offer', offerId], offerResponseSnap)
-  }
-
+const renderOfferDescription = ({ description, setup }: Params) => {
   const wrapper = render(
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
     reactQueryProviderHOC(<OfferPartialDescription id={offerId} description={description} />, setup)

--- a/src/features/offer/components/__tests__/OfferPartialDescription.web.test.tsx
+++ b/src/features/offer/components/__tests__/OfferPartialDescription.web.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient } from 'react-query'
 
 import { offerResponseSnap } from 'features/offer/api/snaps/offerResponseSnap'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { render } from 'tests/utils/web'
+import { CustomRenderOptions, render } from 'tests/utils/web'
 
 import { OfferPartialDescription } from '../OfferPartialDescription'
 
@@ -18,10 +18,12 @@ const defaultSetup: Setup = (queryClient) => {
 type Params = {
   description?: string
   setup: Setup
+  options?: CustomRenderOptions
 }
 const defaultParams: Params = {
   description: defaultDescription,
   setup: defaultSetup,
+  options: undefined,
 }
 
 describe('OfferPartialDescription', () => {
@@ -67,6 +69,25 @@ describe('OfferPartialDescription', () => {
       expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
     })
     describe('should be rendered', () => {
+      it('on phone when the description is ellipsed', () => {
+        const { queryByTestId } = renderOfferDescription({
+          ...defaultParams,
+          setup: (queryClient) => {
+            queryClient.setQueryData(['offer', offerId], {
+              image: {},
+              extraData: {},
+            })
+          },
+          options: {
+            theme: {
+              isMobileViewport: true,
+              isTabletViewport: false,
+              isDesktopViewport: false,
+            },
+          },
+        })
+        expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
+      })
       it('when there is image on the description page', () => {
         const { queryByTestId } = renderOfferDescription({
           ...defaultParams,
@@ -102,7 +123,7 @@ describe('OfferPartialDescription', () => {
         })
         expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
       })
-      it('when there is only description on the description page', () => {
+      it('on desktop when there is only description on the description page', () => {
         const { queryByTestId } = renderOfferDescription({
           ...defaultParams,
           setup: (queryClient) => {
@@ -111,6 +132,13 @@ describe('OfferPartialDescription', () => {
               extraData: {},
             })
           },
+          options: {
+            theme: {
+              isMobileViewport: false,
+              isTabletViewport: false,
+              isDesktopViewport: true,
+            },
+          },
         })
         expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
       })
@@ -118,10 +146,14 @@ describe('OfferPartialDescription', () => {
   })
 })
 
-const renderOfferDescription = ({ description, setup }: Params) => {
+const renderOfferDescription = ({ description, setup, options }: Params) => {
   const wrapper = render(
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-    reactQueryProviderHOC(<OfferPartialDescription id={offerId} description={description} />, setup)
+    reactQueryProviderHOC(
+      <OfferPartialDescription id={offerId} description={description} />,
+      setup
+    ),
+    options
   )
   return wrapper
 }

--- a/src/features/offer/components/useShouldDisplaySeeMoreButton.tsx
+++ b/src/features/offer/components/useShouldDisplaySeeMoreButton.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react'
+import { Platform } from 'react-native'
+import { useTheme } from 'styled-components/native'
+
+import { getContentFromOffer } from '../pages/OfferDescription'
+
+export const useShouldDisplaySeeMoreButton = (
+  maxTheoricalDisplayedDescriptionLines: number,
+  contentOfferDescription: ReturnType<typeof getContentFromOffer>
+): {
+  shouldDisplaySeeMoreButton: boolean
+  maxDisplayedDescriptionLines?: number
+  setLinesDisplayed: (linesDisplayed: number) => void
+} => {
+  const theme = useTheme()
+  const shouldTruncateDescription = !(Platform.OS === 'web' && theme.isDesktopViewport)
+  const maxDisplayedDescriptionLines = shouldTruncateDescription
+    ? maxTheoricalDisplayedDescriptionLines
+    : undefined
+  const [isLongerThanMaximumLines, setIsLongerThanMaximumLines] =
+    useState(shouldTruncateDescription)
+  const setLinesDisplayed = (linesDisplayed: number): void => {
+    if (typeof maxDisplayedDescriptionLines !== 'undefined') {
+      setIsLongerThanMaximumLines(linesDisplayed >= maxDisplayedDescriptionLines)
+    }
+  }
+  const shouldDisplaySeeMoreButton = shouldTruncateDescription
+    ? contentOfferDescription.length > 0 && isLongerThanMaximumLines
+    : contentOfferDescription.filter(({ key }) => key !== 'description').length > 0
+
+  return { shouldDisplaySeeMoreButton, maxDisplayedDescriptionLines, setLinesDisplayed }
+}

--- a/src/features/offer/components/useShouldDisplaySeeMoreButton.tsx
+++ b/src/features/offer/components/useShouldDisplaySeeMoreButton.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { Platform } from 'react-native'
 import { useTheme } from 'styled-components/native'
 
 import { getContentFromOffer } from '../pages/OfferDescription'
@@ -13,7 +12,7 @@ export const useShouldDisplaySeeMoreButton = (
   setLinesDisplayed: (linesDisplayed: number) => void
 } => {
   const theme = useTheme()
-  const shouldTruncateDescription = !(Platform.OS === 'web' && theme.isDesktopViewport)
+  const shouldTruncateDescription = theme.isDesktopViewport === false
   const maxDisplayedDescriptionLines = shouldTruncateDescription
     ? maxTheoricalDisplayedDescriptionLines
     : undefined

--- a/src/tests/utils.tsx
+++ b/src/tests/utils.tsx
@@ -97,7 +97,7 @@ const DefaultWrapper = ({ theme, children }: PropsWithTheme) => {
   )
 }
 
-type CustomRenderOptions = {
+export type CustomRenderOptions = {
   theme?: Partial<DefaultTheme>
 } & RenderOptions
 

--- a/src/tests/utils/web.tsx
+++ b/src/tests/utils/web.tsx
@@ -92,7 +92,7 @@ const DefaultWrapper = ({ children, theme }: PropsWithTheme) => {
   )
 }
 
-type CustomRenderOptions = {
+export type CustomRenderOptions = {
   theme?: Partial<DefaultTheme>
 } & RenderOptions
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-8471

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.

## Screenshots

| iOS description courte | iOS description longue | Firefox desktop (pas de changement) |
| :--: | :------: | :--------------: |
|![image](https://user-images.githubusercontent.com/95220086/147658087-cf8b5f86-f376-4a16-8716-6e14f3a5d065.png)|![image](https://user-images.githubusercontent.com/95220086/147658101-b8933500-ebde-44ab-9fea-5a496d0e6e8b.png)| ![image](https://user-images.githubusercontent.com/95220086/147657978-7df74848-7e79-44aa-85d5-9afe91aeb4b5.png)|

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
