### PR TITLE
(PC-13506) fix(bookings): on web, fix booking details page

### DIFF
--- a/src/libs/network/__mocks__/useNetwork.web.ts
+++ b/src/libs/network/__mocks__/useNetwork.web.ts
@@ -1,0 +1,3 @@
+export const useNetwork = () => {
+  return { isConnected: true }
+}

--- a/src/libs/network/useNetwork.web.ts
+++ b/src/libs/network/useNetwork.web.ts
@@ -1,0 +1,11 @@
+// useNetwork is used on mobile to disable network requests when the user is offline.
+// (example: `enabled: network.isConnected`)
+// by default on mobile, upon initialization, whilst networkInfo.isConnected is null,
+// we consider that we don't have network yet. This is useful when we start the application without network
+// since it would crash if trying to do a network request while offline.
+
+// on web, we don't have caching and we don't use network connection info.
+// if the network is down, we just let the query fail (this will not crash)
+export const useNetwork = () => {
+  return { isConnected: true }
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13506

## Bug

Le problème était uniquement sur web et apparaissait quand on consultais le détail d'une réservation sans appeler `/bookings` avant.
Ceci se passait dans 2 cas:
- après un refresh de l'app: accéder au détail d'une réservation depuis la home ou la recherche
- après un refresh de l'app: accéder au détail d'une réservation directement avec l'url.

Idéalement il faudrait revoir le système de caching des réservations dans react-query. Pour l'instant il y a une seule clef utilisée `QueryKeys.BOOKINGS` et pour avoir un booking on va chercher dans cet les bookings (ongoing ou ended). Ce serait avantageux d'avoir une clef `[QueryKeys.BOOKING, bookingId]` comme les offres pour ne pas avoir à requêter tous les bookings lors de la consultation d'une réservation, mais il faudrait faire un chantier backend avant. 

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).