### PR TITLE
(PC-12843) feat(accessibility): Hide accordion's children when not expanded

### DIFF
--- a/__snapshots__/features/offer/pages/tests/OfferBody.deprecated.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferBody.deprecated.native.test.tsx.native-snap
@@ -988,19 +988,19 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                             testID="accordionBody"
                           >
                             <View
-                              hidden={false}
+                              hidden={true}
                               onLayout={[Function]}
                               style={
                                 Array [
                                   Object {
                                     "bottom": 0,
+                                    "display": "none",
                                     "paddingBottom": 24,
                                     "paddingHorizontal": 24,
                                     "paddingTop": 0,
                                     "position": "absolute",
                                     "width": "100%",
                                   },
-                                  undefined,
                                 ]
                               }
                               testID="accordionBodyContainer"
@@ -1142,19 +1142,19 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                             testID="accordionBody"
                           >
                             <View
-                              hidden={false}
+                              hidden={true}
                               onLayout={[Function]}
                               style={
                                 Array [
                                   Object {
                                     "bottom": 0,
+                                    "display": "none",
                                     "paddingBottom": 24,
                                     "paddingHorizontal": 24,
                                     "paddingTop": 0,
                                     "position": "absolute",
                                     "width": "100%",
                                   },
-                                  undefined,
                                 ]
                               }
                               testID="accordionBodyContainer"
@@ -3635,19 +3635,19 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                             testID="accordionBody"
                           >
                             <View
-                              hidden={false}
+                              hidden={true}
                               onLayout={[Function]}
                               style={
                                 Array [
                                   Object {
                                     "bottom": 0,
+                                    "display": "none",
                                     "paddingBottom": 24,
                                     "paddingHorizontal": 24,
                                     "paddingTop": 0,
                                     "position": "absolute",
                                     "width": "100%",
                                   },
-                                  undefined,
                                 ]
                               }
                               testID="accordionBodyContainer"
@@ -3789,19 +3789,19 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                             testID="accordionBody"
                           >
                             <View
-                              hidden={false}
+                              hidden={true}
                               onLayout={[Function]}
                               style={
                                 Array [
                                   Object {
                                     "bottom": 0,
+                                    "display": "none",
                                     "paddingBottom": 24,
                                     "paddingHorizontal": 24,
                                     "paddingTop": 0,
                                     "position": "absolute",
                                     "width": "100%",
                                   },
-                                  undefined,
                                 ]
                               }
                               testID="accordionBodyContainer"

--- a/__snapshots__/features/offer/pages/tests/OfferBody.deprecated.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferBody.deprecated.native.test.tsx.native-snap
@@ -988,6 +988,7 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                             testID="accordionBody"
                           >
                             <View
+                              hidden={false}
                               onLayout={[Function]}
                               style={
                                 Array [
@@ -1141,6 +1142,7 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                             testID="accordionBody"
                           >
                             <View
+                              hidden={false}
                               onLayout={[Function]}
                               style={
                                 Array [
@@ -3633,6 +3635,7 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                             testID="accordionBody"
                           >
                             <View
+                              hidden={false}
                               onLayout={[Function]}
                               style={
                                 Array [
@@ -3786,6 +3789,7 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
                             testID="accordionBody"
                           >
                             <View
+                              hidden={false}
                               onLayout={[Function]}
                               style={
                                 Array [

--- a/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
@@ -598,6 +598,7 @@ exports[`SearchFilter component should render correctly 1`] = `
         testID="accordionBody"
       >
         <View
+          hidden={true}
           onLayout={[Function]}
           style={
             Array [
@@ -1563,6 +1564,7 @@ exports[`SearchFilter component should render correctly 1`] = `
         testID="accordionBody"
       >
         <View
+          hidden={true}
           onLayout={[Function]}
           style={
             Array [

--- a/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
@@ -598,19 +598,19 @@ exports[`SearchFilter component should render correctly 1`] = `
         testID="accordionBody"
       >
         <View
-          hidden={true}
+          hidden={false}
           onLayout={[Function]}
           style={
             Array [
               Object {
                 "bottom": 0,
+                "display": "flex",
                 "paddingBottom": 24,
                 "paddingHorizontal": 24,
                 "paddingTop": 0,
                 "position": "absolute",
                 "width": "100%",
               },
-              undefined,
             ]
           }
           testID="accordionBodyContainer"
@@ -1564,19 +1564,19 @@ exports[`SearchFilter component should render correctly 1`] = `
         testID="accordionBody"
       >
         <View
-          hidden={true}
+          hidden={false}
           onLayout={[Function]}
           style={
             Array [
               Object {
                 "bottom": 0,
+                "display": "flex",
                 "paddingBottom": 24,
                 "paddingHorizontal": 24,
                 "paddingTop": 0,
                 "position": "absolute",
                 "width": "100%",
               },
-              undefined,
             ]
           }
           testID="accordionBodyContainer"

--- a/__snapshots__/features/venue/pages/__tests__/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/__tests__/Venue.native.test.tsx.native-snap
@@ -2024,19 +2024,19 @@ exports[`<Venue /> should match snapshot 1`] = `
         testID="accordionBody"
       >
         <View
-          hidden={false}
+          hidden={true}
           onLayout={[Function]}
           style={
             Array [
               Object {
                 "bottom": 0,
+                "display": "none",
                 "paddingBottom": 24,
                 "paddingHorizontal": 24,
                 "paddingTop": 0,
                 "position": "absolute",
                 "width": "100%",
               },
-              undefined,
             ]
           }
           testID="accordionBodyContainer"
@@ -2182,19 +2182,19 @@ exports[`<Venue /> should match snapshot 1`] = `
         testID="accordionBody"
       >
         <View
-          hidden={false}
+          hidden={true}
           onLayout={[Function]}
           style={
             Array [
               Object {
                 "bottom": 0,
+                "display": "none",
                 "paddingBottom": 24,
                 "paddingHorizontal": 24,
                 "paddingTop": 0,
                 "position": "absolute",
                 "width": "100%",
               },
-              undefined,
             ]
           }
           testID="accordionBodyContainer"
@@ -2783,19 +2783,19 @@ exports[`<Venue /> should match snapshot 1`] = `
         testID="accordionBody"
       >
         <View
-          hidden={false}
+          hidden={true}
           onLayout={[Function]}
           style={
             Array [
               Object {
                 "bottom": 0,
+                "display": "none",
                 "paddingBottom": 24,
                 "paddingHorizontal": 24,
                 "paddingTop": 0,
                 "position": "absolute",
                 "width": "100%",
               },
-              undefined,
             ]
           }
           testID="accordionBodyContainer"

--- a/__snapshots__/features/venue/pages/__tests__/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/__tests__/Venue.native.test.tsx.native-snap
@@ -2024,6 +2024,7 @@ exports[`<Venue /> should match snapshot 1`] = `
         testID="accordionBody"
       >
         <View
+          hidden={false}
           onLayout={[Function]}
           style={
             Array [
@@ -2181,6 +2182,7 @@ exports[`<Venue /> should match snapshot 1`] = `
         testID="accordionBody"
       >
         <View
+          hidden={false}
           onLayout={[Function]}
           style={
             Array [
@@ -2781,6 +2783,7 @@ exports[`<Venue /> should match snapshot 1`] = `
         testID="accordionBody"
       >
         <View
+          hidden={false}
           onLayout={[Function]}
           style={
             Array [

--- a/__snapshots__/features/venue/pages/__tests__/Venue.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/pages/__tests__/Venue.web.test.tsx.web-snap
@@ -831,7 +831,7 @@ Object {
               <div
                 class="css-view-1dbjc4n"
                 data-testid="accordionBodyContainer"
-                style="bottom: 0px; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
+                style="bottom: 0px; display: none; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
               >
                 <div
                   class="css-text-901oao"
@@ -913,7 +913,7 @@ Object {
               <div
                 class="css-view-1dbjc4n"
                 data-testid="accordionBodyContainer"
-                style="bottom: 0px; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
+                style="bottom: 0px; display: none; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
               >
                 <div
                   class="css-view-1dbjc4n"
@@ -1218,7 +1218,7 @@ Object {
               <div
                 class="css-view-1dbjc4n"
                 data-testid="accordionBodyContainer"
-                style="bottom: 0px; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
+                style="bottom: 0px; display: none; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
               >
                 <div
                   class="css-text-901oao"
@@ -2241,7 +2241,7 @@ Object {
             <div
               class="css-view-1dbjc4n"
               data-testid="accordionBodyContainer"
-              style="bottom: 0px; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
+              style="bottom: 0px; display: none; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
             >
               <div
                 class="css-text-901oao"
@@ -2323,7 +2323,7 @@ Object {
             <div
               class="css-view-1dbjc4n"
               data-testid="accordionBodyContainer"
-              style="bottom: 0px; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
+              style="bottom: 0px; display: none; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
             >
               <div
                 class="css-view-1dbjc4n"
@@ -2628,7 +2628,7 @@ Object {
             <div
               class="css-view-1dbjc4n"
               data-testid="accordionBodyContainer"
-              style="bottom: 0px; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
+              style="bottom: 0px; display: none; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
             >
               <div
                 class="css-text-901oao"

--- a/__snapshots__/features/venue/pages/__tests__/VenueBody.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/__tests__/VenueBody.native.test.tsx.native-snap
@@ -2012,19 +2012,19 @@ exports[`<VenueBody /> should render correctly 1`] = `
       testID="accordionBody"
     >
       <View
-        hidden={false}
+        hidden={true}
         onLayout={[Function]}
         style={
           Array [
             Object {
               "bottom": 0,
+              "display": "none",
               "paddingBottom": 24,
               "paddingHorizontal": 24,
               "paddingTop": 0,
               "position": "absolute",
               "width": "100%",
             },
-            undefined,
           ]
         }
         testID="accordionBodyContainer"
@@ -2170,19 +2170,19 @@ exports[`<VenueBody /> should render correctly 1`] = `
       testID="accordionBody"
     >
       <View
-        hidden={false}
+        hidden={true}
         onLayout={[Function]}
         style={
           Array [
             Object {
               "bottom": 0,
+              "display": "none",
               "paddingBottom": 24,
               "paddingHorizontal": 24,
               "paddingTop": 0,
               "position": "absolute",
               "width": "100%",
             },
-            undefined,
           ]
         }
         testID="accordionBodyContainer"
@@ -2771,19 +2771,19 @@ exports[`<VenueBody /> should render correctly 1`] = `
       testID="accordionBody"
     >
       <View
-        hidden={false}
+        hidden={true}
         onLayout={[Function]}
         style={
           Array [
             Object {
               "bottom": 0,
+              "display": "none",
               "paddingBottom": 24,
               "paddingHorizontal": 24,
               "paddingTop": 0,
               "position": "absolute",
               "width": "100%",
             },
-            undefined,
           ]
         }
         testID="accordionBodyContainer"

--- a/__snapshots__/features/venue/pages/__tests__/VenueBody.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/__tests__/VenueBody.native.test.tsx.native-snap
@@ -2012,6 +2012,7 @@ exports[`<VenueBody /> should render correctly 1`] = `
       testID="accordionBody"
     >
       <View
+        hidden={false}
         onLayout={[Function]}
         style={
           Array [
@@ -2169,6 +2170,7 @@ exports[`<VenueBody /> should render correctly 1`] = `
       testID="accordionBody"
     >
       <View
+        hidden={false}
         onLayout={[Function]}
         style={
           Array [
@@ -2769,6 +2771,7 @@ exports[`<VenueBody /> should render correctly 1`] = `
       testID="accordionBody"
     >
       <View
+        hidden={false}
         onLayout={[Function]}
         style={
           Array [

--- a/__snapshots__/features/venue/pages/__tests__/VenueBody.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/pages/__tests__/VenueBody.web.test.tsx.web-snap
@@ -827,7 +827,7 @@ Object {
             <div
               class="css-view-1dbjc4n"
               data-testid="accordionBodyContainer"
-              style="bottom: 0px; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
+              style="bottom: 0px; display: none; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
             >
               <div
                 class="css-text-901oao"
@@ -909,7 +909,7 @@ Object {
             <div
               class="css-view-1dbjc4n"
               data-testid="accordionBodyContainer"
-              style="bottom: 0px; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
+              style="bottom: 0px; display: none; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
             >
               <div
                 class="css-view-1dbjc4n"
@@ -1214,7 +1214,7 @@ Object {
             <div
               class="css-view-1dbjc4n"
               data-testid="accordionBodyContainer"
-              style="bottom: 0px; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
+              style="bottom: 0px; display: none; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
             >
               <div
                 class="css-text-901oao"
@@ -2074,7 +2074,7 @@ Object {
           <div
             class="css-view-1dbjc4n"
             data-testid="accordionBodyContainer"
-            style="bottom: 0px; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
+            style="bottom: 0px; display: none; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
           >
             <div
               class="css-text-901oao"
@@ -2156,7 +2156,7 @@ Object {
           <div
             class="css-view-1dbjc4n"
             data-testid="accordionBodyContainer"
-            style="bottom: 0px; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
+            style="bottom: 0px; display: none; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
           >
             <div
               class="css-view-1dbjc4n"
@@ -2461,7 +2461,7 @@ Object {
           <div
             class="css-view-1dbjc4n"
             data-testid="accordionBodyContainer"
-            style="bottom: 0px; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
+            style="bottom: 0px; display: none; padding: 0px 24px 24px 24px; position: absolute; width: 100%;"
           >
             <div
               class="css-text-901oao"

--- a/src/features/bookings/components/BookingItemTitle.tsx
+++ b/src/features/bookings/components/BookingItemTitle.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { getSpacing, Typo } from 'ui/theme'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 
 type Props = {
   title: string
@@ -19,7 +19,7 @@ export function BookingItemTitle(props: Props) {
 const ButtonText = styled(Typo.ButtonText).attrs(() => ({
   numberOfLines: 2,
   shrink: true,
-  ...getTitleAttrs(3),
+  ...getHeadingAttrs(3),
 }))``
 
 const TitleContainer = styled.View({

--- a/src/features/bookings/components/OnGoingBookingsList.tsx
+++ b/src/features/bookings/components/OnGoingBookingsList.tsx
@@ -18,7 +18,7 @@ import { useSubcategories } from 'libs/subcategories/useSubcategories'
 import { Separator } from 'ui/components/Separator'
 import { getSpacing, Typo } from 'ui/theme'
 import { TAB_BAR_COMP_HEIGHT } from 'ui/theme/constants'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 
 import { NoBookingsView } from './NoBookingsView'
 import { OnGoingBookingItem } from './OnGoingBookingItem'
@@ -113,7 +113,7 @@ const Container = styled.View<{ flex?: number }>(({ flex }) => ({
   height: '100%',
 }))
 
-const BookingsCount = styled(Typo.Body).attrs(() => getTitleAttrs(2))(({ theme }) => ({
+const BookingsCount = styled(Typo.Body).attrs(() => getHeadingAttrs(2))(({ theme }) => ({
   fontSize: 15,
   paddingTop: getSpacing(6),
   paddingHorizontal: getSpacing(6),

--- a/src/features/favorites/atoms/Favorite.tsx
+++ b/src/features/favorites/atoms/Favorite.tsx
@@ -19,7 +19,7 @@ import { useSearchGroupLabel, useSubcategory } from 'libs/subcategories'
 import { ButtonSecondary } from 'ui/components/buttons/ButtonSecondary'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 import { Link } from 'ui/web/link/Link'
 
 import { BookingButton } from './BookingButton'
@@ -208,7 +208,7 @@ const ButtonsRow = styled.View(({ theme }) => ({
   marginHorizontal: getSpacing(6),
 }))
 
-const Name = styled(Typo.ButtonText).attrs(() => getTitleAttrs(3))``
+const Name = styled(Typo.ButtonText).attrs(() => getHeadingAttrs(3))``
 
 const Distance = styled(Typo.Body)(({ theme }) => ({
   textAlign: 'right',

--- a/src/features/favorites/atoms/NumberOfResults.tsx
+++ b/src/features/favorites/atoms/NumberOfResults.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { getSpacing, Typo } from 'ui/theme'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 
 export const NumberOfResults: React.FC<{ nbFavorites: number }> = ({ nbFavorites }) => {
   if (!nbFavorites) return <React.Fragment></React.Fragment>
@@ -24,6 +24,6 @@ const Container = styled.View({
   marginBottom: getSpacing(4),
 })
 
-const Body = styled(Typo.Body).attrs(() => getTitleAttrs(2))(({ theme }) => ({
+const Body = styled(Typo.Body).attrs(() => getHeadingAttrs(2))(({ theme }) => ({
   color: theme.colors.greyDark,
 }))

--- a/src/features/home/components/HomeHeader.tsx
+++ b/src/features/home/components/HomeHeader.tsx
@@ -11,7 +11,7 @@ import { env } from 'libs/environment'
 import { formatToFrenchDecimal } from 'libs/parsers'
 import { HeaderBackground } from 'ui/svg/HeaderBackground'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 export const HomeHeader: FunctionComponent = function () {
@@ -63,7 +63,7 @@ export const HomeHeader: FunctionComponent = function () {
   )
 }
 
-const Body = styled(Typo.Body).attrs(() => getTitleAttrs(2))(({ theme }) => ({
+const Body = styled(Typo.Body).attrs(() => getHeadingAttrs(2))(({ theme }) => ({
   color: theme.colors.white,
 }))
 

--- a/src/features/identityCheck/atoms/CenteredTitle.tsx
+++ b/src/features/identityCheck/atoms/CenteredTitle.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { Typo } from 'ui/theme'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 
 export const CenteredTitle = ({ title }: { title: string }) => (
   <TitleContainer>
@@ -15,6 +15,6 @@ const TitleContainer = styled.View({
   width: '100%',
 })
 
-const Title = styled(Typo.Title4).attrs(() => getTitleAttrs(1))({
+const Title = styled(Typo.Title4).attrs(() => getHeadingAttrs(1))({
   textAlign: 'center',
 })

--- a/src/features/identityCheck/atoms/layout/PageHeader.tsx
+++ b/src/features/identityCheck/atoms/layout/PageHeader.tsx
@@ -7,7 +7,7 @@ import { useGoBack } from 'features/navigation/useGoBack'
 import { accessibilityAndTestId } from 'libs/accessibilityAndTestId'
 import { ArrowPrevious as DefaultArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { getSpacing, Typo } from 'ui/theme'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 
 interface Props {
   title: string
@@ -28,7 +28,7 @@ const HeaderContainer = styled.View(({ theme }) => ({
   height: theme.appBarHeight,
 }))
 
-const Title = styled(Typo.Title4).attrs(() => getTitleAttrs(1))(({ theme }) => ({
+const Title = styled(Typo.Title4).attrs(() => getHeadingAttrs(1))(({ theme }) => ({
   flex: 1,
   textAlign: 'center',
   color: theme.colors.white,

--- a/src/features/identityCheck/pages/Stepper.tsx
+++ b/src/features/identityCheck/pages/Stepper.tsx
@@ -18,7 +18,7 @@ import { ButtonTertiaryWhite } from 'ui/components/buttons/ButtonTertiaryWhite'
 import { useModal } from 'ui/components/modals/useModal'
 import { Background } from 'ui/svg/Background'
 import { Spacer, Typo, getSpacing } from 'ui/theme'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 
 export const IdentityCheckStepper = () => {
   const theme = useTheme()
@@ -111,7 +111,7 @@ export const IdentityCheckStepper = () => {
   )
 }
 
-const Title = styled(Typo.Title3).attrs(() => getTitleAttrs(1))(({ theme }) => ({
+const Title = styled(Typo.Title3).attrs(() => getHeadingAttrs(1))(({ theme }) => ({
   textAlign: 'center',
   color: theme.colors.white,
 }))

--- a/src/features/profile/components/BeneficiaryHeader.tsx
+++ b/src/features/profile/components/BeneficiaryHeader.tsx
@@ -8,7 +8,7 @@ import { computeCredit, useIsUserUnderageBeneficiary } from 'features/profile/ut
 import { formatToFrenchDecimal } from 'libs/parsers'
 import { HeaderBackground } from 'ui/svg/HeaderBackground'
 import { getSpacing, Typo, Spacer } from 'ui/theme'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 
 type BeneficiaryHeaderProps = {
   firstName?: string | null
@@ -68,7 +68,7 @@ const Ceilings = styled(BeneficiaryCeilings)({
   top: getSpacing(42),
 })
 
-const Title = styled(Typo.Title4).attrs(() => getTitleAttrs(1))(({ theme }) => ({
+const Title = styled(Typo.Title4).attrs(() => getHeadingAttrs(1))(({ theme }) => ({
   color: theme.colors.white,
 }))
 

--- a/src/features/profile/components/LoggedOutHeader.tsx
+++ b/src/features/profile/components/LoggedOutHeader.tsx
@@ -10,7 +10,7 @@ import { analytics } from 'libs/analytics'
 import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { HeaderBackground } from 'ui/svg/HeaderBackground'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 export function LoggedOutHeader() {
   const { navigate } = useNavigation<UseNavigationType>()
   return (
@@ -75,7 +75,7 @@ const Description = styled(Typo.Body)(({ theme }) => ({
   color: theme.colors.white,
 }))
 
-const Title = styled(Typo.Title4).attrs(() => getTitleAttrs(1))(({ theme }) => ({
+const Title = styled(Typo.Title4).attrs(() => getHeadingAttrs(1))(({ theme }) => ({
   color: theme.colors.white,
 }))
 

--- a/src/features/search/atoms/Sections.tsx
+++ b/src/features/search/atoms/Sections.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { getSpacing, Typo, Spacer } from 'ui/theme'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 
 import { TitleWithCount } from './TitleWithCount'
 
@@ -63,8 +63,8 @@ const InlineSectionTitleContainer = styled.View({
   alignItems: 'center',
 })
 
-const StyledTitle = styled(Typo.Title4).attrs(() => getTitleAttrs(2))(({ theme }) => ({
+const StyledTitle = styled(Typo.Title4).attrs(() => getHeadingAttrs(2))(({ theme }) => ({
   flex: theme.isMobileViewport ? 1 : undefined,
 }))
 
-const Title = styled(Typo.Title4).attrs(() => getTitleAttrs(2))``
+const Title = styled(Typo.Title4).attrs(() => getHeadingAttrs(2))``

--- a/src/ui/components/AccordionItem.tsx
+++ b/src/ui/components/AccordionItem.tsx
@@ -15,7 +15,7 @@ import {
 import styled from 'styled-components/native'
 
 import { useFunctionOnce } from 'libs/hooks'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 import { ArrowNext as DefaultArrowNext } from '../svg/icons/ArrowNext'
@@ -140,7 +140,7 @@ const StyledView = styled.View<{ hidden: boolean }>(({ hidden }) => ({
   paddingTop: 0,
 }))
 
-const Title = styled(Typo.Title4).attrs(() => getTitleAttrs(2))({
+const Title = styled(Typo.Title4).attrs(() => getHeadingAttrs(2))({
   flex: '0.9',
 })
 

--- a/src/ui/components/GenericErrorPage.tsx
+++ b/src/ui/components/GenericErrorPage.tsx
@@ -5,7 +5,7 @@ import { Helmet } from 'libs/react-helmet/Helmet'
 import { Background } from 'ui/svg/Background'
 import { IconInterface } from 'ui/svg/icons/types'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 
 type Props = {
   header?: ReactNode
@@ -86,7 +86,7 @@ const spacingMatrix = {
   bottom: 10,
 }
 
-const StyledTitle = styled(Typo.Title2).attrs(() => getTitleAttrs(1))(({ theme }) => ({
+const StyledTitle = styled(Typo.Title2).attrs(() => getHeadingAttrs(1))(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/ui/components/GenericInfoPage.tsx
+++ b/src/ui/components/GenericInfoPage.tsx
@@ -7,7 +7,7 @@ import { AnimationObject } from 'ui/animations/type'
 import { Background } from 'ui/svg/Background'
 import { IconInterface } from 'ui/svg/icons/types'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 
 type Props = {
   header?: ReactNode
@@ -123,7 +123,7 @@ const StyledLottieView = styled(LottieView)((props: { size: number }) => ({
   height: props.size,
 }))
 
-const StyledTitle = styled(Typo.Title2).attrs(() => getTitleAttrs(1))(({ theme }) => ({
+const StyledTitle = styled(Typo.Title2).attrs(() => getHeadingAttrs(1))(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/ui/components/headers/PageHeader.tsx
+++ b/src/ui/components/headers/PageHeader.tsx
@@ -9,7 +9,7 @@ import { accessibilityAndTestId } from 'libs/accessibilityAndTestId'
 import { useElementWidth } from 'ui/hooks/useElementWidth'
 import { ArrowPrevious as DefaultArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 import { Header } from 'ui/web/global/Header'
 
 interface Props {
@@ -83,7 +83,7 @@ const Container = styled.View(({ theme }) => ({
 
 const Title = styled(Typo.Body).attrs(() => ({
   numberOfLines: 1,
-  ...getTitleAttrs(1),
+  ...getHeadingAttrs(1),
 }))(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',

--- a/src/ui/components/headers/SvgPageHeader.tsx
+++ b/src/ui/components/headers/SvgPageHeader.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { HeaderBackground } from 'ui/svg/HeaderBackground'
 import { getSpacing, Typo } from 'ui/theme'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 interface SvgPageHeaderProps {
@@ -26,7 +26,7 @@ const HeaderBackgroundWrapper = styled.View({
   alignItems: 'center',
 })
 
-const Title = styled(Typo.Title4).attrs(() => getTitleAttrs(1))(({ theme }) => ({
+const Title = styled(Typo.Title4).attrs(() => getHeadingAttrs(1))(({ theme }) => ({
   position: 'absolute',
   bottom: getSpacing(3),
   color: theme.colors.white,

--- a/src/ui/components/modals/ModalHeader.tsx
+++ b/src/ui/components/modals/ModalHeader.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/native'
 
 import { accessibilityAndTestId } from 'libs/accessibilityAndTestId'
 import { getSpacing, Typo } from 'ui/theme'
-import { getTitleAttrs } from 'ui/theme/typography'
+import { getHeadingAttrs } from 'ui/theme/typography'
 
 import { ModalIconProps } from './types'
 
@@ -100,9 +100,9 @@ const HeaderAction = styled.TouchableOpacity({
   padding: getSpacing(1),
 })
 
-const Title = styled(Typo.Title4).attrs(() => getTitleAttrs(1))({
+const Title = styled(Typo.Title4).attrs(() => getHeadingAttrs(1))({
   textAlign: 'center',
 })
-const BoldTitle = styled(Typo.Title3).attrs(() => getTitleAttrs(1))({
+const BoldTitle = styled(Typo.Title3).attrs(() => getHeadingAttrs(1))({
   textAlign: 'center',
 })

--- a/src/ui/theme/typography.tsx
+++ b/src/ui/theme/typography.tsx
@@ -11,7 +11,7 @@ interface CustomTextProps {
 }
 type TextProps = CustomTextProps & RNTextProps
 
-export const getTitleAttrs = (level: number) => ({
+export const getHeadingAttrs = (level: number) => ({
   ...(Platform.OS === 'web'
     ? {
         accessibilityRole: 'header' as AccessibilityRole,
@@ -29,7 +29,7 @@ const Title1: React.FC<TextProps> = (props) => {
   const grid = useGrid()
   const fontSize = getSpacing(grid({ default: 7, sm: 6 }, 'height'))
   return (
-    <StyledTitle1 {...getTitleAttrs(1)} {...props} fontSize={fontSize}>
+    <StyledTitle1 {...getHeadingAttrs(1)} {...props} fontSize={fontSize}>
       {props.children}
     </StyledTitle1>
   )
@@ -47,7 +47,7 @@ const Title2: React.FC<TextProps> = (props) => {
   const grid = useGrid()
   const fontSize = getSpacing(grid({ default: 6, sm: 5.5 }, 'height'))
   return (
-    <StyledTitle2 {...getTitleAttrs(2)} {...props} fontSize={fontSize}>
+    <StyledTitle2 {...getHeadingAttrs(2)} {...props} fontSize={fontSize}>
       {props.children}
     </StyledTitle2>
   )
@@ -60,12 +60,12 @@ const StyledTitle2 = styled(RNText)<{
   color: theme.colors.black,
 }))
 
-const Title3 = styled(RNText).attrs(() => getTitleAttrs(3))(({ theme }) => ({
+const Title3 = styled(RNText).attrs(() => getHeadingAttrs(3))(({ theme }) => ({
   ...theme.typography.title3,
   color: theme.colors.black,
 }))
 
-const Title4 = styled(RNText).attrs(() => getTitleAttrs(4))(({ theme }) => ({
+const Title4 = styled(RNText).attrs(() => getHeadingAttrs(4))(({ theme }) => ({
   ...theme.typography.title4,
   color: theme.colors.black,
 }))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12843

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
