### PR TITLE
(PC-13715) fix(accessibility): Add duo aria label to offer tiles and date aria label to search hits

### DIFF
--- a/__snapshots__/features/favorites/atoms/__tests__/Favorite.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/atoms/__tests__/Favorite.native.test.tsx.native-snap
@@ -11,8 +11,8 @@ exports[`<Favorite /> component offer name should take full space if no geolocat
     }
   >
     <View
--     accessibilityLabel=\\"Offre Un lit sous une rivière de la catégorie Musique,   Dès le 4 mars 2021, prix Dès 2,70 €\\"
-+     accessibilityLabel=\\"Offre Un lit sous une rivière de la catégorie Musique, à 10 km,  Dès le 4 mars 2021, prix Dès 2,70 €\\"
+-     accessibilityLabel=\\"Offre Un lit sous une rivière de la catégorie Musique,   Dès le 4 mars 2021, prix Dès 2,70 €. \\"
++     accessibilityLabel=\\"Offre Un lit sous une rivière de la catégorie Musique, à 10 km,  Dès le 4 mars 2021, prix Dès 2,70 €. \\"
       accessible={true}
       collapsable={false}
       focusable={true}

--- a/__snapshots__/features/home/components/tests/OffersModule.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/tests/OffersModule.native.test.tsx.native-snap
@@ -259,7 +259,7 @@ exports[`OffersModule component should render correctly - with black title 1`] =
           }
         >
           <View
-            accessibilityLabel="Offre Mensch ! Où sont les Hommes ? de la catégorie Musique,   prix 28 €"
+            accessibilityLabel="Offre Mensch ! Où sont les Hommes ? de la catégorie Musique,   prix 28 €. "
             accessible={true}
             focusable={true}
             onClick={[Function]}
@@ -454,7 +454,7 @@ exports[`OffersModule component should render correctly - with black title 1`] =
           }
         >
           <View
-            accessibilityLabel="Offre I want something more de la catégorie Musique,   prix 23 €"
+            accessibilityLabel="Offre I want something more de la catégorie Musique,   prix 23 €. "
             accessible={true}
             focusable={true}
             onClick={[Function]}
@@ -649,7 +649,7 @@ exports[`OffersModule component should render correctly - with black title 1`] =
           }
         >
           <View
-            accessibilityLabel="Offre Un lit sous une rivière de la catégorie Musique,  le 17 novembre 2020, prix 34 €"
+            accessibilityLabel="Offre Un lit sous une rivière de la catégorie Musique,  le 17 novembre 2020, prix 34 €. Possibilité de réserver 2 places."
             accessible={true}
             focusable={true}
             onClick={[Function]}
@@ -861,7 +861,7 @@ exports[`OffersModule component should render correctly - with black title 1`] =
           }
         >
           <View
-            accessibilityLabel="Offre I want something more de la catégorie Musique,   prix 28 €"
+            accessibilityLabel="Offre I want something more de la catégorie Musique,   prix 28 €. "
             accessible={true}
             focusable={true}
             onClick={[Function]}

--- a/__snapshots__/features/offer/atoms/__tests__/OfferTile.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/atoms/__tests__/OfferTile.native.test.tsx.native-snap
@@ -13,7 +13,7 @@ exports[`OfferTile component should render correctly 1`] = `
   }
 >
   <View
-    accessibilityLabel="Offre Mensch ! Où sont les Hommes ? de la catégorie MUSIQUE, à 1,2km,  Dès le 12 mars 2020, prix 28 €"
+    accessibilityLabel="Offre Mensch ! Où sont les Hommes ? de la catégorie MUSIQUE, à 1,2km,  Dès le 12 mars 2020, prix 28 €. "
     accessible={true}
     focusable={true}
     onClick={[Function]}

--- a/__snapshots__/features/offer/atoms/__tests__/OfferTile.web.test.tsx.web-snap
+++ b/__snapshots__/features/offer/atoms/__tests__/OfferTile.web.test.tsx.web-snap
@@ -10,7 +10,7 @@ Object {
         style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
       >
         <div
-          aria-label="Offre Mensch ! Où sont les Hommes ? de la catégorie MUSIQUE, à 1,2km,  Dès le 12 mars 2020, prix 28 €"
+          aria-label="Offre Mensch ! Où sont les Hommes ? de la catégorie MUSIQUE, à 1,2km,  Dès le 12 mars 2020, prix 28 €. "
           class="css-view-1dbjc4n"
           data-testid="offerTile"
           style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 100px; margin-top: 3px; user-select: none;"
@@ -93,7 +93,7 @@ Object {
       style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
     >
       <div
-        aria-label="Offre Mensch ! Où sont les Hommes ? de la catégorie MUSIQUE, à 1,2km,  Dès le 12 mars 2020, prix 28 €"
+        aria-label="Offre Mensch ! Où sont les Hommes ? de la catégorie MUSIQUE, à 1,2km,  Dès le 12 mars 2020, prix 28 €. "
         class="css-view-1dbjc4n"
         data-testid="offerTile"
         style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 100px; margin-top: 3px; user-select: none;"

--- a/__snapshots__/features/search/atoms/__tests__/Hit.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/atoms/__tests__/Hit.native.test.tsx.native-snap
@@ -7,8 +7,8 @@ exports[`Hit component offer name should take full space if no geolocation 1`] =
 
 @@ -1,7 +1,7 @@
   <View
--   accessibilityLabel=\\"Offre Mensch ! Où sont les Hommes ? de la catégorie Musique,   prix 0,28 €\\"
-+   accessibilityLabel=\\"Offre Mensch ! Où sont les Hommes ? de la catégorie Musique, à 10 km,  prix 0,28 €\\"
+-   accessibilityLabel=\\"Offre Mensch ! Où sont les Hommes ? de la catégorie Musique,   prix 0,28 €. \\"
++   accessibilityLabel=\\"Offre Mensch ! Où sont les Hommes ? de la catégorie Musique, à 10 km,  prix 0,28 €. \\"
     accessible={true}
     collapsable={false}
     focusable={true}

--- a/__snapshots__/features/venue/atoms/__tests__/VenueOfferTile.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/atoms/__tests__/VenueOfferTile.native.test.tsx.native-snap
@@ -13,7 +13,7 @@ exports[`VenueOfferTile component should render correctly 1`] = `
   }
 >
   <View
-    accessibilityLabel="Offre Mensch ! Où sont les Hommes ? de la catégorie MUSIQUE,   Dès le 12 mars 2020, prix 28 €"
+    accessibilityLabel="Offre Mensch ! Où sont les Hommes ? de la catégorie MUSIQUE,   Dès le 12 mars 2020, prix 28 €. "
     accessible={true}
     focusable={true}
     onClick={[Function]}

--- a/__snapshots__/features/venue/atoms/__tests__/VenueOfferTile.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/atoms/__tests__/VenueOfferTile.web.test.tsx.web-snap
@@ -10,7 +10,7 @@ Object {
         style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
       >
         <div
-          aria-label="Offre Mensch ! Où sont les Hommes ? de la catégorie MUSIQUE,   Dès le 12 mars 2020, prix 28 €"
+          aria-label="Offre Mensch ! Où sont les Hommes ? de la catégorie MUSIQUE,   Dès le 12 mars 2020, prix 28 €. "
           class="css-view-1dbjc4n"
           data-testid="offerTile"
           style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 100px; margin-top: 3px; user-select: none;"
@@ -77,7 +77,7 @@ Object {
       style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
     >
       <div
-        aria-label="Offre Mensch ! Où sont les Hommes ? de la catégorie MUSIQUE,   Dès le 12 mars 2020, prix 28 €"
+        aria-label="Offre Mensch ! Où sont les Hommes ? de la catégorie MUSIQUE,   Dès le 12 mars 2020, prix 28 €. "
         class="css-view-1dbjc4n"
         data-testid="offerTile"
         style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 100px; margin-top: 3px; user-select: none;"

--- a/__snapshots__/features/venue/components/__tests__/VenueOffers.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/components/__tests__/VenueOffers.native.test.tsx.native-snap
@@ -269,7 +269,7 @@ Array [
             }
           >
             <View
-              accessibilityLabel="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+              accessibilityLabel="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
               accessible={true}
               focusable={true}
               onClick={[Function]}
@@ -485,7 +485,7 @@ Array [
             }
           >
             <View
-              accessibilityLabel="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+              accessibilityLabel="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
               accessible={true}
               focusable={true}
               onClick={[Function]}
@@ -701,7 +701,7 @@ Array [
             }
           >
             <View
-              accessibilityLabel="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+              accessibilityLabel="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
               accessible={true}
               focusable={true}
               onClick={[Function]}

--- a/__snapshots__/features/venue/components/__tests__/VenueOffers.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/components/__tests__/VenueOffers.web.test.tsx.web-snap
@@ -110,7 +110,7 @@ Object {
                     style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                   >
                     <div
-                      aria-label="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                      aria-label="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                       class="css-view-1dbjc4n"
                       data-testid="offerTile"
                       style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"
@@ -182,7 +182,7 @@ Object {
                     style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                   >
                     <div
-                      aria-label="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                      aria-label="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                       class="css-view-1dbjc4n"
                       data-testid="offerTile"
                       style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"
@@ -254,7 +254,7 @@ Object {
                     style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                   >
                     <div
-                      aria-label="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                      aria-label="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                       class="css-view-1dbjc4n"
                       data-testid="offerTile"
                       style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"
@@ -467,7 +467,7 @@ Object {
                   style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                 >
                   <div
-                    aria-label="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                    aria-label="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                     class="css-view-1dbjc4n"
                     data-testid="offerTile"
                     style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"
@@ -539,7 +539,7 @@ Object {
                   style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                 >
                   <div
-                    aria-label="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                    aria-label="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                     class="css-view-1dbjc4n"
                     data-testid="offerTile"
                     style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"
@@ -611,7 +611,7 @@ Object {
                   style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                 >
                   <div
-                    aria-label="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                    aria-label="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                     class="css-view-1dbjc4n"
                     data-testid="offerTile"
                     style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"

--- a/__snapshots__/features/venue/pages/__tests__/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/__tests__/Venue.native.test.tsx.native-snap
@@ -1170,7 +1170,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                   }
                 >
                   <View
-                    accessibilityLabel="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                    accessibilityLabel="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                     accessible={true}
                     focusable={true}
                     onClick={[Function]}
@@ -1386,7 +1386,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                   }
                 >
                   <View
-                    accessibilityLabel="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                    accessibilityLabel="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                     accessible={true}
                     focusable={true}
                     onClick={[Function]}
@@ -1602,7 +1602,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                   }
                 >
                   <View
-                    accessibilityLabel="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                    accessibilityLabel="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                     accessible={true}
                     focusable={true}
                     onClick={[Function]}

--- a/__snapshots__/features/venue/pages/__tests__/Venue.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/pages/__tests__/Venue.web.test.tsx.web-snap
@@ -649,7 +649,7 @@ Object {
                             style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                           >
                             <div
-                              aria-label="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                              aria-label="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                               class="css-view-1dbjc4n"
                               data-testid="offerTile"
                               style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"
@@ -721,7 +721,7 @@ Object {
                             style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                           >
                             <div
-                              aria-label="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                              aria-label="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                               class="css-view-1dbjc4n"
                               data-testid="offerTile"
                               style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"
@@ -793,7 +793,7 @@ Object {
                             style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                           >
                             <div
-                              aria-label="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                              aria-label="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                               class="css-view-1dbjc4n"
                               data-testid="offerTile"
                               style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"
@@ -2142,7 +2142,7 @@ Object {
                           style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                         >
                           <div
-                            aria-label="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                            aria-label="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                             class="css-view-1dbjc4n"
                             data-testid="offerTile"
                             style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"
@@ -2214,7 +2214,7 @@ Object {
                           style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                         >
                           <div
-                            aria-label="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                            aria-label="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                             class="css-view-1dbjc4n"
                             data-testid="offerTile"
                             style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"
@@ -2286,7 +2286,7 @@ Object {
                           style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                         >
                           <div
-                            aria-label="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                            aria-label="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                             class="css-view-1dbjc4n"
                             data-testid="offerTile"
                             style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"

--- a/__snapshots__/features/venue/pages/__tests__/VenueBody.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/__tests__/VenueBody.native.test.tsx.native-snap
@@ -831,7 +831,7 @@ exports[`<VenueBody /> should render correctly 1`] = `
                 }
               >
                 <View
-                  accessibilityLabel="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                  accessibilityLabel="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                   accessible={true}
                   focusable={true}
                   onClick={[Function]}
@@ -1047,7 +1047,7 @@ exports[`<VenueBody /> should render correctly 1`] = `
                 }
               >
                 <View
-                  accessibilityLabel="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                  accessibilityLabel="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                   accessible={true}
                   focusable={true}
                   onClick={[Function]}
@@ -1263,7 +1263,7 @@ exports[`<VenueBody /> should render correctly 1`] = `
                 }
               >
                 <View
-                  accessibilityLabel="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                  accessibilityLabel="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                   accessible={true}
                   focusable={true}
                   onClick={[Function]}

--- a/__snapshots__/features/venue/pages/__tests__/VenueBody.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/pages/__tests__/VenueBody.web.test.tsx.web-snap
@@ -488,7 +488,7 @@ Object {
                           style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                         >
                           <div
-                            aria-label="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                            aria-label="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                             class="css-view-1dbjc4n"
                             data-testid="offerTile"
                             style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"
@@ -560,7 +560,7 @@ Object {
                           style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                         >
                           <div
-                            aria-label="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                            aria-label="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                             class="css-view-1dbjc4n"
                             data-testid="offerTile"
                             style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"
@@ -632,7 +632,7 @@ Object {
                           style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                         >
                           <div
-                            aria-label="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                            aria-label="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                             class="css-view-1dbjc4n"
                             data-testid="offerTile"
                             style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"
@@ -1818,7 +1818,7 @@ Object {
                         style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                       >
                         <div
-                          aria-label="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                          aria-label="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                           class="css-view-1dbjc4n"
                           data-testid="offerTile"
                           style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"
@@ -1890,7 +1890,7 @@ Object {
                         style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                       >
                         <div
-                          aria-label="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                          aria-label="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                           class="css-view-1dbjc4n"
                           data-testid="offerTile"
                           style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"
@@ -1962,7 +1962,7 @@ Object {
                         style="flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
                       >
                         <div
-                          aria-label="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit"
+                          aria-label="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                           class="css-view-1dbjc4n"
                           data-testid="offerTile"
                           style="border-top-left-radius: 8px; border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; cursor: pointer; height: 288px; margin-top: 3px; user-select: none;"

--- a/src/features/search/atoms/Hit.tsx
+++ b/src/features/search/atoms/Hit.tsx
@@ -44,6 +44,7 @@ export const Hit: React.FC<Props> = ({ hit, query }) => {
     ...offer,
     categoryLabel: searchGroupLabel,
     distance: distanceToOffer,
+    date: formattedDate,
     price: formattedPrice,
   })
 

--- a/src/libs/tileAccessibilityLabel.ts
+++ b/src/libs/tileAccessibilityLabel.ts
@@ -5,7 +5,10 @@ import { OfferTileProps } from 'features/offer/atoms/OfferTile'
 import { parseTypeHomeLabel } from 'libs/parsers/venueType'
 import { VenueHit } from 'libs/search'
 
-type Offer = Pick<OfferTileProps, 'name' | 'categoryLabel' | 'price' | 'date' | 'distance'>
+type Offer = Pick<
+  OfferTileProps,
+  'name' | 'categoryLabel' | 'price' | 'date' | 'distance' | 'isDuo'
+>
 type Venue = Pick<VenueHit, 'name' | 'venueTypeCode'> & { distance?: string }
 type Booking = {
   name: string
@@ -22,14 +25,18 @@ export enum TileContentType {
 }
 
 function getOfferAccessibilityLabel(offer: Offer) {
-  const { name, categoryLabel: category, distance, date, price } = offer
+  const { name, categoryLabel: category, distance, date, price, isDuo } = offer
   const nameLabel = name ? ` ${name}` : ''
   const categoryLabel = category ? t`de la catégorie` + ` ${category},` : ''
   const distanceLabel = distance ? t`à` + ` ${distance},` : ''
   const datePrefix = date?.match(/^\d/) ? t`le` : ''
   const dateLabel = date ? datePrefix + ` ${date},` : ''
   const priceLabel = price === t`Gratuit` ? price : t`prix` + ` ${price}`
-  return t`Offre` + `${nameLabel} ${categoryLabel} ${distanceLabel} ${dateLabel} ${priceLabel}`
+  const duoLabel = isDuo ? t`Possibilité de réserver 2 places.` : ''
+  return (
+    t`Offre` +
+    `${nameLabel} ${categoryLabel} ${distanceLabel} ${dateLabel} ${priceLabel}. ${duoLabel}`
+  )
 }
 
 function getVenueAccessibilityLabel(venue: Venue) {

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1943,6 +1943,10 @@ msgstr "Place-toi dans un lieu bien éclairé"
 msgid "Politique de confidentialité."
 msgstr "Politique de confidentialité."
 
+#: src/libs/tileAccessibilityLabel.ts
+msgid "Possibilité de réserver 2 places."
+msgstr "Possibilité de réserver 2 places."
+
 #: src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
 msgid "Pour en savoir plus sur la gestion de tes données personnelles et exercer tes droits tu peux :"
 msgstr "Pour en savoir plus sur la gestion de tes données personnelles et exercer tes droits tu peux :"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13715

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [x] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
