### PR TITLE
(PC-12835) feat(bookingDetails): display the Duo selector when the offer is duo

### DIFF
--- a/__snapshots__/features/bookOffer/components/__tests__/BookDuoChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookDuoChoice.native.test.tsx.native-snap
@@ -37,6 +37,7 @@ Array [
         },
       ]
     }
+    testID="DuoChoiceSelector"
   >
     <View
       accessibilityState={

--- a/__snapshots__/features/bookOffer/components/__tests__/BookDuoChoice.web.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookDuoChoice.web.test.tsx.web-snap
@@ -19,6 +19,7 @@ Object {
       />
       <div
         class="css-view-1dbjc4n"
+        data-testid="DuoChoiceSelector"
         style="flex-direction: row; flex-wrap: wrap; margin-right: -8px; margin-left: -8px;"
       >
         <div
@@ -157,6 +158,7 @@ Object {
     />
     <div
       class="css-view-1dbjc4n"
+      data-testid="DuoChoiceSelector"
       style="flex-direction: row; flex-wrap: wrap; margin-right: -8px; margin-left: -8px;"
     >
       <div

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingEventChoices.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingEventChoices.native.test.tsx.native-snap
@@ -242,6 +242,7 @@ exports[`<BookingEventChoices /> should display date step and hour step and duo 
         },
       ]
     }
+    testID="DuoChoiceSelector"
   >
     <View
       accessibilityState={

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingEventChoices.web.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingEventChoices.web.test.tsx.web-snap
@@ -103,6 +103,7 @@ Object {
         />
         <div
           class="css-view-1dbjc4n"
+          data-testid="DuoChoiceSelector"
           style="flex-direction: row; flex-wrap: wrap; margin-right: -8px; margin-left: -8px;"
         >
           <div
@@ -355,6 +356,7 @@ Object {
       />
       <div
         class="css-view-1dbjc4n"
+        data-testid="DuoChoiceSelector"
         style="flex-direction: row; flex-wrap: wrap; margin-right: -8px; margin-left: -8px;"
       >
         <div

--- a/src/features/bookOffer/components/BookDuoChoice.tsx
+++ b/src/features/bookOffer/components/BookDuoChoice.tsx
@@ -2,39 +2,13 @@ import { t } from '@lingui/macro'
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { DuoChoice } from 'features/bookOffer/atoms/DuoChoice'
-import {
-  useBooking,
-  useBookingOffer,
-  useBookingStock,
-} from 'features/bookOffer/pages/BookingOfferWrapper'
+import { DuoChoiceSelector } from 'features/bookOffer/components/DuoChoiceSelector'
+import { useBooking } from 'features/bookOffer/pages/BookingOfferWrapper'
 import { Step } from 'features/bookOffer/pages/reducer'
-import { useCreditForOffer } from 'features/offer/services/useHasEnoughCredit'
-import { formatToFrenchDecimal } from 'libs/parsers'
-import { Profile } from 'ui/svg/icons/Profile'
-import { IconInterface } from 'ui/svg/icons/types'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { Spacer, Typo } from 'ui/theme'
 
 export const BookDuoChoice: React.FC = () => {
   const { bookingState, dispatch } = useBooking()
-  const { isDuo } = useBookingOffer() || {}
-  const stock = useBookingStock()
-  const offerCredit = useCreditForOffer(bookingState.offerId)
-
-  const getChoiceInfosForQuantity = (quantity: 1 | 2) => {
-    const enoughCredit = stock ? quantity * stock.price <= offerCredit : false
-    return {
-      price:
-        enoughCredit && stock
-          ? formatToFrenchDecimal(quantity * stock.price).replace(' ', '')
-          : t`crédit insuffisant`,
-      title: quantity === 1 ? t`Solo` : t`Duo`,
-      selected: bookingState.quantity === quantity,
-      icon: quantity === 1 ? Profile : DuoPerson,
-      onPress: () => dispatch({ type: 'SELECT_QUANTITY', payload: quantity }),
-      hasEnoughCredit: enoughCredit,
-    }
-  }
 
   const updateBookingStepToDuo = () => {
     dispatch({ type: 'CHANGE_STEP', payload: Step.DUO })
@@ -45,10 +19,7 @@ export const BookDuoChoice: React.FC = () => {
       <Typo.Title4 testID="DuoStep">{t`Nombre de place`}</Typo.Title4>
       <Spacer.Column numberOfSpaces={2} />
       {bookingState.step === Step.DUO ? (
-        <DuoChoiceContainer>
-          <DuoChoice {...getChoiceInfosForQuantity(1)} testID={`DuoChoice1`} />
-          {!!isDuo && <DuoChoice {...getChoiceInfosForQuantity(2)} testID={`DuoChoice2`} />}
-        </DuoChoiceContainer>
+        <DuoChoiceSelector />
       ) : (
         <TouchableOpacity onPress={updateBookingStepToDuo}>
           <Typo.ButtonText>
@@ -60,21 +31,6 @@ export const BookDuoChoice: React.FC = () => {
   )
 }
 
-const DuoPerson = (props: IconInterface): JSX.Element => (
-  <DuoPersonContainer>
-    <Profile {...props} />
-    <Profile {...props} />
-  </DuoPersonContainer>
-)
-
 const TouchableOpacity = styled.TouchableOpacity.attrs(({ theme }) => ({
   activeOpacity: theme.activeOpacity,
 }))``
-
-const DuoChoiceContainer = styled.View({
-  flexDirection: 'row',
-  flexWrap: 'wrap',
-  marginHorizontal: -getSpacing(2),
-})
-
-const DuoPersonContainer = styled.View({ flexDirection: 'row' })

--- a/src/features/bookOffer/components/BookDuoChoice.tsx
+++ b/src/features/bookOffer/components/BookDuoChoice.tsx
@@ -36,7 +36,7 @@ export const BookDuoChoice: React.FC = () => {
     }
   }
 
-  const changeQuantity = () => {
+  const updateBookingStepToDuo = () => {
     dispatch({ type: 'CHANGE_STEP', payload: Step.DUO })
   }
 
@@ -50,7 +50,7 @@ export const BookDuoChoice: React.FC = () => {
           {!!isDuo && <DuoChoice {...getChoiceInfosForQuantity(2)} testID={`DuoChoice2`} />}
         </DuoChoiceContainer>
       ) : (
-        <TouchableOpacity onPress={changeQuantity}>
+        <TouchableOpacity onPress={updateBookingStepToDuo}>
           <Typo.ButtonText>
             {bookingState.quantity && bookingState.quantity === 1 ? t`Solo` : t`Duo`}
           </Typo.ButtonText>

--- a/src/features/bookOffer/components/BookingDetails.tsx
+++ b/src/features/bookOffer/components/BookingDetails.tsx
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { isApiError } from 'api/apiHelpers'
 import { OfferStockResponse } from 'api/gen'
+import { DuoChoiceSelector } from 'features/bookOffer/components/DuoChoiceSelector'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { useIsUserUnderage } from 'features/profile/utils'
 import { analytics } from 'libs/analytics'
@@ -118,6 +119,17 @@ export const BookingDetails: React.FC<Props> = ({ stocks }) => {
       <CancellationDetails />
 
       <Spacer.Column numberOfSpaces={6} />
+
+      {!!offer?.isDuo && (
+        <React.Fragment>
+          <Separator />
+          <Spacer.Column numberOfSpaces={6} />
+
+          <DuoChoiceSelector />
+
+          <Spacer.Column numberOfSpaces={6} />
+        </React.Fragment>
+      )}
 
       <ButtonPrimary
         disabled={!isStockBookable}

--- a/src/features/bookOffer/components/DuoChoiceSelector.tsx
+++ b/src/features/bookOffer/components/DuoChoiceSelector.tsx
@@ -1,0 +1,59 @@
+import { t } from '@lingui/macro'
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { DuoChoice } from 'features/bookOffer/atoms/DuoChoice'
+import {
+  useBooking,
+  useBookingOffer,
+  useBookingStock,
+} from 'features/bookOffer/pages/BookingOfferWrapper'
+import { useCreditForOffer } from 'features/offer/services/useHasEnoughCredit'
+import { formatToFrenchDecimal } from 'libs/parsers'
+import { Profile } from 'ui/svg/icons/Profile'
+import { IconInterface } from 'ui/svg/icons/types'
+import { getSpacing } from 'ui/theme'
+
+export const DuoChoiceSelector: React.FC = () => {
+  const { bookingState, dispatch } = useBooking()
+  const { isDuo } = useBookingOffer() || {}
+  const stock = useBookingStock()
+  const offerCredit = useCreditForOffer(bookingState.offerId)
+
+  const getChoiceInfosForQuantity = (quantity: 1 | 2) => {
+    const enoughCredit = stock ? quantity * stock.price <= offerCredit : false
+    return {
+      price:
+        enoughCredit && stock
+          ? formatToFrenchDecimal(quantity * stock.price).replace(' ', '')
+          : t`crédit insuffisant`,
+      title: quantity === 1 ? t`Solo` : t`Duo`,
+      selected: bookingState.quantity === quantity,
+      icon: quantity === 1 ? Profile : DuoPerson,
+      onPress: () => dispatch({ type: 'SELECT_QUANTITY', payload: quantity }),
+      hasEnoughCredit: enoughCredit,
+    }
+  }
+
+  return (
+    <DuoChoiceContainer>
+      <DuoChoice {...getChoiceInfosForQuantity(1)} testID={`DuoChoice1`} />
+      {!!isDuo && <DuoChoice {...getChoiceInfosForQuantity(2)} testID={`DuoChoice2`} />}
+    </DuoChoiceContainer>
+  )
+}
+
+const DuoPerson = (props: IconInterface): JSX.Element => (
+  <DuoPersonContainer>
+    <Profile {...props} />
+    <Profile {...props} />
+  </DuoPersonContainer>
+)
+
+const DuoChoiceContainer = styled.View({
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  marginHorizontal: -getSpacing(2),
+})
+
+const DuoPersonContainer = styled.View({ flexDirection: 'row' })

--- a/src/features/bookOffer/components/DuoChoiceSelector.tsx
+++ b/src/features/bookOffer/components/DuoChoiceSelector.tsx
@@ -36,7 +36,7 @@ export const DuoChoiceSelector: React.FC = () => {
   }
 
   return (
-    <DuoChoiceContainer>
+    <DuoChoiceContainer testID="DuoChoiceSelector">
       <DuoChoice {...getChoiceInfosForQuantity(1)} testID={`DuoChoice1`} />
       {!!isDuo && <DuoChoice {...getChoiceInfosForQuantity(2)} testID={`DuoChoice2`} />}
     </DuoChoiceContainer>

--- a/src/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx
+++ b/src/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx
@@ -191,6 +191,33 @@ describe('<BookingDetails />', () => {
       })
     }
   )
+
+  it('should not display the Duo selector when the offer is not duo', async () => {
+    mockBookingState = {
+      bookingState: mockInitialBookingState,
+      dismissModal: mockDismissModal,
+      dispatch: mockDispatch,
+    }
+
+    const { queryByTestId } = await renderBookingDetails(mockDigitalStocks)
+
+    expect(queryByTestId('DuoChoiceSelector')).toBeFalsy()
+  })
+
+  it('should display the Duo selector when the offer is duo', async () => {
+    mockUseBookingOffer.mockReturnValueOnce({ ...mockOffer, isDuo: true })
+
+    const duoBookingState: BookingState = { ...mockInitialBookingState, quantity: 2 }
+    mockBookingState = {
+      bookingState: duoBookingState,
+      dismissModal: mockDismissModal,
+      dispatch: mockDispatch,
+    }
+
+    const { queryByTestId } = await renderBookingDetails(mockDigitalStocks)
+
+    expect(queryByTestId('DuoChoiceSelector')).toBeTruthy()
+  })
 })
 
 const renderBookingDetails = async (stocks: OfferStockResponse[]) => {

--- a/src/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx
+++ b/src/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx
@@ -6,7 +6,7 @@ import waitForExpect from 'wait-for-expect'
 import { navigate } from '__mocks__/@react-navigation/native'
 import { OfferStockResponse } from 'api/gen'
 import { mockDigitalOffer, mockOffer } from 'features/bookOffer/fixtures/offer'
-import { useBookingStock } from 'features/bookOffer/pages/BookingOfferWrapper'
+import { useBookingOffer, useBookingStock } from 'features/bookOffer/pages/BookingOfferWrapper'
 import { BookingState, initialBookingState } from 'features/bookOffer/pages/reducer'
 import { notExpiredStock } from 'features/offer/services/useCtaWordingAndAction.testsFixtures'
 import { useIsUserUnderage } from 'features/profile/utils'
@@ -43,8 +43,10 @@ let mockBookingStock = {
 jest.mock('features/bookOffer/pages/BookingOfferWrapper', () => ({
   useBooking: jest.fn(() => mockBookingState),
   useBookingStock: jest.fn(() => mockBookingStock),
-  useBookingOffer: jest.fn(() => mockOffer),
+  useBookingOffer: jest.fn(),
 }))
+const mockUseBookingOffer = mocked(useBookingOffer)
+mockUseBookingOffer.mockReturnValue({ ...mockOffer, isDuo: false })
 
 const mockShowErrorSnackBar = jest.fn()
 jest.mock('ui/components/snackBar/SnackBarContext', () => ({

--- a/src/features/bookings/helpers.test.ts
+++ b/src/features/bookings/helpers.test.ts
@@ -210,23 +210,45 @@ describe('getBookingProperties', () => {
     })
   })
 
-  it('when duo', () => {
-    const booking = {
-      stock: { offer: { isDigital: true, isPermanent: true } },
-      quantity: 2,
-    } as Booking
+  describe('when duo', () => {
+    it('with an event', () => {
+      const booking = {
+        stock: { offer: { isDigital: true, isPermanent: true } },
+        quantity: 2,
+      } as Booking
 
-    const isEvent = true
+      const isEvent = true
 
-    const bookingProperties = getBookingProperties(booking, isEvent)
+      const bookingProperties = getBookingProperties(booking, isEvent)
 
-    expect(bookingProperties).toEqual({
-      isDuo: true,
-      isEvent: true,
-      isPhysical: false,
-      isDigital: true,
-      isPermanent: true,
-      hasActivationCode: false,
+      expect(bookingProperties).toEqual({
+        isDuo: true,
+        isEvent: true,
+        isPhysical: false,
+        isDigital: true,
+        isPermanent: true,
+        hasActivationCode: false,
+      })
+    })
+
+    it('with an non-event', () => {
+      const booking = {
+        stock: { offer: { isDigital: true, isPermanent: true } },
+        quantity: 2,
+      } as Booking
+
+      const isEvent = false
+
+      const bookingProperties = getBookingProperties(booking, isEvent)
+
+      expect(bookingProperties).toEqual({
+        isDuo: true,
+        isEvent: false,
+        isPhysical: true,
+        isDigital: true,
+        isPermanent: true,
+        hasActivationCode: false,
+      })
     })
   })
 })

--- a/src/features/bookings/helpers.test.ts
+++ b/src/features/bookings/helpers.test.ts
@@ -3,7 +3,11 @@ import mockdate from 'mockdate'
 import { SettingsResponse } from 'api/gen'
 import { bookingsSnap } from 'features/bookings/api/bookingsSnap'
 import { Booking } from 'features/bookings/components/types'
-import { getBookingLabelForActivationCode, getBookingLabels } from 'features/bookings/helpers'
+import {
+  getBookingLabelForActivationCode,
+  getBookingLabels,
+  getBookingProperties,
+} from 'features/bookings/helpers'
 
 describe('getBookingLabelForActivationCode', () => {
   it('should display the date in the label', () => {
@@ -141,6 +145,88 @@ describe('getBookingLabels', () => {
       dateLabel: 'À activer avant le 15 mars 2021',
       locationLabel: '',
       withdrawLabel: '',
+    })
+  })
+})
+
+describe('getBookingProperties', () => {
+  it('when an event booking is provided', () => {
+    const booking = {
+      stock: { offer: { isDigital: true, isPermanent: true } },
+      activationCode: null,
+    } as Booking
+
+    const isEvent = true
+
+    const bookingProperties = getBookingProperties(booking, isEvent)
+
+    expect(bookingProperties).toEqual({
+      isDuo: false,
+      isEvent: true,
+      isPhysical: false,
+      isDigital: true,
+      isPermanent: true,
+      hasActivationCode: false,
+    })
+  })
+
+  it('when a physical booking is provided', () => {
+    const booking = {
+      stock: { offer: { isDigital: true, isPermanent: true } },
+      activationCode: null,
+    } as Booking
+
+    const isEvent = false
+
+    const bookingProperties = getBookingProperties(booking, isEvent)
+
+    expect(bookingProperties).toEqual({
+      isDuo: false,
+      isEvent: false,
+      isPhysical: true,
+      isDigital: true,
+      isPermanent: true,
+      hasActivationCode: false,
+    })
+  })
+
+  it('when a booking with activation code is provided', () => {
+    const booking = {
+      stock: { offer: { isDigital: true, isPermanent: true } },
+      activationCode: { code: 'toto' },
+    } as Booking
+
+    const isEvent = false
+
+    const bookingProperties = getBookingProperties(booking, isEvent)
+
+    expect(bookingProperties).toEqual({
+      isDuo: false,
+      isEvent: false,
+      isPhysical: true,
+      isDigital: true,
+      isPermanent: true,
+      hasActivationCode: true,
+    })
+  })
+
+  it('when duo', () => {
+    const booking = {
+      stock: { offer: { isDigital: true, isPermanent: true } },
+      quantity: 2,
+    } as Booking
+
+    const isEvent = true
+
+    const bookingProperties = getBookingProperties(booking, isEvent)
+
+    expect(bookingProperties).toEqual({
+      isDuo: true,
+      isEvent: true,
+      isPhysical: false,
+      isDigital: true,
+      isPermanent: true,
+      hasActivationCode: false,
     })
   })
 })

--- a/src/features/bookings/helpers.ts
+++ b/src/features/bookings/helpers.ts
@@ -28,7 +28,7 @@ export function getBookingProperties(booking: Booking, isEvent: boolean): Bookin
   const { offer } = stock
 
   return {
-    isDuo: isEvent && isDuoBooking(booking),
+    isDuo: isDuoBooking(booking),
     isEvent,
     isPhysical: !isEvent,
     isDigital: offer.isDigital,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12835

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.

## Screenshots

|Avant|Après|
|:--:|:--:|
|![image](https://user-images.githubusercontent.com/95220086/149962412-88202c28-cfd9-476c-8a33-025af433a265.png)|![image](https://user-images.githubusercontent.com/95220086/149962558-d15681b5-6d81-40fb-b5d2-b926651768a8.png)|
|![image](https://user-images.githubusercontent.com/95220086/149962736-f38c1b9a-4f34-4368-ac90-5f02b61e246a.png)|![image](https://user-images.githubusercontent.com/95220086/149962793-938351b1-24b5-4bc8-8110-718776fee225.png)|
|![image](https://user-images.githubusercontent.com/95220086/149962861-c7fc6c0d-472a-4c6e-bd16-ac340b4c2296.png)|![image](https://user-images.githubusercontent.com/95220086/149962886-862b344d-c994-446c-828f-31f2a06ca376.png)|


[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
