### PR TITLE
(PC-14355) fix(accessibility): Separate navigation and onPress in NotEligibleEduconnect screen

### DIFF
--- a/src/features/identityCheck/errors/eduConnect/NotEligibleEduConnect.tsx
+++ b/src/features/identityCheck/errors/eduConnect/NotEligibleEduConnect.tsx
@@ -30,6 +30,7 @@ export const NotEligibleEduConnect = ({
     primaryButtonText,
     tertiaryButtonVisible = false,
     onPrimaryButtonPress,
+    navigateTo,
   } = useNotEligibleEduConnectErrorData(message, setError)
 
   useEffect(
@@ -61,7 +62,7 @@ export const NotEligibleEduConnect = ({
           key={1}
           as={ButtonPrimaryWhite}
           wording={primaryButtonText ?? "Retourner à l'accueil"}
-          navigateTo={onPrimaryButtonPress ? undefined : navigateToHomeConfig}
+          navigateTo={navigateTo ?? navigateToHomeConfig}
           onPress={onPrimaryButtonPress}
         />,
         !!tertiaryButtonVisible && (

--- a/src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
+++ b/src/features/identityCheck/errors/hooks/useNotEligibleEduConnectErrorData.ts
@@ -5,6 +5,7 @@ import { TextStyle } from 'react-native'
 
 import { useBeneficiaryValidationNavigation } from 'features/auth/signup/useBeneficiaryValidationNavigation'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
+import { TouchableLinkProps } from 'ui/components/touchableLink/types'
 import { MaintenanceCone } from 'ui/svg/icons/MaintenanceCone'
 import { IconInterface } from 'ui/svg/icons/types'
 import { UserError } from 'ui/svg/icons/UserError'
@@ -25,6 +26,7 @@ type NotEligibleEduConnectErrorData = {
   primaryButtonText?: string
   tertiaryButtonVisible?: boolean
   onPrimaryButtonPress?: () => void
+  navigateTo?: TouchableLinkProps['navigateTo']
 }
 
 const UserAgeNotValid: NotEligibleEduConnectErrorData = {
@@ -39,7 +41,8 @@ const UserAgeNotValid: NotEligibleEduConnectErrorData = {
 }
 
 const getInvalidInformation = (
-  onPrimaryButtonPress: () => void
+  onPrimaryButtonPress: () => void,
+  navigateTo: TouchableLinkProps['navigateTo']
 ): NotEligibleEduConnectErrorData => ({
   Icon: UserError,
   title: t`Oh non\u00a0!`,
@@ -51,10 +54,12 @@ const getInvalidInformation = (
   primaryButtonText: t`Vérifier mon identité`,
   tertiaryButtonVisible: true,
   onPrimaryButtonPress,
+  navigateTo,
 })
 
 const getUserTypeNotStudent = (
-  onPrimaryButtonPress: () => void
+  onPrimaryButtonPress: () => void,
+  navigateTo: TouchableLinkProps['navigateTo']
 ): NotEligibleEduConnectErrorData => ({
   Icon: UserError,
   title: t`Qui est-ce\u00a0?`,
@@ -66,6 +71,7 @@ const getUserTypeNotStudent = (
   primaryButtonText: t`Réessayer de m'identifier`,
   tertiaryButtonVisible: true,
   onPrimaryButtonPress,
+  navigateTo,
 })
 
 const GenericError: NotEligibleEduConnectErrorData = {
@@ -80,20 +86,26 @@ export function useNotEligibleEduConnectErrorData(
   message: EduConnectErrorMessageEnum | string,
   setError: (error: Error | undefined) => void
 ) {
-  const { navigateToNextBeneficiaryValidationStep } = useBeneficiaryValidationNavigation(setError)
-  const { goBack, navigate } = useNavigation<UseNavigationType>()
+  const { nextBeneficiaryValidationStepNavConfig, beforeNavigateToNextSubscriptionStep } =
+    useBeneficiaryValidationNavigation(setError)
+  const { goBack } = useNavigation<UseNavigationType>()
   switch (message) {
     case EduConnectErrorMessageEnum.UserAgeNotValid18YearsOld:
-      return getInvalidInformation(navigateToNextBeneficiaryValidationStep)
+      return getInvalidInformation(
+        beforeNavigateToNextSubscriptionStep,
+        nextBeneficiaryValidationStepNavConfig
+      )
 
     case EduConnectErrorMessageEnum.UserAgeNotValid:
       return UserAgeNotValid
 
     case EduConnectErrorMessageEnum.UserTypeNotStudent:
-      return getUserTypeNotStudent(() => {
-        goBack()
-        navigate('IdentityCheckEduConnectForm')
-      })
+      return getUserTypeNotStudent(
+        () => {
+          goBack()
+        },
+        { screen: 'IdentityCheckEduConnectForm' }
+      )
 
     default:
       return GenericError


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-14355

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
