### PR TITLE
(PC-12960) fix(Style): usage of ButtonQuaternary instead of ButtonTertiary in PrivacyPolicyModal and ConsentSettings

### DIFF
--- a/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicy.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicy.native.test.tsx.native-snap
@@ -322,9 +322,9 @@ exports[`<PrivacyPolicy /> should render privacy policy 1`] = `
               testID="Politique des cookies"
             >
               <View
-                height={20}
+                height={16}
                 testID="button-icon"
-                width={20}
+                width={16}
               >
                 <Text>
                   button-icon-SVG-Mock
@@ -333,7 +333,7 @@ exports[`<PrivacyPolicy /> should render privacy policy 1`] = `
               <Text
                 adjustsFontSizeToFit={false}
                 icon={[Function]}
-                iconSize={20}
+                iconSize={16}
                 numberOfLines={1}
                 style={
                   Array [
@@ -365,7 +365,6 @@ exports[`<PrivacyPolicy /> should render privacy policy 1`] = `
               }
             >
               <Text
-                color="#696A6F"
                 style={
                   Array [
                     Object {

--- a/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicyModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicyModal.native.test.tsx.native-snap
@@ -322,9 +322,9 @@ exports[`<PrivacyPolicyModal /> should render correctly 1`] = `
               testID="Politique des cookies"
             >
               <View
-                height={20}
+                height={16}
                 testID="button-icon"
-                width={20}
+                width={16}
               >
                 <Text>
                   button-icon-SVG-Mock
@@ -333,7 +333,7 @@ exports[`<PrivacyPolicyModal /> should render correctly 1`] = `
               <Text
                 adjustsFontSizeToFit={false}
                 icon={[Function]}
-                iconSize={20}
+                iconSize={16}
                 numberOfLines={1}
                 style={
                   Array [
@@ -365,7 +365,6 @@ exports[`<PrivacyPolicyModal /> should render correctly 1`] = `
               }
             >
               <Text
-                color="#696A6F"
                 style={
                   Array [
                     Object {

--- a/src/features/firstLogin/PrivacyPolicy/PrivacyPolicyModal.tsx
+++ b/src/features/firstLogin/PrivacyPolicy/PrivacyPolicyModal.tsx
@@ -6,14 +6,12 @@ import styled from 'styled-components/native'
 import { openUrl } from 'features/navigation/helpers'
 import { env } from 'libs/environment'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { ButtonQuaternary } from 'ui/components/buttons/ButtonQuaternary'
 import { ButtonSecondary } from 'ui/components/buttons/ButtonSecondary'
-import { ButtonTertiary } from 'ui/components/buttons/ButtonTertiary'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { Close } from 'ui/svg/icons/Close'
-import { ExternalSite } from 'ui/svg/icons/ExternalSite'
+import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Typo, Spacer, getSpacing } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 export interface Props {
   visible: boolean
@@ -49,16 +47,15 @@ export const PrivacyPolicyModal: FunctionComponent<Props> = ({
           {t`Nous utilisons des outils pour réaliser des statistiques de navigation et offrir une experience plus sûre. En cliquant sur "Autoriser", tu acceptes l'utilisation de ces services détaillés dans notre`}
         </Typo.Body>
       </Description>
-      <ButtonTertiary
+      <ButtonQuaternary
         wording={cookieButtonText}
         onPress={openCookiesPolicyExternalUrl}
-        icon={ExternalSite}
-        textSize={12}
+        icon={ExternalSiteFilled}
       />
       <SubDescription>
-        <Typo.Caption color={ColorsEnum.GREY_DARK}>
+        <Caption>
           {t`Tu pourras modifier tes paramètres de confidentialité dans ton profil.`}
-        </Typo.Caption>
+        </Caption>
       </SubDescription>
       <CallToActionsContainer>
         <AcceptanceButton wording={t`Autoriser`} onPress={onApproval} />
@@ -68,6 +65,10 @@ export const PrivacyPolicyModal: FunctionComponent<Props> = ({
     </AppModal>
   )
 }
+
+const Caption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))
 
 const CallToActionsContainer = styled.View(({ theme }) => ({
   flexDirection: theme.isDesktopViewport ? 'column' : 'column-reverse',

--- a/src/features/profile/pages/ConsentSettings.tsx
+++ b/src/features/profile/pages/ConsentSettings.tsx
@@ -11,10 +11,10 @@ import { analytics } from 'libs/analytics'
 import { env } from 'libs/environment'
 import { storage } from 'libs/storage'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
-import { ButtonTertiary } from 'ui/components/buttons/ButtonTertiary'
+import { ButtonQuaternary } from 'ui/components/buttons/ButtonQuaternary'
 import { PageHeader } from 'ui/components/headers/PageHeader'
 import { Separator } from 'ui/components/Separator'
-import { ExternalSite } from 'ui/svg/icons/ExternalSite'
+import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Spacer, Typo } from 'ui/theme'
 
 import { ProfileContainer } from '../components/reusables'
@@ -73,11 +73,10 @@ export const ConsentSettings: FunctionComponent<Props> = ({ route }) => {
           <Typo.Caption color={theme.colors.greyDark}>
             {t`Pour plus d'informations, nous t'invitons à consulter notre`}
             <Spacer.Row numberOfSpaces={1} />
-            <ButtonTertiary
+            <ButtonQuaternary
               wording={cookieButtonText}
-              icon={ExternalSite}
+              icon={ExternalSiteFilled}
               onPress={openCookiesPolicyExternalUrl}
-              textSize={12}
               inline
             />
           </Typo.Caption>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12960

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Chrome 2 |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 | ![image](https://user-images.githubusercontent.com/77674046/151952724-9ec4734e-96cf-45e2-824c-97566b4e7575.png)|![image](https://user-images.githubusercontent.com/77674046/151952932-7315ec70-7fe5-4b51-a7c7-7114d59c72c1.png)|



[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
