### PR TITLE
(PC-12981) feat(accessiblity): add label and aria-describedby to email and password inputs

### DIFF
--- a/__snapshots__/features/auth/forgottenPassword/ForgottenPassword/tests/ForgottenPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ForgottenPassword/tests/ForgottenPassword.native.test.tsx.native-snap
@@ -33,7 +33,7 @@ exports[`<ForgottenPassword /> should enable validate button when email input is
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -396,11 +392,11 @@
+@@ -398,11 +394,11 @@
                           \\"paddingTop\\": 0,
                         },
                       ]
@@ -46,7 +46,7 @@ exports[`<ForgottenPassword /> should enable validate button when email input is
               </View>
               <View
                 numberOfSpaces={6}
-@@ -413,24 +409,22 @@
+@@ -415,24 +411,22 @@
                 }
               />
               <View
@@ -73,7 +73,7 @@ exports[`<ForgottenPassword /> should enable validate button when email input is
                     \\"flexDirection\\": \\"row\\",
                     \\"height\\": 40,
                     \\"justifyContent\\": \\"center\\",
-@@ -449,20 +443,20 @@
+@@ -451,20 +445,20 @@
                   adjustsFontSizeToFit={false}
                   numberOfLines={1}
                   style={

--- a/__snapshots__/features/auth/forgottenPassword/ReinitializePassword/tests/ReinitializePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ReinitializePassword/tests/ReinitializePassword.native.test.tsx.native-snap
@@ -33,12 +33,12 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -375,18 +371,16 @@
+@@ -377,18 +373,16 @@
                           \\"flexShrink\\": 1,
                         },
                       ]
                     }
-                    testID=\\"Entrée pour le mot de passe\\"
+                    testID=\\"Mot de passe\\"
 -                   value=\\"\\"
 +                   value=\\"ABCDefgh1234!!!!\\"
                   />
@@ -53,7 +53,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                     onResponderMove={[Function onResponderMove]}
                     onResponderRelease={[Function onResponderRelease]}
                     onResponderTerminate={[Function onResponderTerminate]}
-@@ -440,15 +434,15 @@
+@@ -444,15 +438,15 @@
                     ]
                   }
                 >
@@ -71,7 +71,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                   <View
                     numberOfSpaces={1}
                     style={
-@@ -458,15 +452,15 @@
+@@ -462,15 +456,15 @@
                         },
                       ]
                     }
@@ -89,7 +89,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                           \\"fontSize\\": 12,
                           \\"lineHeight\\": 16,
                           \\"paddingLeft\\": 4,
-@@ -489,15 +483,15 @@
+@@ -493,15 +487,15 @@
                     ]
                   }
                 >
@@ -107,7 +107,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                   <View
                     numberOfSpaces={1}
                     style={
-@@ -507,15 +501,15 @@
+@@ -511,15 +505,15 @@
                         },
                       ]
                     }
@@ -125,7 +125,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                           \\"fontSize\\": 12,
                           \\"lineHeight\\": 16,
                           \\"paddingLeft\\": 4,
-@@ -538,15 +532,15 @@
+@@ -542,15 +536,15 @@
                     ]
                   }
                 >
@@ -143,7 +143,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                   <View
                     numberOfSpaces={1}
                     style={
-@@ -556,15 +550,15 @@
+@@ -560,15 +554,15 @@
                         },
                       ]
                     }
@@ -161,7 +161,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                           \\"fontSize\\": 12,
                           \\"lineHeight\\": 16,
                           \\"paddingLeft\\": 4,
-@@ -587,15 +581,15 @@
+@@ -591,15 +585,15 @@
                     ]
                   }
                 >
@@ -179,7 +179,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                   <View
                     numberOfSpaces={1}
                     style={
-@@ -605,15 +599,15 @@
+@@ -609,15 +603,15 @@
                         },
                       ]
                     }
@@ -197,7 +197,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                           \\"fontSize\\": 12,
                           \\"lineHeight\\": 16,
                           \\"paddingLeft\\": 4,
-@@ -636,15 +630,15 @@
+@@ -640,15 +634,15 @@
                     ]
                   }
                 >
@@ -215,7 +215,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                   <View
                     numberOfSpaces={1}
                     style={
-@@ -654,15 +648,15 @@
+@@ -658,15 +652,15 @@
                         },
                       ]
                     }
@@ -233,7 +233,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                           \\"fontSize\\": 12,
                           \\"lineHeight\\": 16,
                           \\"paddingLeft\\": 4,
-@@ -816,13 +810,11 @@
+@@ -821,13 +815,11 @@
                     value=\\"\\"
                   />
                   <View
@@ -247,7 +247,7 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                     onResponderMove={[Function onResponderMove]}
                     onResponderRelease={[Function onResponderRelease]}
                     onResponderTerminate={[Function onResponderTerminate]}
-@@ -873,13 +865,11 @@
+@@ -878,13 +870,11 @@
                 }
               />
               <View

--- a/__snapshots__/features/auth/login/Login.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/login/Login.native.test.tsx.native-snap
@@ -33,7 +33,7 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -367,11 +363,11 @@
+@@ -369,11 +365,11 @@
                         \\"paddingTop\\": 0,
                       },
                     ]
@@ -46,11 +46,11 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
             </View>
             <View
               numberOfSpaces={6}
-@@ -511,18 +507,16 @@
+@@ -514,18 +510,16 @@
                       },
                     ]
                   }
-                  testID=\\"Entrée pour le mot de passe\\"
+                  testID=\\"Mot de passe\\"
                   textContentType=\\"password\\"
 -                 value=\\"\\"
 +                 value=\\"mypassword\\"
@@ -66,7 +66,7 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -575,13 +569,11 @@
+@@ -578,13 +572,11 @@
               }
             >
               <View
@@ -80,7 +80,7 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
                 onResponderMove={[Function onResponderMove]}
                 onResponderRelease={[Function onResponderRelease]}
                 onResponderTerminate={[Function onResponderTerminate]}
-@@ -650,24 +642,22 @@
+@@ -653,24 +645,22 @@
               }
             />
             <View
@@ -107,7 +107,7 @@ exports[`<Login/> should enable login button when both text inputs are filled 1`
                   \\"flexDirection\\": \\"row\\",
                   \\"height\\": 40,
                   \\"justifyContent\\": \\"center\\",
-@@ -686,20 +676,20 @@
+@@ -689,20 +679,20 @@
                 adjustsFontSizeToFit={false}
                 numberOfLines={1}
                 style={
@@ -187,7 +187,7 @@ exports[`<Login/> should show email error message WHEN signin has failed because
                       \\"borderWidth\\": 1,
                       \\"flexDirection\\": \\"row\\",
                       \\"height\\": 40,
-@@ -367,13 +363,73 @@
+@@ -369,13 +365,73 @@
                         \\"paddingTop\\": 0,
                       },
                     ]
@@ -262,11 +262,11 @@ exports[`<Login/> should show email error message WHEN signin has failed because
               numberOfSpaces={6}
               style={
                 Array [
-@@ -511,18 +567,16 @@
+@@ -514,18 +570,16 @@
                       },
                     ]
                   }
-                  testID=\\"Entrée pour le mot de passe\\"
+                  testID=\\"Mot de passe\\"
                   textContentType=\\"password\\"
 -                 value=\\"\\"
 +                 value=\\"mypassword\\"
@@ -282,7 +282,7 @@ exports[`<Login/> should show email error message WHEN signin has failed because
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -575,13 +629,11 @@
+@@ -578,13 +632,11 @@
               }
             >
               <View
@@ -296,7 +296,7 @@ exports[`<Login/> should show email error message WHEN signin has failed because
                 onResponderMove={[Function onResponderMove]}
                 onResponderRelease={[Function onResponderRelease]}
                 onResponderTerminate={[Function onResponderTerminate]}
-@@ -650,13 +702,11 @@
+@@ -653,13 +705,11 @@
               }
             />
             <View
@@ -443,7 +443,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                       \\"borderWidth\\": 1,
                       \\"flexDirection\\": \\"row\\",
                       \\"height\\": 40,
-@@ -367,11 +425,11 @@
+@@ -369,11 +427,11 @@
                         \\"paddingTop\\": 0,
                       },
                     ]
@@ -456,7 +456,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
             </View>
             <View
               numberOfSpaces={6}
-@@ -446,19 +504,19 @@
+@@ -448,19 +506,19 @@
                     },
                   ]
                 }
@@ -478,11 +478,11 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                       \\"borderWidth\\": 1,
                       \\"flexDirection\\": \\"row\\",
                       \\"height\\": 40,
-@@ -511,18 +569,16 @@
+@@ -514,18 +572,16 @@
                       },
                     ]
                   }
-                  testID=\\"Entrée pour le mot de passe\\"
+                  testID=\\"Mot de passe\\"
                   textContentType=\\"password\\"
 -                 value=\\"\\"
 +                 value=\\"mypassword\\"
@@ -498,7 +498,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -575,13 +631,11 @@
+@@ -578,13 +634,11 @@
               }
             >
               <View
@@ -512,7 +512,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                 onResponderMove={[Function onResponderMove]}
                 onResponderRelease={[Function onResponderRelease]}
                 onResponderTerminate={[Function onResponderTerminate]}
-@@ -650,24 +704,22 @@
+@@ -653,24 +707,22 @@
               }
             />
             <View
@@ -539,7 +539,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                   \\"flexDirection\\": \\"row\\",
                   \\"height\\": 40,
                   \\"justifyContent\\": \\"center\\",
-@@ -686,20 +738,20 @@
+@@ -689,20 +741,20 @@
                 adjustsFontSizeToFit={false}
                 numberOfLines={1}
                 style={
@@ -695,7 +695,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                       \\"borderWidth\\": 1,
                       \\"flexDirection\\": \\"row\\",
                       \\"height\\": 40,
-@@ -367,11 +425,11 @@
+@@ -369,11 +427,11 @@
                         \\"paddingTop\\": 0,
                       },
                     ]
@@ -708,7 +708,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
             </View>
             <View
               numberOfSpaces={6}
-@@ -446,19 +504,19 @@
+@@ -448,19 +506,19 @@
                     },
                   ]
                 }
@@ -730,11 +730,11 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                       \\"borderWidth\\": 1,
                       \\"flexDirection\\": \\"row\\",
                       \\"height\\": 40,
-@@ -511,18 +569,16 @@
+@@ -514,18 +572,16 @@
                       },
                     ]
                   }
-                  testID=\\"Entrée pour le mot de passe\\"
+                  testID=\\"Mot de passe\\"
                   textContentType=\\"password\\"
 -                 value=\\"\\"
 +                 value=\\"mypassword\\"
@@ -750,7 +750,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -575,13 +631,11 @@
+@@ -578,13 +634,11 @@
               }
             >
               <View
@@ -764,7 +764,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                 onResponderMove={[Function onResponderMove]}
                 onResponderRelease={[Function onResponderRelease]}
                 onResponderTerminate={[Function onResponderTerminate]}
-@@ -650,24 +704,22 @@
+@@ -653,24 +707,22 @@
               }
             />
             <View
@@ -791,7 +791,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
                   \\"flexDirection\\": \\"row\\",
                   \\"height\\": 40,
                   \\"justifyContent\\": \\"center\\",
-@@ -686,20 +738,20 @@
+@@ -689,20 +741,20 @@
                 adjustsFontSizeToFit={false}
                 numberOfLines={1}
                 style={
@@ -947,7 +947,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                       \\"borderWidth\\": 1,
                       \\"flexDirection\\": \\"row\\",
                       \\"height\\": 40,
-@@ -367,11 +425,11 @@
+@@ -369,11 +427,11 @@
                         \\"paddingTop\\": 0,
                       },
                     ]
@@ -960,7 +960,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
             </View>
             <View
               numberOfSpaces={6}
-@@ -446,19 +504,19 @@
+@@ -448,19 +506,19 @@
                     },
                   ]
                 }
@@ -982,11 +982,11 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                       \\"borderWidth\\": 1,
                       \\"flexDirection\\": \\"row\\",
                       \\"height\\": 40,
-@@ -511,18 +569,16 @@
+@@ -514,18 +572,16 @@
                       },
                     ]
                   }
-                  testID=\\"Entrée pour le mot de passe\\"
+                  testID=\\"Mot de passe\\"
                   textContentType=\\"password\\"
 -                 value=\\"\\"
 +                 value=\\"mypassword\\"
@@ -1002,7 +1002,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -575,13 +631,11 @@
+@@ -578,13 +634,11 @@
               }
             >
               <View
@@ -1016,7 +1016,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                 onResponderMove={[Function onResponderMove]}
                 onResponderRelease={[Function onResponderRelease]}
                 onResponderTerminate={[Function onResponderTerminate]}
-@@ -650,24 +704,22 @@
+@@ -653,24 +707,22 @@
               }
             />
             <View
@@ -1043,7 +1043,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
                   \\"flexDirection\\": \\"row\\",
                   \\"height\\": 40,
                   \\"justifyContent\\": \\"center\\",
-@@ -686,20 +738,20 @@
+@@ -689,20 +741,20 @@
                 adjustsFontSizeToFit={false}
                 numberOfLines={1}
                 style={

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetAddress.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetAddress.test.tsx.native-snap
@@ -261,6 +261,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
                 accessible={true}
                 autoCorrect={false}
                 editable={true}
+                nativeID="testUuidV4"
                 onBlur={[Function]}
                 onChangeText={[Function]}
                 onFocus={[Function]}

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetAddress.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetAddress.test.tsx.web-snap
@@ -246,20 +246,12 @@ exports[`<SetAddress/> should render correctly 1`] = `
                   }
                 }
               />
-              <div
-                className="css-text-901oao"
-                dir="auto"
-                style={
-                  Object {
-                    "color": "rgba(21,21,21,1.00)",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": "15px",
-                    "lineHeight": "20px",
-                  }
-                }
+              <label
+                className="sc-bdvvtL"
+                htmlFor="testUuidV4"
               >
                 Entre ton adresse
-              </div>
+              </label>
               <div
                 className="css-view-1dbjc4n"
                 style={
@@ -324,6 +316,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
                   data-testid="Entrée pour l'adresse"
                   dir="auto"
                   enterKeyHint="search"
+                  id="testUuidV4"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetCity.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetCity.test.tsx.native-snap
@@ -262,6 +262,7 @@ exports[`<SetCity/> should render correctly 1`] = `
                 autoCorrect={false}
                 editable={true}
                 keyboardType="number-pad"
+                nativeID="testUuidV4"
                 onBlur={[Function]}
                 onChangeText={[Function]}
                 onFocus={[Function]}

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetCity.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetCity.test.tsx.web-snap
@@ -246,20 +246,12 @@ exports[`<SetCity/> should render correctly 1`] = `
                   }
                 }
               />
-              <div
-                className="css-text-901oao"
-                dir="auto"
-                style={
-                  Object {
-                    "color": "rgba(21,21,21,1.00)",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": "15px",
-                    "lineHeight": "20px",
-                  }
-                }
+              <label
+                className="sc-bdvvtL"
+                htmlFor="testUuidV4"
               >
                 Indique ton code postal et choisis ta ville
-              </div>
+              </label>
               <div
                 className="css-view-1dbjc4n"
                 style={
@@ -324,6 +316,7 @@ exports[`<SetCity/> should render correctly 1`] = `
                   data-testid="Entrée pour le code postal"
                   dir="auto"
                   enterKeyHint="search"
+                  id="testUuidV4"
                   inputMode="numeric"
                   onBlur={[Function]}
                   onChange={[Function]}

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetName.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetName.native.test.tsx.native-snap
@@ -270,6 +270,7 @@ exports[`<SetName/> should render correctly 1`] = `
               >
                 <TextInput
                   editable={true}
+                  nativeID="testUuidV4"
                   onBlur={[Function]}
                   onChangeText={[Function]}
                   onFocus={[Function]}
@@ -363,6 +364,7 @@ exports[`<SetName/> should render correctly 1`] = `
               >
                 <TextInput
                   editable={true}
+                  nativeID="testUuidV4"
                   onBlur={[Function]}
                   onChangeText={[Function]}
                   onFocus={[Function]}

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetName.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetName.web.test.tsx.web-snap
@@ -94,13 +94,12 @@ Object {
                       role="form"
                       style="max-width: 500px; width: 100%;"
                     >
-                      <div
-                        class="css-text-901oao"
-                        dir="auto"
-                        style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
+                      <label
+                        class="sc-bdvvtL lavEYF"
+                        for="testUuidV4"
                       >
                         Prénom
-                      </div>
+                      </label>
                       <div
                         class="css-view-1dbjc4n"
                         style="height: 8px;"
@@ -115,6 +114,7 @@ Object {
                           autocorrect="on"
                           class="css-textinput-11aywtz r-placeholderTextColor-18k68vc"
                           dir="auto"
+                          id="testUuidV4"
                           placeholder="Ton prénom"
                           spellcheck="true"
                           style="color: rgb(21, 21, 21); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Regular; font-size: 15px; height: 100%; padding: 0px 0px 0px 0px;"
@@ -126,13 +126,12 @@ Object {
                         class="css-view-1dbjc4n"
                         style="height: 24px;"
                       />
-                      <div
-                        class="css-text-901oao"
-                        dir="auto"
-                        style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
+                      <label
+                        class="sc-bdvvtL lavEYF"
+                        for="testUuidV4"
                       >
                         Nom
-                      </div>
+                      </label>
                       <div
                         class="css-view-1dbjc4n"
                         style="height: 8px;"
@@ -147,6 +146,7 @@ Object {
                           autocorrect="on"
                           class="css-textinput-11aywtz r-placeholderTextColor-18k68vc"
                           dir="auto"
+                          id="testUuidV4"
                           placeholder="Ton nom"
                           spellcheck="true"
                           style="color: rgb(21, 21, 21); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Regular; font-size: 15px; height: 100%; padding: 0px 0px 0px 0px;"
@@ -293,13 +293,12 @@ Object {
                     role="form"
                     style="max-width: 500px; width: 100%;"
                   >
-                    <div
-                      class="css-text-901oao"
-                      dir="auto"
-                      style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
+                    <label
+                      class="sc-bdvvtL lavEYF"
+                      for="testUuidV4"
                     >
                       Prénom
-                    </div>
+                    </label>
                     <div
                       class="css-view-1dbjc4n"
                       style="height: 8px;"
@@ -314,6 +313,7 @@ Object {
                         autocorrect="on"
                         class="css-textinput-11aywtz r-placeholderTextColor-18k68vc"
                         dir="auto"
+                        id="testUuidV4"
                         placeholder="Ton prénom"
                         spellcheck="true"
                         style="color: rgb(21, 21, 21); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Regular; font-size: 15px; height: 100%; padding: 0px 0px 0px 0px;"
@@ -325,13 +325,12 @@ Object {
                       class="css-view-1dbjc4n"
                       style="height: 24px;"
                     />
-                    <div
-                      class="css-text-901oao"
-                      dir="auto"
-                      style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
+                    <label
+                      class="sc-bdvvtL lavEYF"
+                      for="testUuidV4"
                     >
                       Nom
-                    </div>
+                    </label>
                     <div
                       class="css-view-1dbjc4n"
                       style="height: 8px;"
@@ -346,6 +345,7 @@ Object {
                         autocorrect="on"
                         class="css-textinput-11aywtz r-placeholderTextColor-18k68vc"
                         dir="auto"
+                        id="testUuidV4"
                         placeholder="Ton nom"
                         spellcheck="true"
                         style="color: rgb(21, 21, 21); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Regular; font-size: 15px; height: 100%; padding: 0px 0px 0px 0px;"

--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.native.test.tsx.native-snap
@@ -248,10 +248,12 @@ Array [
           >
             <TextInput
               autoCapitalize="none"
+              autoComplete="email"
               disabled={true}
               editable={false}
               keyboardType="email-address"
               maxLength={120}
+              nativeID="testUuidV4"
               onBlur={[Function]}
               onChangeText={[Function]}
               onFocus={[Function]}
@@ -375,10 +377,11 @@ Array [
             }
           >
             <TextInput
-              accessibilityLabel="Entrée pour le mot de passe"
+              accessibilityLabel="Mot de passe"
               accessible={true}
               disabled={true}
               editable={false}
+              nativeID="testUuidV4"
               onBlur={[Function]}
               onChangeText={[Function]}
               onFocus={[Function]}
@@ -407,7 +410,7 @@ Array [
                   },
                 ]
               }
-              testID="Entrée pour le mot de passe"
+              testID="Mot de passe"
               textContentType="password"
               value=""
             />
@@ -878,10 +881,12 @@ Array [
           >
             <TextInput
               autoCapitalize="none"
+              autoComplete="email"
               disabled={false}
               editable={true}
               keyboardType="email-address"
               maxLength={120}
+              nativeID="testUuidV4"
               onBlur={[Function]}
               onChangeText={[Function]}
               onFocus={[Function]}
@@ -1015,10 +1020,11 @@ Array [
             }
           >
             <TextInput
-              accessibilityLabel="Entrée pour le mot de passe"
+              accessibilityLabel="Mot de passe"
               accessible={true}
               disabled={false}
               editable={true}
+              nativeID="testUuidV4"
               onBlur={[Function]}
               onChangeText={[Function]}
               onFocus={[Function]}
@@ -1047,7 +1053,7 @@ Array [
                   },
                 ]
               }
-              testID="Entrée pour le mot de passe"
+              testID="Mot de passe"
               textContentType="password"
               value=""
             />

--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.web.test.tsx.web-snap
@@ -57,13 +57,12 @@ Object {
                   class="css-view-1dbjc4n"
                   style="align-items: flex-end; flex-direction: row; justify-content: space-between; width: 100%;"
                 >
-                  <div
-                    class="css-text-901oao"
-                    dir="auto"
-                    style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
+                  <label
+                    class="sc-bdvvtL lavEYF"
+                    for="testUuidV4"
                   >
                     Nouvel e-mail
-                  </div>
+                  </label>
                   <div
                     class="css-text-901oao"
                     dir="auto"
@@ -82,10 +81,11 @@ Object {
                 >
                   <input
                     autocapitalize="none"
-                    autocomplete="on"
+                    autocomplete="email"
                     autocorrect="on"
                     class="css-textinput-11aywtz r-placeholderTextColor-18k68vc"
                     dir="auto"
+                    id="testUuidV4"
                     maxlength="120"
                     placeholder="tonadresse@email.com"
                     spellcheck="true"
@@ -107,13 +107,12 @@ Object {
                   class="css-view-1dbjc4n"
                   style="align-items: flex-end; flex-direction: row; justify-content: space-between; width: 100%;"
                 >
-                  <div
-                    class="css-text-901oao"
-                    dir="auto"
-                    style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
+                  <label
+                    class="sc-bdvvtL lavEYF"
+                    for="testUuidV4"
                   >
                     Mot de passe
-                  </div>
+                  </label>
                   <div
                     class="css-text-901oao"
                     dir="auto"
@@ -131,13 +130,14 @@ Object {
                   style="align-items: center; background-color: rgb(255, 255, 255); border-top-color: rgba(199,199,204,1.00); border-right-color: rgba(199,199,204,1.00); border-bottom-color: rgba(199,199,204,1.00); border-left-color: rgba(199,199,204,1.00); border-top-left-radius: 22px; border-top-right-radius: 22px; border-bottom-right-radius: 22px; border-bottom-left-radius: 22px; border-top-style: solid; border-right-style: solid; border-bottom-style: solid; border-left-style: solid; border-top-width: 1px; border-right-width: 1px; border-bottom-width: 1px; border-left-width: 1px; flex-direction: row; height: 40px; padding: 4px 16px 4px 16px; width: 100%;"
                 >
                   <input
-                    aria-label="Entrée pour le mot de passe"
+                    aria-label="Mot de passe"
                     autocapitalize="sentences"
                     autocomplete="on"
                     autocorrect="on"
                     class="css-textinput-11aywtz r-placeholderTextColor-18k68vc"
-                    data-testid="Entrée pour le mot de passe"
+                    data-testid="Mot de passe"
                     dir="auto"
+                    id="testUuidV4"
                     placeholder="Ton mot de passe"
                     spellcheck="true"
                     style="color: rgb(21, 21, 21); flex-basis: 0px; flex-grow: 0.9; flex-shrink: 1; font-family: Montserrat-Regular; font-size: 15px; height: 100%; padding: 0px 0px 0px 0px;"
@@ -308,13 +308,12 @@ Object {
                 class="css-view-1dbjc4n"
                 style="align-items: flex-end; flex-direction: row; justify-content: space-between; width: 100%;"
               >
-                <div
-                  class="css-text-901oao"
-                  dir="auto"
-                  style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
+                <label
+                  class="sc-bdvvtL lavEYF"
+                  for="testUuidV4"
                 >
                   Nouvel e-mail
-                </div>
+                </label>
                 <div
                   class="css-text-901oao"
                   dir="auto"
@@ -333,10 +332,11 @@ Object {
               >
                 <input
                   autocapitalize="none"
-                  autocomplete="on"
+                  autocomplete="email"
                   autocorrect="on"
                   class="css-textinput-11aywtz r-placeholderTextColor-18k68vc"
                   dir="auto"
+                  id="testUuidV4"
                   maxlength="120"
                   placeholder="tonadresse@email.com"
                   spellcheck="true"
@@ -358,13 +358,12 @@ Object {
                 class="css-view-1dbjc4n"
                 style="align-items: flex-end; flex-direction: row; justify-content: space-between; width: 100%;"
               >
-                <div
-                  class="css-text-901oao"
-                  dir="auto"
-                  style="color: rgb(21, 21, 21); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
+                <label
+                  class="sc-bdvvtL lavEYF"
+                  for="testUuidV4"
                 >
                   Mot de passe
-                </div>
+                </label>
                 <div
                   class="css-text-901oao"
                   dir="auto"
@@ -382,13 +381,14 @@ Object {
                 style="align-items: center; background-color: rgb(255, 255, 255); border-top-color: rgba(199,199,204,1.00); border-right-color: rgba(199,199,204,1.00); border-bottom-color: rgba(199,199,204,1.00); border-left-color: rgba(199,199,204,1.00); border-top-left-radius: 22px; border-top-right-radius: 22px; border-bottom-right-radius: 22px; border-bottom-left-radius: 22px; border-top-style: solid; border-right-style: solid; border-bottom-style: solid; border-left-style: solid; border-top-width: 1px; border-right-width: 1px; border-bottom-width: 1px; border-left-width: 1px; flex-direction: row; height: 40px; padding: 4px 16px 4px 16px; width: 100%;"
               >
                 <input
-                  aria-label="Entrée pour le mot de passe"
+                  aria-label="Mot de passe"
                   autocapitalize="sentences"
                   autocomplete="on"
                   autocorrect="on"
                   class="css-textinput-11aywtz r-placeholderTextColor-18k68vc"
-                  data-testid="Entrée pour le mot de passe"
+                  data-testid="Mot de passe"
                   dir="auto"
+                  id="testUuidV4"
                   placeholder="Ton mot de passe"
                   spellcheck="true"
                   style="color: rgb(21, 21, 21); flex-basis: 0px; flex-grow: 0.9; flex-shrink: 1; font-family: Montserrat-Regular; font-size: 15px; height: 100%; padding: 0px 0px 0px 0px;"

--- a/__snapshots__/features/profile/pages/ChangePassword/tests/ChangePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangePassword/tests/ChangePassword.native.test.tsx.native-snap
@@ -5,7 +5,7 @@ exports[`ChangePassword should validate PasswordSecurityRules when password is c
 - First value
 + Second value
 
-@@ -182,13 +182,11 @@
+@@ -183,13 +183,11 @@
               value=\\"\\"
             />
             <View
@@ -19,12 +19,12 @@ exports[`ChangePassword should validate PasswordSecurityRules when password is c
               onResponderMove={[Function onResponderMove]}
               onResponderRelease={[Function onResponderRelease]}
               onResponderTerminate={[Function onResponderTerminate]}
-@@ -354,18 +352,16 @@
+@@ -357,18 +355,16 @@
                     \\"flexShrink\\": 1,
                   },
                 ]
               }
-              testID=\\"Entrée pour le mot de passe\\"
+              testID=\\"Mot de passe\\"
 -             value=\\"\\"
 +             value=\\"ABCDefgh1234!!!!\\"
             />
@@ -39,7 +39,7 @@ exports[`ChangePassword should validate PasswordSecurityRules when password is c
               onResponderMove={[Function onResponderMove]}
               onResponderRelease={[Function onResponderRelease]}
               onResponderTerminate={[Function onResponderTerminate]}
-@@ -388,13 +384,271 @@
+@@ -391,16 +387,276 @@
                 height={24}
                 width={24}
               >
@@ -51,6 +51,8 @@ exports[`ChangePassword should validate PasswordSecurityRules when password is c
 +         </View>
 +       </View>
 +       <View
++         accessibilityLabel=\\"Critères à respecter\\"
++         nativeID=\\"testUuidV4\\"
 +         style={
 +           Array [
 +             Object {
@@ -179,8 +181,8 @@ exports[`ChangePassword should validate PasswordSecurityRules when password is c
 +           >
 +             <Text>
 +               rule-icon-check-SVG-Mock
-+             </Text>
-+           </View>
+              </Text>
+            </View>
 +           <View
 +             numberOfSpaces={1}
 +             style={
@@ -208,55 +210,6 @@ exports[`ChangePassword should validate PasswordSecurityRules when password is c
 +           >
 +             1 Minuscule
 +           </Text>
-+         </View>
-+         <View
-+           style={
-+             Array [
-+               Object {
-+                 \\"alignItems\\": \\"center\\",
-+                 \\"flexDirection\\": \\"row\\",
-+                 \\"maxWidth\\": 500,
-+                 \\"width\\": \\"100%\\",
-+               },
-+             ]
-+           }
-+         >
-+           <View
-+             height={10}
-+             testID=\\"rule-icon-check\\"
-+             width={10}
-+           >
-+             <Text>
-+               rule-icon-check-SVG-Mock
-+             </Text>
-+           </View>
-+           <View
-+             numberOfSpaces={1}
-+             style={
-+               Array [
-+                 Object {
-+                   \\"width\\": 4,
-+                 },
-+               ]
-+             }
-+           />
-+           <Text
-+             color=\\"#15884f\\"
-+             style={
-+               Array [
-+                 Object {
-+                   \\"color\\": \\"#15884f\\",
-+                   \\"flexShrink\\": 1,
-+                   \\"fontFamily\\": \\"Montserrat-SemiBold\\",
-+                   \\"fontSize\\": 12,
-+                   \\"lineHeight\\": 16,
-+                   \\"paddingLeft\\": 4,
-+                 },
-+               ]
-+             }
-+           >
-+             1 Chiffre
-            </Text>
           </View>
 +         <View
 +           style={
@@ -304,14 +257,66 @@ exports[`ChangePassword should validate PasswordSecurityRules when password is c
 +               ]
 +             }
 +           >
-+             1 Caractère spécial (!@#$%^&*...)
++             1 Chiffre
 +           </Text>
           </View>
-        </View>
-        <View
+          <View
++           style={
++             Array [
++               Object {
++                 \\"alignItems\\": \\"center\\",
++                 \\"flexDirection\\": \\"row\\",
++                 \\"maxWidth\\": 500,
++                 \\"width\\": \\"100%\\",
++               },
++             ]
++           }
++         >
++           <View
++             height={10}
++             testID=\\"rule-icon-check\\"
++             width={10}
++           >
++             <Text>
++               rule-icon-check-SVG-Mock
++             </Text>
++           </View>
++           <View
++             numberOfSpaces={1}
++             style={
++               Array [
++                 Object {
++                   \\"width\\": 4,
++                 },
++               ]
++             }
++           />
++           <Text
++             color=\\"#15884f\\"
++             style={
++               Array [
++                 Object {
++                   \\"color\\": \\"#15884f\\",
++                   \\"flexShrink\\": 1,
++                   \\"fontFamily\\": \\"Montserrat-SemiBold\\",
++                   \\"fontSize\\": 12,
++                   \\"lineHeight\\": 16,
++                   \\"paddingLeft\\": 4,
++                 },
++               ]
++             }
++           >
++             1 Caractère spécial (!@#$%^&*...)
++           </Text>
++         </View>
++       </View>
++       <View
           numberOfSpaces={5}
           style={
-@@ -536,13 +790,11 @@
+            Array [
+              Object {
+                \\"height\\": 20,
+@@ -540,13 +796,11 @@
               value=\\"\\"
             />
             <View
@@ -325,7 +330,7 @@ exports[`ChangePassword should validate PasswordSecurityRules when password is c
               onResponderMove={[Function onResponderMove]}
               onResponderRelease={[Function onResponderRelease]}
               onResponderTerminate={[Function onResponderTerminate]}
-@@ -597,13 +849,11 @@
+@@ -601,13 +855,11 @@
           }
         >
           <View
@@ -339,7 +344,7 @@ exports[`ChangePassword should validate PasswordSecurityRules when password is c
             onResponderMove={[Function onResponderMove]}
             onResponderRelease={[Function onResponderRelease]}
             onResponderTerminate={[Function onResponderTerminate]}
-@@ -724,13 +974,11 @@
+@@ -728,13 +980,11 @@
           }
         >
           <View

--- a/__snapshots__/features/search/pages/__tests__/Search.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/__tests__/Search.native.test.tsx.native-snap
@@ -125,6 +125,7 @@ exports[`Search component should render correctly 1`] = `
         aria-describedby="testUuidV4"
         autoCorrect={false}
         editable={true}
+        nativeID="testUuidV4"
         onBlur={[Function]}
         onChangeText={[Function]}
         onFocus={[Function]}

--- a/__snapshots__/features/venue/components/__tests__/VenueOffers.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/components/__tests__/VenueOffers.web.test.tsx.web-snap
@@ -306,7 +306,7 @@ Object {
         style="margin-right: 24px; margin-left: 24px;"
       >
         <button
-          class="sc-bdvvtL ixQXfk"
+          class="sc-gsDKAQ gJxVdF"
           type="button"
         >
           <div
@@ -631,7 +631,7 @@ Object {
       style="margin-right: 24px; margin-left: 24px;"
     >
       <button
-        class="sc-bdvvtL ixQXfk"
+        class="sc-gsDKAQ gJxVdF"
         type="button"
       >
         <div

--- a/__snapshots__/features/venue/pages/__tests__/Venue.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/pages/__tests__/Venue.web.test.tsx.web-snap
@@ -673,7 +673,7 @@ Object {
               style="margin-right: 24px; margin-left: 24px;"
             >
               <button
-                class="sc-bdvvtL ixQXfk"
+                class="sc-gsDKAQ gJxVdF"
                 type="button"
               >
                 <div
@@ -2071,7 +2071,7 @@ Object {
             style="margin-right: 24px; margin-left: 24px;"
           >
             <button
-              class="sc-bdvvtL ixQXfk"
+              class="sc-gsDKAQ gJxVdF"
               type="button"
             >
               <div

--- a/__snapshots__/features/venue/pages/__tests__/VenueBody.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/pages/__tests__/VenueBody.web.test.tsx.web-snap
@@ -669,7 +669,7 @@ Object {
             style="margin-right: 24px; margin-left: 24px;"
           >
             <button
-              class="sc-bdvvtL ixQXfk"
+              class="sc-gsDKAQ gJxVdF"
               type="button"
             >
               <div
@@ -1905,7 +1905,7 @@ Object {
           style="margin-right: 24px; margin-left: 24px;"
         >
           <button
-            class="sc-bdvvtL ixQXfk"
+            class="sc-gsDKAQ gJxVdF"
             type="button"
           >
             <div

--- a/__snapshots__/ui/components/inputs/TextInput.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/inputs/TextInput.native.test.tsx.native-snap
@@ -34,6 +34,7 @@ exports[`<TextInput /> should render correctly when NOT focused 1`] = `
 >
   <TextInput
     editable={true}
+    nativeID="testUuidV4"
     onBlur={[Function]}
     onChangeText={[Function]}
     onFocus={[Function]}

--- a/__snapshots__/ui/components/inputs/TextInput.web.test.tsx.web-snap
+++ b/__snapshots__/ui/components/inputs/TextInput.web.test.tsx.web-snap
@@ -15,6 +15,7 @@ Object {
           autocorrect="on"
           class="css-textinput-11aywtz r-placeholderTextColor-18k68vc"
           dir="auto"
+          id="testUuidV4"
           placeholder="placeholder"
           spellcheck="true"
           style="color: rgb(21, 21, 21); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Regular; font-size: 15px; height: 100%; padding: 0px 0px 0px 0px;"
@@ -35,6 +36,7 @@ Object {
         autocorrect="on"
         class="css-textinput-11aywtz r-placeholderTextColor-18k68vc"
         dir="auto"
+        id="testUuidV4"
         placeholder="placeholder"
         spellcheck="true"
         style="color: rgb(21, 21, 21); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Regular; font-size: 15px; height: 100%; padding: 0px 0px 0px 0px;"
@@ -102,7 +104,7 @@ exports[`<TextInput /> should render correctly when in error 1`] = `
 - First value
 + Second value
 
-@@ -41,11 +41,11 @@
+@@ -43,11 +43,11 @@
       </div>
     </body>,
     \\"container\\": <div>

--- a/src/features/auth/components/PasswordSecurityRules.tsx
+++ b/src/features/auth/components/PasswordSecurityRules.tsx
@@ -7,6 +7,7 @@ import { getSpacing } from 'ui/theme'
 
 type Props = {
   password: string
+  nativeID?: string
 }
 
 const PASSWORD_MIN_LENGTH = 12
@@ -45,9 +46,9 @@ function containsSpecialCharacter(password: string): boolean {
   return password.match(SPECIAL_CHARACTER_REGEX) ? true : false
 }
 
-export const PasswordSecurityRules: FunctionComponent<Props> = ({ password }) => {
+export const PasswordSecurityRules: FunctionComponent<Props> = ({ password, nativeID }) => {
   return (
-    <RulesContainer>
+    <RulesContainer nativeID={nativeID} accessibilityLabel={t`Critères à respecter`}>
       <PasswordRule title={t`12 Caractères`} isValidated={isLongEnough(password)} />
       <PasswordRule title={t`1 Majuscule`} isValidated={containsCapital(password)} />
       <PasswordRule title={t`1 Minuscule`} isValidated={containsLowercase(password)} />

--- a/src/features/auth/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
+++ b/src/features/auth/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
@@ -1,6 +1,7 @@
 import { t } from '@lingui/macro'
 import { useFocusEffect, useNavigation, useRoute } from '@react-navigation/native'
 import React, { useCallback, useState } from 'react'
+import { v4 as uuidv4 } from 'uuid'
 
 import {
   isPasswordCorrect,
@@ -31,6 +32,7 @@ export const ReinitializePassword = () => {
   const [isTimestampExpirationVerified, setIsTimestampExpirationVerified] = useState(false)
   const [password, setPassword] = useState('')
   const [confirmedPassword, setConfirmedPassword] = useState('')
+  const passwordDescribedBy = uuidv4()
 
   const allowSubmission = isPasswordCorrect(password) && confirmedPassword === password
   const displayNotMatchingError = confirmedPassword.length > 0 && confirmedPassword !== password
@@ -84,6 +86,7 @@ export const ReinitializePassword = () => {
         <Form.MaxWidth>
           <PasswordInput
             label={t`Nouveau mot de passe`}
+            accessibilityDescribedBy={passwordDescribedBy}
             value={password}
             autoFocus
             onChangeText={setPassword}
@@ -91,7 +94,7 @@ export const ReinitializePassword = () => {
             onSubmitEditing={submitPassword}
             isRequiredField
           />
-          <PasswordSecurityRules password={password} />
+          <PasswordSecurityRules password={password} nativeID={passwordDescribedBy} />
           <Spacer.Column numberOfSpaces={6} />
           <PasswordInput
             label={t`Confirmer le mot de passe`}

--- a/src/features/auth/signup/SetPassword/SetPassword.tsx
+++ b/src/features/auth/signup/SetPassword/SetPassword.tsx
@@ -1,6 +1,7 @@
 import { t } from '@lingui/macro'
 import React, { FunctionComponent, useRef, useState } from 'react'
 import { TextInput as RNTextInput } from 'react-native'
+import { v4 as uuidv4 } from 'uuid'
 
 import {
   isPasswordCorrect,
@@ -17,6 +18,7 @@ export const SetPassword: FunctionComponent<PreValidationSignupStepProps> = (pro
   const disabled = !isPasswordCorrect(password)
 
   const passwordInput = useRef<RNTextInput | null>(null)
+  const passwordDescribedBy = uuidv4()
 
   function submitPassword() {
     if (!disabled) {
@@ -28,6 +30,7 @@ export const SetPassword: FunctionComponent<PreValidationSignupStepProps> = (pro
     <Form.MaxWidth>
       <PasswordInput
         label={t`Mot de passe`}
+        accessibilityDescribedBy={passwordDescribedBy}
         value={password}
         autoFocus={true}
         onChangeText={setPassword}
@@ -35,7 +38,7 @@ export const SetPassword: FunctionComponent<PreValidationSignupStepProps> = (pro
         onSubmitEditing={submitPassword}
         ref={passwordInput}
       />
-      <PasswordSecurityRules password={password} />
+      <PasswordSecurityRules password={password} nativeID={passwordDescribedBy} />
       <Spacer.Column numberOfSpaces={6} />
       <ButtonPrimary
         title={t`Continuer`}

--- a/src/features/profile/pages/ChangePassword/ChangePassword.tsx
+++ b/src/features/profile/pages/ChangePassword/ChangePassword.tsx
@@ -4,6 +4,7 @@ import { Platform, ScrollView, StyleProp, ViewStyle } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled from 'styled-components/native'
 import { useTheme } from 'styled-components/native'
+import { v4 as uuidv4 } from 'uuid'
 
 import {
   isPasswordCorrect,
@@ -33,6 +34,7 @@ export function ChangePassword() {
   const [hasError, setHasError] = useState(false)
   const [keyboardHeight, setKeyboardHeight] = useState(0)
   const [shouldDisplayPasswordRules, setShouldDisplayPasswordRules] = useState(false)
+  const passwordDescribedBy = uuidv4()
 
   const displayNotMatchingError = confirmedPassword.length > 0 && confirmedPassword !== newPassword
 
@@ -112,13 +114,14 @@ export function ChangePassword() {
           <Spacer.Column numberOfSpaces={7} />
           <PasswordInput
             label={t`Nouveau mot de passe`}
+            accessibilityDescribedBy={passwordDescribedBy}
             value={newPassword}
             onChangeText={updateNewPassword}
             placeholder={t`Ton nouveau mot de passe`}
             isRequiredField
           />
           {!!(shouldDisplayPasswordRules && newPassword.length > 0) && (
-            <PasswordSecurityRules password={newPassword} />
+            <PasswordSecurityRules password={newPassword} nativeID={passwordDescribedBy} />
           )}
           <Spacer.Column numberOfSpaces={5} />
           <PasswordInput

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -910,10 +910,6 @@ msgstr "Entrée pour le jour de la date de naissance"
 msgid "Entrée pour le mois de la date de naissance"
 msgstr "Entrée pour le mois de la date de naissance"
 
-#: src/ui/components/inputs/PasswordInput.tsx
-msgid "Entrée pour le mot de passe"
-msgstr "Entrée pour le mot de passe"
-
 #: src/features/identityCheck/pages/profile/SetName.tsx
 msgid "Entrée pour le nom"
 msgstr "Entrée pour le nom"
@@ -1557,6 +1553,7 @@ msgstr "Mon identité"
 #: src/features/profile/pages/ChangeEmail/ChangeEmail.tsx
 #: src/features/profile/pages/ChangePassword/ChangePassword.tsx
 #: src/features/profile/pages/Profile.tsx
+#: src/ui/components/inputs/PasswordInput.tsx
 msgid "Mot de passe"
 msgstr "Mot de passe"
 
@@ -3183,6 +3180,7 @@ msgid "{nbFavorites, plural, one {# favori} other {# favoris}}"
 msgstr "{nbFavorites, plural, one {# favori} other {# favoris}}"
 
 #: src/features/search/atoms/NumberOfResults.tsx
+#: src/features/search/pages/SuggestedPlaces.tsx
 msgid "{nbHits, plural, one {# résultat} other {# résultats}}"
 msgstr "{nbHits, plural, one {# résultat} other {# résultats}}"
 

--- a/src/ui/components/InputLabel.tsx
+++ b/src/ui/components/InputLabel.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+import { Typo } from 'ui/theme'
+
+export const InputLabel = ({ children }: { htmlFor: string; children: string }) => (
+  <Typo.Body>{children}</Typo.Body>
+)

--- a/src/ui/components/InputLabel.web.tsx
+++ b/src/ui/components/InputLabel.web.tsx
@@ -1,0 +1,3 @@
+import styled from 'styled-components'
+
+export const InputLabel = styled.label(({ theme }) => ({ ...theme.typography?.body }))

--- a/src/ui/components/inputs/EmailInput.tsx
+++ b/src/ui/components/inputs/EmailInput.tsx
@@ -1,14 +1,16 @@
 import { t } from '@lingui/macro'
 import React, { forwardRef } from 'react'
 import { TextInput as RNTextInput } from 'react-native'
+import { v4 as uuidv4 } from 'uuid'
 
 import { accessibilityAndTestId } from 'tests/utils'
+import { InputLabel } from 'ui/components/InputLabel'
 import { InputContainer } from 'ui/components/inputs/InputContainer'
 import { LabelContainer } from 'ui/components/inputs/LabelContainer'
 import { RequiredLabel } from 'ui/components/inputs/RequiredLabel'
 import { TextInput } from 'ui/components/inputs/TextInput'
 import { TextInputProps } from 'ui/components/inputs/types'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer } from 'ui/theme'
 
 interface Props extends TextInputProps {
   label: string
@@ -20,30 +22,36 @@ interface Props extends TextInputProps {
 const withRefEmailInput: React.ForwardRefRenderFunction<RNTextInput, Props> = (
   { label, email, onEmailChange, isRequiredField = false, ...inputProps },
   forwardedRef
-) => (
-  <InputContainer>
-    {!!label && (
-      <React.Fragment>
-        <LabelContainer>
-          <Typo.Body>{label}</Typo.Body>
-          {!!isRequiredField && <RequiredLabel />}
-        </LabelContainer>
-        <Spacer.Column numberOfSpaces={2} />
-      </React.Fragment>
-    )}
-    <TextInput
-      autoCapitalize="none"
-      keyboardType="email-address"
-      onChangeText={onEmailChange}
-      placeholder={t`tonadresse@email.com`}
-      textContentType="emailAddress"
-      value={email}
-      maxLength={120}
-      {...accessibilityAndTestId(t`Entrée pour l'email`)}
-      {...inputProps}
-      ref={forwardedRef}
-    />
-  </InputContainer>
-)
+) => {
+  const emailInputID = uuidv4()
+
+  return (
+    <InputContainer>
+      {!!label && (
+        <React.Fragment>
+          <LabelContainer>
+            <InputLabel htmlFor={emailInputID}>{label}</InputLabel>
+            {!!isRequiredField && <RequiredLabel />}
+          </LabelContainer>
+          <Spacer.Column numberOfSpaces={2} />
+        </React.Fragment>
+      )}
+      <TextInput
+        nativeID={emailInputID}
+        autoCapitalize="none"
+        autoComplete="email"
+        keyboardType="email-address"
+        onChangeText={onEmailChange}
+        placeholder={t`tonadresse@email.com`}
+        textContentType="emailAddress"
+        value={email}
+        maxLength={120}
+        {...accessibilityAndTestId(t`Entrée pour l'email`)}
+        {...inputProps}
+        ref={forwardedRef}
+      />
+    </InputContainer>
+  )
+}
 
 export const EmailInput = forwardRef<RNTextInput, Props>(withRefEmailInput)

--- a/src/ui/components/inputs/PasswordInput.tsx
+++ b/src/ui/components/inputs/PasswordInput.tsx
@@ -67,7 +67,8 @@ const WithRefPasswordInput: React.ForwardRefRenderFunction<RNTextInput, TextInpu
           onBlur={onBlur}
           secureTextEntry={shouldHidePassword}
           ref={forwardedRef}
-          {...accessibilityAndTestId(t`Entrée pour le mot de passe`)}
+          aria-describedby={customProps.accessibilityDescribedBy}
+          {...accessibilityAndTestId(t`Mot de passe`)}
         />
         <IconTouchableOpacity
           testID="toggle-password-visibility"

--- a/src/ui/components/inputs/PasswordInput.tsx
+++ b/src/ui/components/inputs/PasswordInput.tsx
@@ -6,14 +6,16 @@ import {
   TextInputFocusEventData,
 } from 'react-native'
 import styled from 'styled-components/native'
+import { v4 as uuidv4 } from 'uuid'
 
 import { accessibilityAndTestId } from 'tests/utils'
+import { InputLabel } from 'ui/components/InputLabel'
 import { InputContainer } from 'ui/components/inputs/InputContainer'
 import { LabelContainer } from 'ui/components/inputs/LabelContainer'
 import { RequiredLabel } from 'ui/components/inputs/RequiredLabel'
 import { Eye } from 'ui/svg/icons/Eye'
 import { EyeSlash } from 'ui/svg/icons/EyeSlash'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer } from 'ui/theme'
 
 import { BaseTextInput } from './BaseTextInput'
 import { StyledInputContainer } from './StyledInputContainer'
@@ -28,6 +30,7 @@ const WithRefPasswordInput: React.ForwardRefRenderFunction<RNTextInput, TextInpu
 
   const [shouldHidePassword, setShouldHidePassword] = useState(true)
   const [isFocus, setIsFocus] = useState(false)
+  const passwordInputID = uuidv4()
 
   function togglePasswordDisplay() {
     setShouldHidePassword(!shouldHidePassword)
@@ -47,7 +50,7 @@ const WithRefPasswordInput: React.ForwardRefRenderFunction<RNTextInput, TextInpu
       {!!customProps.label && (
         <React.Fragment>
           <LabelContainer>
-            <Typo.Body>{customProps.label}</Typo.Body>
+            <InputLabel htmlFor={passwordInputID}>{customProps.label}</InputLabel>
             {!!customProps.isRequiredField && <RequiredLabel />}
           </LabelContainer>
           <Spacer.Column numberOfSpaces={2} />
@@ -59,6 +62,7 @@ const WithRefPasswordInput: React.ForwardRefRenderFunction<RNTextInput, TextInpu
         isInputDisabled={customProps.disabled}>
         <StyledBaseTextInput
           {...nativeProps}
+          nativeID={passwordInputID}
           onFocus={onFocus}
           onBlur={onBlur}
           secureTextEntry={shouldHidePassword}

--- a/src/ui/components/inputs/SearchInput.tsx
+++ b/src/ui/components/inputs/SearchInput.tsx
@@ -2,10 +2,12 @@ import { t } from '@lingui/macro'
 import React, { forwardRef, useState } from 'react'
 import { TextInput as RNTextInput } from 'react-native'
 import styled from 'styled-components/native'
+import { v4 as uuidv4 } from 'uuid'
 
 import { accessibilityAndTestId } from 'tests/utils'
+import { InputLabel } from 'ui/components/InputLabel'
 import { Invalidate } from 'ui/svg/icons/Invalidate'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer } from 'ui/theme'
 // eslint-disable-next-line no-restricted-imports
 import { ColorsEnum } from 'ui/theme/colors'
 
@@ -23,6 +25,7 @@ const WithRefSearchInput: React.ForwardRefRenderFunction<RNTextInput, SearchInpu
   const { LeftIcon, label, accessibilityLabel, accessibilityDescribedBy, onPressRightIcon } =
     customProps
   const { value = '' } = nativeProps
+  const searchInputID = uuidv4()
 
   function onFocus() {
     setIsFocus(true)
@@ -36,7 +39,7 @@ const WithRefSearchInput: React.ForwardRefRenderFunction<RNTextInput, SearchInpu
     <React.Fragment>
       {!!label && (
         <React.Fragment>
-          <Typo.Body>{label}</Typo.Body>
+          <InputLabel htmlFor={searchInputID}>{label}</InputLabel>
           <Spacer.Column numberOfSpaces={2} />
         </React.Fragment>
       )}
@@ -50,6 +53,7 @@ const WithRefSearchInput: React.ForwardRefRenderFunction<RNTextInput, SearchInpu
         )}
         <BaseTextInput
           {...nativeProps}
+          nativeID={searchInputID}
           ref={forwardedRef}
           onFocus={onFocus}
           onBlur={onBlur}

--- a/src/ui/components/inputs/TextInput.tsx
+++ b/src/ui/components/inputs/TextInput.tsx
@@ -1,7 +1,9 @@
 import React, { forwardRef, useState } from 'react'
 import { TextInput as RNTextInput } from 'react-native'
+import { v4 as uuidv4 } from 'uuid'
 
-import { Spacer, Typo } from 'ui/theme'
+import { InputLabel } from 'ui/components/InputLabel'
+import { Spacer } from 'ui/theme'
 
 import { BaseTextInput } from './BaseTextInput'
 import { StyledInputContainer } from './StyledInputContainer'
@@ -14,6 +16,7 @@ const WithRefTextInput: React.ForwardRefRenderFunction<RNTextInput, TextInputPro
   const [isFocus, setIsFocus] = useState(false)
   const nativeProps = getRNTextInputProps(props)
   const customProps = getCustomTextInputProps(props)
+  const textInputID = uuidv4()
 
   function onFocus() {
     setIsFocus(true)
@@ -31,7 +34,7 @@ const WithRefTextInput: React.ForwardRefRenderFunction<RNTextInput, TextInputPro
     <React.Fragment>
       {!!customProps.label && (
         <React.Fragment>
-          <Typo.Body>{customProps.label}</Typo.Body>
+          <InputLabel htmlFor={textInputID}>{customProps.label}</InputLabel>
           <Spacer.Column numberOfSpaces={2} />
         </React.Fragment>
       )}
@@ -40,7 +43,13 @@ const WithRefTextInput: React.ForwardRefRenderFunction<RNTextInput, TextInputPro
         isError={customProps.isError}
         isInputDisabled={customProps.disabled}
         style={customProps.containerStyle}>
-        <BaseTextInput {...nativeProps} ref={forwardedRef} onFocus={onFocus} onBlur={onBlur} />
+        <BaseTextInput
+          {...nativeProps}
+          nativeID={textInputID}
+          ref={forwardedRef}
+          onFocus={onFocus}
+          onBlur={onBlur}
+        />
       </StyledInputContainer>
     </React.Fragment>
   )

--- a/src/ui/components/inputs/types.ts
+++ b/src/ui/components/inputs/types.ts
@@ -7,6 +7,7 @@ type CustomTextInputProps = {
   disabled?: boolean
   containerStyle?: ViewStyle
   isRequiredField?: boolean
+  accessibilityDescribedBy?: string
 }
 
 type CustomSearchInputProps = {
@@ -62,6 +63,7 @@ export function getCustomTextInputProps(props: TextInputProps): CustomTextInputP
     disabled: props.disabled,
     containerStyle: props.containerStyle,
     isRequiredField: props.isRequiredField,
+    accessibilityDescribedBy: props.accessibilityDescribedBy,
   }
 }
 

--- a/src/ui/components/inputs/types.ts
+++ b/src/ui/components/inputs/types.ts
@@ -24,6 +24,7 @@ export type RNTextInputProps = Pick<
    * which adds the web property "disabled" (not focusable) to the input
    * https://github.com/necolas/react-native-web/commit/fc033a3161be76224d120dec7aab7009e9414fa7 */
   | 'autoCapitalize'
+  | 'autoComplete'
   | 'autoCorrect'
   | 'autoFocus'
   | 'blurOnSubmit'
@@ -31,6 +32,7 @@ export type RNTextInputProps = Pick<
   | 'disabled'
   | 'keyboardType'
   | 'maxLength'
+  | 'nativeID'
   | 'onBlur'
   | 'onChangeText'
   | 'onFocus'
@@ -85,6 +87,7 @@ export function getCustomSearchInputProps(props: SearchInputProps): CustomSearch
 export function getRNTextInputProps(props: TextInputProps): RNTextInputProps {
   return {
     autoCapitalize: props.autoCapitalize,
+    autoComplete: props.autoComplete,
     autoCorrect: props.autoCorrect,
     autoFocus: props.autoFocus,
     blurOnSubmit: props.blurOnSubmit,
@@ -92,6 +95,7 @@ export function getRNTextInputProps(props: TextInputProps): RNTextInputProps {
     editable: props.editable,
     keyboardType: props.keyboardType,
     maxLength: props.maxLength,
+    nativeID: props.nativeID,
     onBlur: props.onBlur,
     onChangeText: props.onChangeText,
     onFocus: props.onFocus,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12981

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |     Email : <br/> <img width="272" alt="Capture d’écran 2022-01-24 à 14 20 43" src="https://user-images.githubusercontent.com/46637324/150790326-0f82b75b-4ecb-46bc-ae21-5614084916fa.png">        |
|     |         |                 |                  |    Password : <br/> <img width="280" alt="Capture d’écran 2022-01-24 à 14 21 54" src="https://user-images.githubusercontent.com/46637324/150790359-fe54ebcf-b479-483d-91b1-e9cb6cccb667.png">      |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
