### PR TITLE
(PC-15100) fix(navigation): fix missing navigation object crash

### DIFF
--- a/src/ui/components/GenericErrorPage.tsx
+++ b/src/ui/components/GenericErrorPage.tsx
@@ -1,21 +1,14 @@
-import { t } from '@lingui/macro'
 import React, { ReactNode, FunctionComponent } from 'react'
 import styled, { useTheme } from 'styled-components/native'
 
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
-import { useGoBack } from 'features/navigation/useGoBack'
 import { Helmet } from 'libs/react-helmet/Helmet'
-import { styledButton } from 'ui/components/buttons/styledButton'
-import { Touchable } from 'ui/components/touchable/Touchable'
 import { Background } from 'ui/svg/Background'
-import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { IconInterface } from 'ui/svg/icons/types'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typography'
-import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 type Props = {
-  headerGoBack?: boolean
+  header?: ReactNode
   noIndex?: boolean
   icon?: FunctionComponent<IconInterface>
   title: string
@@ -24,15 +17,13 @@ type Props = {
 
 export const GenericErrorPage: FunctionComponent<Props> = ({
   children,
-  headerGoBack,
+  header,
   noIndex = true,
   icon,
   title,
   buttons,
 }) => {
   const { isTouch } = useTheme()
-  const { top } = useCustomSafeInsets()
-  const { canGoBack, goBack } = useGoBack(...homeNavConfig)
   const Icon =
     !!icon &&
     styled(icon).attrs(({ theme }) => ({
@@ -48,11 +39,7 @@ export const GenericErrorPage: FunctionComponent<Props> = ({
         </Helmet>
       )}
       <Background />
-      {headerGoBack && canGoBack() ? (
-        <HeaderContainer onPress={goBack} top={top + getSpacing(3.5)} testID="Revenir en arrière">
-          <StyledArrowPrevious />
-        </HeaderContainer>
-      ) : null}
+      {header}
       <Content>
         <Spacer.TopScreen />
         <Spacer.Flex />
@@ -97,19 +84,6 @@ const spacingMatrix = {
   afterChildren: 10,
   bottom: 10,
 }
-
-const StyledArrowPrevious = styled(ArrowPrevious).attrs(({ theme }) => ({
-  color: theme.colors.white,
-  size: theme.icons.sizes.small,
-  accessibilityLabel: t`Revenir en arrière`,
-}))``
-
-const HeaderContainer = styledButton(Touchable)<{ top: number }>(({ theme, top }) => ({
-  position: 'absolute',
-  top,
-  left: getSpacing(6),
-  zIndex: theme.zIndex.floatingButton,
-}))
 
 const StyledTitle = styled(Typo.Title2).attrs(() => getHeadingAttrs(1))(({ theme }) => ({
   color: theme.colors.white,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-15100

## Description du problème

On essayait de d'appeler le hook `useGoBack` dans le composant `GenericErrorPage` qui était monté dans la page d'erreur `AsyncErrorBoundaryWithoutNavigation`. Ce composant sert de "FallbackComponent" à `ErrorBoundary` qui est défini avant la navigation dans l'arborescence de `App.tsx`.

Pour reproduire le bug je me suis loggé avec un utilisateur qui a ensuite été supprimé. A l'ouverture de l'app, le premier appel à /me (qui retournait une 401) était catché par l'error boundary qui faisait l'appel à `useGoBack` via le composant `AsyncErrorBoundaryWithoutNavigation` et la `GenericErrorPage`.

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.

## Screenshots
Avant:
<img width="312" alt="Capture d’écran 2022-05-16 à 19 14 00" src="https://user-images.githubusercontent.com/22886846/168649706-d1cad35f-6217-4e2e-8602-4e70669e778a.png">

Après:
<img width="319" alt="Capture d’écran 2022-05-16 à 19 24 01" src="https://user-images.githubusercontent.com/22886846/168649721-403d98c0-ebe6-4854-9f0c-b25d60b4e4b0.png">


[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
