### PR TITLE
(PC-13769) fix(signup): navigate to AccountCreated or UnderageAccoundCreated for DMS oprhans

### DIFF
--- a/src/features/identityCheck/pages/__test__/Stepper.test.tsx
+++ b/src/features/identityCheck/pages/__test__/Stepper.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react'
+import waitForExpect from 'wait-for-expect'
+
+import { navigate } from '__mocks__/@react-navigation/native'
+import {
+  IdentityCheckMethod,
+  NextSubscriptionStepResponse,
+  SubscriptionStep,
+  UserProfileResponse,
+} from 'api/gen'
+import { IdentityCheckStepper } from 'features/identityCheck/pages/Stepper'
+import { render } from 'tests/utils'
+
+let mockNextSubscriptionStep: NextSubscriptionStepResponse = {
+  allowedIdentityCheckMethods: [IdentityCheckMethod.ubble, IdentityCheckMethod.educonnect],
+  nextSubscriptionStep: SubscriptionStep['identity-check'],
+  hasIdentityCheckPending: false,
+}
+const mockIdentityCheckDispatch = jest.fn()
+
+jest.mock('features/auth/signup/nextSubscriptionStep', () => ({
+  useNextSubscriptionStep: jest.fn(() => ({
+    data: mockNextSubscriptionStep,
+  })),
+}))
+jest.mock('features/identityCheck/useSetCurrentSubscriptionStep', () => ({
+  useSetSubscriptionStepAndMethod: jest.fn(() => ({
+    subscription: mockNextSubscriptionStep,
+  })),
+}))
+
+let mockUserProfileData: Partial<UserProfileResponse> = {
+  email: 'christophe.dupont@example.com',
+  firstName: 'Christophe',
+  lastName: 'Dupont',
+  domainsCredit: { all: { initial: 3000, remaining: 3000 } },
+}
+
+jest.mock('features/home/api', () => ({
+  useUserProfileInfo: jest.fn(() => ({
+    refetch: jest.fn(() =>
+      Promise.resolve({
+        data: mockUserProfileData,
+      })
+    ),
+  })),
+}))
+jest.mock('features/identityCheck/context/IdentityCheckContextProvider', () => ({
+  useIdentityCheckContext: jest.fn(() => ({ dispatch: mockIdentityCheckDispatch })),
+}))
+jest.mock('features/identityCheck/useIdentityCheckSteps', () => ({
+  useIdentityCheckSteps: jest.fn(() => [
+    {
+      name: 'IdentityCheckStep.IDENTIFICATION',
+      label: 'Identification',
+      icon: 'Icon',
+      screens: ['IdentityCheckStart', 'IdentityCheckWebview', 'IdentityCheckEnd'],
+    },
+  ]),
+}))
+jest.mock('react-query')
+
+describe('Stepper navigation', () => {
+  beforeEach(jest.clearAllMocks)
+  it('should navigate to UnderageAccountCreated when next_step is null and initialCredit is lower than 300 euros', async () => {
+    mockNextSubscriptionStep = {
+      allowedIdentityCheckMethods: [IdentityCheckMethod.ubble],
+      nextSubscriptionStep: null,
+      hasIdentityCheckPending: false,
+    }
+    render(<IdentityCheckStepper />)
+    await waitForExpect(() => {
+      expect(navigate).toHaveBeenCalledWith('UnderageAccountCreated')
+    })
+  })
+  it('should navigate to AccountCreated when next_step is null and initialCredit is 300 euros', async () => {
+    mockNextSubscriptionStep = {
+      allowedIdentityCheckMethods: [IdentityCheckMethod.ubble],
+      nextSubscriptionStep: null,
+      hasIdentityCheckPending: false,
+    }
+    mockUserProfileData = {
+      ...mockUserProfileData,
+      domainsCredit: { all: { initial: 30000, remaining: 30000 } },
+    }
+    render(<IdentityCheckStepper />)
+    await waitForExpect(() => {
+      expect(navigate).toHaveBeenCalledWith('AccountCreated')
+    })
+  })
+  it('should stay on stepper when next_step is null initialCredit is not between 0 and 300 euros', async () => {
+    mockNextSubscriptionStep = {
+      allowedIdentityCheckMethods: [IdentityCheckMethod.ubble],
+      nextSubscriptionStep: null,
+      hasIdentityCheckPending: false,
+    }
+    mockUserProfileData = {
+      ...mockUserProfileData,
+      // @ts-expect-error we test the case where we don't have credit returned
+      domainsCredit: {},
+    }
+    render(<IdentityCheckStepper />)
+    await waitForExpect(() => {
+      expect(navigate).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13769

L'ajout de fonctionnalité du back DMS Orphan permet de faire correspondre les dossiers déposés sur Démarches-Simplifiées (DMS) avant inscription sur l'application avec les nouveaux comptes créés sur l'application.

Pour tous les dossiers qui ont déjà été validés, on ne veut pas que l'utilisateur ait à soumettre à nouveau son document d'identité. 

On fetch donc le nextSubscriptionStep sur le stepper. S'il est `null` et que le crédit attribué au jeune est non-nul, c'est que le compte a été rattaché au dossier DMS orphelin (il a été "adopté"). Dans ce cas, on force la sortie du stepper et le jeune peut profiter de l'application.

Le code est alourdi, il devra être nettoyé lors de la prochaine amélioration du stepper (en cadrage au 11/03/2022), qui fera en sorte qu'un compte "orphelin" n'ait pas du tout à passer par le stepper pour bénéficier de son crédit. Aujourd'hui, c'est encore nécessaire.

## Checklist

I have:

- [X] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [X] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [X] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
