### PR TITLE
(PC-12998) feat(accessibility): Make dot component inaccessible if not interactive

### DIFF
--- a/__snapshots__/features/firstTutorial/pages/FirstTutorial/FirstTutorial.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstTutorial/pages/FirstTutorial/FirstTutorial.native.test.tsx.native-snap
@@ -1513,6 +1513,11 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                   }
                 >
                   <View
+                    accessibilityState={
+                      Object {
+                        "disabled": true,
+                      }
+                    }
                     accessible={true}
                     focusable={false}
                     onClick={[Function]}
@@ -1546,6 +1551,11 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                     </View>
                   </View>
                   <View
+                    accessibilityState={
+                      Object {
+                        "disabled": true,
+                      }
+                    }
                     accessible={true}
                     focusable={false}
                     onClick={[Function]}
@@ -1579,6 +1589,11 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                     </View>
                   </View>
                   <View
+                    accessibilityState={
+                      Object {
+                        "disabled": true,
+                      }
+                    }
                     accessible={true}
                     focusable={false}
                     onClick={[Function]}
@@ -1612,6 +1627,11 @@ exports[`FirstTutorial page should render first tutorial 1`] = `
                     </View>
                   </View>
                   <View
+                    accessibilityState={
+                      Object {
+                        "disabled": true,
+                      }
+                    }
                     accessible={true}
                     focusable={false}
                     onClick={[Function]}

--- a/__snapshots__/ui/components/DotComponent.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/DotComponent.native.test.tsx.native-snap
@@ -2,6 +2,11 @@
 
 exports[`<DotComponent /> renders dot active color 1`] = `
 <View
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
   accessible={true}
   focusable={true}
   onClick={[Function]}
@@ -38,6 +43,11 @@ exports[`<DotComponent /> renders dot active color 1`] = `
 
 exports[`<DotComponent /> should render correctly 1`] = `
 <View
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
   accessible={true}
   focusable={true}
   onClick={[Function]}

--- a/src/ui/components/DotComponent.tsx
+++ b/src/ui/components/DotComponent.tsx
@@ -48,7 +48,7 @@ export const DotComponent: FunctionComponent<DotComponentProps> = (props) => {
   }
 
   return (
-    <TouchableWithoutFeedback onPress={props.onPress} testID="button">
+    <TouchableWithoutFeedback onPress={props.onPress} disabled={!props.onPress} testID="button">
       <DotContainer>
         <Dot
           aria-label={t`Étape ${step} sur ${totalSteps} ${status}`}

--- a/src/ui/svg/icons/Dot.tsx
+++ b/src/ui/svg/icons/Dot.tsx
@@ -25,6 +25,7 @@ const DotSvg: React.FC<Props> = ({
     height={size}
     viewBox="0 0 9 9"
     testID={testID}
+    accessibilityRole="image"
     // @ts-expect-error : borderColor and fillColor are on <Svg/> only for test purposes
     borderColor={borderColor}
     fillColor={fillColor}>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12998

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
