### PR TITLE
(PC-14944) fix(accessibility): Indicate reading direction for text elements

### DIFF
--- a/__snapshots__/features/_marketingAndCommunication/pages/tests/DeeplinksGenerator.test.tsx.web-snap
+++ b/__snapshots__/features/_marketingAndCommunication/pages/tests/DeeplinksGenerator.test.tsx.web-snap
@@ -128,7 +128,7 @@ Array [
         <h1
           aria-level={1}
           className="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style={
             Object {
@@ -280,7 +280,7 @@ Array [
           <h4
             aria-level={4}
             className="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style={
               Object {
@@ -359,7 +359,7 @@ Array [
               <h2
                 aria-level={2}
                 className="css-reset-4rbku5 css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style={
                   Object {
@@ -516,7 +516,7 @@ Array [
                   >
                     <div
                       className="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style={
                         Object {
                           "WebkitLineClamp": 2,
@@ -649,7 +649,7 @@ Array [
                   >
                     <div
                       className="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style={
                         Object {
                           "WebkitLineClamp": 2,
@@ -782,7 +782,7 @@ Array [
                   >
                     <div
                       className="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style={
                         Object {
                           "WebkitLineClamp": 2,
@@ -926,7 +926,7 @@ Array [
                   >
                     <div
                       className="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style={
                         Object {
                           "WebkitLineClamp": 2,
@@ -1059,7 +1059,7 @@ Array [
                   >
                     <div
                       className="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style={
                         Object {
                           "WebkitLineClamp": 2,
@@ -1192,7 +1192,7 @@ Array [
                   >
                     <div
                       className="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style={
                         Object {
                           "WebkitLineClamp": 2,
@@ -1302,7 +1302,7 @@ Array [
               <h2
                 aria-level={2}
                 className="css-reset-4rbku5 css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style={
                   Object {
@@ -1500,7 +1500,7 @@ Array [
               >
                 <div
                   className="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "color": "rgba(203,205,210,1.00)",
@@ -1582,7 +1582,7 @@ Array [
               <h2
                 aria-level={2}
                 className="css-reset-4rbku5 css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style={
                   Object {
@@ -1780,7 +1780,7 @@ Array [
               >
                 <div
                   className="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "color": "rgba(203,205,210,1.00)",
@@ -1926,7 +1926,7 @@ Array [
               >
                 <div
                   className="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "color": "rgba(203,205,210,1.00)",
@@ -2072,7 +2072,7 @@ Array [
               >
                 <div
                   className="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "color": "rgba(203,205,210,1.00)",
@@ -2218,7 +2218,7 @@ Array [
               >
                 <div
                   className="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "color": "rgba(203,205,210,1.00)",
@@ -2300,7 +2300,7 @@ Array [
               <h2
                 aria-level={2}
                 className="css-reset-4rbku5 css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style={
                   Object {
@@ -2498,7 +2498,7 @@ Array [
               >
                 <div
                   className="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "color": "rgba(203,205,210,1.00)",
@@ -2542,7 +2542,7 @@ Array [
       >
         <div
           className="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style={
             Object {
               "color": "rgba(182,0,37,1.00)",
@@ -2580,7 +2580,7 @@ Array [
         >
           <div
             className="css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             style={
               Object {
                 "WebkitLineClamp": 1,
@@ -2663,7 +2663,7 @@ Array [
           <h4
             aria-level={4}
             className="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style={
               Object {
@@ -2771,7 +2771,7 @@ Array [
                 >
                   <div
                     className="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style={
                       Object {
                         "color": "rgba(22,22,23,1.00)",
@@ -2822,7 +2822,7 @@ Array [
         <h4
           aria-level={4}
           className="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style={
             Object {
@@ -2977,7 +2977,7 @@ Array [
             />
             <div
               className="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style={
                 Object {
                   "WebkitAlignSelf": "center",

--- a/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/forgottenPassword/ResetPasswordEmailSent/tests/ResetPasswordEmailSent.web.test.tsx.web-snap
@@ -126,7 +126,7 @@ Object {
                                           <h1
                                             aria-level="1"
                                             class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                                            dir="auto"
+                                            dir="ltr"
                                             role="heading"
                                             style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                                           >
@@ -167,14 +167,14 @@ Object {
                                         >
                                           <div
                                             class="css-text-901oao"
-                                            dir="auto"
+                                            dir="ltr"
                                             style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                                           >
                                             Clique sur le lien reçu à l’adresse :
                                           </div>
                                           <div
                                             class="css-text-901oao"
-                                            dir="auto"
+                                            dir="ltr"
                                             style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                                           >
                                             john.doe@gmail.com
@@ -185,11 +185,12 @@ Object {
                                           />
                                           <div
                                             class="css-text-901oao"
-                                            dir="auto"
+                                            dir="ltr"
                                             style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
                                           >
                                             <span
                                               class="css-text-901oao css-textHasAncestor-16my406"
+                                              dir="ltr"
                                               style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                                             >
                                               L’e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams !
@@ -219,7 +220,7 @@ Si l’e-mail n’arrive pas, tu peux :
                                             </div>
                                             <div
                                               class="css-text-901oao css-textMultiLine-cens5h"
-                                              dir="auto"
+                                              dir="ltr"
                                               style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
                                             >
                                               Consulter l'article d'aide
@@ -431,7 +432,7 @@ Si l’e-mail n’arrive pas, tu peux :
                                         <h1
                                           aria-level="1"
                                           class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                                          dir="auto"
+                                          dir="ltr"
                                           role="heading"
                                           style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                                         >
@@ -472,14 +473,14 @@ Si l’e-mail n’arrive pas, tu peux :
                                       >
                                         <div
                                           class="css-text-901oao"
-                                          dir="auto"
+                                          dir="ltr"
                                           style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                                         >
                                           Clique sur le lien reçu à l’adresse :
                                         </div>
                                         <div
                                           class="css-text-901oao"
-                                          dir="auto"
+                                          dir="ltr"
                                           style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                                         >
                                           john.doe@gmail.com
@@ -490,11 +491,12 @@ Si l’e-mail n’arrive pas, tu peux :
                                         />
                                         <div
                                           class="css-text-901oao"
-                                          dir="auto"
+                                          dir="ltr"
                                           style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
                                         >
                                           <span
                                             class="css-text-901oao css-textHasAncestor-16my406"
+                                            dir="ltr"
                                             style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                                           >
                                             L’e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams !
@@ -524,7 +526,7 @@ Si l’e-mail n’arrive pas, tu peux :
                                           </div>
                                           <div
                                             class="css-text-901oao css-textMultiLine-cens5h"
-                                            dir="auto"
+                                            dir="ltr"
                                             style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
                                           >
                                             Consulter l'article d'aide

--- a/__snapshots__/features/auth/signup/SetBirthday/SetBirthday.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/signup/SetBirthday/SetBirthday.web.test.tsx.web-snap
@@ -32,7 +32,7 @@ Object {
             </div>
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
             >
               Pour quelle raison ?
@@ -1435,7 +1435,7 @@ Object {
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
             >
               Continuer
@@ -1477,7 +1477,7 @@ Object {
           </div>
           <div
             class="css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
           >
             Pour quelle raison ?
@@ -2880,7 +2880,7 @@ Object {
         >
           <div
             class="css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
           >
             Continuer
@@ -2979,7 +2979,7 @@ Object {
             </div>
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
             >
               Pour quelle raison ?
@@ -3015,7 +3015,7 @@ Object {
             >
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 id="testUuidV4"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
               >
@@ -3989,7 +3989,7 @@ Object {
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
             >
               Continuer
@@ -4031,7 +4031,7 @@ Object {
           </div>
           <div
             class="css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
           >
             Pour quelle raison ?
@@ -4067,7 +4067,7 @@ Object {
           >
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               id="testUuidV4"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
             >
@@ -5041,7 +5041,7 @@ Object {
         >
           <div
             class="css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
           >
             Continuer

--- a/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.web-snap
+++ b/__snapshots__/features/auth/signup/VerifyEligiblity/tests/NotYetUnderageEligibility.test.tsx.web-snap
@@ -112,7 +112,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
     <h1
       aria-level={1}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {
@@ -136,7 +136,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -181,7 +181,7 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
       >
         <div
           className="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style={
             Object {
               "WebkitLineClamp": 1,

--- a/__snapshots__/features/auth/signup/VerifyEligiblity/tests/VerifyEligibility.test.tsx.web-snap
+++ b/__snapshots__/features/auth/signup/VerifyEligiblity/tests/VerifyEligibility.test.tsx.web-snap
@@ -112,7 +112,7 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
     <h1
       aria-level={1}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {
@@ -136,7 +136,7 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -183,7 +183,7 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
       >
         <div
           className="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style={
             Object {
               "WebkitLineClamp": 1,
@@ -227,7 +227,7 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
         </div>
         <div
           className="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style={
             Object {
               "WebkitLineClamp": 1,

--- a/__snapshots__/features/auth/suspendedAccount/AccountReactivationSuccess/tests/AccountReactivation.test.tsx.web-snap
+++ b/__snapshots__/features/auth/suspendedAccount/AccountReactivationSuccess/tests/AccountReactivation.test.tsx.web-snap
@@ -95,7 +95,7 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
   <h1
     aria-level={1}
     className="css-reset-4rbku5 css-text-901oao"
-    dir="auto"
+    dir="ltr"
     role="heading"
     style={
       Object {
@@ -128,7 +128,7 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
   />
   <div
     className="css-text-901oao"
-    dir="auto"
+    dir="ltr"
     style={
       Object {
         "color": "rgba(22,22,23,1.00)",
@@ -176,7 +176,7 @@ Tu peux dès maintenant découvrir l’étendue du catalogue pass Culture.
     >
       <div
         className="css-text-901oao css-textMultiLine-cens5h"
-        dir="auto"
+        dir="ltr"
         style={
           Object {
             "WebkitLineClamp": 1,

--- a/__snapshots__/features/auth/suspendedAccount/FraudulentAccount/tests/FraudulentAccount.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/suspendedAccount/FraudulentAccount/tests/FraudulentAccount.web.test.tsx.web-snap
@@ -66,7 +66,7 @@ Object {
           <h1
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
           >
@@ -78,7 +78,7 @@ Object {
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
           >
             En raison d’une activité suspiscieuse, notre équipe anti fraude a suspendu ton compte.
@@ -89,7 +89,7 @@ Object {
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
           >
             Si tu souhaites revoir cette décision, tu peux contacter le support.
@@ -120,7 +120,7 @@ Object {
               </div>
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
               >
                 Contacter le support
@@ -148,7 +148,7 @@ Object {
               </div>
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
               >
                 Retourner à l'accueil
@@ -225,7 +225,7 @@ Object {
         <h1
           aria-level="1"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
         >
@@ -237,7 +237,7 @@ Object {
         />
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
         >
           En raison d’une activité suspiscieuse, notre équipe anti fraude a suspendu ton compte.
@@ -248,7 +248,7 @@ Object {
         />
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
         >
           Si tu souhaites revoir cette décision, tu peux contacter le support.
@@ -279,7 +279,7 @@ Object {
             </div>
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
             >
               Contacter le support
@@ -307,7 +307,7 @@ Object {
             </div>
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
             >
               Retourner à l'accueil

--- a/__snapshots__/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.web.test.tsx.web-snap
@@ -66,7 +66,7 @@ Object {
           <h1
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
           >
@@ -78,7 +78,7 @@ Object {
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
           >
             Tu as jusqu'au xxxx pour réactiver ton compte.
@@ -89,7 +89,7 @@ Object {
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
           >
             Une fois cette date passée, ton compte pass Culture sera définitivement supprimé.
@@ -100,7 +100,7 @@ Object {
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
           >
             Pour réactiver ton compte, nous allons te demander de réinitialiser ton mot de passe.
@@ -116,7 +116,7 @@ Object {
             >
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
               >
                 Réactiver mon compte
@@ -144,7 +144,7 @@ Object {
               </div>
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
               >
                 Retourner à l'accueil
@@ -221,7 +221,7 @@ Object {
         <h1
           aria-level="1"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
         >
@@ -233,7 +233,7 @@ Object {
         />
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
         >
           Tu as jusqu'au xxxx pour réactiver ton compte.
@@ -244,7 +244,7 @@ Object {
         />
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
         >
           Une fois cette date passée, ton compte pass Culture sera définitivement supprimé.
@@ -255,7 +255,7 @@ Object {
         />
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
         >
           Pour réactiver ton compte, nous allons te demander de réinitialiser ton mot de passe.
@@ -271,7 +271,7 @@ Object {
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
             >
               Réactiver mon compte
@@ -299,7 +299,7 @@ Object {
             </div>
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
             >
               Retourner à l'accueil

--- a/__snapshots__/features/bookOffer/components/__tests__/BookDuoChoice.web.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookDuoChoice.web.test.tsx.web-snap
@@ -9,7 +9,7 @@ Object {
         aria-level="2"
         class="css-reset-4rbku5 css-text-901oao"
         data-testid="DuoStep"
-        dir="auto"
+        dir="ltr"
         role="heading"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
       >
@@ -65,7 +65,7 @@ Object {
               </div>
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
               >
                 Solo
@@ -73,7 +73,7 @@ Object {
               <div
                 class="css-text-901oao"
                 data-testid="DuoChoice1-price"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
               >
                 20 €
@@ -126,7 +126,7 @@ Object {
               </div>
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
               >
                 Duo
@@ -134,7 +134,7 @@ Object {
               <div
                 class="css-text-901oao"
                 data-testid="DuoChoice2-price"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
               >
                 40 €
@@ -150,7 +150,7 @@ Object {
       aria-level="2"
       class="css-reset-4rbku5 css-text-901oao"
       data-testid="DuoStep"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
     >
@@ -206,7 +206,7 @@ Object {
             </div>
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
             >
               Solo
@@ -214,7 +214,7 @@ Object {
             <div
               class="css-text-901oao"
               data-testid="DuoChoice1-price"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
             >
               20 €
@@ -267,7 +267,7 @@ Object {
             </div>
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
             >
               Duo
@@ -275,7 +275,7 @@ Object {
             <div
               class="css-text-901oao"
               data-testid="DuoChoice2-price"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
             >
               40 €

--- a/__snapshots__/features/bookOffer/components/__tests__/BookHourChoice.web.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookHourChoice.web.test.tsx.web-snap
@@ -9,7 +9,7 @@ Object {
         aria-level="2"
         class="css-reset-4rbku5 css-text-901oao"
         data-testid="HourStep"
-        dir="auto"
+        dir="ltr"
         role="heading"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
       >
@@ -45,7 +45,7 @@ Object {
               <div
                 class="css-text-901oao"
                 data-testid="HourChoice148411-hour"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
               >
                 10h00
@@ -53,7 +53,7 @@ Object {
               <div
                 class="css-text-901oao"
                 data-testid="HourChoice148411-price"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
               >
                 épuisé
@@ -86,7 +86,7 @@ Object {
               <div
                 class="css-text-901oao"
                 data-testid="HourChoice148409-hour"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
               >
                 20h00
@@ -94,7 +94,7 @@ Object {
               <div
                 class="css-text-901oao"
                 data-testid="HourChoice148409-price"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
               >
                 24 €
@@ -110,7 +110,7 @@ Object {
       aria-level="2"
       class="css-reset-4rbku5 css-text-901oao"
       data-testid="HourStep"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
     >
@@ -146,7 +146,7 @@ Object {
             <div
               class="css-text-901oao"
               data-testid="HourChoice148411-hour"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
             >
               10h00
@@ -154,7 +154,7 @@ Object {
             <div
               class="css-text-901oao"
               data-testid="HourChoice148411-price"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
             >
               épuisé
@@ -187,7 +187,7 @@ Object {
             <div
               class="css-text-901oao"
               data-testid="HourChoice148409-hour"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
             >
               20h00
@@ -195,7 +195,7 @@ Object {
             <div
               class="css-text-901oao"
               data-testid="HourChoice148409-price"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
             >
               24 €
@@ -268,7 +268,7 @@ Object {
         aria-level="2"
         class="css-reset-4rbku5 css-text-901oao"
         data-testid="HourStep"
-        dir="auto"
+        dir="ltr"
         role="heading"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
       >
@@ -285,7 +285,7 @@ Object {
       >
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
         >
           20:00
@@ -298,7 +298,7 @@ Object {
       aria-level="2"
       class="css-reset-4rbku5 css-text-901oao"
       data-testid="HourStep"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
     >
@@ -315,7 +315,7 @@ Object {
     >
       <div
         class="css-text-901oao"
-        dir="auto"
+        dir="ltr"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
       >
         20:00

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingEventChoices.web.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingEventChoices.web.test.tsx.web-snap
@@ -21,7 +21,7 @@ Object {
           aria-level="2"
           class="css-reset-4rbku5 css-text-901oao"
           data-testid="DateStep"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
         >
@@ -38,7 +38,7 @@ Object {
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
           >
             Samedi 2 janvier 2021
@@ -60,7 +60,7 @@ Object {
           aria-level="2"
           class="css-reset-4rbku5 css-text-901oao"
           data-testid="HourStep"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
         >
@@ -77,7 +77,7 @@ Object {
         >
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
           />
         </div>
@@ -97,7 +97,7 @@ Object {
           aria-level="2"
           class="css-reset-4rbku5 css-text-901oao"
           data-testid="DuoStep"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
         >
@@ -154,7 +154,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                 >
                   Solo
@@ -162,7 +162,7 @@ Object {
                 <div
                   class="css-text-901oao"
                   data-testid="DuoChoice1-price"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
                 >
                   crédit insuffisant
@@ -220,7 +220,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                 >
                   Duo
@@ -228,7 +228,7 @@ Object {
                 <div
                   class="css-text-901oao"
                   data-testid="DuoChoice2-price"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
                 >
                   crédit insuffisant
@@ -252,7 +252,7 @@ Object {
         >
           <div
             class="css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
           >
             Valider ces options
@@ -278,7 +278,7 @@ Object {
         aria-level="2"
         class="css-reset-4rbku5 css-text-901oao"
         data-testid="DateStep"
-        dir="auto"
+        dir="ltr"
         role="heading"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
       >
@@ -295,7 +295,7 @@ Object {
         />
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
         >
           Samedi 2 janvier 2021
@@ -317,7 +317,7 @@ Object {
         aria-level="2"
         class="css-reset-4rbku5 css-text-901oao"
         data-testid="HourStep"
-        dir="auto"
+        dir="ltr"
         role="heading"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
       >
@@ -334,7 +334,7 @@ Object {
       >
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
         />
       </div>
@@ -354,7 +354,7 @@ Object {
         aria-level="2"
         class="css-reset-4rbku5 css-text-901oao"
         data-testid="DuoStep"
-        dir="auto"
+        dir="ltr"
         role="heading"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
       >
@@ -411,7 +411,7 @@ Object {
               </div>
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
               >
                 Solo
@@ -419,7 +419,7 @@ Object {
               <div
                 class="css-text-901oao"
                 data-testid="DuoChoice1-price"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
               >
                 crédit insuffisant
@@ -477,7 +477,7 @@ Object {
               </div>
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
               >
                 Duo
@@ -485,7 +485,7 @@ Object {
               <div
                 class="css-text-901oao"
                 data-testid="DuoChoice2-price"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
               >
                 crédit insuffisant
@@ -509,7 +509,7 @@ Object {
       >
         <div
           class="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
         >
           Valider ces options

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingImpossible.deprecated.web.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingImpossible.deprecated.web.test.tsx.web-snap
@@ -25,7 +25,7 @@ Object {
         />
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; padding-right: 24px; padding-left: 24px; text-align: center;"
         >
           Les conditions générales d'utilisation de l'App Store iOS ne permettent pas de réserver cette offre sur l'application.
@@ -36,7 +36,7 @@ Object {
         />
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; padding-right: 24px; padding-left: 24px; text-align: center;"
         >
           Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !
@@ -52,7 +52,7 @@ Object {
         >
           <div
             class="css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
           >
             Mettre en favoris
@@ -69,7 +69,7 @@ Object {
         >
           <div
             class="css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
           >
             Retourner à l'offre
@@ -103,7 +103,7 @@ Object {
       />
       <div
         class="css-text-901oao"
-        dir="auto"
+        dir="ltr"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; padding-right: 24px; padding-left: 24px; text-align: center;"
       >
         Les conditions générales d'utilisation de l'App Store iOS ne permettent pas de réserver cette offre sur l'application.
@@ -114,7 +114,7 @@ Object {
       />
       <div
         class="css-text-901oao"
-        dir="auto"
+        dir="ltr"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; padding-right: 24px; padding-left: 24px; text-align: center;"
       >
         Mets cette offre en favoris : tu recevras une notification avec un lien pour la réserver sur notre application web !
@@ -130,7 +130,7 @@ Object {
       >
         <div
           class="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
         >
           Mettre en favoris
@@ -147,7 +147,7 @@ Object {
       >
         <div
           class="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
         >
           Retourner à l'offre

--- a/__snapshots__/features/bookOffer/components/__tests__/BookingInformations.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/components/__tests__/BookingInformations.test.tsx.web-snap
@@ -52,7 +52,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -74,7 +74,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -137,7 +137,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -159,7 +159,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -222,7 +222,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -244,7 +244,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -312,7 +312,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -334,7 +334,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -397,7 +397,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -419,7 +419,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -482,7 +482,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "WebkitAlignItems": "center",
@@ -499,6 +499,7 @@ Array [
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
+        dir="ltr"
         style={
           Object {
             "color": "rgba(22,22,23,1.00)",
@@ -521,7 +522,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -584,7 +585,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -606,7 +607,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -674,7 +675,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -696,7 +697,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -759,7 +760,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "WebkitAlignItems": "center",
@@ -776,6 +777,7 @@ Array [
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
+        dir="ltr"
         style={
           Object {
             "color": "rgba(22,22,23,1.00)",
@@ -798,7 +800,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -861,7 +863,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -883,7 +885,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -951,7 +953,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -973,7 +975,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -1036,7 +1038,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -1058,7 +1060,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -1121,7 +1123,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "WebkitAlignItems": "center",
@@ -1138,6 +1140,7 @@ Array [
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
+        dir="ltr"
         style={
           Object {
             "color": "rgba(22,22,23,1.00)",
@@ -1160,7 +1163,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -1223,7 +1226,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -1245,7 +1248,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -1313,7 +1316,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -1335,7 +1338,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -1398,7 +1401,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -1420,7 +1423,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -1488,7 +1491,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -1510,7 +1513,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -1573,7 +1576,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -1595,7 +1598,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -1658,7 +1661,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "WebkitAlignItems": "center",
@@ -1675,6 +1678,7 @@ Array [
     >
       <span
         className="css-text-901oao css-textHasAncestor-16my406"
+        dir="ltr"
         style={
           Object {
             "color": "rgba(22,22,23,1.00)",
@@ -1697,7 +1701,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",
@@ -1760,7 +1764,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -1782,7 +1786,7 @@ Array [
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(105,106,111,1.00)",

--- a/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.web-snap
+++ b/__snapshots__/features/bookOffer/pages/__tests__/BookingConfirmation.test.tsx.web-snap
@@ -112,7 +112,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
     <h1
       aria-level={1}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {
@@ -136,7 +136,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -159,7 +159,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -204,7 +204,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
       >
         <div
           className="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style={
             Object {
               "WebkitLineClamp": 1,
@@ -237,7 +237,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
       >
         <div
           className="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style={
             Object {
               "WebkitLineClamp": 1,

--- a/__snapshots__/features/culturalSurvey/components/__tests__/CulturalSurveyCheckbox.web.test.tsx.web-snap
+++ b/__snapshots__/features/culturalSurvey/components/__tests__/CulturalSurveyCheckbox.web.test.tsx.web-snap
@@ -36,12 +36,12 @@ Object {
           >
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
             />
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
             >
               un monument, une exposition...
@@ -83,12 +83,12 @@ Object {
         >
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
           >
             un monument, une exposition...
@@ -187,12 +187,12 @@ Object {
           >
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
             />
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
             >
               un monument, une exposition...
@@ -249,12 +249,12 @@ Object {
         >
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
           >
             un monument, une exposition...

--- a/__snapshots__/features/culturalSurvey/pages/__tests__/CulturalSurveyIntro.web.test.tsx.web-snap
+++ b/__snapshots__/features/culturalSurvey/pages/__tests__/CulturalSurveyIntro.web.test.tsx.web-snap
@@ -35,7 +35,7 @@ Object {
         <h3
           aria-level="3"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 20px; line-height: 24px; text-align: center;"
         >
@@ -44,7 +44,7 @@ Object {
         <h4
           aria-level="4"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
         >
@@ -56,7 +56,7 @@ Object {
         />
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; margin-bottom: 20px; text-align: center;"
         >
           L'objectif du questionnaire est de nous permettre de te suggérer les meilleures activités culturelles selon tes préférences, tes envies et ta localisation.
@@ -76,7 +76,7 @@ Object {
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
             >
               Débuter le questionnaire
@@ -106,7 +106,7 @@ Object {
             </div>
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
             >
               Plus tard
@@ -151,7 +151,7 @@ Object {
       <h3
         aria-level="3"
         class="css-reset-4rbku5 css-text-901oao"
-        dir="auto"
+        dir="ltr"
         role="heading"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 20px; line-height: 24px; text-align: center;"
       >
@@ -160,7 +160,7 @@ Object {
       <h4
         aria-level="4"
         class="css-reset-4rbku5 css-text-901oao"
-        dir="auto"
+        dir="ltr"
         role="heading"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
       >
@@ -172,7 +172,7 @@ Object {
       />
       <div
         class="css-text-901oao"
-        dir="auto"
+        dir="ltr"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; margin-bottom: 20px; text-align: center;"
       >
         L'objectif du questionnaire est de nous permettre de te suggérer les meilleures activités culturelles selon tes préférences, tes envies et ta localisation.
@@ -192,7 +192,7 @@ Object {
         >
           <div
             class="css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
           >
             Débuter le questionnaire
@@ -222,7 +222,7 @@ Object {
           </div>
           <div
             class="css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
           >
             Plus tard

--- a/__snapshots__/features/culturalSurvey/pages/__tests__/CulturalSurveyQuestions.web.test.tsx.web-snap
+++ b/__snapshots__/features/culturalSurvey/pages/__tests__/CulturalSurveyQuestions.web.test.tsx.web-snap
@@ -74,7 +74,7 @@ Object {
                   >
                     <div
                       class="css-text-901oao"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; margin-left: 8px;"
                     >
                       0%
@@ -86,7 +86,7 @@ Object {
             <h1
               aria-level="1"
               class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               role="heading"
               style="color: rgb(22, 22, 23); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; margin-right: 24px; text-align: right;"
             >
@@ -105,7 +105,7 @@ Object {
             <h3
               aria-level="3"
               class="css-reset-4rbku5 css-text-901oao"
-              dir="auto"
+              dir="ltr"
               role="heading"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 20px; line-height: 24px;"
             >
@@ -117,7 +117,7 @@ Object {
             >
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
               >
                 Tu peux sélectionner une ou plusieurs réponses.
@@ -162,14 +162,14 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                         >
                           Participé à un festival,
                         </div>
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           à une avant-première
@@ -215,14 +215,14 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                         >
                           Assisté à un spectacle
                         </div>
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           Pièce de théâtre, cirque, danse...
@@ -268,14 +268,14 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                         >
                           Allé à la bibliothèque
                         </div>
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           ou à la médiathèque
@@ -321,14 +321,14 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                         >
                           Participé à un jeu
                         </div>
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           escape game, jeu concours
@@ -374,7 +374,7 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                         >
                           Allé à un concert
@@ -420,7 +420,7 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                         >
                           Allé au cinéma
@@ -466,14 +466,14 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                         >
                           Visité un musée,
                         </div>
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           un monument, une exposition...
@@ -519,14 +519,14 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                         >
                           Participé à une conférence,
                         </div>
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           rencontre ou découverte des métiers de la culture
@@ -572,14 +572,14 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                         >
                           Pris un cours
                         </div>
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           danse, théâtre, musique, dessin
@@ -610,7 +610,7 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                         >
                           Aucune de ces sorties culturelles
@@ -636,7 +636,7 @@ Object {
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
             >
               Continuer
@@ -720,7 +720,7 @@ Object {
                 >
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; margin-left: 8px;"
                   >
                     0%
@@ -732,7 +732,7 @@ Object {
           <h1
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(22, 22, 23); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; margin-right: 24px; text-align: right;"
           >
@@ -751,7 +751,7 @@ Object {
           <h3
             aria-level="3"
             class="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 20px; line-height: 24px;"
           >
@@ -763,7 +763,7 @@ Object {
           >
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
             >
               Tu peux sélectionner une ou plusieurs réponses.
@@ -808,14 +808,14 @@ Object {
                     >
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         Participé à un festival,
                       </div>
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         à une avant-première
@@ -861,14 +861,14 @@ Object {
                     >
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         Assisté à un spectacle
                       </div>
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         Pièce de théâtre, cirque, danse...
@@ -914,14 +914,14 @@ Object {
                     >
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         Allé à la bibliothèque
                       </div>
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         ou à la médiathèque
@@ -967,14 +967,14 @@ Object {
                     >
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         Participé à un jeu
                       </div>
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         escape game, jeu concours
@@ -1020,7 +1020,7 @@ Object {
                     >
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         Allé à un concert
@@ -1066,7 +1066,7 @@ Object {
                     >
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         Allé au cinéma
@@ -1112,14 +1112,14 @@ Object {
                     >
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         Visité un musée,
                       </div>
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         un monument, une exposition...
@@ -1165,14 +1165,14 @@ Object {
                     >
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         Participé à une conférence,
                       </div>
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         rencontre ou découverte des métiers de la culture
@@ -1218,14 +1218,14 @@ Object {
                     >
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         Pris un cours
                       </div>
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         danse, théâtre, musique, dessin
@@ -1256,7 +1256,7 @@ Object {
                     >
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         Aucune de ces sorties culturelles
@@ -1282,7 +1282,7 @@ Object {
         >
           <div
             class="css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
           >
             Continuer

--- a/__snapshots__/features/culturalSurvey/pages/__tests__/CulturalSurveyThanks.web.test.tsx.web-snap
+++ b/__snapshots__/features/culturalSurvey/pages/__tests__/CulturalSurveyThanks.web.test.tsx.web-snap
@@ -207,7 +207,7 @@ Object {
         <h1
           aria-level="1"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Black; font-size: 24px; line-height: 36px; text-align: center;"
         >
@@ -216,7 +216,7 @@ Object {
         <h4
           aria-level="4"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
         >
@@ -228,7 +228,7 @@ Object {
         />
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
         >
           Tu peux dès maintenant découvrir 
@@ -250,7 +250,7 @@ l’étendue du catalogue pass Culture.
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
             >
               Découvrir le catalogue
@@ -467,7 +467,7 @@ l’étendue du catalogue pass Culture.
       <h1
         aria-level="1"
         class="css-reset-4rbku5 css-text-901oao"
-        dir="auto"
+        dir="ltr"
         role="heading"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Black; font-size: 24px; line-height: 36px; text-align: center;"
       >
@@ -476,7 +476,7 @@ l’étendue du catalogue pass Culture.
       <h4
         aria-level="4"
         class="css-reset-4rbku5 css-text-901oao"
-        dir="auto"
+        dir="ltr"
         role="heading"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
       >
@@ -488,7 +488,7 @@ l’étendue du catalogue pass Culture.
       />
       <div
         class="css-text-901oao"
-        dir="auto"
+        dir="ltr"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
       >
         Tu peux dès maintenant découvrir 
@@ -510,7 +510,7 @@ l’étendue du catalogue pass Culture.
         >
           <div
             class="css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
           >
             Découvrir le catalogue

--- a/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.web.test.tsx.web-snap
+++ b/__snapshots__/features/errors/pages/tests/AsyncErrorBoundary.web.test.tsx.web-snap
@@ -70,7 +70,7 @@ Object {
           <h1
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
           >
@@ -82,7 +82,7 @@ Object {
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
           >
             Une erreur s'est produite pendant le chargement.
@@ -102,7 +102,7 @@ Object {
             >
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
               >
                 Réessayer
@@ -187,7 +187,7 @@ Object {
         <h1
           aria-level="1"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
         >
@@ -199,7 +199,7 @@ Object {
         />
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
         >
           Une erreur s'est produite pendant le chargement.
@@ -219,7 +219,7 @@ Object {
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
             >
               Réessayer

--- a/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.web-snap
+++ b/__snapshots__/features/favorites/components/__tests__/NotConnectedFavorites.test.tsx.web-snap
@@ -108,7 +108,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
     <h4
       aria-level={4}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {
@@ -140,7 +140,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
     >
       <div
         className="css-text-901oao"
-        dir="auto"
+        dir="ltr"
         style={
           Object {
             "color": "rgba(22,22,23,1.00)",
@@ -153,6 +153,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
       >
         <span
           className="css-text-901oao css-textHasAncestor-16my406"
+          dir="ltr"
           style={
             Object {
               "color": "rgba(255,255,255,1.00)",
@@ -206,7 +207,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
       >
         <div
           className="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style={
             Object {
               "WebkitLineClamp": 1,
@@ -239,7 +240,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
       >
         <div
           className="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style={
             Object {
               "WebkitLineClamp": 1,

--- a/__snapshots__/features/favorites/pages/__tests__/FavoritesSorts.web.test.tsx.web-snap
+++ b/__snapshots__/features/favorites/pages/__tests__/FavoritesSorts.web.test.tsx.web-snap
@@ -55,7 +55,7 @@ Object {
               <h1
                 aria-level="1"
                 class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
               >
@@ -98,7 +98,7 @@ Object {
               <h2
                 aria-level="2"
                 class="css-reset-4rbku5 css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
               >
@@ -127,7 +127,7 @@ Object {
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         Ajouté récemment
@@ -174,7 +174,7 @@ Object {
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         Prix croissant
@@ -210,7 +210,7 @@ Object {
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         Proximité géographique
@@ -241,7 +241,7 @@ Object {
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
             >
               Valider
@@ -302,7 +302,7 @@ Object {
             <h1
               aria-level="1"
               class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               role="heading"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
             >
@@ -345,7 +345,7 @@ Object {
             <h2
               aria-level="2"
               class="css-reset-4rbku5 css-text-901oao"
-              dir="auto"
+              dir="ltr"
               role="heading"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
             >
@@ -374,7 +374,7 @@ Object {
                   >
                     <div
                       class="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                     >
                       Ajouté récemment
@@ -421,7 +421,7 @@ Object {
                   >
                     <div
                       class="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                     >
                       Prix croissant
@@ -457,7 +457,7 @@ Object {
                   >
                     <div
                       class="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                     >
                       Proximité géographique
@@ -488,7 +488,7 @@ Object {
         >
           <div
             class="css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
           >
             Valider

--- a/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.web-snap
+++ b/__snapshots__/features/forceUpdate/__tests__/ForceUpdate.test.tsx.web-snap
@@ -112,7 +112,7 @@ exports[`<ForceUpdate/> should match snapshot 1`] = `
     <h1
       aria-level={1}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {
@@ -136,7 +136,7 @@ exports[`<ForceUpdate/> should match snapshot 1`] = `
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -182,7 +182,7 @@ Pour des questions de performance et de sécurité merci d'actualiser la page po
       >
         <div
           className="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style={
             Object {
               "WebkitLineClamp": 1,

--- a/__snapshots__/features/home/atoms/tests/ModuleTitle.web.test.tsx.web-snap
+++ b/__snapshots__/features/home/atoms/tests/ModuleTitle.web.test.tsx.web-snap
@@ -13,7 +13,7 @@ Object {
           aria-level="3"
           class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
           data-testid="moduleTitle"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 20px; line-height: 24px;"
         >
@@ -31,7 +31,7 @@ Object {
         aria-level="3"
         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
         data-testid="moduleTitle"
-        dir="auto"
+        dir="ltr"
         role="heading"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 20px; line-height: 24px;"
       >

--- a/__snapshots__/features/home/atoms/tests/SeeMore.web.test.tsx.web-snap
+++ b/__snapshots__/features/home/atoms/tests/SeeMore.web.test.tsx.web-snap
@@ -58,7 +58,7 @@ Object {
           >
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
             >
               En voir plus
@@ -122,7 +122,7 @@ Object {
         >
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
           >
             En voir plus

--- a/__snapshots__/features/home/atoms/tests/VenueCaption.test.tsx.web-snap
+++ b/__snapshots__/features/home/atoms/tests/VenueCaption.test.tsx.web-snap
@@ -12,7 +12,7 @@ exports[`VenueCaption component should render correctly 1`] = `
 >
   <div
     className="css-text-901oao css-textMultiLine-cens5h"
-    dir="auto"
+    dir="ltr"
     style={
       Object {
         "WebkitLineClamp": 2,
@@ -61,7 +61,7 @@ exports[`VenueCaption component should render correctly 1`] = `
     />
     <div
       className="css-text-901oao css-textMultiLine-cens5h"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "WebkitFlexShrink": 1,
@@ -80,7 +80,7 @@ exports[`VenueCaption component should render correctly 1`] = `
   </div>
   <div
     className="css-text-901oao"
-    dir="auto"
+    dir="ltr"
     style={
       Object {
         "color": "rgba(105,106,111,1.00)",

--- a/__snapshots__/features/home/atoms/tests/VenueTile.web.test.tsx.web-snap
+++ b/__snapshots__/features/home/atoms/tests/VenueTile.web.test.tsx.web-snap
@@ -8,6 +8,7 @@ Object {
       <h3
         aria-level="3"
         class="css-reset-4rbku5 css-view-1dbjc4n"
+        dir="ltr"
         role="heading"
       >
         <div
@@ -27,7 +28,7 @@ Object {
             >
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
               >
                 Le Petit Rintintin 1
@@ -52,7 +53,7 @@ Object {
                 />
                 <div
                   class="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(105, 106, 111); flex-shrink: 1; font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                 >
                   Salle de projections
@@ -60,7 +61,7 @@ Object {
               </div>
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
               />
             </div>
@@ -73,6 +74,7 @@ Object {
     <h3
       aria-level="3"
       class="css-reset-4rbku5 css-view-1dbjc4n"
+      dir="ltr"
       role="heading"
     >
       <div
@@ -92,7 +94,7 @@ Object {
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
             >
               Le Petit Rintintin 1
@@ -117,7 +119,7 @@ Object {
               />
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(105, 106, 111); flex-shrink: 1; font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
               >
                 Salle de projections
@@ -125,7 +127,7 @@ Object {
             </div>
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
             />
           </div>

--- a/__snapshots__/features/home/components/tests/BusinessModule.web.test.tsx.web-snap
+++ b/__snapshots__/features/home/components/tests/BusinessModule.web.test.tsx.web-snap
@@ -69,14 +69,14 @@ Object {
                   <div
                     class="css-text-901oao"
                     data-testid="firstLine"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                   >
                     firstLine
                   </div>
                   <div
                     class="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                   >
                     secondLine
@@ -158,14 +158,14 @@ Object {
                 <div
                   class="css-text-901oao"
                   data-testid="firstLine"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                 >
                   firstLine
                 </div>
                 <div
                   class="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                 >
                   secondLine
@@ -304,14 +304,14 @@ Object {
                   <div
                     class="css-text-901oao"
                     data-testid="firstLine"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                   >
                     firstLine
                   </div>
                   <div
                     class="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                   >
                     secondLine
@@ -408,14 +408,14 @@ Object {
                 <div
                   class="css-text-901oao"
                   data-testid="firstLine"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                 >
                   firstLine
                 </div>
                 <div
                   class="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                 >
                   secondLine
@@ -591,14 +591,14 @@ Object {
                   <div
                     class="css-text-901oao"
                     data-testid="firstLine"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                   >
                     firstLine
                   </div>
                   <div
                     class="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                   >
                     secondLine
@@ -717,14 +717,14 @@ Object {
                 <div
                   class="css-text-901oao"
                   data-testid="firstLine"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                 >
                   firstLine
                 </div>
                 <div
                   class="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                 >
                   secondLine

--- a/__snapshots__/features/identityCheck/components/layout/PageWithHeader.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/components/layout/PageWithHeader.test.tsx.web-snap
@@ -56,7 +56,7 @@ exports[`<PageWithHeader/> should render correctly 1`] = `
     <h1
       aria-level={1}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {

--- a/__snapshots__/features/identityCheck/pages/confirmation/__test__/BeneficiaryRequestSent.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/__test__/BeneficiaryRequestSent.test.tsx.web-snap
@@ -112,7 +112,7 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
     <h1
       aria-level={1}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {
@@ -136,7 +136,7 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -151,7 +151,7 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
     </div>
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -196,7 +196,7 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
       >
         <div
           className="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style={
             Object {
               "WebkitLineClamp": 1,

--- a/__snapshots__/features/identityCheck/pages/confirmation/__test__/IdentityCheckHonor.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/__test__/IdentityCheckHonor.test.tsx.web-snap
@@ -56,7 +56,7 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
     <h1
       aria-level={1}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {
@@ -229,7 +229,7 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
                 <h2
                   aria-level={2}
                   className="css-reset-4rbku5 css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   role="heading"
                   style={
                     Object {
@@ -295,7 +295,7 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
                 </div>
                 <div
                   className="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "color": "rgba(22,22,23,1.00)",
@@ -332,7 +332,7 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
                 </div>
                 <div
                   className="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "color": "rgba(22,22,23,1.00)",
@@ -381,7 +381,7 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
                 >
                   <div
                     className="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style={
                       Object {
                         "WebkitLineClamp": 1,

--- a/__snapshots__/features/identityCheck/pages/confirmation/__test__/UnderageAccountCreated.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/__test__/UnderageAccountCreated.test.tsx.web-snap
@@ -94,7 +94,7 @@ exports[`<UnderageAccountCreated/> should render correctly 1`] = `
   <h1
     aria-level={1}
     className="css-reset-4rbku5 css-text-901oao"
-    dir="auto"
+    dir="ltr"
     role="heading"
     style={
       Object {
@@ -127,7 +127,7 @@ exports[`<UnderageAccountCreated/> should render correctly 1`] = `
   />
   <div
     className="css-text-901oao"
-    dir="auto"
+    dir="ltr"
     style={
       Object {
         "color": "rgba(22,22,23,1.00)",
@@ -277,7 +277,7 @@ exports[`<UnderageAccountCreated/> should render correctly 1`] = `
     </div>
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(22,22,23,1.00)",
@@ -301,7 +301,7 @@ exports[`<UnderageAccountCreated/> should render correctly 1`] = `
   />
   <div
     className="css-text-901oao"
-    dir="auto"
+    dir="ltr"
     style={
       Object {
         "color": "rgba(22,22,23,1.00)",
@@ -342,7 +342,7 @@ exports[`<UnderageAccountCreated/> should render correctly 1`] = `
     >
       <div
         className="css-text-901oao css-textMultiLine-cens5h"
-        dir="auto"
+        dir="ltr"
         style={
           Object {
             "WebkitLineClamp": 1,

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckDMS.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckDMS.test.tsx.web-snap
@@ -56,7 +56,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
     <h1
       aria-level={1}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {
@@ -259,7 +259,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                 <h2
                   aria-level={2}
                   className="css-reset-4rbku5 css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   role="heading"
                   style={
                     Object {
@@ -284,7 +284,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
               />
               <div
                 className="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style={
                   Object {
                     "color": "rgba(105,106,111,1.00)",
@@ -346,7 +346,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                   </div>
                   <div
                     className="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style={
                       Object {
                         "WebkitLineClamp": 1,
@@ -364,7 +364,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                 </a>
                 <div
                   className="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "color": "rgba(105,106,111,1.00)",
@@ -423,7 +423,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                   >
                     <div
                       className="css-text-901oao"
-                      dir="auto"
+                      dir="ltr"
                       style={
                         Object {
                           "color": "rgba(22,22,23,1.00)",
@@ -459,7 +459,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                   </div>
                   <div
                     className="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style={
                       Object {
                         "WebkitLineClamp": 1,
@@ -477,7 +477,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                 </a>
                 <div
                   className="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "color": "rgba(105,106,111,1.00)",

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnect.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnect.test.tsx.web-snap
@@ -56,7 +56,7 @@ exports[`<IdentityCheckEduConnect /> should render correctly 1`] = `
     <h1
       aria-level={1}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {
@@ -304,7 +304,7 @@ exports[`<IdentityCheckEduConnect /> should render correctly 1`] = `
                   <h2
                     aria-level={2}
                     className="css-reset-4rbku5 css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     role="heading"
                     style={
                       Object {
@@ -329,7 +329,7 @@ exports[`<IdentityCheckEduConnect /> should render correctly 1`] = `
                 />
                 <div
                   className="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "color": "rgba(105,106,111,1.00)",
@@ -389,7 +389,7 @@ exports[`<IdentityCheckEduConnect /> should render correctly 1`] = `
               </div>
               <div
                 className="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style={
                   Object {
                     "WebkitLineClamp": 1,

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnectForm.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEduConnectForm.web.test.tsx.web-snap
@@ -20,7 +20,7 @@ Object {
           <h1
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(255, 255, 255); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
           >
@@ -87,7 +87,7 @@ Object {
                     </div>
                     <div
                       class="css-text-901oao"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; text-align: center;"
                     >
                       Identification
@@ -98,7 +98,7 @@ Object {
                     />
                     <div
                       class="css-text-901oao"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(105, 106, 111); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
                     >
                       Pour t’identifier, nous allons te demander de te connecter à EduConnect. Munis-toi de ton identifiant et ton mot de passe EduConnect ! Si tu ne les as pas, contacte ton établissement pour les récupérer.
@@ -127,7 +127,7 @@ Object {
                       />
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         Un souci pour accéder à la page ? Essaie en navigation privée ou pense bien à accepter les pop-ups de ton navigateur.
@@ -161,7 +161,7 @@ Object {
                     </div>
                     <div
                       class="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
                     >
                       Ouvrir un onglet ÉduConnect
@@ -210,7 +210,7 @@ Object {
         <h1
           aria-level="1"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(255, 255, 255); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
         >
@@ -277,7 +277,7 @@ Object {
                   </div>
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; text-align: center;"
                   >
                     Identification
@@ -288,7 +288,7 @@ Object {
                   />
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
                   >
                     Pour t’identifier, nous allons te demander de te connecter à EduConnect. Munis-toi de ton identifiant et ton mot de passe EduConnect ! Si tu ne les as pas, contacte ton établissement pour les récupérer.
@@ -317,7 +317,7 @@ Object {
                     />
                     <div
                       class="css-text-901oao"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                     >
                       Un souci pour accéder à la page ? Essaie en navigation privée ou pense bien à accepter les pop-ups de ton navigateur.
@@ -351,7 +351,7 @@ Object {
                   </div>
                   <div
                     class="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
                   >
                     Ouvrir un onglet ÉduConnect

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEnd.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckEnd.test.tsx.web-snap
@@ -112,7 +112,7 @@ exports[`<IdentityCheckEnd/> should render correctly 1`] = `
     <h1
       aria-level={1}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckPending.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckPending.test.tsx.web-snap
@@ -112,7 +112,7 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
     <h1
       aria-level={1}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {
@@ -136,7 +136,7 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -159,7 +159,7 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -204,7 +204,7 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
       >
         <div
           className="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style={
             Object {
               "WebkitLineClamp": 1,

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckStart.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckStart.web.test.tsx.web-snap
@@ -5,7 +5,7 @@ exports[`<IdentityCheckStart/> should render correctly 1`] = `
 - First value
 + Second value
 
-@@ -497,11 +497,11 @@
+@@ -499,11 +499,11 @@
               class=\\"css-view-1dbjc4n\\"
               style=\\"align-items: center; background-color: rgb(255, 255, 255); border-top-left-radius: 22px; border-top-right-radius: 22px; display: flex; flex-direction: column; height: 100%; overflow-x: scroll; overflow-y: scroll; padding-top: 12px;\\"
             >
@@ -18,7 +18,7 @@ exports[`<IdentityCheckStart/> should render correctly 1`] = `
                   class=\\"css-view-1dbjc4n\\"
                   style=\\"flex-direction: column; flex-grow: 1; flex-shrink: 1; overflow-x: hidden; overflow-y: auto; transform: translateZ(0px);\\"
                 >
-@@ -513,96 +513,85 @@
+@@ -515,96 +515,87 @@
                       class=\\"css-view-1dbjc4n\\"
                       style=\\"align-items: center; height: 100%;\\"
                     >
@@ -51,7 +51,7 @@ exports[`<IdentityCheckStart/> should render correctly 1`] = `
                         <h4
                           aria-level=\\"4\\"
                           class=\\"css-reset-4rbku5 css-text-901oao\\"
-                          dir=\\"auto\\"
+                          dir=\\"ltr\\"
                           role=\\"heading\\"
                           style=\\"color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;\\"
                         >
@@ -64,15 +64,10 @@ exports[`<IdentityCheckStart/> should render correctly 1`] = `
                         />
                         <div
                           class=\\"css-text-901oao\\"
-                          dir=\\"auto\\"
+                          dir=\\"ltr\\"
 -                         style=\\"color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;\\"
 +                         style=\\"color: rgb(105, 106, 111); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;\\"
-+                       >
-+                         Prends une photo de ta
-+                         <span
-+                           class=\\"css-text-901oao css-textHasAncestor-16my406\\"
-+                           style=\\"color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;\\"
-                          >
+                        >
 -                         Gagne du temps en vérifiant ton identité directement sur ton smartphone ! Sinon tu peux passer par le site Démarches-Simplifiées mais le traitement sera plus long.
 -                       </div>
 -                       <div
@@ -81,13 +76,19 @@ exports[`<IdentityCheckStart/> should render correctly 1`] = `
 -                       />
 -                       <div
 -                         class=\\"css-text-901oao\\"
--                         dir=\\"auto\\"
++                         Prends une photo de ta
++                         <span
++                           class=\\"css-text-901oao css-textHasAncestor-16my406\\"
+                            dir=\\"ltr\\"
 -                         style=\\"color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;\\"
++                           style=\\"color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;\\"
++                         >
 +                            carte d'identité 
 +                         </span>
 +                         ou de ton
 +                         <span
 +                           class=\\"css-text-901oao css-textHasAncestor-16my406\\"
++                           dir=\\"ltr\\"
 +                           style=\\"color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;\\"
                           >
 -                         Prends une photo de ta carte d'identité ou de ton passeport en cours de validité pour accéder à ton pass Culture.
@@ -107,7 +108,7 @@ exports[`<IdentityCheckStart/> should render correctly 1`] = `
 -                     >
                         <div
 -                         class=\\"css-text-901oao css-textMultiLine-cens5h\\"
--                         dir=\\"auto\\"
+-                         dir=\\"ltr\\"
 -                         style=\\"color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;\\"
 -                       >
 -                         Vérification par smartphone
@@ -125,7 +126,7 @@ exports[`<IdentityCheckStart/> should render correctly 1`] = `
                         >
                           <div
                             class=\\"css-text-901oao\\"
-                            dir=\\"auto\\"
+                            dir=\\"ltr\\"
 -                         style=\\"color: rgb(105, 106, 111); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;\\"
 +                           style=\\"color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;\\"
                           >
@@ -144,12 +145,12 @@ exports[`<IdentityCheckStart/> should render correctly 1`] = `
                           >
                             <div
                               class=\\"css-view-1dbjc4n\\"
-@@ -616,29 +605,45 @@
+@@ -618,29 +609,45 @@
                               </div>
                             </div>
                             <div
                               class=\\"css-text-901oao css-textMultiLine-cens5h\\"
-                              dir=\\"auto\\"
+                              dir=\\"ltr\\"
 -                           style=\\"color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;\\"
 +                             style=\\"color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 12px; line-height: 20px; margin-left: 4px; max-width: 100%;\\"
                             >
@@ -178,7 +179,7 @@ exports[`<IdentityCheckStart/> should render correctly 1`] = `
 +                 >
 +                   <div
 +                     class=\\"css-text-901oao css-textMultiLine-cens5h\\"
-                      dir=\\"auto\\"
+                      dir=\\"ltr\\"
 -                         style=\\"color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;\\"
 +                     style=\\"color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;\\"
                     >

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckUnavailable.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckUnavailable.test.tsx.web-snap
@@ -112,7 +112,7 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
     <h1
       aria-level={1}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {
@@ -136,7 +136,7 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -159,7 +159,7 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -223,7 +223,7 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
         </div>
         <div
           className="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style={
             Object {
               "WebkitLineClamp": 1,

--- a/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckValidation.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/__test__/IdentityCheckValidation.web.test.tsx.web-snap
@@ -20,7 +20,7 @@ Object {
           <h1
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(255, 255, 255); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
           >
@@ -73,7 +73,7 @@ Object {
                     <h2
                       aria-level="2"
                       class="css-reset-4rbku5 css-text-901oao"
-                      dir="auto"
+                      dir="ltr"
                       role="heading"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                     >
@@ -99,7 +99,7 @@ Object {
                       />
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                       >
                         Ton prénom
@@ -111,7 +111,7 @@ Object {
                       <div
                         class="css-text-901oao"
                         data-testid="validation-first-name"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 20px; line-height: 24px;"
                       >
                         John
@@ -122,7 +122,7 @@ Object {
                       />
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                       >
                         Ton nom de famille
@@ -134,7 +134,7 @@ Object {
                       <div
                         class="css-text-901oao"
                         data-testid="validation-name"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 20px; line-height: 24px;"
                       >
                         Doe
@@ -145,7 +145,7 @@ Object {
                       />
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                       >
                         Ta date de naissance
@@ -157,7 +157,7 @@ Object {
                       <div
                         class="css-text-901oao"
                         data-testid="validation-birth-date"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 20px; line-height: 24px;"
                       >
                         28/01/1993
@@ -176,7 +176,7 @@ Object {
                   >
                     <div
                       class="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                     >
                       Valider mes informations
@@ -225,7 +225,7 @@ Object {
         <h1
           aria-level="1"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(255, 255, 255); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
         >
@@ -278,7 +278,7 @@ Object {
                   <h2
                     aria-level="2"
                     class="css-reset-4rbku5 css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     role="heading"
                     style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                   >
@@ -304,7 +304,7 @@ Object {
                     />
                     <div
                       class="css-text-901oao"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(105, 106, 111); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                     >
                       Ton prénom
@@ -316,7 +316,7 @@ Object {
                     <div
                       class="css-text-901oao"
                       data-testid="validation-first-name"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 20px; line-height: 24px;"
                     >
                       John
@@ -327,7 +327,7 @@ Object {
                     />
                     <div
                       class="css-text-901oao"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(105, 106, 111); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                     >
                       Ton nom de famille
@@ -339,7 +339,7 @@ Object {
                     <div
                       class="css-text-901oao"
                       data-testid="validation-name"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 20px; line-height: 24px;"
                     >
                       Doe
@@ -350,7 +350,7 @@ Object {
                     />
                     <div
                       class="css-text-901oao"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(105, 106, 111); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                     >
                       Ta date de naissance
@@ -362,7 +362,7 @@ Object {
                     <div
                       class="css-text-901oao"
                       data-testid="validation-birth-date"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 20px; line-height: 24px;"
                     >
                       28/01/1993
@@ -381,7 +381,7 @@ Object {
                 >
                   <div
                     class="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                   >
                     Valider mes informations

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetAddress.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetAddress.web.test.tsx.web-snap
@@ -20,7 +20,7 @@ Object {
           <h1
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(255, 255, 255); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
           >
@@ -76,7 +76,7 @@ Object {
                       <h2
                         aria-level="2"
                         class="css-reset-4rbku5 css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                       >
@@ -162,7 +162,7 @@ Object {
                   >
                     <div
                       class="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                     >
                       Continuer
@@ -211,7 +211,7 @@ Object {
         <h1
           aria-level="1"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(255, 255, 255); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
         >
@@ -267,7 +267,7 @@ Object {
                     <h2
                       aria-level="2"
                       class="css-reset-4rbku5 css-text-901oao"
-                      dir="auto"
+                      dir="ltr"
                       role="heading"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                     >
@@ -353,7 +353,7 @@ Object {
                 >
                   <div
                     class="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                   >
                     Continuer

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetCity.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetCity.web.test.tsx.web-snap
@@ -20,7 +20,7 @@ Object {
           <h1
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(255, 255, 255); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
           >
@@ -76,7 +76,7 @@ Object {
                       <h2
                         aria-level="2"
                         class="css-reset-4rbku5 css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                       >
@@ -166,7 +166,7 @@ Object {
                   >
                     <div
                       class="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                     >
                       Continuer
@@ -215,7 +215,7 @@ Object {
         <h1
           aria-level="1"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(255, 255, 255); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
         >
@@ -271,7 +271,7 @@ Object {
                     <h2
                       aria-level="2"
                       class="css-reset-4rbku5 css-text-901oao"
-                      dir="auto"
+                      dir="ltr"
                       role="heading"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                     >
@@ -361,7 +361,7 @@ Object {
                 >
                   <div
                     class="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                   >
                     Continuer

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetName.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetName.web.test.tsx.web-snap
@@ -20,7 +20,7 @@ Object {
           <h1
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(255, 255, 255); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
           >
@@ -73,7 +73,7 @@ Object {
                     <h2
                       aria-level="2"
                       class="css-reset-4rbku5 css-text-901oao"
-                      dir="auto"
+                      dir="ltr"
                       role="heading"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                     >
@@ -125,7 +125,7 @@ Object {
                         >
                           <div
                             class="css-text-901oao"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                           >
                             Saisis ton nom et ton prénom tels qu'ils sont affichés sur ta carte d'identité.
@@ -152,7 +152,7 @@ Object {
                           </label>
                           <div
                             class="css-text-901oao"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                           >
                             Obligatoire
@@ -209,7 +209,7 @@ Object {
                           </label>
                           <div
                             class="css-text-901oao"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                           >
                             Obligatoire
@@ -262,7 +262,7 @@ Object {
                   >
                     <div
                       class="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                     >
                       Continuer
@@ -311,7 +311,7 @@ Object {
         <h1
           aria-level="1"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(255, 255, 255); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
         >
@@ -364,7 +364,7 @@ Object {
                   <h2
                     aria-level="2"
                     class="css-reset-4rbku5 css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     role="heading"
                     style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                   >
@@ -416,7 +416,7 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           Saisis ton nom et ton prénom tels qu'ils sont affichés sur ta carte d'identité.
@@ -443,7 +443,7 @@ Object {
                         </label>
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           Obligatoire
@@ -500,7 +500,7 @@ Object {
                         </label>
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           Obligatoire
@@ -553,7 +553,7 @@ Object {
                 >
                   <div
                     class="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                   >
                     Continuer

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetSchoolType.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetSchoolType.web.test.tsx.web-snap
@@ -20,7 +20,7 @@ Object {
           <h1
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(255, 255, 255); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
           >
@@ -73,7 +73,7 @@ Object {
                     <h2
                       aria-level="2"
                       class="css-reset-4rbku5 css-text-901oao"
-                      dir="auto"
+                      dir="ltr"
                       role="heading"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                     >
@@ -113,7 +113,7 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               >
                                 Lycée agricole
@@ -135,7 +135,7 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               />
                             </div>
@@ -155,7 +155,7 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               />
                             </div>
@@ -175,7 +175,7 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               />
                             </div>
@@ -195,7 +195,7 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               />
                             </div>
@@ -215,14 +215,14 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               >
                                 Accompagnement spécialisé
                               </div>
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 À domicile, CNED, institut de santé, etc.
@@ -244,7 +244,7 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               >
                                 Centre de formation d'apprentis
@@ -269,7 +269,7 @@ Object {
                   >
                     <div
                       class="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                     >
                       Choisis ton statut
@@ -318,7 +318,7 @@ Object {
         <h1
           aria-level="1"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(255, 255, 255); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
         >
@@ -371,7 +371,7 @@ Object {
                   <h2
                     aria-level="2"
                     class="css-reset-4rbku5 css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     role="heading"
                     style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                   >
@@ -411,7 +411,7 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             >
                               Lycée agricole
@@ -433,7 +433,7 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             />
                           </div>
@@ -453,7 +453,7 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             />
                           </div>
@@ -473,7 +473,7 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             />
                           </div>
@@ -493,7 +493,7 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             />
                           </div>
@@ -513,14 +513,14 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             >
                               Accompagnement spécialisé
                             </div>
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               À domicile, CNED, institut de santé, etc.
@@ -542,7 +542,7 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             >
                               Centre de formation d'apprentis
@@ -567,7 +567,7 @@ Object {
                 >
                   <div
                     class="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                   >
                     Choisis ton statut
@@ -673,7 +673,7 @@ Object {
           <h1
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(255, 255, 255); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
           >
@@ -726,7 +726,7 @@ Object {
                     <h2
                       aria-level="2"
                       class="css-reset-4rbku5 css-text-901oao"
-                      dir="auto"
+                      dir="ltr"
                       role="heading"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                     >
@@ -766,7 +766,7 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               >
                                 Collège privé
@@ -788,7 +788,7 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               >
                                 Collège public
@@ -810,14 +810,14 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               >
                                 Accompagnement spécialisé
                               </div>
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 À domicile, CNED, institut de santé, etc.
@@ -842,7 +842,7 @@ Object {
                   >
                     <div
                       class="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                     >
                       Choisis ton statut
@@ -891,7 +891,7 @@ Object {
         <h1
           aria-level="1"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(255, 255, 255); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
         >
@@ -944,7 +944,7 @@ Object {
                   <h2
                     aria-level="2"
                     class="css-reset-4rbku5 css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     role="heading"
                     style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                   >
@@ -984,7 +984,7 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             >
                               Collège privé
@@ -1006,7 +1006,7 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             >
                               Collège public
@@ -1028,14 +1028,14 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             >
                               Accompagnement spécialisé
                             </div>
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               À domicile, CNED, institut de santé, etc.
@@ -1060,7 +1060,7 @@ Object {
                 >
                   <div
                     class="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                   >
                     Choisis ton statut

--- a/__snapshots__/features/identityCheck/pages/profile/__test__/SetStatus.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/__test__/SetStatus.web.test.tsx.web-snap
@@ -20,7 +20,7 @@ Object {
           <h1
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(255, 255, 255); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
           >
@@ -73,7 +73,7 @@ Object {
                     <h2
                       aria-level="2"
                       class="css-reset-4rbku5 css-text-901oao"
-                      dir="auto"
+                      dir="ltr"
                       role="heading"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                     >
@@ -113,7 +113,7 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               >
                                 Collégien
@@ -135,7 +135,7 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               >
                                 Lycéen
@@ -157,7 +157,7 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               >
                                 Étudiant
@@ -179,7 +179,7 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               >
                                 Employé
@@ -201,7 +201,7 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               >
                                 Apprenti
@@ -223,7 +223,7 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               >
                                 Alternant
@@ -245,14 +245,14 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               >
                                 Volontaire
                               </div>
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 En service civique
@@ -274,14 +274,14 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               >
                                 Inactif
                               </div>
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 En incapacité de travailler
@@ -303,14 +303,14 @@ Object {
                             >
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                               >
                                 Chômeur
                               </div>
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 En recherche d'emploi
@@ -335,7 +335,7 @@ Object {
                   >
                     <div
                       class="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                     >
                       Choisis ton statut
@@ -384,7 +384,7 @@ Object {
         <h1
           aria-level="1"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(255, 255, 255); flex-basis: 0px; flex-grow: 1; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
         >
@@ -437,7 +437,7 @@ Object {
                   <h2
                     aria-level="2"
                     class="css-reset-4rbku5 css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     role="heading"
                     style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                   >
@@ -477,7 +477,7 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             >
                               Collégien
@@ -499,7 +499,7 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             >
                               Lycéen
@@ -521,7 +521,7 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             >
                               Étudiant
@@ -543,7 +543,7 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             >
                               Employé
@@ -565,7 +565,7 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             >
                               Apprenti
@@ -587,7 +587,7 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             >
                               Alternant
@@ -609,14 +609,14 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             >
                               Volontaire
                             </div>
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               En service civique
@@ -638,14 +638,14 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             >
                               Inactif
                             </div>
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               En incapacité de travailler
@@ -667,14 +667,14 @@ Object {
                           >
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                             >
                               Chômeur
                             </div>
                             <div
                               class="css-text-901oao"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               En recherche d'emploi
@@ -699,7 +699,7 @@ Object {
                 >
                   <div
                     class="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                   >
                     Choisis ton statut

--- a/__snapshots__/features/landscapePosition/tests/LandscapePositionPage.test.tsx.web-snap
+++ b/__snapshots__/features/landscapePosition/tests/LandscapePositionPage.test.tsx.web-snap
@@ -123,7 +123,7 @@ exports[`<LandscapePositionPage /> should match snapshot with default message 1`
       <h1
         aria-level={1}
         className="css-reset-4rbku5 css-text-901oao"
-        dir="auto"
+        dir="ltr"
         role="heading"
         style={
           Object {
@@ -147,7 +147,7 @@ exports[`<LandscapePositionPage /> should match snapshot with default message 1`
       />
       <div
         className="css-text-901oao"
-        dir="auto"
+        dir="ltr"
         style={
           Object {
             "color": "rgba(255,255,255,1.00)",

--- a/__snapshots__/features/maintenance/tests/Maintenance.test.tsx.web-snap
+++ b/__snapshots__/features/maintenance/tests/Maintenance.test.tsx.web-snap
@@ -112,7 +112,7 @@ exports[`<Maintenance /> should match snapshot with custom message 1`] = `
     <h1
       aria-level={1}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {
@@ -144,7 +144,7 @@ exports[`<Maintenance /> should match snapshot with custom message 1`] = `
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -299,7 +299,7 @@ exports[`<Maintenance /> should match snapshot with default message 1`] = `
     <h1
       aria-level={1}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {
@@ -331,7 +331,7 @@ exports[`<Maintenance /> should match snapshot with default message 1`] = `
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",

--- a/__snapshots__/features/navigation/RootNavigator/Header/tests/AccessibleTabBar.web.test.tsx.web-snap
+++ b/__snapshots__/features/navigation/RootNavigator/Header/tests/AccessibleTabBar.web.test.tsx.web-snap
@@ -61,7 +61,7 @@ Object {
                   </div>
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                   >
                     Accueil
@@ -101,7 +101,7 @@ Object {
                   </div>
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                   >
                     Recherche
@@ -137,7 +137,7 @@ Object {
                   </div>
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                   >
                     Réservations
@@ -173,7 +173,7 @@ Object {
                   </div>
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                   >
                     Favoris
@@ -209,7 +209,7 @@ Object {
                   </div>
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                   >
                     Profil
@@ -291,7 +291,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                 >
                   Accueil
@@ -331,7 +331,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                 >
                   Recherche
@@ -367,7 +367,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                 >
                   Réservations
@@ -403,7 +403,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                 >
                   Favoris
@@ -439,7 +439,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                 >
                   Profil

--- a/__snapshots__/features/navigation/__tests__/RootNavigator.web.test.tsx.web-snap
+++ b/__snapshots__/features/navigation/__tests__/RootNavigator.web.test.tsx.web-snap
@@ -102,7 +102,7 @@ Object {
                   </div>
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                   >
                     Accueil
@@ -142,7 +142,7 @@ Object {
                   </div>
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                   >
                     Recherche
@@ -178,7 +178,7 @@ Object {
                   </div>
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                   >
                     Réservations
@@ -214,7 +214,7 @@ Object {
                   </div>
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                   >
                     Favoris
@@ -250,7 +250,7 @@ Object {
                   </div>
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                   >
                     Profil
@@ -371,7 +371,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                 >
                   Accueil
@@ -411,7 +411,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                 >
                   Recherche
@@ -447,7 +447,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                 >
                   Réservations
@@ -483,7 +483,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                 >
                   Favoris
@@ -519,7 +519,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 10px; line-height: 16px; text-align: center;"
                 >
                   Profil

--- a/__snapshots__/features/offer/atoms/__tests__/OfferCategory.test.tsx.web-snap
+++ b/__snapshots__/features/offer/atoms/__tests__/OfferCategory.test.tsx.web-snap
@@ -55,7 +55,7 @@ exports[`OfferCategory renders correctly 1`] = `
   <div
     className="css-text-901oao"
     data-testid="caption-undefined"
-    dir="auto"
+    dir="ltr"
     style={
       Object {
         "color": "rgba(22,22,23,1.00)",

--- a/__snapshots__/features/offer/atoms/__tests__/OfferTile.web.test.tsx.web-snap
+++ b/__snapshots__/features/offer/atoms/__tests__/OfferTile.web.test.tsx.web-snap
@@ -8,6 +8,7 @@ Object {
       <h3
         aria-level="3"
         class="css-reset-4rbku5 css-view-1dbjc4n"
+        dir="ltr"
         role="heading"
       >
         <div
@@ -27,14 +28,14 @@ Object {
             >
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
               >
                 Mensch ! Où sont les Hommes ?
               </div>
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
               >
                 Dès le 12 mars 2020
@@ -42,7 +43,7 @@ Object {
               <div
                 class="css-text-901oao"
                 data-testid="priceIsDuo"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
               >
                 28 €
@@ -62,7 +63,7 @@ Object {
                   <div
                     class="css-text-901oao css-textMultiLine-cens5h"
                     data-testid="categoryImageCaption"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                   >
                     MUSIQUE
@@ -79,7 +80,7 @@ Object {
                   <div
                     class="css-text-901oao"
                     data-testid="distanceImageCaption"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                   >
                     1,2km
@@ -96,6 +97,7 @@ Object {
     <h3
       aria-level="3"
       class="css-reset-4rbku5 css-view-1dbjc4n"
+      dir="ltr"
       role="heading"
     >
       <div
@@ -115,14 +117,14 @@ Object {
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
             >
               Mensch ! Où sont les Hommes ?
             </div>
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
             >
               Dès le 12 mars 2020
@@ -130,7 +132,7 @@ Object {
             <div
               class="css-text-901oao"
               data-testid="priceIsDuo"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
             >
               28 €
@@ -150,7 +152,7 @@ Object {
                 <div
                   class="css-text-901oao css-textMultiLine-cens5h"
                   data-testid="categoryImageCaption"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                 >
                   MUSIQUE
@@ -167,7 +169,7 @@ Object {
                 <div
                   class="css-text-901oao"
                   data-testid="distanceImageCaption"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                 >
                   1,2km

--- a/__snapshots__/features/offer/components/__tests__/OfferHeader.web.test.tsx.web-snap
+++ b/__snapshots__/features/offer/components/__tests__/OfferHeader.web.test.tsx.web-snap
@@ -101,6 +101,7 @@ Object {
           >
             <span
               class="css-text-901oao css-textHasAncestor-16my406"
+              dir="ltr"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
             >
               Some very nice offer
@@ -332,6 +333,7 @@ Object {
         >
           <span
             class="css-text-901oao css-textHasAncestor-16my406"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
           >
             Some very nice offer

--- a/__snapshots__/features/offer/components/__tests__/OfferIconCaptions.web.test.tsx.web-snap
+++ b/__snapshots__/features/offer/components/__tests__/OfferIconCaptions.web.test.tsx.web-snap
@@ -39,7 +39,7 @@ Object {
           <div
             class="css-text-901oao"
             data-testid="caption-undefined"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
           >
             Abonnements concerts
@@ -76,7 +76,7 @@ Object {
           <div
             class="css-text-901oao"
             data-testid="caption-iconPrice"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
           >
             28 €
@@ -124,7 +124,7 @@ Object {
         <div
           class="css-text-901oao"
           data-testid="caption-undefined"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
         >
           Abonnements concerts
@@ -161,7 +161,7 @@ Object {
         <div
           class="css-text-901oao"
           data-testid="caption-iconPrice"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
         >
           28 €

--- a/__snapshots__/features/offer/pages/tests/OfferDescription.web.test.tsx.web-snap
+++ b/__snapshots__/features/offer/pages/tests/OfferDescription.web.test.tsx.web-snap
@@ -107,7 +107,7 @@ Object {
                                     <h1
                                       aria-level="1"
                                       class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                                      dir="auto"
+                                      dir="ltr"
                                       role="heading"
                                       style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
                                     >
@@ -335,7 +335,7 @@ Object {
                                   <h1
                                     aria-level="1"
                                     class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                                    dir="auto"
+                                    dir="ltr"
                                     role="heading"
                                     style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
                                   >

--- a/__snapshots__/features/profile/components/CreditCeiling.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/components/CreditCeiling.web.test.tsx.web-snap
@@ -42,7 +42,7 @@ Object {
         </div>
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(50, 0, 150); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
         >
           155 €
@@ -52,7 +52,7 @@ Object {
         >
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
           >
             en offres physiques (livres...)
@@ -99,7 +99,7 @@ Object {
       </div>
       <div
         class="css-text-901oao"
-        dir="auto"
+        dir="ltr"
         style="color: rgb(50, 0, 150); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
       >
         155 €
@@ -109,7 +109,7 @@ Object {
       >
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
         >
           en offres physiques (livres...)

--- a/__snapshots__/features/profile/components/SectionWithSwitch.test.tsx.web-snap
+++ b/__snapshots__/features/profile/components/SectionWithSwitch.test.tsx.web-snap
@@ -77,7 +77,7 @@ exports[`<SectionWithSwitch/> should display different if isDesktopViewport or w
 +   >
 +     <div
 +       className=\\"css-text-901oao\\"
-+       dir=\\"auto\\"
++       dir=\\"ltr\\"
 +       style={
 +         Object {
 +           \\"color\\": \\"rgba(105,106,111,1.00)\\",

--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmail.web.test.tsx.web-snap
@@ -51,7 +51,7 @@ Object {
             <h1
               aria-level="1"
               class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               role="heading"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
             >
@@ -86,7 +86,7 @@ Object {
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
           >
             Saisis ta nouvelle adresse e-mail et ton mot de passe. Tu vas recevoir un e-mail sur ta nouvelle adresse avec un lien de confirmation valable 24h. Tu ne peux modifier ton adresse e-mail qu'une fois par jour.
@@ -126,7 +126,7 @@ Object {
                   </label>
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                   >
                     Obligatoire
@@ -184,7 +184,7 @@ Object {
                   </label>
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                   >
                     Obligatoire
@@ -257,7 +257,7 @@ Object {
                 >
                   <div
                     class="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                   >
                     Enregistrer
@@ -321,7 +321,7 @@ Object {
           <h1
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
           >
@@ -356,7 +356,7 @@ Object {
         />
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
         >
           Saisis ta nouvelle adresse e-mail et ton mot de passe. Tu vas recevoir un e-mail sur ta nouvelle adresse avec un lien de confirmation valable 24h. Tu ne peux modifier ton adresse e-mail qu'une fois par jour.
@@ -396,7 +396,7 @@ Object {
                 </label>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                 >
                   Obligatoire
@@ -454,7 +454,7 @@ Object {
                 </label>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                 >
                   Obligatoire
@@ -527,7 +527,7 @@ Object {
               >
                 <div
                   class="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(105, 106, 111); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                 >
                   Enregistrer

--- a/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/__tests__/ChangeEmailExpiredLink.web.test.tsx.web-snap
@@ -49,7 +49,7 @@ Object {
           <h1
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
           >
@@ -61,14 +61,14 @@ Object {
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
           >
             Le lien est expiré !
           </div>
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
           >
             Ton adresse e-mail n’a pas été modifiée. Le lien que tu reçois par e-mail expire 24h après sa réception.
@@ -90,7 +90,7 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
             >
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
               >
                 Faire une nouvelle demande
@@ -118,7 +118,7 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
               </div>
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
               >
                 Retourner à l'accueil
@@ -178,7 +178,7 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
         <h1
           aria-level="1"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
         >
@@ -190,14 +190,14 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
         />
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
         >
           Le lien est expiré !
         </div>
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
         >
           Ton adresse e-mail n’a pas été modifiée. Le lien que tu reçois par e-mail expire 24h après sa réception.
@@ -219,7 +219,7 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
             >
               Faire une nouvelle demande
@@ -247,7 +247,7 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
             </div>
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
             >
               Retourner à l'accueil
@@ -364,7 +364,7 @@ Object {
           <h1
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
           >
@@ -376,14 +376,14 @@ Object {
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
           >
             Le lien est expiré !
           </div>
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
           >
             Ton adresse e-mail n’a pas été modifiée. Le lien que tu reçois par e-mail expire 24h après sa réception.
@@ -405,7 +405,7 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
             >
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
               >
                 Se connecter
@@ -433,7 +433,7 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
               </div>
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
               >
                 Retourner à l'accueil
@@ -493,7 +493,7 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
         <h1
           aria-level="1"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
         >
@@ -505,14 +505,14 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
         />
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
         >
           Le lien est expiré !
         </div>
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
         >
           Ton adresse e-mail n’a pas été modifiée. Le lien que tu reçois par e-mail expire 24h après sa réception.
@@ -534,7 +534,7 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
             >
               Se connecter
@@ -562,7 +562,7 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
             </div>
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
             >
               Retourner à l'accueil

--- a/__snapshots__/features/profile/pages/DeleteProfile/__tests__/ConfirmDeleteProfile.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/__tests__/ConfirmDeleteProfile.web.test.tsx.web-snap
@@ -48,7 +48,7 @@ Object {
         <h1
           aria-level="1"
           class="css-reset-4rbku5 css-text-901oao"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
         >
@@ -64,7 +64,7 @@ Object {
         >
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
           >
             Les conséquences :
@@ -94,7 +94,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; margin-left: 12px;"
                 >
                   tes réservations seront annulées et supprimées
@@ -123,7 +123,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; margin-left: 12px;"
                 >
                   si tu as un dossier en cours, tu ne pourras pas en déposer un nouveau
@@ -152,7 +152,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; margin-left: 12px;"
                 >
                   tu n’auras plus accès au catalogue
@@ -166,14 +166,14 @@ Object {
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
           >
             Les données qu’on conserve :
           </div>
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
           >
             Nous gardons toutes les informations personnelles que tu nous as transmises lors de la vérification de ton identité.
@@ -193,7 +193,7 @@ Object {
             >
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
               >
                 Supprimer mon compte
@@ -222,7 +222,7 @@ Object {
               </div>
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
               >
                 Consulter l’article d’aide
@@ -281,7 +281,7 @@ Object {
       <h1
         aria-level="1"
         class="css-reset-4rbku5 css-text-901oao"
-        dir="auto"
+        dir="ltr"
         role="heading"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 22px; line-height: 28px; text-align: center;"
       >
@@ -297,7 +297,7 @@ Object {
       >
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
         >
           Les conséquences :
@@ -327,7 +327,7 @@ Object {
               </div>
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; margin-left: 12px;"
               >
                 tes réservations seront annulées et supprimées
@@ -356,7 +356,7 @@ Object {
               </div>
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; margin-left: 12px;"
               >
                 si tu as un dossier en cours, tu ne pourras pas en déposer un nouveau
@@ -385,7 +385,7 @@ Object {
               </div>
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; margin-left: 12px;"
               >
                 tu n’auras plus accès au catalogue
@@ -399,14 +399,14 @@ Object {
         />
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
         >
           Les données qu’on conserve :
         </div>
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
         >
           Nous gardons toutes les informations personnelles que tu nous as transmises lors de la vérification de ton identité.
@@ -426,7 +426,7 @@ Object {
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
             >
               Supprimer mon compte
@@ -455,7 +455,7 @@ Object {
             </div>
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
             >
               Consulter l’article d’aide

--- a/__snapshots__/features/profile/pages/DeleteProfile/__tests__/DeleteProfileSuccess.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/__tests__/DeleteProfileSuccess.test.tsx.web-snap
@@ -112,7 +112,7 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
     <h1
       aria-level={1}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {
@@ -136,7 +136,7 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -159,7 +159,7 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -204,7 +204,7 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
       >
         <div
           className="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style={
             Object {
               "WebkitLineClamp": 1,

--- a/__snapshots__/features/profile/pages/LegalNotices/tests/LegalNotices.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/LegalNotices/tests/LegalNotices.web.test.tsx.web-snap
@@ -51,7 +51,7 @@ Object {
             <h1
               aria-level="1"
               class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               role="heading"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
             >
@@ -109,7 +109,7 @@ Object {
             >
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
               >
                 Conditions Générales d’Utilisation
@@ -154,7 +154,7 @@ Object {
             >
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
               >
                 Charte de protection des données personnelles
@@ -216,7 +216,7 @@ Object {
           <h1
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
           >
@@ -274,7 +274,7 @@ Object {
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
             >
               Conditions Générales d’Utilisation
@@ -319,7 +319,7 @@ Object {
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
             >
               Charte de protection des données personnelles

--- a/__snapshots__/features/search/atoms/Buttons/__tests__/Filter.web.test.tsx.web-snap
+++ b/__snapshots__/features/search/atoms/Buttons/__tests__/Filter.web.test.tsx.web-snap
@@ -31,7 +31,7 @@ Object {
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
           >
             Filtrer
@@ -51,7 +51,7 @@ Object {
             <div
               aria-label="1 filtre sélectionné"
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
             >
               1
@@ -92,7 +92,7 @@ Object {
         />
         <div
           class="css-text-901oao"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
         >
           Filtrer
@@ -112,7 +112,7 @@ Object {
           <div
             aria-label="1 filtre sélectionné"
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
           >
             1

--- a/__snapshots__/features/search/pages/__tests__/Categories.test.tsx.web-snap
+++ b/__snapshots__/features/search/pages/__tests__/Categories.test.tsx.web-snap
@@ -20,7 +20,7 @@ exports[`Categories component should match diff snapshot when new category is se
               onContextMenu={[Function onContextMenu]}
 @@ -349,11 +349,11 @@
                     className=\\"css-text-901oao css-textMultiLine-cens5h\\"
-                    dir=\\"auto\\"
+                    dir=\\"ltr\\"
                     style={
                       Object {
                         \\"WebkitLineClamp\\": 2,
@@ -70,7 +70,7 @@ exports[`Categories component should match diff snapshot when new category is se
               onContextMenu={[Function onContextMenu]}
 @@ -605,11 +616,11 @@
                     className=\\"css-text-901oao css-textMultiLine-cens5h\\"
-                    dir=\\"auto\\"
+                    dir=\\"ltr\\"
                     style={
                       Object {
                         \\"WebkitLineClamp\\": 2,
@@ -252,7 +252,7 @@ exports[`Categories component should render correctly 1`] = `
         <h1
           aria-level={1}
           className="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style={
             Object {
@@ -457,7 +457,7 @@ exports[`Categories component should render correctly 1`] = `
               >
                 <div
                   className="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "WebkitLineClamp": 2,
@@ -596,7 +596,7 @@ exports[`Categories component should render correctly 1`] = `
               >
                 <div
                   className="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "WebkitLineClamp": 2,
@@ -724,7 +724,7 @@ exports[`Categories component should render correctly 1`] = `
               >
                 <div
                   className="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "WebkitLineClamp": 2,
@@ -852,7 +852,7 @@ exports[`Categories component should render correctly 1`] = `
               >
                 <div
                   className="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "WebkitLineClamp": 2,
@@ -980,7 +980,7 @@ exports[`Categories component should render correctly 1`] = `
               >
                 <div
                   className="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "WebkitLineClamp": 2,
@@ -1108,7 +1108,7 @@ exports[`Categories component should render correctly 1`] = `
               >
                 <div
                   className="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "WebkitLineClamp": 2,
@@ -1236,7 +1236,7 @@ exports[`Categories component should render correctly 1`] = `
               >
                 <div
                   className="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "WebkitLineClamp": 2,
@@ -1364,7 +1364,7 @@ exports[`Categories component should render correctly 1`] = `
               >
                 <div
                   className="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "WebkitLineClamp": 2,
@@ -1492,7 +1492,7 @@ exports[`Categories component should render correctly 1`] = `
               >
                 <div
                   className="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "WebkitLineClamp": 2,
@@ -1620,7 +1620,7 @@ exports[`Categories component should render correctly 1`] = `
               >
                 <div
                   className="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "WebkitLineClamp": 2,
@@ -1748,7 +1748,7 @@ exports[`Categories component should render correctly 1`] = `
               >
                 <div
                   className="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "WebkitLineClamp": 2,
@@ -1876,7 +1876,7 @@ exports[`Categories component should render correctly 1`] = `
               >
                 <div
                   className="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "WebkitLineClamp": 2,
@@ -2004,7 +2004,7 @@ exports[`Categories component should render correctly 1`] = `
               >
                 <div
                   className="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "WebkitLineClamp": 2,
@@ -2132,7 +2132,7 @@ exports[`Categories component should render correctly 1`] = `
               >
                 <div
                   className="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style={
                     Object {
                       "WebkitLineClamp": 2,

--- a/__snapshots__/features/search/pages/__tests__/LocationFilter.web.test.tsx.web-snap
+++ b/__snapshots__/features/search/pages/__tests__/LocationFilter.web.test.tsx.web-snap
@@ -55,7 +55,7 @@ Object {
               <h1
                 aria-level="1"
                 class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
               >
@@ -125,7 +125,7 @@ Object {
                 >
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                   >
                     Seules les sorties et offres physiques seront affichées pour une recherche avec une localisation
@@ -178,7 +178,7 @@ Object {
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         Choisir un lieu
@@ -244,7 +244,7 @@ Object {
                       <div
                         aria-describedby="testUuidV4"
                         class="css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         Autour de moi
@@ -307,7 +307,7 @@ Object {
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         Partout
@@ -388,7 +388,7 @@ Object {
             <h1
               aria-level="1"
               class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               role="heading"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-align: center;"
             >
@@ -458,7 +458,7 @@ Object {
               >
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                 >
                   Seules les sorties et offres physiques seront affichées pour une recherche avec une localisation
@@ -511,7 +511,7 @@ Object {
                   >
                     <div
                       class="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                     >
                       Choisir un lieu
@@ -577,7 +577,7 @@ Object {
                     <div
                       aria-describedby="testUuidV4"
                       class="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                     >
                       Autour de moi
@@ -640,7 +640,7 @@ Object {
                   >
                     <div
                       class="css-text-901oao css-textMultiLine-cens5h"
-                      dir="auto"
+                      dir="ltr"
                       style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                     >
                       Partout

--- a/__snapshots__/features/venue/atoms/__tests__/IconWithCaption.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/atoms/__tests__/IconWithCaption.web.test.tsx.web-snap
@@ -32,7 +32,7 @@ Object {
         <div
           class="css-text-901oao"
           data-testid="caption-Cinéma - Salle de projections"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
         >
           Cinéma - Salle de projections
@@ -68,7 +68,7 @@ Object {
       <div
         class="css-text-901oao"
         data-testid="caption-Cinéma - Salle de projections"
-        dir="auto"
+        dir="ltr"
         style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
       >
         Cinéma - Salle de projections
@@ -139,7 +139,7 @@ exports[`IconWithCaption should render different when isDisabled is true 1`] = `
         <div
           class=\\"css-text-901oao\\"
           data-testid=\\"caption-undefined\\"
-          dir=\\"auto\\"
+          dir=\\"ltr\\"
 -         style=\\"color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;\\"
 +         style=\\"color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;\\"
         >

--- a/__snapshots__/features/venue/atoms/__tests__/VenueOfferTile.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/atoms/__tests__/VenueOfferTile.web.test.tsx.web-snap
@@ -8,6 +8,7 @@ Object {
       <h3
         aria-level="3"
         class="css-reset-4rbku5 css-view-1dbjc4n"
+        dir="ltr"
         role="heading"
       >
         <div
@@ -27,14 +28,14 @@ Object {
             >
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
               >
                 Mensch ! Où sont les Hommes ?
               </div>
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
               >
                 Dès le 12 mars 2020
@@ -42,7 +43,7 @@ Object {
               <div
                 class="css-text-901oao"
                 data-testid="priceIsDuo"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
               >
                 28 €
@@ -62,7 +63,7 @@ Object {
                   <div
                     class="css-text-901oao css-textMultiLine-cens5h"
                     data-testid="categoryImageCaption"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                   >
                     MUSIQUE
@@ -79,6 +80,7 @@ Object {
     <h3
       aria-level="3"
       class="css-reset-4rbku5 css-view-1dbjc4n"
+      dir="ltr"
       role="heading"
     >
       <div
@@ -98,14 +100,14 @@ Object {
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
             >
               Mensch ! Où sont les Hommes ?
             </div>
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
             >
               Dès le 12 mars 2020
@@ -113,7 +115,7 @@ Object {
             <div
               class="css-text-901oao"
               data-testid="priceIsDuo"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
             >
               28 €
@@ -133,7 +135,7 @@ Object {
                 <div
                   class="css-text-901oao css-textMultiLine-cens5h"
                   data-testid="categoryImageCaption"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                 >
                   MUSIQUE

--- a/__snapshots__/features/venue/atoms/__tests__/VenueType.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/atoms/__tests__/VenueType.web.test.tsx.web-snap
@@ -31,7 +31,7 @@ Object {
         <div
           class="css-text-901oao"
           data-testid="caption-undefined"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
         >
           Cinéma - Salle de projections
@@ -66,7 +66,7 @@ Object {
       <div
         class="css-text-901oao"
         data-testid="caption-undefined"
-        dir="auto"
+        dir="ltr"
         style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
       >
         Cinéma - Salle de projections

--- a/__snapshots__/features/venue/components/__tests__/VenueHeader.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/components/__tests__/VenueHeader.web.test.tsx.web-snap
@@ -91,6 +91,7 @@ Object {
           >
             <span
               class="css-text-901oao css-textHasAncestor-16my406"
+              dir="ltr"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
             >
               Le Petit Rintintin 1
@@ -252,6 +253,7 @@ Object {
         >
           <span
             class="css-text-901oao css-textHasAncestor-16my406"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
           >
             Le Petit Rintintin 1

--- a/__snapshots__/features/venue/components/__tests__/VenueOffers.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/components/__tests__/VenueOffers.web.test.tsx.web-snap
@@ -21,7 +21,7 @@ Object {
             aria-level="2"
             class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
             data-testid="playlistTitle"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
           >
@@ -62,7 +62,7 @@ Object {
             />
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
             >
               En voir plus
@@ -101,6 +101,7 @@ Object {
                 <h3
                   aria-level="3"
                   class="css-reset-4rbku5 css-view-1dbjc4n"
+                  dir="ltr"
                   role="heading"
                 >
                   <div
@@ -120,14 +121,14 @@ Object {
                       >
                         <div
                           class="css-text-901oao css-textMultiLine-cens5h"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           Titane - VF
                         </div>
                         <div
                           class="css-text-901oao css-textMultiLine-cens5h"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           Dès le 18 août 2021
@@ -135,7 +136,7 @@ Object {
                         <div
                           class="css-text-901oao"
                           data-testid="priceIsDuo"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           Gratuit
@@ -155,7 +156,7 @@ Object {
                             <div
                               class="css-text-901oao css-textMultiLine-cens5h"
                               data-testid="categoryImageCaption"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Cinéma
@@ -178,6 +179,7 @@ Object {
                 <h3
                   aria-level="3"
                   class="css-reset-4rbku5 css-view-1dbjc4n"
+                  dir="ltr"
                   role="heading"
                 >
                   <div
@@ -197,14 +199,14 @@ Object {
                       >
                         <div
                           class="css-text-901oao css-textMultiLine-cens5h"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           Bac Nord - VF
                         </div>
                         <div
                           class="css-text-901oao css-textMultiLine-cens5h"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           Dès le 18 août 2021
@@ -212,7 +214,7 @@ Object {
                         <div
                           class="css-text-901oao"
                           data-testid="priceIsDuo"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           Gratuit
@@ -232,7 +234,7 @@ Object {
                             <div
                               class="css-text-901oao css-textMultiLine-cens5h"
                               data-testid="categoryImageCaption"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Cinéma
@@ -255,6 +257,7 @@ Object {
                 <h3
                   aria-level="3"
                   class="css-reset-4rbku5 css-view-1dbjc4n"
+                  dir="ltr"
                   role="heading"
                 >
                   <div
@@ -274,14 +277,14 @@ Object {
                       >
                         <div
                           class="css-text-901oao css-textMultiLine-cens5h"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           Black Widow - VF
                         </div>
                         <div
                           class="css-text-901oao css-textMultiLine-cens5h"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           Dès le 18 août 2021
@@ -289,7 +292,7 @@ Object {
                         <div
                           class="css-text-901oao"
                           data-testid="priceIsDuo"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                         >
                           Gratuit
@@ -309,7 +312,7 @@ Object {
                             <div
                               class="css-text-901oao css-textMultiLine-cens5h"
                               data-testid="categoryImageCaption"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Cinéma
@@ -347,7 +350,7 @@ Object {
           >
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; padding: 8px 8px 8px 8px;"
             >
               Voir toutes les offres
@@ -378,7 +381,7 @@ Object {
           aria-level="2"
           class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
           data-testid="playlistTitle"
-          dir="auto"
+          dir="ltr"
           role="heading"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
         >
@@ -419,7 +422,7 @@ Object {
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
           >
             En voir plus
@@ -458,6 +461,7 @@ Object {
               <h3
                 aria-level="3"
                 class="css-reset-4rbku5 css-view-1dbjc4n"
+                dir="ltr"
                 role="heading"
               >
                 <div
@@ -477,14 +481,14 @@ Object {
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         Titane - VF
                       </div>
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         Dès le 18 août 2021
@@ -492,7 +496,7 @@ Object {
                       <div
                         class="css-text-901oao"
                         data-testid="priceIsDuo"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         Gratuit
@@ -512,7 +516,7 @@ Object {
                           <div
                             class="css-text-901oao css-textMultiLine-cens5h"
                             data-testid="categoryImageCaption"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                           >
                             Cinéma
@@ -535,6 +539,7 @@ Object {
               <h3
                 aria-level="3"
                 class="css-reset-4rbku5 css-view-1dbjc4n"
+                dir="ltr"
                 role="heading"
               >
                 <div
@@ -554,14 +559,14 @@ Object {
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         Bac Nord - VF
                       </div>
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         Dès le 18 août 2021
@@ -569,7 +574,7 @@ Object {
                       <div
                         class="css-text-901oao"
                         data-testid="priceIsDuo"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         Gratuit
@@ -589,7 +594,7 @@ Object {
                           <div
                             class="css-text-901oao css-textMultiLine-cens5h"
                             data-testid="categoryImageCaption"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                           >
                             Cinéma
@@ -612,6 +617,7 @@ Object {
               <h3
                 aria-level="3"
                 class="css-reset-4rbku5 css-view-1dbjc4n"
+                dir="ltr"
                 role="heading"
               >
                 <div
@@ -631,14 +637,14 @@ Object {
                     >
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         Black Widow - VF
                       </div>
                       <div
                         class="css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         Dès le 18 août 2021
@@ -646,7 +652,7 @@ Object {
                       <div
                         class="css-text-901oao"
                         data-testid="priceIsDuo"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                       >
                         Gratuit
@@ -666,7 +672,7 @@ Object {
                           <div
                             class="css-text-901oao css-textMultiLine-cens5h"
                             data-testid="categoryImageCaption"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                           >
                             Cinéma
@@ -704,7 +710,7 @@ Object {
         >
           <div
             class="css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; padding: 8px 8px 8px 8px;"
           >
             Voir toutes les offres

--- a/__snapshots__/features/venue/pages/__tests__/Venue.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/pages/__tests__/Venue.web.test.tsx.web-snap
@@ -95,6 +95,7 @@ Object {
             >
               <span
                 class="css-text-901oao css-textHasAncestor-16my406"
+                dir="ltr"
                 style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
               >
                 Le Petit Rintintin 1
@@ -362,7 +363,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); flex-shrink: 1; font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-transform: capitalize;"
                 >
                   1 boulevard Poissonnière, 75000 Paris
@@ -377,7 +378,7 @@ Object {
                 aria-level="1"
                 class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
                 data-testid="venueTitle"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 20px; line-height: 24px; text-align: center;"
               >
@@ -422,7 +423,7 @@ Object {
                 <div
                   class="css-text-901oao"
                   data-testid="caption-undefined"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
                 >
                   Autre type de lieu
@@ -465,7 +466,7 @@ Object {
                   <div
                     class="css-text-901oao"
                     data-testid="caption-undefined"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
                   >
                     Géolocalisation désactivée
@@ -493,7 +494,7 @@ Object {
                 >
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; width: 100%;"
                   >
                      
@@ -504,6 +505,7 @@ Object {
                     >
                       <span
                         class="css-text-901oao css-textHasAncestor-16my406"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                       >
                         <div
@@ -555,7 +557,7 @@ Object {
                   aria-level="2"
                   class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
                   data-testid="playlistTitle"
-                  dir="auto"
+                  dir="ltr"
                   role="heading"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
                 >
@@ -596,7 +598,7 @@ Object {
                   />
                   <div
                     class="css-text-901oao"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                   >
                     En voir plus
@@ -635,6 +637,7 @@ Object {
                       <h3
                         aria-level="3"
                         class="css-reset-4rbku5 css-view-1dbjc4n"
+                        dir="ltr"
                         role="heading"
                       >
                         <div
@@ -654,14 +657,14 @@ Object {
                             >
                               <div
                                 class="css-text-901oao css-textMultiLine-cens5h"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 Titane - VF
                               </div>
                               <div
                                 class="css-text-901oao css-textMultiLine-cens5h"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 Dès le 18 août 2021
@@ -669,7 +672,7 @@ Object {
                               <div
                                 class="css-text-901oao"
                                 data-testid="priceIsDuo"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 Gratuit
@@ -689,7 +692,7 @@ Object {
                                   <div
                                     class="css-text-901oao css-textMultiLine-cens5h"
                                     data-testid="categoryImageCaption"
-                                    dir="auto"
+                                    dir="ltr"
                                     style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                                   >
                                     Cinéma
@@ -712,6 +715,7 @@ Object {
                       <h3
                         aria-level="3"
                         class="css-reset-4rbku5 css-view-1dbjc4n"
+                        dir="ltr"
                         role="heading"
                       >
                         <div
@@ -731,14 +735,14 @@ Object {
                             >
                               <div
                                 class="css-text-901oao css-textMultiLine-cens5h"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 Bac Nord - VF
                               </div>
                               <div
                                 class="css-text-901oao css-textMultiLine-cens5h"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 Dès le 18 août 2021
@@ -746,7 +750,7 @@ Object {
                               <div
                                 class="css-text-901oao"
                                 data-testid="priceIsDuo"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 Gratuit
@@ -766,7 +770,7 @@ Object {
                                   <div
                                     class="css-text-901oao css-textMultiLine-cens5h"
                                     data-testid="categoryImageCaption"
-                                    dir="auto"
+                                    dir="ltr"
                                     style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                                   >
                                     Cinéma
@@ -789,6 +793,7 @@ Object {
                       <h3
                         aria-level="3"
                         class="css-reset-4rbku5 css-view-1dbjc4n"
+                        dir="ltr"
                         role="heading"
                       >
                         <div
@@ -808,14 +813,14 @@ Object {
                             >
                               <div
                                 class="css-text-901oao css-textMultiLine-cens5h"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 Black Widow - VF
                               </div>
                               <div
                                 class="css-text-901oao css-textMultiLine-cens5h"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 Dès le 18 août 2021
@@ -823,7 +828,7 @@ Object {
                               <div
                                 class="css-text-901oao"
                                 data-testid="priceIsDuo"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 Gratuit
@@ -843,7 +848,7 @@ Object {
                                   <div
                                     class="css-text-901oao css-textMultiLine-cens5h"
                                     data-testid="categoryImageCaption"
-                                    dir="auto"
+                                    dir="ltr"
                                     style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                                   >
                                     Cinéma
@@ -881,7 +886,7 @@ Object {
                 >
                   <div
                     class="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; padding: 8px 8px 8px 8px;"
                   >
                     Voir toutes les offres
@@ -908,7 +913,7 @@ Object {
               <h2
                 aria-level="2"
                 class="css-reset-4rbku5 css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
               >
@@ -920,7 +925,7 @@ Object {
               />
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
               >
                 Adresse
@@ -931,7 +936,7 @@ Object {
               />
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-transform: capitalize;"
               >
                 1 boulevard Poissonnière, 75000 Paris
@@ -971,7 +976,7 @@ Object {
                   </div>
                   <div
                     class="css-text-901oao css-textMultiLine-cens5h"
-                    dir="auto"
+                    dir="ltr"
                     style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
                   >
                     Voir l'itinéraire
@@ -1003,7 +1008,7 @@ Object {
                 <h2
                   aria-level="2"
                   class="css-reset-4rbku5 css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   role="heading"
                   style="color: rgb(22, 22, 23); flex-basis: 0px; flex-grow: 0.9; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
                 >
@@ -1041,7 +1046,7 @@ Object {
               >
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                 >
                   How to withdraw, 
@@ -1052,6 +1057,7 @@ Object {
                   >
                     <span
                       class="css-text-901oao css-textHasAncestor-16my406"
+                      dir="ltr"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                     >
                       <div
@@ -1101,7 +1107,7 @@ Object {
                 <h2
                   aria-level="2"
                   class="css-reset-4rbku5 css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   role="heading"
                   style="color: rgb(22, 22, 23); flex-basis: 0px; flex-grow: 0.9; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
                 >
@@ -1205,7 +1211,7 @@ Object {
                         >
                           <div
                             class="css-text-901oao"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; padding-right: 1px; padding-left: 1px; text-align: center;"
                           >
                             Handicap visuel
@@ -1274,7 +1280,7 @@ Object {
                         >
                           <div
                             class="css-text-901oao"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; padding-right: 1px; padding-left: 1px; text-align: center;"
                           >
                             Handicap psychique ou cognitif
@@ -1343,7 +1349,7 @@ Object {
                         >
                           <div
                             class="css-text-901oao"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; padding-right: 1px; padding-left: 1px; text-align: center;"
                           >
                             Handicap moteur
@@ -1412,7 +1418,7 @@ Object {
                         >
                           <div
                             class="css-text-901oao"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; padding-right: 1px; padding-left: 1px; text-align: center;"
                           >
                             Handicap auditif
@@ -1444,7 +1450,7 @@ Object {
                 <h2
                   aria-level="2"
                   class="css-reset-4rbku5 css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   role="heading"
                   style="color: rgb(22, 22, 23); flex-basis: 0px; flex-grow: 0.9; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
                 >
@@ -1482,21 +1488,21 @@ Object {
               >
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                 >
                   contact@venue.com
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                 >
                   +33102030405
                 </div>
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
                 >
                   https://my@website.com
@@ -1608,6 +1614,7 @@ Object {
           >
             <span
               class="css-text-901oao css-textHasAncestor-16my406"
+              dir="ltr"
               style="color: rgb(255, 255, 255); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
             >
               Le Petit Rintintin 1
@@ -1875,7 +1882,7 @@ Object {
               </div>
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); flex-shrink: 1; font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-transform: capitalize;"
               >
                 1 boulevard Poissonnière, 75000 Paris
@@ -1890,7 +1897,7 @@ Object {
               aria-level="1"
               class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
               data-testid="venueTitle"
-              dir="auto"
+              dir="ltr"
               role="heading"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 20px; line-height: 24px; text-align: center;"
             >
@@ -1935,7 +1942,7 @@ Object {
               <div
                 class="css-text-901oao"
                 data-testid="caption-undefined"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
               >
                 Autre type de lieu
@@ -1978,7 +1985,7 @@ Object {
                 <div
                   class="css-text-901oao"
                   data-testid="caption-undefined"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
                 >
                   Géolocalisation désactivée
@@ -2006,7 +2013,7 @@ Object {
               >
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; width: 100%;"
                 >
                    
@@ -2017,6 +2024,7 @@ Object {
                   >
                     <span
                       class="css-text-901oao css-textHasAncestor-16my406"
+                      dir="ltr"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                     >
                       <div
@@ -2068,7 +2076,7 @@ Object {
                 aria-level="2"
                 class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
                 data-testid="playlistTitle"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
               >
@@ -2109,7 +2117,7 @@ Object {
                 />
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                 >
                   En voir plus
@@ -2148,6 +2156,7 @@ Object {
                     <h3
                       aria-level="3"
                       class="css-reset-4rbku5 css-view-1dbjc4n"
+                      dir="ltr"
                       role="heading"
                     >
                       <div
@@ -2167,14 +2176,14 @@ Object {
                           >
                             <div
                               class="css-text-901oao css-textMultiLine-cens5h"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Titane - VF
                             </div>
                             <div
                               class="css-text-901oao css-textMultiLine-cens5h"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Dès le 18 août 2021
@@ -2182,7 +2191,7 @@ Object {
                             <div
                               class="css-text-901oao"
                               data-testid="priceIsDuo"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Gratuit
@@ -2202,7 +2211,7 @@ Object {
                                 <div
                                   class="css-text-901oao css-textMultiLine-cens5h"
                                   data-testid="categoryImageCaption"
-                                  dir="auto"
+                                  dir="ltr"
                                   style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                                 >
                                   Cinéma
@@ -2225,6 +2234,7 @@ Object {
                     <h3
                       aria-level="3"
                       class="css-reset-4rbku5 css-view-1dbjc4n"
+                      dir="ltr"
                       role="heading"
                     >
                       <div
@@ -2244,14 +2254,14 @@ Object {
                           >
                             <div
                               class="css-text-901oao css-textMultiLine-cens5h"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Bac Nord - VF
                             </div>
                             <div
                               class="css-text-901oao css-textMultiLine-cens5h"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Dès le 18 août 2021
@@ -2259,7 +2269,7 @@ Object {
                             <div
                               class="css-text-901oao"
                               data-testid="priceIsDuo"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Gratuit
@@ -2279,7 +2289,7 @@ Object {
                                 <div
                                   class="css-text-901oao css-textMultiLine-cens5h"
                                   data-testid="categoryImageCaption"
-                                  dir="auto"
+                                  dir="ltr"
                                   style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                                 >
                                   Cinéma
@@ -2302,6 +2312,7 @@ Object {
                     <h3
                       aria-level="3"
                       class="css-reset-4rbku5 css-view-1dbjc4n"
+                      dir="ltr"
                       role="heading"
                     >
                       <div
@@ -2321,14 +2332,14 @@ Object {
                           >
                             <div
                               class="css-text-901oao css-textMultiLine-cens5h"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Black Widow - VF
                             </div>
                             <div
                               class="css-text-901oao css-textMultiLine-cens5h"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Dès le 18 août 2021
@@ -2336,7 +2347,7 @@ Object {
                             <div
                               class="css-text-901oao"
                               data-testid="priceIsDuo"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Gratuit
@@ -2356,7 +2367,7 @@ Object {
                                 <div
                                   class="css-text-901oao css-textMultiLine-cens5h"
                                   data-testid="categoryImageCaption"
-                                  dir="auto"
+                                  dir="ltr"
                                   style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                                 >
                                   Cinéma
@@ -2394,7 +2405,7 @@ Object {
               >
                 <div
                   class="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; padding: 8px 8px 8px 8px;"
                 >
                   Voir toutes les offres
@@ -2421,7 +2432,7 @@ Object {
             <h2
               aria-level="2"
               class="css-reset-4rbku5 css-text-901oao"
-              dir="auto"
+              dir="ltr"
               role="heading"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
             >
@@ -2433,7 +2444,7 @@ Object {
             />
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
             >
               Adresse
@@ -2444,7 +2455,7 @@ Object {
             />
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-transform: capitalize;"
             >
               1 boulevard Poissonnière, 75000 Paris
@@ -2484,7 +2495,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
                 >
                   Voir l'itinéraire
@@ -2516,7 +2527,7 @@ Object {
               <h2
                 aria-level="2"
                 class="css-reset-4rbku5 css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style="color: rgb(22, 22, 23); flex-basis: 0px; flex-grow: 0.9; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
               >
@@ -2554,7 +2565,7 @@ Object {
             >
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
               >
                 How to withdraw, 
@@ -2565,6 +2576,7 @@ Object {
                 >
                   <span
                     class="css-text-901oao css-textHasAncestor-16my406"
+                    dir="ltr"
                     style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                   >
                     <div
@@ -2614,7 +2626,7 @@ Object {
               <h2
                 aria-level="2"
                 class="css-reset-4rbku5 css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style="color: rgb(22, 22, 23); flex-basis: 0px; flex-grow: 0.9; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
               >
@@ -2718,7 +2730,7 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; padding-right: 1px; padding-left: 1px; text-align: center;"
                         >
                           Handicap visuel
@@ -2787,7 +2799,7 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; padding-right: 1px; padding-left: 1px; text-align: center;"
                         >
                           Handicap psychique ou cognitif
@@ -2856,7 +2868,7 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; padding-right: 1px; padding-left: 1px; text-align: center;"
                         >
                           Handicap moteur
@@ -2925,7 +2937,7 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; padding-right: 1px; padding-left: 1px; text-align: center;"
                         >
                           Handicap auditif
@@ -2957,7 +2969,7 @@ Object {
               <h2
                 aria-level="2"
                 class="css-reset-4rbku5 css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style="color: rgb(22, 22, 23); flex-basis: 0px; flex-grow: 0.9; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
               >
@@ -2995,21 +3007,21 @@ Object {
             >
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
               >
                 contact@venue.com
               </div>
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
               >
                 +33102030405
               </div>
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
               >
                 https://my@website.com

--- a/__snapshots__/features/venue/pages/__tests__/VenueBody.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/pages/__tests__/VenueBody.web.test.tsx.web-snap
@@ -200,7 +200,7 @@ Object {
               </div>
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); flex-shrink: 1; font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-transform: capitalize;"
               >
                 1 boulevard Poissonnière, 75000 Paris
@@ -215,7 +215,7 @@ Object {
               aria-level="1"
               class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
               data-testid="venueTitle"
-              dir="auto"
+              dir="ltr"
               role="heading"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 20px; line-height: 24px; text-align: center;"
             >
@@ -260,7 +260,7 @@ Object {
               <div
                 class="css-text-901oao"
                 data-testid="caption-undefined"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
               >
                 Autre type de lieu
@@ -303,7 +303,7 @@ Object {
                 <div
                   class="css-text-901oao"
                   data-testid="caption-undefined"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
                 >
                   Géolocalisation désactivée
@@ -331,7 +331,7 @@ Object {
               >
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; width: 100%;"
                 >
                    
@@ -342,6 +342,7 @@ Object {
                   >
                     <span
                       class="css-text-901oao css-textHasAncestor-16my406"
+                      dir="ltr"
                       style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                     >
                       <div
@@ -393,7 +394,7 @@ Object {
                 aria-level="2"
                 class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
                 data-testid="playlistTitle"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
               >
@@ -434,7 +435,7 @@ Object {
                 />
                 <div
                   class="css-text-901oao"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                 >
                   En voir plus
@@ -473,6 +474,7 @@ Object {
                     <h3
                       aria-level="3"
                       class="css-reset-4rbku5 css-view-1dbjc4n"
+                      dir="ltr"
                       role="heading"
                     >
                       <div
@@ -492,14 +494,14 @@ Object {
                           >
                             <div
                               class="css-text-901oao css-textMultiLine-cens5h"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Titane - VF
                             </div>
                             <div
                               class="css-text-901oao css-textMultiLine-cens5h"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Dès le 18 août 2021
@@ -507,7 +509,7 @@ Object {
                             <div
                               class="css-text-901oao"
                               data-testid="priceIsDuo"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Gratuit
@@ -527,7 +529,7 @@ Object {
                                 <div
                                   class="css-text-901oao css-textMultiLine-cens5h"
                                   data-testid="categoryImageCaption"
-                                  dir="auto"
+                                  dir="ltr"
                                   style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                                 >
                                   Cinéma
@@ -550,6 +552,7 @@ Object {
                     <h3
                       aria-level="3"
                       class="css-reset-4rbku5 css-view-1dbjc4n"
+                      dir="ltr"
                       role="heading"
                     >
                       <div
@@ -569,14 +572,14 @@ Object {
                           >
                             <div
                               class="css-text-901oao css-textMultiLine-cens5h"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Bac Nord - VF
                             </div>
                             <div
                               class="css-text-901oao css-textMultiLine-cens5h"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Dès le 18 août 2021
@@ -584,7 +587,7 @@ Object {
                             <div
                               class="css-text-901oao"
                               data-testid="priceIsDuo"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Gratuit
@@ -604,7 +607,7 @@ Object {
                                 <div
                                   class="css-text-901oao css-textMultiLine-cens5h"
                                   data-testid="categoryImageCaption"
-                                  dir="auto"
+                                  dir="ltr"
                                   style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                                 >
                                   Cinéma
@@ -627,6 +630,7 @@ Object {
                     <h3
                       aria-level="3"
                       class="css-reset-4rbku5 css-view-1dbjc4n"
+                      dir="ltr"
                       role="heading"
                     >
                       <div
@@ -646,14 +650,14 @@ Object {
                           >
                             <div
                               class="css-text-901oao css-textMultiLine-cens5h"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Black Widow - VF
                             </div>
                             <div
                               class="css-text-901oao css-textMultiLine-cens5h"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Dès le 18 août 2021
@@ -661,7 +665,7 @@ Object {
                             <div
                               class="css-text-901oao"
                               data-testid="priceIsDuo"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                             >
                               Gratuit
@@ -681,7 +685,7 @@ Object {
                                 <div
                                   class="css-text-901oao css-textMultiLine-cens5h"
                                   data-testid="categoryImageCaption"
-                                  dir="auto"
+                                  dir="ltr"
                                   style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                                 >
                                   Cinéma
@@ -719,7 +723,7 @@ Object {
               >
                 <div
                   class="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; padding: 8px 8px 8px 8px;"
                 >
                   Voir toutes les offres
@@ -746,7 +750,7 @@ Object {
             <h2
               aria-level="2"
               class="css-reset-4rbku5 css-text-901oao"
-              dir="auto"
+              dir="ltr"
               role="heading"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
             >
@@ -758,7 +762,7 @@ Object {
             />
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
             >
               Adresse
@@ -769,7 +773,7 @@ Object {
             />
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-transform: capitalize;"
             >
               1 boulevard Poissonnière, 75000 Paris
@@ -809,7 +813,7 @@ Object {
                 </div>
                 <div
                   class="css-text-901oao css-textMultiLine-cens5h"
-                  dir="auto"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
                 >
                   Voir l'itinéraire
@@ -841,7 +845,7 @@ Object {
               <h2
                 aria-level="2"
                 class="css-reset-4rbku5 css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style="color: rgb(22, 22, 23); flex-basis: 0px; flex-grow: 0.9; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
               >
@@ -879,7 +883,7 @@ Object {
             >
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
               >
                 How to withdraw, 
@@ -890,6 +894,7 @@ Object {
                 >
                   <span
                     class="css-text-901oao css-textHasAncestor-16my406"
+                    dir="ltr"
                     style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                   >
                     <div
@@ -939,7 +944,7 @@ Object {
               <h2
                 aria-level="2"
                 class="css-reset-4rbku5 css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style="color: rgb(22, 22, 23); flex-basis: 0px; flex-grow: 0.9; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
               >
@@ -1043,7 +1048,7 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; padding-right: 1px; padding-left: 1px; text-align: center;"
                         >
                           Handicap visuel
@@ -1112,7 +1117,7 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; padding-right: 1px; padding-left: 1px; text-align: center;"
                         >
                           Handicap psychique ou cognitif
@@ -1181,7 +1186,7 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; padding-right: 1px; padding-left: 1px; text-align: center;"
                         >
                           Handicap moteur
@@ -1250,7 +1255,7 @@ Object {
                       >
                         <div
                           class="css-text-901oao"
-                          dir="auto"
+                          dir="ltr"
                           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; padding-right: 1px; padding-left: 1px; text-align: center;"
                         >
                           Handicap auditif
@@ -1282,7 +1287,7 @@ Object {
               <h2
                 aria-level="2"
                 class="css-reset-4rbku5 css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 role="heading"
                 style="color: rgb(22, 22, 23); flex-basis: 0px; flex-grow: 0.9; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
               >
@@ -1320,21 +1325,21 @@ Object {
             >
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
               >
                 contact@venue.com
               </div>
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
               >
                 +33102030405
               </div>
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
               >
                 https://my@website.com
@@ -1549,7 +1554,7 @@ Object {
             </div>
             <div
               class="css-text-901oao css-textMultiLine-cens5h"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); flex-shrink: 1; font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-transform: capitalize;"
             >
               1 boulevard Poissonnière, 75000 Paris
@@ -1564,7 +1569,7 @@ Object {
             aria-level="1"
             class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
             data-testid="venueTitle"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 20px; line-height: 24px; text-align: center;"
           >
@@ -1609,7 +1614,7 @@ Object {
             <div
               class="css-text-901oao"
               data-testid="caption-undefined"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
             >
               Autre type de lieu
@@ -1652,7 +1657,7 @@ Object {
               <div
                 class="css-text-901oao"
                 data-testid="caption-undefined"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; text-align: center;"
               >
                 Géolocalisation désactivée
@@ -1680,7 +1685,7 @@ Object {
             >
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; width: 100%;"
               >
                  
@@ -1691,6 +1696,7 @@ Object {
                 >
                   <span
                     class="css-text-901oao css-textHasAncestor-16my406"
+                    dir="ltr"
                     style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                   >
                     <div
@@ -1742,7 +1748,7 @@ Object {
               aria-level="2"
               class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
               data-testid="playlistTitle"
-              dir="auto"
+              dir="ltr"
               role="heading"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
             >
@@ -1783,7 +1789,7 @@ Object {
               />
               <div
                 class="css-text-901oao"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(235, 0, 85); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
               >
                 En voir plus
@@ -1822,6 +1828,7 @@ Object {
                   <h3
                     aria-level="3"
                     class="css-reset-4rbku5 css-view-1dbjc4n"
+                    dir="ltr"
                     role="heading"
                   >
                     <div
@@ -1841,14 +1848,14 @@ Object {
                         >
                           <div
                             class="css-text-901oao css-textMultiLine-cens5h"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                           >
                             Titane - VF
                           </div>
                           <div
                             class="css-text-901oao css-textMultiLine-cens5h"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                           >
                             Dès le 18 août 2021
@@ -1856,7 +1863,7 @@ Object {
                           <div
                             class="css-text-901oao"
                             data-testid="priceIsDuo"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                           >
                             Gratuit
@@ -1876,7 +1883,7 @@ Object {
                               <div
                                 class="css-text-901oao css-textMultiLine-cens5h"
                                 data-testid="categoryImageCaption"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 Cinéma
@@ -1899,6 +1906,7 @@ Object {
                   <h3
                     aria-level="3"
                     class="css-reset-4rbku5 css-view-1dbjc4n"
+                    dir="ltr"
                     role="heading"
                   >
                     <div
@@ -1918,14 +1926,14 @@ Object {
                         >
                           <div
                             class="css-text-901oao css-textMultiLine-cens5h"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                           >
                             Bac Nord - VF
                           </div>
                           <div
                             class="css-text-901oao css-textMultiLine-cens5h"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                           >
                             Dès le 18 août 2021
@@ -1933,7 +1941,7 @@ Object {
                           <div
                             class="css-text-901oao"
                             data-testid="priceIsDuo"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                           >
                             Gratuit
@@ -1953,7 +1961,7 @@ Object {
                               <div
                                 class="css-text-901oao css-textMultiLine-cens5h"
                                 data-testid="categoryImageCaption"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 Cinéma
@@ -1976,6 +1984,7 @@ Object {
                   <h3
                     aria-level="3"
                     class="css-reset-4rbku5 css-view-1dbjc4n"
+                    dir="ltr"
                     role="heading"
                   >
                     <div
@@ -1995,14 +2004,14 @@ Object {
                         >
                           <div
                             class="css-text-901oao css-textMultiLine-cens5h"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                           >
                             Black Widow - VF
                           </div>
                           <div
                             class="css-text-901oao css-textMultiLine-cens5h"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                           >
                             Dès le 18 août 2021
@@ -2010,7 +2019,7 @@ Object {
                           <div
                             class="css-text-901oao"
                             data-testid="priceIsDuo"
-                            dir="auto"
+                            dir="ltr"
                             style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                           >
                             Gratuit
@@ -2030,7 +2039,7 @@ Object {
                               <div
                                 class="css-text-901oao css-textMultiLine-cens5h"
                                 data-testid="categoryImageCaption"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 Cinéma
@@ -2068,7 +2077,7 @@ Object {
             >
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; padding: 8px 8px 8px 8px;"
               >
                 Voir toutes les offres
@@ -2095,7 +2104,7 @@ Object {
           <h2
             aria-level="2"
             class="css-reset-4rbku5 css-text-901oao"
-            dir="auto"
+            dir="ltr"
             role="heading"
             style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
           >
@@ -2107,7 +2116,7 @@ Object {
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
           >
             Adresse
@@ -2118,7 +2127,7 @@ Object {
           />
           <div
             class="css-text-901oao"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px; text-transform: capitalize;"
           >
             1 boulevard Poissonnière, 75000 Paris
@@ -2158,7 +2167,7 @@ Object {
               </div>
               <div
                 class="css-text-901oao css-textMultiLine-cens5h"
-                dir="auto"
+                dir="ltr"
                 style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
               >
                 Voir l'itinéraire
@@ -2190,7 +2199,7 @@ Object {
             <h2
               aria-level="2"
               class="css-reset-4rbku5 css-text-901oao"
-              dir="auto"
+              dir="ltr"
               role="heading"
               style="color: rgb(22, 22, 23); flex-basis: 0px; flex-grow: 0.9; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
             >
@@ -2228,7 +2237,7 @@ Object {
           >
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
             >
               How to withdraw, 
@@ -2239,6 +2248,7 @@ Object {
               >
                 <span
                   class="css-text-901oao css-textHasAncestor-16my406"
+                  dir="ltr"
                   style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
                 >
                   <div
@@ -2288,7 +2298,7 @@ Object {
             <h2
               aria-level="2"
               class="css-reset-4rbku5 css-text-901oao"
-              dir="auto"
+              dir="ltr"
               role="heading"
               style="color: rgb(22, 22, 23); flex-basis: 0px; flex-grow: 0.9; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
             >
@@ -2392,7 +2402,7 @@ Object {
                     >
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; padding-right: 1px; padding-left: 1px; text-align: center;"
                       >
                         Handicap visuel
@@ -2461,7 +2471,7 @@ Object {
                     >
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; padding-right: 1px; padding-left: 1px; text-align: center;"
                       >
                         Handicap psychique ou cognitif
@@ -2530,7 +2540,7 @@ Object {
                     >
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; padding-right: 1px; padding-left: 1px; text-align: center;"
                       >
                         Handicap moteur
@@ -2599,7 +2609,7 @@ Object {
                     >
                       <div
                         class="css-text-901oao"
-                        dir="auto"
+                        dir="ltr"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px; padding-right: 1px; padding-left: 1px; text-align: center;"
                       >
                         Handicap auditif
@@ -2631,7 +2641,7 @@ Object {
             <h2
               aria-level="2"
               class="css-reset-4rbku5 css-text-901oao"
-              dir="auto"
+              dir="ltr"
               role="heading"
               style="color: rgb(22, 22, 23); flex-basis: 0px; flex-grow: 0.9; flex-shrink: 1; font-family: Montserrat-Medium; font-size: 18px; line-height: 22px;"
             >
@@ -2669,21 +2679,21 @@ Object {
           >
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
             >
               contact@venue.com
             </div>
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
             >
               +33102030405
             </div>
             <div
               class="css-text-901oao"
-              dir="auto"
+              dir="ltr"
               style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
             >
               https://my@website.com

--- a/__snapshots__/libs/geolocation/components/__tests__/WhereSection.test.tsx.web-snap
+++ b/__snapshots__/libs/geolocation/components/__tests__/WhereSection.test.tsx.web-snap
@@ -13,7 +13,7 @@ Array [
   <h2
     aria-level={2}
     className="css-reset-4rbku5 css-text-901oao"
-    dir="auto"
+    dir="ltr"
     role="heading"
     style={
       Object {
@@ -108,7 +108,7 @@ Array [
     />
     <div
       className="css-text-901oao css-textMultiLine-cens5h"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "WebkitFlexShrink": 1,
@@ -164,7 +164,7 @@ Array [
   />,
   <div
     className="css-text-901oao"
-    dir="auto"
+    dir="ltr"
     style={
       Object {
         "color": "rgba(22,22,23,1.00)",
@@ -186,7 +186,7 @@ Array [
   />,
   <div
     className="css-text-901oao"
-    dir="auto"
+    dir="ltr"
     style={
       Object {
         "color": "rgba(22,22,23,1.00)",
@@ -256,7 +256,7 @@ Array [
       </div>
       <div
         className="css-text-901oao css-textMultiLine-cens5h"
-        dir="auto"
+        dir="ltr"
         style={
           Object {
             "WebkitLineClamp": 1,
@@ -368,7 +368,7 @@ exports[`WhereSection should render correctly 2`] = `
 +     />
 +     <div
 +       className=\\"css-text-901oao css-textMultiLine-cens5h\\"
-+       dir=\\"auto\\"
++       dir=\\"ltr\\"
 +       style={
 +         Object {
 +           \\"WebkitFlexShrink\\": 1,
@@ -424,7 +424,7 @@ exports[`WhereSection should render correctly 2`] = `
 +   />,
 +   <div
       className=\\"css-text-901oao\\"
-      dir=\\"auto\\"
+      dir=\\"ltr\\"
       style={
         Object {
           \\"color\\": \\"rgba(22,22,23,1.00)\\","

--- a/__snapshots__/libs/share/__tests__/WebShareModal.web.test.tsx.web-snap
+++ b/__snapshots__/libs/share/__tests__/WebShareModal.web.test.tsx.web-snap
@@ -123,7 +123,7 @@ Object {
                       <h1
                         aria-level="1"
                         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         id="testUuidV4"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
@@ -216,7 +216,7 @@ Object {
                                 </div>
                                 <div
                                   class="css-text-901oao css-textMultiLine-cens5h"
-                                  dir="auto"
+                                  dir="ltr"
                                   style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
                                 >
                                   Copier
@@ -247,7 +247,7 @@ Object {
                                 </div>
                                 <div
                                   class="css-text-901oao css-textMultiLine-cens5h"
-                                  dir="auto"
+                                  dir="ltr"
                                   style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 8px; max-width: 100%;"
                                 >
                                   E-mail
@@ -292,7 +292,7 @@ Object {
                               />
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 Facebook
@@ -319,7 +319,7 @@ Object {
                               />
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 Twitter
@@ -346,7 +346,7 @@ Object {
                               />
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 WhatsApp
@@ -373,7 +373,7 @@ Object {
                               />
                               <div
                                 class="css-text-901oao"
-                                dir="auto"
+                                dir="ltr"
                                 style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
                               >
                                 Telegram
@@ -391,7 +391,7 @@ Object {
                           >
                             <div
                               class="css-text-901oao css-textMultiLine-cens5h"
-                              dir="auto"
+                              dir="ltr"
                               style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px; margin-left: 0px; max-width: 100%;"
                             >
                               Annuler

--- a/__snapshots__/ui/components/__tests__/ClippedTag.web.test.tsx.web-snap
+++ b/__snapshots__/ui/components/__tests__/ClippedTag.web.test.tsx.web-snap
@@ -15,7 +15,7 @@ Object {
         >
           <div
             class="css-text-901oao css-textMultiLine-cens5h"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
           >
             Musée du louvre
@@ -53,7 +53,7 @@ Object {
       >
         <div
           class="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(255, 255, 255); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
         >
           Musée du louvre

--- a/__snapshots__/ui/components/__tests__/ImageCaption.web.test.tsx.web-snap
+++ b/__snapshots__/ui/components/__tests__/ImageCaption.web.test.tsx.web-snap
@@ -16,7 +16,7 @@ Object {
           <div
             class="css-text-901oao css-textMultiLine-cens5h"
             data-testid="categoryImageCaption"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
           >
             Musique
@@ -33,7 +33,7 @@ Object {
           <div
             class="css-text-901oao"
             data-testid="distanceImageCaption"
-            dir="auto"
+            dir="ltr"
             style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
           >
             1,2km
@@ -54,7 +54,7 @@ Object {
         <div
           class="css-text-901oao css-textMultiLine-cens5h"
           data-testid="categoryImageCaption"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
         >
           Musique
@@ -71,7 +71,7 @@ Object {
         <div
           class="css-text-901oao"
           data-testid="distanceImageCaption"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(255, 255, 255); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
         >
           1,2km

--- a/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.web-snap
+++ b/__snapshots__/ui/components/__tests__/LayoutExpiredLink.test.tsx.web-snap
@@ -112,7 +112,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
     <h1
       aria-level={1}
       className="css-reset-4rbku5 css-text-901oao"
-      dir="auto"
+      dir="ltr"
       role="heading"
       style={
         Object {
@@ -136,7 +136,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -151,7 +151,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
     </div>
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -174,7 +174,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
     />
     <div
       className="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style={
         Object {
           "color": "rgba(255,255,255,1.00)",
@@ -216,7 +216,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
       </div>
       <div
         className="css-text-901oao css-textMultiLine-cens5h"
-        dir="auto"
+        dir="ltr"
         style={
           Object {
             "WebkitLineClamp": 1,
@@ -254,7 +254,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
       </div>
       <div
         className="css-text-901oao css-textMultiLine-cens5h"
-        dir="auto"
+        dir="ltr"
         style={
           Object {
             "WebkitLineClamp": 1,
@@ -303,7 +303,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
       >
         <div
           className="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style={
             Object {
               "WebkitLineClamp": 1,
@@ -347,7 +347,7 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
         </div>
         <div
           className="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style={
             Object {
               "WebkitLineClamp": 1,

--- a/__snapshots__/ui/components/__tests__/OfferCaption.web.test.tsx.web-snap
+++ b/__snapshots__/ui/components/__tests__/OfferCaption.web.test.tsx.web-snap
@@ -11,14 +11,14 @@ Object {
       >
         <div
           class="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
         >
           Mensch ! Où sont les Hommes ?
         </div>
         <div
           class="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
         >
           Dès le 2 mars 2020
@@ -26,7 +26,7 @@ Object {
         <div
           class="css-text-901oao"
           data-testid="priceIsDuo"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
         >
           Dès 5€ - Duo
@@ -41,14 +41,14 @@ Object {
     >
       <div
         class="css-text-901oao css-textMultiLine-cens5h"
-        dir="auto"
+        dir="ltr"
         style="color: rgb(22, 22, 23); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
       >
         Mensch ! Où sont les Hommes ?
       </div>
       <div
         class="css-text-901oao css-textMultiLine-cens5h"
-        dir="auto"
+        dir="ltr"
         style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
       >
         Dès le 2 mars 2020
@@ -56,7 +56,7 @@ Object {
       <div
         class="css-text-901oao"
         data-testid="priceIsDuo"
-        dir="auto"
+        dir="ltr"
         style="color: rgb(105, 106, 111); font-family: Montserrat-SemiBold; font-size: 12px; line-height: 16px;"
       >
         Dès 5€ - Duo

--- a/__snapshots__/ui/components/buttons/AppButton/AppButton.web.test.tsx.web-snap
+++ b/__snapshots__/ui/components/buttons/AppButton/AppButton.web.test.tsx.web-snap
@@ -23,7 +23,7 @@ Object {
         </div>
         <div
           class="css-text-901oao css-textMultiLine-cens5h"
-          dir="auto"
+          dir="ltr"
           style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
         >
           Testing inline
@@ -50,7 +50,7 @@ Object {
       </div>
       <div
         class="css-text-901oao css-textMultiLine-cens5h"
-        dir="auto"
+        dir="ltr"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Bold; font-size: 15px; line-height: 20px;"
       >
         Testing inline

--- a/__snapshots__/ui/components/contact/__tests__/ContactBlock.web.test.tsx.web-snap
+++ b/__snapshots__/ui/components/contact/__tests__/ContactBlock.web.test.tsx.web-snap
@@ -7,21 +7,21 @@ Object {
     <div>
       <div
         class="css-text-901oao"
-        dir="auto"
+        dir="ltr"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
       >
         contact@venue.com
       </div>
       <div
         class="css-text-901oao"
-        dir="auto"
+        dir="ltr"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
       >
         +33102030405
       </div>
       <div
         class="css-text-901oao"
-        dir="auto"
+        dir="ltr"
         style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
       >
         https://my@website.com
@@ -31,21 +31,21 @@ Object {
   "container": <div>
     <div
       class="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
     >
       contact@venue.com
     </div>
     <div
       class="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
     >
       +33102030405
     </div>
     <div
       class="css-text-901oao"
-      dir="auto"
+      dir="ltr"
       style="color: rgb(22, 22, 23); font-family: Montserrat-Regular; font-size: 15px; line-height: 20px;"
     >
       https://my@website.com

--- a/__snapshots__/ui/components/modals/AppModal.test.tsx.web-snap
+++ b/__snapshots__/ui/components/modals/AppModal.test.tsx.web-snap
@@ -60,7 +60,7 @@ Object {
                       <h1
                         aria-level="1"
                         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                       >
@@ -226,7 +226,7 @@ Object {
                       <h1
                         aria-level="1"
                         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                       >
@@ -452,7 +452,7 @@ Object {
                       <h1
                         aria-level="1"
                         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                       >
@@ -618,7 +618,7 @@ Object {
                       <h1
                         aria-level="1"
                         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                       >
@@ -784,7 +784,7 @@ Object {
                       <h1
                         aria-level="1"
                         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                       >
@@ -969,7 +969,7 @@ Object {
                       <h1
                         aria-level="1"
                         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                       >
@@ -1135,7 +1135,7 @@ Object {
                       <h1
                         aria-level="1"
                         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                       >
@@ -1301,7 +1301,7 @@ Object {
                       <h1
                         aria-level="1"
                         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                       >
@@ -1466,7 +1466,7 @@ Object {
                       <h1
                         aria-level="1"
                         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         id="testUuidV4"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
@@ -1633,7 +1633,7 @@ Object {
                       <h1
                         aria-level="1"
                         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                       >
@@ -1818,7 +1818,7 @@ Object {
                       <h1
                         aria-level="1"
                         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                       >
@@ -1984,7 +1984,7 @@ Object {
                       <h1
                         aria-level="1"
                         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                       >
@@ -2150,7 +2150,7 @@ Object {
                       <h1
                         aria-level="1"
                         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                       >
@@ -2316,7 +2316,7 @@ Object {
                       <h1
                         aria-level="1"
                         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                       >
@@ -2475,7 +2475,7 @@ Object {
                       <h1
                         aria-level="1"
                         class="css-reset-4rbku5 css-text-901oao css-textMultiLine-cens5h"
-                        dir="auto"
+                        dir="ltr"
                         role="heading"
                         style="color: rgb(22, 22, 23); font-family: Montserrat-Medium; font-size: 18px; line-height: 22px; text-align: center;"
                       />

--- a/src/ui/theme/typography.tsx
+++ b/src/ui/theme/typography.tsx
@@ -16,11 +16,19 @@ export const getHeadingAttrs = (level?: number) => ({
     ? {
         accessibilityRole: level ? ('header' as AccessibilityRole) : undefined,
         'aria-level': level,
+        ...getTextAttrs(),
       }
     : {}),
 })
 
-const Hero = styled(RNText)(({ theme }) => ({
+const getTextAttrs = (dir?: string) =>
+  Platform.OS === 'web'
+    ? {
+        dir: dir ?? 'ltr',
+      }
+    : {}
+
+const Hero = styled(RNText).attrs(getTextAttrs())(({ theme }) => ({
   ...theme.typography.hero,
 }))
 
@@ -69,18 +77,20 @@ const Title4 = styled(RNText).attrs<{ 'aria-level': number }>(({ 'aria-level': a
   ...theme.typography.title4,
 }))
 
-const ButtonText = styled(RNText)<{ shrink?: boolean }>(({ shrink, theme }) => ({
-  fontFamily: theme.typography.buttonText.fontFamily,
-  fontSize: theme.typography.buttonText.fontSize,
-  color: theme.typography.buttonText.color,
-  ...(!shrink ? { lineHeight: theme.typography.buttonText.lineHeight } : { flexShrink: 1 }),
-}))
+const ButtonText = styled(RNText).attrs(getTextAttrs())<{ shrink?: boolean }>(
+  ({ shrink, theme }) => ({
+    fontFamily: theme.typography.buttonText.fontFamily,
+    fontSize: theme.typography.buttonText.fontSize,
+    color: theme.typography.buttonText.color,
+    ...(!shrink ? { lineHeight: theme.typography.buttonText.lineHeight } : { flexShrink: 1 }),
+  })
+)
 
-const Body = styled(RNText)(({ theme }) => ({
+const Body = styled(RNText).attrs(getTextAttrs())(({ theme }) => ({
   ...theme.typography.body,
 }))
 
-const Caption = styled(RNText)(({ theme }) => ({
+const Caption = styled(RNText).attrs(getTextAttrs())(({ theme }) => ({
   ...theme.typography.caption,
 }))
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-14944

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
