### PR TITLE
(PC-13621) fix(home): show distance for offers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
         minimumDescriptionLength: 5,
       },
     ],
-    // not ideal, but progamatically necessary sometimes
+    // not ideal, but programmatically necessary sometimes
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': [
       'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended', // Uses the recommended rules from @typescript-eslint/eslint-plugin
     'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
     'plugin:import/errors',
+    'plugin:react-hooks/recommended',
   ],
   parserOptions: {
     ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
@@ -41,9 +42,6 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     'react/prop-types': 'off',
     'react-native/sort-styles': 'off',
-    // This is essential. Without this misplaced hooks would go straight to production
-    // since there is no way to detect this during testing.
-    'react-hooks/rules-of-hooks': 'error',
     'react/jsx-fragments': ['error', 'element'], // Otherwise `lingui extract` fails when using the shorthand syntax i.e. <></>
     'no-restricted-imports': [
       'error',

--- a/src/features/home/components/OffersModule.tsx
+++ b/src/features/home/components/OffersModule.tsx
@@ -109,7 +109,7 @@ export const OffersModule = (props: OffersModuleProps) => {
         </Link>
       )
     },
-    [onPressSeeMore, params]
+    [params]
   )
 
   if (!shouldModuleBeDisplayed) return <React.Fragment />

--- a/src/libs/geolocation/hooks/useDistance.ts
+++ b/src/libs/geolocation/hooks/useDistance.ts
@@ -6,7 +6,7 @@ export const useDistance = (offerPosition: {
   lng?: number | null
 }): string | undefined => {
   const { position: userPosition } = useGeolocation()
-  // TODO check if  !offerPosition check is usefull - add data validation from API if needed
+  // TODO check if !offerPosition check is useful - add data validation from API if needed
   if (!userPosition || !offerPosition) return undefined
   return formatDistance(offerPosition, userPosition)
 }

--- a/src/ui/components/Playlist.tsx
+++ b/src/ui/components/Playlist.tsx
@@ -109,7 +109,7 @@ export const Playlist: FunctionComponent<Props> = ({
         return stepIndex
       })
     },
-    [flatListRef.current, nbOfSteps, steps]
+    [nbOfSteps, steps]
   )
 
   const renderItemWithHeaderAndFooter: ListRenderItem<any> = useCallback(

--- a/src/ui/components/Playlist.tsx
+++ b/src/ui/components/Playlist.tsx
@@ -1,7 +1,7 @@
 /* We use many `any` on purpose in this module, so we deactivate the following rule : */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import range from 'lodash/range'
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import React, { FunctionComponent, useCallback, useMemo, useRef, useState } from 'react'
 import { FlatList, ListRenderItem, ListRenderItemInfo } from 'react-native'
 import webStyled from 'styled-components'
 import styled, { useTheme } from 'styled-components/native'
@@ -37,6 +37,7 @@ type Props = {
   renderHeader?: RenderHeaderItem
   renderFooter?: RenderFooterItem
   onEndReached?: () => void
+  children?: never
 }
 
 function defaultKeyExtractor(item: any, index: number): string {
@@ -47,7 +48,18 @@ const defaultProps = {
   keyExtractor: defaultKeyExtractor,
 }
 
-export const Playlist = (props: Props) => {
+export const Playlist: FunctionComponent<Props> = ({
+  data,
+  itemWidth,
+  itemHeight,
+  scrollButtonOffsetY,
+  testID,
+  renderItem,
+  keyExtractor,
+  renderHeader,
+  renderFooter,
+  onEndReached,
+}) => {
   const { isTouch } = useTheme()
 
   const [playlistWidth, setPlaylistWidth] = useState(0)
@@ -58,14 +70,13 @@ export const Playlist = (props: Props) => {
   // in order to have the correct array length available for the scroll functions and renderItem
   // See also renderItemWithHeaderAndFooter(...)
   const dataWithHeaderAndFooter = useMemo(() => {
-    if (props.renderHeader && props.renderFooter)
-      return [{ dataHeader: true }, ...props.data, { dataFooter: true }]
-    if (props.renderHeader) return [{ dataHeader: true }, ...props.data]
-    if (props.renderFooter) return [...props.data, { dataFooter: true }]
-    return props.data
-  }, [props.data, props.renderHeader, props.renderFooter])
+    if (renderHeader && renderFooter) return [{ dataHeader: true }, ...data, { dataFooter: true }]
+    if (renderHeader) return [{ dataHeader: true }, ...data]
+    if (renderFooter) return [...data, { dataFooter: true }]
+    return data
+  }, [data, renderHeader, renderFooter])
 
-  const itemWidthWithOffset = props.itemWidth + ITEM_SEPARATOR_WIDTH
+  const itemWidthWithOffset = itemWidth + ITEM_SEPARATOR_WIDTH
   const nbOfItems = dataWithHeaderAndFooter.length
   const { steps, nbOfSteps } = useMemo(
     () => getItemSteps(nbOfItems, itemWidthWithOffset, playlistWidth),
@@ -75,16 +86,16 @@ export const Playlist = (props: Props) => {
   // It is required to know the exact width of an item width and its offset if we want to use
   // FlatList's scrollToIndex() function.
   function getItemLayout(_data: any[] | null | undefined, index: number) {
-    return { length: props.itemWidth, offset: itemWidthWithOffset * index, index }
+    return { length: itemWidth, offset: itemWidthWithOffset * index, index }
   }
 
   const keyExtractorWithHeaderAndFooter = useCallback(
     function (item: any, index: number) {
-      if (props.renderHeader && index === 0) return 'playlist-data-header'
-      if (props.renderFooter && index === nbOfItems - 1) return 'playlist-data-footer'
-      return props.keyExtractor(item, index)
+      if (renderHeader && index === 0) return 'playlist-data-header'
+      if (renderFooter && index === nbOfItems - 1) return 'playlist-data-footer'
+      return keyExtractor(item, index)
     },
-    [props.renderHeader, props.renderFooter, props.keyExtractor, nbOfItems]
+    [renderHeader, renderFooter, keyExtractor, nbOfItems]
   )
 
   const displayItems = useCallback(
@@ -103,16 +114,15 @@ export const Playlist = (props: Props) => {
 
   const renderItemWithHeaderAndFooter: ListRenderItem<any> = useCallback(
     function ({ item, index, separators }) {
-      const { itemWidth: width, itemHeight: height } = props
-      if (props.renderHeader && index === 0) {
-        return props.renderHeader({ height, width })
+      if (renderHeader && index === 0) {
+        return renderHeader({ height: itemHeight, width: itemWidth })
       }
-      if (props.renderFooter && index === nbOfItems - 1) {
-        return props.renderFooter({ height, width })
+      if (renderFooter && index === nbOfItems - 1) {
+        return renderFooter({ height: itemHeight, width: itemWidth })
       }
-      return props.renderItem({ item, index, separators, width, height })
+      return renderItem({ item, index, separators, width: itemWidth, height: itemHeight })
     },
-    [nbOfItems, props.itemWidth, props.itemHeight]
+    [nbOfItems, itemWidth, itemHeight]
   )
 
   const displayLeftScrollButtonForNotTouchDevice = !isTouch && playlistStepIndex > 0
@@ -122,7 +132,7 @@ export const Playlist = (props: Props) => {
       {displayLeftScrollButtonForNotTouchDevice ? (
         <ScrollButtonForNotTouchDevice
           horizontalAlign="left"
-          top={props.scrollButtonOffsetY}
+          top={scrollButtonOffsetY}
           onPress={() => displayItems('previous')}>
           <BicolorArrowLeft />
         </ScrollButtonForNotTouchDevice>
@@ -130,7 +140,7 @@ export const Playlist = (props: Props) => {
       {displayRightScrollButtonForNotTouchDevice ? (
         <ScrollButtonForNotTouchDevice
           horizontalAlign="right"
-          top={props.scrollButtonOffsetY}
+          top={scrollButtonOffsetY}
           onPress={() => displayItems('next')}>
           <BicolorArrowRight />
         </ScrollButtonForNotTouchDevice>
@@ -140,7 +150,7 @@ export const Playlist = (props: Props) => {
           onLayout={({ nativeEvent }) => {
             setPlaylistWidth(nativeEvent.layout.width)
           }}
-          testID={props.testID}
+          testID={testID}
           ref={flatListRef}
           scrollEnabled={isTouch}
           data={dataWithHeaderAndFooter}
@@ -154,7 +164,7 @@ export const Playlist = (props: Props) => {
           ItemSeparatorComponent={ItemSeparatorComponent}
           ListHeaderComponent={HorizontalMargin}
           ListFooterComponent={HorizontalMargin}
-          onEndReached={props.onEndReached}
+          onEndReached={onEndReached}
           onEndReachedThreshold={0.2}
         />
       </StyledUl>

--- a/src/ui/components/Playlist.tsx
+++ b/src/ui/components/Playlist.tsx
@@ -122,7 +122,7 @@ export const Playlist: FunctionComponent<Props> = ({
       }
       return renderItem({ item, index, separators, width: itemWidth, height: itemHeight })
     },
-    [nbOfItems, itemWidth, itemHeight]
+    [renderHeader, renderFooter, nbOfItems, renderItem, itemWidth, itemHeight]
   )
 
   const displayLeftScrollButtonForNotTouchDevice = !isTouch && playlistStepIndex > 0


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13621

Analyse du bug → https://www.notion.so/passcultureapp/Homepage-La-distance-de-certaines-offres-n-est-pas-affich-e-85cc17514152436e8546847e792dee0d

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [x] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
