### PR TITLE
build(sonar): Sonar should ignore coverage of Storybook

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,6 @@ sonar.dynamicAnalysis=reuseReports
 sonar.sources=src
 sonar.javascript.jstest.reportsPath=coverage
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.exclusions=**/*.test.*,src/**/*.d.ts
+sonar.exclusions=**/*.test.*,src/**/*.d.ts,**/*.stories.mdx,**/*.stories.@(js|jsx|ts|tsx)
 sonar.tests=src
 sonar.test.inclusions=src/**/*test.*


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

ça devrait permettre d'éviter que Sonar soit au rouge sur le test coverage https://github.com/pass-culture/pass-culture-app-native/pull/2595#issuecomment-1032836874

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.


[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
