### PR TITLE
(PC-14856) feat(home): use remote config homeEntryId to select playlist

### DIFF
--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -18,6 +18,7 @@ import { RecommendationPane, ProcessedModule } from 'features/home/contentful/mo
 import { useShowSkeleton } from 'features/home/pages/useShowSkeleton'
 import { isOfferModuleTypeguard, isVenuesModuleTypeguard } from 'features/home/typeguards'
 import { UseRouteType } from 'features/navigation/RootNavigator'
+import { useABTestingContext } from 'libs/ABTesting'
 import { analytics, isCloseToBottom } from 'libs/analytics'
 import useFunctionOnce from 'libs/hooks/useFunctionOnce'
 import { Spacer } from 'ui/theme'
@@ -62,7 +63,8 @@ const renderModule = ({ item, index }: { item: ProcessedModule; index: number })
 
 export const Home: FunctionComponent = () => {
   const { params } = useRoute<UseRouteType<'Home'>>()
-  const modules = useHomepageModules(params?.entryId) || []
+  const { homeEntryId } = useABTestingContext()
+  const modules = useHomepageModules(params?.entryId ?? homeEntryId) || []
   const logHasSeenAllModules = useFunctionOnce(() => analytics.logAllModulesSeen(modules.length))
   const showSkeleton = useShowSkeleton()
 

--- a/src/features/home/selectPlaylist.ts
+++ b/src/features/home/selectPlaylist.ts
@@ -30,7 +30,7 @@ export const useSelectPlaylist = (entryId?: string) => {
       // If no playlist is tagged, we show the last published homepage.
       const firstEntry = entries[0]
 
-      // If we are coming from a deeplink, we suppose the entryId exists
+      // If we are coming from a deeplink or firebase remote config we suppose the entryId exists
       if (entryId) return entries.find(({ sys }) => sys.id === entryId) || firstEntry
 
       const scoredEntries = entries

--- a/src/libs/ABTesting/ABTesting.constants.ts
+++ b/src/libs/ABTesting/ABTesting.constants.ts
@@ -1,3 +1,3 @@
 import { CustomRemoteConfig } from './ABTesting.types'
 
-export const DEFAULT_REMOTE_CONFIG: CustomRemoteConfig = { test_param: 'A' }
+export const DEFAULT_REMOTE_CONFIG: CustomRemoteConfig = { test_param: 'A', homeEntryId: '' }

--- a/src/libs/ABTesting/ABTesting.services.ts
+++ b/src/libs/ABTesting/ABTesting.services.ts
@@ -21,6 +21,7 @@ export const abTesting = {
     const parameters = firebaseRemoteConfig().getAll()
     return {
       test_param: parameters.test_param.asString() as CustomRemoteConfig['test_param'],
+      homeEntryId: parameters.homeEntryId.asString() as CustomRemoteConfig['homeEntryId'],
     }
   },
 }

--- a/src/libs/ABTesting/ABTesting.types.ts
+++ b/src/libs/ABTesting/ABTesting.types.ts
@@ -1,5 +1,6 @@
 export type CustomRemoteConfig = {
   test_param: 'A' | 'B'
+  homeEntryId: ''
 }
 
 /* The purpose of GenericRemoteConfig is only to resolve type conflicts.

--- a/src/libs/ABTesting/ABTestingProvider.tsx
+++ b/src/libs/ABTesting/ABTestingProvider.tsx
@@ -24,7 +24,7 @@ export const ABTestingProvider = memo(function ABTestingProvider(props: { childr
         }
       })
       .catch(() => {
-        // We do nothing if this call fails as we don't even use remote config
+        console.error('Failed to retrieve firebase remote config')
       })
   }, [])
 

--- a/src/libs/firebase/shims/firebase-init.ts
+++ b/src/libs/firebase/shims/firebase-init.ts
@@ -5,8 +5,8 @@ import firebase from 'firebase/compat/app'
 
 import { FIREBASE_CONFIG } from 'libs/firebase/firebaseConfig'
 
-const initializeApp = (): void => {
-  firebase.initializeApp(FIREBASE_CONFIG)
+const initializeApp = () => {
+  return firebase.initializeApp(FIREBASE_CONFIG)
 }
 
 export default initializeApp

--- a/src/libs/firebase/shims/remote-config/index.web.ts
+++ b/src/libs/firebase/shims/remote-config/index.web.ts
@@ -1,0 +1,12 @@
+import { getRemoteConfig } from 'firebase/remote-config'
+
+import { DEFAULT_REMOTE_CONFIG } from 'libs/ABTesting/ABTesting.constants'
+
+import initializeApp from '../firebase-init'
+
+const app = initializeApp()
+
+const remoteConfig = getRemoteConfig(app)
+remoteConfig.defaultConfig = DEFAULT_REMOTE_CONFIG
+
+export default remoteConfig


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-14856

## Contexte
On veut faire de l'A/B testing sur la homepage de l'app. Pour cela on utilise le service d'A/B testing de firebase. Celui ci se base sur le service de remote config.
Cette PR sert à utiliser le paramètre `homeEntryId` défini dans firebase remote config :
<img width="935" alt="Capture d’écran 2022-05-06 à 16 13 13" src="https://user-images.githubusercontent.com/22886846/167150459-f5fc9148-7ecc-4abc-988c-18156f46339c.png">

Cet identifiant correspond à l'id d'une playlist sur contentful :
<img width="1627" alt="Capture d’écran 2022-05-06 à 14 24 57" src="https://user-images.githubusercontent.com/22886846/167150370-b1ae0224-7857-486f-9f89-fc8f0b6bc101.png">

Pour rappel, si aucun `entryId` n'est spécifié à l'arrivée sur la home, l'app sélectionne par défaut les playlists selon leurs tags => https://www.notion.so/passcultureapp/Cr-er-une-home-sur-Contentful-627cdd67c44f4da88a370b21cbe1746b#0df79a3cc974481fb014832cccd06a8e

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Added a **screenshot** for UI tickets.

## Screenshots

![Simulator Screen Shot - iPhone 12 - 2022-05-06 at 16 15 24](https://user-images.githubusercontent.com/22886846/167150912-b6d4ca0c-d0b2-4ed5-87d0-edaba6125a1b.png)

<img width="489" alt="image" src="https://user-images.githubusercontent.com/22886846/167151004-44ed1087-3156-4e84-87cd-76f77c637613.png">


[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
