### PR TITLE
(PC-12709) refactor(icons): update icon separation in cheatcodes

### DIFF
--- a/src/features/cheatcodes/pages/AppComponents/Icons.tsx
+++ b/src/features/cheatcodes/pages/AppComponents/Icons.tsx
@@ -103,85 +103,11 @@ export const Icons: FunctionComponent = () => {
       <Spacer.Column numberOfSpaces={4} />
       <IdentityCheckIcons />
       <Spacer.Column numberOfSpaces={4} />
-      <Icon name="BicolorAroundMe" component={BicolorAroundMe} isNew />
-      <Icon name="BicolorBookings" component={BicolorBookings} isNew />
-      <Icon name="BicolorConfidentiality" component={BicolorConfidentiality} isNew />
-      <Icon name="BicolorEverywhere" component={BicolorEverywhere} isNew />
-      <Icon name="BicolorFavorite" component={BicolorFavorite} isNew />
-      <Icon
-        name="BicolorIdCardWithMagnifyingGlass"
-        component={BicolorIdCardWithMagnifyingGlass}
-        isNew
-      />
-      <Icon name="BicolorLock" component={BicolorLock} isNew />
-      <Icon name="BicolorLocationPointer" component={BicolorLocationPointer} isNew />
-      <Icon name="BicolorLocationBuilding" component={BicolorLocationBuilding} isNew />
-      <Icon name="BicolorLogo" component={BicolorLogo} isNew />
-      <Icon name="BicolorProfile" component={BicolorProfile} isNew />
-      <Icon name="BicolorSearch" component={BicolorSearch} isNew />
-      <AlignedText>
-        <BicolorSelector width={ICON_SIZE} height={getSpacing(1)} />
-        <Text> - BicolorSelector </Text>
-      </AlignedText>
-      <Icon name="Again" component={Again} isNew />
-      <Icon name="ArrowNext" component={ArrowNext} isNew />
-      <Icon name="ArrowPrevious" component={ArrowPrevious} isNew />
-      <Icon name="Bell" component={Bell} isNew />
-      <Icon name="Booking" component={Booking} isNew />
-      <Icon name="Calendar" component={Calendar} isNew />
-      <Icon name="Check" component={Check} isNew />
-      <Icon name="Clock" component={Clock} isNew />
-      <Icon name="Close" component={Close} isNew />
-      <Icon name="Confidentiality" component={Confidentiality} isNew />
-      <Icon name="Digital" component={Digital} isNew />
-      <Icon name="Duo" component={Duo} isNew />
-      <Icon name="EditPen" component={EditPen} isNew />
-      <Icon name="Email" component={Email} isNew />
-      <Icon name="EmailFilled" component={EmailFilled} isNew />
-      <Icon name="Error" component={Error} isNew />
-      <Icon name="ExternalSite" component={ExternalSite} isNew />
-      <Icon name="ExternalSiteFilled" component={ExternalSiteFilled} isNew />
-      <Icon name="Eye" component={Eye} isNew />
-      <Icon name="EyeSlash" component={EyeSlash} isNew />
-      <Icon name="Favorite" component={Favorite} isNew />
-      <Icon name="FavoriteFilled" component={FavoriteFilled} isNew />
-      <Icon name="Flag" component={Flag} />
-      <Icon name="Flash" component={Flash} isNew />
-      <Icon name="HandicapVisual" component={HandicapVisual} isNew />
-      <Icon name="HandicapMental" component={HandicapMental} isNew />
-      <Icon name="HandicapMotor" component={HandicapMotor} isNew />
-      <Icon name="HandicapAudio" component={HandicapAudio} isNew />
-      <Icon name="Info" component={Info} isNew />
-      <Icon name="InfoFraud" component={InfoFraud} isNew />
-      <Icon name="InfoPlain" component={InfoPlain} isNew />
-      <Icon name="Invalidate" component={Invalidate} isNew />
-      <Icon name="Key" component={Key} isNew />
-      <Icon name="LegalNotices" component={LegalNotices} isNew />
-      <Icon name="LifeBuoy" component={LifeBuoy} isNew />
-      <Icon name="LocationBuilding" component={LocationBuilding} isNew />
-      <Icon name="LocationPointer" component={LocationPointer} isNew />
-      <Icon name="LocationPointerNotFilled" component={LocationPointerNotFilled} isNew />
-      <Icon name="Lock" component={Lock} isNew />
-      <Icon name="Logo" component={Logo} />
-      <Icon name="MagnifyingGlass" component={MagnifyingGlass} isNew />
-      <Icon name="NoOffer" component={NoOffer} />
-      <Icon name="OfferDigital" component={OfferDigital} isNew />
-      <Icon name="OfferEvent" component={OfferEvent} isNew />
-      <Icon name="OfferPhysical" component={OfferPhysical} isNew />
-      <Icon name="Offers" component={Offers} isNew />
-      <Icon name="OrderPrice" component={OrderPrice} isNew />
-      <Icon name="PhoneFilled" component={PhoneFilled} isNew />
-      <Icon name="PlainArrowPrevious" component={PlainArrowPrevious} isNew />
-      <Icon name="ProfileDeletion" component={ProfileDeletion} isNew />
-      <Icon name="Quote" component={Quote} isNew />
-      <Icon name="RequestSent" component={RequestSent} />
-      <Icon name="SignOut" component={SignOut} isNew />
-      <Icon name="Share" component={Share} isNew />
-      <Icon name="Sun" component={Sun} isNew />
-      <Icon name="Validate" component={Validate} isNew />
-      <Icon name="SadFace" component={SadFace} />
-      <Icon name="HappyFace" component={HappyFace} />
-      <Icon name="Warning" component={Warning} isNew />
+      <SecondaryAndBiggerIcons />
+      <Spacer.Column numberOfSpaces={4} />
+      <TertiaryAndSmallerIcons />
+      <Spacer.Column numberOfSpaces={4} />
+      <Text> Icônes à uniformiser (conversion en illustrations) </Text>
       <AlignedText>
         <TicketBooked width={ICON_SIZE} height={ICON_SIZE} />
         <Text> - TicketBooked </Text>
@@ -260,6 +186,103 @@ const IdentityCheckIcons = () => {
       <Icon name="Profile" component={Profile} isNew />
       <Icon name="IdCard" component={IdCard} isNew />
       <Icon name="Confirmation" component={Confirmation} isNew />
+      <Text>{'\n'}</Text>
+    </React.Fragment>
+  )
+}
+
+const TertiaryAndSmallerIcons = () => {
+  return (
+    <React.Fragment>
+      <Text>{'Tertiary and smaller plain Icons ( <= 20x20 )'}</Text>
+      <Icon name="Again" component={Again} isNew />
+      <Icon name="Digital" component={Digital} isNew />
+      <Icon name="EditPen" component={EditPen} isNew />
+      <Icon name="EmailFilled" component={EmailFilled} isNew />
+      <Icon name="ExternalSiteFilled" component={ExternalSiteFilled} isNew />
+      <Icon name="InfoPlain" component={InfoPlain} isNew />
+      <Icon name="Invalidate" component={Invalidate} isNew />
+      <Icon name="Key" component={Key} isNew />
+      <Icon name="LocationPointer" component={LocationPointer} isNew />
+      <Icon name="PhoneFilled" component={PhoneFilled} isNew />
+      <Icon name="PlainArrowPrevious" component={PlainArrowPrevious} isNew />
+      <Icon name="Validate" component={Validate} isNew />
+      <Text>{'\n'}</Text>
+    </React.Fragment>
+  )
+}
+
+const SecondaryAndBiggerIcons = () => {
+  return (
+    <React.Fragment>
+      <Text>{'Secondary and bigger Icons ( > 20x20 )'}</Text>
+      <Icon name="BicolorAroundMe" component={BicolorAroundMe} isNew />
+      <Icon name="BicolorBookings" component={BicolorBookings} isNew />
+      <Icon name="BicolorConfidentiality" component={BicolorConfidentiality} isNew />
+      <Icon name="BicolorEverywhere" component={BicolorEverywhere} isNew />
+      <Icon name="BicolorFavorite" component={BicolorFavorite} isNew />
+      <Icon
+        name="BicolorIdCardWithMagnifyingGlass"
+        component={BicolorIdCardWithMagnifyingGlass}
+        isNew
+      />
+      <Icon name="BicolorLock" component={BicolorLock} isNew />
+      <Icon name="BicolorLocationPointer" component={BicolorLocationPointer} isNew />
+      <Icon name="BicolorLocationBuilding" component={BicolorLocationBuilding} isNew />
+      <Icon name="BicolorLogo" component={BicolorLogo} isNew />
+      <Icon name="BicolorProfile" component={BicolorProfile} isNew />
+      <Icon name="BicolorSearch" component={BicolorSearch} isNew />
+      <AlignedText>
+        <BicolorSelector width={ICON_SIZE} height={getSpacing(1)} />
+        <Text> - BicolorSelector </Text>
+      </AlignedText>
+      <Icon name="ArrowNext" component={ArrowNext} isNew />
+      <Icon name="ArrowPrevious" component={ArrowPrevious} isNew />
+      <Icon name="Bell" component={Bell} isNew />
+      <Icon name="Booking" component={Booking} isNew />
+      <Icon name="Calendar" component={Calendar} isNew />
+      <Icon name="Check" component={Check} isNew />
+      <Icon name="Clock" component={Clock} isNew />
+      <Icon name="Close" component={Close} isNew />
+      <Icon name="Confidentiality" component={Confidentiality} isNew />
+      <Icon name="Duo" component={Duo} isNew />
+      <Icon name="Email" component={Email} isNew />
+      <Icon name="Error" component={Error} isNew />
+      <Icon name="ExternalSite" component={ExternalSite} isNew />
+      <Icon name="Eye" component={Eye} isNew />
+      <Icon name="EyeSlash" component={EyeSlash} isNew />
+      <Icon name="Favorite" component={Favorite} isNew />
+      <Icon name="FavoriteFilled" component={FavoriteFilled} isNew />
+      <Icon name="Flag" component={Flag} />
+      <Icon name="Flash" component={Flash} isNew />
+      <Icon name="HandicapVisual" component={HandicapVisual} isNew />
+      <Icon name="HandicapMental" component={HandicapMental} isNew />
+      <Icon name="HandicapMotor" component={HandicapMotor} isNew />
+      <Icon name="HandicapAudio" component={HandicapAudio} isNew />
+      <Icon name="Info" component={Info} isNew />
+      <Icon name="InfoFraud" component={InfoFraud} isNew />
+      <Icon name="LegalNotices" component={LegalNotices} isNew />
+      <Icon name="LifeBuoy" component={LifeBuoy} isNew />
+      <Icon name="LocationBuilding" component={LocationBuilding} isNew />
+      <Icon name="LocationPointerNotFilled" component={LocationPointerNotFilled} isNew />
+      <Icon name="Lock" component={Lock} isNew />
+      <Icon name="Logo" component={Logo} />
+      <Icon name="MagnifyingGlass" component={MagnifyingGlass} isNew />
+      <Icon name="NoOffer" component={NoOffer} />
+      <Icon name="OfferDigital" component={OfferDigital} isNew />
+      <Icon name="OfferEvent" component={OfferEvent} isNew />
+      <Icon name="OfferPhysical" component={OfferPhysical} isNew />
+      <Icon name="Offers" component={Offers} isNew />
+      <Icon name="OrderPrice" component={OrderPrice} isNew />
+      <Icon name="ProfileDeletion" component={ProfileDeletion} isNew />
+      <Icon name="Quote" component={Quote} isNew />
+      <Icon name="RequestSent" component={RequestSent} />
+      <Icon name="SignOut" component={SignOut} isNew />
+      <Icon name="Share" component={Share} isNew />
+      <Icon name="Sun" component={Sun} isNew />
+      <Icon name="SadFace" component={SadFace} />
+      <Icon name="HappyFace" component={HappyFace} />
+      <Icon name="Warning" component={Warning} isNew />
       <Text>{'\n'}</Text>
     </React.Fragment>
   )


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12709

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

<img width="383" alt="Capture d’écran 2022-01-11 à 11 24 28" src="https://user-images.githubusercontent.com/44037911/148925529-8bc0e8cb-7748-471c-99f9-2ddc8bbbf1cc.png">
<img width="383" alt="Capture d’écran 2022-01-11 à 11 24 39" src="https://user-images.githubusercontent.com/44037911/148925538-e8594d6e-0b91-4fed-a460-a53bfc57ebc8.png">



[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
