### PR TITLE
(PC-14394) fix(accessibility): Use existant typography component for credit label

### DIFF
--- a/__snapshots__/features/_marketingAndCommunication/pages/tests/DeeplinksGenerator.test.tsx.web-snap
+++ b/__snapshots__/features/_marketingAndCommunication/pages/tests/DeeplinksGenerator.test.tsx.web-snap
@@ -2627,9 +2627,11 @@ Array [
           }
         }
       >
-        <div
-          className="css-text-901oao"
+        <h4
+          aria-level={4}
+          className="css-reset-4rbku5 css-text-901oao"
           dir="auto"
+          role="heading"
           style={
             Object {
               "color": "rgba(22,22,23,1.00)",
@@ -2641,7 +2643,7 @@ Array [
           }
         >
           Historique
-        </div>
+        </h4>
         <div
           className="css-view-1dbjc4n"
           onScroll={[Function]}

--- a/__snapshots__/features/auth/forgottenPassword/ForgottenPassword/tests/ForgottenPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ForgottenPassword/tests/ForgottenPassword.native.test.tsx.native-snap
@@ -33,7 +33,7 @@ exports[`<ForgottenPassword /> should enable validate button when email input is
                   onResponderMove={[Function onResponderMove]}
                   onResponderRelease={[Function onResponderRelease]}
                   onResponderTerminate={[Function onResponderTerminate]}
-@@ -403,11 +399,11 @@
+@@ -407,11 +403,11 @@
                           \\"paddingTop\\": 0,
                         },
                       ]
@@ -46,7 +46,7 @@ exports[`<ForgottenPassword /> should enable validate button when email input is
               </View>
               <View
                 numberOfSpaces={6}
-@@ -420,24 +416,22 @@
+@@ -424,24 +420,22 @@
                 }
               />
               <View
@@ -73,7 +73,7 @@ exports[`<ForgottenPassword /> should enable validate button when email input is
                     \\"justifyContent\\": \\"center\\",
                     \\"maxWidth\\": 500,
                     \\"minHeight\\": 40,
-@@ -456,11 +450,11 @@
+@@ -460,11 +454,11 @@
                   adjustsFontSizeToFit={false}
                   numberOfLines={1}
                   style={

--- a/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -617,6 +617,10 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                                       style={
                                         Array [
                                           Object {
+                                            "color": "#161617",
+                                            "fontFamily": "Montserrat-Regular",
+                                            "fontSize": 15,
+                                            "lineHeight": 20,
                                             "textAlign": "center",
                                           },
                                         ]

--- a/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.web.test.tsx.web-snap
@@ -188,7 +188,7 @@ Object {
                                           <div
                                             class="css-text-901oao"
                                             dir="auto"
-                                            style="text-align: center;"
+                                            style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
                                           >
                                             <span
                                               class="css-text-901oao css-textHasAncestor-16my406"
@@ -498,7 +498,7 @@ Object {
                                         <div
                                           class="css-text-901oao"
                                           dir="auto"
-                                          style="text-align: center;"
+                                          style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
                                         >
                                           <span
                                             class="css-text-901oao css-textHasAncestor-16my406"

--- a/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.native-snap
@@ -121,6 +121,10 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
         style={
           Array [
             Object {
+              "color": "#161617",
+              "fontFamily": "Montserrat-Regular",
+              "fontSize": 15,
+              "lineHeight": 20,
               "textAlign": "center",
             },
           ]

--- a/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.web-snap
+++ b/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.web-snap
@@ -143,6 +143,10 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
         dir="auto"
         style={
           Object {
+            "color": "rgba(22,22,23,1.00)",
+            "fontFamily": "Montserrat-Regular",
+            "fontSize": "15px",
+            "lineHeight": "20px",
             "textAlign": "center",
           }
         }

--- a/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicy.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicy.native.test.tsx.native-snap
@@ -273,6 +273,10 @@ exports[`<PrivacyPolicy /> should render privacy policy 1`] = `
               style={
                 Array [
                   Object {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
                     "textAlign": "center",
                   },
                 ]
@@ -358,6 +362,10 @@ exports[`<PrivacyPolicy /> should render privacy policy 1`] = `
               style={
                 Array [
                   Object {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 12,
+                    "lineHeight": 16,
                     "paddingHorizontal": "10%",
                     "paddingVertical": 20,
                     "textAlign": "center",

--- a/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicyModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicyModal.native.test.tsx.native-snap
@@ -273,6 +273,10 @@ exports[`<PrivacyPolicyModal /> should render correctly 1`] = `
               style={
                 Array [
                   Object {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
                     "textAlign": "center",
                   },
                 ]
@@ -358,6 +362,10 @@ exports[`<PrivacyPolicyModal /> should render correctly 1`] = `
               style={
                 Array [
                   Object {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 12,
+                    "lineHeight": 16,
                     "paddingHorizontal": "10%",
                     "paddingVertical": 20,
                     "textAlign": "center",

--- a/__snapshots__/features/identityCheck/components/__test__/SomeAdviceBeforeIdentityCheckModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/__test__/SomeAdviceBeforeIdentityCheckModal.native.test.tsx.native-snap
@@ -273,6 +273,10 @@ exports[`<SomeAdviceBeforeIdentityCheckModal/> should render correctly 1`] = `
               style={
                 Array [
                   Object {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
                     "textAlign": "center",
                   },
                 ]

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckStart.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckStart.native.test.tsx.native-snap
@@ -1262,6 +1262,10 @@ Array [
                 style={
                   Array [
                     Object {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
                       "textAlign": "center",
                     },
                   ]

--- a/__snapshots__/features/offer/components/__tests__/OfferHeader.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/__tests__/OfferHeader.native.test.tsx.native-snap
@@ -713,6 +713,10 @@ Array [
                 style={
                   Array [
                     Object {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
                       "paddingBottom": 30,
                       "textAlign": "center",
                     },

--- a/__snapshots__/features/profile/components/CreditCeiling.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/CreditCeiling.native.test.tsx.native-snap
@@ -118,8 +118,10 @@ exports[`CreditCeiling should render properly 1`] = `
       style={
         Array [
           Object {
-            "fontFamily": "Montserrat-Medium",
+            "color": "#161617",
+            "fontFamily": "Montserrat-SemiBold",
             "fontSize": 12,
+            "lineHeight": 16,
           },
         ]
       }

--- a/__snapshots__/features/profile/components/CreditCeiling.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/components/CreditCeiling.web.test.tsx.web-snap
@@ -53,7 +53,7 @@ Object {
           <div
             class="css-text-901oao"
             dir="auto"
-            style="font-family: Montserrat-Medium; font-size: 12px;"
+            style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
           >
             en offres physiques (livres...)
           </div>
@@ -110,7 +110,7 @@ Object {
         <div
           class="css-text-901oao"
           dir="auto"
-          style="font-family: Montserrat-Medium; font-size: 12px;"
+          style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
         >
           en offres physiques (livres...)
         </div>

--- a/src/features/_marketingAndCommunication/atoms/DeeplinkItem.tsx
+++ b/src/features/_marketingAndCommunication/atoms/DeeplinkItem.tsx
@@ -7,7 +7,7 @@ import { openUrl } from 'features/navigation/helpers'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { Share as DefaultShare } from 'ui/svg/icons/Share'
-import { getSpacing, getSpacingString, Spacer } from 'ui/theme'
+import { getSpacing, Spacer, Typo } from 'ui/theme'
 import { TouchableLink } from 'ui/web/link/TouchableLink'
 
 interface Props {
@@ -50,7 +50,7 @@ export const DeeplinkItem = ({ deeplink, before }: Props) => {
           <TouchableLink
             externalHref={deeplink.universalLink}
             onPress={() => openUrl(deeplink.universalLink, { shouldLogEvent: false })}>
-            <Title>{deeplink.universalLink}</Title>
+            <Typo.Caption>{deeplink.universalLink}</Typo.Caption>
           </TouchableLink>
         </Spacer.Flex>
 
@@ -71,7 +71,7 @@ export const DeeplinkItem = ({ deeplink, before }: Props) => {
           <TouchableLink
             externalHref={deeplink.firebaseLink}
             onPress={() => openUrl(deeplink.firebaseLink, { shouldLogEvent: false })}>
-            <Title>{deeplink.firebaseLink}</Title>
+            <Typo.Caption>{deeplink.firebaseLink}</Typo.Caption>
           </TouchableLink>
         </Spacer.Flex>
 
@@ -96,14 +96,6 @@ DeeplinkItem.defaultProps = {
 }
 
 const iconContainerStyle = { margin: 'auto' }
-
-const Title = styled.Text(({ theme }) => ({
-  fontFamily: theme.fontFamily.regular,
-  fontSize: getSpacing(3),
-  lineHeight: getSpacingString(4.5),
-  color: theme.colors.black,
-  flexDirection: 'row',
-}))
 
 const Container = styled.View({
   flexDirection: 'row',

--- a/src/features/_marketingAndCommunication/components/DeeplinksHistory.tsx
+++ b/src/features/_marketingAndCommunication/components/DeeplinksHistory.tsx
@@ -126,10 +126,9 @@ const Container = styled.View({
   padding: getSpacing(2),
 })
 
-const TitleContainer = styled.Text(({ theme }) => ({
-  ...theme.typography.title4,
+const TitleContainer = styled(Typo.Title4)({
   textAlign: 'center',
-}))
+})
 
 const Separator = styled.View(({ theme }) => ({
   height: 2,

--- a/src/features/auth/components/signupComponents.tsx
+++ b/src/features/auth/components/signupComponents.tsx
@@ -1,13 +1,13 @@
 import styled from 'styled-components/native'
 
-import { padding } from 'ui/theme'
+import { padding, Typo } from 'ui/theme'
 
 export const CardContent = styled.View({
   width: '100%',
   alignItems: 'center',
 })
 
-export const Paragraphe = styled.Text({
+export const Paragraphe = styled(Typo.Body)({
   flexWrap: 'wrap',
   flexShrink: 1,
   textAlign: 'center',
@@ -24,6 +24,6 @@ export const Description = styled.View({
   alignItems: 'center',
 })
 
-export const CenteredText = styled.Text({
+export const CenteredText = styled(Typo.Body)({
   textAlign: 'center',
 })

--- a/src/features/auth/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
+++ b/src/features/auth/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
@@ -178,7 +178,7 @@ const ModalContent = styled.View({
   width: '100%',
 })
 
-const CenteredText = styled.Text(({ theme }) => ({
+const CenteredText = styled(Typo.Body)(({ theme }) => ({
   textAlign: 'center',
   maxWidth: theme.contentPage.maxWidth,
 }))

--- a/src/features/auth/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.tsx
+++ b/src/features/auth/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.tsx
@@ -66,6 +66,6 @@ const Description = styled.View({
   alignItems: 'center',
 })
 
-const CenteredText = styled.Text({
+const CenteredText = styled(Typo.Body)({
   textAlign: 'center',
 })

--- a/src/features/auth/signup/PhoneValidation/SetPhoneNumber.tsx
+++ b/src/features/auth/signup/PhoneValidation/SetPhoneNumber.tsx
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { ApiError, extractApiErrorMessage } from 'api/apiHelpers'
 import { useSendPhoneValidationMutation } from 'features/auth/api'
 import { QuitSignupModal } from 'features/auth/components/QuitSignupModal'
+import { Paragraphe } from 'features/auth/components/signupComponents'
 import { useAppSettings } from 'features/auth/settings'
 import { SignupStep } from 'features/auth/signup/enums'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
@@ -193,12 +194,6 @@ const ModalContent = styled.View(({ theme }) => ({
   width: '100%',
   maxWidth: theme.contentPage.maxWidth,
 }))
-
-const Paragraphe = styled.Text({
-  flexWrap: 'wrap',
-  flexShrink: 1,
-  textAlign: 'center',
-})
 
 const InputContainer = styled.View(({ theme }) => ({
   flexDirection: 'row',

--- a/src/features/auth/signup/PhoneValidation/SetPhoneValidationCode.tsx
+++ b/src/features/auth/signup/PhoneValidation/SetPhoneValidationCode.tsx
@@ -14,6 +14,7 @@ import { ApiError, extractApiErrorMessage } from 'api/apiHelpers'
 import { UserProfilingFraudRequest } from 'api/gen'
 import { useSendPhoneValidationMutation, useValidatePhoneNumberMutation } from 'features/auth/api'
 import { QuitSignupModal } from 'features/auth/components/QuitSignupModal'
+import { Paragraphe } from 'features/auth/components/signupComponents'
 import { useAppSettings } from 'features/auth/settings'
 import { SignupStep } from 'features/auth/signup/enums'
 import { useBeneficiaryValidationNavigation } from 'features/auth/signup/useBeneficiaryValidationNavigation'
@@ -337,12 +338,6 @@ const Break = styled.View({
 const ModalContent = styled.View({
   width: '100%',
   alignItems: 'center',
-})
-
-const Paragraphe = styled.Text({
-  flexWrap: 'wrap',
-  flexShrink: 1,
-  textAlign: 'center',
 })
 
 const HelpRow = styled.View(({ theme }) => ({

--- a/src/features/cheatcodes/pages/Navigation/Navigation.tsx
+++ b/src/features/cheatcodes/pages/Navigation/Navigation.tsx
@@ -23,7 +23,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ModalHeader } from 'ui/components/modals/ModalHeader'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
-import { padding, Spacer } from 'ui/theme'
+import { padding, Spacer, Typo } from 'ui/theme'
 
 const MAX_ASYNC_TEST_REQ_COUNT = 3
 const EIFFEL_TOWER_COORDINATES = { lat: 48.8584, lng: 2.2945 }
@@ -378,8 +378,7 @@ const Row = styled.View<{ half?: boolean }>(({ half = false }) => ({
   ...padding(2, 0.5),
 }))
 
-const CenteredText = styled.Text({
+const CenteredText = styled(Typo.Caption)({
   width: '100%',
   textAlign: 'center',
-  fontSize: 13,
 })

--- a/src/features/favorites/components/NotConnectedFavorites.tsx
+++ b/src/features/favorites/components/NotConnectedFavorites.tsx
@@ -85,7 +85,7 @@ const ButtonContainer = styled.View({ flex: 1, maxWidth: getSpacing(44) })
 
 const TextContainer = styled.View({ maxWidth: getSpacing(88) })
 
-const CenteredText = styled.Text({
+const CenteredText = styled(Typo.Body)({
   textAlign: 'center',
 })
 

--- a/src/features/firstLogin/PrivacyPolicy/PrivacyPolicyModal.tsx
+++ b/src/features/firstLogin/PrivacyPolicy/PrivacyPolicyModal.tsx
@@ -87,11 +87,11 @@ const CallToActionsContainer = styled.View(({ theme }) => ({
   width: '100%',
 }))
 
-const Description = styled.Text({
+const Description = styled(Typo.Body)({
   textAlign: 'center',
 })
 
-const SubDescription = styled.Text({
+const SubDescription = styled(Typo.Caption)({
   textAlign: 'center',
   paddingVertical: 20,
   paddingHorizontal: '10%',

--- a/src/features/identityCheck/components/SomeAdviceBeforeIdentityCheckModal.tsx
+++ b/src/features/identityCheck/components/SomeAdviceBeforeIdentityCheckModal.tsx
@@ -46,7 +46,7 @@ export const SomeAdviceBeforeIdentityCheckModal: FunctionComponent<Props> = ({
   </AppModal>
 )
 
-const Description = styled.Text({ textAlign: 'center' })
+const Description = styled(Typo.Body)({ textAlign: 'center' })
 
 interface InstructionProps {
   title: string

--- a/src/features/offer/components/SignUpSignInChoiceOfferModal.tsx
+++ b/src/features/offer/components/SignUpSignInChoiceOfferModal.tsx
@@ -63,7 +63,7 @@ export const SignUpSignInChoiceOfferModal: FunctionComponent<Props> = ({
   )
 }
 
-const Description = styled.Text({
+const Description = styled(Typo.Body)({
   textAlign: 'center',
   paddingBottom: 30,
 })

--- a/src/features/profile/components/CreditCeiling.tsx
+++ b/src/features/profile/components/CreditCeiling.tsx
@@ -82,7 +82,7 @@ export function CreditCeiling(props: CreditCeilingProps) {
       <AnimatedProgressBar progress={progress} color={color} icon={ceilingConfig.icon} />
       <Amount color={color}>{amountLabel}</Amount>
       <View>
-        <Label>{ceilingConfig.label}</Label>
+        <Typo.Caption>{ceilingConfig.label}</Typo.Caption>
       </View>
     </Container>
   )
@@ -97,8 +97,3 @@ const Container = styled.View({
 const Amount = styled(Typo.Title4).attrs(getHeadingAttrs(undefined))<{ color: ColorsEnum }>(
   ({ color }) => ({ color })
 )
-
-const Label = styled.Text({
-  fontSize: 12,
-  fontFamily: 'Montserrat-Medium',
-})

--- a/src/features/search/atoms/NoSearchResult.tsx
+++ b/src/features/search/atoms/NoSearchResult.tsx
@@ -74,7 +74,7 @@ const DescriptionErrorText = styled(Typo.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 
-const DescriptionErrorTextContainer = styled.Text({
+const DescriptionErrorTextContainer = styled(Typo.Body)({
   marginTop: getSpacing(6.5),
   textAlign: 'center',
 })

--- a/src/features/search/pages/SuggestedPlaces.tsx
+++ b/src/features/search/pages/SuggestedPlaces.tsx
@@ -120,7 +120,7 @@ const ItemContainer = styled(TouchableOpacity)({
   alignItems: 'center',
 })
 
-const Text = styled.Text({ flex: 1 })
+const Text = styled.Text(({ theme }) => ({ color: theme.colors.black, flex: 1 }))
 
 const Separator = styled.View(({ theme }) => ({
   height: 2,
@@ -128,7 +128,7 @@ const Separator = styled.View(({ theme }) => ({
   marginHorizontal: getSpacing(6),
 }))
 
-const DescriptionErrorTextContainer = styled.Text({
+const DescriptionErrorTextContainer = styled(Typo.Body)({
   marginTop: getSpacing(6.5),
   textAlign: 'center',
 })

--- a/src/ui/components/ModuleBanner/ModuleBanner.tsx
+++ b/src/ui/components/ModuleBanner/ModuleBanner.tsx
@@ -70,7 +70,7 @@ const IconContainer = styled.View({
   textAlign: 'left',
 })
 
-const TitleContainer = styled.Text({
+const TitleContainer = styled(Typo.ButtonText)({
   marginRight: 5,
 })
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-14394

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots
On a déjà rencontré ce problème dans la page des offres, j'avais fait une analyse de bugs, le problème était qu'on ne fixait pas de couleur au composant `Text` -> il faut privilégier l'utilisation des composants Typo

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     | Pas de différence entre mode sombre et clair : <img width="310" alt="Capture d’écran 2022-04-11 à 18 06 53" src="https://user-images.githubusercontent.com/46637324/162783409-0693d43d-cfac-4ac4-9443-b580fb457411.png">   |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
