### PR TITLE
feat(ui): add ProgressBar component to storybook

### DIFF
--- a/src/ui/components/bars/ProgressBar.stories.tsx
+++ b/src/ui/components/bars/ProgressBar.stories.tsx
@@ -1,0 +1,45 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+import React from 'react'
+
+import { EditPen } from 'ui/svg/icons/EditPen'
+import { Email } from 'ui/svg/icons/Email'
+// eslint-disable-next-line no-restricted-imports
+import { ColorsEnum } from 'ui/theme/colors'
+
+import { ProgressBar } from './ProgressBar'
+
+export default {
+  title: 'ui/ProgressBar',
+  component: ProgressBar,
+} as ComponentMeta<typeof ProgressBar>
+
+const Template: ComponentStory<typeof ProgressBar> = (props) => <ProgressBar {...props} />
+
+export const Default = Template.bind({})
+Default.args = {
+  progress: 0.5,
+  color: ColorsEnum.PRIMARY,
+  icon: Email,
+}
+
+export const Empty = Template.bind({})
+Empty.args = {
+  progress: 0,
+  color: ColorsEnum.GREEN_LIGHT,
+  icon: Email,
+}
+
+export const Full = Template.bind({})
+Full.args = {
+  progress: 1,
+  color: ColorsEnum.ERROR,
+  icon: EditPen,
+}
+
+export const Animated = Template.bind({})
+Animated.args = {
+  progress: 1,
+  color: ColorsEnum.GREEN_VALID,
+  icon: EditPen,
+  isAnimated: true,
+}

--- a/src/ui/components/bars/ProgressBar.tsx
+++ b/src/ui/components/bars/ProgressBar.tsx
@@ -13,6 +13,7 @@ interface ProgressBarProps {
   color: ColorsEnum | UniqueColors
   icon: FunctionComponent<IconInterface>
   isAnimated?: boolean
+  children?: never
 }
 
 const ProgressBarComponent: React.FC<ProgressBarProps> = ({


### PR DESCRIPTION
## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
