### PR TITLE
(PC-13566) fix(accessibility): Revert accessibility labels for tab bar

### DIFF
--- a/src/features/navigation/RootNavigator/Header/NavItem.tsx
+++ b/src/features/navigation/RootNavigator/Header/NavItem.tsx
@@ -32,7 +32,7 @@ export const NavItem: React.FC<NavItemInterface> = ({
       activeOpacity={1}
       testID={`${tabName} nav`}>
       <BicolorIcon />
-      <Title isSelected={isSelected}>{menu[tabName].displayName}</Title>
+      <Title isSelected={isSelected}>{menu[tabName]}</Title>
     </StyledTouchableOpacity>
   )
 }

--- a/src/features/navigation/TabBar/TabBarComponent.tsx
+++ b/src/features/navigation/TabBar/TabBarComponent.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { menu } from 'features/navigation/TabBar/routes'
-import { TabRouteName } from 'features/navigation/TabBar/types'
 import { accessibilityAndTestId } from 'libs/accessibilityAndTestId'
 import { BicolorSelector } from 'ui/svg/icons/BicolorSelector'
 import { BicolorIconInterface } from 'ui/svg/icons/types'
@@ -15,7 +13,7 @@ interface Props {
   isSelected?: boolean
   BicolorIcon: React.FC<BicolorIconInterface>
   onPress: () => void
-  tabName: TabRouteName
+  tabName: string
 }
 
 export const TabBarComponent: React.FC<Props> = ({ isSelected, BicolorIcon, onPress, tabName }) => {
@@ -29,7 +27,7 @@ export const TabBarComponent: React.FC<Props> = ({ isSelected, BicolorIcon, onPr
     <TabComponentContainer
       onPress={onPress}
       activeOpacity={1}
-      {...accessibilityAndTestId(menu[tabName].accessibilityLabel)}>
+      {...accessibilityAndTestId(`${tabName} tab`)}>
       {!!isSelected && (
         <BicolorSelector
           width={SELECTOR_WIDTH}

--- a/src/features/navigation/TabBar/routes.ts
+++ b/src/features/navigation/TabBar/routes.ts
@@ -65,12 +65,12 @@ export function isTabScreen(screen: ScreenNames): screen is TabRouteName {
   return tabRouteNames.includes(screen)
 }
 
-export const menu: Record<TabRouteName, { displayName: string; accessibilityLabel: string }> = {
-  Home: { displayName: t`Accueil`, accessibilityLabel: t`Accueil` },
-  Search: { displayName: t`Recherche`, accessibilityLabel: t`Rechercher des offres` },
-  Bookings: { displayName: t`Réservations`, accessibilityLabel: t`Mes réservations` },
-  Favorites: { displayName: t`Favoris`, accessibilityLabel: t`Mes favoris` },
-  Profile: { displayName: t`Profil`, accessibilityLabel: t`Mon profil` },
+export const menu: Record<TabRouteName, string> = {
+  Home: t`Accueil`,
+  Search: t`Recherche`,
+  Bookings: t`Réservations`,
+  Favorites: t`Favoris`,
+  Profile: t`Profil`,
 }
 
 const { screensConfig: tabScreensConfig, Screens: TabScreens } = getScreensAndConfig(

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -86,7 +86,6 @@ msgid "Accessibilité"
 msgstr "Accessibilité"
 
 #: src/features/navigation/TabBar/routes.ts
-#: src/features/navigation/TabBar/routes.ts
 msgid "Accueil"
 msgstr "Accueil"
 
@@ -1493,7 +1492,6 @@ msgstr "Mentions légales"
 
 #: src/features/favorites/pages/Favorites.tsx
 #: src/features/navigation/TabBar/routes.ts
-#: src/features/navigation/TabBar/routes.ts
 msgid "Mes favoris"
 msgstr "Mes favoris"
 
@@ -1506,7 +1504,6 @@ msgid "Mes options"
 msgstr "Mes options"
 
 #: src/features/bookings/pages/Bookings.tsx
-#: src/features/navigation/TabBar/routes.ts
 #: src/features/navigation/TabBar/routes.ts
 msgid "Mes réservations"
 msgstr "Mes réservations"
@@ -1565,7 +1562,6 @@ msgstr "Mon crédit est expiré, que faire ?"
 msgid "Mon identité"
 msgstr "Mon identité"
 
-#: src/features/navigation/TabBar/routes.ts
 #: src/features/navigation/TabBar/routes.ts
 msgid "Mon profil"
 msgstr "Mon profil"
@@ -2087,10 +2083,6 @@ msgstr "Recherche par localisation"
 #: src/features/search/atoms/Buttons/Search.tsx
 msgid "Rechercher"
 msgstr "Rechercher"
-
-#: src/features/navigation/TabBar/routes.ts
-msgid "Rechercher des offres"
-msgstr "Rechercher des offres"
 
 #: src/features/home/components/NoContentError.tsx
 msgid "Rechercher une offre"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13566

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
