### PR TITLE
(PC-14471) fix(accessibility): Add label to favorite icon when user is logged out and no label is shown

### DIFF
--- a/src/features/favorites/atoms/BicolorFavoriteCount.tsx
+++ b/src/features/favorites/atoms/BicolorFavoriteCount.tsx
@@ -29,7 +29,16 @@ export const BicolorFavoriteCount: React.FC<BicolorIconInterface> = ({
   const scale = useScaleFavoritesAnimation(favoritesCount)
 
   if (!isLoggedIn || typeof favoritesCount === 'undefined') {
-    return <BicolorFavorite size={size} color={color} color2={color2} thin={thin} testID={testID} />
+    return (
+      <BicolorFavorite
+        size={size}
+        color={color}
+        color2={color2}
+        thin={thin}
+        accessibilityLabel={showTabBar && !showLabels ? t`Mes favoris` : undefined}
+        testID={testID}
+      />
+    )
   }
 
   const widthFactor = showTabBar ? 0.95 : 0.8

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1526,6 +1526,7 @@ msgstr "Maximum :"
 msgid "Mentions légales"
 msgstr "Mentions légales"
 
+#: src/features/favorites/atoms/BicolorFavoriteCount.tsx
 #: src/features/favorites/pages/Favorites.tsx
 #: src/features/navigation/TabBar/routes.ts
 msgid "Mes favoris"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-14471

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
