### PR TITLE
(PC-13115) refactor(Typo): Use theme instead of props.color to style text components where possible

### DIFF
--- a/__snapshots__/features/auth/forgottenPassword/ReinitializePassword/tests/ReinitializePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ReinitializePassword/tests/ReinitializePassword.native.test.tsx.native-snap
@@ -63,8 +63,8 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                     }
                   />
                   <Text
--                   color=\\"#b60025\\"
-+                   color=\\"#15884f\\"
+-                   isValid={false}
++                   isValid={true}
                     style={
                       Array [
                         Object {
@@ -112,8 +112,8 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                     }
                   />
                   <Text
--                   color=\\"#b60025\\"
-+                   color=\\"#15884f\\"
+-                   isValid={false}
++                   isValid={true}
                     style={
                       Array [
                         Object {
@@ -161,8 +161,8 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                     }
                   />
                   <Text
--                   color=\\"#b60025\\"
-+                   color=\\"#15884f\\"
+-                   isValid={false}
++                   isValid={true}
                     style={
                       Array [
                         Object {
@@ -210,8 +210,8 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                     }
                   />
                   <Text
--                   color=\\"#b60025\\"
-+                   color=\\"#15884f\\"
+-                   isValid={false}
++                   isValid={true}
                     style={
                       Array [
                         Object {
@@ -259,8 +259,8 @@ exports[`ReinitializePassword Page should validate PasswordSecurityRules when pa
                     }
                   />
                   <Text
--                   color=\\"#b60025\\"
-+                   color=\\"#15884f\\"
+-                   isValid={false}
++                   isValid={true}
                     style={
                       Array [
                         Object {

--- a/__snapshots__/features/auth/login/Login.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/login/Login.native.test.tsx.native-snap
@@ -241,7 +241,7 @@ exports[`<Login/> should show email error message WHEN signin has failed because
 +               }
 +             />
 +             <Text
-+               color=\\"#b60025\\"
++               isValid={false}
 +               style={
 +                 Array [
 +                   Object {
@@ -399,7 +399,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
 +             />
 +             <Text
 +               centered={true}
-+               color=\\"#b60025\\"
++               isValid={false}
 +               style={
 +                 Array [
 +                   Object {
@@ -651,7 +651,7 @@ exports[`<Login/> should show error message and error inputs WHEN signin has fai
 +             />
 +             <Text
 +               centered={true}
-+               color=\\"#b60025\\"
++               isValid={false}
 +               style={
 +                 Array [
 +                   Object {
@@ -903,7 +903,7 @@ exports[`<Login/> should show specific error message when signin rate limit is e
 +             />
 +             <Text
 +               centered={true}
-+               color=\\"#b60025\\"
++               isValid={false}
 +               style={
 +                 Array [
 +                   Object {

--- a/__snapshots__/features/auth/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
@@ -164,7 +164,6 @@ Array [
             testID="Entrée pour le jour de la date de naissance"
           >
             <Text
-              color="#696A6F"
               numberOfLines={1}
               style={
                 Array [
@@ -178,6 +177,7 @@ Array [
                 ]
               }
               testID="date-input-label-text"
+              valueLength={0}
             >
               JJ
             </Text>
@@ -236,7 +236,6 @@ Array [
             testID="Entrée pour le mois de la date de naissance"
           >
             <Text
-              color="#696A6F"
               numberOfLines={1}
               style={
                 Array [
@@ -250,6 +249,7 @@ Array [
                 ]
               }
               testID="date-input-label-text"
+              valueLength={0}
             >
               MM
             </Text>
@@ -308,7 +308,6 @@ Array [
             testID="Entrée pour l'année jour de la date de naissance"
           >
             <Text
-              color="#696A6F"
               numberOfLines={1}
               style={
                 Array [
@@ -322,6 +321,7 @@ Array [
                 ]
               }
               testID="date-input-label-text"
+              valueLength={0}
             >
               AAAA
             </Text>
@@ -839,7 +839,6 @@ exports[`SetBirthday Page should render properly 1`] = `
           testID="Entrée pour le jour de la date de naissance"
         >
           <Text
-            color="#696A6F"
             numberOfLines={1}
             style={
               Array [
@@ -853,6 +852,7 @@ exports[`SetBirthday Page should render properly 1`] = `
               ]
             }
             testID="date-input-label-text"
+            valueLength={0}
           >
             JJ
           </Text>
@@ -911,7 +911,6 @@ exports[`SetBirthday Page should render properly 1`] = `
           testID="Entrée pour le mois de la date de naissance"
         >
           <Text
-            color="#696A6F"
             numberOfLines={1}
             style={
               Array [
@@ -925,6 +924,7 @@ exports[`SetBirthday Page should render properly 1`] = `
               ]
             }
             testID="date-input-label-text"
+            valueLength={0}
           >
             MM
           </Text>
@@ -983,7 +983,6 @@ exports[`SetBirthday Page should render properly 1`] = `
           testID="Entrée pour l'année jour de la date de naissance"
         >
           <Text
-            color="#696A6F"
             numberOfLines={1}
             style={
               Array [
@@ -997,6 +996,7 @@ exports[`SetBirthday Page should render properly 1`] = `
               ]
             }
             testID="date-input-label-text"
+            valueLength={0}
           >
             AAAA
           </Text>

--- a/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.native-snap
+++ b/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.native-snap
@@ -136,7 +136,6 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
       }
     />
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {

--- a/__snapshots__/features/bookOffer/components/__tests__/BookDuoChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookDuoChoice.native.test.tsx.native-snap
@@ -128,7 +128,8 @@ Array [
             </Text>
           </View>
           <Text
-            color="#ffffff"
+            disabled={false}
+            selected={true}
             style={
               Array [
                 Object {
@@ -143,7 +144,8 @@ Array [
             Solo
           </Text>
           <Text
-            color="#ffffff"
+            disabled={false}
+            selected={true}
             style={
               Array [
                 Object {
@@ -260,7 +262,8 @@ Array [
             </View>
           </View>
           <Text
-            color="#161617"
+            disabled={false}
+            selected={false}
             style={
               Array [
                 Object {
@@ -275,7 +278,8 @@ Array [
             Duo
           </Text>
           <Text
-            color="#161617"
+            disabled={false}
+            selected={false}
             style={
               Array [
                 Object {

--- a/__snapshots__/features/bookOffer/components/__tests__/BookHourChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookHourChoice.native.test.tsx.native-snap
@@ -108,7 +108,8 @@ Array [
           }
         >
           <Text
-            color="#696A6F"
+            disabled={true}
+            selected={false}
             style={
               Array [
                 Object {
@@ -124,7 +125,8 @@ Array [
             10h00
           </Text>
           <Text
-            color="#696A6F"
+            disabled={true}
+            selected={false}
             style={
               Array [
                 Object {
@@ -232,7 +234,8 @@ Array [
           }
         >
           <Text
-            color="#161617"
+            disabled={false}
+            selected={false}
             style={
               Array [
                 Object {
@@ -248,7 +251,8 @@ Array [
             20h00
           </Text>
           <Text
-            color="#161617"
+            disabled={false}
+            selected={false}
             style={
               Array [
                 Object {

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx.native-snap
@@ -54,7 +54,6 @@ exports[`<BookingDetails /> should render correctly when user has selected optio
       }
     >
       <Text
-        color="#161617"
         style={
           Array [
             Object {
@@ -135,7 +134,6 @@ exports[`<BookingDetails /> should render correctly when user has selected optio
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -205,7 +203,6 @@ exports[`<BookingDetails /> should render correctly when user has selected optio
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -290,7 +287,6 @@ exports[`<BookingDetails /> should render correctly when user has selected optio
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -361,7 +357,6 @@ exports[`<BookingDetails /> should render correctly when user has selected optio
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -582,7 +577,6 @@ exports[`<BookingDetails /> should render disable CTA when user is underage and 
       }
     >
       <Text
-        color="#161617"
         style={
           Array [
             Object {
@@ -663,7 +657,6 @@ exports[`<BookingDetails /> should render disable CTA when user is underage and 
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -733,7 +726,6 @@ exports[`<BookingDetails /> should render disable CTA when user is underage and 
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -818,7 +810,6 @@ exports[`<BookingDetails /> should render disable CTA when user is underage and 
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -889,7 +880,6 @@ exports[`<BookingDetails /> should render disable CTA when user is underage and 
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingEventChoices.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingEventChoices.native.test.tsx.native-snap
@@ -333,7 +333,8 @@ exports[`<BookingEventChoices /> should display date step and hour step and duo 
             </Text>
           </View>
           <Text
-            color="#ffffff"
+            disabled={true}
+            selected={true}
             style={
               Array [
                 Object {
@@ -348,7 +349,8 @@ exports[`<BookingEventChoices /> should display date step and hour step and duo 
             Solo
           </Text>
           <Text
-            color="#ffffff"
+            disabled={true}
+            selected={true}
             style={
               Array [
                 Object {
@@ -484,7 +486,8 @@ exports[`<BookingEventChoices /> should display date step and hour step and duo 
             </View>
           </View>
           <Text
-            color="#696A6F"
+            disabled={true}
+            selected={false}
             style={
               Array [
                 Object {
@@ -499,7 +502,8 @@ exports[`<BookingEventChoices /> should display date step and hour step and duo 
             Duo
           </Text>
           <Text
-            color="#696A6F"
+            disabled={true}
+            selected={false}
             style={
               Array [
                 Object {

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingInformations.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingInformations.test.tsx.native-snap
@@ -57,7 +57,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -128,7 +127,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -198,7 +196,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -273,7 +270,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -343,7 +339,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -428,7 +423,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -499,7 +493,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -574,7 +567,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -659,7 +651,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -730,7 +721,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -805,7 +795,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -875,7 +864,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -960,7 +948,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -1031,7 +1018,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -1106,7 +1092,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -1177,7 +1162,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -1252,7 +1236,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -1322,7 +1305,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -1407,7 +1389,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {
@@ -1478,7 +1459,6 @@ Array [
       }
     />
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {

--- a/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.native-snap
@@ -136,7 +136,6 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
       }
     />
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {
@@ -162,7 +161,6 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
       }
     />
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {

--- a/__snapshots__/features/bookings/pages/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails.native.test.tsx.native-snap
@@ -1710,7 +1710,6 @@ exports[`BookingDetails should render correctly 1`] = `
         }
       >
         <Text
-          color="#ffffff"
           style={
             Array [
               Object {

--- a/__snapshots__/features/favorites/pages/__tests__/FavoritesSorts.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/__tests__/FavoritesSorts.native.test.tsx.native-snap
@@ -403,7 +403,6 @@ exports[`FavoritesSorts component should render correctly 1`] = `
         </View>
       </View>
       <Text
-        color="#ffffff"
         numberOfLines={1}
         style={
           Array [

--- a/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.native-snap
+++ b/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.native-snap
@@ -136,7 +136,6 @@ exports[`<ForceUpdate/> should match snapshot 1`] = `
       }
     />
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {

--- a/__snapshots__/features/home/atoms/tests/ModuleTitle.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/atoms/tests/ModuleTitle.native.test.tsx.native-snap
@@ -11,7 +11,6 @@ exports[`ModuleTitle component should render correctly 1`] = `
   }
 >
   <Text
-    color="#161617"
     numberOfLines={2}
     style={
       Array [

--- a/__snapshots__/features/home/atoms/tests/SeeMore.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/atoms/tests/SeeMore.native.test.tsx.native-snap
@@ -138,7 +138,6 @@ exports[`<SeeMore /> renders correctly 1`] = `
       }
     >
       <Text
-        color="#eb0055"
         style={
           Array [
             Object {

--- a/__snapshots__/features/home/atoms/tests/VenueCaption.test.tsx.native-snap
+++ b/__snapshots__/features/home/atoms/tests/VenueCaption.test.tsx.native-snap
@@ -57,7 +57,6 @@ exports[`VenueCaption component should render correctly 1`] = `
       }
     />
     <Text
-      color="#696A6F"
       numberOfLines={1}
       style={
         Array [
@@ -75,7 +74,6 @@ exports[`VenueCaption component should render correctly 1`] = `
     </Text>
   </View>
   <Text
-    color="#696A6F"
     style={
       Array [
         Object {

--- a/__snapshots__/features/home/atoms/tests/VenueTile.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/atoms/tests/VenueTile.native.test.tsx.native-snap
@@ -125,7 +125,6 @@ exports[`VenueTile component should render correctly 1`] = `
         }
       />
       <Text
-        color="#696A6F"
         numberOfLines={1}
         style={
           Array [
@@ -143,7 +142,6 @@ exports[`VenueTile component should render correctly 1`] = `
       </Text>
     </View>
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {

--- a/__snapshots__/features/home/components/tests/BusinessModule.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/tests/BusinessModule.native.test.tsx.native-snap
@@ -139,7 +139,6 @@ exports[`BusinessModule component should disable click when no URL 1`] = `
             }
           >
             <Text
-              color="#ffffff"
               style={
                 Array [
                   Object {
@@ -155,7 +154,6 @@ exports[`BusinessModule component should disable click when no URL 1`] = `
               firstLine
             </Text>
             <Text
-              color="#ffffff"
               numberOfLines={2}
               style={
                 Array [
@@ -327,7 +325,6 @@ exports[`BusinessModule component should render correctly - with leftIcon = Idea
             }
           >
             <Text
-              color="#ffffff"
               style={
                 Array [
                   Object {
@@ -343,7 +340,6 @@ exports[`BusinessModule component should render correctly - with leftIcon = Idea
               firstLine
             </Text>
             <Text
-              color="#ffffff"
               numberOfLines={2}
               style={
                 Array [
@@ -547,7 +543,6 @@ exports[`BusinessModule component should render correctly - with leftIcon provid
             }
           >
             <Text
-              color="#ffffff"
               style={
                 Array [
                   Object {
@@ -563,7 +558,6 @@ exports[`BusinessModule component should render correctly - with leftIcon provid
               firstLine
             </Text>
             <Text
-              color="#ffffff"
               numberOfLines={2}
               style={
                 Array [

--- a/__snapshots__/features/home/components/tests/OffersModule.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/tests/OffersModule.native.test.tsx.native-snap
@@ -22,8 +22,8 @@ exports[`OffersModule component should render correctly - with black title 1`] =
     }
   >
     <Text
-      color="#161617"
       numberOfLines={2}
+      onDarkBackground={false}
       style={
         Array [
           Object {
@@ -375,7 +375,6 @@ exports[`OffersModule component should render correctly - with black title 1`] =
                 Mensch ! Où sont les Hommes ?
               </Text>
               <Text
-                color="#696A6F"
                 style={
                   Array [
                     Object {
@@ -576,7 +575,6 @@ exports[`OffersModule component should render correctly - with black title 1`] =
                 I want something more
               </Text>
               <Text
-                color="#696A6F"
                 style={
                   Array [
                     Object {
@@ -777,7 +775,6 @@ exports[`OffersModule component should render correctly - with black title 1`] =
                 Un lit sous une rivière
               </Text>
               <Text
-                color="#696A6F"
                 numberOfLines={1}
                 style={
                   Array [
@@ -793,7 +790,6 @@ exports[`OffersModule component should render correctly - with black title 1`] =
                 17 novembre 2020
               </Text>
               <Text
-                color="#696A6F"
                 style={
                   Array [
                     Object {
@@ -996,7 +992,6 @@ exports[`OffersModule component should render correctly - with black title 1`] =
                 I want something more
               </Text>
               <Text
-                color="#696A6F"
                 style={
                   Array [
                     Object {

--- a/__snapshots__/features/identityCheck/components/__test__/DMSModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/__test__/DMSModal.native.test.tsx.native-snap
@@ -265,7 +265,6 @@ exports[`<DMSModal/> should render correctly 1`] = `
         >
           <View>
             <Text
-              color="#696A6F"
               style={
                 Array [
                   Object {
@@ -354,7 +353,6 @@ exports[`<DMSModal/> should render correctly 1`] = `
               </Text>
             </View>
             <Text
-              color="#696A6F"
               style={
                 Array [
                   Object {
@@ -443,7 +441,6 @@ exports[`<DMSModal/> should render correctly 1`] = `
               </Text>
             </View>
             <Text
-              color="#696A6F"
               style={
                 Array [
                   Object {

--- a/__snapshots__/features/identityCheck/components/__test__/FastEduconnectConnectionRequestModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/__test__/FastEduconnectConnectionRequestModal.native.test.tsx.native-snap
@@ -269,7 +269,6 @@ exports[`<IdentityCheckEnd/> should render correctly if modal not visible 1`] = 
         >
           <View>
             <Text
-              color="#696A6F"
               style={
                 Array [
                   Object {
@@ -524,7 +523,6 @@ exports[`<IdentityCheckEnd/> should render correctly if modal not visible 1`] = 
               </Text>
             </View>
             <Text
-              color="#696A6F"
               style={
                 Array [
                   Object {
@@ -812,7 +810,6 @@ exports[`<IdentityCheckEnd/> should render correctly if modal visible 1`] = `
         >
           <View>
             <Text
-              color="#696A6F"
               style={
                 Array [
                   Object {
@@ -1067,7 +1064,6 @@ exports[`<IdentityCheckEnd/> should render correctly if modal visible 1`] = `
               </Text>
             </View>
             <Text
-              color="#696A6F"
               style={
                 Array [
                   Object {

--- a/__snapshots__/features/identityCheck/components/layout/PageWithHeader.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/layout/PageWithHeader.test.tsx.native-snap
@@ -38,7 +38,6 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
     }
   >
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {

--- a/__snapshots__/features/identityCheck/pages/confirmation/__test__/IdentityCheckHonor.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/__test__/IdentityCheckHonor.test.tsx.native-snap
@@ -38,7 +38,6 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
     }
   >
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {

--- a/__snapshots__/features/identityCheck/pages/confirmation/__test__/UnderageAccountCreated.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/__test__/UnderageAccountCreated.test.tsx.native-snap
@@ -208,7 +208,7 @@ exports[`<UnderageAccountCreated/> should render correctly 1`] = `
       style={
         Array [
           Object {
-            "color": "#870087",
+            "color": "#161617",
             "fontFamily": "Montserrat-Medium",
             "fontSize": 24,
             "lineHeight": 28,

--- a/__snapshots__/features/identityCheck/pages/confirmation/__test__/UnderageAccountCreated.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/__test__/UnderageAccountCreated.test.tsx.web-snap
@@ -276,7 +276,7 @@ exports[`<UnderageAccountCreated/> should render correctly 1`] = `
       dir="auto"
       style={
         Object {
-          "color": "rgba(135,0,135,1.00)",
+          "color": "rgba(22,22,23,1.00)",
           "fontFamily": "Montserrat-Medium",
           "fontSize": "22px",
           "lineHeight": "28px",

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckDMS.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckDMS.test.tsx.native-snap
@@ -38,7 +38,6 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
     }
   >
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnect.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnect.test.tsx.native-snap
@@ -38,7 +38,6 @@ exports[`<IdentityCheckEduConnect /> should render correctly 1`] = `
     }
   >
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {
@@ -242,7 +241,6 @@ exports[`<IdentityCheckEduConnect /> should render correctly 1`] = `
                   }
                 />
                 <Text
-                  color="#696A6F"
                   style={
                     Array [
                       Object {

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnectForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnectForm.native.test.tsx.native-snap
@@ -38,7 +38,6 @@ exports[`<IdentityCheckEduConnectForm /> should render IdentityCheckEduConnectFo
     }
   >
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckStart.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckStart.native.test.tsx.native-snap
@@ -39,7 +39,6 @@ Array [
       }
     >
       <Text
-        color="#ffffff"
         style={
           Array [
             Object {
@@ -312,7 +311,6 @@ Array [
                     }
                   >
                     <Text
-                      color="#696A6F"
                       style={
                         Array [
                           Object {
@@ -660,7 +658,6 @@ Array [
                           >
                             <View>
                               <Text
-                                color="#696A6F"
                                 style={
                                   Array [
                                     Object {
@@ -749,7 +746,6 @@ Array [
                                 </Text>
                               </View>
                               <Text
-                                color="#696A6F"
                                 style={
                                   Array [
                                     Object {
@@ -838,7 +834,6 @@ Array [
                                 </Text>
                               </View>
                               <Text
-                                color="#696A6F"
                                 style={
                                   Array [
                                     Object {

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckUnavailable.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckUnavailable.test.tsx.native-snap
@@ -453,7 +453,6 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
             >
               <View>
                 <Text
-                  color="#696A6F"
                   style={
                     Array [
                       Object {
@@ -542,7 +541,6 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
                   </Text>
                 </View>
                 <Text
-                  color="#696A6F"
                   style={
                     Array [
                       Object {
@@ -631,7 +629,6 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
                   </Text>
                 </View>
                 <Text
-                  color="#696A6F"
                   style={
                     Array [
                       Object {

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckValidation.native.test.tsx.native-snap
@@ -38,7 +38,6 @@ exports[`<IdentityCheckValidation /> should render IdentityCheckValidation compo
     }
   >
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetAddress.native.test.tsx.native-snap
@@ -38,7 +38,6 @@ exports[`<SetAddress/> should render correctly 1`] = `
     }
   >
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetCity.native.test.tsx.native-snap
@@ -38,7 +38,6 @@ exports[`<SetCity/> should render correctly 1`] = `
     }
   >
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetName.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetName.native.test.tsx.native-snap
@@ -38,7 +38,6 @@ exports[`<SetName/> should render correctly 1`] = `
     }
   >
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetSchoolType.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetSchoolType.native.test.tsx.native-snap
@@ -38,7 +38,6 @@ exports[`<SetSchoolType /> shoud render a list of high school types if profile.s
     }
   >
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {
@@ -252,7 +251,7 @@ exports[`<SetSchoolType /> shoud render a list of high school types if profile.s
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -307,7 +306,7 @@ exports[`<SetSchoolType /> shoud render a list of high school types if profile.s
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -360,7 +359,7 @@ exports[`<SetSchoolType /> shoud render a list of high school types if profile.s
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -413,7 +412,7 @@ exports[`<SetSchoolType /> shoud render a list of high school types if profile.s
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -466,7 +465,7 @@ exports[`<SetSchoolType /> shoud render a list of high school types if profile.s
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -519,7 +518,7 @@ exports[`<SetSchoolType /> shoud render a list of high school types if profile.s
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -534,7 +533,6 @@ exports[`<SetSchoolType /> shoud render a list of high school types if profile.s
                     Accompagnement spécialisé
                   </Text>
                   <Text
-                    color="#696A6F"
                     style={
                       Array [
                         Object {
@@ -589,7 +587,7 @@ exports[`<SetSchoolType /> shoud render a list of high school types if profile.s
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -762,7 +760,6 @@ exports[`<SetSchoolType /> shoud render a list of middle school types if profile
     }
   >
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {
@@ -976,7 +973,7 @@ exports[`<SetSchoolType /> shoud render a list of middle school types if profile
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -1031,7 +1028,7 @@ exports[`<SetSchoolType /> shoud render a list of middle school types if profile
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -1086,7 +1083,7 @@ exports[`<SetSchoolType /> shoud render a list of middle school types if profile
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -1101,7 +1098,6 @@ exports[`<SetSchoolType /> shoud render a list of middle school types if profile
                     Accompagnement spécialisé
                   </Text>
                   <Text
-                    color="#696A6F"
                     style={
                       Array [
                         Object {

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/Status.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/Status.native.test.tsx.native-snap
@@ -38,7 +38,6 @@ exports[`<Status/> should render correctly 1`] = `
     }
   >
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {
@@ -252,7 +251,7 @@ exports[`<Status/> should render correctly 1`] = `
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -307,7 +306,7 @@ exports[`<Status/> should render correctly 1`] = `
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -362,7 +361,7 @@ exports[`<Status/> should render correctly 1`] = `
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -417,7 +416,7 @@ exports[`<Status/> should render correctly 1`] = `
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -472,7 +471,7 @@ exports[`<Status/> should render correctly 1`] = `
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -527,7 +526,7 @@ exports[`<Status/> should render correctly 1`] = `
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -582,7 +581,7 @@ exports[`<Status/> should render correctly 1`] = `
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -597,7 +596,6 @@ exports[`<Status/> should render correctly 1`] = `
                     Volontaire
                   </Text>
                   <Text
-                    color="#696A6F"
                     style={
                       Array [
                         Object {
@@ -652,7 +650,7 @@ exports[`<Status/> should render correctly 1`] = `
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -667,7 +665,6 @@ exports[`<Status/> should render correctly 1`] = `
                     Inactif
                   </Text>
                   <Text
-                    color="#696A6F"
                     style={
                       Array [
                         Object {
@@ -722,7 +719,7 @@ exports[`<Status/> should render correctly 1`] = `
                   }
                 >
                   <Text
-                    color="#161617"
+                    selected={false}
                     style={
                       Array [
                         Object {
@@ -737,7 +734,6 @@ exports[`<Status/> should render correctly 1`] = `
                     Chômeur
                   </Text>
                   <Text
-                    color="#696A6F"
                     style={
                       Array [
                         Object {

--- a/__snapshots__/features/offer/atoms/__tests__/OfferTile.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/atoms/__tests__/OfferTile.native.test.tsx.native-snap
@@ -185,7 +185,6 @@ exports[`OfferTile component should render correctly 1`] = `
       Mensch ! Où sont les Hommes ?
     </Text>
     <Text
-      color="#696A6F"
       numberOfLines={1}
       style={
         Array [
@@ -201,7 +200,6 @@ exports[`OfferTile component should render correctly 1`] = `
       Dès le 12 mars 2020
     </Text>
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {

--- a/__snapshots__/features/offer/pages/tests/OfferDescription.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferDescription.native.test.tsx.native-snap
@@ -670,7 +670,6 @@ Tous les détails du film sur AlloCiné:
                               </View>
                             </View>
                             <Text
-                              color="#ffffff"
                               numberOfLines={1}
                               style={
                                 Array [

--- a/__snapshots__/features/profile/components/ProfileBadge.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/ProfileBadge.native.test.tsx.native-snap
@@ -31,7 +31,6 @@ exports[`ProfileBadge should not show CTA if no link is provided 1`] = `
     }
   >
     <Text
-      color="#161617"
       style={
         Array [
           Object {
@@ -98,7 +97,6 @@ exports[`ProfileBadge should render component correctly if icon is provided 1`] 
     }
   >
     <Text
-      color="#161617"
       style={
         Array [
           Object {
@@ -147,7 +145,6 @@ exports[`ProfileBadge should render component correctly if no icon is provided 1
     }
   >
     <Text
-      color="#161617"
       style={
         Array [
           Object {
@@ -196,7 +193,7 @@ exports[`ProfileBadge should show CTA Icon and CTA message if Icon, Message and 
     }
   >
     <Text
-      color="#696A6F"
+      callToAction="https://calltoaction.com"
       style={
         Array [
           Object {
@@ -320,7 +317,6 @@ exports[`ProfileBadge should show neither CTA Icon nor CTA message if no CTA mes
     }
   >
     <Text
-      color="#161617"
       style={
         Array [
           Object {

--- a/__snapshots__/features/profile/components/ProfileHeader.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/ProfileHeader.native.test.tsx.native-snap
@@ -63,7 +63,6 @@ exports[`ProfileHeader should display the LoggedOutHeader if no user 1`] = `
     }
   >
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {
@@ -88,7 +87,6 @@ exports[`ProfileHeader should display the LoggedOutHeader if no user 1`] = `
       }
     />
     <Text
-      color="#ffffff"
       style={
         Array [
           Object {
@@ -187,7 +185,6 @@ exports[`ProfileHeader should display the LoggedOutHeader if no user 1`] = `
       }
     >
       <Text
-        color="#ffffff"
         style={
           Array [
             Object {
@@ -222,7 +219,6 @@ exports[`ProfileHeader should display the LoggedOutHeader if no user 1`] = `
         testID="Connecte-toi"
       >
         <Text
-          color="#ffffff"
           style={
             Array [
               Object {

--- a/__snapshots__/features/profile/components/SubscriptionMessageBadge.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/SubscriptionMessageBadge.native.test.tsx.native-snap
@@ -3,7 +3,6 @@
 exports[`SubscriptionMessageBadge should display component correctly 1`] = `
 Array [
   <Text
-    color="#696A6F"
     style={
       Array [
         Object {
@@ -75,7 +74,6 @@ Array [
       }
     >
       <Text
-        color="#161617"
         style={
           Array [
             Object {
@@ -143,7 +141,6 @@ exports[`SubscriptionMessageBadge should not display last update sentence if upd
     }
   >
     <Text
-      color="#161617"
       style={
         Array [
           Object {

--- a/__snapshots__/features/profile/pages/AfterChangeEmailValidationBuffer/__tests__/AfterChangeEmailValidationBuffer.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/AfterChangeEmailValidationBuffer/__tests__/AfterChangeEmailValidationBuffer.native.test.tsx.native-snap
@@ -48,7 +48,6 @@ exports[`<AfterChangeEmailValidationBuffer/> should render correctly 1`] = `
     Loading-Animation-Lottie-Mock
   </View>
   <Text
-    color="#ffffff"
     style={
       Array [
         Object {

--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.native.test.tsx.native-snap
@@ -104,7 +104,6 @@ Array [
         }
       />
       <Text
-        color="#696A6F"
         style={
           Array [
             Object {
@@ -636,7 +635,6 @@ Array [
         </View>
       </View>
       <Text
-        color="#ffffff"
         numberOfLines={1}
         style={
           Array [
@@ -728,7 +726,6 @@ Array [
         }
       />
       <Text
-        color="#696A6F"
         style={
           Array [
             Object {
@@ -1280,7 +1277,6 @@ Array [
         </View>
       </View>
       <Text
-        color="#ffffff"
         numberOfLines={1}
         style={
           Array [

--- a/__snapshots__/features/profile/pages/ChangePassword/tests/ChangePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangePassword/tests/ChangePassword.native.test.tsx.native-snap
@@ -96,7 +96,7 @@ exports[`ChangePassword should validate PasswordSecurityRules when password is c
 +             }
 +           />
 +           <Text
-+             color=\\"#15884f\\"
++             isValid={true}
 +             style={
 +               Array [
 +                 Object {
@@ -156,7 +156,7 @@ exports[`ChangePassword should validate PasswordSecurityRules when password is c
 +             }
 +           />
 +           <Text
-+             color=\\"#15884f\\"
++             isValid={true}
 +             style={
 +               Array [
 +                 Object {
@@ -216,7 +216,7 @@ exports[`ChangePassword should validate PasswordSecurityRules when password is c
 +             }
 +           />
 +           <Text
-+             color=\\"#15884f\\"
++             isValid={true}
 +             style={
 +               Array [
 +                 Object {
@@ -276,7 +276,7 @@ exports[`ChangePassword should validate PasswordSecurityRules when password is c
 +             }
 +           />
 +           <Text
-+             color=\\"#15884f\\"
++             isValid={true}
 +             style={
 +               Array [
 +                 Object {
@@ -336,7 +336,7 @@ exports[`ChangePassword should validate PasswordSecurityRules when password is c
 +             }
 +           />
 +           <Text
-+             color=\\"#15884f\\"
++             isValid={true}
 +             style={
 +               Array [
 +                 Object {

--- a/__snapshots__/features/profile/pages/LegalNotices/tests/LegalNotices.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/LegalNotices/tests/LegalNotices.native.test.tsx.native-snap
@@ -433,7 +433,6 @@ Array [
         </View>
       </View>
       <Text
-        color="#ffffff"
         numberOfLines={1}
         style={
           Array [

--- a/__snapshots__/features/profile/pages/PersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/PersonalData.native.test.tsx.native-snap
@@ -389,7 +389,6 @@ Array [
         </View>
       </View>
       <Text
-        color="#ffffff"
         numberOfLines={1}
         style={
           Array [

--- a/__snapshots__/features/search/pages/__tests__/Categories.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/__tests__/Categories.test.tsx.native-snap
@@ -11,8 +11,8 @@ exports[`Categories component should match diff snapshot when new category is se
             }
           />
           <Text
--           color=\\"#161617\\"
-+           color=\\"#eb0055\\"
+-           isSelected={false}
++           isSelected={true}
             numberOfLines={2}
             style={
               Array [
@@ -49,8 +49,8 @@ exports[`Categories component should match diff snapshot when new category is se
             }
           />
           <Text
--           color=\\"#eb0055\\"
-+           color=\\"#161617\\"
+-           isSelected={true}
++           isSelected={false}
             numberOfLines={2}
             style={
               Array [
@@ -177,7 +177,7 @@ exports[`Categories component should render correctly 1`] = `
           }
         />
         <Text
-          color="#eb0055"
+          isSelected={true}
           numberOfLines={2}
           style={
             Array [
@@ -263,7 +263,7 @@ exports[`Categories component should render correctly 1`] = `
           }
         />
         <Text
-          color="#161617"
+          isSelected={false}
           numberOfLines={2}
           style={
             Array [
@@ -341,7 +341,7 @@ exports[`Categories component should render correctly 1`] = `
           }
         />
         <Text
-          color="#161617"
+          isSelected={false}
           numberOfLines={2}
           style={
             Array [
@@ -419,7 +419,7 @@ exports[`Categories component should render correctly 1`] = `
           }
         />
         <Text
-          color="#161617"
+          isSelected={false}
           numberOfLines={2}
           style={
             Array [
@@ -497,7 +497,7 @@ exports[`Categories component should render correctly 1`] = `
           }
         />
         <Text
-          color="#161617"
+          isSelected={false}
           numberOfLines={2}
           style={
             Array [
@@ -575,7 +575,7 @@ exports[`Categories component should render correctly 1`] = `
           }
         />
         <Text
-          color="#161617"
+          isSelected={false}
           numberOfLines={2}
           style={
             Array [
@@ -653,7 +653,7 @@ exports[`Categories component should render correctly 1`] = `
           }
         />
         <Text
-          color="#161617"
+          isSelected={false}
           numberOfLines={2}
           style={
             Array [
@@ -731,7 +731,7 @@ exports[`Categories component should render correctly 1`] = `
           }
         />
         <Text
-          color="#161617"
+          isSelected={false}
           numberOfLines={2}
           style={
             Array [
@@ -809,7 +809,7 @@ exports[`Categories component should render correctly 1`] = `
           }
         />
         <Text
-          color="#161617"
+          isSelected={false}
           numberOfLines={2}
           style={
             Array [
@@ -887,7 +887,7 @@ exports[`Categories component should render correctly 1`] = `
           }
         />
         <Text
-          color="#161617"
+          isSelected={false}
           numberOfLines={2}
           style={
             Array [
@@ -965,7 +965,7 @@ exports[`Categories component should render correctly 1`] = `
           }
         />
         <Text
-          color="#161617"
+          isSelected={false}
           numberOfLines={2}
           style={
             Array [
@@ -1043,7 +1043,7 @@ exports[`Categories component should render correctly 1`] = `
           }
         />
         <Text
-          color="#161617"
+          isSelected={false}
           numberOfLines={2}
           style={
             Array [
@@ -1121,7 +1121,7 @@ exports[`Categories component should render correctly 1`] = `
           }
         />
         <Text
-          color="#161617"
+          isSelected={false}
           numberOfLines={2}
           style={
             Array [
@@ -1243,7 +1243,6 @@ exports[`Categories component should render correctly 1`] = `
         </View>
       </View>
       <Text
-        color="#ffffff"
         numberOfLines={1}
         style={
           Array [

--- a/__snapshots__/features/search/pages/__tests__/LocationFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/__tests__/LocationFilter.native.test.tsx.native-snap
@@ -105,7 +105,6 @@ exports[`LocationFilter component should render correctly 1`] = `
             }
           >
             <Text
-              color="#161617"
               style={
                 Array [
                   Object {
@@ -210,7 +209,7 @@ exports[`LocationFilter component should render correctly 1`] = `
             }
           >
             <Text
-              color="#161617"
+              isSelected={false}
               numberOfLines={3}
               style={
                 Array [
@@ -335,7 +334,7 @@ exports[`LocationFilter component should render correctly 1`] = `
             }
           >
             <Text
-              color="#161617"
+              isSelected={false}
               numberOfLines={3}
               style={
                 Array [
@@ -462,7 +461,7 @@ exports[`LocationFilter component should render correctly 1`] = `
             }
           >
             <Text
-              color="#eb0055"
+              isSelected={true}
               numberOfLines={3}
               style={
                 Array [
@@ -596,7 +595,6 @@ exports[`LocationFilter component should render correctly 1`] = `
         </View>
       </View>
       <Text
-        color="#ffffff"
         numberOfLines={1}
         style={
           Array [

--- a/__snapshots__/features/search/pages/__tests__/Search.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/__tests__/Search.native.test.tsx.native-snap
@@ -219,7 +219,6 @@ exports[`Search component should render correctly 1`] = `
           }
         >
           <Text
-            color="#696A6F"
             style={
               Array [
                 Object {
@@ -345,7 +344,6 @@ exports[`Search component should render correctly 1`] = `
           }
         >
           <Text
-            color="#696A6F"
             style={
               Array [
                 Object {

--- a/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
@@ -179,7 +179,6 @@ exports[`SearchFilter component should render correctly 1`] = `
           }
         />
         <Text
-          color="#696A6F"
           style={
             Array [
               Object {
@@ -3003,7 +3002,6 @@ exports[`SearchFilter component should render correctly 1`] = `
         </View>
       </View>
       <Text
-        color="#ffffff"
         numberOfLines={1}
         style={
           Array [

--- a/__snapshots__/features/venue/atoms/__tests__/VenueOfferTile.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/atoms/__tests__/VenueOfferTile.native.test.tsx.native-snap
@@ -144,7 +144,6 @@ exports[`VenueOfferTile component should render correctly 1`] = `
       Mensch ! Où sont les Hommes ?
     </Text>
     <Text
-      color="#696A6F"
       numberOfLines={1}
       style={
         Array [
@@ -160,7 +159,6 @@ exports[`VenueOfferTile component should render correctly 1`] = `
       Dès le 12 mars 2020
     </Text>
     <Text
-      color="#696A6F"
       style={
         Array [
           Object {

--- a/__snapshots__/features/venue/components/__tests__/VenueOffers.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/components/__tests__/VenueOffers.native.test.tsx.native-snap
@@ -33,7 +33,6 @@ Array [
       }
     >
       <Text
-        color="#161617"
         numberOfLines={2}
         style={
           Array [
@@ -386,7 +385,6 @@ Array [
                   Titane - VF
                 </Text>
                 <Text
-                  color="#696A6F"
                   numberOfLines={1}
                   style={
                     Array [
@@ -402,7 +400,6 @@ Array [
                   Dès le 18 août 2021
                 </Text>
                 <Text
-                  color="#696A6F"
                   style={
                     Array [
                       Object {
@@ -609,7 +606,6 @@ Array [
                   Bac Nord - VF
                 </Text>
                 <Text
-                  color="#696A6F"
                   numberOfLines={1}
                   style={
                     Array [
@@ -625,7 +621,6 @@ Array [
                   Dès le 18 août 2021
                 </Text>
                 <Text
-                  color="#696A6F"
                   style={
                     Array [
                       Object {
@@ -832,7 +827,6 @@ Array [
                   Black Widow - VF
                 </Text>
                 <Text
-                  color="#696A6F"
                   numberOfLines={1}
                   style={
                     Array [
@@ -848,7 +842,6 @@ Array [
                   Dès le 18 août 2021
                 </Text>
                 <Text
-                  color="#696A6F"
                   style={
                     Array [
                       Object {
@@ -1049,7 +1042,6 @@ Array [
                   }
                 >
                   <Text
-                    color="#eb0055"
                     style={
                       Array [
                         Object {

--- a/__snapshots__/features/venue/pages/__tests__/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/__tests__/Venue.native.test.tsx.native-snap
@@ -667,7 +667,6 @@ exports[`<Venue /> should match snapshot 1`] = `
           }
         >
           <Text
-            color="#161617"
             numberOfLines={2}
             style={
               Array [
@@ -1020,7 +1019,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                       Titane - VF
                     </Text>
                     <Text
-                      color="#696A6F"
                       numberOfLines={1}
                       style={
                         Array [
@@ -1036,7 +1034,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                       Dès le 18 août 2021
                     </Text>
                     <Text
-                      color="#696A6F"
                       style={
                         Array [
                           Object {
@@ -1243,7 +1240,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                       Bac Nord - VF
                     </Text>
                     <Text
-                      color="#696A6F"
                       numberOfLines={1}
                       style={
                         Array [
@@ -1259,7 +1255,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                       Dès le 18 août 2021
                     </Text>
                     <Text
-                      color="#696A6F"
                       style={
                         Array [
                           Object {
@@ -1466,7 +1461,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                       Black Widow - VF
                     </Text>
                     <Text
-                      color="#696A6F"
                       numberOfLines={1}
                       style={
                         Array [
@@ -1482,7 +1476,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                       Dès le 18 août 2021
                     </Text>
                     <Text
-                      color="#696A6F"
                       style={
                         Array [
                           Object {
@@ -1683,7 +1676,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                       }
                     >
                       <Text
-                        color="#eb0055"
                         style={
                           Array [
                             Object {

--- a/__snapshots__/features/venue/pages/__tests__/VenueBody.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/__tests__/VenueBody.native.test.tsx.native-snap
@@ -655,7 +655,6 @@ exports[`<VenueBody /> should render correctly 1`] = `
         }
       >
         <Text
-          color="#161617"
           numberOfLines={2}
           style={
             Array [
@@ -1008,7 +1007,6 @@ exports[`<VenueBody /> should render correctly 1`] = `
                     Titane - VF
                   </Text>
                   <Text
-                    color="#696A6F"
                     numberOfLines={1}
                     style={
                       Array [
@@ -1024,7 +1022,6 @@ exports[`<VenueBody /> should render correctly 1`] = `
                     Dès le 18 août 2021
                   </Text>
                   <Text
-                    color="#696A6F"
                     style={
                       Array [
                         Object {
@@ -1231,7 +1228,6 @@ exports[`<VenueBody /> should render correctly 1`] = `
                     Bac Nord - VF
                   </Text>
                   <Text
-                    color="#696A6F"
                     numberOfLines={1}
                     style={
                       Array [
@@ -1247,7 +1243,6 @@ exports[`<VenueBody /> should render correctly 1`] = `
                     Dès le 18 août 2021
                   </Text>
                   <Text
-                    color="#696A6F"
                     style={
                       Array [
                         Object {
@@ -1454,7 +1449,6 @@ exports[`<VenueBody /> should render correctly 1`] = `
                     Black Widow - VF
                   </Text>
                   <Text
-                    color="#696A6F"
                     numberOfLines={1}
                     style={
                       Array [
@@ -1470,7 +1464,6 @@ exports[`<VenueBody /> should render correctly 1`] = `
                     Dès le 18 août 2021
                   </Text>
                   <Text
-                    color="#696A6F"
                     style={
                       Array [
                         Object {
@@ -1671,7 +1664,6 @@ exports[`<VenueBody /> should render correctly 1`] = `
                     }
                   >
                     <Text
-                      color="#eb0055"
                       style={
                         Array [
                           Object {

--- a/__snapshots__/ui/components/__tests__/ClippedTag.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/__tests__/ClippedTag.native.test.tsx.native-snap
@@ -25,7 +25,6 @@ exports[`<ClippedTag/> should render correctly 1`] = `
     }
   >
     <Text
-      color="#ffffff"
       numberOfLines={1}
       style={
         Array [

--- a/__snapshots__/ui/components/__tests__/OfferCaption.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/__tests__/OfferCaption.native.test.tsx.native-snap
@@ -28,7 +28,6 @@ exports[`OfferCaption component should render correctly 1`] = `
     Mensch ! Où sont les Hommes ?
   </Text>
   <Text
-    color="#696A6F"
     numberOfLines={1}
     style={
       Array [
@@ -44,7 +43,6 @@ exports[`OfferCaption component should render correctly 1`] = `
     Dès le 2 mars 2020
   </Text>
   <Text
-    color="#696A6F"
     style={
       Array [
         Object {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -957,7 +957,7 @@ SPEC CHECKSUMS:
   FirebaseCore: 98b29e3828f0a53651c363937a7f7d92a19f1ba2
   FirebaseCoreDiagnostics: 56fb7216d87e0e6ec2feddefa9d8a392fe8b2c18
   FirebaseDynamicLinks: cf76a46274569da2d4491548a39ef35f3c1a992d
-  FirebaseFirestore: d09c620ac1fe1570cb1e909f6f165d6b55bc4ee0
+  FirebaseFirestore: 7103ab89eff01c90ced62a65dc071e010eeec4a7
   FirebaseInstallations: 830327b45345ffc859eaa9c17bcd5ae893fd5425
   FirebasePerformance: 0c01a7a496657d7cea86d40c0b1725259d164c6c
   FirebaseRemoteConfig: f6365883d7950d784ee97bcdbbf1e442d4fa6119

--- a/src/features/_marketingAndCommunication/atoms/DeeplinkItem.tsx
+++ b/src/features/_marketingAndCommunication/atoms/DeeplinkItem.tsx
@@ -13,11 +13,10 @@ import { ColorsEnum } from 'ui/theme/colors'
 
 interface Props {
   deeplink: GeneratedDeeplink
-  color: ColorsEnum
   before?: JSX.Element | JSX.Element[]
 }
 
-export const DeeplinkItem = ({ deeplink, color, before }: Props) => {
+export const DeeplinkItem = ({ deeplink, before }: Props) => {
   const { showSuccessSnackBar, showErrorSnackBar } = useSnackBarContext()
   const copyToClipboard = useCallback(
     (url: string) => {
@@ -50,7 +49,7 @@ export const DeeplinkItem = ({ deeplink, color, before }: Props) => {
         <Spacer.Flex flex={0.85}>
           <TouchableOpacity
             onPress={() => openUrl(deeplink.universalLink, { shouldLogEvent: false })}>
-            <Title color={color}>{deeplink.universalLink}</Title>
+            <Title>{deeplink.universalLink}</Title>
           </TouchableOpacity>
         </Spacer.Flex>
 
@@ -61,7 +60,7 @@ export const DeeplinkItem = ({ deeplink, color, before }: Props) => {
             accessibilityLabel={t`Copier`}
             accessible
             testID="copy-universalLink">
-            <Share color={color} size={24} />
+            <Share color={ColorsEnum.BLACK} size={24} />
           </TouchableOpacity>
         </Spacer.Flex>
       </Container>
@@ -70,7 +69,7 @@ export const DeeplinkItem = ({ deeplink, color, before }: Props) => {
         <Spacer.Flex flex={0.85}>
           <TouchableOpacity
             onPress={() => openUrl(deeplink.firebaseLink, { shouldLogEvent: false })}>
-            <Title color={color}>{deeplink.firebaseLink}</Title>
+            <Title>{deeplink.firebaseLink}</Title>
           </TouchableOpacity>
         </Spacer.Flex>
 
@@ -81,7 +80,7 @@ export const DeeplinkItem = ({ deeplink, color, before }: Props) => {
             accessibilityLabel={t`Copier dans le press-papier`}
             accessible
             testID="copy-firebaselink">
-            <Share color={color} size={24} />
+            <Share color={ColorsEnum.BLACK} size={24} />
           </TouchableOpacity>
         </Spacer.Flex>
       </Container>
@@ -90,18 +89,17 @@ export const DeeplinkItem = ({ deeplink, color, before }: Props) => {
 }
 
 DeeplinkItem.defaultProps = {
-  color: ColorsEnum.BLACK,
   size: getSpacing(3.75),
   iconSize: 32,
 }
 
 const iconContainerStyle = { margin: 'auto' }
 
-const Title = styled.Text<{ color: ColorsEnum }>(({ color, theme }) => ({
+const Title = styled.Text(({ theme }) => ({
   fontFamily: theme.fontFamily.regular,
   fontSize: getSpacing(3),
   lineHeight: getSpacingString(4.5),
-  color: color,
+  color: theme.colors.black,
   flexDirection: 'row',
 }))
 

--- a/src/features/_marketingAndCommunication/components/DeeplinksGeneratorForm.tsx
+++ b/src/features/_marketingAndCommunication/components/DeeplinksGeneratorForm.tsx
@@ -22,10 +22,8 @@ import { RadioButton } from 'ui/components/RadioButton'
 import { Separator } from 'ui/components/Separator'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
-import { Warning } from 'ui/svg/icons/Warning'
+import { Warning as WarningDefault } from 'ui/svg/icons/Warning'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 export interface GeneratedDeeplink {
   universalLink: string
@@ -97,7 +95,7 @@ export const DeeplinksGeneratorForm = ({ onCreate }: Props) => {
         )}
         {!!config.description && (
           <DescriptionContainer>
-            <Typo.Caption color={ColorsEnum.GREY_MEDIUM}>{config.description}</Typo.Caption>
+            <StyledCaption>{config.description}</StyledCaption>
           </DescriptionContainer>
         )}
         <Separator />
@@ -187,10 +185,10 @@ export const DeeplinksGeneratorForm = ({ onCreate }: Props) => {
         </AccordionItem>
       </Container>
       <BottomContainer>
-        <Banner color={ColorsEnum.ERROR}>
-          <Warning color={ColorsEnum.ERROR} size={getSpacing(3.5)} />
+        <ErrorBanner>
+          <Warning />
           {t`Seulement les "ids" disposent de validation\u00a0!`}
-        </Banner>
+        </ErrorBanner>
         <ButtonPrimary wording={t`Générer le lien`} disabled={disabled} onPress={onPress} />
       </BottomContainer>
     </React.Fragment>
@@ -215,9 +213,10 @@ const Container = styled.ScrollView(({ theme }) => ({
   flexDirection: 'column',
 }))
 
-const Banner = styled(Typo.Caption)({
+const ErrorBanner = styled(Typo.Caption)(({ theme }) => ({
   paddingVertical: getSpacing(1.5),
-})
+  color: theme.colors.error,
+}))
 
 const TitleContainer = styled(Typo.Title4)({
   textAlign: 'center',
@@ -232,3 +231,12 @@ const BottomContainer = styled.View({
 const DescriptionContainer = styled.View({
   padding: getSpacing(5),
 })
+
+const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyMedium,
+}))
+
+const Warning = styled(WarningDefault).attrs(({ theme }) => ({
+  color: theme.colors.error,
+  size: getSpacing(3.5),
+}))``

--- a/src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
+++ b/src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
@@ -15,8 +15,6 @@ import { InputError } from 'ui/components/inputs/InputError'
 import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { Email } from 'ui/svg/icons/Email'
 import { Spacer, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 import { useAppSettings } from '../../settings'
 
@@ -105,14 +103,14 @@ export const AcceptCgu: FC<PreValidationSignupStepProps> = (props) => {
           <ExternalLink
             text={t`Conditions Générales d'Utilisation`}
             url={env.CGU_LINK}
-            color={ColorsEnum.PRIMARY}
+            primary
             testID="external-link-cgu"
           />
           <Spacer.Row numberOfSpaces={1} />
           <Typo.Body>{t` ainsi que notre `}</Typo.Body>
           <ExternalLink
             text={t`Politique de confidentialité.`}
-            color={ColorsEnum.PRIMARY}
+            primary
             url={env.PRIVACY_POLICY_LINK}
             testID="external-link-privacy-policy"
           />

--- a/src/features/auth/signup/PhoneValidation/SetPhoneNumber.tsx
+++ b/src/features/auth/signup/PhoneValidation/SetPhoneNumber.tsx
@@ -25,8 +25,6 @@ import { ModalHeader } from 'ui/components/modals/ModalHeader'
 import { useModal } from 'ui/components/modals/useModal'
 import { Close } from 'ui/svg/icons/Close'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 import { Form } from 'ui/web/form/Form'
 
 const TIMER = 60
@@ -134,9 +132,9 @@ export const SetPhoneNumber = memo(function SetPhoneNumberComponent() {
         <ModalContent>
           <Form.MaxWidth>
             <Paragraphe>
-              <Typo.Body color={ColorsEnum.GREY_DARK}>
+              <StyledBody>
                 {t`Pour sécuriser l'accès à ton pass nous avons besoin de valider ton numéro.`}
-              </Typo.Body>
+              </StyledBody>
             </Paragraphe>
             <Spacer.Column numberOfSpaces={8} />
             <InputContainer>
@@ -199,6 +197,10 @@ const InputContainer = styled.View(({ theme }) => ({
   width: '100%',
   maxWidth: getSpacing(90),
   marginHorizontal: theme.isMobileViewport ? undefined : 'auto',
+}))
+
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.greyDark,
 }))
 
 const PICKER_WIDTH_DESKTOP = 30 // in %

--- a/src/features/auth/signup/VerifyEligiblity/NotYetUnderageEligibility.tsx
+++ b/src/features/auth/signup/VerifyEligiblity/NotYetUnderageEligibility.tsx
@@ -10,8 +10,6 @@ import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { GenericInfoPage } from 'ui/components/GenericInfoPage'
 import { CalendarIllustration } from 'ui/svg/icons/CalendarIllustration'
 import { Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 type Props = StackScreenProps<RootStackParamList, 'NotYetUnderageEligibility'>
 
@@ -37,8 +35,7 @@ export const NotYetUnderageEligibility: FunctionComponent<Props> = (props) => {
   )
 }
 
-const StyledBody = styled(Typo.Body).attrs({
-  color: ColorsEnum.WHITE,
-})({
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
   textAlign: 'center',
-})
+  color: theme.colors.white,
+}))

--- a/src/features/bookOffer/atoms/DuoChoice.tsx
+++ b/src/features/bookOffer/atoms/DuoChoice.tsx
@@ -33,9 +33,11 @@ export const DuoChoice: React.FC<Props> = ({
     <ChoiceBloc onPress={onPress} testID={testID} selected={selected} disabled={disabled}>
       <Container>
         <Icon color={textColor} size={28} />
-        <Typo.ButtonText color={textColor}>{title}</Typo.ButtonText>
+        <ButtonText selected={selected} disabled={disabled}>
+          {title}
+        </ButtonText>
 
-        <Caption testID={`${testID}-price`} color={textColor}>
+        <Caption testID={`${testID}-price`} selected={selected} disabled={disabled}>
           {price}
         </Caption>
       </Container>
@@ -49,4 +51,16 @@ const Container = styled.View({
   alignItems: 'center',
 })
 
-const Caption = styled(Typo.Caption)({ textAlign: 'center' })
+interface TypoProps {
+  selected: boolean
+  disabled: boolean
+}
+
+const ButtonText = styled(Typo.ButtonText)<TypoProps>(({ selected, disabled, theme }) => ({
+  color: getTextColor(theme, selected, disabled),
+}))
+
+const Caption = styled(Typo.Caption)<TypoProps>(({ selected, disabled, theme }) => ({
+  color: getTextColor(theme, selected, disabled),
+  textAlign: 'center',
+}))

--- a/src/features/bookOffer/atoms/HourChoice.tsx
+++ b/src/features/bookOffer/atoms/HourChoice.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro'
 import React from 'react'
-import styled, { useTheme } from 'styled-components/native'
+import styled from 'styled-components/native'
 
 import { formatToFrenchDecimal } from 'libs/parsers'
 import { getSpacing, Typo } from 'ui/theme'
@@ -34,18 +34,16 @@ export const HourChoice: React.FC<Props> = ({
 }) => {
   const enoughCredit = price <= offerCredit
   const disabled = !isBookable || !enoughCredit
-  const theme = useTheme()
-  const textColor = getTextColor(theme, selected, disabled)
   const wording = getWording(price, isBookable, enoughCredit)
 
   return (
     <ChoiceBloc onPress={onPress} testID={testID} selected={selected} disabled={disabled}>
       <Container>
-        <Typo.ButtonText testID={`${testID}-hour`} color={textColor}>
+        <ButtonText testID={`${testID}-hour`} selected={selected} disabled={disabled}>
           {hour}
-        </Typo.ButtonText>
+        </ButtonText>
 
-        <Caption testID={`${testID}-price`} color={textColor}>
+        <Caption testID={`${testID}-price`} selected={selected} disabled={disabled}>
           {wording}
         </Caption>
       </Container>
@@ -59,4 +57,16 @@ const Container = styled.View({
   justifyContent: 'center',
 })
 
-const Caption = styled(Typo.Caption)({ textAlign: 'center' })
+interface TypoProps {
+  selected: boolean
+  disabled: boolean
+}
+
+const ButtonText = styled(Typo.ButtonText)<TypoProps>(({ selected, disabled, theme }) => ({
+  color: getTextColor(theme, selected, disabled),
+}))
+
+const Caption = styled(Typo.Caption)<TypoProps>(({ selected, disabled, theme }) => ({
+  color: getTextColor(theme, selected, disabled),
+  textAlign: 'center',
+}))

--- a/src/features/bookOffer/components/BookingInformations.tsx
+++ b/src/features/bookOffer/components/BookingInformations.tsx
@@ -119,7 +119,7 @@ const Item: React.FC<{
       <Spacer.Row numberOfSpaces={3} />
       {typeof message === 'string' ? <Typo.Caption>{message}</Typo.Caption> : message}
       <Spacer.Row numberOfSpaces={2} />
-      <Typo.Caption color={ColorsEnum.GREY_DARK}>{subtext}</Typo.Caption>
+      <StyledCaption>{subtext}</StyledCaption>
     </Row>
   )
 }
@@ -134,3 +134,6 @@ const StyledAddress = styled(Typo.Body)({
   textTransform: 'capitalize',
   alignItems: 'center',
 })
+const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/bookOffer/pages/BookingConfirmation.tsx
+++ b/src/features/bookOffer/pages/BookingConfirmation.tsx
@@ -14,8 +14,6 @@ import { ButtonTertiaryWhite } from 'ui/components/buttons/ButtonTertiaryWhite'
 import { GenericInfoPage } from 'ui/components/GenericInfoPage'
 import { TicketBooked } from 'ui/svg/icons/TicketBooked'
 import { Spacer, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 export function BookingConfirmation() {
   const { params } = useRoute<UseRouteType<'BookingConfirmation'>>()
@@ -74,8 +72,7 @@ export function BookingConfirmation() {
   )
 }
 
-const StyledBody = styled(Typo.Body).attrs({
-  color: ColorsEnum.WHITE,
-})({
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
   textAlign: 'center',
-})
+  color: theme.colors.white,
+}))

--- a/src/features/bookings/components/BookingDetailsHeader.tsx
+++ b/src/features/bookings/components/BookingDetailsHeader.tsx
@@ -8,8 +8,6 @@ import { useGoBack } from 'features/navigation/useGoBack'
 import { getAnimationState } from 'ui/components/headers/animationHelpers'
 import { HeaderIcon } from 'ui/components/headers/HeaderIcon'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 interface Props {
   headerTransition: Animated.AnimatedInterpolation
   title: string
@@ -39,7 +37,7 @@ export const BookingDetailsHeader: React.FC<Props> = (props) => {
           </IconContainer>
 
           <Title style={{ opacity: headerTransition }}>
-            <Typo.Body color={ColorsEnum.WHITE}>{title}</Typo.Body>
+            <StyledBody>{title}</StyledBody>
           </Title>
 
           <Spacer.Row numberOfSpaces={3} />
@@ -72,3 +70,7 @@ const Title = styled(Animated.Text).attrs({ numberOfLines: 1 })({
   textAlign: 'center',
   flex: 5,
 })
+
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
+}))

--- a/src/features/bookings/components/EndedBookingItem.tsx
+++ b/src/features/bookings/components/EndedBookingItem.tsx
@@ -92,17 +92,12 @@ function getEndedBookingReason(
   cancellationReason?: BookingCancellationReasons | null,
   dateUsed?: string | null
 ) {
-  if (dateUsed)
-    return (
-      <InputRule title={t`Utilisé`} icon={Check} color={ColorsEnum.GREEN_VALID} iconSize={20} />
-    )
+  if (dateUsed) return <InputRule title={t`Utilisé`} icon={Check} isValid iconSize={20} />
 
   if (cancellationReason === BookingCancellationReasons.OFFERER)
-    return <InputRule title={t`Annulé`} icon={Check} color={ColorsEnum.ERROR} iconSize={20} />
+    return <InputRule title={t`Annulé`} icon={Check} isValid={false} iconSize={20} />
 
-  return (
-    <InputRule title={t`Réservation annulée`} icon={Check} color={ColorsEnum.ERROR} iconSize={20} />
-  )
+  return <InputRule title={t`Réservation annulée`} icon={Check} isValid={false} iconSize={20} />
 }
 
 function getEndedBookingDateLabel(cancellationDate?: string | null, dateUsed?: string | null) {

--- a/src/features/bookings/components/NoBookingsView.tsx
+++ b/src/features/bookings/components/NoBookingsView.tsx
@@ -16,7 +16,7 @@ export function NoBookingsView() {
     <Container>
       <Spacer.Flex />
       <NoBookings size={197} color={ColorsEnum.GREY_MEDIUM} />
-      <Explanation color={ColorsEnum.GREY_DARK}>
+      <Explanation>
         {t`Tu n’as pas de réservations en cours.
       Découvre les offres disponibles 
       sans attendre\u00a0!`}
@@ -48,7 +48,8 @@ const ButtonContainer = styled.View({
   width: '100%',
 })
 
-const Explanation = styled(Typo.Body)({
+const Explanation = styled(Typo.Body)(({ theme }) => ({
   flex: 1,
   textAlign: 'center',
-})
+  color: theme.colors.greyDark,
+}))

--- a/src/features/bookings/components/OnGoingBookingItem.tsx
+++ b/src/features/bookings/components/OnGoingBookingItem.tsx
@@ -34,7 +34,7 @@ export const OnGoingBookingItem = ({ booking }: BookingItemProps) => {
       <OnGoingTicket image={stock.offer.image?.url} altIcon={mapCategoryToIcon(categoryId)} />
       <AttributesView>
         <BookingItemTitle title={stock.offer.name} />
-        {!!dateLabel && <DateLabel color={ColorsEnum.GREY_DARK}>{dateLabel}</DateLabel>}
+        {!!dateLabel && <DateLabel>{dateLabel}</DateLabel>}
         <Spacer.Column numberOfSpaces={1} />
         {!!bookingProperties.isDuo && <Duo />}
         <Spacer.Flex />
@@ -42,9 +42,7 @@ export const OnGoingBookingItem = ({ booking }: BookingItemProps) => {
           <WithDrawContainer>
             <Clock size={16} color={ColorsEnum.PRIMARY} />
             <Spacer.Row numberOfSpaces={1} />
-            <WithdrawCaption color={ColorsEnum.PRIMARY} numberOfLines={2}>
-              {withdrawLabel}
-            </WithdrawCaption>
+            <WithdrawCaption numberOfLines={2}>{withdrawLabel}</WithdrawCaption>
           </WithDrawContainer>
         )}
       </AttributesView>
@@ -65,15 +63,17 @@ const AttributesView = styled.View({
   paddingRight: getSpacing(1),
 })
 
-const WithDrawContainer = styled.View({
+const WithDrawContainer = styled.View(({ theme }) => ({
   flex: 1,
   flexDirection: 'row',
   alignItems: 'center',
-})
+  color: theme.colors.primary,
+}))
 
-const DateLabel = styled(Typo.Body)({
+const DateLabel = styled(Typo.Body)(({ theme }) => ({
   flex: 1,
-})
+  color: theme.colors.greyDark,
+}))
 
 const WithdrawCaption = styled(Typo.Caption)({
   marginRight: getSpacing(4),

--- a/src/features/bookings/components/OnGoingBookingsList.tsx
+++ b/src/features/bookings/components/OnGoingBookingsList.tsx
@@ -16,8 +16,6 @@ import { useIsFalseWithDelay } from 'libs/hooks/useIsFalseWithDelay'
 import { useSubcategories } from 'libs/subcategories/useSubcategories'
 import { Separator } from 'ui/components/Separator'
 import { getSpacing, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 import { TAB_BAR_COMP_HEIGHT } from 'ui/theme/constants'
 
 import { NoBookingsView } from './NoBookingsView'
@@ -106,14 +104,13 @@ const Container = styled.View<{ flex?: number }>(({ flex }) => ({
   height: '100%',
 }))
 
-const BookingsCount = styled(Typo.Body).attrs({
-  color: ColorsEnum.GREY_DARK,
-})({
+const BookingsCount = styled(Typo.Body)(({ theme }) => ({
   fontSize: 15,
   paddingTop: getSpacing(6),
   paddingHorizontal: getSpacing(6),
   paddingBottom: getSpacing(4),
-})
+  color: theme.colors.greyDark,
+}))
 
 const FooterContainer = styled.View<{ safeBottom: number }>(({ safeBottom }) => ({
   marginBottom: safeBottom ? safeBottom / 2 : 0,

--- a/src/features/cheatcodes/pages/AppComponents/AppComponents.tsx
+++ b/src/features/cheatcodes/pages/AppComponents/AppComponents.tsx
@@ -289,7 +289,7 @@ export const AppComponents: FunctionComponent = () => {
       {/* Modals */}
       <AccordionItem title="Modals">
         <TouchableOpacity onPress={showBasicModal}>
-          <Typo.Title4 color={ColorsEnum.TERTIARY}>Modal - Basic</Typo.Title4>
+          <StyledTitle4>Modal - Basic</StyledTitle4>
         </TouchableOpacity>
         <AppModal
           title="a basic modal"
@@ -358,17 +358,17 @@ export const AppComponents: FunctionComponent = () => {
 
       {/* Inputs */}
       <AccordionItem title="Inputs">
-        <Typo.Title4 color={ColorsEnum.TERTIARY}>Text Input</Typo.Title4>
+        <StyledTitle4>Text Input</StyledTitle4>
         <TextInput value={inputText} onChangeText={setInputText} placeholder={'Placeholder'} />
         <Spacer.Column numberOfSpaces={1} />
         <InputRule
           title={'12 Caractères'}
           icon={inputText.length >= 12 ? Check : Close}
-          color={inputText.length >= 12 ? ColorsEnum.GREEN_VALID : ColorsEnum.ERROR}
+          isValid={inputText.length >= 12}
           iconSize={16}
         />
         <Spacer.Column numberOfSpaces={1} />
-        <Typo.Title4 color={ColorsEnum.TERTIARY}>Text Input - Email</Typo.Title4>
+        <StyledTitle4>Text Input - Email</StyledTitle4>
         <TextInput
           autoCapitalize="none"
           keyboardType="email-address"
@@ -377,28 +377,28 @@ export const AppComponents: FunctionComponent = () => {
           value=""
         />
         <Spacer.Column numberOfSpaces={1} />
-        <Typo.Title4 color={ColorsEnum.TERTIARY}>Text Input - Error</Typo.Title4>
+        <StyledTitle4>Text Input - Error</StyledTitle4>
         <TextInput value="" onChangeText={doNothingFn} placeholder={'Placeholder'} isError={true} />
         <Spacer.Column numberOfSpaces={1} />
-        <Typo.Title4 color={ColorsEnum.TERTIARY}>Password Input</Typo.Title4>
+        <StyledTitle4>Password Input</StyledTitle4>
         <PasswordInput value="" onChangeText={doNothingFn} placeholder={'Placeholder'} />
         <Spacer.Column numberOfSpaces={1} />
-        <Typo.Title4 color={ColorsEnum.TERTIARY}>Short Input</Typo.Title4>
+        <StyledTitle4>Short Input</StyledTitle4>
         <Spacer.Column numberOfSpaces={1} />
-        <Typo.Title4 color={ColorsEnum.TERTIARY}>Date Input</Typo.Title4>
+        <StyledTitle4>Date Input</StyledTitle4>
         <Spacer.Column numberOfSpaces={1} />
         <Spacer.Flex flex={1}>
           <DateInput />
         </Spacer.Flex>
         <Spacer.Column numberOfSpaces={1} />
-        <Typo.Title4 color={ColorsEnum.TERTIARY}>Code Input of length 20</Typo.Title4>
+        <StyledTitle4>Code Input of length 20</StyledTitle4>
         <Spacer.Column numberOfSpaces={1} />
-        <Typo.Caption color={ColorsEnum.BLACK}>is valid if number of 5 digits</Typo.Caption>
+        <Typo.Caption>is valid if number of 5 digits</Typo.Caption>
         <Spacer.Column numberOfSpaces={1} />
-        <Typo.Caption color={ColorsEnum.BLACK}>{inputText}</Typo.Caption>
+        <Typo.Caption>{inputText}</Typo.Caption>
         <Spacer.Column numberOfSpaces={1} />
 
-        <Typo.Title4 color={ColorsEnum.TERTIARY}>Large input</Typo.Title4>
+        <StyledTitle4>Large input</StyledTitle4>
         <Spacer.Column numberOfSpaces={1} />
         <LargeTextInput value={largeInputText} onChangeText={setLargeInputText} maxLength={200} />
       </AccordionItem>
@@ -507,7 +507,7 @@ export const AppComponents: FunctionComponent = () => {
             <Button title="+1 an" onPress={() => setYear((year) => year - 1)} />
           </AlignedText>
         </View>
-        <Typo.Title4 color={ColorsEnum.TERTIARY}>Communication InApp</Typo.Title4>
+        <StyledTitle4>Communication InApp</StyledTitle4>
         <Text>Long texte</Text>
         <View>
           <SubscriptionMessageBadge
@@ -676,6 +676,10 @@ export const AppComponents: FunctionComponent = () => {
     </StyledScrollView>
   )
 }
+
+const StyledTitle4 = styled(Typo.Title4)(({ theme }) => ({
+  color: theme.colors.tertiary,
+}))
 
 const AlignedText = styled(View)({
   flexDirection: 'row',

--- a/src/features/favorites/atoms/BicolorFavoriteCount.tsx
+++ b/src/features/favorites/atoms/BicolorFavoriteCount.tsx
@@ -47,12 +47,8 @@ export const BicolorFavoriteCount: React.FC<BicolorIconInterface> = ({
       <StyledAnimatedView style={{ transform: [{ scale }] }} {...pastilleDimensions}>
         <Pastille color={thin ? colors.greyDark : undefined} {...pastilleDimensions} />
         <PastilleContent {...pastilleDimensions}>
-          <Count {...pastilleDimensions} color={colors.white}>
-            {count}
-          </Count>
-          <Plus {...pastilleDimensions} color={colors.white}>
-            {plusSign}
-          </Plus>
+          <Count {...pastilleDimensions}>{count}</Count>
+          <Plus {...pastilleDimensions}>{plusSign}</Plus>
         </PastilleContent>
       </StyledAnimatedView>
     </Container>
@@ -80,14 +76,16 @@ const PastilleContent = styled.View<{ height: number; width: number }>((props) =
   width: props.width,
 }))
 
-const Plus = styled(Typo.Caption)<{ height: number }>(({ height }) => ({
+const Plus = styled(Typo.Caption)<{ height: number }>(({ height, theme }) => ({
   fontSize: 8,
   height: Platform.select<number>({ web: height, default: height + getSpacing(1) }),
+  color: theme.colors.white,
 }))
 
-const Count = styled(Typo.Caption)<{ height: number }>(({ height }) => ({
+const Count = styled(Typo.Caption)<{ height: number }>(({ height, theme }) => ({
   fontSize: 9,
   height: Platform.select<number>({ web: height, default: height + getSpacing(1) }),
+  color: theme.colors.white,
 }))
 
 const useScaleFavoritesAnimation = (nbFavorites?: number) => {

--- a/src/features/forceUpdate/ForceUpdate.tsx
+++ b/src/features/forceUpdate/ForceUpdate.tsx
@@ -10,8 +10,6 @@ import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { GenericInfoPage } from 'ui/components/GenericInfoPage'
 import { Star } from 'ui/svg/icons/Star'
 import { Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 const ANDROID_STORE_LINK = `https://play.google.com/store/apps/details?id=${env.ANDROID_APP_ID}`
 const IOS_STORE_LINK = `https://apps.apple.com/fr/app/pass-culture/id${env.IOS_APP_STORE_ID}`
@@ -59,8 +57,7 @@ export const ForceUpdate = () => {
     </React.Fragment>
   )
 }
-const StyledBody = styled(Typo.Body).attrs({
-  color: ColorsEnum.WHITE,
-})({
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
   textAlign: 'center',
-})
+  color: theme.colors.white,
+}))

--- a/src/features/home/atoms/ModuleTitle.tsx
+++ b/src/features/home/atoms/ModuleTitle.tsx
@@ -3,14 +3,12 @@ import { PixelRatio } from 'react-native'
 import styled from 'styled-components/native'
 
 import { Typo, MARGIN_DP } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
-export const ModuleTitle = (props: { title: string; color?: ColorsEnum }) => {
-  const { title, color = ColorsEnum.BLACK } = props
+export const ModuleTitle = (props: { title: string }) => {
+  const { title } = props
   return (
     <Container>
-      <Typo.Title3 numberOfLines={2} testID="moduleTitle" color={color}>
+      <Typo.Title3 numberOfLines={2} testID="moduleTitle">
         {title}
       </Typo.Title3>
     </Container>

--- a/src/features/home/atoms/SeeMore.tsx
+++ b/src/features/home/atoms/SeeMore.tsx
@@ -26,7 +26,7 @@ export const SeeMore: React.FC<SeeMoreProps> = ({ height, width, onPress }) => (
       </Row>
       <Spacer.Column numberOfSpaces={2} />
       <Row>
-        <Typo.ButtonText color={ColorsEnum.PRIMARY}>{t`En voir plus`}</Typo.ButtonText>
+        <ButtonText>{t`En voir plus`}</ButtonText>
       </Row>
     </ClickableArea>
   </Container>
@@ -62,3 +62,7 @@ const RoundContainer = styled.TouchableOpacity({
   }),
   alignItems: 'center',
 })
+
+const ButtonText = styled(Typo.ButtonText)(({ theme }) => ({
+  color: theme.colors.primary,
+}))

--- a/src/features/home/atoms/VenueCaption.tsx
+++ b/src/features/home/atoms/VenueCaption.tsx
@@ -49,9 +49,6 @@ const IconWithCaption = styled.View({
 
 const TypeLabel = styled(Typo.Caption).attrs({
   numberOfLines: 1,
-  color: ColorsEnum.GREY_DARK,
-})({ flexShrink: 1 })
+})(({ theme }) => ({ flexShrink: 1, color: theme.colors.greyDark }))
 
-const Distance = styled(Typo.Caption).attrs({
-  color: ColorsEnum.GREY_DARK,
-})({})
+const Distance = styled(Typo.Caption)(({ theme }) => ({ color: theme.colors.greyDark }))

--- a/src/features/home/components/BusinessModule.tsx
+++ b/src/features/home/components/BusinessModule.tsx
@@ -69,12 +69,8 @@ export const BusinessModule = ({ module }: { module: BusinessPane }) => {
                 {leftIcon ? <Image source={{ uri: leftIcon }} /> : <IdeaIcon />}
               </IconContainer>
               <TextContainer>
-                <Typo.ButtonText color={ColorsEnum.WHITE} testID="firstLine">
-                  {firstLine}
-                </Typo.ButtonText>
-                <Typo.Body numberOfLines={2} color={ColorsEnum.WHITE}>
-                  {secondLine}
-                </Typo.Body>
+                <ButtonText testID="firstLine">{firstLine}</ButtonText>
+                <StyledBody numberOfLines={2}>{secondLine}</StyledBody>
               </TextContainer>
               {!isDisabled && (
                 <IconContainer>
@@ -138,3 +134,11 @@ const IconContainer = styled.View({
   justifyContent: 'center',
   alignItems: 'center',
 })
+
+const ButtonText = styled(Typo.ButtonText)(({ theme }) => ({
+  color: theme.colors.white,
+}))
+
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
+}))

--- a/src/features/home/components/tests/OffersModule.native.test.tsx
+++ b/src/features/home/components/tests/OffersModule.native.test.tsx
@@ -47,12 +47,12 @@ describe('OffersModule component', () => {
   it('should render correctly - with black title', () => {
     const component = render(<OffersModule {...props} index={1} />)
     expect(component).toMatchSnapshot()
-    expect(component.getByTestId('playlistTitle').props.color).toBe(ColorsEnum.BLACK)
+    expect(component.getByTestId('playlistTitle').props.style[0].color).toBe(ColorsEnum.BLACK)
   })
 
   it('should render with white title if first module displayed', async () => {
     const component = render(<OffersModule {...props} index={0} />)
-    expect(component.getByTestId('playlistTitle').props.color).toBe(ColorsEnum.WHITE)
+    expect(component.getByTestId('playlistTitle').props.style[0].color).toBe(ColorsEnum.WHITE)
   })
 })
 

--- a/src/features/identityCheck/atoms/form/RadioButton.tsx
+++ b/src/features/identityCheck/atoms/form/RadioButton.tsx
@@ -15,10 +15,8 @@ interface Props {
 export const RadioButton = ({ name, description, selected, onPress }: Props) => (
   <Label selected={selected} onPress={() => onPress(name)}>
     <TextContainer>
-      <Typo.ButtonText color={selected ? ColorsEnum.PRIMARY : ColorsEnum.BLACK}>
-        {name}
-      </Typo.ButtonText>
-      {description ? <Typo.Caption color={ColorsEnum.GREY_DARK}>{description}</Typo.Caption> : null}
+      <ButtonText selected={selected}>{name}</ButtonText>
+      {description ? <Caption>{description}</Caption> : null}
     </TextContainer>
     {selected ? (
       <IconContainer>
@@ -50,3 +48,11 @@ const IconContainer = styled.View({
   position: 'absolute',
   right: getSpacing(3),
 })
+
+const ButtonText = styled(Typo.ButtonText)<{ selected: boolean }>(({ selected, theme }) => ({
+  color: selected ? theme.colors.primary : theme.colors.black,
+}))
+
+const Caption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/identityCheck/atoms/layout/PageHeader.tsx
+++ b/src/features/identityCheck/atoms/layout/PageHeader.tsx
@@ -30,9 +30,11 @@ const HeaderContainer = styled.View({
   height: HEADER_HEIGHT,
 })
 
-const Title = styled(Typo.Title4).attrs({
-  color: ColorsEnum.WHITE,
-})({ flex: 1, textAlign: 'center' })
+const Title = styled(Typo.Title4)(({ theme }) => ({
+  flex: 1,
+  textAlign: 'center',
+  color: theme.colors.white,
+}))
 
 interface BackButtonProps {
   onGoBack?: () => void

--- a/src/features/identityCheck/components/DMSModal.tsx
+++ b/src/features/identityCheck/components/DMSModal.tsx
@@ -1,5 +1,6 @@
 import { t } from '@lingui/macro'
 import React, { FunctionComponent } from 'react'
+import styled from 'styled-components/native'
 
 import { openUrl } from 'features/navigation/helpers'
 import { analytics } from 'libs/analytics'
@@ -9,8 +10,6 @@ import { AppModal } from 'ui/components/modals/AppModal'
 import { Close } from 'ui/svg/icons/Close'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Spacer, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 interface Props {
   visible: boolean
@@ -37,9 +36,9 @@ export const DMSModal: FunctionComponent<Props> = ({ visible, hideModal }) => (
     rightIconAccessibilityLabel={t`Fermer la modale pour transmettre un document sur le site Démarches Simplifiée`}
     rightIcon={Close}
     onRightIconPress={hideModal}>
-    <Typo.Body color={ColorsEnum.GREY_DARK}>
+    <StyledBody>
       {t`Tu peux aussi compléter ton dossier sur Démarches simplifiées. Attention le traitement sera plus long\u00a0!`}
-    </Typo.Body>
+    </StyledBody>
     <Spacer.Column numberOfSpaces={8} />
     <ButtonTertiaryBlack
       wording={t`Je suis de nationalité française`}
@@ -47,7 +46,7 @@ export const DMSModal: FunctionComponent<Props> = ({ visible, hideModal }) => (
       icon={ExternalSiteFilled}
       justifyContent="flex-start"
     />
-    <Typo.Caption color={ColorsEnum.GREY_DARK}>{t`Carte d’identité ou passeport.`}</Typo.Caption>
+    <StyledCaption>{t`Carte d’identité ou passeport.`}</StyledCaption>
     <Spacer.Column numberOfSpaces={8} />
     <ButtonTertiaryBlack
       wording={t`Je suis de nationalité étrangère`}
@@ -55,9 +54,15 @@ export const DMSModal: FunctionComponent<Props> = ({ visible, hideModal }) => (
       icon={ExternalSiteFilled}
       justifyContent="flex-start"
     />
-    <Typo.Caption color={ColorsEnum.GREY_DARK}>
-      {t`Titre de séjour, carte d'identité, ou passeport.`}
-    </Typo.Caption>
+    <StyledCaption>{t`Titre de séjour, carte d'identité, ou passeport.`}</StyledCaption>
     <Spacer.Column numberOfSpaces={4} />
   </AppModal>
 )
+
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))
+
+const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/identityCheck/components/FastEduconnectConnectionRequestModal.tsx
+++ b/src/features/identityCheck/components/FastEduconnectConnectionRequestModal.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro'
 import { useNavigation } from '@react-navigation/native'
 import React from 'react'
-import styled, { useTheme } from 'styled-components/native'
+import styled from 'styled-components/native'
 
 import { IdentityCheckMethod } from 'api/gen'
 import { useIdentityCheckContext } from 'features/identityCheck/context/IdentityCheckContextProvider'
@@ -28,7 +28,6 @@ interface FastEduconnectConnectionRequestModalProps {
 export const FastEduconnectConnectionRequestModal: React.FC<
   FastEduconnectConnectionRequestModalProps
 > = ({ visible, hideModal }) => {
-  const { colors } = useTheme()
   const { dispatch } = useIdentityCheckContext()
   const { navigate } = useNavigation<UseNavigationType>()
   const { data: ubbleETAMessage } = useUbbleETAMessage()
@@ -62,7 +61,7 @@ export const FastEduconnectConnectionRequestModal: React.FC<
       rightIconAccessibilityLabel={t`Fermer la modale de propositions d'identifications avec ÉduConnect ou Démarches Simplifiées`}
       rightIcon={Close}
       onRightIconPress={onModalRightIconPress}>
-      <MainContent color={colors.greyDark}>
+      <MainContent>
         {t`Tu peux vérifier ton identité en moins de 2 minutes en utilisant ton compte ÉduConnect. Si tu n'as pas d'identifiants ÉduConnect rapproche toi de ton établissement. `}
       </MainContent>
 
@@ -81,18 +80,20 @@ export const FastEduconnectConnectionRequestModal: React.FC<
         wording={t`Identification manuelle`}
         onPress={onPressManualIdentification}
       />
-      <DurationInfoText color={colors.greyDark}>{ubbleETAMessage}</DurationInfoText>
+      <DurationInfoText>{ubbleETAMessage}</DurationInfoText>
     </AppModal>
   )
 }
 
-const MainContent = styled(Typo.Body)({
+const MainContent = styled(Typo.Body)(({ theme }) => ({
   textAlign: 'center',
-})
+  color: theme.colors.greyDark,
+}))
 
-const DurationInfoText = styled(Typo.Body)({
+const DurationInfoText = styled(Typo.Body)(({ theme }) => ({
   textAlign: 'center',
-})
+  color: theme.colors.greyDark,
+}))
 
 const TextQuestion = styled(ButtonQuaternaryBlack)({
   marginBottom: getSpacing(4),

--- a/src/features/identityCheck/components/QuitIdentityCheckModal.tsx
+++ b/src/features/identityCheck/components/QuitIdentityCheckModal.tsx
@@ -63,7 +63,7 @@ export const QuitIdentityCheckModal: FunctionComponent<Props> = ({
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme, color }) => ({
-  color: color ?? theme.colors.white,
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/identityCheck/errors/eduConnect/NotEligibleEduConnect.tsx
+++ b/src/features/identityCheck/errors/eduConnect/NotEligibleEduConnect.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro'
 import React, { useEffect, useRef, useState } from 'react'
 import { TextProps, TextStyle } from 'react-native'
-import styled, { useTheme } from 'styled-components/native'
+import styled from 'styled-components/native'
 
 import { navigateToHome } from 'features/navigation/helpers'
 import { analytics } from 'libs/analytics'
@@ -30,7 +30,6 @@ export const NotEligibleEduConnect = ({
     tertiaryButtonVisible = false,
     onPrimaryButtonPress,
   } = useNotEligibleEduConnectErrorData(message, setError)
-  const { colors } = useTheme()
 
   useEffect(
     () => () => {
@@ -75,9 +74,7 @@ export const NotEligibleEduConnect = ({
       <Helmet>
         <title>{title}</title>
       </Helmet>
-      <Body textAlign={descriptionAlignment} color={colors.white}>
-        {description}
-      </Body>
+      <Body textAlign={descriptionAlignment}>{description}</Body>
     </GenericInfoPage>
   )
 }
@@ -89,5 +86,6 @@ const Body = styled(Typo.Body).attrs<TextBodyProps>((props) => props)<TextBodyPr
   ({ theme, textAlign }) => ({
     ...theme.typography.body,
     textAlign,
+    color: theme.colors.white,
   })
 )

--- a/src/features/identityCheck/pages/Stepper.tsx
+++ b/src/features/identityCheck/pages/Stepper.tsx
@@ -18,8 +18,6 @@ import { ButtonTertiaryWhite } from 'ui/components/buttons/ButtonTertiaryWhite'
 import { useModal } from 'ui/components/modals/useModal'
 import { Background } from 'ui/svg/Background'
 import { Spacer, Typo, getSpacing } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 export const IdentityCheckStepper = () => {
   const theme = useTheme()
@@ -112,13 +110,15 @@ export const IdentityCheckStepper = () => {
   )
 }
 
-const Title = styled(Typo.Title3).attrs({ color: ColorsEnum.WHITE })({
+const Title = styled(Typo.Title3)(({ theme }) => ({
   textAlign: 'center',
-})
+  color: theme.colors.white,
+}))
 
-const StyledBody = styled(Typo.Body).attrs({ color: ColorsEnum.WHITE })({
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
   textAlign: 'center',
-})
+  color: theme.colors.white,
+}))
 
 const CenteredContainer = styled.View({
   flex: 1,

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.tsx
@@ -52,7 +52,7 @@ export function BeneficiaryRequestSent() {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ color, theme }) => ({
-  color: color ?? theme.colors.white,
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/identityCheck/pages/identification/IdentityCheckEduConnect.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckEduConnect.tsx
@@ -60,7 +60,7 @@ export const IdentityCheckEduConnect = () => {
 
           <Spacer.Column numberOfSpaces={4} />
 
-          <TextContent color={ColorsEnum.GREY_DARK}>
+          <TextContent>
             {t`Pour t’identifier, nous allons te demander de te connecter à EduConnect. Munis-toi de ton identifiant et ton mot de passe EduConnect\u00a0! Si tu ne les as pas, contacte ton établissement pour les récupérer.`}
           </TextContent>
 
@@ -75,5 +75,8 @@ export const IdentityCheckEduConnect = () => {
 }
 
 const Center = styled.View({ alignSelf: 'center' })
-const TextContent = styled(Typo.Body)({ textAlign: 'center' })
 const Container = styled.View({ flexGrow: 1, justifyContent: 'center' })
+const TextContent = styled(Typo.Body)(({ theme }) => ({
+  textAlign: 'center',
+  color: theme.colors.greyDark,
+}))

--- a/src/features/identityCheck/pages/identification/IdentityCheckEduConnectForm.web.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckEduConnectForm.web.tsx
@@ -11,8 +11,6 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { BicolorIdCardWithMagnifyingGlassDeprecated as BicolorIdCardWithMagnifyingGlass } from 'ui/svg/icons/BicolorIdCardWithMagnifyingGlass_deprecated'
 import { Info } from 'ui/svg/icons/Info'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 export const IdentityCheckEduConnectForm = () => {
   const { error, openEduConnect } = useEduConnectLogin()
@@ -31,10 +29,10 @@ export const IdentityCheckEduConnectForm = () => {
               <BicolorIdCardWithMagnifyingGlass size={getSpacing(33)} />
             </Center>
 
-            <JustifiedHeader color={ColorsEnum.GREY_DARK}>{t`Identification`}</JustifiedHeader>
+            <JustifiedHeader>{t`Identification`}</JustifiedHeader>
             <Spacer.Column numberOfSpaces={4} />
 
-            <JustifiedText color={ColorsEnum.GREY_DARK}>
+            <JustifiedText>
               {t`Pour t’identifier, nous allons te demander de te connecter à EduConnect. Munis-toi de ton identifiant et ton mot de passe EduConnect\u00a0! Si tu ne les as pas, contacte ton établissement pour les récupérer.`}
             </JustifiedText>
             <Spacer.Column numberOfSpaces={4} />
@@ -42,9 +40,9 @@ export const IdentityCheckEduConnectForm = () => {
               <Info />
               <Spacer.Row numberOfSpaces={2} />
 
-              <Typo.Caption color={ColorsEnum.GREY_DARK}>
+              <StyledCaption>
                 {t`Un souci pour accéder à la page\u00a0? Essaie en navigation privée ou pense bien à accepter les pop-ups de ton navigateur.`}
-              </Typo.Caption>
+              </StyledCaption>
             </HavingTroubleContainer>
 
             <Spacer.Column numberOfSpaces={8} />
@@ -64,13 +62,19 @@ const Center = styled.View({
   padding: getSpacing(7),
 })
 
-const JustifiedText = styled(Typo.Body)({
+const JustifiedText = styled(Typo.Body)(({ theme }) => ({
   textAlign: 'center',
-})
+  color: theme.colors.greyDark,
+}))
 
-const JustifiedHeader = styled(Typo.ButtonText)({
+const JustifiedHeader = styled(Typo.ButtonText)(({ theme }) => ({
   textAlign: 'center',
-})
+  color: theme.colors.greyDark,
+}))
+
+const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))
 
 const HavingTroubleContainer = styled.View(({ theme }) => ({
   display: 'flex',

--- a/src/features/identityCheck/pages/identification/IdentityCheckPending.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckPending.tsx
@@ -23,7 +23,7 @@ export function IdentityCheckPending() {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ color, theme }) => ({
-  color: color ?? theme.colors.white,
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/identityCheck/pages/identification/IdentityCheckStart/IdentityCheckStartContent.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckStart/IdentityCheckStartContent.tsx
@@ -10,8 +10,6 @@ import { Spacer } from 'ui/components/spacer/Spacer'
 import { BicolorIdCardWithMagnifyingGlassDeprecated as BicolorIdCardWithMagnifyingGlass } from 'ui/svg/icons/BicolorIdCardWithMagnifyingGlass_deprecated'
 import { Plus } from 'ui/svg/icons/Plus'
 import { getSpacing, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 export function IdentityCheckStartContent() {
   const { visible, showModal, hideModal } = useModal(false)
   const showDMSModal = () => {
@@ -36,10 +34,7 @@ export function IdentityCheckStartContent() {
       <Spacer.Column numberOfSpaces={6} />
       <Spacer.Flex />
       <DMSInformationContainer>
-        <Typo.Caption
-          color={
-            ColorsEnum.GREY_DARK
-          }>{t`Si tu n’es pas en mesure de prendre en photo ta pièce d’identité, tu peux transmettre un autre document via le site Démarches-Simplifiées`}</Typo.Caption>
+        <Caption>{t`Si tu n’es pas en mesure de prendre en photo ta pièce d’identité, tu peux transmettre un autre document via le site Démarches-Simplifiées`}</Caption>
         <ButtonQuaternaryBlack
           wording={t`Transmettre un document`}
           onPress={showDMSModal}
@@ -57,12 +52,16 @@ const Container = styled.View({ height: '100%', alignItems: 'center' })
 
 const Title = styled(Typo.Title4)({ textAlign: 'center' })
 
-const Body = styled(Typo.Body)(({ theme, color }) => ({
-  color: color ?? theme.colors.greyDark,
+const Body = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.greyDark,
   textAlign: 'center',
 }))
 
 const Bold = styled(Typo.Body)(({ theme }) => ({ fontFamily: theme.fontFamily.bold }))
+
+const Caption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))
 
 const DMSInformationContainer = styled.View(({ theme }) => ({
   display: 'flex',

--- a/src/features/identityCheck/pages/identification/IdentityCheckStart/IdentityCheckStartContentDesktop.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckStart/IdentityCheckStartContentDesktop.tsx
@@ -10,8 +10,6 @@ import { useModal } from 'ui/components/modals/useModal'
 import { BicolorPhonePending } from 'ui/svg/icons/BicolorPhonePending'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 interface Props {
   showSomeAdviceBeforeIdentityCheckModal: () => void
@@ -48,14 +46,14 @@ export function IdentityCheckStartContentDesktop({
       />
       <Spacer.Column numberOfSpaces={8} />
       <DMSInformationContainer>
-        <Typo.Body color={ColorsEnum.GREY_DARK}>{t`Tu n'as pas de smartphone\u00a0?`}</Typo.Body>
+        <StyledBody>{t`Tu n'as pas de smartphone\u00a0?`}</StyledBody>
         <Spacer.Column numberOfSpaces={4} />
         <ButtonTertiaryBlack
           wording={t`Identification par le site Démarches-Simplifiées`}
           onPress={showDMSModal}
           icon={ExternalSiteFilled}
         />
-        <Typo.Caption color={ColorsEnum.GREY_DARK}>{t`Environ 10 jours`}</Typo.Caption>
+        <StyledCaption>{t`Environ 10 jours`}</StyledCaption>
       </DMSInformationContainer>
       <DMSModal visible={visible} hideModal={hideModal} />
       <Spacer.Column numberOfSpaces={6} />
@@ -66,6 +64,14 @@ export function IdentityCheckStartContentDesktop({
 const Title = styled(Typo.Title4)({ textAlign: 'center' })
 
 const Body = styled(Typo.Body)({ textAlign: 'center' })
+
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))
+
+const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))
 
 const ContentDesktopContainer = styled.View({ marginHorizontal: getSpacing(2) })
 

--- a/src/features/identityCheck/pages/identification/IdentityCheckUnavailable.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckUnavailable.tsx
@@ -58,7 +58,7 @@ Nous reviendrons vers toi d’ici quelques jours.`}</StyledBody>
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ color, theme }) => ({
-  color: color ?? theme.colors.white,
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/identityCheck/pages/identification/IdentityCheckValidation.web.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckValidation.web.tsx
@@ -13,8 +13,6 @@ import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigat
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { Spacer, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 export function IdentityCheckValidation() {
   const { params } = useRoute<UseRouteType<'IdentityCheckValidation'>>()
@@ -60,15 +58,15 @@ export function IdentityCheckValidation() {
       scrollChildren={
         <BodyContainer>
           <Spacer.Column numberOfSpaces={6} />
-          <Typo.Body color={ColorsEnum.GREY_DARK}>{t`Ton prénom`}</Typo.Body>
+          <Body>{t`Ton prénom`}</Body>
           <Spacer.Column numberOfSpaces={2} />
           <Typo.Title3 testID="validation-first-name">{identification.firstName}</Typo.Title3>
           <Spacer.Column numberOfSpaces={5} />
-          <Typo.Body color={ColorsEnum.GREY_DARK}>{t`Ton nom de famille`}</Typo.Body>
+          <Body>{t`Ton nom de famille`}</Body>
           <Spacer.Column numberOfSpaces={2} />
           <Typo.Title3 testID="validation-name">{identification.lastName}</Typo.Title3>
           <Spacer.Column numberOfSpaces={5} />
-          <Typo.Body color={ColorsEnum.GREY_DARK}>{t`Ta date de naissance`}</Typo.Body>
+          <Body>{t`Ta date de naissance`}</Body>
           <Spacer.Column numberOfSpaces={2} />
           <Typo.Title3 testID="validation-birth-date">{birthDate}</Typo.Title3>
         </BodyContainer>
@@ -86,3 +84,7 @@ export function IdentityCheckValidation() {
 const BodyContainer = styled.View({
   alignItems: 'center',
 })
+
+const Body = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/maintenance/Maintenance.tsx
+++ b/src/features/maintenance/Maintenance.tsx
@@ -32,8 +32,8 @@ export const Maintenance: React.FC<MaintenanceProps> = (props) => {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ color, theme }) => ({
-  color: color ?? theme.colors.white,
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
   textAlign: 'center',
 }))
 

--- a/src/features/navigation/PageNotFound.tsx
+++ b/src/features/navigation/PageNotFound.tsx
@@ -21,7 +21,7 @@ export const PageNotFound: React.FC = () => {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ color, theme }) => ({
-  color: color ?? theme.colors.white,
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/navigation/RootNavigator/Header/NavItem.tsx
+++ b/src/features/navigation/RootNavigator/Header/NavItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled, { useTheme } from 'styled-components/native'
+import styled from 'styled-components/native'
 
 import { menu } from 'features/navigation/TabBar/routes'
 import { TabRouteName } from 'features/navigation/TabBar/types'
@@ -14,24 +14,25 @@ interface NavItemInterface {
 }
 
 export const NavItem: React.FC<NavItemInterface> = ({
-  BicolorIcon,
+  BicolorIcon: DefaultBicolorIcon,
   onPress,
   tabName,
   isSelected,
 }) => {
-  const { uniqueColors, colors } = useTheme()
+  const BicolorIcon = styled(DefaultBicolorIcon).attrs(({ theme }) => ({
+    color: isSelected ? undefined : theme.colors.greyDark,
+    size: theme.icons.sizes.small,
+    thin: !isSelected,
+  }))``
+
   return (
     <StyledTouchableOpacity
       isSelected={isSelected}
       onPress={onPress}
       activeOpacity={1}
       testID={`${tabName} nav`}>
-      <BicolorIcon
-        color={isSelected ? undefined : colors.greyDark}
-        size={getSpacing(6)}
-        thin={!isSelected}
-      />
-      <Title color={isSelected ? uniqueColors.brand : colors.black}>{menu[tabName]}</Title>
+      <BicolorIcon />
+      <Title>{menu[tabName]}</Title>
     </StyledTouchableOpacity>
   )
 }
@@ -49,4 +50,7 @@ const StyledTouchableOpacity = styled.TouchableOpacity<{ isSelected?: boolean }>
   })
 )
 
-const Title = styled(Typo.ButtonText)({ marginLeft: 12 })
+const Title = styled(Typo.ButtonText)<{ isSelected?: boolean }>(({ theme, isSelected }) => ({
+  marginLeft: 12,
+  color: isSelected ? theme.uniqueColors.brand : theme.colors.black,
+}))

--- a/src/features/offer/pages/OfferNotFound.tsx
+++ b/src/features/offer/pages/OfferNotFound.tsx
@@ -50,7 +50,7 @@ export const OfferNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ color, theme }) => ({
-  color: color ?? theme.colors.white,
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/profile/components/BeneficiaryHeader.tsx
+++ b/src/features/profile/components/BeneficiaryHeader.tsx
@@ -8,8 +8,6 @@ import { computeCredit, useIsUserUnderageBeneficiary } from 'features/profile/ut
 import { formatToFrenchDecimal } from 'libs/parsers'
 import { HeaderBackground } from 'ui/svg/HeaderBackground'
 import { getSpacing, Typo, Spacer } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 type BeneficiaryHeaderProps = {
   firstName?: string | null
@@ -32,14 +30,12 @@ export function BeneficiaryHeader(props: PropsWithChildren<BeneficiaryHeaderProp
       </HeaderBackgroundWrapper>
       <Spacer.Column numberOfSpaces={6} />
       <UserNameAndCredit>
-        <Typo.Title4 color={ColorsEnum.WHITE}>{name}</Typo.Title4>
+        <Title4>{name}</Title4>
         <Spacer.Column numberOfSpaces={4.5} />
-        {!isUserUnderageBeneficiary && <Typo.Hero color={ColorsEnum.WHITE}>{credit}</Typo.Hero>}
+        {!isUserUnderageBeneficiary && <Hero>{credit}</Hero>}
         <Spacer.Column numberOfSpaces={2} />
         {!!depositExpirationDate && (
-          <Typo.Caption color={ColorsEnum.WHITE}>
-            {t`crédit valable jusqu'au` + `\u00a0${depositExpirationDate}`}
-          </Typo.Caption>
+          <Caption>{t`crédit valable jusqu'au` + `\u00a0${depositExpirationDate}`}</Caption>
         )}
         <Spacer.Column numberOfSpaces={6} />
       </UserNameAndCredit>
@@ -70,3 +66,15 @@ const UserNameAndCredit = styled.View({
 const Ceilings = styled(BeneficiaryCeilings)({
   top: getSpacing(42),
 })
+
+const Title4 = styled(Typo.Title4)(({ theme }) => ({
+  color: theme.colors.white,
+}))
+
+const Hero = styled(Typo.Hero)(({ theme }) => ({
+  color: theme.colors.white,
+}))
+
+const Caption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.white,
+}))

--- a/src/features/profile/components/CreditCeiling.tsx
+++ b/src/features/profile/components/CreditCeiling.tsx
@@ -93,7 +93,7 @@ const Container = styled.View({
   paddingHorizontal: getSpacing(1),
 })
 
-const Amount = styled(Typo.Title4)``
+const Amount = styled(Typo.Title4)<{ color: ColorsEnum }>(({ color }) => ({ color }))
 
 const Label = styled.Text({
   fontSize: 12,

--- a/src/features/profile/components/ExBeneficiaryHeader.tsx
+++ b/src/features/profile/components/ExBeneficiaryHeader.tsx
@@ -6,8 +6,6 @@ import { DomainsCredit } from 'api/gen/api'
 import { AccordionItem } from 'ui/components/AccordionItem'
 import { HeaderBackground } from 'ui/svg/HeaderBackground'
 import { getSpacing, Typo, Spacer } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 import { accordionStyle, GreyContainer, Description } from './reusables'
 
@@ -30,16 +28,16 @@ export function ExBeneficiaryHeader(props: ExBeneficiaryHeaderProps) {
       </HeaderBackgroundWrapper>
       <Spacer.Column numberOfSpaces={6} />
       <TitleContainer>
-        <Typo.Title4 color={ColorsEnum.WHITE}>{name}</Typo.Title4>
+        <Title4>{name}</Title4>
         <Spacer.Column numberOfSpaces={4.5} />
         {!!depositExpirationDate && (
-          <Typo.Caption color={ColorsEnum.WHITE}>
+          <Caption>
             {t({
               id: 'credit expired on date',
               values: { deadline: depositExpirationDate },
               message: 'crédit expiré le {deadline}',
             })}
-          </Typo.Caption>
+          </Caption>
         )}
       </TitleContainer>
       <Spacer.Column numberOfSpaces={6} />
@@ -81,3 +79,11 @@ const TitleContainer = styled.View({
 })
 
 const DescriptionContainer = styled(GreyContainer)({})
+
+const Title4 = styled(Typo.Title4)(({ theme }) => ({
+  color: theme.colors.white,
+}))
+
+const Caption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.white,
+}))

--- a/src/features/profile/components/LoggedOutHeader.tsx
+++ b/src/features/profile/components/LoggedOutHeader.tsx
@@ -10,8 +10,6 @@ import { accessibilityAndTestId } from 'tests/utils'
 import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { HeaderBackground } from 'ui/svg/HeaderBackground'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 export function LoggedOutHeader() {
   const { navigate } = useNavigation<UseNavigationType>()
   return (
@@ -22,9 +20,9 @@ export function LoggedOutHeader() {
       </HeaderBackgroundWrapper>
       <Spacer.Column numberOfSpaces={6} />
       <HeaderContent>
-        <Typo.Title4 color={ColorsEnum.WHITE}>{t`Profil`}</Typo.Title4>
+        <Title4>{t`Profil`}</Title4>
         <Spacer.Column numberOfSpaces={7} />
-        <Description color={ColorsEnum.WHITE}>
+        <Description>
           {t`Inscris-toi pour accéder à toutes les fonctionnalités de l’application`}
         </Description>
         <Spacer.Column numberOfSpaces={8} />
@@ -37,13 +35,11 @@ export function LoggedOutHeader() {
         />
         <Spacer.Column numberOfSpaces={5} />
         <LoginCta>
-          <Typo.Body color={ColorsEnum.WHITE}>
-            {t`Tu as déjà un compte\u00a0?` + '\u00a0'}
-          </Typo.Body>
+          <Body>{t`Tu as déjà un compte\u00a0?` + '\u00a0'}</Body>
           <TouchableOpacity
             onPress={() => navigate('Login', { preventCancellation: true })}
             {...accessibilityAndTestId(t`Connecte-toi`)}>
-            <Typo.ButtonText color={ColorsEnum.WHITE}>{t`Connecte-toi`}</Typo.ButtonText>
+            <ButtonText>{t`Connecte-toi`}</ButtonText>
           </TouchableOpacity>
         </LoginCta>
         <Spacer.Column numberOfSpaces={7} />
@@ -72,6 +68,19 @@ const LoginCta = styled.View({
   flexDirection: 'row',
 })
 
-const Description = styled(Typo.Body)({
+const Description = styled(Typo.Body)(({ theme }) => ({
   textAlign: 'center',
-})
+  color: theme.colors.white,
+}))
+
+const Title4 = styled(Typo.Title4)(({ theme }) => ({
+  color: theme.colors.white,
+}))
+
+const Body = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
+}))
+
+const ButtonText = styled(Typo.ButtonText)(({ theme }) => ({
+  color: theme.colors.white,
+}))

--- a/src/features/profile/components/ProfileBadge.tsx
+++ b/src/features/profile/components/ProfileBadge.tsx
@@ -49,14 +49,9 @@ export function ProfileBadge(props: ProfileBadgeProps) {
         </IconContainer>
       ) : null}
       <TextContainer>
-        <Typo.Caption
-          color={
-            props.callToActionMessage && props.callToActionLink
-              ? ColorsEnum.GREY_DARK
-              : ColorsEnum.BLACK
-          }>
+        <Caption callToAction={props.callToActionMessage && props.callToActionLink}>
           {props.message}
-        </Typo.Caption>
+        </Caption>
         {renderCallToAction(
           props.callToActionMessage,
           props.callToActionLink,
@@ -83,3 +78,9 @@ const IconContainer = styled.View({
 const TextContainer = styled.View({
   flex: 1,
 })
+
+const Caption = styled(Typo.Caption)<{ callToAction: string | null | undefined }>(
+  ({ theme, callToAction }) => ({
+    color: callToAction ? theme.colors.greyDark : theme.colors.black,
+  })
+)

--- a/src/features/profile/components/SectionWithSwitch.tsx
+++ b/src/features/profile/components/SectionWithSwitch.tsx
@@ -71,6 +71,6 @@ const FilterSwitchLabelContainer = styled.View({
   alignItems: 'center',
 })
 
-const ToggleLabel = styled(Typo.Caption)(({ theme, color }) => ({
-  color: color ?? theme.colors.greyDark,
+const ToggleLabel = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
 }))

--- a/src/features/profile/components/SubscriptionMessageBadge.tsx
+++ b/src/features/profile/components/SubscriptionMessageBadge.tsx
@@ -1,5 +1,6 @@
 import { t } from '@lingui/macro'
 import React from 'react'
+import styled from 'styled-components/native'
 
 import { SubscriptionMessage } from 'api/gen'
 import { ProfileBadge } from 'features/profile/components/ProfileBadge'
@@ -8,8 +9,6 @@ import { formatToSlashedFrenchDate } from 'libs/dates'
 import { formatToHour } from 'libs/parsers/formatDates'
 import { Clock } from 'ui/svg/icons/Clock'
 import { Spacer, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 type SubscriptionMessageBadgeProps = {
   subscriptionMessage?: SubscriptionMessage | null
@@ -32,9 +31,9 @@ export function SubscriptionMessageBadge(props: SubscriptionMessageBadgeProps) {
     <React.Fragment>
       {!!props.subscriptionMessage?.updatedAt && (
         <React.Fragment>
-          <Typo.Caption color={ColorsEnum.GREY_DARK}>
+          <Caption>
             {formatDateToLastUpdatedAtMessage(props.subscriptionMessage?.updatedAt)}
-          </Typo.Caption>
+          </Caption>
           <Spacer.Column numberOfSpaces={2} />
         </React.Fragment>
       )}
@@ -56,3 +55,7 @@ export function SubscriptionMessageBadge(props: SubscriptionMessageBadgeProps) {
     </React.Fragment>
   )
 }
+
+const Caption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/profile/pages/ChangeEmail/ChangeEmailDisclaimer.tsx
+++ b/src/features/profile/pages/ChangeEmail/ChangeEmailDisclaimer.tsx
@@ -1,18 +1,21 @@
 import { t } from '@lingui/macro'
 import React from 'react'
+import styled from 'styled-components/native'
 
 import { Separator } from 'ui/components/Separator'
 import { Spacer, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 export function ChangeEmailDisclaimer() {
   const message = t`Saisis ta nouvelle adresse e-mail et ton mot de passe. Tu vas recevoir un e-mail sur ta nouvelle adresse avec un lien de confirmation valable 24h. Tu ne peux modifier ton adresse e-mail qu'une fois par jour.`
   return (
     <React.Fragment>
-      <Typo.Caption color={ColorsEnum.GREY_DARK}>{message}</Typo.Caption>
+      <Caption>{message}</Caption>
       <Spacer.Column numberOfSpaces={4} />
       <Separator />
     </React.Fragment>
   )
 }
+
+const Caption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/profile/pages/ConfirmDeleteProfile.tsx
+++ b/src/features/profile/pages/ConfirmDeleteProfile.tsx
@@ -57,7 +57,7 @@ export function ConfirmDeleteProfile() {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ color, theme }) => ({
-  color: color ?? theme.colors.white,
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/profile/pages/ConsentSettings.tsx
+++ b/src/features/profile/pages/ConsentSettings.tsx
@@ -2,7 +2,7 @@ import { t } from '@lingui/macro'
 import { useNavigation } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { FunctionComponent, useEffect, useState } from 'react'
-import styled, { useTheme } from 'styled-components/native'
+import styled from 'styled-components/native'
 
 import { openUrl } from 'features/navigation/helpers'
 import { RootStackParamList } from 'features/navigation/RootNavigator'
@@ -26,7 +26,6 @@ export const ConsentSettings: FunctionComponent<Props> = ({ route }) => {
   const { goBack } = useNavigation()
   const [isTrackingSwitchActive, setIsTrackingSwitchActive] = useState(false)
   const [isSaveButtonDisabled, setIsSaveButtonDisabled] = useState(true)
-  const theme = useTheme()
 
   useEffect(() => {
     storage.readObject('has_accepted_cookie').then((hasAcceptedCookie) => {
@@ -65,12 +64,12 @@ export const ConsentSettings: FunctionComponent<Props> = ({ route }) => {
       <Spacer.TopScreen />
       <Spacer.Column numberOfSpaces={18} />
       <ProfileContainer>
-        <Typo.Body color={theme.colors.black}>
+        <StyledBody>
           {t`L'application pass Culture utilise des traceurs susceptibles de réaliser des statistiques sur ta navigation. Ceci permet d'améliorer la qualité et la sureté de ton expérience. Pour ces besoins, les analyses réalisées sont strictement anonymes et ne comportent aucune donnée personnelle.`}
-        </Typo.Body>
+        </StyledBody>
         <Spacer.Column numberOfSpaces={4} />
         <MoreInformationContainer>
-          <Typo.Caption color={theme.colors.greyDark}>
+          <StyledCaption>
             {t`Pour plus d'informations, nous t'invitons à consulter notre`}
             <Spacer.Row numberOfSpaces={1} />
             <ButtonQuaternary
@@ -79,7 +78,7 @@ export const ConsentSettings: FunctionComponent<Props> = ({ route }) => {
               onPress={openCookiesPolicyExternalUrl}
               inline
             />
-          </Typo.Caption>
+          </StyledCaption>
         </MoreInformationContainer>
         <Spacer.Column numberOfSpaces={4} />
         <Separator />
@@ -101,6 +100,14 @@ export const ConsentSettings: FunctionComponent<Props> = ({ route }) => {
     </Container>
   )
 }
+
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.black,
+}))
+
+const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))
 
 const Container = styled.View(({ theme }) => ({
   flex: 1,

--- a/src/features/profile/pages/DeleteProfileSuccess.tsx
+++ b/src/features/profile/pages/DeleteProfileSuccess.tsx
@@ -23,7 +23,7 @@ export function DeleteProfileSuccess() {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ color, theme }) => ({
-  color: color ?? theme.colors.white,
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/profile/pages/NotificationSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings.tsx
@@ -207,8 +207,8 @@ const StyledButtonPrimary = styled(ButtonPrimary)({
   alignSelf: 'center',
 })
 
-const StyledCaption = styled(Typo.Caption)(({ theme, color }) => ({
-  color: color ?? theme.colors.greyDark,
+const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
 }))
 
 const getInitialSwitchesState = (

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -227,8 +227,8 @@ const Row = styled(SectionRow).attrs({ iconSize: SECTION_ROW_ICON_SIZE })({
   paddingVertical,
 })
 
-const StyledCaption = styled(Typo.Caption)(({ theme, color }) => ({
-  color: color ?? theme.colors.greyDark,
+const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
 }))
 
 const LogoMinistereContainer = styled.View({

--- a/src/features/search/atoms/Buttons/DateFilter.tsx
+++ b/src/features/search/atoms/Buttons/DateFilter.tsx
@@ -12,11 +12,9 @@ interface Props {
 }
 
 export const DateFilter: React.FC<Props> = ({ text, onPress, isSelected }: Props) => {
-  const color = isSelected ? ColorsEnum.PRIMARY : ColorsEnum.BLACK
-
   return (
     <TouchableOpacity onPress={onPress}>
-      <Typo.ButtonText color={color}>{text}</Typo.ButtonText>
+      <ButtonText isSelected={isSelected}>{text}</ButtonText>
       {!!isSelected && <Validate color={ColorsEnum.PRIMARY} size={getSpacing(6)} />}
     </TouchableOpacity>
   )
@@ -30,3 +28,7 @@ const TouchableOpacity = styled.TouchableOpacity.attrs(({ theme }) => ({
   alignItems: 'center',
   justifyContent: 'space-between',
 })
+
+const ButtonText = styled(Typo.ButtonText)<{ isSelected: boolean }>(({ isSelected, theme }) => ({
+  color: isSelected ? theme.colors.primary : theme.colors.black,
+}))

--- a/src/features/search/components/LocationChoice.tsx
+++ b/src/features/search/components/LocationChoice.tsx
@@ -28,11 +28,9 @@ export const LocationChoice: React.FC<Props> = (props) => {
         <Icon color2={iconColor2} />
         <Spacer.Row numberOfSpaces={3} />
         <TextContainer>
-          <Typo.ButtonText
-            numberOfLines={3}
-            color={isSelected ? ColorsEnum.PRIMARY : ColorsEnum.BLACK}>
+          <ButtonText numberOfLines={3} isSelected={isSelected}>
             {label}
-          </Typo.ButtonText>
+          </ButtonText>
         </TextContainer>
       </FirstPart>
       <SecondPart>
@@ -71,3 +69,7 @@ const SecondPart = styled.View({
   alignItems: 'center',
   height: '100%',
 })
+
+const ButtonText = styled(Typo.ButtonText)<{ isSelected: boolean }>(({ isSelected, theme }) => ({
+  color: isSelected ? theme.colors.primary : theme.colors.black,
+}))

--- a/src/features/search/components/SearchLandingPage.tsx
+++ b/src/features/search/components/SearchLandingPage.tsx
@@ -119,7 +119,7 @@ const BicolorListItem: React.FC<{
   const { colors } = useTheme()
   return (
     <Container>
-      <Typo.Body color={colors.greyDark}>{secondaryText}</Typo.Body>
+      <StyledBody>{secondaryText}</StyledBody>
       <Spacer.Column numberOfSpaces={2} />
       <TitleIconContainer>
         <Icon size={iconSize} color={colors.primary} color2={colors.secondary} />
@@ -143,3 +143,7 @@ const TitleIconContainer = styled.View({
 const Title = styled(Typo.Title3)({
   flexShrink: 1,
 })
+
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/search/pages/Categories.tsx
+++ b/src/features/search/pages/Categories.tsx
@@ -48,7 +48,6 @@ export const Categories: React.FC = () => {
           const searchGroup = category as SearchGroupNameEnum
           const isSelected = isCategorySelected(searchGroup)
           const color2 = isSelected ? ColorsEnum.PRIMARY : ColorsEnum.SECONDARY
-          const textColor = isSelected ? ColorsEnum.PRIMARY : ColorsEnum.BLACK
 
           return (
             <LabelContainer
@@ -58,9 +57,9 @@ export const Categories: React.FC = () => {
               <Spacer.Row numberOfSpaces={4} />
               <Icon size={getSpacing(9)} color={ColorsEnum.PRIMARY} color2={color2} />
               <Spacer.Row numberOfSpaces={4} />
-              <Typo.ButtonText numberOfLines={2} color={textColor}>
+              <ButtonText numberOfLines={2} isSelected={isSelected}>
                 {searchGroupLabelMapping[searchGroup]}
-              </Typo.ButtonText>
+              </ButtonText>
               <Spacer.Flex />
               {!!isSelected && <Validate color={ColorsEnum.PRIMARY} size={getSpacing(6)} />}
             </LabelContainer>
@@ -87,3 +86,7 @@ const LabelContainer = styled.TouchableOpacity.attrs(({ theme }) => ({
   alignItems: 'center',
   marginBottom: getSpacing(4),
 })
+
+const ButtonText = styled(Typo.ButtonText)<{ isSelected: boolean }>(({ isSelected, theme }) => ({
+  color: isSelected ? theme.colors.primary : theme.colors.black,
+}))

--- a/src/features/search/sections/Location.tsx
+++ b/src/features/search/sections/Location.tsx
@@ -42,9 +42,7 @@ export const Location: React.FC = () => {
       {locationType === LocationType.AROUND_ME ? (
         <React.Fragment>
           <Spacer.Column numberOfSpaces={2} />
-          <Typo.Caption color={ColorsEnum.GREY_DARK}>
-            {t`Seules les sorties et offres physiques seront affichées`}
-          </Typo.Caption>
+          <Caption>{t`Seules les sorties et offres physiques seront affichées`}</Caption>
         </React.Fragment>
       ) : null}
     </Section>
@@ -63,3 +61,7 @@ const LocationContentContainer = styled.TouchableOpacity.attrs(({ theme }) => ({
 const Label = styled(Typo.ButtonText)({
   flexShrink: 1,
 })
+
+const Caption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/search/sections/OfferDate.tsx
+++ b/src/features/search/sections/OfferDate.tsx
@@ -12,8 +12,6 @@ import { SectionTitle } from 'features/search/sections/titles'
 import { useLogFilterOnce } from 'features/search/utils/useLogFilterOnce'
 import { formatToCompleteFrenchDate } from 'libs/parsers'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 type Props = {
   setScrollEnabled?: ((setScrollEnabled: boolean) => void) | Dispatch<SetStateAction<boolean>>
 }
@@ -74,9 +72,7 @@ export function OfferDate({ setScrollEnabled }: Props) {
         />
         {option === DATE_FILTER_OPTIONS.USER_PICK && (
           <TouchableOpacity testID="pickedDate" onPress={() => setShowTimePicker(true)}>
-            <Typo.Body color={ColorsEnum.BLACK}>
-              {formatToCompleteFrenchDate(selectedDate)}
-            </Typo.Body>
+            <StyledBody>{formatToCompleteFrenchDate(selectedDate)}</StyledBody>
           </TouchableOpacity>
         )}
       </Container>
@@ -95,3 +91,7 @@ const TouchableOpacity = styled(TouchableOpacityGestureHandler).attrs(({ theme }
 }))``
 
 const Container = styled.View({ marginHorizontal: getSpacing(6) })
+
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.black,
+}))

--- a/src/features/venue/pages/VenueNotFound.tsx
+++ b/src/features/venue/pages/VenueNotFound.tsx
@@ -11,8 +11,6 @@ import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { GenericInfoPage } from 'ui/components/GenericInfoPage'
 import { NoOffer } from 'ui/svg/icons/NoOffer'
 import { Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 export const VenueNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
   const timer = useRef<number>()
@@ -53,8 +51,7 @@ export const VenueNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
   )
 }
 
-const StyledBody = styled(Typo.Body).attrs({
-  color: ColorsEnum.WHITE,
-})({
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
   textAlign: 'center',
-})
+  color: theme.colors.white,
+}))

--- a/src/ui/components/Banner.tsx
+++ b/src/ui/components/Banner.tsx
@@ -12,7 +12,7 @@ export const Banner: React.FC<{ title: string }> = ({ title }) => (
     <Error size={24} color={ColorsEnum.BLACK} />
     <Spacer.Row numberOfSpaces={3} />
     <TextContainer>
-      <Typo.Caption color={ColorsEnum.BLACK}>{title}</Typo.Caption>
+      <Caption>{title}</Caption>
     </TextContainer>
   </Background>
 )
@@ -31,3 +31,7 @@ const Background = styled(View)(({ theme }) => ({
 const TextContainer = styled(View)({
   flexShrink: 1,
 })
+
+const Caption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.black,
+}))

--- a/src/ui/components/ClippedTag.tsx
+++ b/src/ui/components/ClippedTag.tsx
@@ -39,10 +39,9 @@ const VenueLabelContainer = styled.View(({ theme }) => ({
   maxWidth: '70%',
 }))
 
-const VenueLabel = styled(Typo.ButtonText).attrs(() => ({
+const VenueLabel = styled(Typo.ButtonText).attrs({
   numberOfLines: 1,
-  color: ColorsEnum.WHITE,
-}))({})
+})(({ theme }) => ({ color: theme.colors.white }))
 
 const TouchableOpacity = styled.TouchableOpacity.attrs(({ theme }) => ({
   activeOpacity: theme.activeOpacity,

--- a/src/ui/components/LayoutExpiredLink.tsx
+++ b/src/ui/components/LayoutExpiredLink.tsx
@@ -73,7 +73,7 @@ export function LayoutExpiredLink({
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ color, theme }) => ({
-  color: color ?? theme.colors.white,
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/ui/components/LoadingPage.tsx
+++ b/src/ui/components/LoadingPage.tsx
@@ -6,8 +6,6 @@ import LottieView from 'libs/lottie'
 import LoadingAnimation from 'ui/animations/lottie_loading.json'
 import { Background } from 'ui/svg/Background'
 import { Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 export const LoadingPage: FunctionComponent = () => {
   return (
     <Container>
@@ -32,10 +30,9 @@ const StyledLottieView = styled(LottieView)({
   height: 150,
 })
 
-const LoadingText = styled(Typo.Body).attrs({
-  color: ColorsEnum.WHITE,
-})({
+const LoadingText = styled(Typo.Body)(({ theme }) => ({
   top: -16,
   textAlign: 'center',
   fontSize: 15,
-})
+  color: theme.colors.white,
+}))

--- a/src/ui/components/ModuleBanner/ModuleBanner.tsx
+++ b/src/ui/components/ModuleBanner/ModuleBanner.tsx
@@ -4,8 +4,6 @@ import styled from 'styled-components/native'
 
 import { NextArrowIcon } from 'features/home/assets/NextArrowIcon'
 import { getSpacing, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 import { BACKGROUND_IMAGE_SOURCE } from './backgroundImageSource'
 
@@ -26,10 +24,10 @@ export function ModuleBanner(props: ModuleBannerProps) {
           <Container>
             <IconContainer>{props.leftIcon}</IconContainer>
             <TextContainer>
-              <Typo.ButtonText color={ColorsEnum.WHITE} testID="module-title">
+              <ButtonText testID="module-title">
                 <TitleContainer>{props.title}</TitleContainer>
-              </Typo.ButtonText>
-              <Typo.Body color={ColorsEnum.WHITE}>{props.subTitle}</Typo.Body>
+              </ButtonText>
+              <Body>{props.subTitle}</Body>
             </TextContainer>
             <IconContainer>{props.rightIcon || <NextArrowIcon />}</IconContainer>
           </Container>
@@ -74,3 +72,11 @@ const IconContainer = styled.View({
 const TitleContainer = styled.Text({
   marginRight: 5,
 })
+
+const ButtonText = styled(Typo.ButtonText)(({ theme }) => ({
+  color: theme.colors.white,
+}))
+
+const Body = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
+}))

--- a/src/ui/components/OfferCaption.tsx
+++ b/src/ui/components/OfferCaption.tsx
@@ -4,8 +4,6 @@ import { PixelRatio } from 'react-native'
 import styled from 'styled-components/native'
 
 import { Typo, GUTTER_DP } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 interface OfferCaptionProps {
   imageWidth: number
@@ -22,14 +20,10 @@ export const OfferCaption = (props: OfferCaptionProps) => {
   return (
     <CaptionContainer imageWidth={imageWidth}>
       <Typo.Caption numberOfLines={2}>{name}</Typo.Caption>
-      {!!date && (
-        <Typo.Caption numberOfLines={1} color={ColorsEnum.GREY_DARK}>
-          {date}
-        </Typo.Caption>
-      )}
-      <Typo.Caption color={ColorsEnum.GREY_DARK} testID="priceIsDuo">
+      {!!date && <StyledCaption numberOfLines={1}>{date}</StyledCaption>}
+      <StyledCaption testID="priceIsDuo">
         {isDuo && isBeneficiary ? `${price} - ${t`Duo`}` : price}
-      </Typo.Caption>
+      </StyledCaption>
     </CaptionContainer>
   )
 }
@@ -37,4 +31,8 @@ export const OfferCaption = (props: OfferCaptionProps) => {
 const CaptionContainer = styled.View<{ imageWidth: number }>(({ imageWidth }) => ({
   maxWidth: imageWidth,
   marginTop: PixelRatio.roundToNearestPixel(GUTTER_DP / 2),
+}))
+
+const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
 }))

--- a/src/ui/components/PassPlaylist.tsx
+++ b/src/ui/components/PassPlaylist.tsx
@@ -30,9 +30,14 @@ export const PassPlaylist = (props: Props) => {
   const showTitleSeeMore = !!props.onPressSeeMore && !isTouch
   const showFooterSeeMore = !!props.onPressSeeMore && isTouch
 
-  const titleColor = props.onDarkBackground ? colors.white : colors.black
   const titleSeparatorColor = props.onDarkBackground ? colors.white : colors.greyMedium
   const seeMoreColor = props.onDarkBackground ? colors.white : colors.primary
+
+  const StyledTitleComponent = styled(TitleComponent).attrs({
+    numberOfLines: 2,
+  })<{ onDarkBackground?: boolean }>(({ onDarkBackground, theme }) => ({
+    color: onDarkBackground ? theme.colors.white : theme.colors.black,
+  }))
 
   const renderHeader: RenderHeaderItem = useCallback(
     ({ width, height }) => <Cover width={width} height={height} uri={props.coverUrl as string} />,
@@ -48,9 +53,9 @@ export const PassPlaylist = (props: Props) => {
   return (
     <Container>
       <Row>
-        <TitleComponent numberOfLines={2} testID="playlistTitle" color={titleColor}>
+        <StyledTitleComponent testID="playlistTitle" onDarkBackground={props.onDarkBackground}>
           {props.title}
-        </TitleComponent>
+        </StyledTitleComponent>
         {!!showTitleSeeMore && (
           <React.Fragment>
             <Spacer.Row numberOfSpaces={4} />
@@ -63,7 +68,7 @@ export const PassPlaylist = (props: Props) => {
               )}>
               <EyeSophisticated color={seeMoreColor} size={getSpacing(4)} />
               <Spacer.Row numberOfSpaces={2} />
-              <Typo.ButtonText color={seeMoreColor}>{t`En voir plus`}</Typo.ButtonText>
+              <ButtonText onDarkBackground={props.onDarkBackground}>{t`En voir plus`}</ButtonText>
             </StyledTouchableOpacity>
           </React.Fragment>
         )}
@@ -106,3 +111,9 @@ const StyledTouchableOpacity = styled.TouchableOpacity({
   alignItems: 'center',
   padding: getSpacing(1),
 })
+
+const ButtonText = styled(Typo.ButtonText)<{ onDarkBackground?: boolean }>(
+  ({ onDarkBackground, theme }) => ({
+    color: onDarkBackground ? theme.colors.white : theme.colors.primary,
+  })
+)

--- a/src/ui/components/RadioButton.tsx
+++ b/src/ui/components/RadioButton.tsx
@@ -21,9 +21,7 @@ export function RadioButton(props: RadioButtonProps) {
         onPress={() => props.onSelect(props.id)}
         testID={`radio-button-${props.id}`}>
         <Spacer.Flex flex={0.9}>
-          <Title color={props.selectedValue === props.id ? ColorsEnum.PRIMARY : ColorsEnum.BLACK}>
-            {props.title}
-          </Title>
+          <Title match={props.selectedValue === props.id}>{props.title}</Title>
           {!!props.description && <Subtitle>{props.description}</Subtitle>}
         </Spacer.Flex>
 
@@ -44,8 +42,8 @@ const PressableContainer = styled.TouchableOpacity({
   justifyContent: 'space-between',
 })
 
-const Title = styled(Typo.ButtonText)<{ color: ColorsEnum }>(({ color }) => ({
-  color: color,
+const Title = styled(Typo.ButtonText)<{ match: boolean }>(({ match, theme }) => ({
+  color: match ? theme.colors.primary : theme.colors.black,
 }))
 
 const Subtitle = styled(Typo.Caption)({

--- a/src/ui/components/Section.tsx
+++ b/src/ui/components/Section.tsx
@@ -24,6 +24,6 @@ const Container = styled.View({
   paddingTop: getSpacing(2),
 })
 
-const StyledCaption = styled(Typo.Caption)(({ theme, color }) => ({
-  color: color ?? theme.colors.greyDark,
+const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
 }))

--- a/src/ui/components/buttons/externalLink/ExternalLink.tsx
+++ b/src/ui/components/buttons/externalLink/ExternalLink.tsx
@@ -1,31 +1,41 @@
 import React from 'react'
 import { Text } from 'react-native'
+import styled from 'styled-components/native'
 
 import { openUrl } from 'features/navigation/helpers'
 import { extractExternalLinkParts } from 'ui/components/buttons/externalLink/ExternalLink.service'
-import { ExternalSite } from 'ui/svg/icons/ExternalSite'
+import { ExternalSite as DefaultExternalSite } from 'ui/svg/icons/ExternalSite'
 import { Spacer, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 interface Props {
   url: string
+  primary?: boolean
   text?: string
-  color?: ColorsEnum
   testID?: string
 }
 
-export const ExternalLink: React.FC<Props> = ({ url, text, color, testID }) => {
+export const ExternalLink: React.FC<Props> = ({ url, text, primary, testID }) => {
   const [firstWord, remainingWords] = extractExternalLinkParts(text || url)
 
   return (
-    <Typo.ButtonText color={color} onPress={() => openUrl(url)} testID={testID}>
+    <ButtonText primary={primary} onPress={() => openUrl(url)} testID={testID}>
       <Spacer.Row numberOfSpaces={1} />
       <Text>
-        <ExternalSite size={14} color={color} testID="externalSiteIcon" />
+        <ExternalSite primary={primary} testID="externalSiteIcon" />
         {firstWord}
       </Text>
       {remainingWords}
-    </Typo.ButtonText>
+    </ButtonText>
   )
 }
+
+const ButtonText = styled(Typo.ButtonText)<{ primary?: boolean }>(({ primary, theme }) => ({
+  color: primary ? theme.colors.primary : undefined,
+}))
+
+const ExternalSite = styled(DefaultExternalSite).attrs<{ primary?: boolean }>(
+  ({ primary, theme }) => ({
+    color: primary ? theme.colors.primary : undefined,
+    size: 14,
+  })
+)<{ primary?: boolean }>``

--- a/src/ui/components/buttons/externalLink/ExternalLink.web.tsx
+++ b/src/ui/components/buttons/externalLink/ExternalLink.web.tsx
@@ -3,33 +3,42 @@ import styled from 'styled-components/native'
 
 import { openUrl } from 'features/navigation/helpers'
 import { extractExternalLinkParts } from 'ui/components/buttons/externalLink/ExternalLink.service'
-import { ExternalSite } from 'ui/svg/icons/ExternalSite'
+import { ExternalSite as DefaultExternalSite } from 'ui/svg/icons/ExternalSite'
 import { Spacer, Typo } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 interface Props {
   url: string
+  primary?: boolean
   text?: string
-  color?: ColorsEnum
   testID?: string
 }
 
-export const ExternalLink: React.FC<Props> = ({ url, text, color, testID }) => {
+export const ExternalLink: React.FC<Props> = ({ url, text, primary, testID }) => {
   const [firstWord, remainingWords] = extractExternalLinkParts(text || url)
 
   return (
-    <Typo.ButtonText color={color} onPress={() => openUrl(url)} testID={testID}>
+    <ButtonText primary={primary} onPress={() => openUrl(url)} testID={testID}>
       <Spacer.Row numberOfSpaces={1} />
       <Text>
-        <ExternalSite size={14} color={color} testID="externalSiteIcon" />
+        <ExternalSite primary={primary} testID="externalSiteIcon" />
         {firstWord}
       </Text>
       {remainingWords}
-    </Typo.ButtonText>
+    </ButtonText>
   )
 }
 
 const Text = styled.Text({
   whiteSpace: 'nowrap',
 })
+
+const ButtonText = styled(Typo.ButtonText)<{ primary?: boolean }>(({ primary, theme }) => ({
+  color: primary ? theme.colors.primary : undefined,
+}))
+
+const ExternalSite = styled(DefaultExternalSite).attrs<{ primary?: boolean }>(
+  ({ primary, theme }) => ({
+    color: primary ? theme.colors.primary : undefined,
+    size: 14,
+  })
+)<{ primary?: boolean }>``

--- a/src/ui/components/headers/PageHeader.tsx
+++ b/src/ui/components/headers/PageHeader.tsx
@@ -49,7 +49,7 @@ export const PageHeader: React.FC<Props> = (props) => {
             <HeaderIconBack onGoBack={props.onGoBack} />
           </ButtonContainer>
 
-          <Title color={ColorsEnum.WHITE}>{title}</Title>
+          <Title>{title}</Title>
 
           <ButtonContainer positionInHeader="right">
             {!!RightComponent && (

--- a/src/ui/components/inputs/DateInput.tsx
+++ b/src/ui/components/inputs/DateInput.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro'
 import React, { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { Platform, TextInput, TextInputProps } from 'react-native'
-import styled, { useTheme } from 'styled-components/native'
+import styled from 'styled-components/native'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import validateDate from 'validate-date'
@@ -78,12 +78,14 @@ const DateInputLabel: React.FC<DateInputLabelProps> = ({
   onFocus,
   accessibilityLabel,
 }) => {
-  const { colors } = useTheme()
-  const text = value?.trim?.()?.length ? value.trim() : placeholder
-  const color = value?.trim?.()?.length ? undefined : colors.greyDark
+  const valueLength = value?.trim?.()?.length
+  const text = valueLength ? value.trim() : placeholder
   return (
     <StyledTouchableOpacity {...accessibilityAndTestId(accessibilityLabel)} onPress={onFocus}>
-      <DateInputLabelText testID={'date-input-label-text'} numberOfLines={1} color={color}>
+      <DateInputLabelText
+        testID={'date-input-label-text'}
+        numberOfLines={1}
+        valueLength={valueLength}>
         {text}
       </DateInputLabelText>
       <ValidationBar
@@ -103,11 +105,14 @@ const StyledTouchableOpacity = styled.TouchableOpacity({
   maxWidth: 130,
 })
 
-export const DateInputLabelText = styled(Typo.Body)({
-  textAlign: 'center',
-  fontSize: 18,
-  lineHeight: '22px',
-})
+export const DateInputLabelText = styled(Typo.Body)<{ valueLength: number }>(
+  ({ valueLength, theme }) => ({
+    textAlign: 'center',
+    fontSize: 18,
+    lineHeight: '22px',
+    color: valueLength ? undefined : theme.colors.greyDark,
+  })
+)
 
 const WithRefDateInput: React.ForwardRefRenderFunction<DateInputRef, DateInputProps> = (
   { onSubmit, minDate, maxDate, initialDay, initialMonth, initialYear, ...props },

--- a/src/ui/components/inputs/InputError.tsx
+++ b/src/ui/components/inputs/InputError.tsx
@@ -2,8 +2,6 @@ import React, { FC } from 'react'
 
 import { Error } from 'ui/svg/icons/Error'
 import { Spacer } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 import { ErrorMessage } from 'ui/web/errors/ErrorMessage'
 
 import { InputRule } from './rules/InputRule'
@@ -21,7 +19,7 @@ export const InputError: FC<Props> = (props) => {
       <Spacer.Column testID="input-error-top-spacer" numberOfSpaces={props.numberOfSpacesTop} />
       <InputRule
         title={props.messageId}
-        color={ColorsEnum.ERROR}
+        isValid={false}
         icon={Error}
         testIdSuffix="warn"
         iconSize={16}

--- a/src/ui/components/inputs/RequiredLabel.tsx
+++ b/src/ui/components/inputs/RequiredLabel.tsx
@@ -8,6 +8,6 @@ export function RequiredLabel() {
   return <Label>{t`Obligatoire`}</Label>
 }
 
-const Label = styled(Typo.Caption)(({ theme, color }) => ({
-  color: color ?? theme.colors.greyDark,
+const Label = styled(Typo.Caption)(({ theme }) => ({
+  color: theme.colors.greyDark,
 }))

--- a/src/ui/components/inputs/rules/InputRule.tsx
+++ b/src/ui/components/inputs/rules/InputRule.tsx
@@ -3,25 +3,27 @@ import styled from 'styled-components/native'
 
 import { IconInterface } from 'ui/svg/icons/types'
 import { getSpacing, Typo, Spacer } from 'ui/theme'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 type Props = {
   title: string
   icon: FunctionComponent<IconInterface>
   iconSize: number
-  color: ColorsEnum
+  isValid: boolean
   testIdSuffix?: string
   centered?: boolean
 }
 
 export const InputRule: FunctionComponent<Props> = (props) => {
-  const { title, icon, iconSize, color, testIdSuffix, centered } = props
-  const Icon = icon
+  const { title, icon, iconSize, isValid, testIdSuffix, centered } = props
+  const Icon = styled(icon).attrs<{ testID: string }>(({ theme }) => ({
+    color: isValid ? theme.colors.greenValid : theme.colors.error,
+    size: iconSize,
+  }))``
+
   return (
     <StyledView centered={centered}>
-      <Icon testID={`rule-icon-${testIdSuffix}`} color={color} size={iconSize} />
+      <Icon testID={`rule-icon-${testIdSuffix}`} />
       <Spacer.Row numberOfSpaces={1} />
-      <StyledCaption color={color} centered={centered}>
+      <StyledCaption isValid={isValid} centered={centered}>
         {title}
       </StyledCaption>
     </StyledView>
@@ -35,8 +37,12 @@ const StyledView = styled.View<{ centered?: boolean }>(({ centered, theme }) => 
   ...(centered ? {} : { width: '100%' }),
 }))
 
-const StyledCaption = styled(Typo.Caption)<{ centered?: boolean }>(({ centered }) => ({
+const StyledCaption = styled(Typo.Caption)<{
+  isValid: boolean
+  centered?: boolean
+}>(({ isValid, theme, centered }) => ({
   paddingLeft: getSpacing(1),
   flexShrink: 1,
+  color: isValid ? theme.colors.greenValid : theme.colors.error,
   ...(centered ? { textAlign: 'center' } : {}),
 }))

--- a/src/ui/components/inputs/rules/PasswordRule.tsx
+++ b/src/ui/components/inputs/rules/PasswordRule.tsx
@@ -5,8 +5,6 @@ import { AriaLive } from 'ui/components/AriaLive'
 import { InputRule } from 'ui/components/inputs/rules/InputRule'
 import { Check } from 'ui/svg/icons/Check'
 import { Close } from 'ui/svg/icons/Close'
-// eslint-disable-next-line no-restricted-imports
-import { ColorsEnum } from 'ui/theme/colors'
 
 type Props = {
   title: string
@@ -21,7 +19,7 @@ export const PasswordRule: FunctionComponent<Props> = ({ title, isValidated }) =
         icon={isValidated ? Check : Close}
         iconSize={10}
         testIdSuffix={isValidated ? 'check' : 'close'}
-        color={isValidated ? ColorsEnum.GREEN_VALID : ColorsEnum.ERROR}
+        isValid={isValidated}
       />
       <AriaLive liveType="polite">{isValidated ? title + ' ' + t`validé` : ''}</AriaLive>
     </React.Fragment>

--- a/src/ui/theme/typography.tsx
+++ b/src/ui/theme/typography.tsx
@@ -11,12 +11,9 @@ interface CustomTextProps {
 }
 type TextProps = CustomTextProps & RNTextProps
 
-const ColoredText = styled(RNText)<TextProps>(({ color, theme }) => ({
-  color: color ?? theme.colors.black,
-}))
-
-const Hero = styled(ColoredText)(({ theme }) => ({
+const Hero = styled(RNText)(({ theme }) => ({
   ...theme.typography.hero,
+  color: theme.colors.black,
 }))
 
 const Title1: React.FC<TextProps> = (props) => {
@@ -29,9 +26,10 @@ const Title1: React.FC<TextProps> = (props) => {
   )
 }
 
-const StyledTitle1 = styled(ColoredText)<{ fontSize: number }>(({ fontSize, theme }) => ({
+const StyledTitle1 = styled(RNText)<{ fontSize: number }>(({ fontSize, theme }) => ({
   ...theme.typography.title1,
   fontSize: fontSize ?? theme.typography.title1.fontSize,
+  color: theme.colors.black,
 }))
 
 const Title2: React.FC<TextProps> = (props) => {
@@ -43,31 +41,37 @@ const Title2: React.FC<TextProps> = (props) => {
     </StyledTitle2>
   )
 }
-const StyledTitle2 = styled(ColoredText)<{ fontSize: number }>(({ fontSize, theme }) => ({
+const StyledTitle2 = styled(RNText)<{ fontSize: number }>(({ fontSize, theme }) => ({
   ...theme.typography.title2,
   fontSize: fontSize ?? theme.typography.title2.fontSize,
+  color: theme.colors.black,
 }))
 
-const Title3 = styled(ColoredText)(({ theme }) => ({
+const Title3 = styled(RNText)(({ theme }) => ({
   ...theme.typography.title3,
+  color: theme.colors.black,
 }))
 
-const Title4 = styled(ColoredText)(({ theme }) => ({
+const Title4 = styled(RNText)(({ theme }) => ({
   ...theme.typography.title4,
+  color: theme.colors.black,
 }))
 
-const ButtonText = styled(ColoredText)<{ shrink?: boolean }>(({ shrink, theme }) => ({
+const ButtonText = styled(RNText)<{ shrink?: boolean }>(({ shrink, theme }) => ({
   fontFamily: theme.typography.buttonText.fontFamily,
   fontSize: theme.typography.buttonText.fontSize,
+  color: theme.colors.black,
   ...(!shrink ? { lineHeight: theme.typography.buttonText.lineHeight } : { flexShrink: 1 }),
 }))
 
-const Body = styled(ColoredText)(({ theme }) => ({
+const Body = styled(RNText)(({ theme }) => ({
   ...theme.typography.body,
+  color: theme.colors.black,
 }))
 
-const Caption = styled(ColoredText)(({ theme }) => ({
+const Caption = styled(RNText)(({ theme }) => ({
   ...theme.typography.caption,
+  color: theme.colors.black,
 }))
 
 export const Typo = {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13115

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
