### PR TITLE
(PC-12063) fix(GenericInfoPage): remove custom text size in EduConnect errors

### DIFF
--- a/__snapshots__/features/auth/signup/AccountCreated/tests/AccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/AccountCreated/tests/AccountCreated.native.test.tsx.native-snap
@@ -137,11 +137,11 @@ exports[`<AccountCreated /> should render correctly 1`] = `
       Aide-nous à en savoir plus sur tes pratiques culturelles ! Ta sélection n'aura pas d'impact sur les offres proposées.
     </Text>
     <View
-      numberOfSpaces={12}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 48,
+            "height": 120,
           },
         ]
       }

--- a/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.native-snap
@@ -142,11 +142,11 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
       Reviens à partir du 01 décembre pour poursuivre ton inscription et bénéficier des offres du pass Culture.
     </Text>
     <View
-      numberOfSpaces={12}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 48,
+            "height": 120,
           },
         ]
       }

--- a/__snapshots__/features/auth/signup/VerifyEligiblity/tests/VerifyEligibility.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/VerifyEligiblity/tests/VerifyEligibility.test.tsx.native-snap
@@ -144,11 +144,11 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
  Assure-toi que toutes les informations que tu nous transmets sont correctes pour faciliter ton inscription.
     </Text>
     <View
-      numberOfSpaces={12}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 48,
+            "height": 120,
           },
         ]
       }

--- a/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.native-snap
@@ -168,11 +168,11 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
       Tu peux retrouver toutes les informations concernant ta réservation sur l’application
     </Text>
     <View
-      numberOfSpaces={12}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 48,
+            "height": 120,
           },
         ]
       }

--- a/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.native-snap
+++ b/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.native-snap
@@ -143,11 +143,11 @@ exports[`<ForceUpdate/> should match snapshot 1`] = `
 Pour des questions de performance et de sécurité merci de télécharger la dernière version disponible.
     </Text>
     <View
-      numberOfSpaces={12}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 48,
+            "height": 120,
           },
         ]
       }

--- a/__snapshots__/features/home/components/tests/NoContentError.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/tests/NoContentError.native.test.tsx.native-snap
@@ -126,7 +126,6 @@ exports[`NoContentError should render correctly 1`] = `
       }
     />
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {
@@ -142,90 +141,95 @@ exports[`NoContentError should render correctly 1`] = `
       Une erreur s’est produite pendant le chargement de nos recommandations.
     </Text>
     <View
-      numberOfSpaces={4}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 16,
+            "height": 120,
           },
         ]
       }
     />
     <View
-      accessibilityLabel="Rechercher une offre"
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      nativeID="animatedComponent"
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "alignItems": "center",
-          "backgroundColor": "transparent",
-          "borderColor": "#ffffff",
-          "borderRadius": 24,
-          "borderWidth": 2,
-          "flexDirection": "row",
-          "height": 40,
-          "justifyContent": "center",
-          "maxWidth": 500,
-          "opacity": 1,
-          "paddingBottom": 2,
-          "paddingLeft": 24,
-          "paddingRight": 24,
-          "paddingTop": 2,
-          "width": "auto",
-        }
+        Array [
+          Object {
+            "alignSelf": "stretch",
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+            "justifyContent": "flex-end",
+            "marginBottom": 32,
+          },
+        ]
       }
-      testID="Rechercher une offre"
     >
       <View
-        height={22}
-        testID="button-icon"
-        width={22}
+        accessibilityLabel="Rechercher une offre"
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        nativeID="animatedComponent"
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderColor": "#ffffff",
+            "borderRadius": 24,
+            "borderWidth": 2,
+            "flexDirection": "row",
+            "height": 40,
+            "justifyContent": "center",
+            "maxWidth": 500,
+            "opacity": 1,
+            "paddingBottom": 2,
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "paddingTop": 2,
+            "width": "auto",
+          }
+        }
+        testID="Rechercher une offre"
       >
-        <Text>
-          button-icon-SVG-Mock
+        <View
+          height={22}
+          testID="button-icon"
+          width={22}
+        >
+          <Text>
+            button-icon-SVG-Mock
+          </Text>
+        </View>
+        <Text
+          adjustsFontSizeToFit={false}
+          icon={[Function]}
+          iconSize={22}
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "color": "#ffffff",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 15,
+                "lineHeight": 20,
+                "marginLeft": 12,
+                "maxWidth": "100%",
+              },
+            ]
+          }
+          textColor="#ffffff"
+        >
+          Rechercher une offre
         </Text>
       </View>
-      <Text
-        adjustsFontSizeToFit={false}
-        icon={[Function]}
-        iconSize={22}
-        numberOfLines={1}
-        style={
-          Array [
-            Object {
-              "color": "#ffffff",
-              "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
-              "marginLeft": 12,
-              "maxWidth": "100%",
-            },
-          ]
-        }
-        textColor="#ffffff"
-      >
-        Rechercher une offre
-      </Text>
     </View>
-    <View
-      numberOfSpaces={12}
-      style={
-        Array [
-          Object {
-            "height": 48,
-          },
-        ]
-      }
-    />
     <View
       customHeight={8}
       enable={true}

--- a/__snapshots__/features/identityCheck/components/__test__/QuitIdentityCheckModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/__test__/QuitIdentityCheckModal.native.test.tsx.native-snap
@@ -167,11 +167,11 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
         Les informations que tu as renseignées ne seront pas enregistrées.
       </Text>
       <View
-        numberOfSpaces={12}
+        numberOfSpaces={30}
         style={
           Array [
             Object {
-              "height": 48,
+              "height": 120,
             },
           ]
         }

--- a/__snapshots__/features/identityCheck/pages/confirmation/__test__/BeneficiaryRequestSent.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/__test__/BeneficiaryRequestSent.test.tsx.native-snap
@@ -156,11 +156,11 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
       Tu recevras un e-mail lorsque ta demande sera validée. En attendant, aide-nous à en savoir plus sur tes pratiques culturelles !
     </Text>
     <View
-      numberOfSpaces={12}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 48,
+            "height": 120,
           },
         ]
       }

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEnd.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEnd.test.tsx.native-snap
@@ -126,11 +126,11 @@ exports[`<IdentityCheckEnd/> should render correctly 1`] = `
       }
     />
     <View
-      numberOfSpaces={12}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 48,
+            "height": 120,
           },
         ]
       }

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckPending.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckPending.test.tsx.native-snap
@@ -166,11 +166,11 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
       Ton inscription est en cours de vérification. Tu recevras une notification dès que ton dossier sera validé.
     </Text>
     <View
-      numberOfSpaces={12}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 48,
+            "height": 120,
           },
         ]
       }

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckUnavailable.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckUnavailable.test.tsx.native-snap
@@ -676,11 +676,11 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
       </View>
     </Modal>
     <View
-      numberOfSpaces={12}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 48,
+            "height": 120,
           },
         ]
       }

--- a/__snapshots__/features/landscapePosition/tests/LandscapePositionPage.test.tsx.native-snap
+++ b/__snapshots__/features/landscapePosition/tests/LandscapePositionPage.test.tsx.native-snap
@@ -155,11 +155,11 @@ exports[`<LandscapePositionPage /> should match snapshot with default message 1`
         Place ton téléphone ou ta tablette à la verticale pour afficher l’application.
       </Text>
       <View
-        numberOfSpaces={12}
+        numberOfSpaces={30}
         style={
           Array [
             Object {
-              "height": 48,
+              "height": 120,
             },
           ]
         }

--- a/__snapshots__/features/maintenance/tests/Maintenance.test.tsx.native-snap
+++ b/__snapshots__/features/maintenance/tests/Maintenance.test.tsx.native-snap
@@ -169,11 +169,11 @@ exports[`<Maintenance /> should match snapshot with custom message 1`] = `
       </Text>
     </View>
     <View
-      numberOfSpaces={12}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 48,
+            "height": 120,
           },
         ]
       }
@@ -362,11 +362,11 @@ exports[`<Maintenance /> should match snapshot with default message 1`] = `
       </Text>
     </View>
     <View
-      numberOfSpaces={12}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 48,
+            "height": 120,
           },
         ]
       }

--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.native.test.tsx.native-snap
@@ -168,11 +168,11 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
       }
     />
     <View
-      numberOfSpaces={12}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 48,
+            "height": 120,
           },
         ]
       }
@@ -502,11 +502,11 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
       }
     />
     <View
-      numberOfSpaces={12}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 48,
+            "height": 120,
           },
         ]
       }

--- a/__snapshots__/features/profile/pages/ConfirmDeleteProfile.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConfirmDeleteProfile.test.tsx.native-snap
@@ -141,11 +141,11 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
       Cela entraînera l'annulation de l'ensemble de tes réservations en cours, ainsi que la suppression définitive de ton crédit pass Culture si tu en bénéficies.
     </Text>
     <View
-      numberOfSpaces={12}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 48,
+            "height": 120,
           },
         ]
       }

--- a/__snapshots__/features/profile/pages/DeleteProfileSuccess.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfileSuccess.test.tsx.native-snap
@@ -166,11 +166,11 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
       Une fois ce délai écoulé, ton compte pass Culture sera définitivement supprimé.
     </Text>
     <View
-      numberOfSpaces={12}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 48,
+            "height": 120,
           },
         ]
       }

--- a/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.native-snap
+++ b/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.native-snap
@@ -319,11 +319,11 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
       </Text>
     </View>
     <View
-      numberOfSpaces={12}
+      numberOfSpaces={30}
       style={
         Array [
           Object {
-            "height": 48,
+            "height": 120,
           },
         ]
       }

--- a/src/features/home/components/NoContentError.tsx
+++ b/src/features/home/components/NoContentError.tsx
@@ -9,7 +9,7 @@ import { ButtonSecondaryWhite } from 'ui/components/buttons/ButtonSecondaryWhite
 import { GenericInfoPage } from 'ui/components/GenericInfoPage'
 import { BrokenConnection } from 'ui/svg/BrokenConnection'
 import { MagnifyingGlass } from 'ui/svg/icons/MagnifyingGlass'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Typo } from 'ui/theme'
 
 export const NoContentError = () => {
   const { navigate } = useNavigation<UseNavigationType>()
@@ -19,21 +19,26 @@ export const NoContentError = () => {
   }
 
   return (
-    <GenericInfoPage title={t`Oups\u00a0!`} icon={BrokenConnection}>
+    <GenericInfoPage
+      title={t`Oups\u00a0!`}
+      icon={BrokenConnection}
+      buttons={[
+        <SearchButton
+          key={1}
+          title={t`Rechercher une offre`}
+          icon={MagnifyingGlass}
+          onPress={navigateToSearchTab}
+        />,
+      ]}>
       <BodyText>{t`Une erreur s’est produite pendant le chargement de nos recommandations.`}</BodyText>
-      <Spacer.Column numberOfSpaces={4} />
-      <SearchButton
-        title={t`Rechercher une offre`}
-        icon={MagnifyingGlass}
-        onPress={navigateToSearchTab}
-      />
     </GenericInfoPage>
   )
 }
 
-const BodyText = styled(Typo.Body).attrs(({ theme }) => ({ color: theme.colors.white }))({
+const BodyText = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
   textAlign: 'center',
-})
+}))
 
 const SearchButton = styled(ButtonSecondaryWhite).attrs({
   iconSize: 22,

--- a/src/features/identityCheck/errors/eduConnect/NotEligibleEduConnect.tsx
+++ b/src/features/identityCheck/errors/eduConnect/NotEligibleEduConnect.tsx
@@ -7,17 +7,13 @@ import { navigateToHome } from 'features/navigation/helpers'
 import { analytics } from 'libs/analytics'
 import { ScreenErrorProps } from 'libs/monitoring/errors'
 import { Helmet } from 'libs/react-helmet/Helmet'
-import { useMediaQuery } from 'libs/react-responsive/useMediaQuery'
 import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { ButtonTertiaryWhite } from 'ui/components/buttons/ButtonTertiaryWhite'
 import { GenericInfoPage } from 'ui/components/GenericInfoPage'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
-import { getSpacing, getSpacingString, Typo } from 'ui/theme'
-import { useGrid } from 'ui/theme/grid'
+import { Typo } from 'ui/theme'
 
 import { useNotEligibleEduConnectErrorData } from '../hooks/useNotEligibleEduConnectErrorData'
-
-const SMALL_HEIGHT = 576
 
 export const NotEligibleEduConnect = ({
   error: { message },
@@ -35,9 +31,6 @@ export const NotEligibleEduConnect = ({
     onPrimaryButtonPress,
   } = useNotEligibleEduConnectErrorData(message, setError)
   const { colors } = useTheme()
-  const isSmallScreen = useMediaQuery({ maxHeight: SMALL_HEIGHT })
-  const getGrid = useGrid()
-  const bodyFontSize = getSpacing(getGrid({ default: 3.75, sm: 3 }, 'height'))
 
   useEffect(
     () => () => {
@@ -82,11 +75,7 @@ export const NotEligibleEduConnect = ({
       <Helmet>
         <title>{title}</title>
       </Helmet>
-      <Body
-        textAlign={descriptionAlignment}
-        color={colors.white}
-        fontSize={bodyFontSize}
-        isSmallScreen={!!isSmallScreen}>
+      <Body textAlign={descriptionAlignment} color={colors.white}>
         {description}
       </Body>
     </GenericInfoPage>
@@ -94,15 +83,11 @@ export const NotEligibleEduConnect = ({
 }
 
 type TextBodyProps = TextProps & {
-  isSmallScreen: boolean
-  fontSize: number
   textAlign?: Exclude<TextStyle['textAlign'], 'auto'>
 }
 const Body = styled(Typo.Body).attrs<TextBodyProps>((props) => props)<TextBodyProps>(
-  ({ theme, isSmallScreen, fontSize, textAlign }) => ({
+  ({ theme, textAlign }) => ({
     ...theme.typography.body,
-    fontSize,
-    lineHeight: getSpacingString(isSmallScreen ? 4 : 5),
     textAlign,
   })
 )

--- a/src/ui/components/GenericInfoPage.tsx
+++ b/src/ui/components/GenericInfoPage.tsx
@@ -58,7 +58,7 @@ export const GenericInfoPage: FunctionComponent<Props> = ({
         <StyledTitle2>{title}</StyledTitle2>
         <Spacer.Column numberOfSpaces={spacingMatrix.afterTitle} />
         {children}
-        {!!isTouch && <Spacer.Column numberOfSpaces={12} />}
+        {!!isTouch && <Spacer.Column numberOfSpaces={30} />}
         {!!buttons && (
           <BottomContainer>
             {buttons.map((button, index) => (
@@ -69,6 +69,7 @@ export const GenericInfoPage: FunctionComponent<Props> = ({
             ))}
           </BottomContainer>
         )}
+
         <Spacer.BottomScreen />
       </Content>
     </Wrapper>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12063

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|    ![image](https://user-images.githubusercontent.com/77674046/149192396-6c080d57-e8a2-4ef6-9ed9-ea63d75e1255.png)![image](https://user-images.githubusercontent.com/77674046/149192458-40a34c10-8226-43eb-9119-956053c1baad.png) |  ![image](https://user-images.githubusercontent.com/77674046/149190032-0ae2506a-891a-4682-a6ba-5e15426a4b75.png) ![image](https://user-images.githubusercontent.com/77674046/149190156-890c675b-2afc-4e94-8d25-b6bdc97a0204.png)      |   ![image](https://user-images.githubusercontent.com/77674046/149190306-3c2b36b9-278f-4a9e-b171-3ffbb6d58cd3.png)![image](https://user-images.githubusercontent.com/77674046/149190380-68a1e7af-53a4-4a69-812d-e3d6e41933a4.png)              |                  |                  |





[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
