### PR TITLE
(PC-13196) fix(connection): distinct errors to investigate why users are disconn…

### DIFF
--- a/src/api/__mocks__/apiHelpers.ts
+++ b/src/api/__mocks__/apiHelpers.ts
@@ -2,7 +2,7 @@
 import { getUniqueId } from 'react-native-device-info'
 
 import { navigateFromRef } from 'features/navigation/navigationRef'
-import { Headers, FailedToRefreshAccessTokenError } from 'libs/fetch'
+import { Headers, FailedToRefreshAccessTokenError, FailedToGetRefreshTokenError } from 'libs/fetch'
 import { decodeAccessToken } from 'libs/jwt'
 import { clearRefreshToken, getRefreshToken } from 'libs/keychain'
 import { storage } from 'libs/storage'
@@ -100,7 +100,7 @@ export const refreshAccessToken = async (api: DefaultApi): Promise<string | null
 
   // if not connected, we also redirect to the login page
   if (refreshToken == null) {
-    throw new FailedToRefreshAccessTokenError()
+    throw new FailedToGetRefreshTokenError()
   }
   try {
     const response = await api.postnativev1refreshAccessToken({

--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -2,7 +2,7 @@
 import { t } from '@lingui/macro'
 
 import { navigateFromRef } from 'features/navigation/navigationRef'
-import { Headers, FailedToRefreshAccessTokenError } from 'libs/fetch'
+import { Headers, FailedToRefreshAccessTokenError, FailedToGetRefreshTokenError } from 'libs/fetch'
 import { decodeAccessToken } from 'libs/jwt'
 import { clearRefreshToken, getRefreshToken } from 'libs/keychain'
 import { eventMonitoring } from 'libs/monitoring'
@@ -103,7 +103,7 @@ export const refreshAccessToken = async (api: DefaultApi): Promise<string | null
 
   // if not connected, we also redirect to the login page
   if (refreshToken == null) {
-    throw new FailedToRefreshAccessTokenError()
+    throw new FailedToGetRefreshTokenError()
   }
   try {
     const response = await api.postnativev1refreshAccessToken({

--- a/src/libs/fetch.ts
+++ b/src/libs/fetch.ts
@@ -51,8 +51,14 @@ class NotAuthenticatedError extends Error {
   }
 }
 
+export class FailedToGetRefreshTokenError extends Error {
+  constructor() {
+    super(`Erreur lors de la récupération du refresh token`)
+  }
+}
+
 export class FailedToRefreshAccessTokenError extends Error {
   constructor() {
-    super(`Erreur lors de la récupération du token d'accès`)
+    super(`Erreur lors de la régénération du token d'accès`)
   }
 }


### PR DESCRIPTION
…ected

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13196


je pense que c’est lié à cette erreur https://sentry.internal-passculture.app/organizations/sentry/issues/328320/?environment=production&project=6&query=is%3Aunresolved&sort=user&statsPeriod=14d

 

dans le code, cette erreur peut apparaitre à 2 endroits, je propose une première PR pour pouvoir savoir de quel endroit l’erreur provient pour savoir où corriger

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
