### PR TITLE
(PC-13202) fix(signup): add tilted apostrophe in name regex

### DIFF
--- a/src/ui/components/inputs/addressCheck.test.ts
+++ b/src/ui/components/inputs/addressCheck.test.ts
@@ -1,13 +1,18 @@
 import { isAddressValid } from './addressCheck'
 
 describe('isAddressValid function', () => {
-  it.each(['1 ', '1', '1 rue', '1, rue de Loïc-Raison', 'àâçéèêîôœùûÀÂÇÉÈÊÎÔŒÙÛ'])(
-    'should accept a well-formatted address: %s',
-    (address) => {
-      const isValid = isAddressValid(address)
-      expect(isValid).toEqual(true)
-    }
-  )
+  it.each([
+    '1 ',
+    '1',
+    '1 rue',
+    '1, rue de Loïc-Raison',
+    'àâçéèêîôœùûÀÂÇÉÈÊÎÔŒÙÛ',
+    '1 rue de l’artillerie',
+    "1 rue de l'artillerie",
+  ])('should accept a well-formatted address: %s', (address) => {
+    const isValid = isAddressValid(address)
+    expect(isValid).toEqual(true)
+  })
 
   it.each(['J@hn', 'ჯონ', '𝘑𝘦𝘢𝘯 𝘩𝘦𝘯𝘳𝘺', ' ', '  ', '1() rue de Loïc-Raison'])(
     'should reject a unwell-formatted address: %s',

--- a/src/ui/components/inputs/addressCheck.ts
+++ b/src/ui/components/inputs/addressCheck.ts
@@ -1,4 +1,4 @@
-const ADDRESS_REGEX = /\p{sc=Latin}|[ \-,'.]|[0-9]/gu // Latin characters, spaces and numbers
+const ADDRESS_REGEX = /\p{sc=Latin}|[ \-,'.’]|[0-9]/gu // Latin characters, spaces and numbers
 
 export function isAddressValid(name: string) {
   const trimmedName = name.trim()

--- a/src/ui/components/inputs/nameCheck.test.ts
+++ b/src/ui/components/inputs/nameCheck.test.ts
@@ -4,6 +4,7 @@ describe('isNameValid function', () => {
   it.each([
     'John',
     "John O'Wick",
+    'John O’Wick',
     'John Doe-Smith',
     'Loïc',
     'Martin king, Jr.',

--- a/src/ui/components/inputs/nameCheck.ts
+++ b/src/ui/components/inputs/nameCheck.ts
@@ -1,6 +1,6 @@
 const SPECIAL_CHARACTER_AT_THE_BEGINNING_OR_END_REGEX = /^['-]|['-]$/
 const NUMBER_REGEX = /[0-9]+/
-const LATIN_REGEX = /\p{sc=Latin}|[',-. ]/gu
+const LATIN_REGEX = /\p{sc=Latin}|[',-.’ ]/gu
 
 export function isNameValid(name: string) {
   const trimmedName = name.trim()


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13202

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|   <img width="310" alt="Capture d’écran 2022-02-07 à 11 01 21" src="https://user-images.githubusercontent.com/44037911/152766481-a5e58ab5-80de-422e-869a-ddb4e106de8a.png">  |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
