### PR TITLE
(PC-12044) fix(CalendarWeb): no scroll on SearchFilter on Web mobile

### DIFF
--- a/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
@@ -14,6 +14,7 @@ exports[`SearchFilter component should render correctly 1`] = `
   }
 >
   <RCTScrollView
+    scrollEnabled={true}
     style={
       Array [
         Object {

--- a/src/features/search/components/CalendarPicker.web.tsx
+++ b/src/features/search/components/CalendarPicker.web.tsx
@@ -205,6 +205,7 @@ const CalendarPickerWrapper = styled.View(({ theme }) => ({
   flexDirection: 'row',
   alignItems: 'stretch',
   fontFamily: theme.fontFamily.regular,
+  userSelect: 'none',
 }))
 
 const CalendarPickerWrapperDesktop = styled.View(({ theme }) => ({

--- a/src/features/search/pages/SearchFilter.tsx
+++ b/src/features/search/pages/SearchFilter.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro'
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { LayoutChangeEvent, ScrollView } from 'react-native'
 import { useWindowDimensions } from 'react-native'
 import styled from 'styled-components/native'
@@ -40,11 +40,12 @@ export const SearchFilter: React.FC = () => {
   const { searchState } = useStagedSearch()
   const { data: profile } = useUserProfileInfo()
   const { scrollViewRef, scrollToEnd } = useScrollToEndOnTimeOrDateActivation()
+  const [scrollEnabled, setScrollEnabled] = useState(true)
 
   return (
     <Container>
       <React.Fragment>
-        <StyledScrollView ref={scrollViewRef}>
+        <StyledScrollView ref={scrollViewRef} scrollEnabled={scrollEnabled}>
           <Spacer.TopScreen />
           <Spacer.Column numberOfSpaces={16} />
 
@@ -101,7 +102,7 @@ export const SearchFilter: React.FC = () => {
           {/* Date de l'offre */}
           {!!searchState.date && (
             <React.Fragment>
-              <Section.OfferDate />
+              <Section.OfferDate setScrollEnabled={setScrollEnabled} />
               <Separator marginVertical={getSpacing(6)} />
               <Spacer.Column numberOfSpaces={0} onLayout={scrollToEnd} />
             </React.Fragment>
@@ -138,7 +139,9 @@ const Container = styled.View(({ theme }) => ({
   backgroundColor: theme.colors.white,
 }))
 
-const StyledScrollView = styled(ScrollView)({ flex: 1 })
+const StyledScrollView = styled(ScrollView)({
+  flex: 1,
+})
 const Separator = styled.View<{ marginVertical?: number }>(({ theme, marginVertical = 0 }) => ({
   width: theme.appContentWidth - getSpacing(2 * 6),
   height: 2,

--- a/src/features/search/sections/OfferDate.tsx
+++ b/src/features/search/sections/OfferDate.tsx
@@ -1,7 +1,8 @@
 import { t } from '@lingui/macro'
-import React, { useState } from 'react'
+import React, { Dispatch, SetStateAction, useEffect, useState } from 'react'
+import { Platform } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
-import styled from 'styled-components/native'
+import styled, { useTheme } from 'styled-components/native'
 
 import { DateFilter } from 'features/search/atoms/Buttons'
 import { CalendarPicker } from 'features/search/components'
@@ -13,10 +14,21 @@ import { formatToCompleteFrenchDate } from 'libs/parsers'
 import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
 import { ACTIVE_OPACITY } from 'ui/theme/colors'
 
-export const OfferDate: React.FC = () => {
+type Props = {
+  setScrollEnabled?: ((setScrollEnabled: boolean) => void) | Dispatch<SetStateAction<boolean>>
+}
+
+export function OfferDate({ setScrollEnabled }: Props) {
   const { searchState, dispatch } = useStagedSearch()
   const [showTimePicker, setShowTimePicker] = useState<boolean>(false)
   const logUseFilter = useLogFilterOnce(SectionTitle.OfferDate)
+  const { isTouch } = useTheme()
+
+  useEffect(() => {
+    if (setScrollEnabled && isTouch && Platform.OS === 'web') {
+      setScrollEnabled(!showTimePicker)
+    }
+  }, [setScrollEnabled, showTimePicker])
 
   if (!searchState.date) return <React.Fragment />
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12044

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
