### PR TITLE
(PC-13691) fix(WebCalendarPicker): Display error only when date is invalid

### DIFF
--- a/src/features/search/components/CalendarPicker.web.tsx
+++ b/src/features/search/components/CalendarPicker.web.tsx
@@ -185,7 +185,7 @@ export const CalendarPicker: React.FC<Props> = ({
           onPress={onValidate}
           adjustsFontSizeToFit={true}
         />
-        {
+        {isMobileDateInvalid ? (
           <React.Fragment>
             <InputError
               visible
@@ -195,7 +195,9 @@ export const CalendarPicker: React.FC<Props> = ({
             />
             <Spacer.Column numberOfSpaces={1} />
           </React.Fragment>
-        }
+        ) : (
+          <Spacer.Column numberOfSpaces={7} />
+        )}
       </CalendarButtonWrapper>
       <Spacer.BottomScreen />
     </AppModal>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13691

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
