### PR TITLE
(PC-9881) feat(url): highlight URL even without http://

### DIFF
--- a/src/libs/parsers/highlightLinks.tsx
+++ b/src/libs/parsers/highlightLinks.tsx
@@ -6,7 +6,7 @@ import { ExternalLink } from 'ui/components/buttons/externalLink/ExternalLink'
 export type ParsedDescription = Array<string | React.ReactNode>
 
 const externalUrlRegex = new RegExp(
-  /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/,
+  /((?<=^|\s)|https?:\/\/)[a-z]([-a-z0-9@:%._+~#=]*[a-z0-9])?\.[a-z0-9]{1,6}([/?#]\S*)?(?=\s|$)/,
   'gi'
 )
 
@@ -31,17 +31,25 @@ export const customFindUrlChunks = ({ textToHighlight }: FindChunksArgs): Chunk[
   return chunks
 }
 
+const normalizeURL = (partialURL: string): string => {
+  if (partialURL.startsWith('http://')) return partialURL
+  if (partialURL.startsWith('https://')) return partialURL
+  return `http://${partialURL}`
+}
+
 export const highlightLinks = (description: string): ParsedDescription => {
   const chunks = findAll({
     searchWords: [],
     findChunks: customFindUrlChunks,
     textToHighlight: description,
   })
-  return chunks.map(({ start, end, highlight }, index) =>
-    highlight ? (
-      <ExternalLink key={`external-link-${index}`} url={description.slice(start, end)} />
+
+  return chunks.map(({ start, end, highlight }, index) => {
+    const url = normalizeURL(description.slice(start, end))
+    return highlight ? (
+      <ExternalLink key={`external-link-${index}`} url={url} />
     ) : (
       description.slice(start, end)
     )
-  )
+  })
 }

--- a/src/libs/parsers/tests/highlightLinks.test.tsx
+++ b/src/libs/parsers/tests/highlightLinks.test.tsx
@@ -9,7 +9,7 @@ const description1WithoutUrl = `PRESSE / ILS EN PARLENT !
 « Irrésistible ! » Elle
 « Intelligent et revigorant » Le Parisien
 « Hilarant » Vanity Fair 
-Voir plus de critiques en suivant le lien suivant : `
+Voir plus de critiques en suivant le lien suivant :`
 
 const description1 = description1WithoutUrl + 'https://fauxliencritique.com/'
 
@@ -40,13 +40,118 @@ describe('customFindUrlChunks', () => {
 })
 
 describe('highlightLinks', () => {
-  it('transforms a description into an array of strings or <ExternalLink/>', () => {
-    const parsedDescription = highlightLinks(description1)
-    expect(parsedDescription.length).toBe(2)
-    expect(parsedDescription[0]).toEqual(description1WithoutUrl)
-    expect(typeof parsedDescription[1]).toBe('object')
-    expect(JSON.stringify(parsedDescription[1])).toBe(
-      JSON.stringify(<ExternalLink key="external-link-1" url="https://fauxliencritique.com/" />)
-    )
+  describe('transforms a description into an array of strings or <ExternalLink/>', () => {
+    describe('composition', () => {
+      describe('protocol', () => {
+        it('without protocol', () => {
+          const parsedDescription = highlightLinks('perdu.com')
+
+          expect(parsedDescription).toEqual([
+            <ExternalLink key="external-link-0" url="http://perdu.com" />,
+          ])
+        })
+
+        it('with http protocol', () => {
+          const parsedDescription = highlightLinks('http://penofchaos.com/')
+
+          expect(parsedDescription).toEqual([
+            <ExternalLink key="external-link-0" url="http://penofchaos.com/" />,
+          ])
+        })
+
+        it('with https protocol', () => {
+          const parsedDescription = highlightLinks('https://kaamelott.com')
+
+          expect(parsedDescription).toEqual([
+            <ExternalLink key="external-link-0" url="https://kaamelott.com" />,
+          ])
+        })
+      })
+
+      it('with subdomain', () => {
+        const parsedDescription = highlightLinks('www.penofchaos.com')
+
+        expect(parsedDescription).toEqual([
+          <ExternalLink key="external-link-0" url="http://www.penofchaos.com" />,
+        ])
+      })
+
+      it('with path', () => {
+        const parsedDescription = highlightLinks('httpstat.us/418')
+
+        expect(parsedDescription).toEqual([
+          <ExternalLink key="external-link-0" url="http://httpstat.us/418" />,
+        ])
+      })
+
+      it('with query params', () => {
+        const parsedDescription = highlightLinks('httpstat.us/200?sleep=500')
+
+        expect(parsedDescription).toEqual([
+          <ExternalLink key="external-link-0" url="http://httpstat.us/200?sleep=500" />,
+        ])
+      })
+
+      it('with hash', () => {
+        const parsedDescription = highlightLinks('httpstat.us#anchor')
+
+        expect(parsedDescription).toEqual([
+          <ExternalLink key="external-link-0" url="http://httpstat.us#anchor" />,
+        ])
+      })
+    })
+
+    describe('position', () => {
+      describe('without protocol', () => {
+        it('must be preceded by space', () => {
+          const parsedDescription = highlightLinks(
+            `${description1WithoutUrl} www.penofchaos.com/warham/donjon.htm`
+          )
+
+          expect(parsedDescription).toEqual([
+            `${description1WithoutUrl} `,
+            <ExternalLink
+              key="external-link-1"
+              url="http://www.penofchaos.com/warham/donjon.htm"
+            />,
+          ])
+        })
+
+        it('is not recognized without a previous space', () => {
+          const description = `${description1WithoutUrl}www.penofchaos.com/warham/donjon.htm`
+
+          const parsedDescription = highlightLinks(description)
+
+          expect(parsedDescription).toEqual([description])
+        })
+      })
+
+      describe('with protocol', () => {
+        it('can begin without space', () => {
+          const parsedDescription = highlightLinks(
+            `${description1WithoutUrl}http://www.penofchaos.com/warham/donjon.htm`
+          )
+
+          expect(parsedDescription).toEqual([
+            description1WithoutUrl,
+            <ExternalLink
+              key="external-link-1"
+              url="http://www.penofchaos.com/warham/donjon.htm"
+            />,
+          ])
+        })
+      })
+
+      it('must be followed by space', () => {
+        const parsedDescription = highlightLinks(
+          `www.penofchaos.com/warham/donjon.htm ${description1WithoutUrl}`
+        )
+
+        expect(parsedDescription).toEqual([
+          <ExternalLink key="external-link-0" url="http://www.penofchaos.com/warham/donjon.htm" />,
+          ` ${description1WithoutUrl}`,
+        ])
+      })
+    })
   })
 })

--- a/src/libs/parsers/tests/highlightLinks.test.tsx
+++ b/src/libs/parsers/tests/highlightLinks.test.tsx
@@ -21,14 +21,16 @@ some text here as well https://www.google.com/?key=valeu&key2=value2 Lorem ipsum
 https://www.google.com/`
 
 describe('customFindUrlChunks', () => {
-  it('finds url chunks and mark them as highlited', () => {
+  it('finds url chunk and mark it as highlited', () => {
     const highlightedChunks1 = customFindUrlChunks({
       textToHighlight: description1,
       searchWords: [],
     })
     expect(highlightedChunks1.length).toBe(1)
     expect(description1.slice(0, highlightedChunks1[0].start)).toBe(description1WithoutUrl)
+  })
 
+  it('finds url chunks and mark them as highlited', () => {
     const highlightedChunks2 = customFindUrlChunks({
       textToHighlight: description2,
       searchWords: [],


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-9881

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.

## Screenshots

|Input coté Pro|Affichage Firefox Desktop (avant)|Affichage Firefox Desktop (après)|
|:--:|:--:|:--:|
|![image](https://user-images.githubusercontent.com/95220086/148574336-6e43b663-130c-4a09-be57-6ddd1a352dd2.png)|![image](https://user-images.githubusercontent.com/95220086/148575230-e4ce6152-a52c-4784-8401-186994205a65.png)|![image](https://user-images.githubusercontent.com/95220086/148574383-07e793ad-b273-4985-a238-6bcc553542ab.png)|


[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
