### PR TITLE
ci(app native): add deps to testing deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -696,6 +696,8 @@ workflows:
                 - master
           requires:
             - checkout-and-install-deps
+            - test-lint-and-types
+            - test-native
       - deploy-android-testing-hard:
           filters:
             tags:


### PR DESCRIPTION
so that we don't deploy a bundle which fails tests or linter

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX
pas de ticket 🎟 


## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
