### PR TITLE
(PC-14104) fix(test): Fix OfferHeader flaky test

### DIFF
--- a/src/features/offer/components/__tests__/OfferHeader.web.test.tsx
+++ b/src/features/offer/components/__tests__/OfferHeader.web.test.tsx
@@ -17,7 +17,7 @@ import { env } from 'libs/environment'
 import { EmptyResponse } from 'libs/fetch'
 import { reactQueryProviderHOC, queryCache } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
-import { superFlushWithAct, act, cleanup, fireEvent, render } from 'tests/utils/web'
+import { superFlushWithAct, act, cleanup, fireEvent, render, waitFor } from 'tests/utils/web'
 import {
   showSuccessSnackBar,
   showErrorSnackBar,
@@ -167,11 +167,11 @@ describe('<OfferHeader />', () => {
 
     expect(queryByTestId('icon-favorite-filled')).toBeTruthy()
 
-    await superFlushWithAct(20)
-
-    expect(showErrorSnackBar).toBeCalledWith({
-      message: `L'offre n'a pas été ajoutée à tes favoris`,
-      timeout: SNACK_BAR_TIME_OUT,
+    await waitFor(() => {
+      expect(showErrorSnackBar).toBeCalledWith({
+        message: `L'offre n'a pas été ajoutée à tes favoris`,
+        timeout: SNACK_BAR_TIME_OUT,
+      })
     })
 
     await superFlushWithAct(20)
@@ -228,11 +228,11 @@ describe('<OfferHeader />', () => {
       mutateData.favorites?.find((f: FavoriteResponse) => f.offer.id === favoriteOfferId)?.offer.id
     ).toBe(undefined)
 
-    await superFlushWithAct()
-
-    expect(showErrorSnackBar).toBeCalledWith({
-      message: `L'offre n'a pas été retirée de tes favoris`,
-      timeout: SNACK_BAR_TIME_OUT,
+    await waitFor(() => {
+      expect(showErrorSnackBar).toBeCalledWith({
+        message: `L'offre n'a pas été retirée de tes favoris`,
+        timeout: SNACK_BAR_TIME_OUT,
+      })
     })
 
     const dataAfter = queryCache.find('favorites')?.state?.data as PaginatedFavoritesResponse
@@ -250,11 +250,11 @@ describe('<OfferHeader />', () => {
 
     fireEvent.click(getByTestId('icon-favorite'))
 
-    await superFlushWithAct()
-
-    expect(showErrorSnackBar).toBeCalledWith({
-      message: `Trop de favoris enregistrés. Supprime des favoris pour en ajouter de nouveaux.`,
-      timeout: SNACK_BAR_TIME_OUT,
+    await waitFor(() => {
+      expect(showErrorSnackBar).toBeCalledWith({
+        message: `Trop de favoris enregistrés. Supprime des favoris pour en ajouter de nouveaux.`,
+        timeout: SNACK_BAR_TIME_OUT,
+      })
     })
   })
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-14104

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
