### PR TITLE
(PC-8471) fix(offer): display see more with small description and image

### DIFF
--- a/src/features/offer/components/__tests__/OfferPartialDescription.native.test.tsx
+++ b/src/features/offer/components/__tests__/OfferPartialDescription.native.test.tsx
@@ -122,35 +122,37 @@ describe('OfferPartialDescription', () => {
         expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
       })
     })
-    it("shouldn't be rendered when there is no content on the description page", () => {
-      const { queryByTestId } = renderOfferDescription({
-        description: undefined,
-        setup: setupWithNoDataInDescriptionPage,
+    describe("shouldn't be rendered", () => {
+      it('when there is no content on the description page', () => {
+        const { queryByTestId } = renderOfferDescription({
+          description: undefined,
+          setup: setupWithNoDataInDescriptionPage,
+        })
+        expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
       })
-      expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
-    })
-    it("shouldn't be rendered when the description is small enough to be fully readable", () => {
-      const lines = [
-        { text: 'Combattant sans risque, vous devez agir ' },
-        { text: 'sans précaution. En effet, pour vous autres ' },
-        { text: 'hommes, les défaites ne sont que des ' },
-        { text: 'succès de moins. Dans cette partie si ' },
-        { text: 'inégale, notre fortune est de ne pas perdre, ' },
-        { text: 'et votre malheur de ne pas gagner.' },
-      ]
-      const description = lines.map(({ text }) => text).join(' ')
-      const { getByTestId, queryByTestId } = renderOfferDescription({
-        ...defaultParams,
-        description,
-        setup: setupWithNoDataInDescriptionPage,
-      })
-      const descriptionComponent = getByTestId('offerPartialDescriptionBody')
+      it('when the description is small enough to be fully readable', () => {
+        const lines = [
+          { text: 'Combattant sans risque, vous devez agir ' },
+          { text: 'sans précaution. En effet, pour vous autres ' },
+          { text: 'hommes, les défaites ne sont que des ' },
+          { text: 'succès de moins. Dans cette partie si ' },
+          { text: 'inégale, notre fortune est de ne pas perdre, ' },
+          { text: 'et votre malheur de ne pas gagner.' },
+        ]
+        const description = lines.map(({ text }) => text).join(' ')
+        const { getByTestId, queryByTestId } = renderOfferDescription({
+          ...defaultParams,
+          description,
+          setup: setupWithNoDataInDescriptionPage,
+        })
+        const descriptionComponent = getByTestId('offerPartialDescriptionBody')
 
-      act(() => {
-        descriptionComponent.props.onTextLayout({ nativeEvent: { lines } })
-      })
+        act(() => {
+          descriptionComponent.props.onTextLayout({ nativeEvent: { lines } })
+        })
 
-      expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
+        expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
+      })
     })
   })
 })

--- a/src/features/offer/components/__tests__/OfferPartialDescription.native.test.tsx
+++ b/src/features/offer/components/__tests__/OfferPartialDescription.native.test.tsx
@@ -122,6 +122,29 @@ describe('OfferPartialDescription', () => {
         })
         expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
       })
+      it('when the description is small enough to be fully readable and there is image on the description page', () => {
+        const lines = [
+          { text: 'Combattant sans risque, vous devez agir ' },
+          { text: 'sans précaution. En effet, pour vous autres ' },
+          { text: 'hommes, les défaites ne sont que des ' },
+          { text: 'succès de moins. Dans cette partie si ' },
+          { text: 'inégale, notre fortune est de ne pas perdre, ' },
+          { text: 'et votre malheur de ne pas gagner.' },
+        ]
+        const description = lines.map(({ text }) => text).join(' ')
+        const { getByTestId, queryByTestId } = renderOfferDescription({
+          ...defaultParams,
+          description,
+          setup: setupWithImage,
+        })
+        const descriptionComponent = getByTestId('offerPartialDescriptionBody')
+
+        act(() => {
+          descriptionComponent.props.onTextLayout({ nativeEvent: { lines } })
+        })
+
+        expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
+      })
     })
     describe("shouldn't be rendered", () => {
       it('when there is no content on the description page', () => {

--- a/src/features/offer/components/__tests__/OfferPartialDescription.native.test.tsx
+++ b/src/features/offer/components/__tests__/OfferPartialDescription.native.test.tsx
@@ -96,15 +96,16 @@ describe('OfferPartialDescription', () => {
         expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
       })
       it('when there is image on the description page', () => {
+        const setupWithImage = (queryClient: QueryClient): void => {
+          queryClient.setQueryData(['offer', offerId], {
+            image: offerResponseSnap.image,
+            extraData: {},
+          })
+        }
         const { queryByTestId } = renderOfferDescription({
           ...defaultParams,
           description: undefined,
-          setup: (queryClient) => {
-            queryClient.setQueryData(['offer', offerId], {
-              image: offerResponseSnap.image,
-              extraData: {},
-            })
-          },
+          setup: setupWithImage,
         })
         expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
       })

--- a/src/features/offer/components/__tests__/OfferPartialDescription.native.test.tsx
+++ b/src/features/offer/components/__tests__/OfferPartialDescription.native.test.tsx
@@ -57,6 +57,12 @@ describe('OfferPartialDescription', () => {
         extraData: {},
       })
     }
+    const setupWithImage = (queryClient: QueryClient): void => {
+      queryClient.setQueryData(['offer', offerId], {
+        image: offerResponseSnap.image,
+        extraData: {},
+      })
+    }
 
     it('should be rendered when there is some content on the description page', () => {
       const { queryByTestId } = renderOfferDescription(defaultParams)
@@ -96,12 +102,6 @@ describe('OfferPartialDescription', () => {
         expect(queryByTestId('offerSeeMoreContainer')).toBeTruthy()
       })
       it('when there is image on the description page', () => {
-        const setupWithImage = (queryClient: QueryClient): void => {
-          queryClient.setQueryData(['offer', offerId], {
-            image: offerResponseSnap.image,
-            extraData: {},
-          })
-        }
         const { queryByTestId } = renderOfferDescription({
           ...defaultParams,
           description: undefined,

--- a/src/features/offer/components/__tests__/OfferPartialDescription.web.test.tsx
+++ b/src/features/offer/components/__tests__/OfferPartialDescription.web.test.tsx
@@ -126,12 +126,7 @@ describe('OfferPartialDescription', () => {
       it('on desktop when there is only description on the description page', () => {
         const { queryByTestId } = renderOfferDescription({
           ...defaultParams,
-          setup: (queryClient) => {
-            queryClient.setQueryData(['offer', offerId], {
-              image: {},
-              extraData: {},
-            })
-          },
+          setup: setupWithNoDataInDescriptionPage,
           options: {
             theme: {
               isMobileViewport: false,

--- a/src/features/offer/components/__tests__/OfferPartialDescription.web.test.tsx
+++ b/src/features/offer/components/__tests__/OfferPartialDescription.web.test.tsx
@@ -140,6 +140,7 @@ describe('OfferPartialDescription', () => {
             },
           },
         })
+
         expect(queryByTestId('offerSeeMoreContainer')).toBeFalsy()
       })
     })

--- a/src/features/offer/components/useShouldDisplaySeeMoreButton.tsx
+++ b/src/features/offer/components/useShouldDisplaySeeMoreButton.tsx
@@ -23,10 +23,11 @@ export const useShouldDisplaySeeMoreButton = (
       setIsLongerThanMaximumLines(linesDisplayed >= maxDisplayedDescriptionLines)
     }
   }
+  const hasDataToDisplayOnDescriptionPage =
+    contentOfferDescription.filter(({ key }) => key !== 'description').length > 0
   const shouldDisplaySeeMoreButton = shouldTruncateDescription
-    ? contentOfferDescription.filter(({ key }) => key !== 'description').length > 0 ||
-      isLongerThanMaximumLines
-    : contentOfferDescription.filter(({ key }) => key !== 'description').length > 0
+    ? hasDataToDisplayOnDescriptionPage || isLongerThanMaximumLines
+    : hasDataToDisplayOnDescriptionPage
 
   return { shouldDisplaySeeMoreButton, maxDisplayedDescriptionLines, setLinesDisplayed }
 }

--- a/src/features/offer/components/useShouldDisplaySeeMoreButton.tsx
+++ b/src/features/offer/components/useShouldDisplaySeeMoreButton.tsx
@@ -24,7 +24,8 @@ export const useShouldDisplaySeeMoreButton = (
     }
   }
   const shouldDisplaySeeMoreButton = shouldTruncateDescription
-    ? contentOfferDescription.length > 0 && isLongerThanMaximumLines
+    ? contentOfferDescription.filter(({ key }) => key !== 'description').length > 0 ||
+      isLongerThanMaximumLines
     : contentOfferDescription.filter(({ key }) => key !== 'description').length > 0
 
   return { shouldDisplaySeeMoreButton, maxDisplayedDescriptionLines, setLinesDisplayed }

--- a/src/features/offer/components/useShouldDisplaySeeMoreButton.tsx
+++ b/src/features/offer/components/useShouldDisplaySeeMoreButton.tsx
@@ -25,9 +25,8 @@ export const useShouldDisplaySeeMoreButton = (
   }
   const hasDataToDisplayOnDescriptionPage =
     contentOfferDescription.filter(({ key }) => key !== 'description').length > 0
-  const shouldDisplaySeeMoreButton = shouldTruncateDescription
-    ? hasDataToDisplayOnDescriptionPage || isLongerThanMaximumLines
-    : hasDataToDisplayOnDescriptionPage
+  const shouldDisplaySeeMoreButton =
+    hasDataToDisplayOnDescriptionPage || (shouldTruncateDescription && isLongerThanMaximumLines)
 
   return { shouldDisplaySeeMoreButton, maxDisplayedDescriptionLines, setLinesDisplayed }
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-8471

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.

## Screenshots


|app description courte metada|app description longue|app description courte|
|:--:|:--:|:--:|
|![image](https://user-images.githubusercontent.com/95220086/148990162-90b7c757-7196-4283-9d6b-2af3807d2c41.png)|![image](https://user-images.githubusercontent.com/95220086/148990881-b8458e6a-8730-44a6-aed8-d48f3905e081.png)|![image](https://user-images.githubusercontent.com/95220086/148991012-09ab6209-25fb-4178-899f-b0f3d0a569d8.png)|




|web mobile description courte metada|web mobile description longue|web mobile description courte|
|:--:|:--:|:--:|
|![image](https://user-images.githubusercontent.com/95220086/148991071-8d35d056-3e77-4b65-93c4-81e69f45b308.png)|![image](https://user-images.githubusercontent.com/95220086/148991182-958f5a87-6e44-448e-8f0f-118e6a13ebb7.png)|![image](https://user-images.githubusercontent.com/95220086/148991237-a21c73a8-4056-473a-b95b-f42d3a16c80c.png)|



|web desktop description courte metada|web desktop description longue|web desktop description courte|
|:--:|:--:|:--:|
|![image](https://user-images.githubusercontent.com/95220086/148991325-d4b0a556-3f2a-4aa6-94e8-e519ef6bea0c.png)|![image](https://user-images.githubusercontent.com/95220086/148991414-e904c0fa-3525-4cb3-8540-f1bd0b6c7b9f.png)|![image](https://user-images.githubusercontent.com/95220086/148991476-6e6277c0-e76a-4f31-a271-162048620a4b.png)|


[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
