### PR TITLE
(PC-12511) feat(modal): increase modal header icons

### DIFF
--- a/__snapshots__/features/auth/forgottenPassword/ForgottenPassword/tests/ForgottenPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ForgottenPassword/tests/ForgottenPassword.native.test.tsx.native-snap
@@ -5,7 +5,7 @@ exports[`<ForgottenPassword /> should enable validate button when email input is
 - First value
 + Second value
 
-@@ -126,13 +126,11 @@
+@@ -125,13 +125,11 @@
                 }
               >
                 <View
@@ -19,7 +19,7 @@ exports[`<ForgottenPassword /> should enable validate button when email input is
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -206,13 +204,11 @@
+@@ -207,13 +205,11 @@
                 }
               >
                 <View
@@ -33,7 +33,7 @@ exports[`<ForgottenPassword /> should enable validate button when email input is
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -390,11 +386,11 @@
+@@ -395,11 +391,11 @@
                             \\"paddingTop\\": 0,
                           },
                         ]
@@ -46,7 +46,7 @@ exports[`<ForgottenPassword /> should enable validate button when email input is
                 </View>
               </View>
               <View
-@@ -408,24 +404,22 @@
+@@ -413,24 +409,22 @@
                 }
               />
               <View
@@ -73,7 +73,7 @@ exports[`<ForgottenPassword /> should enable validate button when email input is
                     \\"flexDirection\\": \\"row\\",
                     \\"height\\": 40,
                     \\"justifyContent\\": \\"center\\",
-@@ -444,20 +438,20 @@
+@@ -449,20 +443,20 @@
                   adjustsFontSizeToFit={false}
                   numberOfLines={1}
                   style={

--- a/__snapshots__/features/auth/forgottenPassword/ReinitializePassword/tests/ReinitializePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ReinitializePassword/tests/ReinitializePassword.native.test.tsx.native-snap
@@ -5,7 +5,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
 - First value
 + Second value
 
-@@ -119,13 +119,11 @@
+@@ -118,13 +118,11 @@
                 }
               >
                 <View
@@ -19,7 +19,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -189,13 +187,11 @@
+@@ -190,13 +188,11 @@
                 }
               >
                 <View
@@ -33,7 +33,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -343,18 +339,16 @@
+@@ -348,18 +344,16 @@
                           \\"flexShrink\\": 1,
                         },
                       ]
@@ -53,7 +53,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                     onResponderMove={[Function onResponderMove]}
                     onResponderRelease={[Function onResponderRelease]}
                     onResponderTerminate={[Function onResponderTerminate]}
-@@ -405,15 +399,15 @@
+@@ -410,15 +404,15 @@
                     ]
                   }
                 >
@@ -71,7 +71,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                   <View
                     numberOfSpaces={1}
                     style={
-@@ -423,15 +417,15 @@
+@@ -428,15 +422,15 @@
                         },
                       ]
                     }
@@ -89,7 +89,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                           \\"fontSize\\": 12,
                           \\"lineHeight\\": 16,
                           \\"paddingLeft\\": 4,
-@@ -453,15 +447,15 @@
+@@ -458,15 +452,15 @@
                     ]
                   }
                 >
@@ -107,7 +107,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                   <View
                     numberOfSpaces={1}
                     style={
-@@ -471,15 +465,15 @@
+@@ -476,15 +470,15 @@
                         },
                       ]
                     }
@@ -125,7 +125,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                           \\"fontSize\\": 12,
                           \\"lineHeight\\": 16,
                           \\"paddingLeft\\": 4,
-@@ -501,15 +495,15 @@
+@@ -506,15 +500,15 @@
                     ]
                   }
                 >
@@ -143,7 +143,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                   <View
                     numberOfSpaces={1}
                     style={
-@@ -519,15 +513,15 @@
+@@ -524,15 +518,15 @@
                         },
                       ]
                     }
@@ -161,7 +161,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                           \\"fontSize\\": 12,
                           \\"lineHeight\\": 16,
                           \\"paddingLeft\\": 4,
-@@ -549,15 +543,15 @@
+@@ -554,15 +548,15 @@
                     ]
                   }
                 >
@@ -179,7 +179,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                   <View
                     numberOfSpaces={1}
                     style={
-@@ -567,15 +561,15 @@
+@@ -572,15 +566,15 @@
                         },
                       ]
                     }
@@ -197,7 +197,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                           \\"fontSize\\": 12,
                           \\"lineHeight\\": 16,
                           \\"paddingLeft\\": 4,
-@@ -597,15 +591,15 @@
+@@ -602,15 +596,15 @@
                     ]
                   }
                 >
@@ -215,7 +215,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                   <View
                     numberOfSpaces={1}
                     style={
-@@ -615,15 +609,15 @@
+@@ -620,15 +614,15 @@
                         },
                       ]
                     }
@@ -233,7 +233,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                           \\"fontSize\\": 12,
                           \\"lineHeight\\": 16,
                           \\"paddingLeft\\": 4,
-@@ -750,13 +744,11 @@
+@@ -755,13 +749,11 @@
                     value=\\"\\"
                   />
                   <View
@@ -247,7 +247,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                     onResponderMove={[Function onResponderMove]}
                     onResponderRelease={[Function onResponderRelease]}
                     onResponderTerminate={[Function onResponderTerminate]}
-@@ -807,13 +799,11 @@
+@@ -812,13 +804,11 @@
                 }
               />
               <View

--- a/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -429,7 +429,6 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                                           "flexGrow": 0.1,
                                           "flexShrink": 1,
                                           "justifyContent": "flex-start",
-                                          "paddingTop": 2,
                                         },
                                       ]
                                     }
@@ -449,16 +448,20 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                                       onStartShouldSetResponder={[Function]}
                                       style={
                                         Object {
-                                          "marginLeft": -5,
+                                          "marginLeft": -8,
                                           "opacity": 1,
+                                          "paddingBottom": 4,
+                                          "paddingLeft": 4,
+                                          "paddingRight": 4,
+                                          "paddingTop": 4,
                                         }
                                       }
                                       testID="Revenir en arrière"
                                     >
                                       <View
-                                        height={18}
+                                        height={20}
                                         testID="leftIcon"
-                                        width={18}
+                                        width={20}
                                       >
                                         <Text>
                                           leftIcon-SVG-Mock
@@ -470,11 +473,10 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                                     style={
                                       Array [
                                         Object {
-                                          "alignItems": "center",
                                           "flexBasis": 0,
                                           "flexGrow": 0.8,
                                           "flexShrink": 1,
-                                          "justifyContent": "flex-start",
+                                          "justifyContent": "center",
                                           "paddingLeft": 12,
                                           "paddingRight": 12,
                                           "zIndex": 1,
@@ -509,7 +511,6 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                                           "flexGrow": 0.1,
                                           "flexShrink": 1,
                                           "justifyContent": "flex-end",
-                                          "paddingTop": 2,
                                         },
                                       ]
                                     }
@@ -529,16 +530,20 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                                       onStartShouldSetResponder={[Function]}
                                       style={
                                         Object {
-                                          "marginRight": -5,
+                                          "marginRight": -8,
                                           "opacity": 1,
+                                          "paddingBottom": 4,
+                                          "paddingLeft": 4,
+                                          "paddingRight": 4,
+                                          "paddingTop": 4,
                                         }
                                       }
                                       testID="Revenir à l'accueil"
                                     >
                                       <View
-                                        height={18}
+                                        height={20}
                                         testID="rightIcon"
-                                        width={18}
+                                        width={20}
                                       >
                                         <Text>
                                           rightIcon-SVG-Mock

--- a/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.web.test.tsx.web-snap
@@ -100,13 +100,13 @@ Object {
                                       >
                                         <div
                                           class="css-view-1dbjc4n"
-                                          style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                                          style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                                         >
                                           <div
                                             aria-label="Revenir en arrière"
                                             class="css-view-1dbjc4n"
                                             data-testid="Revenir en arrière"
-                                            style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                                            style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                                             tabindex="0"
                                           >
                                             <div
@@ -124,7 +124,7 @@ Object {
                                         </div>
                                         <div
                                           class="css-view-1dbjc4n"
-                                          style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                                          style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                                         >
                                           <div
                                             class="css-text-901oao css-textMultiLine-cens5h"
@@ -136,13 +136,13 @@ Object {
                                         </div>
                                         <div
                                           class="css-view-1dbjc4n"
-                                          style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                                          style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                                         >
                                           <div
                                             aria-label="Revenir à l'accueil"
                                             class="css-view-1dbjc4n"
                                             data-testid="Revenir à l'accueil"
-                                            style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                                            style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                                             tabindex="0"
                                           >
                                             <div
@@ -419,13 +419,13 @@ Object {
                                     >
                                       <div
                                         class="css-view-1dbjc4n"
-                                        style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                                        style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                                       >
                                         <div
                                           aria-label="Revenir en arrière"
                                           class="css-view-1dbjc4n"
                                           data-testid="Revenir en arrière"
-                                          style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                                          style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                                           tabindex="0"
                                         >
                                           <div
@@ -443,7 +443,7 @@ Object {
                                       </div>
                                       <div
                                         class="css-view-1dbjc4n"
-                                        style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                                        style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                                       >
                                         <div
                                           class="css-text-901oao css-textMultiLine-cens5h"
@@ -455,13 +455,13 @@ Object {
                                       </div>
                                       <div
                                         class="css-view-1dbjc4n"
-                                        style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                                        style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                                       >
                                         <div
                                           aria-label="Revenir à l'accueil"
                                           class="css-view-1dbjc4n"
                                           data-testid="Revenir à l'accueil"
-                                          style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                                          style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                                           tabindex="0"
                                         >
                                           <div

--- a/__snapshots__/features/auth/login/Login.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/login/Login.native.test.tsx.native-snap
@@ -5,7 +5,7 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
 - First value
 + Second value
 
-@@ -119,13 +119,11 @@
+@@ -118,13 +118,11 @@
                 }
               >
                 <View
@@ -19,7 +19,7 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -199,13 +197,11 @@
+@@ -200,13 +198,11 @@
                 }
               >
                 <View
@@ -33,7 +33,7 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -348,11 +344,11 @@
+@@ -353,11 +349,11 @@
                           \\"paddingTop\\": 0,
                         },
                       ]
@@ -46,7 +46,7 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
               </View>
             </View>
             <View
-@@ -466,18 +462,16 @@
+@@ -471,18 +467,16 @@
                       },
                     ]
                   }
@@ -66,7 +66,7 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -529,13 +523,11 @@
+@@ -534,13 +528,11 @@
                 ]
               }
             >
@@ -80,7 +80,7 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
                 onResponderMove={[Function onResponderMove]}
                 onResponderRelease={[Function onResponderRelease]}
                 onResponderTerminate={[Function onResponderTerminate]}
-@@ -574,24 +566,22 @@
+@@ -579,24 +571,22 @@
               }
             />
             <View
@@ -107,7 +107,7 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
                   \\"flexDirection\\": \\"row\\",
                   \\"height\\": 40,
                   \\"justifyContent\\": \\"center\\",
-@@ -610,20 +600,20 @@
+@@ -615,20 +605,20 @@
                 adjustsFontSizeToFit={false}
                 numberOfLines={1}
                 style={
@@ -137,7 +137,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
 - First value
 + Second value
 
-@@ -119,13 +119,11 @@
+@@ -118,13 +118,11 @@
                 }
               >
                 <View
@@ -151,7 +151,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -199,13 +197,11 @@
+@@ -200,13 +198,11 @@
                 }
               >
                 <View
@@ -165,8 +165,8 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -225,15 +221,74 @@
-                    width={18}
+@@ -230,15 +226,74 @@
+                    width={20}
                   >
                     <Text>
                       rightIcon-SVG-Mock
@@ -240,7 +240,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                 Array [
                   Object {
                     \\"height\\": 28,
-@@ -290,19 +345,19 @@
+@@ -295,19 +350,19 @@
                       },
                     ]
                   }
@@ -262,7 +262,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                         \\"borderWidth\\": 1,
                         \\"flexDirection\\": \\"row\\",
                         \\"height\\": 40,
-@@ -348,11 +403,11 @@
+@@ -353,11 +408,11 @@
                           \\"paddingTop\\": 0,
                         },
                       ]
@@ -275,7 +275,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
               </View>
             </View>
             <View
-@@ -401,19 +456,19 @@
+@@ -406,19 +461,19 @@
                     },
                   ]
                 }
@@ -297,7 +297,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                       \\"borderWidth\\": 1,
                       \\"flexDirection\\": \\"row\\",
                       \\"height\\": 40,
-@@ -466,18 +521,16 @@
+@@ -471,18 +526,16 @@
                       },
                     ]
                   }
@@ -317,7 +317,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -529,13 +582,11 @@
+@@ -534,13 +587,11 @@
                 ]
               }
             >
@@ -331,7 +331,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                 onResponderMove={[Function onResponderMove]}
                 onResponderRelease={[Function onResponderRelease]}
                 onResponderTerminate={[Function onResponderTerminate]}
-@@ -574,24 +625,22 @@
+@@ -579,24 +630,22 @@
               }
             />
             <View
@@ -358,7 +358,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                   \\"flexDirection\\": \\"row\\",
                   \\"height\\": 40,
                   \\"justifyContent\\": \\"center\\",
-@@ -610,20 +659,20 @@
+@@ -615,20 +664,20 @@
                 adjustsFontSizeToFit={false}
                 numberOfLines={1}
                 style={
@@ -388,7 +388,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
 - First value
 + Second value
 
-@@ -119,13 +119,11 @@
+@@ -118,13 +118,11 @@
                 }
               >
                 <View
@@ -402,7 +402,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -199,13 +197,11 @@
+@@ -200,13 +198,11 @@
                 }
               >
                 <View
@@ -416,8 +416,8 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -225,15 +221,74 @@
-                    width={18}
+@@ -230,15 +226,74 @@
+                    width={20}
                   >
                     <Text>
                       rightIcon-SVG-Mock
@@ -491,7 +491,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                 Array [
                   Object {
                     \\"height\\": 28,
-@@ -290,19 +345,19 @@
+@@ -295,19 +350,19 @@
                       },
                     ]
                   }
@@ -513,7 +513,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                         \\"borderWidth\\": 1,
                         \\"flexDirection\\": \\"row\\",
                         \\"height\\": 40,
-@@ -348,11 +403,11 @@
+@@ -353,11 +408,11 @@
                           \\"paddingTop\\": 0,
                         },
                       ]
@@ -526,7 +526,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
               </View>
             </View>
             <View
-@@ -401,19 +456,19 @@
+@@ -406,19 +461,19 @@
                     },
                   ]
                 }
@@ -548,7 +548,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                       \\"borderWidth\\": 1,
                       \\"flexDirection\\": \\"row\\",
                       \\"height\\": 40,
-@@ -466,18 +521,16 @@
+@@ -471,18 +526,16 @@
                       },
                     ]
                   }
@@ -568,7 +568,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -529,13 +582,11 @@
+@@ -534,13 +587,11 @@
                 ]
               }
             >
@@ -582,7 +582,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                 onResponderMove={[Function onResponderMove]}
                 onResponderRelease={[Function onResponderRelease]}
                 onResponderTerminate={[Function onResponderTerminate]}
-@@ -574,24 +625,22 @@
+@@ -579,24 +630,22 @@
               }
             />
             <View
@@ -609,7 +609,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                   \\"flexDirection\\": \\"row\\",
                   \\"height\\": 40,
                   \\"justifyContent\\": \\"center\\",
-@@ -610,20 +659,20 @@
+@@ -615,20 +664,20 @@
                 adjustsFontSizeToFit={false}
                 numberOfLines={1}
                 style={
@@ -639,7 +639,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
 - First value
 + Second value
 
-@@ -119,13 +119,11 @@
+@@ -118,13 +118,11 @@
                 }
               >
                 <View
@@ -653,7 +653,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -199,13 +197,11 @@
+@@ -200,13 +198,11 @@
                 }
               >
                 <View
@@ -667,8 +667,8 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -225,15 +221,74 @@
-                    width={18}
+@@ -230,15 +226,74 @@
+                    width={20}
                   >
                     <Text>
                       rightIcon-SVG-Mock
@@ -742,7 +742,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                 Array [
                   Object {
                     \\"height\\": 28,
-@@ -290,19 +345,19 @@
+@@ -295,19 +350,19 @@
                       },
                     ]
                   }
@@ -764,7 +764,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                         \\"borderWidth\\": 1,
                         \\"flexDirection\\": \\"row\\",
                         \\"height\\": 40,
-@@ -348,11 +403,11 @@
+@@ -353,11 +408,11 @@
                           \\"paddingTop\\": 0,
                         },
                       ]
@@ -777,7 +777,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
               </View>
             </View>
             <View
-@@ -401,19 +456,19 @@
+@@ -406,19 +461,19 @@
                     },
                   ]
                 }
@@ -799,7 +799,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                       \\"borderWidth\\": 1,
                       \\"flexDirection\\": \\"row\\",
                       \\"height\\": 40,
-@@ -466,18 +521,16 @@
+@@ -471,18 +526,16 @@
                       },
                     ]
                   }
@@ -819,7 +819,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -529,13 +582,11 @@
+@@ -534,13 +587,11 @@
                 ]
               }
             >
@@ -833,7 +833,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                 onResponderMove={[Function onResponderMove]}
                 onResponderRelease={[Function onResponderRelease]}
                 onResponderTerminate={[Function onResponderTerminate]}
-@@ -574,24 +625,22 @@
+@@ -579,24 +630,22 @@
               }
             />
             <View
@@ -860,7 +860,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                   \\"flexDirection\\": \\"row\\",
                   \\"height\\": 40,
                   \\"justifyContent\\": \\"center\\",
-@@ -610,20 +659,20 @@
+@@ -615,20 +664,20 @@
                 adjustsFontSizeToFit={false}
                 numberOfLines={1}
                 style={

--- a/__snapshots__/features/auth/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
@@ -512,7 +512,6 @@ Array [
                   "flexGrow": 0.1,
                   "flexShrink": 1,
                   "justifyContent": "flex-start",
-                  "paddingTop": 2,
                 },
               ]
             }
@@ -532,8 +531,12 @@ Array [
               onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "marginLeft": -5,
+                  "marginLeft": -8,
                   "opacity": 1,
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
                 }
               }
               testID="leftIconButton"
@@ -543,11 +546,10 @@ Array [
             style={
               Array [
                 Object {
-                  "alignItems": "center",
                   "flexBasis": 0,
                   "flexGrow": 0.8,
                   "flexShrink": 1,
-                  "justifyContent": "flex-start",
+                  "justifyContent": "center",
                   "paddingLeft": 12,
                   "paddingRight": 12,
                   "zIndex": 1,
@@ -582,7 +584,6 @@ Array [
                   "flexGrow": 0.1,
                   "flexShrink": 1,
                   "justifyContent": "flex-end",
-                  "paddingTop": 2,
                 },
               ]
             }
@@ -602,16 +603,20 @@ Array [
               onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "marginRight": -5,
+                  "marginRight": -8,
                   "opacity": 1,
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
                 }
               }
               testID="Fermer la modale"
             >
               <View
-                height={18}
+                height={20}
                 testID="rightIcon"
-                width={18}
+                width={20}
               >
                 <Text>
                   rightIcon-SVG-Mock

--- a/__snapshots__/features/bookings/pages/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails.native.test.tsx.native-snap
@@ -788,7 +788,6 @@ exports[`BookingDetails should render correctly 1`] = `
                   "flexGrow": 0.1,
                   "flexShrink": 1,
                   "justifyContent": "flex-start",
-                  "paddingTop": 2,
                 },
               ]
             }
@@ -808,8 +807,12 @@ exports[`BookingDetails should render correctly 1`] = `
               onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "marginLeft": -5,
+                  "marginLeft": -8,
                   "opacity": 1,
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
                 }
               }
               testID="leftIconButton"
@@ -819,11 +822,10 @@ exports[`BookingDetails should render correctly 1`] = `
             style={
               Array [
                 Object {
-                  "alignItems": "center",
                   "flexBasis": 0,
                   "flexGrow": 0.8,
                   "flexShrink": 1,
-                  "justifyContent": "flex-start",
+                  "justifyContent": "center",
                   "paddingLeft": 12,
                   "paddingRight": 12,
                   "zIndex": 1,
@@ -858,7 +860,6 @@ exports[`BookingDetails should render correctly 1`] = `
                   "flexGrow": 0.1,
                   "flexShrink": 1,
                   "justifyContent": "flex-end",
-                  "paddingTop": 2,
                 },
               ]
             }
@@ -878,16 +879,20 @@ exports[`BookingDetails should render correctly 1`] = `
               onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "marginRight": -5,
+                  "marginRight": -8,
                   "opacity": 1,
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
                 }
               }
               testID="Ne pas annuler"
             >
               <View
-                height={18}
+                height={20}
                 testID="rightIcon"
-                width={18}
+                width={20}
               >
                 <Text>
                   rightIcon-SVG-Mock
@@ -1244,7 +1249,6 @@ exports[`BookingDetails should render correctly 1`] = `
                   "flexGrow": 0.1,
                   "flexShrink": 1,
                   "justifyContent": "flex-start",
-                  "paddingTop": 2,
                 },
               ]
             }
@@ -1264,8 +1268,12 @@ exports[`BookingDetails should render correctly 1`] = `
               onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "marginLeft": -5,
+                  "marginLeft": -8,
                   "opacity": 1,
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
                 }
               }
               testID="leftIconButton"
@@ -1275,11 +1283,10 @@ exports[`BookingDetails should render correctly 1`] = `
             style={
               Array [
                 Object {
-                  "alignItems": "center",
                   "flexBasis": 0,
                   "flexGrow": 0.8,
                   "flexShrink": 1,
-                  "justifyContent": "flex-start",
+                  "justifyContent": "center",
                   "paddingLeft": 12,
                   "paddingRight": 12,
                   "zIndex": 1,
@@ -1314,7 +1321,6 @@ exports[`BookingDetails should render correctly 1`] = `
                   "flexGrow": 0.1,
                   "flexShrink": 1,
                   "justifyContent": "flex-end",
-                  "paddingTop": 2,
                 },
               ]
             }
@@ -1334,16 +1340,20 @@ exports[`BookingDetails should render correctly 1`] = `
               onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "marginRight": -5,
+                  "marginRight": -8,
                   "opacity": 1,
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
                 }
               }
               testID="Ne pas archiver"
             >
               <View
-                height={18}
+                height={20}
                 testID="rightIcon"
-                width={18}
+                width={20}
               >
                 <Text>
                   rightIcon-SVG-Mock

--- a/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicy.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicy.native.test.tsx.native-snap
@@ -150,7 +150,6 @@ exports[`<PrivacyPolicy /> should render privacy policy 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -170,8 +169,12 @@ exports[`<PrivacyPolicy /> should render privacy policy 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -181,11 +184,10 @@ exports[`<PrivacyPolicy /> should render privacy policy 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -220,7 +222,6 @@ exports[`<PrivacyPolicy /> should render privacy policy 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -240,16 +241,20 @@ exports[`<PrivacyPolicy /> should render privacy policy 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="Fermer la modale et refuser la collecte des données"
           >
             <View
-              height={18}
+              height={20}
               testID="rightIcon"
-              width={18}
+              width={20}
             >
               <Text>
                 rightIcon-SVG-Mock

--- a/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicyModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicyModal.native.test.tsx.native-snap
@@ -150,7 +150,6 @@ exports[`<PrivacyPolicyModal /> should render correctly 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -170,8 +169,12 @@ exports[`<PrivacyPolicyModal /> should render correctly 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -181,11 +184,10 @@ exports[`<PrivacyPolicyModal /> should render correctly 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -220,7 +222,6 @@ exports[`<PrivacyPolicyModal /> should render correctly 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -240,16 +241,20 @@ exports[`<PrivacyPolicyModal /> should render correctly 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="Fermer la modale et refuser la collecte des données"
           >
             <View
-              height={18}
+              height={20}
               testID="rightIcon"
-              width={18}
+              width={20}
             >
               <Text>
                 rightIcon-SVG-Mock

--- a/__snapshots__/features/identityCheck/components/__test__/DMSModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/__test__/DMSModal.native.test.tsx.native-snap
@@ -150,7 +150,6 @@ exports[`<DMSModal/> should render correctly 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -170,8 +169,12 @@ exports[`<DMSModal/> should render correctly 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -181,11 +184,10 @@ exports[`<DMSModal/> should render correctly 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -220,7 +222,6 @@ exports[`<DMSModal/> should render correctly 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -240,16 +241,20 @@ exports[`<DMSModal/> should render correctly 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="Fermer la modale pour transmettre un document sur le site Démarches Simplifiée"
           >
             <View
-              height={18}
+              height={20}
               testID="rightIcon"
-              width={18}
+              width={20}
             >
               <Text>
                 rightIcon-SVG-Mock

--- a/__snapshots__/features/identityCheck/components/__test__/FastEduconnectConnectionRequestModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/__test__/FastEduconnectConnectionRequestModal.native.test.tsx.native-snap
@@ -154,7 +154,6 @@ exports[`<IdentityCheckEnd/> should render correctly if modal not visible 1`] = 
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -174,8 +173,12 @@ exports[`<IdentityCheckEnd/> should render correctly if modal not visible 1`] = 
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -185,11 +188,10 @@ exports[`<IdentityCheckEnd/> should render correctly if modal not visible 1`] = 
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -224,7 +226,6 @@ exports[`<IdentityCheckEnd/> should render correctly if modal not visible 1`] = 
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -244,16 +245,20 @@ exports[`<IdentityCheckEnd/> should render correctly if modal not visible 1`] = 
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="Fermer la modale de propositions d'identifications avec ÉduConnect ou Démarches Simplifiées"
           >
             <View
-              height={18}
+              height={20}
               testID="rightIcon"
-              width={18}
+              width={20}
             >
               <Text>
                 rightIcon-SVG-Mock
@@ -951,7 +956,6 @@ exports[`<IdentityCheckEnd/> should render correctly if modal visible 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -971,8 +975,12 @@ exports[`<IdentityCheckEnd/> should render correctly if modal visible 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -982,11 +990,10 @@ exports[`<IdentityCheckEnd/> should render correctly if modal visible 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -1021,7 +1028,6 @@ exports[`<IdentityCheckEnd/> should render correctly if modal visible 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -1041,16 +1047,20 @@ exports[`<IdentityCheckEnd/> should render correctly if modal visible 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="Fermer la modale de propositions d'identifications avec ÉduConnect ou Démarches Simplifiées"
           >
             <View
-              height={18}
+              height={20}
               testID="rightIcon"
-              width={18}
+              width={20}
             >
               <Text>
                 rightIcon-SVG-Mock

--- a/__snapshots__/features/identityCheck/components/__test__/SomeAdviceBeforeIdentityCheckModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/__test__/SomeAdviceBeforeIdentityCheckModal.native.test.tsx.native-snap
@@ -150,7 +150,6 @@ exports[`<SomeAdviceBeforeIdentityCheckModal/> should render correctly 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -170,8 +169,12 @@ exports[`<SomeAdviceBeforeIdentityCheckModal/> should render correctly 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -181,11 +184,10 @@ exports[`<SomeAdviceBeforeIdentityCheckModal/> should render correctly 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -220,7 +222,6 @@ exports[`<SomeAdviceBeforeIdentityCheckModal/> should render correctly 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -240,16 +241,20 @@ exports[`<SomeAdviceBeforeIdentityCheckModal/> should render correctly 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="Fermer la modale de conseils pour avoir un document lisible"
           >
             <View
-              height={18}
+              height={20}
               testID="rightIcon"
-              width={18}
+              width={20}
             >
               <Text>
                 rightIcon-SVG-Mock

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckStart.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckStart.native.test.tsx.native-snap
@@ -546,7 +546,6 @@ Array [
                                   "flexGrow": 0.1,
                                   "flexShrink": 1,
                                   "justifyContent": "flex-start",
-                                  "paddingTop": 2,
                                 },
                               ]
                             }
@@ -566,8 +565,12 @@ Array [
                               onStartShouldSetResponder={[Function]}
                               style={
                                 Object {
-                                  "marginLeft": -5,
+                                  "marginLeft": -8,
                                   "opacity": 1,
+                                  "paddingBottom": 4,
+                                  "paddingLeft": 4,
+                                  "paddingRight": 4,
+                                  "paddingTop": 4,
                                 }
                               }
                               testID="leftIconButton"
@@ -577,11 +580,10 @@ Array [
                             style={
                               Array [
                                 Object {
-                                  "alignItems": "center",
                                   "flexBasis": 0,
                                   "flexGrow": 0.8,
                                   "flexShrink": 1,
-                                  "justifyContent": "flex-start",
+                                  "justifyContent": "center",
                                   "paddingLeft": 12,
                                   "paddingRight": 12,
                                   "zIndex": 1,
@@ -616,7 +618,6 @@ Array [
                                   "flexGrow": 0.1,
                                   "flexShrink": 1,
                                   "justifyContent": "flex-end",
-                                  "paddingTop": 2,
                                 },
                               ]
                             }
@@ -636,16 +637,20 @@ Array [
                               onStartShouldSetResponder={[Function]}
                               style={
                                 Object {
-                                  "marginRight": -5,
+                                  "marginRight": -8,
                                   "opacity": 1,
+                                  "paddingBottom": 4,
+                                  "paddingLeft": 4,
+                                  "paddingRight": 4,
+                                  "paddingTop": 4,
                                 }
                               }
                               testID="Fermer la modale pour transmettre un document sur le site Démarches Simplifiée"
                             >
                               <View
-                                height={18}
+                                height={20}
                                 testID="rightIcon"
-                                width={18}
+                                width={20}
                               >
                                 <Text>
                                   rightIcon-SVG-Mock
@@ -1168,7 +1173,6 @@ Array [
                   "flexGrow": 0.1,
                   "flexShrink": 1,
                   "justifyContent": "flex-start",
-                  "paddingTop": 2,
                 },
               ]
             }
@@ -1188,8 +1192,12 @@ Array [
               onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "marginLeft": -5,
+                  "marginLeft": -8,
                   "opacity": 1,
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
                 }
               }
               testID="leftIconButton"
@@ -1199,11 +1207,10 @@ Array [
             style={
               Array [
                 Object {
-                  "alignItems": "center",
                   "flexBasis": 0,
                   "flexGrow": 0.8,
                   "flexShrink": 1,
-                  "justifyContent": "flex-start",
+                  "justifyContent": "center",
                   "paddingLeft": 12,
                   "paddingRight": 12,
                   "zIndex": 1,
@@ -1238,7 +1245,6 @@ Array [
                   "flexGrow": 0.1,
                   "flexShrink": 1,
                   "justifyContent": "flex-end",
-                  "paddingTop": 2,
                 },
               ]
             }
@@ -1258,16 +1264,20 @@ Array [
               onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "marginRight": -5,
+                  "marginRight": -8,
                   "opacity": 1,
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
                 }
               }
               testID="Fermer la modale de conseils pour avoir un document lisible"
             >
               <View
-                height={18}
+                height={20}
                 testID="rightIcon"
-                width={18}
+                width={20}
               >
                 <Text>
                   rightIcon-SVG-Mock

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckUnavailable.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckUnavailable.test.tsx.native-snap
@@ -328,7 +328,6 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
                     "flexGrow": 0.1,
                     "flexShrink": 1,
                     "justifyContent": "flex-start",
-                    "paddingTop": 2,
                   },
                 ]
               }
@@ -348,8 +347,12 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
                 onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "marginLeft": -5,
+                    "marginLeft": -8,
                     "opacity": 1,
+                    "paddingBottom": 4,
+                    "paddingLeft": 4,
+                    "paddingRight": 4,
+                    "paddingTop": 4,
                   }
                 }
                 testID="leftIconButton"
@@ -359,11 +362,10 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
               style={
                 Array [
                   Object {
-                    "alignItems": "center",
                     "flexBasis": 0,
                     "flexGrow": 0.8,
                     "flexShrink": 1,
-                    "justifyContent": "flex-start",
+                    "justifyContent": "center",
                     "paddingLeft": 12,
                     "paddingRight": 12,
                     "zIndex": 1,
@@ -398,7 +400,6 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
                     "flexGrow": 0.1,
                     "flexShrink": 1,
                     "justifyContent": "flex-end",
-                    "paddingTop": 2,
                   },
                 ]
               }
@@ -418,16 +419,20 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
                 onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "marginRight": -5,
+                    "marginRight": -8,
                     "opacity": 1,
+                    "paddingBottom": 4,
+                    "paddingLeft": 4,
+                    "paddingRight": 4,
+                    "paddingTop": 4,
                   }
                 }
                 testID="Fermer la modale pour transmettre un document sur le site Démarches Simplifiée"
               >
                 <View
-                  height={18}
+                  height={20}
                   testID="rightIcon"
-                  width={18}
+                  width={20}
                 >
                   <Text>
                     rightIcon-SVG-Mock

--- a/__snapshots__/features/offer/components/__tests__/OfferHeader.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/__tests__/OfferHeader.native.test.tsx.native-snap
@@ -582,7 +582,6 @@ Array [
                   "flexGrow": 0.1,
                   "flexShrink": 1,
                   "justifyContent": "flex-start",
-                  "paddingTop": 2,
                 },
               ]
             }
@@ -600,8 +599,12 @@ Array [
               onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "marginLeft": -5,
+                  "marginLeft": -8,
                   "opacity": 1,
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
                 }
               }
               testID="leftIconButton"
@@ -611,11 +614,10 @@ Array [
             style={
               Array [
                 Object {
-                  "alignItems": "center",
                   "flexBasis": 0,
                   "flexGrow": 0.8,
                   "flexShrink": 1,
-                  "justifyContent": "flex-start",
+                  "justifyContent": "center",
                   "paddingLeft": 12,
                   "paddingRight": 12,
                   "zIndex": 1,
@@ -650,7 +652,6 @@ Array [
                   "flexGrow": 0.1,
                   "flexShrink": 1,
                   "justifyContent": "flex-end",
-                  "paddingTop": 2,
                 },
               ]
             }
@@ -668,16 +669,20 @@ Array [
               onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "marginRight": -5,
+                  "marginRight": -8,
                   "opacity": 1,
+                  "paddingBottom": 4,
+                  "paddingLeft": 4,
+                  "paddingRight": 4,
+                  "paddingTop": 4,
                 }
               }
               testID="Fermer la modale"
             >
               <View
-                height={18}
+                height={20}
                 testID="rightIcon"
-                width={18}
+                width={20}
               >
                 <Text>
                   rightIcon-SVG-Mock

--- a/__snapshots__/features/offer/components/__tests__/ReportOffer.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/__tests__/ReportOffer.native.test.tsx.native-snap
@@ -150,7 +150,6 @@ exports[`ReportOffer General modal behavior Report offer snapshots should displa
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -170,16 +169,20 @@ exports[`ReportOffer General modal behavior Report offer snapshots should displa
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
           >
             <View
-              height={18}
+              height={20}
               testID="leftIcon"
-              width={18}
+              width={20}
             >
               <Text>
                 leftIcon-SVG-Mock
@@ -191,11 +194,10 @@ exports[`ReportOffer General modal behavior Report offer snapshots should displa
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -230,7 +232,6 @@ exports[`ReportOffer General modal behavior Report offer snapshots should displa
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -250,16 +251,20 @@ exports[`ReportOffer General modal behavior Report offer snapshots should displa
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="Fermer la modale"
           >
             <View
-              height={18}
+              height={20}
               testID="rightIcon"
-              width={18}
+              width={20}
             >
               <Text>
                 rightIcon-SVG-Mock
@@ -470,7 +475,6 @@ exports[`ReportOffer General modal behavior Report offer snapshots should not di
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -490,16 +494,20 @@ exports[`ReportOffer General modal behavior Report offer snapshots should not di
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
           >
             <View
-              height={18}
+              height={20}
               testID="leftIcon"
-              width={18}
+              width={20}
             >
               <Text>
                 leftIcon-SVG-Mock
@@ -511,11 +519,10 @@ exports[`ReportOffer General modal behavior Report offer snapshots should not di
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -550,7 +557,6 @@ exports[`ReportOffer General modal behavior Report offer snapshots should not di
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -570,16 +576,20 @@ exports[`ReportOffer General modal behavior Report offer snapshots should not di
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="Fermer la modale"
           >
             <View
-              height={18}
+              height={20}
               testID="rightIcon"
-              width={18}
+              width={20}
             >
               <Text>
                 rightIcon-SVG-Mock

--- a/__snapshots__/features/offer/pages/tests/OfferBody.deprecated.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferBody.deprecated.native.test.tsx.native-snap
@@ -2092,7 +2092,6 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                                           "flexGrow": 0.1,
                                           "flexShrink": 1,
                                           "justifyContent": "flex-start",
-                                          "paddingTop": 2,
                                         },
                                       ]
                                     }
@@ -2110,8 +2109,12 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                                       onStartShouldSetResponder={[Function]}
                                       style={
                                         Object {
-                                          "marginLeft": -5,
+                                          "marginLeft": -8,
                                           "opacity": 1,
+                                          "paddingBottom": 4,
+                                          "paddingLeft": 4,
+                                          "paddingRight": 4,
+                                          "paddingTop": 4,
                                         }
                                       }
                                       testID="leftIconButton"
@@ -2121,11 +2124,10 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                                     style={
                                       Array [
                                         Object {
-                                          "alignItems": "center",
                                           "flexBasis": 0,
                                           "flexGrow": 0.8,
                                           "flexShrink": 1,
-                                          "justifyContent": "flex-start",
+                                          "justifyContent": "center",
                                           "paddingLeft": 12,
                                           "paddingRight": 12,
                                           "zIndex": 1,
@@ -2160,7 +2162,6 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                                           "flexGrow": 0.1,
                                           "flexShrink": 1,
                                           "justifyContent": "flex-end",
-                                          "paddingTop": 2,
                                         },
                                       ]
                                     }
@@ -2178,16 +2179,20 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                                       onStartShouldSetResponder={[Function]}
                                       style={
                                         Object {
-                                          "marginRight": -5,
+                                          "marginRight": -8,
                                           "opacity": 1,
+                                          "paddingBottom": 4,
+                                          "paddingLeft": 4,
+                                          "paddingRight": 4,
+                                          "paddingTop": 4,
                                         }
                                       }
                                       testID="Fermer la modale"
                                     >
                                       <View
-                                        height={18}
+                                        height={20}
                                         testID="rightIcon"
-                                        width={18}
+                                        width={20}
                                       >
                                         <Text>
                                           rightIcon-SVG-Mock
@@ -4966,7 +4971,6 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                                           "flexGrow": 0.1,
                                           "flexShrink": 1,
                                           "justifyContent": "flex-start",
-                                          "paddingTop": 2,
                                         },
                                       ]
                                     }
@@ -4984,8 +4988,12 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                                       onStartShouldSetResponder={[Function]}
                                       style={
                                         Object {
-                                          "marginLeft": -5,
+                                          "marginLeft": -8,
                                           "opacity": 1,
+                                          "paddingBottom": 4,
+                                          "paddingLeft": 4,
+                                          "paddingRight": 4,
+                                          "paddingTop": 4,
                                         }
                                       }
                                       testID="leftIconButton"
@@ -4995,11 +5003,10 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                                     style={
                                       Array [
                                         Object {
-                                          "alignItems": "center",
                                           "flexBasis": 0,
                                           "flexGrow": 0.8,
                                           "flexShrink": 1,
-                                          "justifyContent": "flex-start",
+                                          "justifyContent": "center",
                                           "paddingLeft": 12,
                                           "paddingRight": 12,
                                           "zIndex": 1,
@@ -5034,7 +5041,6 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                                           "flexGrow": 0.1,
                                           "flexShrink": 1,
                                           "justifyContent": "flex-end",
-                                          "paddingTop": 2,
                                         },
                                       ]
                                     }
@@ -5052,16 +5058,20 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                                       onStartShouldSetResponder={[Function]}
                                       style={
                                         Object {
-                                          "marginRight": -5,
+                                          "marginRight": -8,
                                           "opacity": 1,
+                                          "paddingBottom": 4,
+                                          "paddingLeft": 4,
+                                          "paddingRight": 4,
+                                          "paddingTop": 4,
                                         }
                                       }
                                       testID="Fermer la modale"
                                     >
                                       <View
-                                        height={18}
+                                        height={20}
                                         testID="rightIcon"
-                                        width={18}
+                                        width={20}
                                       >
                                         <Text>
                                           rightIcon-SVG-Mock

--- a/__snapshots__/features/offer/pages/tests/OfferBody.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferBody.native.test.tsx.native-snap
@@ -1256,7 +1256,6 @@ exports[`<OfferBody /> should open the report modal upon clicking on 'signaler l
                     "flexGrow": 0.1,
                     "flexShrink": 1,
                     "justifyContent": "flex-start",
-                    "paddingTop": 2,
                   },
                 ]
               }
@@ -1274,8 +1273,12 @@ exports[`<OfferBody /> should open the report modal upon clicking on 'signaler l
                 onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "marginLeft": -5,
+                    "marginLeft": -8,
                     "opacity": 1,
+                    "paddingBottom": 4,
+                    "paddingLeft": 4,
+                    "paddingRight": 4,
+                    "paddingTop": 4,
                   }
                 }
                 testID="leftIconButton"
@@ -1285,11 +1288,10 @@ exports[`<OfferBody /> should open the report modal upon clicking on 'signaler l
               style={
                 Array [
                   Object {
-                    "alignItems": "center",
                     "flexBasis": 0,
                     "flexGrow": 0.8,
                     "flexShrink": 1,
-                    "justifyContent": "flex-start",
+                    "justifyContent": "center",
                     "paddingLeft": 12,
                     "paddingRight": 12,
                     "zIndex": 1,
@@ -1324,7 +1326,6 @@ exports[`<OfferBody /> should open the report modal upon clicking on 'signaler l
                     "flexGrow": 0.1,
                     "flexShrink": 1,
                     "justifyContent": "flex-end",
-                    "paddingTop": 2,
                   },
                 ]
               }
@@ -1342,16 +1343,20 @@ exports[`<OfferBody /> should open the report modal upon clicking on 'signaler l
                 onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "marginRight": -5,
+                    "marginRight": -8,
                     "opacity": 1,
+                    "paddingBottom": 4,
+                    "paddingLeft": 4,
+                    "paddingRight": 4,
+                    "paddingTop": 4,
                   }
                 }
                 testID="Fermer la modale"
               >
                 <View
-                  height={18}
+                  height={20}
                   testID="rightIcon"
-                  width={18}
+                  width={20}
                 >
                   <Text>
                     rightIcon-SVG-Mock

--- a/__snapshots__/ui/components/modals/AppModal.test.tsx.native-snap
+++ b/__snapshots__/ui/components/modals/AppModal.test.tsx.native-snap
@@ -150,7 +150,6 @@ exports[`<AppModal /> on big screen 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -170,8 +169,12 @@ exports[`<AppModal /> on big screen 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -181,11 +184,10 @@ exports[`<AppModal /> on big screen 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -220,7 +222,6 @@ exports[`<AppModal /> on big screen 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -240,8 +241,12 @@ exports[`<AppModal /> on big screen 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="rightIconButton"
@@ -436,7 +441,6 @@ exports[`<AppModal /> on small screen 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -456,8 +460,12 @@ exports[`<AppModal /> on small screen 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -467,11 +475,10 @@ exports[`<AppModal /> on small screen 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -506,7 +513,6 @@ exports[`<AppModal /> on small screen 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -526,8 +532,12 @@ exports[`<AppModal /> on small screen 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="rightIconButton"
@@ -726,7 +736,6 @@ exports[`<AppModal /> when hidden 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -746,8 +755,12 @@ exports[`<AppModal /> when hidden 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -757,11 +770,10 @@ exports[`<AppModal /> when hidden 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -796,7 +808,6 @@ exports[`<AppModal /> when hidden 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -816,8 +827,12 @@ exports[`<AppModal /> when hidden 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="rightIconButton"
@@ -987,7 +1002,6 @@ exports[`<AppModal /> with backdrop disabled 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -1007,8 +1021,12 @@ exports[`<AppModal /> with backdrop disabled 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -1018,11 +1036,10 @@ exports[`<AppModal /> with backdrop disabled 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -1057,7 +1074,6 @@ exports[`<AppModal /> with backdrop disabled 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -1077,8 +1093,12 @@ exports[`<AppModal /> with backdrop disabled 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="rightIconButton"
@@ -1273,7 +1293,6 @@ exports[`<AppModal /> with backdrop enabled by default 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -1293,8 +1312,12 @@ exports[`<AppModal /> with backdrop enabled by default 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -1304,11 +1327,10 @@ exports[`<AppModal /> with backdrop enabled by default 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -1343,7 +1365,6 @@ exports[`<AppModal /> with backdrop enabled by default 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -1363,8 +1384,12 @@ exports[`<AppModal /> with backdrop enabled by default 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="rightIconButton"
@@ -1559,7 +1584,6 @@ exports[`<AppModal /> with backdrop explicitly enabled 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -1579,8 +1603,12 @@ exports[`<AppModal /> with backdrop explicitly enabled 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -1590,11 +1618,10 @@ exports[`<AppModal /> with backdrop explicitly enabled 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -1629,7 +1656,6 @@ exports[`<AppModal /> with backdrop explicitly enabled 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -1649,8 +1675,12 @@ exports[`<AppModal /> with backdrop explicitly enabled 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="rightIconButton"
@@ -1845,7 +1875,6 @@ exports[`<AppModal /> with left icon render 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -1865,16 +1894,20 @@ exports[`<AppModal /> with left icon render 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="Revenir à l'étape précédente"
           >
             <View
-              height={18}
+              height={20}
               testID="leftIcon"
-              width={18}
+              width={20}
             >
               <Text>
                 leftIcon-SVG-Mock
@@ -1886,11 +1919,10 @@ exports[`<AppModal /> with left icon render 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -1925,7 +1957,6 @@ exports[`<AppModal /> with left icon render 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -1945,8 +1976,12 @@ exports[`<AppModal /> with left icon render 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="rightIconButton"
@@ -2141,7 +2176,6 @@ exports[`<AppModal /> with long title on 1 line 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -2161,8 +2195,12 @@ exports[`<AppModal /> with long title on 1 line 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -2172,11 +2210,10 @@ exports[`<AppModal /> with long title on 1 line 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -2211,7 +2248,6 @@ exports[`<AppModal /> with long title on 1 line 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -2231,8 +2267,12 @@ exports[`<AppModal /> with long title on 1 line 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="rightIconButton"
@@ -2427,7 +2467,6 @@ exports[`<AppModal /> with long title on 2 lines by default 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -2447,8 +2486,12 @@ exports[`<AppModal /> with long title on 2 lines by default 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -2458,11 +2501,10 @@ exports[`<AppModal /> with long title on 2 lines by default 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -2497,7 +2539,6 @@ exports[`<AppModal /> with long title on 2 lines by default 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -2517,8 +2558,12 @@ exports[`<AppModal /> with long title on 2 lines by default 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="rightIconButton"
@@ -2713,7 +2758,6 @@ exports[`<AppModal /> with minimal props 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -2733,8 +2777,12 @@ exports[`<AppModal /> with minimal props 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -2744,11 +2792,10 @@ exports[`<AppModal /> with minimal props 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -2783,7 +2830,6 @@ exports[`<AppModal /> with minimal props 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -2803,8 +2849,12 @@ exports[`<AppModal /> with minimal props 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="rightIconButton"
@@ -2999,7 +3049,6 @@ exports[`<AppModal /> with right icon render 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -3019,8 +3068,12 @@ exports[`<AppModal /> with right icon render 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -3030,11 +3083,10 @@ exports[`<AppModal /> with right icon render 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -3069,7 +3121,6 @@ exports[`<AppModal /> with right icon render 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -3089,16 +3140,20 @@ exports[`<AppModal /> with right icon render 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="Fermer la modale et annuler"
           >
             <View
-              height={18}
+              height={20}
               testID="rightIcon"
-              width={18}
+              width={20}
             >
               <Text>
                 rightIcon-SVG-Mock
@@ -3295,7 +3350,6 @@ exports[`<AppModal /> with scroll disabled 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -3315,8 +3369,12 @@ exports[`<AppModal /> with scroll disabled 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -3326,11 +3384,10 @@ exports[`<AppModal /> with scroll disabled 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -3365,7 +3422,6 @@ exports[`<AppModal /> with scroll disabled 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -3385,8 +3441,12 @@ exports[`<AppModal /> with scroll disabled 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="rightIconButton"
@@ -3581,7 +3641,6 @@ exports[`<AppModal /> with scroll enabled by default 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -3601,8 +3660,12 @@ exports[`<AppModal /> with scroll enabled by default 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -3612,11 +3675,10 @@ exports[`<AppModal /> with scroll enabled by default 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -3651,7 +3713,6 @@ exports[`<AppModal /> with scroll enabled by default 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -3671,8 +3732,12 @@ exports[`<AppModal /> with scroll enabled by default 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="rightIconButton"
@@ -3867,7 +3932,6 @@ exports[`<AppModal /> with scroll explicitly enabled 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -3887,8 +3951,12 @@ exports[`<AppModal /> with scroll explicitly enabled 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -3898,11 +3966,10 @@ exports[`<AppModal /> with scroll explicitly enabled 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -3937,7 +4004,6 @@ exports[`<AppModal /> with scroll explicitly enabled 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -3957,8 +4023,12 @@ exports[`<AppModal /> with scroll explicitly enabled 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="rightIconButton"
@@ -4153,7 +4223,6 @@ exports[`<AppModal /> without children 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -4173,8 +4242,12 @@ exports[`<AppModal /> without children 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -4184,11 +4257,10 @@ exports[`<AppModal /> without children 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -4223,7 +4295,6 @@ exports[`<AppModal /> without children 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -4243,8 +4314,12 @@ exports[`<AppModal /> without children 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="rightIconButton"
@@ -4435,7 +4510,6 @@ exports[`<AppModal /> without title 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-start",
-                "paddingTop": 2,
               },
             ]
           }
@@ -4455,8 +4529,12 @@ exports[`<AppModal /> without title 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginLeft": -5,
+                "marginLeft": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="leftIconButton"
@@ -4466,11 +4544,10 @@ exports[`<AppModal /> without title 1`] = `
           style={
             Array [
               Object {
-                "alignItems": "center",
                 "flexBasis": 0,
                 "flexGrow": 0.8,
                 "flexShrink": 1,
-                "justifyContent": "flex-start",
+                "justifyContent": "center",
                 "paddingLeft": 12,
                 "paddingRight": 12,
                 "zIndex": 1,
@@ -4505,7 +4582,6 @@ exports[`<AppModal /> without title 1`] = `
                 "flexGrow": 0.1,
                 "flexShrink": 1,
                 "justifyContent": "flex-end",
-                "paddingTop": 2,
               },
             ]
           }
@@ -4525,8 +4601,12 @@ exports[`<AppModal /> without title 1`] = `
             onStartShouldSetResponder={[Function]}
             style={
               Object {
-                "marginRight": -5,
+                "marginRight": -8,
                 "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
               }
             }
             testID="rightIconButton"

--- a/__snapshots__/ui/components/modals/AppModal.test.tsx.web-snap
+++ b/__snapshots__/ui/components/modals/AppModal.test.tsx.web-snap
@@ -51,19 +51,19 @@ Object {
                   >
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                     >
                       <div
                         aria-label="leftIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="leftIconButton"
-                        style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                      style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
@@ -75,13 +75,13 @@ Object {
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                     >
                       <div
                         aria-label="rightIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="rightIconButton"
-                        style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
@@ -230,19 +230,19 @@ Object {
                   >
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                     >
                       <div
                         aria-label="leftIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="leftIconButton"
-                        style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                      style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
@@ -254,13 +254,13 @@ Object {
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                     >
                       <div
                         aria-label="rightIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="rightIconButton"
-                        style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
@@ -467,20 +467,20 @@ Object {
                   >
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                     >
                       <div
                         aria-label="leftIconButton"
                         class="css-view-1dbjc4n"
                         data-focusvisible-polyfill="true"
                         data-testid="leftIconButton"
-                        style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                      style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
@@ -492,13 +492,13 @@ Object {
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                     >
                       <div
                         aria-label="rightIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="rightIconButton"
-                        style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
@@ -647,19 +647,19 @@ Object {
                   >
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                     >
                       <div
                         aria-label="leftIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="leftIconButton"
-                        style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                      style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
@@ -671,13 +671,13 @@ Object {
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                     >
                       <div
                         aria-label="rightIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="rightIconButton"
-                        style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
@@ -826,19 +826,19 @@ Object {
                   >
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                     >
                       <div
                         aria-label="leftIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="leftIconButton"
-                        style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                      style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
@@ -850,13 +850,13 @@ Object {
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                     >
                       <div
                         aria-label="rightIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="rightIconButton"
-                        style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
@@ -1005,13 +1005,13 @@ Object {
                   >
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                     >
                       <div
                         aria-label="Revenir à l'étape précédente"
                         class="css-view-1dbjc4n"
                         data-testid="Revenir à l'étape précédente"
-                        style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       >
                         <div
@@ -1029,7 +1029,7 @@ Object {
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                      style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
@@ -1041,13 +1041,13 @@ Object {
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                     >
                       <div
                         aria-label="rightIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="rightIconButton"
-                        style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
@@ -1196,19 +1196,19 @@ Object {
                   >
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                     >
                       <div
                         aria-label="leftIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="leftIconButton"
-                        style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                      style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                     >
                       <div
                         class="css-text-901oao css-textOneLine-vcwn7f"
@@ -1220,13 +1220,13 @@ Object {
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                     >
                       <div
                         aria-label="rightIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="rightIconButton"
-                        style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
@@ -1375,19 +1375,19 @@ Object {
                   >
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                     >
                       <div
                         aria-label="leftIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="leftIconButton"
-                        style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                      style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
@@ -1399,13 +1399,13 @@ Object {
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                     >
                       <div
                         aria-label="rightIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="rightIconButton"
-                        style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
@@ -1552,19 +1552,19 @@ Object {
                   >
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                     >
                       <div
                         aria-label="leftIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="leftIconButton"
-                        style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                      style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
@@ -1576,13 +1576,13 @@ Object {
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                     >
                       <div
                         aria-label="rightIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="rightIconButton"
-                        style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
@@ -1731,19 +1731,19 @@ Object {
                   >
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                     >
                       <div
                         aria-label="leftIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="leftIconButton"
-                        style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                      style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
@@ -1755,13 +1755,13 @@ Object {
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                     >
                       <div
                         aria-label="Fermer la modale et annuler"
                         class="css-view-1dbjc4n"
                         data-testid="Fermer la modale et annuler"
-                        style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       >
                         <div
@@ -1922,19 +1922,19 @@ Object {
                   >
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                     >
                       <div
                         aria-label="leftIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="leftIconButton"
-                        style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                      style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
@@ -1946,13 +1946,13 @@ Object {
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                     >
                       <div
                         aria-label="rightIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="rightIconButton"
-                        style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
@@ -2101,19 +2101,19 @@ Object {
                   >
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                     >
                       <div
                         aria-label="leftIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="leftIconButton"
-                        style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                      style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
@@ -2125,13 +2125,13 @@ Object {
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                     >
                       <div
                         aria-label="rightIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="rightIconButton"
-                        style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
@@ -2280,19 +2280,19 @@ Object {
                   >
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                     >
                       <div
                         aria-label="leftIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="leftIconButton"
-                        style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                      style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
@@ -2304,13 +2304,13 @@ Object {
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                     >
                       <div
                         aria-label="rightIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="rightIconButton"
-                        style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
@@ -2459,19 +2459,19 @@ Object {
                   >
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                     >
                       <div
                         aria-label="leftIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="leftIconButton"
-                        style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                      style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
@@ -2483,13 +2483,13 @@ Object {
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                     >
                       <div
                         aria-label="rightIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="rightIconButton"
-                        style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
@@ -2631,19 +2631,19 @@ Object {
                   >
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-start;"
                     >
                       <div
                         aria-label="leftIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="leftIconButton"
-                        style="cursor: pointer; margin-left: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-left: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: center; flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: flex-start; padding-left: 12px; padding-right: 12px; z-index: 1;"
+                      style="flex-basis: 0px; flex-grow: 0.8; flex-shrink: 1; justify-content: center; padding-left: 12px; padding-right: 12px; z-index: 1;"
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
@@ -2653,13 +2653,13 @@ Object {
                     </div>
                     <div
                       class="css-view-1dbjc4n"
-                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end; padding-top: 2px;"
+                      style="align-items: flex-start; flex-basis: 0px; flex-direction: row; flex-grow: 0.1; flex-shrink: 1; justify-content: flex-end;"
                     >
                       <div
                         aria-label="rightIconButton"
                         class="css-view-1dbjc4n"
                         data-testid="rightIconButton"
-                        style="cursor: pointer; margin-right: -5px; transition-duration: 0s; transition-property: opacity; user-select: none;"
+                        style="cursor: pointer; margin-right: -8px; padding: 4px 4px 4px 4px; transition-duration: 0s; transition-property: opacity; user-select: none;"
                         tabindex="0"
                       />
                     </div>

--- a/src/ui/components/modals/ModalHeader.tsx
+++ b/src/ui/components/modals/ModalHeader.tsx
@@ -34,7 +34,7 @@ export const ModalHeader: FunctionComponent<ModalHeaderProps> = ({
         <LeftHeaderAction
           onPress={onLeftIconPress}
           {...accessibilityAndTestId(leftIconAccessibilityLabel)}>
-          {!!LeftIcon && <LeftIcon size={18} testID="leftIcon" />}
+          {!!LeftIcon && <LeftIcon size={getSpacing(5)} testID="leftIcon" />}
         </LeftHeaderAction>
       </LeftHeaderActionContainer>
       <TitleContainer>
@@ -44,7 +44,7 @@ export const ModalHeader: FunctionComponent<ModalHeaderProps> = ({
         <RightHeaderAction
           onPress={onRightIconPress}
           {...accessibilityAndTestId(rightIconAccessibilityLabel)}>
-          {!!RightIcon && <RightIcon size={18} testID="rightIcon" />}
+          {!!RightIcon && <RightIcon size={getSpacing(5)} testID="rightIcon" />}
         </RightHeaderAction>
       </RightHeaderActionContainer>
     </HeaderContainer>
@@ -59,34 +59,38 @@ const HeaderContainer = styled.View({
 })
 
 const TitleContainer = styled.View({
-  justifyContent: 'flex-start',
-  alignItems: 'center',
+  justifyContent: 'center',
   paddingRight: getSpacing(3),
   paddingLeft: getSpacing(3),
   flex: 0.8,
   zIndex: ZIndex.MODAL_HEADER,
 })
 
+const LeftHeaderActionContainer = styled.View({
+  flexDirection: 'row',
+  flex: 0.1,
+  alignItems: 'flex-start',
+  justifyContent: 'flex-start',
+})
+
 const RightHeaderActionContainer = styled.View({
-  paddingTop: getSpacing(0.5),
   flexDirection: 'row',
   flex: 0.1,
   alignItems: 'flex-start',
   justifyContent: 'flex-end',
 })
 
-const LeftHeaderActionContainer = styled.View({
-  flexDirection: 'row',
-  paddingTop: getSpacing(0.5),
-  flex: 0.1,
-  alignItems: 'flex-start',
-  justifyContent: 'flex-start',
-})
-
 /* The negative margins are used to compensate for the
  "empty" space of SVG icons. */
-const LeftHeaderAction = styled.TouchableOpacity({ marginLeft: -5 })
-const RightHeaderAction = styled.TouchableOpacity({ marginRight: -5 })
+const LeftHeaderAction = styled.TouchableOpacity({
+  marginLeft: -getSpacing(2),
+  padding: getSpacing(1),
+})
+
+const RightHeaderAction = styled.TouchableOpacity({
+  marginRight: -getSpacing(2),
+  padding: getSpacing(1),
+})
 
 const Title = styled(Typo.Title4)({ textAlign: 'center' })
 const BoldTitle = styled(Typo.Title3)({ textAlign: 'center' })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12511

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.

## Screenshots

| Plateforme | Avant | Après |
| --- | --- | --- |
| Web | <img width="1081" alt="avant web" src="https://user-images.githubusercontent.com/10118284/148441490-643ff2e9-e8d9-492e-b473-45404070fe2b.png"> | <img width="1050" alt="après web" src="https://user-images.githubusercontent.com/10118284/148441497-6caa3a5f-4fda-4f5e-997f-ff55b431732b.png"> | 
| Mobile | <img width="343" alt="avant mobile" src="https://user-images.githubusercontent.com/10118284/148441546-6b9c9311-3650-4b99-82fa-4354187f0999.png"> | <img width="342" alt="après mobile" src="https://user-images.githubusercontent.com/10118284/148441563-c1d32a0f-3367-458e-96f9-5381824ade9c.png"> |

### Plusieurs lignes
<img width="355" alt="Capture d’écran 2022-01-07 à 11 06 34" src="https://user-images.githubusercontent.com/10118284/148528245-afccdfa0-dcee-424f-8ccb-ee8f690ee647.png">

### Sans highlighting
<img width="340" alt="after without" src="https://user-images.githubusercontent.com/10118284/148441639-6af50144-73f7-4a6b-8132-ab6905a8c02d.png">


[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md

