### PR TITLE
(PC-14556) feat(ProfileDeletion): Add new info screen for suspended users

### DIFF
--- a/__snapshots__/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.native.test.tsx.native-snap
@@ -1,0 +1,410 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SuspendedAccount /> should match snapshot 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+      },
+    ]
+  }
+>
+  <View
+    height="100%"
+    style={
+      Array [
+        Object {
+          "bottom": 0,
+          "height": "100%",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "width": "100%",
+          "zIndex": -1,
+        },
+      ]
+    }
+    width="100%"
+  >
+    <View
+      height="100%"
+      width="100%"
+    >
+      <Text>
+        undefined-SVG-Mock
+      </Text>
+    </View>
+  </View>
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    nativeID="animatedComponent"
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "left": 24,
+        "opacity": 1,
+        "position": "absolute",
+        "top": 30,
+        "userSelect": "auto",
+        "zIndex": 1,
+      }
+    }
+    testID="Revenir en arrière"
+  >
+    <View
+      height={24}
+      width={24}
+    >
+      <Text>
+        undefined-SVG-Mock
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "flexBasis": 0,
+          "flexDirection": "column",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "justifyContent": "center",
+          "maxWidth": 360,
+          "overflow": "scroll",
+          "paddingHorizontal": 16,
+        },
+      ]
+    }
+  >
+    <View
+      customHeight={16}
+      enable={true}
+      style={
+        Array [
+          Object {
+            "height": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+        ]
+      }
+    />
+    <View
+      numberOfSpaces={10}
+      style={
+        Array [
+          Object {
+            "height": 40,
+          },
+        ]
+      }
+    />
+    <View
+      height={156}
+      width={200}
+    >
+      <Text>
+        undefined-SVG-Mock
+      </Text>
+    </View>
+    <View
+      numberOfSpaces={5}
+      style={
+        Array [
+          Object {
+            "height": 20,
+          },
+        ]
+      }
+    />
+    <Text
+      fontSize={24}
+      style={
+        Array [
+          Object {
+            "color": "#161617",
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 24,
+            "lineHeight": 28,
+          },
+          Object {
+            "color": "#ffffff",
+            "textAlign": "center",
+          },
+        ]
+      }
+    >
+      Ton compte est désactivé
+    </Text>
+    <View
+      numberOfSpaces={5}
+      style={
+        Array [
+          Object {
+            "height": 20,
+          },
+        ]
+      }
+    />
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#ffffff",
+            "fontFamily": "Montserrat-Regular",
+            "fontSize": 15,
+            "lineHeight": 20,
+            "textAlign": "center",
+          },
+        ]
+      }
+    >
+      Tu as jusqu'au xxxx pour réactiver ton compte.
+    </Text>
+    <View
+      numberOfSpaces={5}
+      style={
+        Array [
+          Object {
+            "height": 20,
+          },
+        ]
+      }
+    />
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#ffffff",
+            "fontFamily": "Montserrat-Regular",
+            "fontSize": 15,
+            "lineHeight": 20,
+            "textAlign": "center",
+          },
+        ]
+      }
+    >
+      Une fois cette date passée, ton compte pass Culture sera définitivement supprimé.
+    </Text>
+    <View
+      numberOfSpaces={5}
+      style={
+        Array [
+          Object {
+            "height": 20,
+          },
+        ]
+      }
+    />
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#ffffff",
+            "fontFamily": "Montserrat-Regular",
+            "fontSize": 15,
+            "lineHeight": 20,
+            "textAlign": "center",
+          },
+        ]
+      }
+    >
+      Pour réactiver ton compte nous allons te demander de réinitialiser ton mot de passe.
+    </Text>
+    <View
+      numberOfSpaces={30}
+      style={
+        Array [
+          Object {
+            "height": 120,
+          },
+        ]
+      }
+    />
+    <View
+      flex={0.5}
+      style={
+        Array [
+          Object {
+            "flexBasis": 0,
+            "flexGrow": 0.5,
+            "flexShrink": 1,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "alignSelf": "stretch",
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+            "justifyContent": "flex-end",
+            "marginBottom": 32,
+          },
+        ]
+      }
+    >
+      <View
+        accessibilityLabel="Réactiver mon compte"
+        accessible={true}
+        collapsable={false}
+        focusable={false}
+        nativeID="animatedComponent"
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#ffffff",
+            "borderRadius": 24,
+            "flexDirection": "row",
+            "justifyContent": "center",
+            "maxWidth": 500,
+            "minHeight": 40,
+            "opacity": 1,
+            "paddingBottom": 2,
+            "paddingLeft": 2,
+            "paddingRight": 2,
+            "paddingTop": 2,
+            "userSelect": "auto",
+            "width": "100%",
+          }
+        }
+        testID="Réactiver mon compte"
+      >
+        <Text
+          adjustsFontSizeToFit={false}
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "color": "#eb0055",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 15,
+                "lineHeight": 20,
+                "marginLeft": 0,
+                "maxWidth": "100%",
+              },
+            ]
+          }
+        >
+          Réactiver mon compte
+        </Text>
+      </View>
+      <View
+        numberOfSpaces={4}
+        style={
+          Array [
+            Object {
+              "height": 16,
+            },
+          ]
+        }
+      />
+      <View
+        accessibilityLabel="Retourner à l'accueil"
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        nativeID="animatedComponent"
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderRadius": 24,
+            "flexDirection": "row",
+            "justifyContent": "center",
+            "maxWidth": 500,
+            "minHeight": 40,
+            "opacity": 1,
+            "paddingBottom": 2,
+            "paddingLeft": 2,
+            "paddingRight": 2,
+            "paddingTop": 2,
+            "userSelect": "auto",
+            "width": "100%",
+          }
+        }
+        testID="Retourner à l'accueil"
+      >
+        <View
+          height={20}
+          testID="button-icon"
+          width={20}
+        >
+          <Text>
+            button-icon-SVG-Mock
+          </Text>
+        </View>
+        <Text
+          adjustsFontSizeToFit={false}
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "color": "#ffffff",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 15,
+                "lineHeight": 20,
+                "marginLeft": 8,
+                "maxWidth": "100%",
+              },
+            ]
+          }
+        >
+          Retourner à l'accueil
+        </Text>
+      </View>
+    </View>
+    <View
+      customHeight={8}
+      enable={true}
+      style={
+        Array [
+          Object {
+            "height": 8,
+          },
+        ]
+      }
+    />
+  </View>
+</View>
+`;

--- a/__snapshots__/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.web.test.tsx.web-snap
@@ -1,0 +1,368 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SuspendedAccount /> should match snapshot 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="css-view-1dbjc4n"
+        style="align-items: center; flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
+      >
+        <div
+          class="css-view-1dbjc4n"
+          style="bottom: 0px; height: 100%; left: 0px; position: absolute; right: 0px; top: 0px; width: 100%; z-index: -1;"
+        >
+          <div
+            class="css-view-1dbjc4n"
+          >
+            <div
+              class="css-text-901oao"
+              dir="auto"
+            >
+              undefined-SVG-Mock
+            </div>
+          </div>
+        </div>
+        <button
+          class="sc-eCImPb eivvKD sc-jRQBWg guzjoD sc-jRQBWg guzjoD"
+          data-testid="Revenir en arrière"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="css-view-1dbjc4n"
+          >
+            <div
+              class="css-text-901oao"
+              dir="auto"
+            >
+              undefined-SVG-Mock
+            </div>
+          </div>
+        </button>
+        <div
+          class="css-view-1dbjc4n"
+          style="align-items: center; flex-basis: 0px; flex-direction: column; flex-grow: 1; flex-shrink: 1; justify-content: center; max-width: 360px; overflow-x: scroll; overflow-y: scroll; padding-right: 16px; padding-left: 16px;"
+        >
+          <div
+            class="css-view-1dbjc4n"
+            style="height: 16px;"
+          />
+          <div
+            class="css-view-1dbjc4n"
+          >
+            <div
+              class="css-text-901oao"
+              dir="auto"
+            >
+              undefined-SVG-Mock
+            </div>
+          </div>
+          <div
+            class="css-view-1dbjc4n"
+            style="height: 20px;"
+          />
+          <h1
+            aria-level="1"
+            class="css-reset-4rbku5 css-text-901oao"
+            dir="auto"
+            role="heading"
+            style="color: rgb(255, 255, 255); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
+          >
+            Ton compte est désactivé
+          </h1>
+          <div
+            class="css-view-1dbjc4n"
+            style="height: 20px;"
+          />
+          <div
+            class="css-text-901oao"
+            dir="auto"
+            style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
+          >
+            Tu as jusqu'au xxxx pour réactiver ton compte.
+          </div>
+          <div
+            class="css-view-1dbjc4n"
+            style="height: 20px;"
+          />
+          <div
+            class="css-text-901oao"
+            dir="auto"
+            style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
+          >
+            Une fois cette date passée, ton compte pass Culture sera définitivement supprimé.
+          </div>
+          <div
+            class="css-view-1dbjc4n"
+            style="height: 20px;"
+          />
+          <div
+            class="css-text-901oao"
+            dir="auto"
+            style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
+          >
+            Pour réactiver ton compte nous allons te demander de réinitialiser ton mot de passe.
+          </div>
+          <div
+            class="css-view-1dbjc4n"
+            style="align-self: stretch; flex-basis: 0px; flex-grow: 1; flex-shrink: 1; margin-top: 32px; max-height: 96px;"
+          >
+            <button
+              class="sc-bdvvtL krGSRA sc-dkPtRN gNpZyI"
+              tabindex="0"
+              type="button"
+            >
+              <div
+                class="css-text-901oao css-textMultiLine-cens5h"
+                dir="auto"
+                style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
+              >
+                Réactiver mon compte
+              </div>
+            </button>
+            <div
+              class="css-view-1dbjc4n"
+              style="height: 16px;"
+            />
+            <button
+              class="sc-bdvvtL krGSRA sc-hKwDye gvtKtm"
+              tabindex="0"
+              type="button"
+            >
+              <div
+                class="css-view-1dbjc4n"
+                data-testid="button-icon"
+              >
+                <div
+                  class="css-text-901oao"
+                  dir="auto"
+                >
+                  button-icon-SVG-Mock
+                </div>
+              </div>
+              <div
+                class="css-text-901oao css-textMultiLine-cens5h"
+                dir="auto"
+                style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
+              >
+                Retourner à l'accueil
+              </div>
+            </button>
+          </div>
+          <div
+            class="css-view-1dbjc4n"
+            style="height: 8px;"
+          />
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="css-view-1dbjc4n"
+      style="align-items: center; flex-basis: 0px; flex-grow: 1; flex-shrink: 1;"
+    >
+      <div
+        class="css-view-1dbjc4n"
+        style="bottom: 0px; height: 100%; left: 0px; position: absolute; right: 0px; top: 0px; width: 100%; z-index: -1;"
+      >
+        <div
+          class="css-view-1dbjc4n"
+        >
+          <div
+            class="css-text-901oao"
+            dir="auto"
+          >
+            undefined-SVG-Mock
+          </div>
+        </div>
+      </div>
+      <button
+        class="sc-eCImPb eivvKD sc-jRQBWg guzjoD sc-jRQBWg guzjoD"
+        data-testid="Revenir en arrière"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="css-view-1dbjc4n"
+        >
+          <div
+            class="css-text-901oao"
+            dir="auto"
+          >
+            undefined-SVG-Mock
+          </div>
+        </div>
+      </button>
+      <div
+        class="css-view-1dbjc4n"
+        style="align-items: center; flex-basis: 0px; flex-direction: column; flex-grow: 1; flex-shrink: 1; justify-content: center; max-width: 360px; overflow-x: scroll; overflow-y: scroll; padding-right: 16px; padding-left: 16px;"
+      >
+        <div
+          class="css-view-1dbjc4n"
+          style="height: 16px;"
+        />
+        <div
+          class="css-view-1dbjc4n"
+        >
+          <div
+            class="css-text-901oao"
+            dir="auto"
+          >
+            undefined-SVG-Mock
+          </div>
+        </div>
+        <div
+          class="css-view-1dbjc4n"
+          style="height: 20px;"
+        />
+        <h1
+          aria-level="1"
+          class="css-reset-4rbku5 css-text-901oao"
+          dir="auto"
+          role="heading"
+          style="color: rgb(255, 255, 255); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
+        >
+          Ton compte est désactivé
+        </h1>
+        <div
+          class="css-view-1dbjc4n"
+          style="height: 20px;"
+        />
+        <div
+          class="css-text-901oao"
+          dir="auto"
+          style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
+        >
+          Tu as jusqu'au xxxx pour réactiver ton compte.
+        </div>
+        <div
+          class="css-view-1dbjc4n"
+          style="height: 20px;"
+        />
+        <div
+          class="css-text-901oao"
+          dir="auto"
+          style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
+        >
+          Une fois cette date passée, ton compte pass Culture sera définitivement supprimé.
+        </div>
+        <div
+          class="css-view-1dbjc4n"
+          style="height: 20px;"
+        />
+        <div
+          class="css-text-901oao"
+          dir="auto"
+          style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
+        >
+          Pour réactiver ton compte nous allons te demander de réinitialiser ton mot de passe.
+        </div>
+        <div
+          class="css-view-1dbjc4n"
+          style="align-self: stretch; flex-basis: 0px; flex-grow: 1; flex-shrink: 1; margin-top: 32px; max-height: 96px;"
+        >
+          <button
+            class="sc-bdvvtL krGSRA sc-dkPtRN gNpZyI"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="css-text-901oao css-textMultiLine-cens5h"
+              dir="auto"
+              style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
+            >
+              Réactiver mon compte
+            </div>
+          </button>
+          <div
+            class="css-view-1dbjc4n"
+            style="height: 16px;"
+          />
+          <button
+            class="sc-bdvvtL krGSRA sc-hKwDye gvtKtm"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="css-view-1dbjc4n"
+              data-testid="button-icon"
+            >
+              <div
+                class="css-text-901oao"
+                dir="auto"
+              >
+                button-icon-SVG-Mock
+              </div>
+            </div>
+            <div
+              class="css-text-901oao css-textMultiLine-cens5h"
+              dir="auto"
+              style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
+            >
+              Retourner à l'accueil
+            </div>
+          </button>
+        </div>
+        <div
+          class="css-view-1dbjc4n"
+          style="height: 8px;"
+        />
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount.tsx
+++ b/src/features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount.tsx
@@ -1,0 +1,88 @@
+import { t } from '@lingui/macro'
+import { useFocusEffect } from '@react-navigation/native'
+import React, { useCallback } from 'react'
+import styled from 'styled-components/native'
+
+import { useAppSettings } from 'features/auth/settings'
+import { navigateToHome, navigateToHomeConfig } from 'features/navigation/helpers'
+import { PageNotFound } from 'features/navigation/PageNotFound'
+import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { useGoBack } from 'features/navigation/useGoBack'
+import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
+import { ButtonTertiaryWhite } from 'ui/components/buttons/ButtonTertiaryWhite'
+import { styledButton } from 'ui/components/buttons/styledButton'
+import { GenericInfoPage } from 'ui/components/GenericInfoPage'
+import { Touchable } from 'ui/components/touchable/Touchable'
+import { TouchableLink } from 'ui/components/touchableLink/TouchableLink'
+import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
+import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
+import { ProfileDeletionIllustration } from 'ui/svg/icons/ProfileDeletionIllustration'
+import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
+
+export const SuspendedAccount = () => {
+  const { goBack, canGoBack } = useGoBack(...homeNavConfig)
+  const { top } = useCustomSafeInsets()
+  const { data: settings } = useAppSettings()
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!settings?.allowAccountReactivation) {
+        navigateToHome()
+      }
+    }, [settings])
+  )
+
+  return settings?.allowAccountReactivation ? (
+    <GenericInfoPage
+      header={
+        !!canGoBack() && (
+          <HeaderContainer onPress={goBack} top={top + getSpacing(3.5)} testID="Revenir en arrière">
+            <StyledArrowPrevious />
+          </HeaderContainer>
+        )
+      }
+      title={t`Ton compte est désactivé`}
+      icon={ProfileDeletionIllustration}
+      buttons={[
+        <ButtonPrimaryWhite key={1} wording={t`Réactiver mon compte`} />,
+        <TouchableLink
+          key={2}
+          as={ButtonTertiaryWhite}
+          wording={t`Retourner à l'accueil`}
+          navigateTo={navigateToHomeConfig}
+          icon={PlainArrowPrevious}
+        />,
+      ]}>
+      <StyledBody>{t`Tu as jusqu'au xxxx pour réactiver ton compte.`}</StyledBody>
+      <Spacer.Column numberOfSpaces={5} />
+      <StyledBody>
+        {t`Une fois cette date passée, ton compte pass Culture sera définitivement supprimé.`}
+      </StyledBody>
+      <Spacer.Column numberOfSpaces={5} />
+      <StyledBody>
+        {t`Pour réactiver ton compte nous allons te demander de réinitialiser ton mot de passe.`}
+      </StyledBody>
+    </GenericInfoPage>
+  ) : (
+    <PageNotFound />
+  )
+}
+
+const StyledArrowPrevious = styled(ArrowPrevious).attrs(({ theme }) => ({
+  color: theme.colors.white,
+  size: theme.icons.sizes.small,
+  accessibilityLabel: t`Revenir en arrière`,
+}))``
+
+const HeaderContainer = styledButton(Touchable)<{ top: number }>(({ top, theme }) => ({
+  position: 'absolute',
+  top,
+  left: getSpacing(6),
+  zIndex: theme.zIndex.floatingButton,
+}))
+
+const StyledBody = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
+  textAlign: 'center',
+}))

--- a/src/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.native.test.tsx
+++ b/src/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.native.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import waitForExpect from 'wait-for-expect'
+
+import { navigate } from '__mocks__/@react-navigation/native'
+import { mockGoBack } from 'features/navigation/__mocks__/useGoBack'
+import { navigateToHome, navigateToHomeConfig } from 'features/navigation/helpers'
+import { fireEvent, render } from 'tests/utils'
+
+import { SuspendedAccount } from '../SuspendedAccount'
+
+const mockSettings = {
+  allowAccountReactivation: true,
+}
+
+jest.mock('features/navigation/helpers')
+jest.mock('features/auth/settings', () => ({
+  useAppSettings: jest.fn(() => ({
+    data: mockSettings,
+  })),
+}))
+
+describe('<SuspendedAccount />', () => {
+  it('should match snapshot', () => {
+    expect(render(<SuspendedAccount />)).toMatchSnapshot()
+  })
+
+  it('should go back when clicking on go back icon', async () => {
+    const { getByTestId } = render(<SuspendedAccount />)
+
+    const leftIconButton = getByTestId('Revenir en arrière')
+    fireEvent.press(leftIconButton)
+
+    await waitForExpect(() => {
+      expect(mockGoBack).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('should go to home page when clicking on go to home button', async () => {
+    const { getByTestId } = render(<SuspendedAccount />)
+
+    const homeButton = getByTestId("Retourner à l'accueil")
+    fireEvent.press(homeButton)
+
+    await waitForExpect(() => {
+      expect(navigate).toBeCalledWith(navigateToHomeConfig.screen, navigateToHomeConfig.params)
+    })
+  })
+
+  it('should redirect to home if feature is disabled', async () => {
+    mockSettings.allowAccountReactivation = false
+    render(<SuspendedAccount />)
+
+    await waitForExpect(() => {
+      expect(navigateToHome).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.web.test.tsx
+++ b/src/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.web.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import waitForExpect from 'wait-for-expect'
+
+import { navigate } from '__mocks__/@react-navigation/native'
+import { mockGoBack } from 'features/navigation/__mocks__/useGoBack'
+import { navigateToHome, navigateToHomeConfig } from 'features/navigation/helpers'
+import { fireEvent, render } from 'tests/utils/web'
+
+import { SuspendedAccount } from '../SuspendedAccount'
+
+const mockSettings = {
+  allowAccountReactivation: true,
+}
+
+jest.mock('features/navigation/helpers')
+jest.mock('features/auth/settings', () => ({
+  useAppSettings: jest.fn(() => ({
+    data: mockSettings,
+  })),
+}))
+
+describe('<SuspendedAccount />', () => {
+  it('should match snapshot', () => {
+    expect(render(<SuspendedAccount />)).toMatchSnapshot()
+  })
+
+  it('should go back when clicking on go back icon', async () => {
+    const { getByTestId } = render(<SuspendedAccount />)
+
+    const leftIconButton = getByTestId('Revenir en arrière')
+    fireEvent.click(leftIconButton)
+
+    await waitForExpect(() => {
+      expect(mockGoBack).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('should go to home page when clicking on go to home button', async () => {
+    const { getByText } = render(<SuspendedAccount />)
+
+    const homeButton = getByText("Retourner à l'accueil")
+    fireEvent.click(homeButton)
+
+    await waitForExpect(() => {
+      expect(navigate).toBeCalledWith(navigateToHomeConfig.screen, navigateToHomeConfig.params)
+    })
+  })
+
+  it('should redirect to home if feature is disabled', async () => {
+    mockSettings.allowAccountReactivation = false
+    render(<SuspendedAccount />)
+
+    await waitForExpect(() => {
+      expect(navigateToHome).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/features/cheatcodes/pages/Navigation/Navigation.tsx
+++ b/src/features/cheatcodes/pages/Navigation/Navigation.tsx
@@ -188,6 +188,12 @@ export function Navigation(): JSX.Element {
         </Row>
         <Row half>
           <ButtonPrimary
+            wording={'Suspended Account'}
+            onPress={() => navigate('SuspendedAccount')}
+          />
+        </Row>
+        <Row half>
+          <ButtonPrimary
             wording={'Confirm delete profile'}
             onPress={() => navigate('ConfirmDeleteProfile')}
           />

--- a/src/features/navigation/RootNavigator/routes.ts
+++ b/src/features/navigation/RootNavigator/routes.ts
@@ -18,6 +18,7 @@ import { SignupConfirmationExpiredLink } from 'features/auth/signup/SignupConfir
 import { SignupForm } from 'features/auth/signup/SignupForm'
 import { VerifyEligibility } from 'features/auth/signup/VerifyEligiblity'
 import { NotYetUnderageEligibility } from 'features/auth/signup/VerifyEligiblity/NotYetUnderageEligibility'
+import { SuspendedAccount } from 'features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount'
 import { BookingDetails } from 'features/bookings/pages/BookingDetails'
 import { EndedBookings } from 'features/bookings/pages/EndedBookings'
 import { BookingConfirmation } from 'features/bookOffer/pages/BookingConfirmation'
@@ -189,6 +190,12 @@ export const routes: Route[] = [
     component: LegalNotices,
     path: 'notices-legales',
     options: { title: t`Mentions légales` },
+  },
+  {
+    name: 'SuspendedAccount',
+    component: SuspendedAccount,
+    path: 'compte-desactive',
+    options: { title: t`Compte désactivé` },
   },
   {
     name: 'ConfirmDeleteProfile',

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -115,6 +115,7 @@ export type RootStackParamList = {
   SearchFilter: undefined
   SignupConfirmationEmailSent: { email: string }
   SignupConfirmationExpiredLink: { email: string }
+  SuspendedAccount: undefined
   TabNavigator: {
     screen: TabRouteName
     params: TabParamList[TabRouteName]

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -573,6 +573,7 @@ msgstr "Compte 15-17 créé !"
 msgid "Compte créé !"
 msgstr "Compte créé !"
 
+#: src/features/navigation/RootNavigator/routes.ts
 #: src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.tsx
 msgid "Compte désactivé"
 msgstr "Compte désactivé"
@@ -2098,6 +2099,10 @@ msgstr "Pour quelle raison me demande-t-on ma date de naissance ?"
 msgid "Pour quelle raison ?"
 msgstr "Pour quelle raison ?"
 
+#: src/features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount.tsx
+msgid "Pour réactiver ton compte nous allons te demander de réinitialiser ton mot de passe."
+msgstr "Pour réactiver ton compte nous allons te demander de réinitialiser ton mot de passe."
+
 #: src/features/auth/signup/PhoneValidation/SetPhoneNumber.tsx
 msgid "Pour sécuriser l'accès à ton pass nous avons besoin de valider ton numéro."
 msgstr "Pour sécuriser l'accès à ton pass nous avons besoin de valider ton numéro."
@@ -2300,6 +2305,7 @@ msgstr "Reste informé des actualités du pass Culture et ne rate aucun de nos b
 #: src/features/auth/signup/PhoneValidation/PhoneValidationTooManySMSSent/PhoneValidationTooManySMSSent.tsx
 #: src/features/auth/signup/VerifyEligiblity/NotYetUnderageEligibility.tsx
 #: src/features/auth/signup/VerifyEligiblity/VerifyEligibility.tsx
+#: src/features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount.tsx
 #: src/features/bookOffer/pages/BookingConfirmation.tsx
 #: src/features/bookings/pages/BookingNotFound.tsx
 #: src/features/identityCheck/errors/eduConnect/NotEligibleEduConnect.tsx
@@ -2337,6 +2343,7 @@ msgstr "Retrouve toutes tes offres en un clin d'oeil en les ajoutant à tes favo
 #: src/features/auth/signup/PhoneValidation/SetPhoneValidationCode.tsx
 #: src/features/auth/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSent.tsx
 #: src/features/auth/signup/SignupForm.tsx
+#: src/features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount.tsx
 #: src/features/bookings/components/BookingDetailsHeader.tsx
 #: src/features/culturalSurvey/components/layout/CulturalSurveyPageHeader.tsx
 #: src/features/identityCheck/atoms/layout/PageHeader.tsx
@@ -2370,6 +2377,7 @@ msgstr "Revenir à l'accueil"
 msgid "Revenir à l'étape précédente"
 msgstr "Revenir à l'étape précédente"
 
+#: src/features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount.tsx
 #: src/features/profile/pages/DeleteProfile/DeleteProfileSuccessV2.tsx
 msgid "Réactiver mon compte"
 msgstr "Réactiver mon compte"
@@ -2672,6 +2680,10 @@ msgstr "Ton compte a été activé !"
 msgid "Ton compte a été désactivé"
 msgstr "Ton compte a été désactivé"
 
+#: src/features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount.tsx
+msgid "Ton compte est désactivé"
+msgstr "Ton compte est désactivé"
+
 #: src/features/favorites/components/NotConnectedFavorites.tsx
 #: src/features/offer/components/SignUpSignInChoiceOfferModal.tsx
 msgid "Ton compte te permettra de retrouver tous tes favoris en un clin d'oeil !"
@@ -2850,6 +2862,10 @@ msgstr "Tu as dépassé le nombre d’essais autorisés. Tu pourras réessayer d
 #: src/features/bookings/components/BookingDetailsTicketContent.tsx
 msgid "Tu as dû recevoir ton billet par e-mail. Pense à vérifier tes spams."
 msgstr "Tu as dû recevoir ton billet par e-mail. Pense à vérifier tes spams."
+
+#: src/features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount.tsx
+msgid "Tu as jusqu'au xxxx pour réactiver ton compte."
+msgstr "Tu as jusqu'au xxxx pour réactiver ton compte."
 
 #: src/features/recreditBirthdayNotification/pages/components/RecreditBirthdayNotification.tsx
 msgid "Tu as jusqu’à la veille de tes 18 ans pour profiter de ton budget."
@@ -3083,7 +3099,11 @@ msgstr "Une fois ce délai écoulé, ton compte pass Culture sera définitivemen
 
 #: src/features/profile/pages/DeleteProfile/DeleteProfileSuccessV2.tsx
 msgid "Une fois ce délai écoulé, tu n’auras plus accès à ton compte pass Culture."
-msgstr "Une fois ce délai écoulé, tu n’auras plus accès à ton compte pass Culture."
+msgstr "Une fois ce délai écoulé, tu n’auras plus accès à ton compte pass Culture.
+
+#: src/features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount.tsx
+msgid "Une fois cette date passée, ton compte pass Culture sera définitivement supprimé."
+msgstr "Une fois cette date passée, ton compte pass Culture sera définitivement supprimé."
 
 #: src/features/search/sections/titles.ts
 msgid "Uniquement les nouveautés"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-14556

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [x] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|   ![Simulator Screen Shot - iPhone 13 - 2022-04-28 at 16 03 35](https://user-images.githubusercontent.com/46637324/165770640-a0f24012-08ad-4adc-84bb-5df159ec381f.png)  |         |                 | <img width="1173" alt="Capture d’écran 2022-04-28 à 16 03 20" src="https://user-images.githubusercontent.com/46637324/165770658-518c29eb-841a-4542-b511-d2943428c5e2.png">       |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
