### PR TITLE
(PC-13993) fix(offer): do not parse email as link

### DIFF
--- a/src/libs/parsers/highlightLinks.tsx
+++ b/src/libs/parsers/highlightLinks.tsx
@@ -6,7 +6,7 @@ import { ExternalLink } from 'ui/components/buttons/externalLink/ExternalLink'
 export type ParsedDescription = Array<string | React.ReactNode>
 
 const externalUrlRegex = new RegExp(
-  /((^|\s)|https?:\/\/)[a-z]([-a-z0-9@:%._+~#=]*[a-z0-9])?\.[a-z0-9]{1,6}([/?#]\S*)?(\s|$)/,
+  /((^|\s)|https?:\/\/)[a-z]([-a-z0-9:%._+~#=]*[a-z0-9])?\.[a-z0-9]{1,6}([/?#]\S*)?(\s|$)/,
   'gmi'
 )
 

--- a/src/libs/parsers/tests/highlightLinks.test.tsx
+++ b/src/libs/parsers/tests/highlightLinks.test.tsx
@@ -168,5 +168,11 @@ describe('highlightLinks', () => {
         ])
       })
     })
+
+    it('can contain an email', () => {
+      const parsedDescription = highlightLinks('test@passculture.app')
+
+      expect(parsedDescription).toEqual(['test@passculture.app'])
+    })
   })
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13993

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| Before | After |
| --: | ------: |
|<img width="1438" alt="Capture d’écran 2022-03-16 à 10 12 47" src="https://user-images.githubusercontent.com/78556024/158557068-a694dd3a-88ac-4412-906d-7d5aa0ee25b4.png">|<img width="721" alt="Capture d’écran 2022-03-16 à 10 12 24" src="https://user-images.githubusercontent.com/78556024/158557138-cd7fd837-cc60-4afb-ac07-e4d3210854ab.png">|

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
