### PR TITLE
(PC-13229) feat(booking): display duo selector only for not event offer

### DIFF
--- a/src/features/bookOffer/components/BookingDetails.tsx
+++ b/src/features/bookOffer/components/BookingDetails.tsx
@@ -12,6 +12,7 @@ import { useIsUserUnderage } from 'features/profile/utils'
 import { analytics } from 'libs/analytics'
 import { campaignTracker, CampaignEvents } from 'libs/campaign'
 import { formatToFrenchDecimal } from 'libs/parsers'
+import { useSubcategoriesMapping } from 'libs/subcategories'
 import { Banner } from 'ui/components/Banner'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
@@ -42,6 +43,7 @@ export const BookingDetails: React.FC<Props> = ({ stocks }) => {
   const offer = useBookingOffer()
   const { showErrorSnackBar } = useSnackBarContext()
   const isUserUnderage = useIsUserUnderage()
+  const mapping = useSubcategoriesMapping()
   const { quantity, offerId } = bookingState
   const accessibilityDescribedBy = uuidv4()
 
@@ -103,6 +105,8 @@ export const BookingDetails: React.FC<Props> = ({ stocks }) => {
 
   const isStockBookable = !(isUserUnderage && selectedStock.isForbiddenToUnderage)
 
+  const isEvent = offer?.subcategoryId ? mapping[offer?.subcategoryId].isEvent : undefined
+
   return (
     <Container>
       <Banner title={disclaimer} />
@@ -118,7 +122,7 @@ export const BookingDetails: React.FC<Props> = ({ stocks }) => {
 
       <Spacer.Column numberOfSpaces={6} />
 
-      {!!offer?.isDuo && (
+      {!!(offer?.isDuo && !isEvent) && (
         <React.Fragment>
           <Separator />
           <Spacer.Column numberOfSpaces={6} />

--- a/src/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx
+++ b/src/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx
@@ -192,31 +192,33 @@ describe('<BookingDetails />', () => {
     }
   )
 
-  it('should not display the Duo selector when the offer is not duo', async () => {
-    mockBookingState = {
-      bookingState: mockInitialBookingState,
-      dismissModal: mockDismissModal,
-      dispatch: mockDispatch,
-    }
+  describe('duo selector', () => {
+    it('should not display the Duo selector when the offer is not duo', async () => {
+      mockBookingState = {
+        bookingState: mockInitialBookingState,
+        dismissModal: mockDismissModal,
+        dispatch: mockDispatch,
+      }
 
-    const { queryByTestId } = await renderBookingDetails(mockDigitalStocks)
+      const { queryByTestId } = await renderBookingDetails(mockDigitalStocks)
 
-    expect(queryByTestId('DuoChoiceSelector')).toBeFalsy()
-  })
+      expect(queryByTestId('DuoChoiceSelector')).toBeFalsy()
+    })
 
-  it('should display the Duo selector when the offer is duo', async () => {
-    mockUseBookingOffer.mockReturnValueOnce({ ...mockOffer, isDuo: true })
+    it('should display the Duo selector when the offer is duo', async () => {
+      mockUseBookingOffer.mockReturnValueOnce({ ...mockOffer, isDuo: true })
 
-    const duoBookingState: BookingState = { ...mockInitialBookingState, quantity: 2 }
-    mockBookingState = {
-      bookingState: duoBookingState,
-      dismissModal: mockDismissModal,
-      dispatch: mockDispatch,
-    }
+      const duoBookingState: BookingState = { ...mockInitialBookingState, quantity: 2 }
+      mockBookingState = {
+        bookingState: duoBookingState,
+        dismissModal: mockDismissModal,
+        dispatch: mockDispatch,
+      }
 
-    const { queryByTestId } = await renderBookingDetails(mockDigitalStocks)
+      const { queryByTestId } = await renderBookingDetails(mockDigitalStocks)
 
-    expect(queryByTestId('DuoChoiceSelector')).toBeTruthy()
+      expect(queryByTestId('DuoChoiceSelector')).toBeTruthy()
+    })
   })
 })
 

--- a/src/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx
+++ b/src/features/bookOffer/components/__tests__/BookingDetails.native.test.tsx
@@ -62,6 +62,14 @@ const mockDigitalStocks = mockDigitalOffer.stocks
 jest.mock('features/profile/utils')
 const mockedUseIsUserUnderage = mocked(useIsUserUnderage)
 
+const mockUseSubcategoriesMapping = jest.fn()
+jest.mock('libs/subcategories', () => ({
+  useSubcategoriesMapping: jest.fn(() => mockUseSubcategoriesMapping()),
+}))
+mockUseSubcategoriesMapping.mockReturnValue({
+  EVENEMENT_PATRIMOINE: { isEvent: true },
+})
+
 describe('<BookingDetails />', () => {
   it('should initialize correctly state when offer isDigital', async () => {
     mockBookingState = {
@@ -205,7 +213,7 @@ describe('<BookingDetails />', () => {
       expect(queryByTestId('DuoChoiceSelector')).toBeFalsy()
     })
 
-    it('should display the Duo selector when the offer is duo', async () => {
+    it('should not display the Duo selector when the offer is duo but is an event', async () => {
       mockUseBookingOffer.mockReturnValueOnce({ ...mockOffer, isDuo: true })
 
       const duoBookingState: BookingState = { ...mockInitialBookingState, quantity: 2 }
@@ -214,6 +222,29 @@ describe('<BookingDetails />', () => {
         dismissModal: mockDismissModal,
         dispatch: mockDispatch,
       }
+
+      mockUseSubcategoriesMapping.mockReturnValueOnce({
+        EVENEMENT_PATRIMOINE: { isEvent: true },
+      })
+
+      const { queryByTestId } = await renderBookingDetails(mockDigitalStocks)
+
+      expect(queryByTestId('DuoChoiceSelector')).toBeFalsy()
+    })
+
+    it('should display the Duo selector when the offer is duo and not an event', async () => {
+      mockUseBookingOffer.mockReturnValueOnce({ ...mockOffer, isDuo: true })
+
+      const duoBookingState: BookingState = { ...mockInitialBookingState, quantity: 2 }
+      mockBookingState = {
+        bookingState: duoBookingState,
+        dismissModal: mockDismissModal,
+        dispatch: mockDispatch,
+      }
+
+      mockUseSubcategoriesMapping.mockReturnValueOnce({
+        EVENEMENT_PATRIMOINE: { isEvent: false },
+      })
 
       const { queryByTestId } = await renderBookingDetails(mockDigitalStocks)
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13229

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

avec une offre de type event
| avant  | après |
| :--: | :-----: |
|  ![image](https://user-images.githubusercontent.com/95220086/152141266-927bf579-5d57-446b-a993-1432abdb5f1d.png)   | ![image](https://user-images.githubusercontent.com/95220086/152141324-a938be9e-1ef4-49b5-8064-3d3e70dda2ca.png)|

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
