### PR TITLE
(PC-12961) fix(ZIndex): remove last import of ZIndex constant in profit of theme

### DIFF
--- a/src/ui/components/snackBar/SnackBar.tsx
+++ b/src/ui/components/snackBar/SnackBar.tsx
@@ -18,7 +18,6 @@ import { IconInterface } from 'ui/svg/icons/types'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 import { ColorsEnum } from 'ui/theme'
 import { ACTIVE_OPACITY } from 'ui/theme/colors'
-import { ZIndex } from 'ui/theme/layers'
 
 type RefType = RefObject<
   React.Component<AnimatableProperties<ViewStyle> & ViewProps, never, never> & {
@@ -129,9 +128,9 @@ const _SnackBar = (props: SnackBarProps) => {
 
 export const SnackBar = memo(_SnackBar)
 
-/* 
-  Display rules : 
-  - On mobile : at the very top of the screen, with a full width 
+/*
+  Display rules :
+  - On mobile : at the very top of the screen, with a full width
   - On tablet or desktop : below top menu on the right side of the screen, with a max width
 */
 const RootContainer = styled(View)(({ theme }) => ({
@@ -140,7 +139,7 @@ const RootContainer = styled(View)(({ theme }) => ({
   top: theme.isMobileViewport ? 0 : theme.navTopHeight,
   left: theme.isMobileViewport ? 0 : 'auto',
   right: 0,
-  zIndex: ZIndex.SNACKBAR,
+  zIndex: theme.zIndex.snackbar,
 }))
 
 // Troobleshoot Animated types issue with forwaded 'backgroundColor' prop


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12961

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
