### PR TITLE
(PC-14591) feat(CulturalSurvey): make sure we redirect to native cultural survey when FF is active

### DIFF
--- a/src/features/firstLogin/CulturalSurvey.native.test.tsx
+++ b/src/features/firstLogin/CulturalSurvey.native.test.tsx
@@ -3,7 +3,8 @@ import { UseQueryResult } from 'react-query'
 import waitForExpect from 'wait-for-expect'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import { UserProfileResponse } from 'api/gen'
+import { SettingsResponse, UserProfileResponse } from 'api/gen'
+import { useAppSettings } from 'features/auth/settings'
 import { useUserProfileInfo } from 'features/home/api'
 import { useCurrentRoute, navigateToHome } from 'features/navigation/helpers'
 import { homeNavConfig } from 'features/navigation/TabBar/helpers'
@@ -36,6 +37,9 @@ function mockUseCurrentRoute(name: string) {
   mockedUseCurrentRoute.mockReturnValue({ name, key: 'key' })
 }
 
+jest.mock('features/auth/settings')
+const mockedUseAppSettings = useAppSettings as jest.MockedFunction<typeof useAppSettings>
+
 const DEFAULT_USER = {
   id: 1234,
   needsToFillCulturalSurvey: true,
@@ -49,6 +53,14 @@ describe('<CulturalSurvey />', () => {
   it('should render correctly', async () => {
     const renderAPI = await renderCulturalSurveyWithNavigation()
     expect(renderAPI).toMatchSnapshot()
+  })
+
+  it('should redirect to native cultural survey if FF is active', async () => {
+    mockedUseAppSettings.mockReturnValueOnce({
+      data: { enableNativeCulturalSurvey: true },
+    } as UseQueryResult<SettingsResponse, unknown>)
+    await renderCulturalSurveyWithNavigation()
+    expect(navigate).toHaveBeenCalledWith('CulturalSurveyIntro')
   })
 
   it('should not display webview when another screen is displayed', async () => {

--- a/src/features/firstLogin/CulturalSurvey.tsx
+++ b/src/features/firstLogin/CulturalSurvey.tsx
@@ -1,12 +1,17 @@
-import React from 'react'
+import { useNavigation } from '@react-navigation/native'
+import React, { useEffect } from 'react'
 import { WebView } from 'react-native-webview'
 import styled from 'styled-components/native'
 
+import { useAppSettings } from 'features/auth/settings'
 import { withCulturalSurveyProvider } from 'features/firstLogin/helpers'
+import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { Spacer } from 'ui/theme'
 
 export const CulturalSurvey: React.FC = withCulturalSurveyProvider(function (props) {
   const { userId, userPk, url } = props.culturalSurveyConfig
+  const { navigate } = useNavigation<UseNavigationType>()
+  const { data: settings } = useAppSettings()
 
   function onNavigationStateChange(webviewUrl: string, idUser: string, pkUser: string) {
     const isTypeformShowedInWebview = webviewUrl.includes('typeform.com')
@@ -14,6 +19,13 @@ export const CulturalSurvey: React.FC = withCulturalSurveyProvider(function (pro
       props.onCulturalSurveyExit(idUser, pkUser)
     }
   }
+
+  useEffect(() => {
+    // make sure we redirect to the right cultural survey if feature flag is activated
+    if (settings?.enableNativeCulturalSurvey) {
+      navigate('CulturalSurveyIntro')
+    }
+  })
 
   return (
     <React.Fragment>

--- a/src/features/firstLogin/CulturalSurvey.web.tsx
+++ b/src/features/firstLogin/CulturalSurvey.web.tsx
@@ -1,10 +1,22 @@
+import { useNavigation } from '@react-navigation/native'
 import { Widget as TypeformWidget } from '@typeform/embed-react'
-import React from 'react'
+import React, { useEffect } from 'react'
 
+import { useAppSettings } from 'features/auth/settings'
 import { withCulturalSurveyProvider } from 'features/firstLogin/helpers'
+import { UseNavigationType } from 'features/navigation/RootNavigator'
 
 export const CulturalSurvey: React.FC = withCulturalSurveyProvider(function (props) {
   const { formId, userId, userPk, source } = props.culturalSurveyConfig
+  const { navigate } = useNavigation<UseNavigationType>()
+  const { data: settings } = useAppSettings()
+
+  useEffect(() => {
+    // make sure we redirect to the right cultural survey if feature flag is activated
+    if (settings?.enableNativeCulturalSurvey) {
+      navigate('CulturalSurveyIntro')
+    }
+  })
   return (
     <TypeformWidget
       id={formId}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-14591

## Contexte
On souhaite montrer le QPI à l'ouverture de l'app si `user.needsToFillCulturalSurvey=true`. Problème: à l'ouverture de l'app, si les settings sont `undefined`, on redirige vers le typeform et on ne peut plus rediriger vers le QPI natif (même si le FF ENABLE_NATIVE_CULTURAL_SURVEY est true). Cette PR sert à rediriger vers le typeform vers le QPI natif si le FF est activé.

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
