### PR TITLE
fix(pipeline): remove animated storybook

### DIFF
--- a/src/ui/components/bars/ProgressBar.stories.tsx
+++ b/src/ui/components/bars/ProgressBar.stories.tsx
@@ -35,11 +35,3 @@ Full.args = {
   color: ColorsEnum.ERROR,
   icon: EditPen,
 }
-
-export const Animated = Template.bind({})
-Animated.args = {
-  progress: 1,
-  color: ColorsEnum.GREEN_VALID,
-  icon: EditPen,
-  isAnimated: true,
-}


### PR DESCRIPTION
Chromatic have different screenshot because of the animation

https://www.chromatic.com/test?appId=61fd537ecf081f003a135235&id=621cb013459f04003a267c7b

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
