### PR TITLE
build(patch_script): remove now useless warning for patches

### DIFF
--- a/scripts/update_app_version.sh
+++ b/scripts/update_app_version.sh
@@ -46,25 +46,7 @@ update_app_version(){
   fi
 }
 
-check_hard_hotfix_integrity(){
-  CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
-  echo $CURRENT_BRANCH
-  if [ "$CURRENT_BRANCH" != "master" ];
-  then
-    read -p "Do not forget to cherry-pick your bump version commit to master" -n 1 -r
-    echo    # step a new line
-    if [[ $REPLY =~ ^[Yy]$ ]]
-    then
-       echo "Thanks"
-    else
-     echo "Why not? :("
-     exit 1
-    fi
-  fi
-}
 
 # $1 is the tag used to trigger the ci deployment (see .circleci/config.yml)
 # $2 is upgrade level (major, minor or patch)
 update_app_version "$1" "$2"
-
-check_hard_hotfix_integrity


### PR DESCRIPTION
This warning is no longer necessary since we do not release a hard build of testing when we patch staging.

Therefore, no need to bump master.


[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
