### PR TITLE
(PC-13502) fix(Search): allow removal of locationFilter in current and staged search

### DIFF
--- a/src/features/search/atoms/NumberOfResults.tsx
+++ b/src/features/search/atoms/NumberOfResults.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components/native'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { LocationType } from 'features/search/enums'
-import { useSearch } from 'features/search/pages/SearchWrapper'
+import { useSearch, useStagedSearch } from 'features/search/pages/SearchWrapper'
 import { LocationFilter } from 'features/search/types'
 import { useGeolocation } from 'libs/geolocation'
 import { ClippedTag } from 'ui/components/ClippedTag'
@@ -19,6 +19,7 @@ interface Props {
 export const NumberOfResults: React.FC<Props> = ({ nbHits }) => {
   const { navigate } = useNavigation<UseNavigationType>()
   const { searchState } = useSearch()
+  const { dispatch: dispatchStagedSearch } = useStagedSearch()
   const { position } = useGeolocation()
 
   const venueLabel =
@@ -31,6 +32,10 @@ export const NumberOfResults: React.FC<Props> = ({ nbHits }) => {
       ? { locationType: LocationType.AROUND_ME, aroundRadius: 100 }
       : { locationType: LocationType.EVERYWHERE }
 
+    // this reset staged in case of new search
+    dispatchStagedSearch({ type: 'SET_STATE_FROM_NAVIGATE', payload: { locationFilter } })
+
+    // this reset current search results
     navigate(...getTabNavConfig('Search', { locationFilter }))
   }, [!position])
 

--- a/src/features/search/atoms/__tests__/NumberOfResults.native.test.tsx
+++ b/src/features/search/atoms/__tests__/NumberOfResults.native.test.tsx
@@ -20,8 +20,14 @@ let mockLocationFilter: LocationFilter = {
   locationType: LocationType.VENUE,
   venue: mockedSuggestedVenues[0],
 }
+
+const mockStagedSearchDispatch = jest.fn()
+
 jest.mock('features/search/pages/SearchWrapper', () => ({
   useSearch: () => ({ searchState: { locationFilter: mockLocationFilter } }),
+  useStagedSearch: () => ({
+    dispatch: mockStagedSearchDispatch,
+  }),
 }))
 
 describe('NumberOfResults component', () => {
@@ -51,9 +57,15 @@ describe('NumberOfResults component', () => {
 
       fireEvent.press(getByTestId('Enlever le lieu'))
 
+      const params = { locationFilter: { locationType: LocationType.EVERYWHERE } }
+      expect(mockStagedSearchDispatch).toBeCalledWith({
+        type: 'SET_STATE_FROM_NAVIGATE',
+        payload: params,
+      })
+
       expect(navigate).toBeCalledWith('TabNavigator', {
         screen: 'Search',
-        params: { locationFilter: { locationType: LocationType.EVERYWHERE } },
+        params,
       })
     })
 

--- a/src/features/search/atoms/__tests__/NumberOfResults.web.test.tsx
+++ b/src/features/search/atoms/__tests__/NumberOfResults.web.test.tsx
@@ -20,8 +20,14 @@ let mockLocationFilter: LocationFilter = {
   locationType: LocationType.VENUE,
   venue: mockedSuggestedVenues[0],
 }
+
+const mockStagedSearchDispatch = jest.fn()
+
 jest.mock('features/search/pages/SearchWrapper', () => ({
   useSearch: () => ({ searchState: { locationFilter: mockLocationFilter } }),
+  useStagedSearch: () => ({
+    dispatch: mockStagedSearchDispatch,
+  }),
 }))
 
 describe('NumberOfResults component', () => {
@@ -63,9 +69,15 @@ describe('NumberOfResults component', () => {
 
       fireEvent.click(getByTestId('Enlever le lieu'))
 
+      const params = { locationFilter: { locationType: LocationType.AROUND_ME, aroundRadius: 100 } }
+      expect(mockStagedSearchDispatch).toBeCalledWith({
+        type: 'SET_STATE_FROM_NAVIGATE',
+        payload: params,
+      })
+
       expect(navigate).toBeCalledWith('TabNavigator', {
         screen: 'Search',
-        params: { locationFilter: { locationType: LocationType.AROUND_ME, aroundRadius: 100 } },
+        params,
       })
     })
   })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13502

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
