### PR TITLE
(PC-12864) feat(InputError): handle accessibility on input error

### DIFF
--- a/__snapshots__/ui/web/errors/__tests__/ErrorMessage.test.tsx.native-snap
+++ b/__snapshots__/ui/web/errors/__tests__/ErrorMessage.test.tsx.native-snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ErrorMessage /> should render correctly 1`] = `
+<Text>
+  Error Text Message
+</Text>
+`;

--- a/__snapshots__/ui/web/errors/__tests__/ErrorMessage.test.tsx.web-snap
+++ b/__snapshots__/ui/web/errors/__tests__/ErrorMessage.test.tsx.web-snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ErrorMessage /> should render correctly 1`] = `
+<div
+  role="alert"
+>
+  <div
+    className="css-text-901oao"
+    dir="auto"
+  >
+    Error Text Message
+  </div>
+</div>
+`;

--- a/src/ui/components/inputs/InputError.tsx
+++ b/src/ui/components/inputs/InputError.tsx
@@ -1,9 +1,10 @@
-import React, { FC, Fragment } from 'react'
+import React, { FC } from 'react'
 
 import { Error } from 'ui/svg/icons/Error'
 import { Spacer } from 'ui/theme'
 // eslint-disable-next-line no-restricted-imports
 import { ColorsEnum } from 'ui/theme/colors'
+import { ErrorMessage } from 'ui/web/errors/ErrorMessage'
 
 import { InputRule } from './rules/InputRule'
 
@@ -16,7 +17,7 @@ interface Props {
 
 export const InputError: FC<Props> = (props) => {
   return props.visible ? (
-    <Fragment>
+    <ErrorMessage>
       <Spacer.Column testID="input-error-top-spacer" numberOfSpaces={props.numberOfSpacesTop} />
       <InputRule
         title={props.messageId}
@@ -26,6 +27,6 @@ export const InputError: FC<Props> = (props) => {
         iconSize={16}
         centered={props.centered}
       />
-    </Fragment>
+    </ErrorMessage>
   ) : null
 }

--- a/src/ui/web/errors/ErrorMessage.tsx
+++ b/src/ui/web/errors/ErrorMessage.tsx
@@ -1,0 +1,1 @@
+export { Fragment as ErrorMessage } from 'react'

--- a/src/ui/web/errors/ErrorMessage.web.tsx
+++ b/src/ui/web/errors/ErrorMessage.web.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export const ErrorMessage: React.FC = (props) => {
+  return <div role="alert">{props.children}</div>
+}

--- a/src/ui/web/errors/__tests__/ErrorMessage.test.tsx
+++ b/src/ui/web/errors/__tests__/ErrorMessage.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Text } from 'react-native'
+
+import { render } from 'tests/utils'
+
+import { ErrorMessage } from '../ErrorMessage'
+
+describe('<ErrorMessage />', () => {
+  it('should render correctly', () => {
+    const renderErrorMessage = render(
+      <ErrorMessage>
+        <Text>Error Text Message</Text>
+      </ErrorMessage>
+    )
+    expect(renderErrorMessage).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12864

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [x] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |         
![image](https://user-images.githubusercontent.com/43779561/150960567-04f833e4-8bda-4445-a9bf-6026963b995a.png)
         |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
