### PR TITLE
(PC-12740) fix(educonnect): call logout url on the web

### DIFF
--- a/src/features/identityCheck/pages/errors/EduConnectErrors.tsx
+++ b/src/features/identityCheck/pages/errors/EduConnectErrors.tsx
@@ -3,20 +3,13 @@ import { useRoute } from '@react-navigation/native'
 import { withEduConnectErrorBoundary } from 'features/identityCheck/errors/eduConnect/EduConnectErrorBoundary'
 import { EduConnectError } from 'features/identityCheck/errors/eduConnect/types'
 import { EduConnectErrorMessageEnum } from 'features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData'
+import { logoutFromEduConnectIfAllowed } from 'features/identityCheck/utils/logoutFromEduConnectIfAllowed'
 import { UseRouteType } from 'features/navigation/RootNavigator'
-
-const allowedDomains = [
-  'https://educonnect.education.gouv.fr',
-  // environnement hors production
-  'https://pr4.educonnect.phm.education.gouv.fr',
-]
 
 export const EduConnectErrors = withEduConnectErrorBoundary(() => {
   const { params } = useRoute<UseRouteType<'EduConnectErrors'>>()
   const logoutUrl = params.logoutUrl
-  if (logoutUrl && allowedDomains.find((domain) => new RegExp(`^${domain}`, 'i').test(logoutUrl))) {
-    globalThis.window.open(logoutUrl)
-  }
+  logoutFromEduConnectIfAllowed(logoutUrl)
 
   if (params?.code === 'UserAgeNotValid18YearsOld') {
     throw new EduConnectError(EduConnectErrorMessageEnum.UserAgeNotValid18YearsOld)

--- a/src/features/identityCheck/pages/identification/IdentityCheckValidation.web.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckValidation.web.tsx
@@ -8,6 +8,7 @@ import { CenteredTitle } from 'features/identityCheck/atoms/CenteredTitle'
 import { PageWithHeader } from 'features/identityCheck/components/layout/PageWithHeader'
 import { useIdentityCheckContext } from 'features/identityCheck/context/IdentityCheckContextProvider'
 import { IdentityCheckStep } from 'features/identityCheck/types'
+import { logoutFromEduConnectIfAllowed } from 'features/identityCheck/utils/logoutFromEduConnectIfAllowed'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
@@ -24,6 +25,8 @@ export function IdentityCheckValidation() {
     : ''
 
   const navigateToNextEduConnectStep = () => {
+    const logoutUrl = params.logoutUrl
+    logoutFromEduConnectIfAllowed(logoutUrl)
     dispatch({ type: 'SET_STEP', payload: IdentityCheckStep.CONFIRMATION })
     // in web context, we are redirected to this page after educonnect login in a new tab.
     // Therefore, the identity check context loses the state before educonnect login and we

--- a/src/features/identityCheck/utils/logoutFromEduConnectIfAllowed.ts
+++ b/src/features/identityCheck/utils/logoutFromEduConnectIfAllowed.ts
@@ -1,0 +1,11 @@
+const allowedDomains = [
+  'https://educonnect.education.gouv.fr',
+  // environnement hors production
+  'https://pr4.educonnect.phm.education.gouv.fr',
+]
+
+export const logoutFromEduConnectIfAllowed = (logoutUrl: string | undefined) => {
+  if (logoutUrl && allowedDomains.find((domain) => new RegExp(`^${domain}`, 'i').test(logoutUrl))) {
+    globalThis.window.open(logoutUrl)
+  }
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12740

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
