### PR TITLE
(PC-13501) feat(accessibility): Keep single focus when link wraps a component

### DIFF
--- a/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.web.test.tsx.web-snap
@@ -204,6 +204,7 @@ Object {
                                           <a
                                             class="sc-dkPtRN ivluxN"
                                             href="https://passculture-reset-password.faq"
+                                            tabindex="-1"
                                             target="_blank"
                                           >
                                             <button
@@ -518,6 +519,7 @@ Object {
                                         <a
                                           class="sc-dkPtRN ivluxN"
                                           href="https://passculture-reset-password.faq"
+                                          tabindex="-1"
                                           target="_blank"
                                         >
                                           <button

--- a/__snapshots__/features/home/components/tests/ExclusivityModule.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/tests/ExclusivityModule.native.test.tsx.native-snap
@@ -71,7 +71,7 @@ exports[`ExclusivityModule component should render correctly 1`] = `
       >
         <FastImageView
           accessibilityLabel="Image d'Adèle"
-          accessible={true}
+          accessible={false}
           resizeMode="cover"
           source={
             Object {

--- a/__snapshots__/features/home/components/tests/ExclusivityModule.web.test.tsx.web-snap
+++ b/__snapshots__/features/home/components/tests/ExclusivityModule.web.test.tsx.web-snap
@@ -27,6 +27,7 @@ Object {
               class="css-text-901oao"
               dir="auto"
               style="display: flex; flex-direction: column;"
+              tabindex="-1"
             />
           </div>
         </div>
@@ -60,6 +61,7 @@ Object {
             class="css-text-901oao"
             dir="auto"
             style="display: flex; flex-direction: column;"
+            tabindex="-1"
           />
         </div>
       </div>

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckDMS.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckDMS.test.tsx.web-snap
@@ -324,6 +324,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                 <a
                   className="sc-gKclnd bWYkKD"
                   href="https://dmsfrenchcitizen"
+                  tabIndex={-1}
                   target="_blank"
                 >
                   <button
@@ -441,6 +442,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                 <a
                   className="sc-gKclnd bWYkKD"
                   href="https://dmsforeigncitizen"
+                  tabIndex={-1}
                   target="_blank"
                 >
                   <button

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetSchoolType.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetSchoolType.web.test.tsx.web-snap
@@ -229,7 +229,9 @@ Object {
                   style="background-color: rgb(255, 255, 255); bottom: 0px; left: 0px; padding: 12px 20px 20px 20px; position: absolute; right: 0px;"
                 >
                   <button
+                    aria-label="Choisis ton statut"
                     class="sc-bdvvtL kwQCoR sc-hKwDye gqAQWB"
+                    data-testid="Choisis ton statut"
                     disabled=""
                     type="button"
                   >
@@ -493,7 +495,9 @@ Object {
                 style="background-color: rgb(255, 255, 255); bottom: 0px; left: 0px; padding: 12px 20px 20px 20px; position: absolute; right: 0px;"
               >
                 <button
+                  aria-label="Choisis ton statut"
                   class="sc-bdvvtL kwQCoR sc-hKwDye gqAQWB"
+                  data-testid="Choisis ton statut"
                   disabled=""
                   type="button"
                 >
@@ -750,7 +754,9 @@ Object {
                   style="background-color: rgb(255, 255, 255); bottom: 0px; left: 0px; padding: 12px 20px 20px 20px; position: absolute; right: 0px;"
                 >
                   <button
+                    aria-label="Choisis ton statut"
                     class="sc-bdvvtL kwQCoR sc-hKwDye gqAQWB"
+                    data-testid="Choisis ton statut"
                     disabled=""
                     type="button"
                   >
@@ -950,7 +956,9 @@ Object {
                 style="background-color: rgb(255, 255, 255); bottom: 0px; left: 0px; padding: 12px 20px 20px 20px; position: absolute; right: 0px;"
               >
                 <button
+                  aria-label="Choisis ton statut"
                   class="sc-bdvvtL kwQCoR sc-hKwDye gqAQWB"
+                  data-testid="Choisis ton statut"
                   disabled=""
                   type="button"
                 >

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/Status.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/Status.web.test.tsx.web-snap
@@ -287,7 +287,9 @@ Object {
                   style="background-color: rgb(255, 255, 255); bottom: 0px; left: 0px; padding: 12px 20px 20px 20px; position: absolute; right: 0px;"
                 >
                   <button
+                    aria-label="Choisis ton statut"
                     class="sc-bdvvtL kwQCoR sc-gsDKAQ lkBHtq"
+                    data-testid="Choisis ton statut"
                     disabled=""
                     type="button"
                   >
@@ -609,7 +611,9 @@ Object {
                 style="background-color: rgb(255, 255, 255); bottom: 0px; left: 0px; padding: 12px 20px 20px 20px; position: absolute; right: 0px;"
               >
                 <button
+                  aria-label="Choisis ton statut"
                   class="sc-bdvvtL kwQCoR sc-gsDKAQ lkBHtq"
+                  data-testid="Choisis ton statut"
                   disabled=""
                   type="button"
                 >

--- a/__snapshots__/features/offer/atoms/__tests__/OfferTile.web.test.tsx.web-snap
+++ b/__snapshots__/features/offer/atoms/__tests__/OfferTile.web.test.tsx.web-snap
@@ -20,6 +20,7 @@ Object {
             class="css-text-901oao"
             dir="auto"
             style="display: flex; flex-direction: column;"
+            tabindex="-1"
           >
             <div
               class="css-view-1dbjc4n"
@@ -102,6 +103,7 @@ Object {
           class="css-text-901oao"
           dir="auto"
           style="display: flex; flex-direction: column;"
+          tabindex="-1"
         >
           <div
             class="css-view-1dbjc4n"

--- a/__snapshots__/features/profile/pages/LegalNotices/tests/LegalNotices.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/LegalNotices/tests/LegalNotices.web.test.tsx.web-snap
@@ -83,6 +83,7 @@ Object {
         <a
           class="sc-jRQBWg cmDpap"
           href="https://passculture.cgu"
+          tabindex="-1"
           target="_blank"
         >
           <div
@@ -136,6 +137,7 @@ Object {
         <a
           class="sc-jRQBWg cmDpap"
           href="https://passculture.data-privacy-chart"
+          tabindex="-1"
           target="_blank"
         >
           <div
@@ -311,6 +313,7 @@ Object {
       <a
         class="sc-jRQBWg cmDpap"
         href="https://passculture.cgu"
+        tabindex="-1"
         target="_blank"
       >
         <div
@@ -364,6 +367,7 @@ Object {
       <a
         class="sc-jRQBWg cmDpap"
         href="https://passculture.data-privacy-chart"
+        tabindex="-1"
         target="_blank"
       >
         <div

--- a/__snapshots__/features/venue/atoms/__tests__/VenueOfferTile.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/atoms/__tests__/VenueOfferTile.web.test.tsx.web-snap
@@ -20,6 +20,7 @@ Object {
             class="css-text-901oao"
             dir="auto"
             style="display: flex; flex-direction: column;"
+            tabindex="-1"
           >
             <div
               class="css-view-1dbjc4n"
@@ -86,6 +87,7 @@ Object {
           class="css-text-901oao"
           dir="auto"
           style="display: flex; flex-direction: column;"
+          tabindex="-1"
         >
           <div
             class="css-view-1dbjc4n"

--- a/__snapshots__/features/venue/components/__tests__/VenueOffers.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/components/__tests__/VenueOffers.web.test.tsx.web-snap
@@ -42,6 +42,7 @@ Object {
           <div
             class="css-text-901oao"
             dir="auto"
+            tabindex="-1"
           >
             <div
               aria-label="Voir plus d’offres de la sélection Offres"
@@ -117,6 +118,7 @@ Object {
                       class="css-text-901oao"
                       dir="auto"
                       style="display: flex; flex-direction: column;"
+                      tabindex="-1"
                     >
                       <div
                         class="css-view-1dbjc4n"
@@ -189,6 +191,7 @@ Object {
                       class="css-text-901oao"
                       dir="auto"
                       style="display: flex; flex-direction: column;"
+                      tabindex="-1"
                     >
                       <div
                         class="css-view-1dbjc4n"
@@ -261,6 +264,7 @@ Object {
                       class="css-text-901oao"
                       dir="auto"
                       style="display: flex; flex-direction: column;"
+                      tabindex="-1"
                     >
                       <div
                         class="css-view-1dbjc4n"
@@ -330,6 +334,7 @@ Object {
           class="css-text-901oao"
           dir="auto"
           style="display: flex; flex-direction: column;"
+          tabindex="-1"
         >
           <button
             class="sc-kDTinF gRNtfL"
@@ -393,6 +398,7 @@ Object {
         <div
           class="css-text-901oao"
           dir="auto"
+          tabindex="-1"
         >
           <div
             aria-label="Voir plus d’offres de la sélection Offres"
@@ -468,6 +474,7 @@ Object {
                     class="css-text-901oao"
                     dir="auto"
                     style="display: flex; flex-direction: column;"
+                    tabindex="-1"
                   >
                     <div
                       class="css-view-1dbjc4n"
@@ -540,6 +547,7 @@ Object {
                     class="css-text-901oao"
                     dir="auto"
                     style="display: flex; flex-direction: column;"
+                    tabindex="-1"
                   >
                     <div
                       class="css-view-1dbjc4n"
@@ -612,6 +620,7 @@ Object {
                     class="css-text-901oao"
                     dir="auto"
                     style="display: flex; flex-direction: column;"
+                    tabindex="-1"
                   >
                     <div
                       class="css-view-1dbjc4n"
@@ -681,6 +690,7 @@ Object {
         class="css-text-901oao"
         dir="auto"
         style="display: flex; flex-direction: column;"
+        tabindex="-1"
       >
         <button
           class="sc-kDTinF gRNtfL"

--- a/__snapshots__/features/venue/pages/__tests__/Venue.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/pages/__tests__/Venue.web.test.tsx.web-snap
@@ -498,6 +498,7 @@ Object {
                       <a
                         class="sc-iCfMLu iaRsUK"
                         href="https://pass.culture.fr/"
+                        tabindex="-1"
                         target="_blank"
                       >
                         <span
@@ -574,6 +575,7 @@ Object {
                   <div
                     class="css-text-901oao"
                     dir="auto"
+                    tabindex="-1"
                   >
                     <div
                       aria-label="Voir plus d’offres de la sélection Offres"
@@ -649,6 +651,7 @@ Object {
                               class="css-text-901oao"
                               dir="auto"
                               style="display: flex; flex-direction: column;"
+                              tabindex="-1"
                             >
                               <div
                                 class="css-view-1dbjc4n"
@@ -721,6 +724,7 @@ Object {
                               class="css-text-901oao"
                               dir="auto"
                               style="display: flex; flex-direction: column;"
+                              tabindex="-1"
                             >
                               <div
                                 class="css-view-1dbjc4n"
@@ -793,6 +797,7 @@ Object {
                               class="css-text-901oao"
                               dir="auto"
                               style="display: flex; flex-direction: column;"
+                              tabindex="-1"
                             >
                               <div
                                 class="css-view-1dbjc4n"
@@ -862,6 +867,7 @@ Object {
                   class="css-text-901oao"
                   dir="auto"
                   style="display: flex; flex-direction: column;"
+                  tabindex="-1"
                 >
                   <button
                     class="sc-iqseJM fzmVpo"
@@ -942,6 +948,7 @@ Object {
                   <a
                     class="sc-iCfMLu iaRsUK"
                     href="https://www.google.com/maps/dir/?api=1&destination=1%20boulevard%20Poissonni%C3%A8re"
+                    tabindex="-1"
                     target="_blank"
                   >
                     <div
@@ -1035,6 +1042,7 @@ Object {
                   <a
                     class="sc-iCfMLu iaRsUK"
                     href="https://test.com"
+                    tabindex="-1"
                     target="_blank"
                   >
                     <span
@@ -1950,6 +1958,7 @@ Object {
                     <a
                       class="sc-iCfMLu iaRsUK"
                       href="https://pass.culture.fr/"
+                      tabindex="-1"
                       target="_blank"
                     >
                       <span
@@ -2026,6 +2035,7 @@ Object {
                 <div
                   class="css-text-901oao"
                   dir="auto"
+                  tabindex="-1"
                 >
                   <div
                     aria-label="Voir plus d’offres de la sélection Offres"
@@ -2101,6 +2111,7 @@ Object {
                             class="css-text-901oao"
                             dir="auto"
                             style="display: flex; flex-direction: column;"
+                            tabindex="-1"
                           >
                             <div
                               class="css-view-1dbjc4n"
@@ -2173,6 +2184,7 @@ Object {
                             class="css-text-901oao"
                             dir="auto"
                             style="display: flex; flex-direction: column;"
+                            tabindex="-1"
                           >
                             <div
                               class="css-view-1dbjc4n"
@@ -2245,6 +2257,7 @@ Object {
                             class="css-text-901oao"
                             dir="auto"
                             style="display: flex; flex-direction: column;"
+                            tabindex="-1"
                           >
                             <div
                               class="css-view-1dbjc4n"
@@ -2314,6 +2327,7 @@ Object {
                 class="css-text-901oao"
                 dir="auto"
                 style="display: flex; flex-direction: column;"
+                tabindex="-1"
               >
                 <button
                   class="sc-iqseJM fzmVpo"
@@ -2394,6 +2408,7 @@ Object {
                 <a
                   class="sc-iCfMLu iaRsUK"
                   href="https://www.google.com/maps/dir/?api=1&destination=1%20boulevard%20Poissonni%C3%A8re"
+                  tabindex="-1"
                   target="_blank"
                 >
                   <div
@@ -2487,6 +2502,7 @@ Object {
                 <a
                   class="sc-iCfMLu iaRsUK"
                   href="https://test.com"
+                  tabindex="-1"
                   target="_blank"
                 >
                   <span

--- a/__snapshots__/features/venue/pages/__tests__/VenueBody.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/pages/__tests__/VenueBody.web.test.tsx.web-snap
@@ -337,6 +337,7 @@ Object {
                     <a
                       class="sc-jrQzAO gbtGqz"
                       href="https://pass.culture.fr/"
+                      tabindex="-1"
                       target="_blank"
                     >
                       <span
@@ -413,6 +414,7 @@ Object {
                 <div
                   class="css-text-901oao"
                   dir="auto"
+                  tabindex="-1"
                 >
                   <div
                     aria-label="Voir plus d’offres de la sélection Offres"
@@ -488,6 +490,7 @@ Object {
                             class="css-text-901oao"
                             dir="auto"
                             style="display: flex; flex-direction: column;"
+                            tabindex="-1"
                           >
                             <div
                               class="css-view-1dbjc4n"
@@ -560,6 +563,7 @@ Object {
                             class="css-text-901oao"
                             dir="auto"
                             style="display: flex; flex-direction: column;"
+                            tabindex="-1"
                           >
                             <div
                               class="css-view-1dbjc4n"
@@ -632,6 +636,7 @@ Object {
                             class="css-text-901oao"
                             dir="auto"
                             style="display: flex; flex-direction: column;"
+                            tabindex="-1"
                           >
                             <div
                               class="css-view-1dbjc4n"
@@ -701,6 +706,7 @@ Object {
                 class="css-text-901oao"
                 dir="auto"
                 style="display: flex; flex-direction: column;"
+                tabindex="-1"
               >
                 <button
                   class="sc-bqiRlB jxxkPX"
@@ -781,6 +787,7 @@ Object {
                 <a
                   class="sc-jrQzAO gbtGqz"
                   href="https://www.google.com/maps/dir/?api=1&destination=1%20boulevard%20Poissonni%C3%A8re"
+                  tabindex="-1"
                   target="_blank"
                 >
                   <div
@@ -874,6 +881,7 @@ Object {
                 <a
                   class="sc-jrQzAO gbtGqz"
                   href="https://test.com"
+                  tabindex="-1"
                   target="_blank"
                 >
                   <span
@@ -1626,6 +1634,7 @@ Object {
                   <a
                     class="sc-jrQzAO gbtGqz"
                     href="https://pass.culture.fr/"
+                    tabindex="-1"
                     target="_blank"
                   >
                     <span
@@ -1702,6 +1711,7 @@ Object {
               <div
                 class="css-text-901oao"
                 dir="auto"
+                tabindex="-1"
               >
                 <div
                   aria-label="Voir plus d’offres de la sélection Offres"
@@ -1777,6 +1787,7 @@ Object {
                           class="css-text-901oao"
                           dir="auto"
                           style="display: flex; flex-direction: column;"
+                          tabindex="-1"
                         >
                           <div
                             class="css-view-1dbjc4n"
@@ -1849,6 +1860,7 @@ Object {
                           class="css-text-901oao"
                           dir="auto"
                           style="display: flex; flex-direction: column;"
+                          tabindex="-1"
                         >
                           <div
                             class="css-view-1dbjc4n"
@@ -1921,6 +1933,7 @@ Object {
                           class="css-text-901oao"
                           dir="auto"
                           style="display: flex; flex-direction: column;"
+                          tabindex="-1"
                         >
                           <div
                             class="css-view-1dbjc4n"
@@ -1990,6 +2003,7 @@ Object {
               class="css-text-901oao"
               dir="auto"
               style="display: flex; flex-direction: column;"
+              tabindex="-1"
             >
               <button
                 class="sc-bqiRlB jxxkPX"
@@ -2070,6 +2084,7 @@ Object {
               <a
                 class="sc-jrQzAO gbtGqz"
                 href="https://www.google.com/maps/dir/?api=1&destination=1%20boulevard%20Poissonni%C3%A8re"
+                tabindex="-1"
                 target="_blank"
               >
                 <div
@@ -2163,6 +2178,7 @@ Object {
               <a
                 class="sc-jrQzAO gbtGqz"
                 href="https://test.com"
+                tabindex="-1"
                 target="_blank"
               >
                 <span

--- a/__snapshots__/libs/geolocation/components/__tests__/WhereSection.test.tsx.web-snap
+++ b/__snapshots__/libs/geolocation/components/__tests__/WhereSection.test.tsx.web-snap
@@ -40,6 +40,7 @@ Array [
           "msFlexDirection": "column",
         }
       }
+      tabIndex="-1"
     >
       <div
         className="css-view-1dbjc4n"
@@ -244,6 +245,7 @@ Array [
     <a
       className="sc-iCfMLu iaRsUK"
       href="https://www.google.com/maps/dir/?api=1&destination=1%20boulevard%20Poissonni%C3%A8re"
+      tabIndex={-1}
       target="_blank"
     >
       <div
@@ -311,7 +313,7 @@ exports[`WhereSection should render correctly 2`] = `
 - First value
 + Second value
 
-@@ -24,10 +24,163 @@
+@@ -24,10 +24,164 @@
         }
       />
       <div
@@ -328,6 +330,7 @@ exports[`WhereSection should render correctly 2`] = `
 +           \\"msFlexDirection\\": \\"column\\",
 +         }
 +       }
++       tabIndex=\\"-1\\"
 +     >
 +       <div
 +         className=\\"css-view-1dbjc4n\\"

--- a/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.web-snap
+++ b/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.web-snap
@@ -196,6 +196,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
     <a
       className="sc-gKclnd bWYkKD"
       href="https://passculture.zendesk.com/hc/fr/"
+      tabIndex={-1}
       target="_blank"
     >
       <button

--- a/src/features/bookings/components/BookingDetailsTicketContent.tsx
+++ b/src/features/bookings/components/BookingDetailsTicketContent.tsx
@@ -2,6 +2,7 @@ import { t } from '@lingui/macro'
 import * as React from 'react'
 import { Platform, View } from 'react-native'
 import QRCode from 'react-native-qrcode-svg'
+import webStyled from 'styled-components'
 import styled from 'styled-components/native'
 
 import { CategoryIdEnum, BookingOfferResponse, BookingReponse } from 'api/gen'
@@ -36,14 +37,14 @@ export const BookingDetailsTicketContent = (props: BookingDetailsTicketContentPr
   const shouldDisplayEAN = offer.extraData?.isbn && categoryId === CategoryIdEnum.LIVRE
 
   const accessOfferButton = (
-    <A href={offer.url || undefined}>
+    <StyledA href={offer.url || undefined}>
       <ButtonWithLinearGradient
         wording={t`Accéder à l'offre`}
         isExternal
         isDisabled={false}
         onPress={accessExternalOffer}
       />
-    </A>
+    </StyledA>
   )
 
   const isDigitalAndActivationCodeEnabled =
@@ -130,4 +131,9 @@ const EANContainer = styled.View({
   marginTop: getSpacing(3),
   alignItems: 'center',
   justifyContent: 'center',
+})
+
+const StyledA = webStyled(A)({
+  display: 'flex',
+  flexDirection: 'column',
 })

--- a/src/features/bookings/components/EndedBookingItem.tsx
+++ b/src/features/bookings/components/EndedBookingItem.tsx
@@ -53,7 +53,9 @@ export const EndedBookingItem = ({ booking }: BookingItemProps) => {
   }
 
   return (
-    <Link to={{ screen: 'Offer', params: { id: stock.offer.id, from: 'endedbookings' } }}>
+    <Link
+      to={{ screen: 'Offer', params: { id: stock.offer.id, from: 'endedbookings' } }}
+      accessible={false}>
       <TouchableOpacity onPress={handlePressOffer} testID="EndedBookingItem">
         <ItemContainer>
           <EndedBookingTicket image={stock.offer.image?.url} categoryId={categoryId} />

--- a/src/features/bookings/components/OnGoingBookingItem.tsx
+++ b/src/features/bookings/components/OnGoingBookingItem.tsx
@@ -28,7 +28,10 @@ export const OnGoingBookingItem = ({ booking }: BookingItemProps) => {
   const { dateLabel, withdrawLabel } = getBookingLabels(booking, bookingProperties, settings)
 
   return (
-    <Link to={{ screen: 'BookingDetails', params: { id: booking.id } }} style={styles.link}>
+    <Link
+      to={{ screen: 'BookingDetails', params: { id: booking.id } }}
+      style={styles.link}
+      accessible={false}>
       <Container
         onPress={() => navigate('BookingDetails', { id: booking.id })}
         testID="OnGoingBookingItem">

--- a/src/features/bookings/pages/BookingDetails.tsx
+++ b/src/features/bookings/pages/BookingDetails.tsx
@@ -179,7 +179,8 @@ export function BookingDetails() {
           <Spacer.Column numberOfSpaces={8} />
           <Link
             to={{ screen: 'Offer', params: { id: offer.id, from: 'bookingdetails' } }}
-            style={styles.link}>
+            style={styles.link}
+            accessible={false}>
             <ButtonPrimary
               testID="Voir le détail de l’offre"
               wording={t`Voir le détail de l’offre`}

--- a/src/features/bookings/pages/EndedBookingsSection.tsx
+++ b/src/features/bookings/pages/EndedBookingsSection.tsx
@@ -30,7 +30,10 @@ export const EndedBookingsSection: React.FC<{ endedBookings?: Booking[] }> = (pr
       <Separator />
       <Spacer.Column numberOfSpaces={4} />
       <EndedBookingsSectionWrapper>
-        <Link to={{ screen: 'EndedBookings', params: undefined }} style={styles.link}>
+        <Link
+          to={{ screen: 'EndedBookings', params: undefined }}
+          style={styles.link}
+          accessible={false}>
           <SectionRow
             type="navigable"
             title={endedBookingsLabel}

--- a/src/features/favorites/atoms/Favorite.tsx
+++ b/src/features/favorites/atoms/Favorite.tsx
@@ -129,7 +129,9 @@ export const Favorite: React.FC<Props> = (props) => {
           : undefined,
       }}>
       <Container onPress={handlePressOffer} testID="favorite">
-        <Link to={{ screen: 'Offer', params: { id: offer.id, from: 'favorites' } }}>
+        <Link
+          to={{ screen: 'Offer', params: { id: offer.id, from: 'favorites' } }}
+          accessible={false}>
           <Row>
             <OfferImage imageUrl={offer.image?.url} categoryId={categoryId} />
             <Spacer.Row numberOfSpaces={4} />

--- a/src/features/home/components/ExclusivityModule.tsx
+++ b/src/features/home/components/ExclusivityModule.tsx
@@ -41,8 +41,11 @@ export const ExclusivityModule = ({
       <Spacer.Row numberOfSpaces={6} />
       <ImageContainer>
         <TouchableHighlight onPress={handlePressExclu} testID="imageExclu">
-          <Link to={{ screen: 'Offer', params: { id, from: 'home' } }} style={styles.link}>
-            <Image source={source} accessible={!!alt} accessibilityLabel={alt} />
+          <Link
+            to={{ screen: 'Offer', params: { id, from: 'home' } }}
+            style={styles.link}
+            accessible={false}>
+            <Image source={source} accessible={false} accessibilityLabel={alt} />
           </Link>
         </TouchableHighlight>
       </ImageContainer>

--- a/src/features/home/components/OffersModule.tsx
+++ b/src/features/home/components/OffersModule.tsx
@@ -93,7 +93,7 @@ export const OffersModule = (props: OffersModuleProps) => {
   const renderFooter: RenderFooterItem = useCallback(
     ({ width, height }) => {
       return (
-        <Link to={{ screen: 'Search', params }}>
+        <Link to={{ screen: 'Search', params }} accessible={false}>
           <SeeMore width={width} height={height} onPress={onPressSeeMore as () => void} />
         </Link>
       )
@@ -103,7 +103,11 @@ export const OffersModule = (props: OffersModuleProps) => {
 
   const renderTitleSeeMore = useCallback(
     ({ children }: { children: ReactNode }) => {
-      return <Link to={{ screen: 'Search', params }}>{children}</Link>
+      return (
+        <Link to={{ screen: 'Search', params }} accessible={false}>
+          {children}
+        </Link>
+      )
     },
     [onPressSeeMore, params]
   )

--- a/src/features/identityCheck/pages/profile/SetSchoolType.tsx
+++ b/src/features/identityCheck/pages/profile/SetSchoolType.tsx
@@ -73,6 +73,9 @@ export const SetSchoolType = () => {
         <ButtonPrimary
           onPress={onPressContinue}
           wording={!selectedSchoolTypeId ? t`Choisis ton statut` : t`Continuer`}
+          accessibilityLabel={
+            !selectedSchoolTypeId ? t`Choisis ton statut` : t`Continuer vers l'étape suivante`
+          }
           disabled={!selectedSchoolTypeId}
         />
       }

--- a/src/features/identityCheck/pages/profile/Status.tsx
+++ b/src/features/identityCheck/pages/profile/Status.tsx
@@ -74,6 +74,9 @@ export const Status = () => {
         <ButtonPrimary
           onPress={submitStatus}
           wording={!selectedStatus ? t`Choisis ton statut` : t`Continuer`}
+          accessibilityLabel={
+            !selectedStatus ? t`Choisis ton statut` : t`Continuer vers l'étape suivante`
+          }
           disabled={!selectedStatus}
         />
       }

--- a/src/features/navigation/RootNavigator/Header/Header.web.tsx
+++ b/src/features/navigation/RootNavigator/Header/Header.web.tsx
@@ -85,7 +85,7 @@ export const Header = memo(function Header() {
     <HeaderContainer>
       <LeftContainer margin={margin} isVisible={!!isDesktopOffset} style={fadeAnim}>
         <LogoContainer onPress={navigateToHome}>
-          <Link to={{ screen: homeNavConfig[0], params: homeNavConfig[1] }}>
+          <Link to={{ screen: homeNavConfig[0], params: homeNavConfig[1] }} accessible={false}>
             <LogoPassCulture
               color={theme.uniqueColors.brand}
               height={getSpacing(10)}

--- a/src/features/offer/atoms/OfferSeeMore.tsx
+++ b/src/features/offer/atoms/OfferSeeMore.tsx
@@ -25,7 +25,7 @@ export const OfferSeeMore: React.FC<Props> = ({ id, longWording = false }) => {
 
   return (
     <Container>
-      <Link to={{ screen: 'OfferDescription', params: { id } }}>
+      <Link to={{ screen: 'OfferDescription', params: { id } }} accessible={false}>
         <ButtonTertiaryBlack
           inline
           testID="description-details-button"

--- a/src/features/offer/atoms/OfferTile.tsx
+++ b/src/features/offer/atoms/OfferTile.tsx
@@ -109,7 +109,8 @@ export const OfferTile = (props: OfferTileProps) => {
         {...accessibilityAndTestId('offerTile')}>
         <Link
           to={{ screen: 'Offer', params: { id: offerId, from: analyticsFrom, moduleName } }}
-          style={styles.link}>
+          style={styles.link}
+          accessible={false}>
           <ImageTile
             width={width}
             height={height - IMAGE_CAPTION_HEIGHT}

--- a/src/features/offer/pages/Offer.tsx
+++ b/src/features/offer/pages/Offer.tsx
@@ -1,5 +1,6 @@
 import { useRoute } from '@react-navigation/native'
 import React, { FunctionComponent } from 'react'
+import webStyled from 'styled-components'
 import styled from 'styled-components/native'
 
 import { BookingOfferModal } from 'features/bookOffer/pages/BookingOfferModal'
@@ -63,7 +64,7 @@ export const Offer: FunctionComponent = () => {
       <OfferBody offerId={offerId} onScroll={onScroll} />
       {!!wording && (
         <CallToActionContainer testID="CTA-button" style={{ paddingBottom: bottom }}>
-          <A href={isExternal ? url : undefined}>
+          <StyledA href={isExternal ? url : undefined}>
             <ButtonWithLinearGradient
               wording={wording}
               onPress={() => {
@@ -75,7 +76,7 @@ export const Offer: FunctionComponent = () => {
               isExternal={isExternal}
               isDisabled={onPressCTA === undefined}
             />
-          </A>
+          </StyledA>
         </CallToActionContainer>
       )}
 
@@ -96,4 +97,9 @@ const Container = styled.View(({ theme }) => ({
 const CallToActionContainer = styled.View({
   marginHorizontal: getSpacing(6),
   marginBottom: getSpacing(8),
+})
+
+const StyledA = webStyled(A)({
+  display: 'flex',
+  flexDirection: 'column',
 })

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -119,7 +119,10 @@ export const Profile: React.FC = () => {
         <Section title={isLoggedIn ? t`Paramètres du compte` : t`Paramètres de l'application`}>
           {!!isLoggedIn && (
             <React.Fragment>
-              <Link to={{ screen: 'PersonalData', params: undefined }} style={styles.link}>
+              <Link
+                to={{ screen: 'PersonalData', params: undefined }}
+                style={styles.link}
+                accessible={false}>
                 <Row
                   title={t`Informations personnelles`}
                   type="navigable"
@@ -127,7 +130,10 @@ export const Profile: React.FC = () => {
                   icon={ProfileIcon}
                 />
               </Link>
-              <Link to={{ screen: 'ChangePassword', params: undefined }} style={styles.link}>
+              <Link
+                to={{ screen: 'ChangePassword', params: undefined }}
+                style={styles.link}
+                accessible={false}>
                 <Row
                   title={t`Mot de passe`}
                   type="navigable"
@@ -137,7 +143,10 @@ export const Profile: React.FC = () => {
               </Link>
             </React.Fragment>
           )}
-          <Link to={{ screen: 'NotificationSettings', params: undefined }} style={styles.link}>
+          <Link
+            to={{ screen: 'NotificationSettings', params: undefined }}
+            style={styles.link}
+            accessible={false}>
             <Row
               type="navigable"
               title={t`Notifications`}
@@ -170,7 +179,8 @@ export const Profile: React.FC = () => {
         <Section title={t`Aides`}>
           <Link
             to={{ screen: 'FirstTutorial', params: { shouldCloseAppOnBackAction: false } }}
-            style={styles.link}>
+            style={styles.link}
+            accessible={false}>
             <Row
               title={t`Comment ça marche\u00a0?`}
               type="navigable"
@@ -196,7 +206,10 @@ export const Profile: React.FC = () => {
               icon={ExternalSite}
             />
           </A>
-          <Link to={{ screen: 'LegalNotices', params: undefined }} style={styles.link}>
+          <Link
+            to={{ screen: 'LegalNotices', params: undefined }}
+            style={styles.link}
+            accessible={false}>
             <Row
               title={t`Mentions légales`}
               type="navigable"
@@ -204,7 +217,10 @@ export const Profile: React.FC = () => {
               icon={LegalNotices}
             />
           </Link>
-          <Link to={{ screen: 'ConsentSettings', params: undefined }} style={styles.link}>
+          <Link
+            to={{ screen: 'ConsentSettings', params: undefined }}
+            style={styles.link}
+            accessible={false}>
             <Row
               title={t`Confidentialité`}
               type="navigable"

--- a/src/features/search/atoms/Hit.tsx
+++ b/src/features/search/atoms/Hit.tsx
@@ -60,7 +60,10 @@ export const Hit: React.FC<Props> = ({ hit, query }) => {
 
   return (
     <Container onPress={handlePressOffer} testID="offerHit">
-      <Link to={{ screen: 'Offer', params: { id: offerId, from: 'search' } }} style={styles.link}>
+      <Link
+        to={{ screen: 'Offer', params: { id: offerId, from: 'search' } }}
+        style={styles.link}
+        accessible={false}>
         <OfferImage imageUrl={offer.thumbUrl} categoryId={categoryId} />
         <Spacer.Row numberOfSpaces={4} />
         <Column>

--- a/src/features/venue/components/VenueOffers.tsx
+++ b/src/features/venue/components/VenueOffers.tsx
@@ -84,7 +84,7 @@ export const VenueOffers: React.FC<Props> = ({ venueId, layout = 'one-item-mediu
 
   const renderFooter: RenderFooterItem = useCallback(
     ({ width, height }) => (
-      <Link to={{ screen: 'Search', params }}>
+      <Link to={{ screen: 'Search', params }} accessible={false}>
         <SeeMore width={width} height={height} onPress={onPressSeeMore as () => void} />
       </Link>
     ),
@@ -93,7 +93,11 @@ export const VenueOffers: React.FC<Props> = ({ venueId, layout = 'one-item-mediu
 
   const renderTitleSeeMore = useCallback(
     ({ children }: { children: ReactNode }) => {
-      return <Link to={{ screen: 'Search', params }}>{children}</Link>
+      return (
+        <Link to={{ screen: 'Search', params }} accessible={false}>
+          {children}
+        </Link>
+      )
     },
     [onPressSeeMore, params]
   )
@@ -119,7 +123,7 @@ export const VenueOffers: React.FC<Props> = ({ venueId, layout = 'one-item-mediu
         keyExtractor={keyExtractor}
       />
       <MarginContainer>
-        <Link to={{ screen: 'Search', params }} style={styles.link}>
+        <Link to={{ screen: 'Search', params }} style={styles.link} accessible={false}>
           <ButtonWithLinearGradient
             wording={VENUE_OFFERS_CTA_WORDING}
             onPress={seeAllOffers}

--- a/src/libs/geolocation/components/WhereSection.tsx
+++ b/src/libs/geolocation/components/WhereSection.tsx
@@ -86,7 +86,10 @@ export const WhereSection: React.FC<Props> = ({
         {showVenueBanner ? (
           <React.Fragment>
             <Spacer.Column numberOfSpaces={4} />
-            <Link to={{ screen: 'Venue', params: { id: venue.id } }} style={styles.link}>
+            <Link
+              to={{ screen: 'Venue', params: { id: venue.id } }}
+              style={styles.link}
+              accessible={false}>
               <VenueNameContainer onPress={navigateToVenuePage} testID="VenueBannerComponent">
                 <Spacer.Row numberOfSpaces={2} />
                 <IconContainer>

--- a/src/ui/web/link/A.web.tsx
+++ b/src/ui/web/link/A.web.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import { AProps } from 'ui/web/link/types'
 
-export function A({ children, ...props }: AProps) {
+export function A({ children, accessible = false, ...props }: AProps) {
   const linkRef = createRef<HTMLAnchorElement>()
 
   function preventDefault(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
@@ -22,7 +22,7 @@ export function A({ children, ...props }: AProps) {
   }, [])
 
   return (
-    <ControlledA ref={linkRef} {...props}>
+    <ControlledA ref={linkRef} {...props} tabIndex={accessible ? 0 : -1}>
       {children}
     </ControlledA>
   )

--- a/src/ui/web/link/types.ts
+++ b/src/ui/web/link/types.ts
@@ -35,4 +35,5 @@ export type AProps = {
   children: React.ReactNode
   href?: string
   className?: string
+  accessible?: boolean
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13501

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
