### PR TITLE
(PC-12727) fix(ReactNativeSreens): upgrade to 3.10.1 (latest) to remove console warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "react-native-qrcode-svg": "^6.1.1",
     "react-native-reanimated": "2.2.4",
     "react-native-safe-area-context": "^3.1.8",
-    "react-native-screens": "^3.4.0",
+    "react-native-screens": "^3.10.1",
     "react-native-splash-screen": "3.2.0",
     "react-native-svg": "^12.1.1",
     "react-native-tracking-transparency": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13979,7 +13979,7 @@ react-native-safe-modules@^1.0.3:
   dependencies:
     dedent "^0.6.0"
 
-react-native-screens@^3.4.0:
+react-native-screens@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.10.1.tgz#2634a1a17380c559a06de391e4969ae72c4365ff"
   integrity sha512-ZF/XHnRsuinvDY1XiCWLXxoUoSf+NgsAes2SZfX9rFQQcv128zmh/+19SSavGrSf6rQNzqytEMdRGI6yr4Gbjw==


### PR DESCRIPTION

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12727

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
