### PR TITLE
(PC-12797) fix(AppButtons): fix loading being overwritten by disabled state

### DIFF
--- a/src/ui/components/buttons/ButtonPrimary.tsx
+++ b/src/ui/components/buttons/ButtonPrimary.tsx
@@ -36,9 +36,7 @@ export const ButtonPrimary = styled(AppButton).attrs<BaseButtonProps>(
 
   if (isLoading) {
     backgroundColor = theme.buttons.loading.primary.backgroundColor
-  }
-
-  if (disabled) {
+  } else if (disabled) {
     backgroundColor = theme.buttons.disabled.primary.backgroundColor
   }
 

--- a/src/ui/components/buttons/ButtonSecondary.tsx
+++ b/src/ui/components/buttons/ButtonSecondary.tsx
@@ -42,9 +42,7 @@ export const ButtonSecondary = styled(AppButton).attrs<BaseButtonProps>(
 
   if (isLoading) {
     borderColor = theme.buttons.loading.secondary.borderColor
-  }
-
-  if (disabled) {
+  } else if (disabled) {
     borderColor = theme.buttons.disabled.secondary.borderColor
   }
 

--- a/src/ui/components/buttons/ButtonSecondaryWhite.tsx
+++ b/src/ui/components/buttons/ButtonSecondaryWhite.tsx
@@ -42,9 +42,7 @@ export const ButtonSecondaryWhite = styled(AppButton).attrs<BaseButtonProps>(
 
   if (isLoading) {
     borderColor = theme.buttons.loading.secondaryWhite.borderColor
-  }
-
-  if (disabled) {
+  } else if (disabled) {
     borderColor = theme.buttons.disabled.secondaryWhite.borderColor
   }
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12797

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
