### PR TITLE
(PC-14340) build(versions): update versioning system

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -754,7 +754,7 @@ workflows:
       - deploy-android-testing-hard:
           filters:
             tags:
-              only: /^(testing\/)?v.*/
+              only: /^testing\/v.*/
             branches:
               ignore: /.*/
           requires:
@@ -764,7 +764,7 @@ workflows:
       - deploy-ios-testing-hard:
           filters:
             tags:
-              only: /^(testing\/)?v.*/
+              only: /^testing\/v.*/
             branches:
               ignore: /.*/
           requires:
@@ -774,7 +774,7 @@ workflows:
       - notify-hard-testing-release:
           filters:
             tags:
-              only: /^(testing\/)?v.*/
+              only: /^testing\/v.*/
             branches:
               ignore: /.*/
           requires:

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "translations:compile": "lingui compile",
     "trigger:production:deploy:ios": "./scripts/deploy.sh -o ios -t hard -e production",
     "trigger:production:deploy": "./scripts/deploy_new_production_version.sh",
-    "trigger:staging:deploy": "./scripts/deploy_new_version.sh v minor",
+    "trigger:staging:deploy": "./scripts/release_staging_minor.sh && ./scripts/deploy_new_version.sh testing/v minor",
     "trigger:staging:deploy:patch": "./scripts/deploy_new_version.sh patch/v patch",
     "trigger:testing:deploy": "./scripts/deploy_new_version.sh testing/v patch",
     "generate:api:client": "SWAGGER_CODEGEN_CLI_VERSION=3.0.30 ./scripts/generate_api_client.sh",

--- a/scripts/create_and_push_tag_from_package_json_version.sh
+++ b/scripts/create_and_push_tag_from_package_json_version.sh
@@ -5,7 +5,7 @@ set -e
 
 create_and_push_tag_from_package_json_version(){
   TAG_PREFIX="$1"
-  VERSION=`yarn --silent json -f package.json version`
+  source ./scripts/get_version.sh
   git tag --annotate "${TAG_PREFIX}${VERSION}" --message "v${VERSION}"
   git push origin "${TAG_PREFIX}${VERSION}"
 }

--- a/scripts/create_and_push_tag_from_package_json_version.sh
+++ b/scripts/create_and_push_tag_from_package_json_version.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+
+create_and_push_tag_from_package_json_version(){
+  TAG_PREFIX="$1"
+  VERSION=`yarn --silent json -f package.json version`
+  git tag --annotate "${TAG_PREFIX}${VERSION}" --message "v${VERSION}"
+  git push origin "${TAG_PREFIX}${VERSION}"
+}
+
+
+# $1 is the tag used to trigger the ci deployment (see .circleci/config.yml)
+
+create_and_push_tag_from_package_json_version "$1"

--- a/scripts/get_version.sh
+++ b/scripts/get_version.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+VERSION=`yarn --silent json -f package.json version`

--- a/scripts/release_staging_minor.sh
+++ b/scripts/release_staging_minor.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+# When releasing a staging minor, all we do is getting the version from 
+# the package.json and pushing the corresponding tag to trigger the CI.
+
+
+./scripts/check_branch.sh
+
+./scripts/create_and_push_tag_from_package_json_version.sh "v"
+

--- a/scripts/update_app_version.sh
+++ b/scripts/update_app_version.sh
@@ -5,7 +5,7 @@ set -e
 update_app_version(){
   yarn version --"$2" --no-git-tag-version
 
-  VERSION=`yarn --silent json -f package.json version`
+  source ./scripts/get_version.sh
   ./scripts/update_build_number_from_package_json_version.sh
   git add package.json
 

--- a/scripts/update_app_version.sh
+++ b/scripts/update_app_version.sh
@@ -5,41 +5,14 @@ set -e
 update_app_version(){
   yarn version --"$2" --no-git-tag-version
 
-  VERSION=`json -f package.json version`
-
-  # We have to increment the build number because it is used as the versionCode
-  # in app/build.gradle: versionCode (packageJson.build as Integer) and the
-  # Play Store requires this value to be strictly increasing. Otherwise, we get this error:
-
-  # ERROR Google Api Error: forbidden: You cannot rollout this release because it does not allow
-  # any existing users to upgrade to the newly added APKs.
-
-  # As such, since the current version is 10136027 = 1 * 10_000_000 + 136 * 1_000 + 27, we build each new version
-  # as the sum of:
-  #  + 10_000_000 * MAJOR,
-  #  + 1_000 * MINOR,
-  #  + PATCH
-  # where <VERSION> = <MAJOR>.<MINOR>.<PATCH> (ex: 1.137.3) as we use semantic versioning.
-
-  # Examples:
-  #   1.136.27 => 10 000 000 + 136 000 + 027 => 10136027
-  #   1.137.1  => 10 000 000 + 137 000 + 001 => 10137001
-
-
-  SEMVER=( ${VERSION//./ } )
-  MAJOR=${SEMVER[0]}
-  MINOR=${SEMVER[1]}
-  PATCH=${SEMVER[2]}
-  BUILD_NUMBER="$((10000000 * MAJOR + 1000 * MINOR + PATCH))"
-  CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
-
-  json -I -f package.json -e "this.build=$BUILD_NUMBER"
-
+  VERSION=`yarn --silent json -f package.json version`
+  ./scripts/update_build_number_from_package_json_version.sh
   git add package.json
-  git commit -m "v${VERSION}"
-  git tag -a "$1${VERSION}" -m "v${VERSION}"
-  git push origin "$1${VERSION}"
 
+  git commit -m "v${VERSION}"
+  ./scripts/create_and_push_tag_from_package_json_version.sh "$1"
+
+  CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
   if [ "$CURRENT_BRANCH" = "master" ]
   then
     git push

--- a/scripts/update_build_number_from_package_json_version.sh
+++ b/scripts/update_build_number_from_package_json_version.sh
@@ -22,7 +22,7 @@ update_build_number_from_package_json_version(){
   #   1.136.27 => 10 000 000 + 136 000 + 027 => 10136027
   #   1.137.1  => 10 000 000 + 137 000 + 001 => 10137001
 
-  VERSION=`yarn --silent json -f package.json version`
+  source ./scripts/get_version.sh
   SEMVER=( ${VERSION//./ } )
   MAJOR=${SEMVER[0]}
   MINOR=${SEMVER[1]}

--- a/scripts/update_build_number_from_package_json_version.sh
+++ b/scripts/update_build_number_from_package_json_version.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+
+update_build_number_from_package_json_version(){
+  # We have to increment the build number because it is used as the versionCode
+  # in app/build.gradle: versionCode (packageJson.build as Integer) and the
+  # Play Store requires this value to be strictly increasing. Otherwise, we get this error:
+
+  # ERROR Google Api Error: forbidden: You cannot rollout this release because it does not allow
+  # any existing users to upgrade to the newly added APKs.
+
+  # As such, since the current version is 10136027 = 1 * 10_000_000 + 136 * 1_000 + 27, we build each new version
+  # as the sum of:
+  #  + 10_000_000 * MAJOR,
+  #  + 1_000 * MINOR,
+  #  + PATCH
+  # where <VERSION> = <MAJOR>.<MINOR>.<PATCH> (ex: 1.137.3) as we use semantic versioning.
+
+  # Examples:
+  #   1.136.27 => 10 000 000 + 136 000 + 027 => 10136027
+  #   1.137.1  => 10 000 000 + 137 000 + 001 => 10137001
+
+  VERSION=`yarn --silent json -f package.json version`
+  SEMVER=( ${VERSION//./ } )
+  MAJOR=${SEMVER[0]}
+  MINOR=${SEMVER[1]}
+  PATCH=${SEMVER[2]}
+  BUILD_NUMBER="$((10000000 * MAJOR + 1000 * MINOR + PATCH))"
+  yarn json --in-place -f package.json -e "this.build=$BUILD_NUMBER"
+}
+
+update_build_number_from_package_json_version


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-14340


![Nouveau flux de MES](https://user-images.githubusercontent.com/44037911/168113650-1f0cacb0-be47-4954-913f-8e3eb5b6b60e.png)


## Goal of the Pull Request

When we develop a new version on our codebase (available on `master`), we want the `testing` app on AppCenter to have a minor version higher than the version avaibable on staging and in production. Therefore, when we deploy code to the staging environment, the released version number is based on the version number we developed on `master`.

### How it worked before

We always had the same minor version on testing and staging. On the days of deploying a new staging version, we bumped both `testing` and `staging` from `v1.X.Y` to `v1.(X+1).0`. It means that what we had on `master` known as `v1.X.Y`
 is released with a different name on staging.

### How it works with this Pull Request

I have changed the `trigger:staging:deploy` script so that it does two different things:

- it gets the current version from the package.json (e.g. `1.184.5`), ~~resets the patch number to 0 (`1.184.0`)~~ and pushes a `v1.184.5` tag to the origin. This allows the deploy of a `1.184.5` staging build.
- Afterwards, it runs the `update_app_version` script for with a `testing/v` tag to bump the minor of the current package.json version, and pushes the tag. This allows the deploy of a `1.185.0` testing build.

### What hasn't changed

All other deploy scripts should work the exact same way. I have done some function extraction without changing the implementation.
- When patching a version of staging, you should still `git checkout <staging_tag>` to cherry-pick the commits you need, then run `yarn trigger:staging:deploy:patch`, and it will deploy the patched build

### What happens on the CI:

#### When running `yarn trigger:staging:deploy` from a 1.23.4 version on `master`

⚠️ The screenshots are a little bit out of date, they describe the behavior when the plan was to reset the patch number to 0 for staging. We decided to keep the patch number from testing, so it should deploy `1.23.4` on staging and `1.24.0` on testing

<img width="1170" alt="Capture d’écran 2022-04-15 à 14 36 47" src="https://user-images.githubusercontent.com/44037911/163571707-2142abb2-f55a-48fc-aa4f-8dcec95cc9dc.png">

#### When running `yarn trigger:staging:deploy:patch` after checking out the v1.23.0 tag

<img width="1170" alt="Capture d’écran 2022-04-15 à 14 36 59" src="https://user-images.githubusercontent.com/44037911/163571823-6fa382ab-72c0-4aa6-a4c6-2ff81a9545c4.png">



I have:

- [X] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.


[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
