### PR TITLE
(PC-12581) fix(EighteenBirthday): Fix bottom padding only for this card

### DIFF
--- a/__snapshots__/features/eighteenBirthday/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/eighteenBirthday/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -245,6 +245,7 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
                   }
                 />
                 <View
+                  paddingBottom={40}
                   style={
                     Array [
                       Object {

--- a/__snapshots__/features/eighteenBirthday/pages/components/EighteenBirthdayCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/eighteenBirthday/pages/components/EighteenBirthdayCard.native.test.tsx.native-snap
@@ -129,6 +129,7 @@ exports[`<EighteenBirthdayCard /> should render eighteen birthday card 1`] = `
     }
   />
   <View
+    paddingBottom={40}
     style={
       Array [
         Object {

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/FirstTutorial.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/FirstTutorial.native.test.tsx.native-snap
@@ -318,6 +318,7 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                   }
                 />
                 <View
+                  paddingBottom={40}
                   style={
                     Array [
                       Object {
@@ -532,6 +533,7 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                   }
                 />
                 <View
+                  paddingBottom={40}
                   style={
                     Array [
                       Object {
@@ -701,6 +703,7 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                   }
                 />
                 <View
+                  paddingBottom={40}
                   style={
                     Array [
                       Object {
@@ -870,6 +873,7 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                   }
                 />
                 <View
+                  paddingBottom={40}
                   style={
                     Array [
                       Object {

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FirstCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FirstCard.native.test.tsx.native-snap
@@ -129,6 +129,7 @@ exports[`FirstCard should render first card 1`] = `
     }
   />
   <View
+    paddingBottom={40}
     style={
       Array [
         Object {

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FourthCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/FourthCard.native.test.tsx.native-snap
@@ -129,6 +129,7 @@ exports[`FourthCard should render fourth card 1`] = `
     }
   />
   <View
+    paddingBottom={40}
     style={
       Array [
         Object {

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/SecondCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/SecondCard.native.test.tsx.native-snap
@@ -129,6 +129,7 @@ exports[`SecondCard should render second card 1`] = `
     }
   />
   <View
+    paddingBottom={40}
     style={
       Array [
         Object {

--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/ThirdCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/components/ThirdCard.native.test.tsx.native-snap
@@ -129,6 +129,7 @@ exports[`ThirdCard should render third card 1`] = `
     }
   />
   <View
+    paddingBottom={40}
     style={
       Array [
         Object {

--- a/src/features/eighteenBirthday/pages/components/EighteenBirthdayCard.tsx
+++ b/src/features/eighteenBirthday/pages/components/EighteenBirthdayCard.tsx
@@ -37,6 +37,7 @@ export function EighteenBirthdayCard(props: AchievementCardKeyProps) {
       activeIndex={props.activeIndex}
       lastIndex={props.lastIndex}
       skip={props.skip}
+      ignoreBottomPadding={true}
     />
   )
 }

--- a/src/ui/components/achievements/components/GenericAchievementCard.tsx
+++ b/src/ui/components/achievements/components/GenericAchievementCard.tsx
@@ -35,6 +35,7 @@ export type AchievementCardProps = AchievementCardKeyProps & {
   centerChild?: (() => JSX.Element) | null
   text: string
   title: string
+  ignoreBottomPadding?: boolean
 }
 
 const SMALL_HEIGHT = 576
@@ -126,7 +127,10 @@ Those props are provided by the GenericAchievementCard and must be passed down t
       )}
       <StyledBody>{props.text}</StyledBody>
       <Spacer.Flex flex={2} />
-      <BottomButtonsContainer>
+      <BottomButtonsContainer
+        paddingBottom={getSpacing(
+          props.ignoreBottomPadding ? grid({ default: 10, sm: 2, md: 5 }, 'height') : 10
+        )}>
         <Animatable.View ref={animatedButtonRef}>
           {props.activeIndex === props.index ? (
             <ButtonPrimary title={props.buttonText} onPress={props.buttonCallback} />
@@ -149,11 +153,11 @@ const FlexContainer = styled.View<{ marginTop: number }>((props) => ({
   marginTop: props.marginTop,
 }))
 
-const BottomButtonsContainer = styled.View({
+const BottomButtonsContainer = styled.View<{ paddingBottom: number }>(({ paddingBottom }) => ({
   flex: 1,
   justifyContent: 'flex-end',
-  paddingBottom: getSpacing(10),
-})
+  paddingBottom,
+}))
 
 const InvisibleButtonHeight = styled.View({
   height: getSpacing(12),

--- a/src/ui/theme/grid.ts
+++ b/src/ui/theme/grid.ts
@@ -46,6 +46,7 @@ export enum Breakpoints {
 
 interface Grid {
   sm?: number
+  md?: number
   default: number
 }
 
@@ -57,7 +58,10 @@ export function useGrid() {
   const grid = useCallback(
     (grid: Grid, axis: Axis = 'width') => {
       const axisLength = axis === 'width' ? appContentWidth : windowHeight
-      if (grid.sm && axisLength < Breakpoints.SM) {
+
+      if (grid.md && axisLength < Breakpoints.MD) {
+        return grid.md
+      } else if (grid.sm && axisLength < Breakpoints.SM) {
         return grid.sm
       }
       return grid.default


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12581

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS iPhone SE | Android Pixel 5 | Mobile - Chrome | Desktop - Chrome (Résolution: 1566 x 768) | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|<img width="366" alt="Capture d’écran 2022-01-18 à 09 28 51" src="https://user-images.githubusercontent.com/90036171/149899487-42985edf-575b-4bef-b0a5-ae84485d49c9.png">|<img width="385" alt="Capture d’écran 2022-01-18 à 09 24 55" src="https://user-images.githubusercontent.com/90036171/149899497-95493da0-c90c-41bd-881b-3ab763ab3523.png">|                 |                  |<img width="1163" alt="Capture d’écran 2022-01-18 à 09 34 50" src="https://user-images.githubusercontent.com/90036171/149900287-4b6c3190-4f3a-4f5b-ada1-5600705f8fce.png">|



[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
