### PR TITLE
(PC-12999) fix(accessibility): Fix header width for app modal

### DIFF
--- a/__snapshots__/features/favorites/pages/__tests__/FavoritesSorts.web.test.tsx.web-snap
+++ b/__snapshots__/features/favorites/pages/__tests__/FavoritesSorts.web.test.tsx.web-snap
@@ -136,7 +136,7 @@ Object {
           </div>
         </div>
         <header
-          class="sc-bdvvtL gqNVAp"
+          class="sc-bdvvtL dEiHBQ"
         >
           <div
             class="css-view-1dbjc4n"
@@ -351,7 +351,7 @@ Object {
         </div>
       </div>
       <header
-        class="sc-bdvvtL gqNVAp"
+        class="sc-bdvvtL dEiHBQ"
       >
         <div
           class="css-view-1dbjc4n"

--- a/__snapshots__/features/offer/pages/tests/OfferDescription.web.test.tsx.web-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferDescription.web.test.tsx.web-snap
@@ -96,7 +96,7 @@ Object {
                                 </div>
                               </div>
                               <header
-                                class="sc-pVTFL bbJidL"
+                                class="sc-pVTFL kaYLzm"
                               >
                                 <div
                                   class="css-view-1dbjc4n"
@@ -322,7 +322,7 @@ Object {
                               </div>
                             </div>
                             <header
-                              class="sc-pVTFL bbJidL"
+                              class="sc-pVTFL kaYLzm"
                             >
                               <div
                                 class="css-view-1dbjc4n"

--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.web.test.tsx.web-snap
@@ -195,7 +195,7 @@ Object {
         </div>
       </div>
       <header
-        class="sc-jrQzAO cuOBoC"
+        class="sc-jrQzAO kiJgfr"
       >
         <div
           class="css-view-1dbjc4n"
@@ -448,7 +448,7 @@ Object {
       </div>
     </div>
     <header
-      class="sc-jrQzAO cuOBoC"
+      class="sc-jrQzAO kiJgfr"
     >
       <div
         class="css-view-1dbjc4n"

--- a/__snapshots__/features/profile/pages/LegalNotices/tests/LegalNotices.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/LegalNotices/tests/LegalNotices.web.test.tsx.web-snap
@@ -156,7 +156,7 @@ Object {
         </div>
       </div>
       <header
-        class="sc-pVTFL bbJidL"
+        class="sc-pVTFL kaYLzm"
       >
         <div
           class="css-view-1dbjc4n"
@@ -370,7 +370,7 @@ Object {
       </div>
     </div>
     <header
-      class="sc-pVTFL bbJidL"
+      class="sc-pVTFL kaYLzm"
     >
       <div
         class="css-view-1dbjc4n"

--- a/__snapshots__/features/search/pages/__tests__/Categories.test.tsx.web-snap
+++ b/__snapshots__/features/search/pages/__tests__/Categories.test.tsx.web-snap
@@ -1373,7 +1373,7 @@ exports[`Categories component should render correctly 1`] = `
     </div>
   </div>
   <header
-    className="sc-bdvvtL gqNVAp"
+    className="sc-bdvvtL dEiHBQ"
   >
     <div
       className="css-view-1dbjc4n"

--- a/__snapshots__/features/search/pages/__tests__/LocationFilter.web.test.tsx.web-snap
+++ b/__snapshots__/features/search/pages/__tests__/LocationFilter.web.test.tsx.web-snap
@@ -247,7 +247,7 @@ Object {
           </div>
         </div>
         <header
-          class="sc-bdvvtL gqNVAp"
+          class="sc-bdvvtL dEiHBQ"
         >
           <div
             class="css-view-1dbjc4n"
@@ -553,7 +553,7 @@ Object {
         </div>
       </div>
       <header
-        class="sc-bdvvtL gqNVAp"
+        class="sc-bdvvtL dEiHBQ"
       >
         <div
           class="css-view-1dbjc4n"

--- a/src/ui/web/global/Header.web.tsx
+++ b/src/ui/web/global/Header.web.tsx
@@ -2,5 +2,5 @@ import styled from 'styled-components'
 
 export const Header = styled.header`
   display: flex;
-  width: inherit;
+  width: 100%;
 `


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12999

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                     <img width="550" alt="Capture d’écran 2022-01-28 à 16 58 06" src="https://user-images.githubusercontent.com/46637324/151579583-31835993-6edd-49dd-8c5c-4dd3f3ed4422.png">  |     |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
