### PR TITLE
(PC-12395) fix(SupportedBrowsersGate): Add FacebookMessenger to supported browsers gate

### DIFF
--- a/src/web/SupportedBrowsersGate.tsx
+++ b/src/web/SupportedBrowsersGate.tsx
@@ -5,6 +5,10 @@ import { StyleSheet, ScrollView, View, Text, TouchableOpacity } from 'react-nati
 
 const browserVersion = Number(DeviceDetect.browserVersion)
 
+const isFacebookMessenger = !!(
+  navigator?.userAgent?.match?.(/(iPod|iPhone|iPad)/) && navigator?.userAgent?.match?.(/FBAV/i)
+)
+
 export const SupportedBrowsersGate: React.FC = ({ children }) => {
   const [shouldDisplayApp, setShouldDisplayApp] = React.useState(() => isBrowserSupported())
 
@@ -19,6 +23,7 @@ const supportedBrowsers: Array<{
   active: boolean
   version: number
 }> = [
+  { message: 'Facebook Messenger', active: isFacebookMessenger, version: 1 },
   { message: 'Chrome', active: DeviceDetect.isChrome, version: 50 },
   { message: 'Safari sur iOS', active: DeviceDetect.isMobileSafari, version: 12 },
   { message: 'Safari sur macOS', active: DeviceDetect.isSafari, version: 10 },


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12395

Testé sur messenger version iOS sur iPhone.

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
