### PR TITLE
(PC-9881) feat(url): revert commit - highlight URL even without http:// 

### DIFF
--- a/src/libs/parsers/highlightLinks.tsx
+++ b/src/libs/parsers/highlightLinks.tsx
@@ -6,7 +6,7 @@ import { ExternalLink } from 'ui/components/buttons/externalLink/ExternalLink'
 export type ParsedDescription = Array<string | React.ReactNode>
 
 const externalUrlRegex = new RegExp(
-  /((?<=^|\s)|https?:\/\/)[a-z]([-a-z0-9@:%._+~#=]*[a-z0-9])?\.[a-z0-9]{1,6}([/?#]\S*)?(?=\s|$)/,
+  /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/,
   'gi'
 )
 
@@ -31,25 +31,17 @@ export const customFindUrlChunks = ({ textToHighlight }: FindChunksArgs): Chunk[
   return chunks
 }
 
-const normalizeURL = (partialURL: string): string => {
-  if (partialURL.startsWith('http://')) return partialURL
-  if (partialURL.startsWith('https://')) return partialURL
-  return `http://${partialURL}`
-}
-
 export const highlightLinks = (description: string): ParsedDescription => {
   const chunks = findAll({
     searchWords: [],
     findChunks: customFindUrlChunks,
     textToHighlight: description,
   })
-
-  return chunks.map(({ start, end, highlight }, index) => {
-    const url = normalizeURL(description.slice(start, end))
-    return highlight ? (
-      <ExternalLink key={`external-link-${index}`} url={url} />
+  return chunks.map(({ start, end, highlight }, index) =>
+    highlight ? (
+      <ExternalLink key={`external-link-${index}`} url={description.slice(start, end)} />
     ) : (
       description.slice(start, end)
     )
-  })
+  )
 }

--- a/src/libs/parsers/tests/highlightLinks.test.tsx
+++ b/src/libs/parsers/tests/highlightLinks.test.tsx
@@ -9,7 +9,7 @@ const description1WithoutUrl = `PRESSE / ILS EN PARLENT !
 « Irrésistible ! » Elle
 « Intelligent et revigorant » Le Parisien
 « Hilarant » Vanity Fair 
-Voir plus de critiques en suivant le lien suivant :`
+Voir plus de critiques en suivant le lien suivant : `
 
 const description1 = description1WithoutUrl + 'https://fauxliencritique.com/'
 
@@ -21,16 +21,14 @@ some text here as well https://www.google.com/?key=valeu&key2=value2 Lorem ipsum
 https://www.google.com/`
 
 describe('customFindUrlChunks', () => {
-  it('finds url chunk and mark it as highlited', () => {
+  it('finds url chunks and mark them as highlited', () => {
     const highlightedChunks1 = customFindUrlChunks({
       textToHighlight: description1,
       searchWords: [],
     })
     expect(highlightedChunks1.length).toBe(1)
     expect(description1.slice(0, highlightedChunks1[0].start)).toBe(description1WithoutUrl)
-  })
 
-  it('finds url chunks and mark them as highlited', () => {
     const highlightedChunks2 = customFindUrlChunks({
       textToHighlight: description2,
       searchWords: [],
@@ -40,118 +38,13 @@ describe('customFindUrlChunks', () => {
 })
 
 describe('highlightLinks', () => {
-  describe('transforms a description into an array of strings or <ExternalLink/>', () => {
-    describe('composition', () => {
-      describe('protocol', () => {
-        it('without protocol', () => {
-          const parsedDescription = highlightLinks('perdu.com')
-
-          expect(parsedDescription).toEqual([
-            <ExternalLink key="external-link-0" url="http://perdu.com" />,
-          ])
-        })
-
-        it('with http protocol', () => {
-          const parsedDescription = highlightLinks('http://penofchaos.com/')
-
-          expect(parsedDescription).toEqual([
-            <ExternalLink key="external-link-0" url="http://penofchaos.com/" />,
-          ])
-        })
-
-        it('with https protocol', () => {
-          const parsedDescription = highlightLinks('https://kaamelott.com')
-
-          expect(parsedDescription).toEqual([
-            <ExternalLink key="external-link-0" url="https://kaamelott.com" />,
-          ])
-        })
-      })
-
-      it('with subdomain', () => {
-        const parsedDescription = highlightLinks('www.penofchaos.com')
-
-        expect(parsedDescription).toEqual([
-          <ExternalLink key="external-link-0" url="http://www.penofchaos.com" />,
-        ])
-      })
-
-      it('with path', () => {
-        const parsedDescription = highlightLinks('httpstat.us/418')
-
-        expect(parsedDescription).toEqual([
-          <ExternalLink key="external-link-0" url="http://httpstat.us/418" />,
-        ])
-      })
-
-      it('with query params', () => {
-        const parsedDescription = highlightLinks('httpstat.us/200?sleep=500')
-
-        expect(parsedDescription).toEqual([
-          <ExternalLink key="external-link-0" url="http://httpstat.us/200?sleep=500" />,
-        ])
-      })
-
-      it('with hash', () => {
-        const parsedDescription = highlightLinks('httpstat.us#anchor')
-
-        expect(parsedDescription).toEqual([
-          <ExternalLink key="external-link-0" url="http://httpstat.us#anchor" />,
-        ])
-      })
-    })
-
-    describe('position', () => {
-      describe('without protocol', () => {
-        it('must be preceded by space', () => {
-          const parsedDescription = highlightLinks(
-            `${description1WithoutUrl} www.penofchaos.com/warham/donjon.htm`
-          )
-
-          expect(parsedDescription).toEqual([
-            `${description1WithoutUrl} `,
-            <ExternalLink
-              key="external-link-1"
-              url="http://www.penofchaos.com/warham/donjon.htm"
-            />,
-          ])
-        })
-
-        it('is not recognized without a previous space', () => {
-          const description = `${description1WithoutUrl}www.penofchaos.com/warham/donjon.htm`
-
-          const parsedDescription = highlightLinks(description)
-
-          expect(parsedDescription).toEqual([description])
-        })
-      })
-
-      describe('with protocol', () => {
-        it('can begin without space', () => {
-          const parsedDescription = highlightLinks(
-            `${description1WithoutUrl}http://www.penofchaos.com/warham/donjon.htm`
-          )
-
-          expect(parsedDescription).toEqual([
-            description1WithoutUrl,
-            <ExternalLink
-              key="external-link-1"
-              url="http://www.penofchaos.com/warham/donjon.htm"
-            />,
-          ])
-        })
-      })
-
-      it('must be followed by space', () => {
-        const parsedDescription = highlightLinks(
-          `www.penofchaos.com/warham/donjon.htm ${description1WithoutUrl}`
-        )
-
-        expect(parsedDescription).toEqual([
-          <ExternalLink key="external-link-0" url="http://www.penofchaos.com/warham/donjon.htm" />,
-          ` ${description1WithoutUrl}`,
-        ])
-      })
-    })
+  it('transforms a description into an array of strings or <ExternalLink/>', () => {
+    const parsedDescription = highlightLinks(description1)
+    expect(parsedDescription.length).toBe(2)
+    expect(parsedDescription[0]).toEqual(description1WithoutUrl)
+    expect(typeof parsedDescription[1]).toBe('object')
+    expect(JSON.stringify(parsedDescription[1])).toBe(
+      JSON.stringify(<ExternalLink key="external-link-1" url="https://fauxliencritique.com/" />)
+    )
   })
 })


### PR DESCRIPTION
This reverts commit 93be2f4d54b5c66dbae2012d161ba6ecada7fee5.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-9881

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Added a **screenshot** for UI tickets.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |  <img width="340" alt="Capture d’écran 2022-01-12 à 10 54 30" src="https://user-images.githubusercontent.com/62059034/149117884-37f54ba6-f86d-4a71-b099-c27c5721a797.png">    |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
