### PR TITLE
(PC-13004) feat(accessibility): Correctly identify tab titles based on focused screen

### DIFF
--- a/src/features/auth/signup/SignupForm.tsx
+++ b/src/features/auth/signup/SignupForm.tsx
@@ -20,6 +20,7 @@ import { StepDots } from 'ui/components/StepDots'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { Close } from 'ui/svg/icons/Close'
 import { Spacer } from 'ui/theme'
+import { Helmet } from 'ui/web/global/Helmet'
 
 import { AcceptCgu } from './AcceptCgu'
 import { PreValidationSignupStep } from './enums'
@@ -81,6 +82,8 @@ export const SignupForm: FunctionComponent<Props> = ({ navigation, route }) => {
       ? t`Continuer vers l'étape` + ' ' + SIGNUP_STEP_CONFIG[stepIndex + 1].headerTitle
       : undefined
   const isFirstStep = stepIndex === 0
+  const helmetTitle =
+    t`Étape ${stepIndex + 1} sur ${SIGNUP_NUMBER_OF_STEPS} - Inscription` + ' | pass Culture'
 
   const { goBack: goBackAndLeaveSignup } = useGoBack(...getTabNavConfig('Profile'))
 
@@ -159,6 +162,7 @@ export const SignupForm: FunctionComponent<Props> = ({ navigation, route }) => {
 
   return (
     <React.Fragment>
+      <Helmet title={helmetTitle} />
       <BottomContentPage>
         <ModalHeader
           title={stepConfig.headerTitle}

--- a/src/features/bookings/pages/BookingDetails.tsx
+++ b/src/features/bookings/pages/BookingDetails.tsx
@@ -36,6 +36,7 @@ import { LoadingPage } from 'ui/components/LoadingPage'
 import { useModal } from 'ui/components/modals/useModal'
 import { Separator } from 'ui/components/Separator'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { Helmet } from 'ui/web/global/Helmet'
 import { A } from 'ui/web/link/A'
 import { Link } from 'ui/web/link/Link'
 const getOfferRules = (
@@ -130,8 +131,10 @@ export function BookingDetails() {
     navigate('Offer', { id: offer.id, from: 'bookingdetails' })
   }
 
+  const helmetTitle = `${t`Ma réservation pour`} ${booking.stock.offer.name} | pass Culture`
   return (
     <Container>
+      <Helmet title={helmetTitle} />
       <ScrollView
         onScroll={onScroll}
         scrollEventThrottle={20}

--- a/src/features/firstTutorial/pages/FirstTutorial/components/FirstCard.tsx
+++ b/src/features/firstTutorial/pages/FirstTutorial/components/FirstCard.tsx
@@ -6,26 +6,35 @@ import {
   AchievementCardKeyProps,
   GenericAchievementCard,
 } from 'ui/components/achievements/components/GenericAchievementCard'
+import { Helmet } from 'ui/web/global/Helmet'
 
 export function FirstCard(props: AchievementCardKeyProps) {
   function onButtonPress() {
     props.swiperRef?.current?.goToNext()
   }
 
+  const helmetTitle =
+    t`Étape ${(props.activeIndex || 0) + 1} sur ${
+      (props.lastIndex || 3) + 1
+    } | Tutoriel "Comment ça marche"` + ' | pass Culture'
+
   return (
-    <GenericAchievementCard
-      animation={TutorialPassLogo}
-      buttonCallback={onButtonPress}
-      buttonText={t`Continuer`}
-      pauseAnimationOnRenderAtFrame={62}
-      subTitle={t`c'est...`}
-      text={t`une initiative du Gouvernement financée par le ministère de la Culture.`}
-      title={t`Le pass Culture`}
-      swiperRef={props.swiperRef}
-      name={props.name}
-      index={props.index}
-      activeIndex={props.activeIndex}
-      lastIndex={props.lastIndex}
-    />
+    <React.Fragment>
+      <Helmet title={helmetTitle} />
+      <GenericAchievementCard
+        animation={TutorialPassLogo}
+        buttonCallback={onButtonPress}
+        buttonText={t`Continuer`}
+        pauseAnimationOnRenderAtFrame={62}
+        subTitle={t`c'est...`}
+        text={t`une initiative du Gouvernement financée par le ministère de la Culture.`}
+        title={t`Le pass Culture`}
+        swiperRef={props.swiperRef}
+        name={props.name}
+        index={props.index}
+        activeIndex={props.activeIndex}
+        lastIndex={props.lastIndex}
+      />
+    </React.Fragment>
   )
 }

--- a/src/features/navigation/RootNavigator/routes.ts
+++ b/src/features/navigation/RootNavigator/routes.ts
@@ -83,7 +83,6 @@ export const routes: Route[] = [
       deeplinkPaths: ['booking/:id/details'],
       parse: screenParamsParser['BookingDetails'],
     },
-    options: { title: t`Détails de réservation` },
     secure: true,
   },
   {
@@ -186,13 +185,13 @@ export const routes: Route[] = [
     name: 'LegalNotices',
     component: LegalNotices,
     path: 'notices-legales',
-    options: { title: t`Notices légales` },
+    options: { title: t`Mentions légales` },
   },
   {
     name: 'ConfirmDeleteProfile',
     component: ConfirmDeleteProfile,
     path: 'profil/suppression',
-    options: { title: t`Suppression profil` },
+    options: { title: t`Suppression de compte` },
     secure: true,
   },
   {
@@ -205,13 +204,13 @@ export const routes: Route[] = [
     name: 'LocationFilter',
     component: LocationFilter,
     path: 'recherche/localisation/filtres',
-    options: { title: t`Recherche` },
+    options: { title: t`Recherche par localisation` },
   },
   {
     name: 'LocationPicker',
     component: LocationPicker,
     path: 'recherche/localisation/choisir-adresse',
-    options: { title: t`Recherche` },
+    options: { title: t`Recherche par localisation` },
   },
   {
     name: 'Login',
@@ -243,7 +242,7 @@ export const routes: Route[] = [
     name: 'PersonalData',
     component: PersonalData,
     path: 'profil/donnees-personnelles',
-    options: { title: t`Données personnelles` },
+    options: { title: t`Mes informations personnelles` },
   },
   {
     name: 'ChangePassword',
@@ -282,13 +281,13 @@ export const routes: Route[] = [
     name: 'SearchCategories',
     component: SearchCategories,
     path: 'recherche/categories',
-    options: { title: t`Recherche - catégories` },
+    options: { title: t`Recherche par catégorie` },
   },
   {
     name: 'SearchFilter',
     component: SearchFilter,
     path: 'recherche/filtres',
-    options: { title: t`Recherche - filtres` },
+    options: { title: t`Filtres de recherche` },
   },
   {
     name: 'SignupForm',
@@ -314,7 +313,7 @@ export const routes: Route[] = [
     name: 'SetPhoneNumber',
     component: SetPhoneNumber,
     path: 'creation-compte/telephone',
-    options: { title: t`Téléphone - Formulaire` },
+    options: { title: t`Ton numéro de téléphone` },
   },
   {
     name: 'LandscapePositionPage',
@@ -356,7 +355,7 @@ export const routes: Route[] = [
     name: 'FirstTutorial',
     component: FirstTutorial,
     path: 'introduction-tutoriel',
-    options: { title: t`1er tutoriel` },
+    options: { title: t`Étape 1 sur 4 | Tutoriel "Comment ça marche"` },
   },
   {
     name: 'Venue',

--- a/src/features/navigation/TabBar/routes.ts
+++ b/src/features/navigation/TabBar/routes.ts
@@ -23,6 +23,7 @@ const routes: TabRoute[] = [
     name: 'Home',
     component: Home,
     pathConfig: { path: 'accueil', deeplinkPaths: ['home'], parse: screenParamsParser['Home'] },
+    options: { title: t`Page d'accueil` },
   },
   {
     name: 'Search',
@@ -39,20 +40,20 @@ const routes: TabRoute[] = [
     component: Bookings,
     path: 'reservations',
     deeplinkPaths: ['bookings'],
-    options: { title: t`Réservations` },
+    options: { title: t`Mes réservations` },
     secure: true,
   },
   {
     name: 'Favorites',
     component: Favorites,
     path: 'favoris',
-    options: { title: t`Favoris` },
+    options: { title: t`Mes favoris` },
   },
   {
     name: 'Profile',
     component: Profile,
     path: 'profil',
-    options: { title: t`Profil` },
+    options: { title: t`Mon profil` },
   },
 ]
 

--- a/src/features/offer/pages/OfferWebHead/OfferWebHead.tsx
+++ b/src/features/offer/pages/OfferWebHead/OfferWebHead.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export const OfferWebHead = ({ offer }: Props) => (
   <Helmet>
-    <title>{offer.name}</title>
+    <title>{offer.name + ' | pass Culture'}</title>
     <meta name="title" content={offer.name} />
     <meta name="description" content={offer.description || description} />
   </Helmet>

--- a/src/features/search/components/SearchResults.tsx
+++ b/src/features/search/components/SearchResults.tsx
@@ -1,3 +1,5 @@
+import { plural, t } from '@lingui/macro'
+import { useIsFocused } from '@react-navigation/native'
 import debounce from 'lodash.debounce'
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 import { FlatList, ActivityIndicator } from 'react-native'
@@ -14,6 +16,7 @@ import { useNetwork } from 'libs/network/useNetwork'
 import { SearchHit } from 'libs/search'
 import { getSpacing, Spacer } from 'ui/theme'
 import { TAB_BAR_COMP_HEIGHT } from 'ui/theme/constants'
+import { Helmet } from 'ui/web/global/Helmet'
 import { Li } from 'ui/web/list/Li'
 import { Ul } from 'ui/web/list/Ul'
 
@@ -38,6 +41,7 @@ export const SearchResults: React.FC = () => {
   const { searchState } = useSearch()
   const showSkeleton = useIsFalseWithDelay(isLoading, ANIMATION_DURATION)
   const isRefreshing = useIsFalseWithDelay(isFetching, ANIMATION_DURATION)
+  const isFocused = useIsFocused()
 
   useEffect(
     // Despite the fact that the useEffect hook being called immediately,
@@ -93,8 +97,19 @@ export const SearchResults: React.FC = () => {
   }
 
   if (showSkeleton) return <SearchResultsPlaceHolder />
+
+  const numberOfResults = plural(nbHits, {
+    one: '# résultat',
+    other: '# résultats',
+  })
+
+  const helmetTitle =
+    numberOfResults +
+    (searchState.query.length > 0 ? ` ${t`pour`} "${searchState.query}"` : '') +
+    ' | Recherche | pass Culture'
   return (
     <React.Fragment>
+      {isFocused ? <Helmet title={helmetTitle} /> : null}
       <Container>
         <Ul>
           <FlatList

--- a/src/features/search/components/__tests__/SearchResults.native.test.tsx
+++ b/src/features/search/components/__tests__/SearchResults.native.test.tsx
@@ -1,3 +1,4 @@
+import { NavigationContainer } from '@react-navigation/native'
 import React from 'react'
 
 import { initialSearchState } from 'features/search/pages/reducer'
@@ -7,6 +8,10 @@ import { render } from 'tests/utils'
 import { SearchResults } from '../SearchResults'
 
 jest.mock('react-query')
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useIsFocused: jest.fn(),
+}))
 const mockSearchState = initialSearchState
 jest.mock('features/search/pages/SearchWrapper', () => ({
   useSearch: () => ({
@@ -37,7 +42,7 @@ jest.mock('features/search/pages/useSearchResults', () => ({
 
 describe('SearchResults component', () => {
   it('should log SearchScrollToPage when hitting the bottom of the page', () => {
-    const { getByTestId } = render(<SearchResults />)
+    const { getByTestId } = render(<SearchResults />, { wrapper: NavigationContainer })
     const flatlist = getByTestId('searchResultsFlatlist')
 
     mockData.pages.push({ hits: [], page: 1, nbHits: 0 })
@@ -53,7 +58,7 @@ describe('SearchResults component', () => {
 
   it('should not log SearchScrollToPage when hitting the bottom of the page if no more results', () => {
     mockHasNextPage = false
-    const { getByTestId } = render(<SearchResults />)
+    const { getByTestId } = render(<SearchResults />, { wrapper: NavigationContainer })
     const flatlist = getByTestId('searchResultsFlatlist')
     flatlist.props.onEndReached()
     expect(analytics.logSearchScrollToPage).not.toHaveBeenCalled()

--- a/src/features/venue/components/VenueWebHeader.tsx
+++ b/src/features/venue/components/VenueWebHeader.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export const VenueWebHeader = ({ venue }: Props) => (
   <Helmet>
-    <title>{venue.publicName || venue.name}</title>
+    <title>{(venue.publicName || venue.name) + ' | pass Culture'}</title>
     <meta name="title" content={venue.publicName || venue.name} />
     <meta name="description" content={venue.description || description} />
   </Helmet>

--- a/src/libs/appWebHead.tsx
+++ b/src/libs/appWebHead.tsx
@@ -14,7 +14,8 @@ if (templateDescription) {
 export const AppWebHead = () => {
   return (
     <Helmet>
-      <title>{description}</title>
+      {/* the default title is defined in NavigationContainer.tsx */}
+      <meta name="description" content={description} />
     </Helmet>
   )
 }

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -43,33 +43,17 @@ msgstr "12 Caractères"
 msgid "15 ans"
 msgstr "15 ans"
 
-#: src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
-msgid "15 ans, le 31 janvier"
-msgstr "15 ans, le 31 janvier"
-
 #: src/features/firstTutorial/pages/FirstTutorial/components/SecondCard.tsx
 msgid "16 ans"
 msgstr "16 ans"
-
-#: src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
-msgid "16 ans, le 20 janvier"
-msgstr "16 ans, le 20 janvier"
 
 #: src/features/firstTutorial/pages/FirstTutorial/components/SecondCard.tsx
 msgid "17 ans"
 msgstr "17 ans"
 
-#: src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
-msgid "17 ans, le 10 janvier"
-msgstr "17 ans, le 10 janvier"
-
 #: src/features/firstTutorial/pages/FirstTutorial/components/SecondCard.tsx
 msgid "18 ans"
 msgstr "18 ans"
-
-#: src/features/navigation/RootNavigator/routes.ts
-msgid "1er tutoriel"
-msgstr "1er tutoriel"
 
 #: src/features/identityCheck/pages/Stepper.tsx
 #: src/features/profile/pages/ConfirmDeleteProfile.tsx
@@ -789,10 +773,6 @@ msgstr "Distance depuis la localisation"
 msgid "Distance indisponible"
 msgstr "Distance indisponible"
 
-#: src/features/navigation/RootNavigator/routes.ts
-msgid "Données personnelles"
-msgstr "Données personnelles"
-
 #: src/features/profile/components/SubscriptionMessageBadge.tsx
 msgid "Dossier déposé, nous avons bien reçu ton dossier et sommes en train de l’analyser !"
 msgstr "Dossier déposé, nous avons bien reçu ton dossier et sommes en train de l’analyser !"
@@ -845,10 +825,6 @@ msgstr "Détails de l'offre"
 msgid "Détails de la réservation"
 msgstr "Détails de la réservation"
 
-#: src/features/navigation/RootNavigator/routes.ts
-msgid "Détails de réservation"
-msgstr "Détails de réservation"
-
 #: src/ui/components/contact/ContactBlock.tsx
 msgid "E-mail"
 msgstr "E-mail"
@@ -893,10 +869,6 @@ msgstr "En attendant, aide-nous à en savoir plus sur tes pratiques culturelles�
 msgid "En attendant, tu peux découvrir l'application !"
 msgstr "En attendant, tu peux découvrir l'application !"
 
-#: src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
-msgid "En attendant, tu peux tout de même découvrir l'application mais sans pouvoir réserver les offres."
-msgstr "En attendant, tu peux tout de même découvrir l'application mais sans pouvoir réserver les offres."
-
 #: src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
 msgid "En cliquant sur “Accepter et s’inscrire”, tu acceptes nos"
 msgstr "En cliquant sur “Accepter et s’inscrire”, tu acceptes nos"
@@ -909,10 +881,6 @@ msgstr "En raison d’une erreur technique, l’offre n’a pas pu être réserv
 #: src/ui/components/PassPlaylist.tsx
 msgid "En voir plus"
 msgstr "En voir plus"
-
-#: src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
-msgid "Encore un peu de patience : en fonction de ton âge, tu pourras compléter ton inscription à la date suivante :"
-msgstr "Encore un peu de patience : en fonction de ton âge, tu pourras compléter ton inscription à la date suivante :"
 
 #: src/features/profile/pages/ChangeEmail/ChangeEmail.tsx
 #: src/features/profile/pages/ChangePassword/ChangePassword.tsx
@@ -1014,7 +982,6 @@ msgid "Faire une nouvelle demande"
 msgstr "Faire une nouvelle demande"
 
 #: src/features/navigation/TabBar/routes.ts
-#: src/features/navigation/TabBar/routes.ts
 msgid "Favoris"
 msgstr "Favoris"
 
@@ -1065,6 +1032,10 @@ msgstr "Festival"
 #: src/features/search/pages/SearchFilter.tsx
 msgid "Filtrer"
 msgstr "Filtrer"
+
+#: src/features/navigation/RootNavigator/routes.ts
+msgid "Filtres de recherche"
+msgstr "Filtres de recherche"
 
 #: src/features/navigation/RootNavigator/identityCheckRoutes.ts
 msgid "Fin du parcours"
@@ -1502,6 +1473,10 @@ msgstr "L’application est actuellement en maintenance, mais sera à nouveau en
 msgid "Ma réservation"
 msgstr "Ma réservation"
 
+#: src/features/bookings/pages/BookingDetails.tsx
+msgid "Ma réservation pour"
+msgstr "Ma réservation pour"
+
 #: src/libs/parsers/venueType.ts
 msgid "Magasin arts créatifs"
 msgstr "Magasin arts créatifs"
@@ -1522,20 +1497,27 @@ msgstr "Maintenance"
 msgid "Maintenance en cours"
 msgstr "Maintenance en cours"
 
+#: src/features/navigation/RootNavigator/routes.ts
 #: src/features/profile/pages/LegalNotices/LegalNotices.tsx
 #: src/features/profile/pages/Profile.tsx
 msgid "Mentions légales"
 msgstr "Mentions légales"
 
 #: src/features/favorites/pages/Favorites.tsx
+#: src/features/navigation/TabBar/routes.ts
 msgid "Mes favoris"
 msgstr "Mes favoris"
+
+#: src/features/navigation/RootNavigator/routes.ts
+msgid "Mes informations personnelles"
+msgstr "Mes informations personnelles"
 
 #: src/features/bookOffer/services/useModalContent.tsx
 msgid "Mes options"
 msgstr "Mes options"
 
 #: src/features/bookings/pages/Bookings.tsx
+#: src/features/navigation/TabBar/routes.ts
 msgid "Mes réservations"
 msgstr "Mes réservations"
 
@@ -1592,6 +1574,10 @@ msgstr "Mon crédit est expiré, que faire ?"
 #: src/features/identityCheck/pages/identification/IdentityCheckValidation.web.tsx
 msgid "Mon identité"
 msgstr "Mon identité"
+
+#: src/features/navigation/TabBar/routes.ts
+msgid "Mon profil"
+msgstr "Mon profil"
 
 #: src/features/auth/login/Login.tsx
 #: src/features/auth/signup/SetPassword/SetPassword.tsx
@@ -1681,10 +1667,6 @@ msgstr "Nos conseils :"
 #: src/features/firstTutorial/pages/FirstTutorial/components/FourthCard.tsx
 msgid "Nos nombreux partenaires ajoutent de nouvelles offres quotidiennement. Découvre les dès maintenant !"
 msgstr "Nos nombreux partenaires ajoutent de nouvelles offres quotidiennement. Découvre les dès maintenant !"
-
-#: src/features/navigation/RootNavigator/routes.ts
-msgid "Notices légales"
-msgstr "Notices légales"
 
 #: src/features/navigation/RootNavigator/routes.ts
 msgid "Notification rechargement anniversaire"
@@ -1850,6 +1832,10 @@ msgstr "Où"
 #: src/libs/geolocation/components/WhereSection.tsx
 msgid "Où ?"
 msgstr "Où ?"
+
+#: src/features/navigation/TabBar/routes.ts
+msgid "Page d'accueil"
+msgstr "Page d'accueil"
 
 #: src/features/navigation/RootNavigator/routes.ts
 msgid "Page introuvable"
@@ -2024,7 +2010,6 @@ msgstr "Problème technique ;("
 #: src/features/identityCheck/pages/profile/Status.tsx
 #: src/features/identityCheck/useIdentityCheckSteps.tsx
 #: src/features/navigation/TabBar/routes.ts
-#: src/features/navigation/TabBar/routes.ts
 #: src/features/profile/components/LoggedOutHeader.tsx
 #: src/features/profile/components/NonBeneficiaryHeader.tsx
 msgid "Profil"
@@ -2078,19 +2063,9 @@ msgstr "Qui est-ce ?"
 msgid "Rayon"
 msgstr "Rayon"
 
-#: src/features/navigation/RootNavigator/routes.ts
-#: src/features/navigation/RootNavigator/routes.ts
 #: src/features/navigation/TabBar/routes.ts
 msgid "Recherche"
 msgstr "Recherche"
-
-#: src/features/navigation/RootNavigator/routes.ts
-msgid "Recherche - catégories"
-msgstr "Recherche - catégories"
-
-#: src/features/navigation/RootNavigator/routes.ts
-msgid "Recherche - filtres"
-msgstr "Recherche - filtres"
 
 #: src/features/navigation/TabBar/routes.ts
 msgid "Recherche des offres"
@@ -2099,6 +2074,15 @@ msgstr "Recherche des offres"
 #: src/features/identityCheck/pages/profile/SetAddress.tsx
 msgid "Recherche et sélectionne ton adresse"
 msgstr "Recherche et sélectionne ton adresse"
+
+#: src/features/navigation/RootNavigator/routes.ts
+msgid "Recherche par catégorie"
+msgstr "Recherche par catégorie"
+
+#: src/features/navigation/RootNavigator/routes.ts
+#: src/features/navigation/RootNavigator/routes.ts
+msgid "Recherche par localisation"
+msgstr "Recherche par localisation"
 
 #: src/features/search/atoms/Buttons/Search.tsx
 msgid "Rechercher"
@@ -2258,7 +2242,6 @@ msgid "Réservation introuvable !"
 msgstr "Réservation introuvable !"
 
 #: src/features/navigation/TabBar/routes.ts
-#: src/features/navigation/TabBar/routes.ts
 msgid "Réservations"
 msgstr "Réservations"
 
@@ -2385,13 +2368,13 @@ msgstr "Spectacle vivant"
 msgid "Suivre pass Culture"
 msgstr "Suivre pass Culture"
 
+#: src/features/navigation/RootNavigator/routes.ts
+msgid "Suppression de compte"
+msgstr "Suppression de compte"
+
 #: src/features/profile/pages/LegalNotices/LegalNotices.tsx
 msgid "Suppression du compte"
 msgstr "Suppression du compte"
-
-#: src/features/navigation/RootNavigator/routes.ts
-msgid "Suppression profil"
-msgstr "Suppression profil"
 
 #: src/features/navigation/RootNavigator/routes.ts
 msgid "Suppression profil confirmée"
@@ -2528,6 +2511,10 @@ msgstr "Ton nom ne doit pas contenir de chiffres ou de caractères spéciaux."
 msgid "Ton nouveau mot de passe"
 msgstr "Ton nouveau mot de passe"
 
+#: src/features/navigation/RootNavigator/routes.ts
+msgid "Ton numéro de téléphone"
+msgstr "Ton numéro de téléphone"
+
 #: src/features/identityCheck/pages/identification/IdentityCheckValidation.tsx
 #: src/features/identityCheck/pages/identification/IdentityCheckValidation.web.tsx
 #: src/features/identityCheck/pages/profile/SetName.tsx
@@ -2660,10 +2647,6 @@ msgstr "Tu n'as pas de smartphone ?"
 msgid "Tu n'as pas reçu le sms ?"
 msgstr "Tu n'as pas reçu le sms ?"
 
-#: src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
-msgid "Tu ne fais pas partie de la phase de test"
-msgstr "Tu ne fais pas partie de la phase de test"
-
 #: src/features/auth/signup/SetBirthday/utils/useDatePickerErrorHandler.tsx
 msgid "Tu ne peux pas choisir une date dans le futur"
 msgstr "Tu ne peux pas choisir une date dans le futur"
@@ -2777,10 +2760,6 @@ msgstr "Télécharger la dernière version"
 #: src/ui/components/contact/ContactBlock.tsx
 msgid "Téléphone"
 msgstr "Téléphone"
-
-#: src/features/navigation/RootNavigator/routes.ts
-msgid "Téléphone - Formulaire"
-msgstr "Téléphone - Formulaire"
 
 #: src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
 #: src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
@@ -3075,10 +3054,6 @@ msgstr "crédit photo"
 msgid "crédit valable jusqu'au"
 msgstr "crédit valable jusqu'au"
 
-#: src/features/firstTutorial/pages/FirstTutorial/components/SecondCard.tsx
-msgid "dans l'année de tes 18 ans, le Gouvernement offre un crédit de {deposit} à dépenser dans l’application."
-msgstr "dans l'année de tes 18 ans, le Gouvernement offre un crédit de {deposit} à dépenser dans l’application."
-
 #: src/features/profile/components/YoungerBadge.tsx
 msgid "date d'éligibilité"
 msgstr "Patience ! Reviens à partir du {date} pour continuer ton inscription et bénéficier du crédit pass Culture."
@@ -3118,10 +3093,6 @@ msgstr "Profite de {deposit}"
 #: src/features/firstTutorial/pages/FirstTutorial/components/SecondCard.tsx
 msgid "et si tu as..."
 msgstr "et si tu as..."
-
-#: src/features/firstTutorial/pages/FirstTutorial/components/SecondCard.tsx
-msgid "et si tu es..."
-msgstr "et si tu es..."
 
 #: src/features/auth/signup/SetBirthday/BirthdayInformationModal/BirthdayInformationModal.tsx
 msgid "financialHelpMessage"
@@ -3199,6 +3170,10 @@ msgstr "page-introuvable"
 #: src/features/identityCheck/pages/identification/IdentityCheckStart/IdentityCheckStartContent.tsx
 msgid "passeport"
 msgstr "passeport"
+
+#: src/features/search/components/SearchResults.tsx
+msgid "pour"
+msgstr "pour"
 
 #: src/features/bookOffer/components/BookingInformations.tsx
 msgid "prix duo"
@@ -3307,6 +3282,7 @@ msgid "{nbFavorites, plural, one {# favori} other {# favoris}}"
 msgstr "{nbFavorites, plural, one {# favori} other {# favoris}}"
 
 #: src/features/search/atoms/NumberOfResults.tsx
+#: src/features/search/components/SearchResults.tsx
 #: src/features/search/pages/SuggestedPlaces.tsx
 msgid "{nbHits, plural, one {# résultat} other {# résultats}}"
 msgstr "{nbHits, plural, one {# résultat} other {# résultats}}"
@@ -3330,6 +3306,18 @@ msgstr "À deux !"
 #: src/features/bookings/helpers.ts
 msgid "À retirer avant le {dateLimit}"
 msgstr "À retirer avant le {dateLimit}"
+
+#: src/features/navigation/RootNavigator/routes.ts
+msgid "Étape 1 sur 4 | Tutoriel \"Comment ça marche\""
+msgstr "Étape 1 sur 4 | Tutoriel \"Comment ça marche\""
+
+#: src/features/firstTutorial/pages/FirstTutorial/components/FirstCard.tsx
+msgid "Étape {0} sur {1} | Tutoriel \"Comment ça marche\""
+msgstr "Étape {0} sur {1} | Tutoriel \"Comment ça marche\""
+
+#: src/features/auth/signup/SignupForm.tsx
+msgid "Étape {0} sur {SIGNUP_NUMBER_OF_STEPS} - Inscription"
+msgstr "Étape {0} sur {SIGNUP_NUMBER_OF_STEPS} - Inscription"
 
 #: src/ui/components/DotComponent.tsx
 msgid "Étape {step} sur {totalSteps} {status}"

--- a/src/ui/web/global/Helmet.tsx
+++ b/src/ui/web/global/Helmet.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+import { Helmet as ReactHelmet } from 'libs/react-helmet/Helmet'
+
+export const Helmet = ({ title }: { title: string }) => (
+  <ReactHelmet>
+    <title>{title}</title>
+  </ReactHelmet>
+)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13004

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [x] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
