### PR TITLE
(PC-14413) feat(apiHelpers): better log when user are disconnected because refresh token is expired

### DIFF
--- a/src/api/__tests__/apiHelpers.test.ts
+++ b/src/api/__tests__/apiHelpers.test.ts
@@ -1,6 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 
-import { FailedToRefreshAccessTokenError } from 'libs/fetch'
 import * as jwt from 'libs/jwt'
 import * as Keychain from 'libs/keychain'
 
@@ -191,24 +190,22 @@ describe('[api] helpers', () => {
       mockGetRefreshToken.mockResolvedValueOnce(password)
       mockFetch.mockResolvedValueOnce(respondWith({ error: 'server error' }, 500))
 
-      try {
-        await refreshAccessToken(api, 0)
-      } catch {
-        // tested in his own test
-      }
+      await refreshAccessToken(api, 0)
 
       expect(AsyncStorage.removeItem).toHaveBeenCalledWith('access_token')
       expect(mockClearRefreshToken).toHaveBeenCalled()
     })
 
-    it('should reject with an exception when there is an unexpected behavior', async () => {
+    it('should return UNKNOWN_ERROR_WHILE_REFRESHING_ACCESS_TOKEN when there is an unexpected behavior', async () => {
       const password = 'refreshToken'
       mockGetRefreshToken.mockResolvedValueOnce(password)
       mockFetch.mockResolvedValueOnce(respondWith({ error: 'server error' }, 500))
 
-      const resultPromise = refreshAccessToken(api, 0)
+      const result = await refreshAccessToken(api, 0)
 
-      await expect(resultPromise).rejects.toEqual(new FailedToRefreshAccessTokenError())
+      expect(result).toStrictEqual({
+        error: "Une erreur inconnue est survenue lors de la regénération de l'access token",
+      })
     })
 
     it('should retry to refresh access token when the first call fails', async () => {

--- a/src/api/__tests__/apiHelpers.test.ts
+++ b/src/api/__tests__/apiHelpers.test.ts
@@ -150,6 +150,14 @@ describe('[api] helpers', () => {
   })
 
   describe('refreshAccessToken', () => {
+    it('should remove access token when there is no refresh token', async () => {
+      mockGetRefreshToken.mockResolvedValueOnce(null)
+
+      await refreshAccessToken(api, 0)
+
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('access_token')
+    })
+
     it('should return FAILED_TO_GET_REFRESH_TOKEN_ERROR when there is no refresh token', async () => {
       mockGetRefreshToken.mockResolvedValueOnce(null)
 

--- a/src/api/__tests__/apiHelpers.test.ts
+++ b/src/api/__tests__/apiHelpers.test.ts
@@ -219,5 +219,26 @@ describe('[api] helpers', () => {
 
       expect(result).toEqual({ result: accessToken })
     })
+
+    it('should remove tokens when refresh token is expired', async () => {
+      const password = 'refreshToken'
+      mockGetRefreshToken.mockResolvedValueOnce(password)
+      mockFetch.mockResolvedValueOnce(respondWith({ error: 'refresh token is expired' }, 401))
+
+      await refreshAccessToken(api, 0)
+
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('access_token')
+      expect(mockClearRefreshToken).toHaveBeenCalled()
+    })
+
+    it('should return REFRESH_TOKEN_IS_EXPIRED_ERROR when refresh token is expired', async () => {
+      const password = 'refreshToken'
+      mockGetRefreshToken.mockResolvedValueOnce(password)
+      mockFetch.mockResolvedValueOnce(respondWith({ error: 'refresh token is expired' }, 401))
+
+      const result = await refreshAccessToken(api, 0)
+
+      expect(result).toEqual({ error: 'Le refresh token est expiré' })
+    })
   })
 })

--- a/src/api/__tests__/apiHelpers.test.ts
+++ b/src/api/__tests__/apiHelpers.test.ts
@@ -24,7 +24,7 @@ const optionsWithAccessToken = {
 describe('[api] helpers', () => {
   const mockFetch = jest.spyOn(global, 'fetch')
   const mockGetAccessTokenStatus = jest.spyOn(jwt, 'getAccessTokenStatus')
-  const mockKeychain = jest.spyOn(Keychain, 'getRefreshToken')
+  const mockGetRefreshToken = jest.spyOn(Keychain, 'getRefreshToken')
 
   describe('[method] safeFetch', () => {
     it('should call fetch with populated header', async () => {
@@ -94,7 +94,7 @@ describe('[api] helpers', () => {
 
     it('needs authentication response when there is no refresh token', async () => {
       mockGetAccessTokenStatus.mockReturnValueOnce('expired')
-      mockKeychain.mockResolvedValueOnce(null)
+      mockGetRefreshToken.mockResolvedValueOnce(null)
 
       const response = await safeFetch('/native/v1/me', optionsWithAccessToken, api)
 
@@ -106,7 +106,7 @@ describe('[api] helpers', () => {
       const apiUrl = '/native/v1/me'
       mockGetAccessTokenStatus.mockReturnValueOnce('expired')
       const password = 'refreshToken'
-      mockKeychain.mockResolvedValueOnce(password).mockResolvedValueOnce(password)
+      mockGetRefreshToken.mockResolvedValueOnce(password).mockResolvedValueOnce(password)
       const expectedResponse = respondWith('some api response')
       mockFetch
         .mockRejectedValueOnce('some error')

--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -115,6 +115,7 @@ export const refreshAccessToken = async (
 
   // if not connected, we also redirect to the login page
   if (refreshToken == null) {
+    await storage.clear('access_token')
     return { error: FAILED_TO_GET_REFRESH_TOKEN_ERROR }
   }
   try {

--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -49,7 +49,14 @@ export const AuthWrapper = memo(function AuthWrapper({ children }: { children: J
       if (getAccessTokenStatus(accessToken) === 'expired') {
         // refreshAccessToken calls the backend to get a new access token
         // and also saves it to the storage
-        const { result } = await refreshAccessToken(api)
+        const { result, error } = await refreshAccessToken(api)
+
+        if (error) {
+          eventMonitoring.captureException(new Error(`AuthWrapper ${error}`))
+          setIsLoggedIn(false)
+          return
+        }
+
         if (result) {
           accessToken = result
         }

--- a/src/libs/eduConnectClient.ts
+++ b/src/libs/eduConnectClient.ts
@@ -17,23 +17,14 @@ export const eduConnectClient = {
       return Promise.reject(new Error())
     }
     if (accessTokenStatus === 'expired') {
-      try {
-        const { result: accessToken, error } = await refreshAccessToken(api)
+      const { result, error } = await refreshAccessToken(api)
 
-        if (error) {
-          eventMonitoring.captureException(error, {
-            message: 'eduConnectClient failed to get refreshAccessToken',
-          })
-          return Promise.reject(new Error('eduConnectClient failed to get refreshAccessToken'))
-        }
-
-        return accessToken
-      } catch (error) {
-        eventMonitoring.captureException(error, {
-          message: 'eduConnectClient failed to refreshAccessToken',
-        })
-        return Promise.reject(new Error('eduConnectClient failed to refreshAccessToken'))
+      if (error) {
+        eventMonitoring.captureException(new Error(`eduConnectClient ${error}`))
+        return Promise.reject(new Error(`eduConnectClient ${error}`))
       }
+
+      return result
     }
     return accessToken
   },

--- a/src/libs/fetch.ts
+++ b/src/libs/fetch.ts
@@ -50,9 +50,3 @@ class NotAuthenticatedError extends Error {
     super(`Erreur d'authentification`)
   }
 }
-
-export class FailedToRefreshAccessTokenError extends Error {
-  constructor() {
-    super(`Erreur lors de la régénération du token d'accès`)
-  }
-}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-14413

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (~~native~~ and **web**).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.

