### PR TITLE
(PC-13805) fix(PriceConversion): Fix number of decimals in price conversion from euro to cents

### DIFF
--- a/src/libs/parsers/pricesConversion.ts
+++ b/src/libs/parsers/pricesConversion.ts
@@ -1,5 +1,7 @@
 export const CENTS_IN_EURO = 100
 
-export const convertEuroToCents = (p: number): number => Math.floor(p * CENTS_IN_EURO)
+export const convertEuroToCents = (p: number): number => {
+  return Math.floor(Number((p * CENTS_IN_EURO).toFixed(2)))
+}
 
 export const convertCentsToEuros = (p: number): number => Math.floor(p / CENTS_IN_EURO)

--- a/src/libs/parsers/tests/getDisplayPrice.test.ts
+++ b/src/libs/parsers/tests/getDisplayPrice.test.ts
@@ -3,6 +3,7 @@ import {
   getDisplayPriceWithDuoMention,
   getFavoriteDisplayPrice,
   formatToFrenchDecimal,
+  formatPriceInEuroToDisplayPrice,
 } from '../getDisplayPrice'
 
 describe('getDisplayPrice', () => {
@@ -82,5 +83,23 @@ describe('formatToFrenchDecimal()', () => {
     ${-1199.6}   | ${'-12,00\u00a0€'}
   `('formatToFrenchDecimal($priceInCents) \t= $expected', ({ priceInCents, expected }) => {
     expect(formatToFrenchDecimal(priceInCents)).toBe(expected)
+  })
+})
+
+describe('formatPriceInEuroToDisplayPrice()', () => {
+  it.each`
+    priceInEuro | expected
+    ${0}        | ${'0\u00a0€'}
+    ${50}       | ${'50\u00a0€'}
+    ${-50}      | ${'-50\u00a0€'}
+    ${10.5}     | ${'10,50\u00a0€'}
+    ${-10.5}    | ${'-10,50\u00a0€'}
+    ${17.9}     | ${'17,90\u00a0€'}
+    ${19.99}    | ${'19,99\u00a0€'}
+    ${-19.99}   | ${'-19,99\u00a0€'}
+    ${20.999}   | ${'20,99\u00a0€'}
+    ${-20.999}  | ${'-21\u00a0€'}
+  `('formatPriceInEuroToDisplayPrice($priceInEuro) \t= $expected', ({ priceInEuro, expected }) => {
+    expect(formatPriceInEuroToDisplayPrice(priceInEuro)).toBe(expected)
   })
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13805

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |      <img width="280" alt="Capture d’écran 2022-03-04 à 17 05 55" src="https://user-images.githubusercontent.com/46637324/156798001-52a41a53-6b47-4f1c-bb20-bfee7b153c08.png"><img width="450" alt="Capture d’écran 2022-03-04 à 17 05 41" src="https://user-images.githubusercontent.com/46637324/156798014-001c722d-57e1-4fb6-a7e0-e62e86a5dccd.png">. <img width="280" alt="Capture d’écran 2022-03-04 à 17 05 47" src="https://user-images.githubusercontent.com/46637324/156798012-df794844-4a52-46ac-900b-4b144ffb6725.png"><img width="450" alt="Capture d’écran 2022-03-04 à 17 05 28" src="https://user-images.githubusercontent.com/46637324/156798017-769bf840-20e0-4670-bff7-3305e1d06220.png">
       |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
