### PR TITLE
(PC-14400) feat(CulturalSurvey): redirect to the right cultural survey on login/signup/initialScreen

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -1725,6 +1725,11 @@
     * @type {boolean}
     * @memberof SettingsResponse
     */
+   enableNativeCulturalSurvey: boolean
+   /**
+    * @type {boolean}
+    * @memberof SettingsResponse
+    */
    enableNativeEacIndividual: boolean
    /**
     * @type {boolean}

--- a/src/features/auth/__mocks__/settings.ts
+++ b/src/features/auth/__mocks__/settings.ts
@@ -9,6 +9,7 @@ export const mockDefaultSettings: SettingsResponse = {
   displayDmsRedirection: true,
   autoActivateDigitalBookings: true,
   enableIdCheckRetention: false,
+  enableNativeCulturalSurvey: false,
   enableNativeIdCheckVerboseDebugging: false,
   idCheckAddressAutocompletion: true,
   objectStorageUrl: 'https://localhost-storage',

--- a/src/features/auth/login/Login.native.test.tsx
+++ b/src/features/auth/login/Login.native.test.tsx
@@ -31,6 +31,16 @@ jest.mock('features/identityCheck/context/IdentityCheckContextProvider', () => (
 
 const mockUsePreviousRoute = usePreviousRoute as jest.Mock
 
+const mockSettings = {
+  enableNativeCulturalSurvey: false,
+}
+
+jest.mock('features/auth/settings', () => ({
+  useAppSettings: jest.fn(() => ({
+    data: mockSettings,
+  })),
+}))
+
 describe('<Login/>', () => {
   beforeEach(() => {
     simulateSignin200()
@@ -85,6 +95,27 @@ describe('<Login/>', () => {
     await waitForExpect(() => {
       expect(navigate).toBeCalledTimes(1)
       expect(navigate).toBeCalledWith('CulturalSurvey')
+    })
+  })
+
+  it('should redirect to NATIVE Cultural Survey WHEN signin is successful, user needs to fill cultural survey when feature flag is activated', async () => {
+    mockSettings.enableNativeCulturalSurvey = true
+    mockMeApiCall({
+      needsToFillCulturalSurvey: true,
+      showEligibleCard: false,
+    } as UserProfileResponse)
+    const renderAPI = renderLogin()
+    const emailInput = renderAPI.getByPlaceholderText('tonadresse@email.com')
+    const passwordInput = renderAPI.getByPlaceholderText('Ton mot de passe')
+    fireEvent.changeText(emailInput, 'email@gmail.com')
+    fireEvent.changeText(passwordInput, 'mypassword')
+
+    fireEvent.press(renderAPI.getByText('Se connecter'))
+    await act(flushAllPromises)
+
+    await waitForExpect(() => {
+      expect(navigate).toBeCalledTimes(1)
+      expect(navigate).toBeCalledWith('CulturalSurveyIntro')
     })
   })
 

--- a/src/features/auth/login/Login.tsx
+++ b/src/features/auth/login/Login.tsx
@@ -7,6 +7,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { api } from 'api/api'
 import { useSignIn, SignInResponseFailure } from 'features/auth/api'
+import { useCulturalSurveyRoute } from 'features/culturalSurvey/helpers/utils'
 import { shouldShowCulturalSurvey } from 'features/firstLogin/helpers'
 import { navigateToHome } from 'features/navigation/helpers'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator'
@@ -52,6 +53,7 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
   const shouldDisableLoginButton = isValueEmpty(email) || isValueEmpty(password) || isLoading
   const emailInputErrorId = uuidv4()
   const passwordInputErrorId = uuidv4()
+  const culturalSurveyRoute = useCulturalSurveyRoute()
 
   const { params } = useRoute<UseRouteType<'Login'>>()
   const { navigate } = useNavigation<UseNavigationType>()
@@ -93,7 +95,7 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
       } else if (!hasSeenEligibleCard && user.showEligibleCard) {
         navigate('EighteenBirthday')
       } else if (shouldShowCulturalSurvey(user)) {
-        navigate('CulturalSurvey')
+        navigate(culturalSurveyRoute)
       } else {
         navigateToHome()
       }

--- a/src/features/auth/signup/AccountCreated/AccountCreated.tsx
+++ b/src/features/auth/signup/AccountCreated/AccountCreated.tsx
@@ -3,6 +3,7 @@ import { useNavigation } from '@react-navigation/native'
 import React, { useEffect } from 'react'
 import styled from 'styled-components/native'
 
+import { useCulturalSurveyRoute } from 'features/culturalSurvey/helpers/utils'
 import { shouldShowCulturalSurvey } from 'features/firstLogin/helpers'
 import { useUserProfileInfo } from 'features/home/api'
 import { navigateToHome } from 'features/navigation/helpers'
@@ -16,12 +17,13 @@ import { Typo } from 'ui/theme'
 export function AccountCreated() {
   const { data: user } = useUserProfileInfo()
   const { navigate } = useNavigation<UseNavigationType>()
+  const culturalSurveyRoute = useCulturalSurveyRoute()
 
   const shouldNavigateToCulturalSurvey = shouldShowCulturalSurvey(user)
 
   function onPress() {
     if (shouldNavigateToCulturalSurvey) {
-      navigate('CulturalSurvey')
+      navigate(culturalSurveyRoute)
     } else {
       navigateToHome()
     }

--- a/src/features/auth/signup/AccountCreated/tests/AccountCreated.native.test.tsx
+++ b/src/features/auth/signup/AccountCreated/tests/AccountCreated.native.test.tsx
@@ -14,6 +14,16 @@ const mockedUseUserProfileInfo = mocked(useUserProfileInfo)
 jest.mock('features/home/api')
 jest.mock('features/navigation/helpers')
 
+const mockSettings = {
+  enableNativeCulturalSurvey: false,
+}
+
+jest.mock('features/auth/settings', () => ({
+  useAppSettings: jest.fn(() => ({
+    data: mockSettings,
+  })),
+}))
+
 beforeEach(() => {
   mockedUseUserProfileInfo.mockReturnValue({
     data: { needsToFillCulturalSurvey: true },
@@ -34,6 +44,17 @@ describe('<AccountCreated />', () => {
     expect(navigateToHome).not.toBeCalledTimes(1)
     expect(navigate).toBeCalledTimes(1)
     expect(navigate).toBeCalledWith('CulturalSurvey')
+  })
+
+  it('should redirect to native cultural survey page WHEN "On y va !" button is clicked when native feature flag is activated', async () => {
+    mockSettings.enableNativeCulturalSurvey = true
+    const renderAPI = render(<AccountCreated />)
+
+    fireEvent.press(await renderAPI.findByText('On y va\u00a0!'))
+
+    expect(navigateToHome).not.toBeCalledTimes(1)
+    expect(navigate).toBeCalledTimes(1)
+    expect(navigate).toBeCalledWith('CulturalSurveyIntro')
   })
 
   it('should redirect to home page WHEN "On y va !" button is clicked and user needs not to fill cultural survey', async () => {

--- a/src/features/culturalSurvey/helpers/utils.ts
+++ b/src/features/culturalSurvey/helpers/utils.ts
@@ -1,4 +1,5 @@
 import { CulturalSurveyQuestionEnum } from 'api/gen/api'
+import { useAppSettings } from 'features/auth/settings'
 
 export const mapQuestionIdToPageTitle = (id: CulturalSurveyQuestionEnum | undefined) => {
   switch (id) {
@@ -11,4 +12,16 @@ export const mapQuestionIdToPageTitle = (id: CulturalSurveyQuestionEnum | undefi
     default:
       return ''
   }
+}
+
+export function useCulturalSurveyRoute() {
+  const { data: settings } = useAppSettings()
+
+  // as long as ENABLE_CULTURAL_SURVEY is still used in the api to define if user should
+  // fill cultural survey, we use enableNativeCulturalSurvey to know which cultural survey
+  // (native or typeform) to show
+  if (settings?.enableNativeCulturalSurvey) {
+    return 'CulturalSurveyIntro'
+  }
+  return 'CulturalSurvey'
 }

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { useAppSettings } from 'features/auth/settings'
+import { useCulturalSurveyRoute } from 'features/culturalSurvey/helpers/utils'
 import { shouldShowCulturalSurvey } from 'features/firstLogin/helpers'
 import { useUserProfileInfo } from 'features/home/api'
 import { navigateToHome } from 'features/navigation/helpers'
@@ -17,12 +18,13 @@ export function BeneficiaryRequestSent() {
   const { navigate } = useNavigation<UseNavigationType>()
   const { data: user } = useUserProfileInfo()
   const { data: settings } = useAppSettings()
+  const culturalSurveyRoute = useCulturalSurveyRoute()
 
   const shouldNavigateToCulturalSurvey = shouldShowCulturalSurvey(user)
 
   function onPress() {
     if (shouldNavigateToCulturalSurvey) {
-      navigate('CulturalSurvey')
+      navigate(culturalSurveyRoute)
     } else {
       navigateToHome()
     }

--- a/src/features/identityCheck/pages/confirmation/__test__/BeneficiaryRequestSent.test.tsx
+++ b/src/features/identityCheck/pages/confirmation/__test__/BeneficiaryRequestSent.test.tsx
@@ -40,7 +40,21 @@ describe('<BeneficiaryRequestSent />', () => {
     expect(navigate).toBeCalledWith('CulturalSurvey')
   })
 
-  it('should redirect to home page WHEN "On y va !" button is clicked and user needs not to fill cultural survey', () => {
+  it('should redirect to native cultural survey page WHEN "On y va !" is clicked and feature flag is activated', () => {
+    mockedUseAppSettings.mockReturnValueOnce({
+      data: { enableNativeCulturalSurvey: true },
+      isLoading: false,
+    } as UseQueryResult<SettingsResponse, unknown>)
+    const { getByText } = render(<BeneficiaryRequestSent />)
+
+    fireEvent.press(getByText('On y va\u00a0!'))
+
+    expect(navigateToHome).not.toBeCalled()
+    expect(navigate).toBeCalledTimes(1)
+    expect(navigate).toBeCalledWith('CulturalSurvey')
+  })
+
+  it('should redirect to home page WHEN "On y va !" button is clicked and user does not need to fill cultural survey', () => {
     mockedUseUserProfileInfo.mockReturnValue({
       data: { needsToFillCulturalSurvey: false },
     } as UseQueryResult<UserProfileResponse>)

--- a/src/features/navigation/RootNavigator/useInitialScreenConfig.tsx
+++ b/src/features/navigation/RootNavigator/useInitialScreenConfig.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 
 import { api } from 'api/api'
 import { useAuthContext } from 'features/auth/AuthContext'
+import { useCulturalSurveyRoute } from 'features/culturalSurvey/helpers/utils'
 import { shouldShowCulturalSurvey } from 'features/firstLogin/helpers'
 import { analytics } from 'libs/analytics'
 import { useSafeState } from 'libs/hooks'
@@ -13,11 +14,12 @@ import { RootScreenNames } from './types'
 
 export function useInitialScreen(): RootScreenNames | undefined {
   const { isLoggedIn } = useAuthContext()
+  const culturalSurveyRoute = useCulturalSurveyRoute()
 
   const [initialScreen, setInitialScreen] = useSafeState<RootScreenNames | undefined>(undefined)
 
   useEffect(() => {
-    getInitialScreen({ isLoggedIn })
+    getInitialScreen({ isLoggedIn, culturalSurveyRoute })
       .then((screen) => {
         setInitialScreen(screen)
         triggerInitialScreenNameAnalytics(screen)
@@ -31,7 +33,13 @@ export function useInitialScreen(): RootScreenNames | undefined {
   return initialScreen
 }
 
-async function getInitialScreen({ isLoggedIn }: { isLoggedIn: boolean }): Promise<RootScreenNames> {
+async function getInitialScreen({
+  isLoggedIn,
+  culturalSurveyRoute,
+}: {
+  isLoggedIn: boolean
+  culturalSurveyRoute: 'CulturalSurveyIntro' | 'CulturalSurvey'
+}): Promise<RootScreenNames> {
   if (isLoggedIn) {
     try {
       const user = await api.getnativev1me()
@@ -45,7 +53,7 @@ async function getInitialScreen({ isLoggedIn }: { isLoggedIn: boolean }): Promis
         return 'EighteenBirthday'
       }
       if (shouldShowCulturalSurvey(user)) {
-        return 'CulturalSurvey'
+        return culturalSurveyRoute
       }
     } catch {
       // If we cannot get user's information, we just go to the homepage

--- a/src/features/navigation/__tests__/useInitialScreenConfig.native.test.tsx
+++ b/src/features/navigation/__tests__/useInitialScreenConfig.native.test.tsx
@@ -17,6 +17,16 @@ import { useInitialScreen } from '../RootNavigator/useInitialScreenConfig'
 const mockedUseAuthContext = useAuthContext as jest.MockedFunction<typeof useAuthContext>
 jest.mock('features/auth/AuthContext')
 
+const mockSettings = {
+  enableNativeCulturalSurvey: false,
+}
+
+jest.mock('features/auth/settings', () => ({
+  useAppSettings: jest.fn(() => ({
+    data: mockSettings,
+  })),
+}))
+
 describe('useInitialScreen()', () => {
   afterAll(async () => {
     await storage.clear('has_seen_tutorials')
@@ -25,27 +35,30 @@ describe('useInitialScreen()', () => {
 
   // prettier-ignore : do not format the following "table" to keep it readable
   it.each`
-    hasSeenTutorials | hasSeenEligibleCard | isLogged | userProfile                                                                                  | expectedScreen                    | expectedAnalyticsScreen
-    ${true}          | ${true}             | ${true}  | ${{ needsToFillCulturalSurvey: false, showEligibleCard: false, recreditAmountToShow: null }} | ${'TabNavigator'}                 | ${'Home'}
-    ${null}          | ${true}             | ${true}  | ${{ needsToFillCulturalSurvey: true, showEligibleCard: false, recreditAmountToShow: null }}  | ${'CulturalSurvey'}               | ${'CulturalSurvey'}
-    ${true}          | ${true}             | ${true}  | ${{ needsToFillCulturalSurvey: true, showEligibleCard: false, recreditAmountToShow: null }}  | ${'CulturalSurvey'}               | ${'CulturalSurvey'}
-    ${true}          | ${true}             | ${true}  | ${{ needsToFillCulturalSurvey: true, showEligibleCard: true, recreditAmountToShow: null }}   | ${'CulturalSurvey'}               | ${'CulturalSurvey'}
-    ${true}          | ${null}             | ${true}  | ${{ needsToFillCulturalSurvey: true, showEligibleCard: true, recreditAmountToShow: null }}   | ${'EighteenBirthday'}             | ${'EighteenBirthday'}
-    ${true}          | ${null}             | ${true}  | ${{ needsToFillCulturalSurvey: true, showEligibleCard: true, recreditAmountToShow: 3000 }}   | ${'RecreditBirthdayNotification'} | ${'RecreditBirthdayNotification'}
-    ${true}          | ${true}             | ${false} | ${{ needsToFillCulturalSurvey: true, showEligibleCard: false, recreditAmountToShow: null }}  | ${'TabNavigator'}                 | ${'Home'}
-    ${true}          | ${true}             | ${false} | ${{ needsToFillCulturalSurvey: false, showEligibleCard: true, recreditAmountToShow: null }}  | ${'TabNavigator'}                 | ${'Home'}
-    ${null}          | ${true}             | ${false} | ${{ needsToFillCulturalSurvey: false, showEligibleCard: false, recreditAmountToShow: null }} | ${'FirstTutorial'}                | ${'FirstTutorial'}
+    hasSeenTutorials | hasSeenEligibleCard | isLogged | userProfile                                                                                  | isNativeCulturalSurveyActive | expectedScreen                    | expectedAnalyticsScreen
+    ${true}          | ${true}             | ${true}  | ${{ needsToFillCulturalSurvey: false, showEligibleCard: false, recreditAmountToShow: null }} | ${true}                      | ${'TabNavigator'}                 | ${'Home'}
+    ${null}          | ${true}             | ${true}  | ${{ needsToFillCulturalSurvey: true, showEligibleCard: false, recreditAmountToShow: null }}  | ${false}                     | ${'CulturalSurvey'}               | ${'CulturalSurvey'}
+    ${true}          | ${true}             | ${true}  | ${{ needsToFillCulturalSurvey: true, showEligibleCard: false, recreditAmountToShow: null }}  | ${false}                     | ${'CulturalSurvey'}               | ${'CulturalSurvey'}
+    ${true}          | ${true}             | ${true}  | ${{ needsToFillCulturalSurvey: true, showEligibleCard: true, recreditAmountToShow: null }}   | ${false}                     | ${'CulturalSurvey'}               | ${'CulturalSurvey'}
+    ${true}          | ${true}             | ${true}  | ${{ needsToFillCulturalSurvey: true, showEligibleCard: true, recreditAmountToShow: null }}   | ${true}                      | ${'CulturalSurveyIntro'}          | ${'CulturalSurveyIntro'}
+    ${true}          | ${null}             | ${true}  | ${{ needsToFillCulturalSurvey: true, showEligibleCard: true, recreditAmountToShow: null }}   | ${true}                      | ${'EighteenBirthday'}             | ${'EighteenBirthday'}
+    ${true}          | ${null}             | ${true}  | ${{ needsToFillCulturalSurvey: true, showEligibleCard: true, recreditAmountToShow: 3000 }}   | ${true}                      | ${'RecreditBirthdayNotification'} | ${'RecreditBirthdayNotification'}
+    ${true}          | ${true}             | ${false} | ${{ needsToFillCulturalSurvey: true, showEligibleCard: false, recreditAmountToShow: null }}  | ${true}                      | ${'TabNavigator'}                 | ${'Home'}
+    ${true}          | ${true}             | ${false} | ${{ needsToFillCulturalSurvey: false, showEligibleCard: true, recreditAmountToShow: null }}  | ${true}                      | ${'TabNavigator'}                 | ${'Home'}
+    ${null}          | ${true}             | ${false} | ${{ needsToFillCulturalSurvey: false, showEligibleCard: false, recreditAmountToShow: null }} | ${true}                      | ${'FirstTutorial'}                | ${'FirstTutorial'}
   `(
     `should return $expectedScreen when 
       - has_seen_tutorials = $hasSeenTutorials 
       - has_seen_eligible_card = $hasSeenEligibleCard
       - isLogged = $isLogged 
-      - user profile = $userProfile`,
+      - user profile = $userProfile
+      - enableNativeCulturalSurvey = $culturalSurveyFF`,
     async ({
       hasSeenTutorials,
       hasSeenEligibleCard,
       isLogged,
       userProfile,
+      isNativeCulturalSurveyActive,
       expectedScreen,
       expectedAnalyticsScreen,
     }) => {
@@ -56,6 +69,7 @@ describe('useInitialScreen()', () => {
         setIsLoggedIn: jest.fn(),
       })
       mockMeApiCall(userProfile as UserProfileResponse)
+      mockSettings.enableNativeCulturalSurvey = isNativeCulturalSurveyActive
 
       const { current: screen } = await renderUseInitialScreen()
 

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -126,6 +126,7 @@ function requestSettingsSuccess(
     isRecaptchaEnabled: true,
     autoActivateDigitalBookings: false,
     enableNativeIdCheckVerboseDebugging: false,
+    enableNativeCulturalSurvey: false,
     enablePhoneValidation: false,
     enableUnderageGeneralisation: false,
     enableIdCheckRetention: false,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-14400

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
