### PR TITLE
(PC-13509) fix(Sentry): android source map (maybe codepush and ios)

### DIFF
--- a/scripts/upload_sourcemaps_to_sentry.sh
+++ b/scripts/upload_sourcemaps_to_sentry.sh
@@ -20,6 +20,8 @@ create_sourcemaps(){
   npx react-native bundle \
     --platform "${APP_OS}" \
     --dev false \
+    --minify false \
+    --reset-cache \
     --entry-file index.js \
     --bundle-output "${SOURCEMAPS_DIR}/${SOURCEMAPS_NAME}" \
     --sourcemap-output "${SOURCEMAPS_DIR}/${SOURCEMAPS_NAME}.packager.map"
@@ -35,6 +37,11 @@ create_sourcemaps(){
     "${SOURCEMAPS_DIR}/${SOURCEMAPS_NAME}.packager.map" \
     "${SOURCEMAPS_DIR}/${SOURCEMAPS_NAME}.hbc.map" \
     -o "${SOURCEMAPS_DIR}/${SOURCEMAPS_NAME}.map"
+
+  echo "Move: ${SOURCEMAPS_DIR}/${BUNDLE_FILE_NAME} -> ${SOURCEMAPS_DIR}/${SOURCEMAPS_NAME}.original"
+  mv "${SOURCEMAPS_DIR}/${SOURCEMAPS_NAME}" "${SOURCEMAPS_DIR}/${SOURCEMAPS_NAME}.original"
+  echo "Move: ${SOURCEMAPS_DIR}/${BUNDLE_FILE_NAME}.hbc -> ${SOURCEMAPS_DIR}/${SOURCEMAPS_NAME}"
+  mv "${SOURCEMAPS_DIR}/${SOURCEMAPS_NAME}.hbc" "${SOURCEMAPS_DIR}/${SOURCEMAPS_NAME}"
 }
 
 upload_sourcemaps(){
@@ -79,7 +86,7 @@ upload_sourcemaps(){
     upload-sourcemaps \
     --dist "${DIST}" \
     --strip-prefix "${PWD}" \
-    --rewrite "${SOURCEMAPS_DIR}/${SOURCEMAPS_NAME}" "${SOURCEMAPS_DIR}/${SOURCEMAPS_NAME}.map"
+    "${SOURCEMAPS_DIR}/${SOURCEMAPS_NAME}" "${SOURCEMAPS_DIR}/${SOURCEMAPS_NAME}.map"
 
   echo "✅ Successfully uploaded sources maps"
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13509


## More details

- https://github.com/getsentry/sentry-react-native/issues/2087
- https://github.com/pass-culture/pass-culture-app-native/pull/2917

## Todo after merge

- Test if Android source map still work in our project.
- Test if iOS source maps work.
- Test if code push version are always having correct source map (if no, try to use sha from commit and always create different `DIST` and `RELEASE`

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
