### PR TITLE
(PC-12805) feat(EduConnect): clarify wording for blocked users on the web

### DIFF
--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnect.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnect.test.tsx.native-snap
@@ -255,7 +255,7 @@ exports[`<IdentityCheckEduConnect /> should render correctly 1`] = `
                     ]
                   }
                 >
-                  Pour t'identifier, nous allons te demander de te connecter à ÉduConnect. Pense bien à avoir ton identifiant et ton mot de passe pour continuer. Si tu ne les as pas, contacte ton établissement pour les récupérer.
+                  Pour t’identifier, nous allons te demander de te connecter à EduConnect. Munis-toi de ton identifiant et ton mot de passe EduConnect ! Si tu ne les as pas, contacte ton établissement pour les récupérer.
                 </Text>
                 <View
                   numberOfSpaces={8}

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnect.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnect.test.tsx.web-snap
@@ -332,7 +332,7 @@ exports[`<IdentityCheckEduConnect /> should render correctly 1`] = `
                     }
                   }
                 >
-                  Pour t'identifier, nous allons te demander de te connecter à ÉduConnect. Pense bien à avoir ton identifiant et ton mot de passe pour continuer. Si tu ne les as pas, contacte ton établissement pour les récupérer.
+                  Pour t’identifier, nous allons te demander de te connecter à EduConnect. Munis-toi de ton identifiant et ton mot de passe EduConnect ! Si tu ne les as pas, contacte ton établissement pour les récupérer.
                 </div>
                 <div
                   className="css-view-1dbjc4n"

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnectForm.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnectForm.web.test.tsx.web-snap
@@ -99,7 +99,37 @@ Object {
                       dir="auto"
                       style="color: rgb(98, 98, 98); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
                     >
-                      Pour procéder à ton identification, nous allons te demander de te connecter à ÉduConnect. Muni toi de ton identifiant et de ton mot de passe ÉduConnect. Dès que tu as bien complété le parcours, reviens sur ce site pour terminer ton inscription et découvrir toutes les offres du pass Culture !
+                      Pour t’identifier, nous allons te demander de te connecter à EduConnect. Munis-toi de ton identifiant et ton mot de passe EduConnect ! Si tu ne les as pas, contacte ton établissement pour les récupérer.
+                    </div>
+                    <div
+                      class="css-view-1dbjc4n"
+                      style="height: 16px;"
+                    />
+                    <div
+                      class="css-view-1dbjc4n"
+                      style="background-color: rgb(245, 245, 245); border-top-left-radius: 4px; border-top-right-radius: 4px; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; display: flex; flex-direction: row; padding: 16px 16px 16px 16px;"
+                    >
+                      <div
+                        class="css-view-1dbjc4n"
+                      >
+                        <div
+                          class="css-text-901oao"
+                          dir="auto"
+                        >
+                          undefined-SVG-Mock
+                        </div>
+                      </div>
+                      <div
+                        class="css-view-1dbjc4n"
+                        style="width: 8px;"
+                      />
+                      <div
+                        class="css-text-901oao"
+                        dir="auto"
+                        style="color: rgb(98, 98, 98); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
+                      >
+                        Un souci pour accéder à la page ? Essaie en navigation privée ou pense bien à accepter les pop-ups de ton navigateur.
+                      </div>
                     </div>
                     <div
                       class="css-view-1dbjc4n"
@@ -248,7 +278,37 @@ Object {
                     dir="auto"
                     style="color: rgb(98, 98, 98); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
                   >
-                    Pour procéder à ton identification, nous allons te demander de te connecter à ÉduConnect. Muni toi de ton identifiant et de ton mot de passe ÉduConnect. Dès que tu as bien complété le parcours, reviens sur ce site pour terminer ton inscription et découvrir toutes les offres du pass Culture !
+                    Pour t’identifier, nous allons te demander de te connecter à EduConnect. Munis-toi de ton identifiant et ton mot de passe EduConnect ! Si tu ne les as pas, contacte ton établissement pour les récupérer.
+                  </div>
+                  <div
+                    class="css-view-1dbjc4n"
+                    style="height: 16px;"
+                  />
+                  <div
+                    class="css-view-1dbjc4n"
+                    style="background-color: rgb(245, 245, 245); border-top-left-radius: 4px; border-top-right-radius: 4px; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; display: flex; flex-direction: row; padding: 16px 16px 16px 16px;"
+                  >
+                    <div
+                      class="css-view-1dbjc4n"
+                    >
+                      <div
+                        class="css-text-901oao"
+                        dir="auto"
+                      >
+                        undefined-SVG-Mock
+                      </div>
+                    </div>
+                    <div
+                      class="css-view-1dbjc4n"
+                      style="width: 8px;"
+                    />
+                    <div
+                      class="css-text-901oao"
+                      dir="auto"
+                      style="color: rgb(98, 98, 98); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
+                    >
+                      Un souci pour accéder à la page ? Essaie en navigation privée ou pense bien à accepter les pop-ups de ton navigateur.
+                    </div>
                   </div>
                   <div
                     class="css-view-1dbjc4n"

--- a/src/features/identityCheck/pages/identification/IdentityCheckEduConnect.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckEduConnect.tsx
@@ -45,7 +45,7 @@ export const IdentityCheckEduConnect = () => {
           <Spacer.Column numberOfSpaces={4} />
 
           <TextContent color={ColorsEnum.GREY_DARK}>
-            {t`Pour t'identifier, nous allons te demander de te connecter à ÉduConnect. Pense bien à avoir ton identifiant et ton mot de passe pour continuer. Si tu ne les as pas, contacte ton établissement pour les récupérer.`}
+            {t`Pour t’identifier, nous allons te demander de te connecter à EduConnect. Munis-toi de ton identifiant et ton mot de passe EduConnect\u00a0! Si tu ne les as pas, contacte ton établissement pour les récupérer.`}
           </TextContent>
 
           <Spacer.Column numberOfSpaces={8} />

--- a/src/features/identityCheck/pages/identification/IdentityCheckEduConnectForm.web.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckEduConnectForm.web.tsx
@@ -12,6 +12,7 @@ import { EduConnectErrorMessageEnum } from 'features/identityCheck/errors/hooks/
 import { eduConnectClient } from 'libs/eduConnectClient'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { BicolorIdCardWithMagnifyingGlass } from 'ui/svg/icons/BicolorIdCardWithMagnifyingGlass'
+import { Info } from 'ui/svg/icons/Info'
 import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
 
 export const IdentityCheckEduConnectForm = () => {
@@ -68,8 +69,17 @@ export const IdentityCheckEduConnectForm = () => {
             <Spacer.Column numberOfSpaces={4} />
 
             <JustifiedText color={ColorsEnum.GREY_DARK}>
-              {t`Pour procéder à ton identification, nous allons te demander de te connecter à ÉduConnect. Muni toi de ton identifiant et de ton mot de passe ÉduConnect. Dès que tu as bien complété le parcours, reviens sur ce site pour terminer ton inscription et découvrir toutes les offres du pass Culture\u00a0!`}
+              {t`Pour t’identifier, nous allons te demander de te connecter à EduConnect. Munis-toi de ton identifiant et ton mot de passe EduConnect\u00a0! Si tu ne les as pas, contacte ton établissement pour les récupérer.`}
             </JustifiedText>
+            <Spacer.Column numberOfSpaces={4} />
+            <HavingTroubleContainer>
+              <Info />
+              <Spacer.Row numberOfSpaces={2} />
+
+              <Typo.Caption color={ColorsEnum.GREY_DARK}>
+                {t`Un souci pour accéder à la page\u00a0? Essaie en navigation privée ou pense bien à accepter les pop-ups de ton navigateur.`}
+              </Typo.Caption>
+            </HavingTroubleContainer>
 
             <Spacer.Column numberOfSpaces={8} />
           </React.Fragment>
@@ -95,3 +105,11 @@ const JustifiedText = styled(Typo.Body)({
 const JustifiedHeader = styled(Typo.ButtonText)({
   textAlign: 'center',
 })
+
+const HavingTroubleContainer = styled.View(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  backgroundColor: theme.colors.greyLight,
+  padding: getSpacing(4),
+  borderRadius: theme.borderRadius.checkbox,
+}))

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -109,10 +109,6 @@ msgstr "Accessibilité"
 msgid "Accueil"
 msgstr "Accueil"
 
-#: src/features/deeplinks/pages/DeeplinkImporter.tsx
-msgid "Accès aux liens"
-msgstr "Accès aux liens"
-
 #: src/features/bookings/components/BookingDetailsTicketContent.tsx
 #: src/features/offer/services/useCtaWordingAndAction.ts
 msgid "Accéder à l'offre"
@@ -461,10 +457,6 @@ msgstr "Clique sur « Renvoyer l’e-mail » pour recevoir un nouveau lien."
 msgid "Code postal - Formulaire"
 msgstr "Code postal - Formulaire"
 
-#: src/features/deeplinks/pages/DeeplinkImporter.tsx
-msgid "Colle ton lien ici ..."
-msgstr "Colle ton lien ici ..."
-
 #: src/features/identityCheck/pages/identification/IdentityCheckStart/IdentityCheckStart.tsx
 #: src/features/identityCheck/pages/identification/IdentityCheckStart/IdentityCheckStart.web.tsx
 msgid "Commencer la vérification"
@@ -621,10 +613,6 @@ msgstr "Continuer la vérification"
 #: src/features/auth/signup/SignupForm.tsx
 msgid "Continuer vers l'étape"
 msgstr "Continuer vers l'étape"
-
-#: src/features/deeplinks/pages/DeeplinkImporter.tsx
-msgid "Copie ici le lien qui t'a été envoyé par email et clique sur le bouton \"Importer le lien\""
-msgstr "Copie ici le lien qui t'a été envoyé par email et clique sur le bouton \"Importer le lien\""
 
 #: src/features/_marketingAndCommunication/atoms/DeeplinkItem.tsx
 msgid "Copier"
@@ -1006,10 +994,6 @@ msgstr "Filtrer"
 msgid "Fin du parcours"
 msgstr "Fin du parcours"
 
-#: src/features/deeplinks/pages/DeeplinkImporter.tsx
-msgid "Format du lien incorrect"
-msgstr "Format du lien incorrect"
-
 #: src/features/identityCheck/pages/identification/IdentityCheckStart/IdentityCheckStartContentDesktop.tsx
 msgid "Gagne du temps en vérifiant ton identité directement sur ton smartphone ! Sinon tu peux passer par le site Démarches-Simplifiées mais le traitement sera plus long."
 msgstr "Gagne du temps en vérifiant ton identité directement sur ton smartphone ! Sinon tu peux passer par le site Démarches-Simplifiées mais le traitement sera plus long."
@@ -1133,10 +1117,6 @@ msgstr "Il y a déjà une demande de crédit pass Culture en cours sur ton compt
 #: src/features/auth/login/Login.tsx
 msgid "Il y a eu un problème. Tu peux réessayer plus tard"
 msgstr "Il y a eu un problème. Tu peux réessayer plus tard"
-
-#: src/features/deeplinks/pages/DeeplinkImporter.tsx
-msgid "Importer le lien"
-msgstr "Importer le lien"
 
 #: src/features/identityCheck/pages/profile/SetCity.tsx
 msgid "Indique ton code postal et choisis ta ville"
@@ -1332,10 +1312,6 @@ msgstr "Le but du pass Culture est de renforcer tes pratiques culturelles, mais 
 #: src/ui/components/LayoutExpiredLink.tsx
 msgid "Le lien est expiré !"
 msgstr "Le lien est expiré !"
-
-#: src/features/deeplinks/useDeeplinkUrlHandler.ts
-msgid "Le lien est incorrect"
-msgstr "Le lien est incorrect"
 
 #: src/features/_marketingAndCommunication/pages/DeeplinksGenerator.tsx
 msgid "Le lien {0} n'a pas été ajouté à l'historique: {1}"
@@ -1877,17 +1853,14 @@ msgstr "Pour en savoir plus sur la gestion de tes données personnelles et exerc
 msgid "Pour plus d'informations, nous t'invitons à consulter notre"
 msgstr "Pour plus d'informations, nous t'invitons à consulter notre"
 
-#: src/features/identityCheck/pages/identification/IdentityCheckEduConnectForm.web.tsx
-msgid "Pour procéder à ton identification, nous allons te demander de te connecter à ÉduConnect. Muni toi de ton identifiant et de ton mot de passe ÉduConnect. Dès que tu as bien complété le parcours, reviens sur ce site pour terminer ton inscription et découvrir toutes les offres du pass Culture !"
-msgstr "Pour procéder à ton identification, nous allons te demander de te connecter à ÉduConnect. Muni toi de ton identifiant et de ton mot de passe ÉduConnect. Dès que tu as bien complété le parcours, reviens sur ce site pour terminer ton inscription et découvrir toutes les offres du pass Culture !"
-
 #: src/features/auth/signup/PhoneValidation/SetPhoneNumber.tsx
 msgid "Pour sécuriser l'accès à ton pass nous avons besoin de valider ton numéro."
 msgstr "Pour sécuriser l'accès à ton pass nous avons besoin de valider ton numéro."
 
 #: src/features/identityCheck/pages/identification/IdentityCheckEduConnect.tsx
-msgid "Pour t'identifier, nous allons te demander de te connecter à ÉduConnect. Pense bien à avoir ton identifiant et ton mot de passe pour continuer. Si tu ne les as pas, contacte ton établissement pour les récupérer."
-msgstr "Pour t'identifier, nous allons te demander de te connecter à ÉduConnect. Pense bien à avoir ton identifiant et ton mot de passe pour continuer. Si tu ne les as pas, contacte ton établissement pour les récupérer."
+#: src/features/identityCheck/pages/identification/IdentityCheckEduConnectForm.web.tsx
+msgid "Pour t’identifier, nous allons te demander de te connecter à EduConnect. Munis-toi de ton identifiant et ton mot de passe EduConnect ! Si tu ne les as pas, contacte ton établissement pour les récupérer."
+msgstr "Pour t’identifier, nous allons te demander de te connecter à EduConnect. Munis-toi de ton identifiant et ton mot de passe EduConnect ! Si tu ne les as pas, contacte ton établissement pour les récupérer."
 
 #: src/features/profile/components/BeneficiaryCeilings.tsx
 msgid "Pourquoi les biens numériques sont-ils limités ?"
@@ -1933,10 +1906,6 @@ msgstr "Prix croissant"
 #: src/features/navigation/helpers/openUrl.ts
 msgid "Problème technique ;("
 msgstr "Problème technique ;("
-
-#: src/features/profile/pages/Profile.tsx
-msgid "Problèmes pour ouvrir un lien ?"
-msgstr "Problèmes pour ouvrir un lien ?"
 
 #: src/features/identityCheck/pages/profile/SetAddress.tsx
 #: src/features/identityCheck/pages/profile/SetCity.tsx
@@ -2110,7 +2079,6 @@ msgstr "Retrouve toutes tes offres en un clin d'oeil en les ajoutant à tes favo
 #: src/features/auth/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSent.tsx
 #: src/features/auth/signup/SignupForm.tsx
 #: src/features/bookings/components/BookingDetailsHeader.tsx
-#: src/features/deeplinks/pages/DeeplinkImporter.tsx
 #: src/features/identityCheck/atoms/layout/PageHeader.tsx
 #: src/features/offer/components/OfferHeader.tsx
 #: src/features/search/components/SearchBox.tsx
@@ -2666,10 +2634,6 @@ msgstr "Téléphone"
 msgid "Téléphone - Formulaire"
 msgstr "Téléphone - Formulaire"
 
-#: src/features/deeplinks/pages/DeeplinkImporter.tsx
-msgid "Un lien ne fonctionne pas ?"
-msgstr "Un lien ne fonctionne pas ?"
-
 #: src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
 #: src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
 msgid "Un problème est survenu pendant l'inscription, réessaie plus tard."
@@ -2679,6 +2643,10 @@ msgstr "Un problème est survenu pendant l'inscription, réessaie plus tard."
 #: src/features/auth/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
 msgid "Un problème est survenu pendant la réinitialisation, réessaie plus tard."
 msgstr "Un problème est survenu pendant la réinitialisation, réessaie plus tard."
+
+#: src/features/identityCheck/pages/identification/IdentityCheckEduConnectForm.web.tsx
+msgid "Un souci pour accéder à la page ? Essaie en navigation privée ou pense bien à accepter les pop-ups de ton navigateur."
+msgstr "Un souci pour accéder à la page ? Essaie en navigation privée ou pense bien à accepter les pop-ups de ton navigateur."
 
 #: src/features/profile/pages/ChangeEmail/AlreadyChangedEmailDisclaimer.tsx
 msgid "Une demande a été envoyée à ta nouvelle adresse. Tu as 24h pour la valider. Pense à vérifier tes spams."


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12805

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [x] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |        <img width="686" alt="Capture d’écran 2022-01-14 à 10 23 28" src="https://user-images.githubusercontent.com/44037911/149491483-4fe6fce7-c440-4104-91e1-e97530b3e407.png">          |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
