### PR TITLE
(PC-9881) fix(url): can have 1 URL per line

### DIFF
--- a/src/libs/parsers/highlightLinks.tsx
+++ b/src/libs/parsers/highlightLinks.tsx
@@ -7,7 +7,7 @@ export type ParsedDescription = Array<string | React.ReactNode>
 
 const externalUrlRegex = new RegExp(
   /((^|\s)|https?:\/\/)[a-z]([-a-z0-9@:%._+~#=]*[a-z0-9])?\.[a-z0-9]{1,6}([/?#]\S*)?(\s|$)/,
-  'gi'
+  'gmi'
 )
 
 export const customFindUrlChunks = ({ textToHighlight }: FindChunksArgs): Chunk[] => {

--- a/src/libs/parsers/tests/highlightLinks.test.tsx
+++ b/src/libs/parsers/tests/highlightLinks.test.tsx
@@ -124,6 +124,21 @@ describe('highlightLinks', () => {
 
           expect(parsedDescription).toEqual([description])
         })
+
+        it('can have one URL per line', () => {
+          const description = 'www.penofchaos.com/warham/donjon.htm\nperdu.com'
+
+          const parsedDescription = highlightLinks(description)
+
+          expect(parsedDescription).toEqual([
+            <ExternalLink
+              key="external-link-0"
+              url="http://www.penofchaos.com/warham/donjon.htm"
+            />,
+            '\n',
+            <ExternalLink key="external-link-2" url="http://perdu.com" />,
+          ])
+        })
       })
 
       describe('with protocol', () => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-9881

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.

## Screenshots

| Avant | Arpès |
| --: | ------: |
| ![image](https://user-images.githubusercontent.com/95220086/149792974-2b2ec4b9-91c3-4a39-a7b9-b703375e52f6.png) |![image](https://user-images.githubusercontent.com/95220086/149793010-9601f50c-9700-4f4a-90b2-bc587ccee1a5.png) |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
