### PR TITLE
fix(ci): fix deploy web for staging patches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -822,7 +822,7 @@ workflows:
           filters:
             tags:
               only:
-                - /^v.*/
+                - /^(patch\/)?v.*/
                 - /^hotfix-staging.*/
             branches:
               ignore: /.*/
@@ -863,7 +863,7 @@ workflows:
               only:
                 - /^prod-hard-deploy.*/
                 - /^hotfix-prod.*/
-                - /^v.*/
+                - /^(patch\/)?v.*/
                 - /^hotfix-staging.*/
             branches:
               ignore: /.*/


### PR DESCRIPTION
The previous CI config [pull request](https://github.com/pass-culture/pass-culture-app-native/pull/2773) did not include the web deployment process.

This fixes it.

