### PR TITLE
(PC-12454) refactor(routes): remove old idcheck/educonnect routes

### DIFF
--- a/src/features/identityCheck/pages/identification/IdentityCheckValidation.web.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckValidation.web.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro'
-import { useNavigation, useFocusEffect, useRoute } from '@react-navigation/native'
+import { useFocusEffect, useRoute } from '@react-navigation/native'
 import moment from 'moment'
 import React, { useCallback } from 'react'
 import styled from 'styled-components/native'
@@ -8,7 +8,7 @@ import { CenteredTitle } from 'features/identityCheck/atoms/CenteredTitle'
 import { PageWithHeader } from 'features/identityCheck/components/layout/PageWithHeader'
 import { useIdentityCheckContext } from 'features/identityCheck/context/IdentityCheckContextProvider'
 import { IdentityCheckStep } from 'features/identityCheck/types'
-import { UseNavigationType } from 'features/navigation/RootNavigator'
+import { useIdentityCheckNavigation } from 'features/identityCheck/useIdentityCheckNavigation'
 import { UseRouteType } from 'features/navigation/RootNavigator'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
@@ -16,9 +16,9 @@ import { ColorsEnum, Spacer, Typo } from 'ui/theme'
 
 export function IdentityCheckValidation() {
   const { params } = useRoute<UseRouteType<'IdentityCheckValidation'>>()
-  const { navigate } = useNavigation<UseNavigationType>()
 
   const { dispatch, identification } = useIdentityCheckContext()
+  const { navigateToNextScreen } = useIdentityCheckNavigation()
 
   const birthDate = identification.birthDate
     ? moment(identification.birthDate, 'YYYY-MM-DD').format('DD/MM/YYYY')
@@ -26,13 +26,7 @@ export function IdentityCheckValidation() {
 
   const navigateToNextEduConnectStep = () => {
     dispatch({ type: 'SET_STEP', payload: IdentityCheckStep.CONFIRMATION })
-    // Here we do not call navigateToNextScreen but navigate directly to the next screen
-    // This is possible because we are the last step of the flow profile.
-    // This is because this component may not be in useIdentityCheckSteps, but we can arrive here
-    // on web by being redirected by the backend from educonnect. See:
-    // https://github.com/pass-culture/pass-culture-main/blob/master/api/src/pcapi/routes/saml/educonnect.py#L161
-    // TODO(antoinewg): once the backend redirects to `validation`, use navigateToNextScreen and delete route
-    navigate('IdentityCheckStepper')
+    navigateToNextScreen()
   }
 
   useFocusEffect(

--- a/src/features/identityCheck/useIdentityCheckSteps.tsx
+++ b/src/features/identityCheck/useIdentityCheckSteps.tsx
@@ -35,13 +35,7 @@ export const useIdentityCheckSteps = (): StepConfig[] => {
       label: t`Identification`,
       screens:
         identification.method === IdentityCheckMethod.educonnect
-          ? [
-              'IdentityCheckEduConnect',
-              'IdentityCheckEduConnectForm',
-              // this route `IdentityCheckValidation` has to be at the end of a step. See comment in the component
-              // TODO(antoinewg): replace this route by `Validation` once the backend redirects to `educonnect/validation`
-              'IdentityCheckValidation',
-            ]
+          ? ['IdentityCheckEduConnect', 'IdentityCheckEduConnectForm', 'IdentityCheckValidation']
           : ['IdentityCheckStart', 'IdentityCheckWebview', 'IdentityCheckEnd'],
     },
     {

--- a/src/features/navigation/RootNavigator/identityCheckRoutes.ts
+++ b/src/features/navigation/RootNavigator/identityCheckRoutes.ts
@@ -111,20 +111,6 @@ export const identityCheckRoutes: GenericRoute<IdentityCheckRootStackParamList>[
   {
     name: 'IdentityCheckValidation',
     component: IdentityCheckValidation,
-    hoc: withEduConnectErrorBoundary,
-    // This route is hardcoded in the backend
-    // https://github.com/pass-culture/pass-culture-main/blob/master/api/src/pcapi/routes/saml/educonnect.py#L161
-    // TODO(antoinewg): delete this route once the backend redirects to `educonnect/validation`
-    path: 'idcheck/validation',
-    options: { title: t`Validation de l'identification` },
-  },
-  {
-    name: 'Validation',
-    component: IdentityCheckValidation,
-    // This route is not used yet but will be once this line is modified in the  backend
-    // https://github.com/pass-culture/pass-culture-main/blob/master/api/src/pcapi/routes/saml/educonnect.py#L161
-    // Once the backend redirects to educonnect/validation instead of idcheck/validation
-    // we can delete the route above and replace IdentityCheckValidation by Validation
     path: 'educonnect/validation',
     hoc: withEduConnectErrorBoundary,
     options: { title: t`Validation de l'identification` },
@@ -183,14 +169,5 @@ export const identityCheckRoutes: GenericRoute<IdentityCheckRootStackParamList>[
     component: EduConnectErrors,
     path: 'educonnect/erreur',
     options: { title: t`Erreur` },
-  },
-  // This route is hardcoded in the backend
-  // https://github.com/pass-culture/pass-culture-main/blob/master/api/src/pcapi/routes/saml/educonnect.py#L28
-  // TODO(anoukhello): delete this route once the backend redirects to `educonnect/erreur`
-  {
-    name: 'EduConnectErrorsPage',
-    component: EduConnectErrors,
-    hoc: withEduConnectErrorBoundary,
-    path: 'idcheck/educonnect/erreur',
   },
 ]


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12454
PR qui renomme les path côté API https://github.com/pass-culture/pass-culture-main/pull/919

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
