### PR TITLE
(PC-12958) fix(activeOpacity): remove last constants imports in profit of theme

### DIFF
--- a/src/features/bookOffer/atoms/ChoiceBloc.tsx
+++ b/src/features/bookOffer/atoms/ChoiceBloc.tsx
@@ -3,7 +3,6 @@ import styled, { useTheme } from 'styled-components/native'
 
 import { Validate } from 'ui/svg/icons/Validate'
 import { ColorsEnum, getSpacing, Spacer } from 'ui/theme'
-import { ACTIVE_OPACITY } from 'ui/theme/colors'
 import { BorderRadiusEnum } from 'ui/theme/grid'
 
 const getBorderColor = (selected: boolean, disabled?: boolean) => {
@@ -35,11 +34,7 @@ export const ChoiceBloc: React.FC<Props> = ({ selected, onPress, testID, childre
     (appContentWidth - 2 * getSpacing(4) - CHOICE_BLOCS_BY_LINE * getSpacing(2)) /
     CHOICE_BLOCS_BY_LINE
   return (
-    <ChoiceContainer
-      onPress={onPress}
-      activeOpacity={ACTIVE_OPACITY}
-      testID={testID}
-      disabled={disabled}>
+    <ChoiceContainer onPress={onPress} testID={testID} disabled={disabled}>
       <ChoiceContent selected={selected} disabled={disabled}>
         {selected ? (
           <IconContainer>
@@ -60,7 +55,9 @@ const IconContainer = styled.View({
   right: getSpacing(0.5),
 })
 
-const ChoiceContainer = styled.TouchableOpacity({
+const ChoiceContainer = styled.TouchableOpacity.attrs(({ theme }) => ({
+  activeOpacity: theme.activeOpacity,
+}))({
   width: '33%',
   padding: getSpacing(2),
 })

--- a/src/features/bookOffer/components/BookDateChoice.tsx
+++ b/src/features/bookOffer/components/BookDateChoice.tsx
@@ -1,12 +1,11 @@
 import { t } from '@lingui/macro'
 import React from 'react'
-import { TouchableOpacity } from 'react-native'
+import styled from 'styled-components/native'
 
 import { OfferStockResponse } from 'api/gen'
 import { useBooking } from 'features/bookOffer/pages/BookingOfferWrapper'
 import { formatToCompleteFrenchDate } from 'libs/parsers'
 import { Spacer, Typo } from 'ui/theme'
-import { ACTIVE_OPACITY } from 'ui/theme/colors'
 
 import { Step } from '../pages/reducer'
 
@@ -37,7 +36,7 @@ export const BookDateChoice: React.FC<Props> = ({ stocks, userRemainingCredit })
           offerId={bookingState.offerId}
         />
       ) : (
-        <TouchableOpacity activeOpacity={ACTIVE_OPACITY} onPress={showCalendar}>
+        <TouchableOpacity onPress={showCalendar}>
           <Spacer.Column numberOfSpaces={2} />
           <Typo.ButtonText>
             {bookingState.date ? formatToCompleteFrenchDate(bookingState.date) : ''}
@@ -47,3 +46,7 @@ export const BookDateChoice: React.FC<Props> = ({ stocks, userRemainingCredit })
     </React.Fragment>
   )
 }
+
+const TouchableOpacity = styled.TouchableOpacity.attrs(({ theme }) => ({
+  activeOpacity: theme.activeOpacity,
+}))``

--- a/src/features/bookOffer/components/BookDuoChoice.tsx
+++ b/src/features/bookOffer/components/BookDuoChoice.tsx
@@ -1,6 +1,5 @@
 import { t } from '@lingui/macro'
 import React from 'react'
-import { TouchableOpacity } from 'react-native'
 import styled from 'styled-components/native'
 
 import { DuoChoice } from 'features/bookOffer/atoms/DuoChoice'
@@ -15,7 +14,6 @@ import { formatToFrenchDecimal } from 'libs/parsers'
 import { Profile } from 'ui/svg/icons/Profile'
 import { IconInterface } from 'ui/svg/icons/types'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-import { ACTIVE_OPACITY } from 'ui/theme/colors'
 
 export const BookDuoChoice: React.FC = () => {
   const { bookingState, dispatch } = useBooking()
@@ -52,7 +50,7 @@ export const BookDuoChoice: React.FC = () => {
           {!!isDuo && <DuoChoice {...getChoiceInfosForQuantity(2)} testID={`DuoChoice2`} />}
         </DuoChoiceContainer>
       ) : (
-        <TouchableOpacity activeOpacity={ACTIVE_OPACITY} onPress={changeQuantity}>
+        <TouchableOpacity onPress={changeQuantity}>
           <Typo.ButtonText>
             {bookingState.quantity && bookingState.quantity === 1 ? t`Solo` : t`Duo`}
           </Typo.ButtonText>
@@ -68,6 +66,10 @@ const DuoPerson = (props: IconInterface): JSX.Element => (
     <Profile {...props} />
   </DuoPersonContainer>
 )
+
+const TouchableOpacity = styled.TouchableOpacity.attrs(({ theme }) => ({
+  activeOpacity: theme.activeOpacity,
+}))``
 
 const DuoChoiceContainer = styled.View({
   flexDirection: 'row',

--- a/src/features/bookOffer/components/BookHourChoice.tsx
+++ b/src/features/bookOffer/components/BookHourChoice.tsx
@@ -1,7 +1,6 @@
 import { t } from '@lingui/macro'
 import debounce from 'lodash/debounce'
 import React, { useMemo, useRef } from 'react'
-import { TouchableOpacity } from 'react-native'
 import styled from 'styled-components/native'
 
 import {
@@ -12,7 +11,6 @@ import {
 import { formatHour, formatToKeyDate } from 'features/bookOffer/services/utils'
 import { useCreditForOffer } from 'features/offer/services/useHasEnoughCredit'
 import { Typo, Spacer, getSpacing } from 'ui/theme'
-import { ACTIVE_OPACITY } from 'ui/theme/colors'
 
 import { HourChoice } from '../atoms/HourChoice'
 import { Step } from '../pages/reducer'
@@ -78,7 +76,7 @@ export const BookHourChoice: React.FC = () => {
       {bookingState.step === Step.HOUR ? (
         <HourChoiceContainer>{filteredStocks}</HourChoiceContainer>
       ) : (
-        <TouchableOpacity activeOpacity={ACTIVE_OPACITY} onPress={changeHour}>
+        <TouchableOpacity onPress={changeHour}>
           <Typo.ButtonText>
             {stock && stock.beginningDatetime ? formatHour(stock.beginningDatetime) : ''}
           </Typo.ButtonText>
@@ -87,6 +85,10 @@ export const BookHourChoice: React.FC = () => {
     </React.Fragment>
   )
 }
+
+const TouchableOpacity = styled.TouchableOpacity.attrs(({ theme }) => ({
+  activeOpacity: theme.activeOpacity,
+}))``
 
 const HourChoiceContainer = styled.View({
   flexDirection: 'row',

--- a/src/features/identityCheck/atoms/AddressOption.tsx
+++ b/src/features/identityCheck/atoms/AddressOption.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components/native'
 import { Separator } from 'ui/components/Separator'
 import { Validate } from 'ui/svg/icons/Validate'
 import { ColorsEnum, getSpacing, Typo } from 'ui/theme'
-import { ACTIVE_OPACITY } from 'ui/theme/colors'
 
 interface Props {
   onPressOption: (optionKey: string) => void
@@ -18,16 +17,14 @@ const ICON_SIZE = getSpacing(6)
 export const AddressOption = ({ optionKey, label, onPressOption, selected }: Props) => {
   return (
     <Container>
-      <StyledTouchableOpacity
-        onPress={() => onPressOption(optionKey)}
-        activeOpacity={ACTIVE_OPACITY}>
+      <TouchableOpacity onPress={() => onPressOption(optionKey)}>
         <TextContainer>
           <StyledBody selected={selected}>{label}</StyledBody>
           <IconContainer>
             {!!selected && <Validate color={ColorsEnum.PRIMARY} size={ICON_SIZE} />}
           </IconContainer>
         </TextContainer>
-      </StyledTouchableOpacity>
+      </TouchableOpacity>
       <Separator />
     </Container>
   )
@@ -37,7 +34,9 @@ const Container = styled.View({
   paddingHorizontal: getSpacing(4),
 })
 
-const StyledTouchableOpacity = styled.TouchableOpacity({
+const TouchableOpacity = styled.TouchableOpacity.attrs(({ theme }) => ({
+  activeOpacity: theme.activeOpacity,
+}))({
   flexDirection: 'column',
   justifyContent: 'flex-start',
   paddingVertical: getSpacing(3),

--- a/src/features/identityCheck/atoms/StepButton.tsx
+++ b/src/features/identityCheck/atoms/StepButton.tsx
@@ -5,7 +5,6 @@ import { StepConfig } from 'features/identityCheck/types'
 import { accessibilityAndTestId } from 'tests/utils'
 import { Validate } from 'ui/svg/icons/Validate'
 import { ColorsEnum, getSpacing, Typo } from 'ui/theme'
-import { ACTIVE_OPACITY } from 'ui/theme/colors'
 import { BorderRadiusEnum } from 'ui/theme/grid'
 
 export type StepButtonState = 'completed' | 'current' | 'disabled'
@@ -20,8 +19,7 @@ export const StepButton = ({ step, state, onPress }: Props) => {
   const { icon: Icon, label } = step
 
   return (
-    <Button
-      activeOpacity={ACTIVE_OPACITY}
+    <TouchableOpacity
       onPress={onPress}
       disabled={state !== 'current'}
       state={state}
@@ -36,11 +34,13 @@ export const StepButton = ({ step, state, onPress }: Props) => {
           {...accessibilityAndTestId(state === 'completed' ? 'StepCompleted' : 'StepNotCompleted')}
         />
       </CompletionContainer>
-    </Button>
+    </TouchableOpacity>
   )
 }
 
-const Button = styled.TouchableOpacity<{ disabled: boolean; state: StepButtonState }>((props) => ({
+const TouchableOpacity = styled.TouchableOpacity.attrs(({ theme }) => ({
+  activeOpacity: theme.activeOpacity,
+}))<{ disabled: boolean; state: StepButtonState }>((props) => ({
   height: getSpacing(24),
   marginTop: getSpacing(6),
   width: '100%',

--- a/src/features/search/atoms/Buttons/DateFilter.tsx
+++ b/src/features/search/atoms/Buttons/DateFilter.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components/native'
 
 import { Validate } from 'ui/svg/icons/Validate'
 import { ColorsEnum, getSpacing, Typo } from 'ui/theme'
-import { ACTIVE_OPACITY } from 'ui/theme/colors'
 
 interface Props {
   isSelected: boolean
@@ -15,14 +14,16 @@ export const DateFilter: React.FC<Props> = ({ text, onPress, isSelected }: Props
   const color = isSelected ? ColorsEnum.PRIMARY : ColorsEnum.BLACK
 
   return (
-    <ButtonContainer onPress={onPress} activeOpacity={ACTIVE_OPACITY}>
+    <TouchableOpacity onPress={onPress}>
       <Typo.ButtonText color={color}>{text}</Typo.ButtonText>
       {!!isSelected && <Validate color={ColorsEnum.PRIMARY} size={getSpacing(6)} />}
-    </ButtonContainer>
+    </TouchableOpacity>
   )
 }
 
-const ButtonContainer = styled.TouchableOpacity({
+const TouchableOpacity = styled.TouchableOpacity.attrs(({ theme }) => ({
+  activeOpacity: theme.activeOpacity,
+}))({
   height: getSpacing(6),
   flexDirection: 'row',
   alignItems: 'center',

--- a/src/features/search/atoms/Buttons/ReinitializeFilters.tsx
+++ b/src/features/search/atoms/Buttons/ReinitializeFilters.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro'
 import React from 'react'
-import { TouchableOpacity } from 'react-native'
+import styled from 'styled-components/native'
 
 import { useStagedSearch } from 'features/search/pages/SearchWrapper'
 import { useMaxPrice } from 'features/search/utils/useMaxPrice'
@@ -8,7 +8,6 @@ import { analytics } from 'libs/analytics'
 import useFunctionOnce from 'libs/hooks/useFunctionOnce'
 import { accessibilityAndTestId } from 'tests/utils'
 import { ColorsEnum, Typo } from 'ui/theme'
-import { ACTIVE_OPACITY } from 'ui/theme/colors'
 
 export const ReinitializeFilters = () => {
   const { dispatch } = useStagedSearch()
@@ -29,10 +28,13 @@ export const ReinitializeFilters = () => {
 
   return (
     <TouchableOpacity
-      activeOpacity={ACTIVE_OPACITY}
       onPress={reinitializeFilters}
       {...accessibilityAndTestId(t`Réinitialiser les filtres`)}>
       <Typo.ButtonText color={ColorsEnum.WHITE}>{t`Réinitialiser`}</Typo.ButtonText>
     </TouchableOpacity>
   )
 }
+
+const TouchableOpacity = styled.TouchableOpacity.attrs(({ theme }) => ({
+  activeOpacity: theme.activeOpacity,
+}))``

--- a/src/features/search/sections/OfferDate.tsx
+++ b/src/features/search/sections/OfferDate.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro'
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react'
 import { Platform } from 'react-native'
-import { TouchableOpacity } from 'react-native-gesture-handler'
+import { TouchableOpacity as TouchableOpacityGestureHandler } from 'react-native-gesture-handler'
 import styled, { useTheme } from 'styled-components/native'
 
 import { DateFilter } from 'features/search/atoms/Buttons'
@@ -12,7 +12,6 @@ import { SectionTitle } from 'features/search/sections/titles'
 import { useLogFilterOnce } from 'features/search/utils/useLogFilterOnce'
 import { formatToCompleteFrenchDate } from 'libs/parsers'
 import { ColorsEnum, getSpacing, Spacer, Typo } from 'ui/theme'
-import { ACTIVE_OPACITY } from 'ui/theme/colors'
 
 type Props = {
   setScrollEnabled?: ((setScrollEnabled: boolean) => void) | Dispatch<SetStateAction<boolean>>
@@ -73,10 +72,7 @@ export function OfferDate({ setScrollEnabled }: Props) {
           onPress={selectDateFilterOption(DATE_FILTER_OPTIONS.USER_PICK)}
         />
         {option === DATE_FILTER_OPTIONS.USER_PICK && (
-          <TouchableOpacity
-            testID="pickedDate"
-            activeOpacity={ACTIVE_OPACITY}
-            onPress={() => setShowTimePicker(true)}>
+          <TouchableOpacity testID="pickedDate" onPress={() => setShowTimePicker(true)}>
             <Typo.Body color={ColorsEnum.BLACK}>
               {formatToCompleteFrenchDate(selectedDate)}
             </Typo.Body>
@@ -93,5 +89,8 @@ export function OfferDate({ setScrollEnabled }: Props) {
     </React.Fragment>
   )
 }
+const TouchableOpacity = styled(TouchableOpacityGestureHandler).attrs(({ theme }) => ({
+  activeOpacity: theme.activeOpacity,
+}))``
 
 const Container = styled.View({ marginHorizontal: getSpacing(6) })

--- a/src/ui/components/buttons/AppButton.tsx
+++ b/src/ui/components/buttons/AppButton.tsx
@@ -6,7 +6,6 @@ import { accessibilityAndTestId } from 'tests/utils'
 import { Logo } from 'ui/svg/icons/Logo'
 import { IconInterface } from 'ui/svg/icons/types'
 import { ColorsEnum, getSpacing, Typo } from 'ui/theme'
-import { ACTIVE_OPACITY } from 'ui/theme/colors'
 import { BorderRadiusEnum } from 'ui/theme/grid'
 
 export interface BaseButtonProps {
@@ -130,8 +129,8 @@ interface StyledTouchableOpacityProps {
   numberOfLines?: number
 }
 
-const StyledTouchableOpacity = styled(TouchableOpacity).attrs(() => ({
-  activeOpacity: ACTIVE_OPACITY,
+const StyledTouchableOpacity = styled(TouchableOpacity).attrs(({ theme }) => ({
+  activeOpacity: theme.activeOpacity,
 }))<StyledTouchableOpacityProps>(
   ({
     inline,

--- a/src/ui/components/snackBar/SnackBar.tsx
+++ b/src/ui/components/snackBar/SnackBar.tsx
@@ -7,7 +7,7 @@ import React, {
   useState,
   memo,
 } from 'react'
-import { TouchableOpacity, View, ViewProps, ViewStyle } from 'react-native'
+import { View, ViewProps, ViewStyle } from 'react-native'
 import { AnimatableProperties, View as AnimatableView } from 'react-native-animatable'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled from 'styled-components/native'
@@ -17,7 +17,6 @@ import { Close } from 'ui/svg/icons/Close'
 import { IconInterface } from 'ui/svg/icons/types'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 import { ColorsEnum } from 'ui/theme'
-import { ACTIVE_OPACITY } from 'ui/theme/colors'
 
 type RefType = RefObject<
   React.Component<AnimatableProperties<ViewStyle> & ViewProps, never, never> & {
@@ -113,10 +112,7 @@ const _SnackBar = (props: SnackBarProps) => {
               {props.message}
             </Text>
           </Spacer.Flex>
-          <TouchableOpacity
-            testID="snackbar-close"
-            onPress={onClose}
-            activeOpacity={ACTIVE_OPACITY}>
+          <TouchableOpacity testID="snackbar-close" onPress={onClose}>
             <Close size={20} color={props.color} />
           </TouchableOpacity>
         </SnackBarContainer>
@@ -127,6 +123,10 @@ const _SnackBar = (props: SnackBarProps) => {
 }
 
 export const SnackBar = memo(_SnackBar)
+
+const TouchableOpacity = styled.TouchableOpacity.attrs(({ theme }) => ({
+  activeOpacity: theme.activeOpacity,
+}))``
 
 /*
   Display rules :


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12958

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
