### PR TITLE
(PC-14826) feat(ProfileDeletion): Get account reactivation limit from settings

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -1702,6 +1702,11 @@ export interface SettingsResponse {
    */
   accountCreationMinimumAge: number
   /**
+   * @type {number}
+   * @memberof SettingsResponse
+   */
+  accountReactivationLimit: number
+  /**
    * @type {boolean}
    * @memberof SettingsResponse
    */

--- a/src/features/auth/__mocks__/settings.ts
+++ b/src/features/auth/__mocks__/settings.ts
@@ -22,6 +22,7 @@ export const mockDefaultSettings: SettingsResponse = {
   enableUnderageGeneralisation: false,
   accountCreationMinimumAge: 15,
   allowAccountReactivation: false,
+  accountReactivationLimit: 60,
 }
 
 export const useAppSettings: typeof actualUseAppSettings = jest.fn(

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileSuccessV2.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileSuccessV2.tsx
@@ -2,6 +2,7 @@ import { t } from '@lingui/macro'
 import React from 'react'
 import styled from 'styled-components/native'
 
+import { useAppSettings } from 'features/auth/settings'
 import { navigateToHomeConfig } from 'features/navigation/helpers'
 import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { ButtonTertiaryWhite } from 'ui/components/buttons/ButtonTertiaryWhite'
@@ -13,6 +14,8 @@ import { ProfileDeletionIllustration } from 'ui/svg/icons/ProfileDeletionIllustr
 import { Spacer, Typo } from 'ui/theme'
 
 export function DeleteProfileSuccessV2() {
+  const { data: settings } = useAppSettings()
+  const reactivationLimit = settings?.accountReactivationLimit
   return (
     <GenericInfoPage
       title={t`Ton compte a été désactivé`}
@@ -31,7 +34,7 @@ export function DeleteProfileSuccessV2() {
         {t`On est super triste de te voir partir.`}
       </StyledBody>
       <Spacer.Column numberOfSpaces={4} />
-      <StyledBody>{t`Tu as 60 jours pour changer d’avis. Tu pourras facilement réactiver ton compte en te connectant.`}</StyledBody>
+      <StyledBody>{t`Tu as ${reactivationLimit} jours pour changer d’avis. Tu pourras facilement réactiver ton compte en te connectant.`}</StyledBody>
       <Spacer.Column numberOfSpaces={4} />
       <StyledBody>{t`Une fois ce délai écoulé, tu n’auras plus accès à ton compte pass Culture.`}</StyledBody>
     </GenericInfoPage>

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -2904,10 +2904,6 @@ msgstr "Tu as 18 ans..."
 msgid "Tu as 30 jours pour te rétracter par e-mail à : support@passculture.app"
 msgstr "Tu as 30 jours pour te rétracter par e-mail à : support@passculture.app"
 
-#: src/features/profile/pages/DeleteProfile/DeleteProfileSuccessV2.tsx
-msgid "Tu as 60 jours pour changer d’avis. Tu pourras facilement réactiver ton compte en te connectant."
-msgstr "Tu as 60 jours pour changer d’avis. Tu pourras facilement réactiver ton compte en te connectant."
-
 #: src/features/offer/pages/OfferBody.tsx
 msgid "Tu as déjà signalé cette offre"
 msgstr "Tu as déjà signalé cette offre"
@@ -2939,6 +2935,10 @@ msgstr "Tu as jusqu’à la veille de tes 18 ans pour profiter de ton budget."
 #: src/features/identityCheck/pages/confirmation/UnderageAccountCreated.tsx
 msgid "Tu as jusqu’à la veille de tes 18 ans pour profiter de ton budget. Découvre dès maintenant les offres culturelles autour de chez toi !"
 msgstr "Tu as jusqu’à la veille de tes 18 ans pour profiter de ton budget. Découvre dès maintenant les offres culturelles autour de chez toi !"
+
+#: src/features/profile/pages/DeleteProfile/DeleteProfileSuccessV2.tsx
+msgid "Tu as {reactivationLimit} jours pour changer d’avis. Tu pourras facilement réactiver ton compte en te connectant."
+msgstr "Tu as {reactivationLimit} jours pour changer d’avis. Tu pourras facilement réactiver ton compte en te connectant."
 
 #: src/features/auth/signup/SetBirthday/utils/useDatePickerErrorHandler.tsx
 msgid "Tu dois avoir au moins {youngestAge} ans pour t’inscrire au pass Culture"

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -141,6 +141,7 @@ function requestSettingsSuccess(
     accountCreationMinimumAge: 15,
     allowAccountReactivation: false,
     appEnableSearchHomepageRework: false,
+    accountReactivationLimit: 60,
   }
 ) {
   return rest.get<SettingsResponse>(env.API_BASE_URL + '/native/v1/settings', (_req, res, ctx) => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-14826

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
