### PR TITLE
(PC-12404) feat(NotYetUnderageEligibility): handle string date on nav

### DIFF
--- a/src/features/auth/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.tsx
+++ b/src/features/auth/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.tsx
@@ -64,7 +64,9 @@ export function AfterSignupEmailValidationBuffer() {
       const eligibilityStartDatetime =
         user.eligibilityStartDatetime && new Date(user.eligibilityStartDatetime)
       if (eligibilityStartDatetime && eligibilityStartDatetime >= new Date()) {
-        delayedNavigate('NotYetUnderageEligibility', { eligibilityStartDatetime })
+        delayedNavigate('NotYetUnderageEligibility', {
+          eligibilityStartDatetime: eligibilityStartDatetime.toString(),
+        })
         return
       }
       delayedNavigate('AccountCreated')

--- a/src/features/auth/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.tsx
+++ b/src/features/auth/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.tsx
@@ -61,11 +61,9 @@ export function AfterSignupEmailValidationBuffer() {
         delayedNavigate(nextScreen)
         return
       }
-      const eligibilityStartDatetime =
-        user.eligibilityStartDatetime && new Date(user.eligibilityStartDatetime)
-      if (eligibilityStartDatetime && eligibilityStartDatetime >= new Date()) {
+      if (user.eligibilityStartDatetime && new Date(user.eligibilityStartDatetime) >= new Date()) {
         delayedNavigate('NotYetUnderageEligibility', {
-          eligibilityStartDatetime: eligibilityStartDatetime.toString(),
+          eligibilityStartDatetime: user.eligibilityStartDatetime.toString(),
         })
         return
       }

--- a/src/features/auth/signup/AfterSignupEmailValidationBuffer/tests/AfterSignupEmailValidationBuffer.native.test.tsx
+++ b/src/features/auth/signup/AfterSignupEmailValidationBuffer/tests/AfterSignupEmailValidationBuffer.native.test.tsx
@@ -156,7 +156,7 @@ describe('<AfterSignupEmailValidationBuffer />', () => {
 
       await waitFor(() => {
         expect(navigate).toHaveBeenCalledWith('NotYetUnderageEligibility', {
-          eligibilityStartDatetime: new Date('2021-12-01T00:00:00Z'),
+          eligibilityStartDatetime: 'Wed Dec 01 2021 00:00:00 GMT+0000 (GMT)',
         })
       })
     })

--- a/src/features/auth/signup/AfterSignupEmailValidationBuffer/tests/AfterSignupEmailValidationBuffer.native.test.tsx
+++ b/src/features/auth/signup/AfterSignupEmailValidationBuffer/tests/AfterSignupEmailValidationBuffer.native.test.tsx
@@ -156,7 +156,7 @@ describe('<AfterSignupEmailValidationBuffer />', () => {
 
       await waitFor(() => {
         expect(navigate).toHaveBeenCalledWith('NotYetUnderageEligibility', {
-          eligibilityStartDatetime: 'Wed Dec 01 2021 00:00:00 GMT+0000 (GMT)',
+          eligibilityStartDatetime: '2021-12-01T00:00:00Z',
         })
       })
     })

--- a/src/features/auth/signup/VerifyEligiblity/NotYetUnderageEligibility.tsx
+++ b/src/features/auth/signup/VerifyEligiblity/NotYetUnderageEligibility.tsx
@@ -23,7 +23,9 @@ export const NotYetUnderageEligibility: FunctionComponent<Props> = (props) => {
         {t({
           id: 'reviens a partir du',
           values: {
-            formatedDate: formatToReadableFrenchDate(props.route.params.eligibilityStartDatetime),
+            formatedDate: formatToReadableFrenchDate(
+              new Date(props.route.params.eligibilityStartDatetime)
+            ),
           },
           message:
             'Reviens à partir du {formatedDate} pour poursuivre ton inscription et bénéficier des offres du pass Culture.',

--- a/src/features/auth/signup/VerifyEligiblity/NotYetUnderageEligibility.tsx
+++ b/src/features/auth/signup/VerifyEligiblity/NotYetUnderageEligibility.tsx
@@ -23,9 +23,7 @@ export const NotYetUnderageEligibility: FunctionComponent<Props> = (props) => {
         {t({
           id: 'reviens a partir du',
           values: {
-            formatedDate: formatToReadableFrenchDate(
-              new Date(props.route.params.eligibilityStartDatetime)
-            ),
+            formatedDate: formatToReadableFrenchDate(props.route.params.eligibilityStartDatetime),
           },
           message:
             'Reviens à partir du {formatedDate} pour poursuivre ton inscription et bénéficier des offres du pass Culture.',

--- a/src/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx
+++ b/src/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx
@@ -10,7 +10,7 @@ import { NotYetUnderageEligibility } from '../NotYetUnderageEligibility'
 jest.mock('features/navigation/helpers')
 
 const navigationProps = {
-  route: { params: { eligibilityStartDatetime: new Date('2019-12-01T00:00:00Z') } },
+  route: { params: { eligibilityStartDatetime: '2019-12-01T00:00:00Z' } },
 } as StackScreenProps<RootStackParamList, 'NotYetUnderageEligibility'>
 
 describe('<NotYetUnderageEligibility />', () => {

--- a/src/features/cheatcodes/pages/Navigation/Navigation.tsx
+++ b/src/features/cheatcodes/pages/Navigation/Navigation.tsx
@@ -146,7 +146,7 @@ export function Navigation(): JSX.Element {
             title={"C'est pour bientôt"}
             onPress={() =>
               navigate('NotYetUnderageEligibility', {
-                eligibilityStartDatetime: new Date('2019-12-01T00:00:00Z'),
+                eligibilityStartDatetime: new Date('2019-12-01T00:00:00Z').toString(),
               })
             }
           />

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -118,7 +118,7 @@ export type RootStackParamList = {
   PhoneValidationTooManyAttempts: undefined
   PhoneValidationTooManySMSSent: undefined
   VerifyEligibility: undefined
-  NotYetUnderageEligibility: { eligibilityStartDatetime: Date }
+  NotYetUnderageEligibility: { eligibilityStartDatetime: string }
   FirstTutorial?: { shouldCloseAppOnBackAction: boolean }
   EighteenBirthday: undefined
   RecreditBirthdayNotification: undefined

--- a/src/libs/dates.test.ts
+++ b/src/libs/dates.test.ts
@@ -19,6 +19,11 @@ describe('formatToReadableFrenchDate()', () => {
     expect(formatToReadableFrenchDate(new Date('2019-12-01T00:00:00Z'))).toEqual('01 décembre')
     expect(formatToReadableFrenchDate(new Date('2019-03-12T00:00:00Z'))).toEqual('12 mars')
   })
+  it('should return formated translated and readable date when string provided', () => {
+    expect(formatToReadableFrenchDate('2019-12-01T00:00:00Z')).toEqual('01 décembre')
+    expect(formatToReadableFrenchDate('2019-03-12T00:00:00Z')).toEqual('12 mars')
+    expect(formatToReadableFrenchDate('no a date')).toEqual('')
+  })
 })
 
 describe('isTimestampExpired()', () => {

--- a/src/libs/dates.ts
+++ b/src/libs/dates.ts
@@ -60,9 +60,12 @@ export const formatToSlashedFrenchDate = (ISODate: string) => {
   return `${day}/${month}/${year}`
 }
 
-export const formatToReadableFrenchDate = (date: Date) => {
-  const monthOrder = date.getMonth()
-  const day = ('0' + date.getDate()).slice(-2)
+export const formatToReadableFrenchDate = (date: Date | string) => {
+  const formattedDate = new Date(date)
+  // @ts-ignore isNan works with empty dates
+  if (isNaN(formattedDate)) return ''
+  const monthOrder = formattedDate.getMonth()
+  const day = ('0' + formattedDate.getDate()).slice(-2)
   const month = monthNames[monthOrder].toLowerCase()
   return `${day} ${month}`
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12404

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |          
![image](https://user-images.githubusercontent.com/43779561/148048455-d2f33f6e-2845-4d0a-8532-1cb3fcaa819b.png)
        |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
