### PR TITLE
(PC-14577) feat(SuspendedAccount): Handle redirection for suspended accounts

### DIFF
--- a/src/api/__tests__/apiHelpers.test.ts
+++ b/src/api/__tests__/apiHelpers.test.ts
@@ -281,10 +281,18 @@ describe('[api] helpers', () => {
       expect(result).toEqual({})
     })
 
+    it('should navigate to suspension screen when status is 403 (forbidden)', async () => {
+      const response = await respondWith('', 403)
+
+      const result = await handleGeneratedApiResponse(response)
+
+      expect(navigateFromRef).toBeCalledWith('SuspensionScreen')
+      expect(result).toEqual({})
+    })
+
     it.each([
       400, // Bad Request
       401, // Unauthorized
-      403, // Forbidden
       404, // Not Found
       500, // Internal Server Error
       503, // Service Unavailable

--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -173,6 +173,11 @@ export async function handleGeneratedApiResponse(response: Response): Promise<an
     return {}
   }
 
+  if (response.status === 403) {
+    navigateFromRef('SuspensionScreen')
+    return {}
+  }
+
   // We are not suppose to have side-effects in this function but this is a special case
   // where the access token is corrupted and we need to recreate it by logging-in again
   if (

--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -108,6 +108,18 @@ export interface AccountRequest {
  * @export
  * @enum {string}
  */
+ export enum AccountState {
+  'ACTIVE' = 'ACTIVE',
+  'INACTIVE' = 'INACTIVE',
+  'SUSPENDED' = 'SUSPENDED',
+  'SUSPENDED_UPON_USER_REQUEST' = 'SUSPENDED_UPON_USER_REQUEST',
+  'DELETED' = 'DELETED',
+}
+/**
+ * An enumeration.
+ * @export
+ * @enum {string}
+ */
 export enum ActivityIdEnum {
   'MIDDLE_SCHOOL_STUDENT' = 'MIDDLE_SCHOOL_STUDENT',
   'HIGH_SCHOOL_STUDENT' = 'HIGH_SCHOOL_STUDENT',
@@ -1845,6 +1857,11 @@ export interface SigninResponse {
    */
   accessToken: string
   /**
+   * @type {boolean}
+   * @memberof SigninResponse
+   */
+  isActive: boolean
+  /**
    * @type {string}
    * @memberof SigninResponse
    */
@@ -2247,6 +2264,28 @@ export enum UserRole {
 }
 /**
  * @export
+ * @interface UserSuspensionDateResponse
+ */
+export interface UserSuspensionDateResponse {
+  /**
+   * @type {string}
+   * @memberof UserSuspensionDateResponse
+   */
+  date?: string | null
+}
+/**
+ * @export
+ * @interface UserSuspensionStatusResponse
+ */
+export interface UserSuspensionStatusResponse {
+  /**
+   * @type {AccountState}
+   * @memberof UserSuspensionStatusResponse
+   */
+  status: AccountState
+}
+/**
+ * @export
  * @interface ValidateEmailRequest
  */
 export interface ValidateEmailRequest {
@@ -2538,6 +2577,24 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
      */
     async getnativev1accountsuspensionDate(options: any = {}): Promise<FetchArgs> {
       const pathname = `/native/v1/account/suspension_date`
+      let secureOptions = Object.assign(options, { credentials: 'omit' })
+      // authentication JWTAuth required
+      secureOptions = Object.assign(secureOptions, { credentials: 'include' })
+      const localVarRequestOptions = Object.assign({ method: 'GET' }, secureOptions)
+      const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
+      localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
+      return {
+        url: pathname,
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     * @summary get_account_suspension_status <GET>
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getnativev1accountsuspensionStatus(options: any = {}): Promise<FetchArgs> {
+      const pathname = `/native/v1/account/suspension_status`
       let secureOptions = Object.assign(options, { credentials: 'omit' })
       // authentication JWTAuth required
       secureOptions = Object.assign(secureOptions, { credentials: 'include' })
@@ -3377,10 +3434,8 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
       const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
       localVarHeaderParameter['Content-Type'] = 'application/json'
       localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
-      const needsSerialization =
-        <any>'SigninRequest' !== 'string' ||
-        localVarRequestOptions.headers['Content-Type'] === 'application/json'
-      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body || {}) : body || ''
+      const needsSerialization = (<any>"SigninRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json'
+      localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "")
       return {
         url: pathname,
         options: localVarRequestOptions,
@@ -3601,10 +3656,30 @@ export const DefaultApiFp = function (api: DefaultApi, configuration?: Configura
     async getnativev1accountsuspensionDate(
       basePath: string,
       options?: any
-    ): Promise<EmptyResponse> {
+    ): Promise<UserSuspensionDateResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(
         configuration
       ).getnativev1accountsuspensionDate(options)
+      const response = await safeFetch(
+        basePath + localVarFetchArgs.url,
+        localVarFetchArgs.options,
+        api
+      )
+      return handleGeneratedApiResponse(response)
+    },
+    /**
+     *
+     * @summary get_account_suspension_status <GET>
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getnativev1accountsuspensionStatus(
+      basePath: string,
+      options?: any
+    ): Promise<UserSuspensionStatusResponse> {
+      const localVarFetchArgs = await DefaultApiFetchParamCreator(
+        configuration
+      ).getnativev1accountsuspensionStatus(options)
       const response = await safeFetch(
         basePath + localVarFetchArgs.url,
         localVarFetchArgs.options,
@@ -4551,6 +4626,19 @@ export class DefaultApi extends BaseAPI {
    */
   public async getnativev1accountsuspensionDate(options?: any) {
     return DefaultApiFp(this, this.configuration).getnativev1accountsuspensionDate(
+      this.basePath,
+      options
+    )
+  }
+  /**
+   *
+   * @summary get_account_suspension_status <GET>
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof DefaultApi
+   */
+  public async getnativev1accountsuspensionStatus(options?: any) {
+    return DefaultApiFp(this, this.configuration).getnativev1accountsuspensionStatus(
       this.basePath,
       options
     )

--- a/src/features/auth/api.ts
+++ b/src/features/auth/api.ts
@@ -14,6 +14,7 @@ export type SignInResponse = SignInResponseSuccess | SignInResponseFailure
 
 export type SignInResponseSuccess = {
   isSuccess: true
+  isActive: boolean
 }
 
 export type SignInResponseFailure = {
@@ -50,7 +51,10 @@ export function useSignIn(): (data: SigninRequest) => Promise<SignInResponse> {
     try {
       const response = await api.postnativev1signin(body, { credentials: 'omit' })
       await loginRoutine(response, 'fromLogin')
-      const successResponse: SignInResponseSuccess = { isSuccess: true }
+      const successResponse: SignInResponseSuccess = {
+        isSuccess: true,
+        isActive: response.isActive === undefined ? true : response.isActive,
+      }
       return successResponse
     } catch (error) {
       const errorResponse: SignInResponseFailure = { isSuccess: false }

--- a/src/features/auth/forgottenPassword/ResetPasswordExpiredLink/tests/ResetPasswordExpiredLink.native.test.tsx
+++ b/src/features/auth/forgottenPassword/ResetPasswordExpiredLink/tests/ResetPasswordExpiredLink.native.test.tsx
@@ -50,7 +50,7 @@ describe('<ResetPasswordExpiredLink/>', () => {
   it('should NOT redirect to reset password link sent page WHEN clicking on resend email and response is failure', async () => {
     server.use(
       rest.post(env.API_BASE_URL + '/native/v1/request_password_reset', async (req, res, ctx) =>
-        res.once(ctx.status(403))
+        res.once(ctx.status(401))
       )
     )
     const { getByText } = await renderResetPasswordExpiredLink()

--- a/src/features/auth/forgottenPassword/ResetPasswordExpiredLink/tests/ResetPasswordExpiredLink.web.test.tsx
+++ b/src/features/auth/forgottenPassword/ResetPasswordExpiredLink/tests/ResetPasswordExpiredLink.web.test.tsx
@@ -38,7 +38,7 @@ describe('<ResetPasswordExpiredLink/>', () => {
   it('should redirect to reset password link sent page WHEN clicking on resend email and response is success', async () => {
     const { getByText } = await renderResetPasswordExpiredLink()
 
-    fireEvent.click(getByText(`Renvoyer l'email`))
+    await fireEvent.click(getByText(`Renvoyer l'email`))
     await superFlushWithAct()
 
     await waitForExpect(() => {
@@ -53,7 +53,7 @@ describe('<ResetPasswordExpiredLink/>', () => {
   it('should NOT redirect to reset password link sent page WHEN clicking on resend email and response is failure', async () => {
     server.use(
       rest.post(env.API_BASE_URL + '/native/v1/request_password_reset', async (req, res, ctx) =>
-        res.once(ctx.status(403))
+        res.once(ctx.status(400))
       )
     )
     const { getByText } = await renderResetPasswordExpiredLink()

--- a/src/features/auth/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.tsx
+++ b/src/features/auth/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.tsx
@@ -44,7 +44,7 @@ export function AfterSignupEmailValidationBuffer() {
   }
 
   async function onEmailValidationSuccess({ accessToken, refreshToken }: ValidateEmailResponse) {
-    await loginRoutine({ accessToken, refreshToken }, 'fromSignup')
+    await loginRoutine({ accessToken, refreshToken, isActive: true }, 'fromSignup')
 
     try {
       const user = await api.getnativev1me()

--- a/src/features/auth/signup/SignupConfirmationEmailSent/tests/SignupConfirmationExpiredLink.native.test.tsx
+++ b/src/features/auth/signup/SignupConfirmationEmailSent/tests/SignupConfirmationExpiredLink.native.test.tsx
@@ -39,7 +39,7 @@ describe('<SignupConfirmationExpiredLink/>', () => {
     const { findByText } = renderSignupConfirmationExpiredLink()
 
     const button = await findByText("Retourner à l'accueil")
-    fireEvent.press(button)
+    await fireEvent.press(button)
 
     await waitForExpect(() => {
       expect(navigateFromRef).toBeCalledWith(
@@ -67,7 +67,7 @@ describe('<SignupConfirmationExpiredLink/>', () => {
   it('should NOT redirect to signup confirmation email sent page WHEN clicking on resend email and response is failure', async () => {
     server.use(
       rest.post(env.API_BASE_URL + '/native/v1/resend_email_validation', async (req, res, ctx) =>
-        res.once(ctx.status(403))
+        res.once(ctx.status(400))
       )
     )
     const { getByText } = renderSignupConfirmationExpiredLink()

--- a/src/features/auth/signup/SignupConfirmationEmailSent/tests/SignupConfirmationExpiredLink.web.test.tsx
+++ b/src/features/auth/signup/SignupConfirmationEmailSent/tests/SignupConfirmationExpiredLink.web.test.tsx
@@ -52,7 +52,7 @@ describe('<SignupConfirmationExpiredLink/>', () => {
   it('should redirect to signup confirmation email sent page WHEN clicking on resend email and response is success', async () => {
     const { getByText } = renderSignupConfirmationExpiredLink()
 
-    fireEvent.click(getByText(`Renvoyer l'email`))
+    await fireEvent.click(getByText(`Renvoyer l'email`))
 
     await waitForExpect(() => {
       expect(navigate).toBeCalledTimes(1)
@@ -66,7 +66,7 @@ describe('<SignupConfirmationExpiredLink/>', () => {
   it('should NOT redirect to signup confirmation email sent page WHEN clicking on resend email and response is failure', async () => {
     server.use(
       rest.post(env.API_BASE_URL + '/native/v1/resend_email_validation', async (req, res, ctx) =>
-        res.once(ctx.status(403))
+        res.once(ctx.status(400))
       )
     )
     const { getByText } = renderSignupConfirmationExpiredLink()

--- a/src/features/auth/suspendedAccount/FraudulentAccount/FraudulentAccount.tsx
+++ b/src/features/auth/suspendedAccount/FraudulentAccount/FraudulentAccount.tsx
@@ -51,7 +51,6 @@ export const FraudulentAccount = () => {
           navigateTo={navigateToHomeConfig}
           onPress={signOut}
           icon={PlainArrowPrevious}
-          navigateBeforeOnPress
         />,
       ]}>
       <StyledBody>{t`En raison d’une activité suspiscieuse, notre équipe anti fraude a suspendu ton compte.`}</StyledBody>

--- a/src/features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount.tsx
+++ b/src/features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount.tsx
@@ -29,16 +29,16 @@ export const SuspendedAccount = () => {
 
   useFocusEffect(
     useCallback(() => {
-      if (!settings?.allowAccountReactivation || accountSuspensionDate === undefined) {
+      if (!settings?.allowAccountReactivation) {
         navigateToHome()
       }
-    }, [settings, accountSuspensionDate])
+    }, [settings])
   )
 
   const reactivationLimit = settings?.accountReactivationLimit || 60
   let formattedDate = ''
 
-  if (accountSuspensionDate) {
+  if (accountSuspensionDate?.date) {
     const suspensionDate = new Date(accountSuspensionDate.date)
     const reactivationDeadline = addDaysToDate(suspensionDate, reactivationLimit)
     formattedDate = formatToCompleteFrenchDateTime(reactivationDeadline, false)
@@ -64,7 +64,6 @@ export const SuspendedAccount = () => {
           navigateTo={navigateToHomeConfig}
           onPress={signOut}
           icon={PlainArrowPrevious}
-          navigateBeforeOnPress
         />,
       ]}>
       <StyledBody>{t`Tu as jusqu'au ${formattedDate} pour réactiver ton compte.`}</StyledBody>

--- a/src/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.native.test.tsx
+++ b/src/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.native.test.tsx
@@ -12,9 +12,8 @@ const mockSettings = {
   allowAccountReactivation: true,
 }
 
-let mockSuspensionDate: { date: string } | undefined = { date: '2022-05-11T10:29:25.332786Z' }
 jest.mock('features/auth/suspendedAccount/SuspendedAccount/useAccountSuspensionDate', () => ({
-  useAccountSuspensionDate: jest.fn(() => ({ data: mockSuspensionDate })),
+  useAccountSuspensionDate: jest.fn(() => ({ data: { date: '2022-05-11T10:29:25.332786Z' } })),
 }))
 jest.mock('features/navigation/helpers')
 jest.mock('features/auth/settings', () => ({
@@ -54,15 +53,6 @@ describe('<SuspendedAccount />', () => {
     await waitForExpect(() => {
       expect(navigate).toBeCalledWith(navigateToHomeConfig.screen, navigateToHomeConfig.params)
       expect(mockSignOut).toBeCalledTimes(1)
-    })
-  })
-
-  it('should redirect to home if account is not suspended', async () => {
-    mockSuspensionDate = undefined
-    render(<SuspendedAccount />)
-
-    await waitForExpect(() => {
-      expect(navigateToHome).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.web.test.tsx
+++ b/src/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.web.test.tsx
@@ -12,9 +12,8 @@ const mockSettings = {
   allowAccountReactivation: true,
 }
 
-let mockSuspensionDate: { date: string } | undefined = { date: '2022-05-11T10:29:25.332786Z' }
 jest.mock('features/auth/suspendedAccount/SuspendedAccount/useAccountSuspensionDate', () => ({
-  useAccountSuspensionDate: jest.fn(() => ({ data: mockSuspensionDate })),
+  useAccountSuspensionDate: jest.fn(() => ({ data: { date: '2022-05-11T10:29:25.332786Z' } })),
 }))
 jest.mock('features/navigation/helpers')
 jest.mock('features/auth/settings', () => ({
@@ -54,15 +53,6 @@ describe('<SuspendedAccount />', () => {
     await waitForExpect(() => {
       expect(navigate).toBeCalledWith(navigateToHomeConfig.screen, navigateToHomeConfig.params)
       expect(mockSignOut).toBeCalledTimes(1)
-    })
-  })
-
-  it('should redirect to home if account is not suspended', async () => {
-    mockSuspensionDate = undefined
-    render(<SuspendedAccount />)
-
-    await waitForExpect(() => {
-      expect(navigateToHome).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/features/auth/suspendedAccount/SuspensionScreen/SuspensionScreen.tsx
+++ b/src/features/auth/suspendedAccount/SuspensionScreen/SuspensionScreen.tsx
@@ -1,0 +1,38 @@
+import { useFocusEffect } from '@react-navigation/native'
+import React, { useCallback } from 'react'
+
+import { AccountState } from 'api/gen'
+import { useAppSettings } from 'features/auth/settings'
+import { FraudulentAccount } from 'features/auth/suspendedAccount/FraudulentAccount/FraudulentAccount'
+import { SuspendedAccount } from 'features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount'
+import { useAccountSuspensionStatus } from 'features/auth/suspendedAccount/SuspensionScreen/useAccountSuspensionStatus'
+import { navigateToHome } from 'features/navigation/helpers'
+import { LoadingPage } from 'ui/components/LoadingPage'
+
+export const SuspensionScreen = () => {
+  const { data: settings } = useAppSettings()
+  const { data: accountSuspensionStatus, isLoading } = useAccountSuspensionStatus()
+  const suspensionStatus = accountSuspensionStatus?.status
+
+  useFocusEffect(
+    useCallback(() => {
+      if (
+        !settings?.allowAccountReactivation ||
+        (suspensionStatus &&
+          ![AccountState.SUSPENDED_UPON_USER_REQUEST, AccountState.SUSPENDED].includes(
+            suspensionStatus
+          ))
+      ) {
+        navigateToHome()
+      }
+    }, [settings, suspensionStatus])
+  )
+
+  if (isLoading) {
+    return <LoadingPage />
+  } else if (suspensionStatus === AccountState.SUSPENDED_UPON_USER_REQUEST) {
+    return <SuspendedAccount />
+  } else {
+    return <FraudulentAccount />
+  }
+}

--- a/src/features/auth/suspendedAccount/SuspensionScreen/tests/SuspensionScreen.test.tsx
+++ b/src/features/auth/suspendedAccount/SuspensionScreen/tests/SuspensionScreen.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import waitForExpect from 'wait-for-expect'
+
+import { AccountState } from 'api/gen'
+import { navigateToHome } from 'features/navigation/helpers'
+import { render } from 'tests/utils'
+
+import { SuspensionScreen } from '../SuspensionScreen'
+
+const mockSettings = {
+  allowAccountReactivation: true,
+}
+
+const mockSuspensionStatus = { status: AccountState.SUSPENDED_UPON_USER_REQUEST }
+jest.mock('features/auth/suspendedAccount/SuspensionScreen/useAccountSuspensionStatus', () => ({
+  useAccountSuspensionStatus: jest.fn(() => ({ data: mockSuspensionStatus })),
+}))
+jest.mock('features/auth/suspendedAccount/SuspendedAccount/useAccountSuspensionDate', () => ({
+  useAccountSuspensionDate: jest.fn(() => ({ data: { date: '2022-05-11T10:29:25.332786Z' } })),
+}))
+jest.mock('features/navigation/helpers')
+jest.mock('features/auth/settings', () => ({
+  useAppSettings: jest.fn(() => ({
+    data: mockSettings,
+  })),
+}))
+jest.mock('features/auth/AuthContext')
+
+describe('<SuspensionsScreen />', () => {
+  it('should display SuspendedAccount component if account is suspended upon user request', async () => {
+    mockSuspensionStatus.status = AccountState.SUSPENDED_UPON_USER_REQUEST
+    const { getByText } = render(<SuspensionScreen />)
+    expect(getByText('Ton compte est désactivé')).toBeTruthy()
+  })
+
+  it('should display FraudulentAccount component if account is suspended for fraud', async () => {
+    mockSuspensionStatus.status = AccountState.SUSPENDED
+    const { getByText } = render(<SuspensionScreen />)
+    expect(getByText('Ton compte a été suspendu')).toBeTruthy()
+  })
+
+  it('should redirect to home if account is not suspended', async () => {
+    mockSuspensionStatus.status = AccountState.ACTIVE
+    render(<SuspensionScreen />)
+
+    await waitForExpect(() => {
+      expect(navigateToHome).toBeCalled()
+    })
+  })
+
+  it('should redirect to home if feature is disabled', async () => {
+    mockSettings.allowAccountReactivation = false
+    render(<SuspensionScreen />)
+
+    await waitForExpect(() => {
+      expect(navigateToHome).toBeCalled()
+    })
+  })
+})

--- a/src/features/auth/suspendedAccount/SuspensionScreen/tests/useAccountSuspensionStatus.test.ts
+++ b/src/features/auth/suspendedAccount/SuspensionScreen/tests/useAccountSuspensionStatus.test.ts
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { rest } from 'msw'
+
+import { AccountState } from 'api/gen'
+import { useAccountSuspensionStatus } from 'features/auth/suspendedAccount/SuspensionScreen/useAccountSuspensionStatus'
+import { env } from 'libs/environment'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { server } from 'tests/server'
+
+const expectedResponse = { status: AccountState.SUSPENDED }
+function simulateSuspensionStatus200() {
+  server.use(
+    rest.get(env.API_BASE_URL + '/native/v1/account/suspension_status', async (_, res, ctx) =>
+      res(ctx.status(200), ctx.json(expectedResponse))
+    )
+  )
+}
+
+function simulateSuspensionStatusError() {
+  server.use(
+    rest.get(env.API_BASE_URL + '/native/v1/account/suspension_status', async (_, res, ctx) =>
+      res(ctx.status(400))
+    )
+  )
+}
+
+describe('useAccountSuspensionStatus', () => {
+  it('should return suspension status if it exists', async () => {
+    simulateSuspensionStatus200()
+    const { result, waitFor } = renderSuspensionDateHook()
+
+    await waitFor(() => result.current.data !== undefined)
+    expect(result.current.data?.status).toBe(expectedResponse.status)
+  })
+
+  it('should return undefined if error', async () => {
+    simulateSuspensionStatusError()
+    const { result } = renderSuspensionDateHook()
+
+    expect(result.current.data).toBeUndefined()
+  })
+})
+
+const renderSuspensionDateHook = () =>
+  renderHook(() => useAccountSuspensionStatus(), {
+    /* eslint-disable local-rules/no-react-query-provider-hoc */
+    wrapper: ({ children }) => reactQueryProviderHOC(children),
+  })

--- a/src/features/auth/suspendedAccount/SuspensionScreen/useAccountSuspensionStatus.ts
+++ b/src/features/auth/suspendedAccount/SuspensionScreen/useAccountSuspensionStatus.ts
@@ -1,0 +1,14 @@
+import { useQuery } from 'react-query'
+
+import { api } from 'api/api'
+import { QueryKeys } from 'libs/queryKeys'
+
+export function useAccountSuspensionStatus() {
+  return useQuery(QueryKeys.ACCOUNT_SUSPENSION_STATUS, async () => {
+    try {
+      return await api.getnativev1accountsuspensionStatus()
+    } catch {
+      return undefined
+    }
+  })
+}

--- a/src/features/bookings/components/EndedBookingItem.native.test.tsx
+++ b/src/features/bookings/components/EndedBookingItem.native.test.tsx
@@ -54,11 +54,11 @@ describe('EndedBookingItem', () => {
     expect(queryByText('le 15/03/2021')).toBeTruthy()
   })
 
-  it('should navigate to offer page ', () => {
+  it('should navigate to offer page ', async () => {
     const { getByTestId } = renderEndedBookingItem(bookingsSnap.ended_bookings[0])
 
     const item = getByTestId('EndedBookingItem')
-    fireEvent.press(item)
+    await fireEvent.press(item)
 
     expect(navigate).toHaveBeenCalledWith('Offer', {
       id: 147874,

--- a/src/features/bookings/components/EndedBookingItem.web.test.tsx
+++ b/src/features/bookings/components/EndedBookingItem.web.test.tsx
@@ -54,11 +54,11 @@ describe('EndedBookingItem', () => {
     expect(queryByText('le 15/03/2021')).toBeTruthy()
   })
 
-  it('should navigate to offer page ', () => {
+  it('should navigate to offer page ', async () => {
     const { getByTestId } = renderEndedBookingItem(bookingsSnap.ended_bookings[0])
 
     const item = getByTestId('EndedBookingItem')
-    fireEvent.click(item)
+    await fireEvent.click(item)
 
     expect(navigate).toHaveBeenCalledWith('Offer', {
       id: 147874,

--- a/src/features/bookings/components/NoBookingsView.test.tsx
+++ b/src/features/bookings/components/NoBookingsView.test.tsx
@@ -17,11 +17,11 @@ jest.mock('features/search/pages/SearchWrapper', () => ({
 }))
 
 describe('<NoBookingsView />', () => {
-  it('should navigate to Search when pressing button and log event', () => {
+  it('should navigate to Search when pressing button and log event', async () => {
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
     const renderAPI = render(reactQueryProviderHOC(<NoBookingsView />))
     const button = renderAPI.getByText('Explorer les offres')
-    fireEvent.press(button)
+    await fireEvent.press(button)
     expect(navigate).toBeCalledWith(...getTabNavConfig('Search', { showResults: true }))
     expect(analytics.logDiscoverOffers).toHaveBeenCalledWith('bookings')
   })

--- a/src/features/bookings/pages/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails.native.test.tsx
@@ -84,7 +84,7 @@ describe('BookingDetails', () => {
 
       const { getByText } = renderBookingDetails(booking)
       const offerButton = getByText("Accéder à l'offre")
-      fireEvent.press(offerButton)
+      await fireEvent.press(offerButton)
 
       expect(mockedOpenUrl).toHaveBeenCalledWith(booking.stock.offer.url, {
         analyticsData: {
@@ -174,12 +174,12 @@ describe('BookingDetails', () => {
     })
   })
 
-  it('should redirect to the Offer page and log event', () => {
+  it('should redirect to the Offer page and log event', async () => {
     const booking = bookingsSnap.ongoing_bookings[0]
     const { getByText } = renderBookingDetails(booking)
 
     const text = getByText('Voir le détail de l’offre')
-    fireEvent.press(text)
+    await fireEvent.press(text)
 
     const offerId = booking.stock.offer.id
 
@@ -191,20 +191,20 @@ describe('BookingDetails', () => {
   })
 
   describe('cancellation button', () => {
-    it('should log event "CancelBooking" when cancelling booking', () => {
+    it('should log event "CancelBooking" when cancelling booking', async () => {
       const booking = { ...bookingsSnap.ongoing_bookings[0] }
       const date = new Date()
       date.setDate(date.getDate() + 1)
       booking.confirmationDate = date.toISOString()
       const { getAllByTestId } = renderBookingDetails(booking)
-      fireEvent.press(getAllByTestId('Annuler ma réservation')[0])
+      await fireEvent.press(getAllByTestId('Annuler ma réservation')[0])
 
       expect(analytics.logCancelBooking).toHaveBeenCalledWith(booking.stock.offer.id)
     })
   })
 
   describe('booking not found', () => {
-    it('should render ScreenError BookingNotFound when booking is not found when data already exists', () => {
+    it('should render ScreenError BookingNotFound when booking is not found when data already exists', async () => {
       const renderAPI = renderBookingDetails(undefined, {
         dataUpdatedAt: new Date().getTime(),
       })
@@ -217,10 +217,10 @@ describe('BookingDetails', () => {
       expect(renderAPI.queryByText('Mes réservations terminées')).toBeTruthy()
       expect(renderAPI.queryByText(`Retourner à l'accueil`)).toBeTruthy()
 
-      fireEvent.press(renderAPI.getByText('Mes réservations terminées'))
+      await fireEvent.press(renderAPI.getByText('Mes réservations terminées'))
       expect(navigate).toBeCalledWith('EndedBookings', undefined)
 
-      fireEvent.press(renderAPI.getByText(`Retourner à l'accueil`))
+      await fireEvent.press(renderAPI.getByText(`Retourner à l'accueil`))
       expect(navigateFromRef).toBeCalledWith(
         navigateToHomeConfig.screen,
         navigateToHomeConfig.params

--- a/src/features/favorites/atoms/__tests__/Favorite.native.test.tsx
+++ b/src/features/favorites/atoms/__tests__/Favorite.native.test.tsx
@@ -73,9 +73,9 @@ describe('<Favorite /> component', () => {
     cleanup()
   })
 
-  it('should navigate to the offer when clicking on the favorite', () => {
+  it('should navigate to the offer when clicking on the favorite', async () => {
     const { getByTestId } = renderFavorite()
-    fireEvent.press(getByTestId('favorite'))
+    await fireEvent.press(getByTestId('favorite'))
     expect(navigate).toHaveBeenCalledWith('Offer', {
       from: 'favorites',
       id: favorite.offer.id,

--- a/src/features/favorites/components/__tests__/NoFavoritesResult.test.tsx
+++ b/src/features/favorites/components/__tests__/NoFavoritesResult.test.tsx
@@ -33,10 +33,10 @@ describe('NoFavoritesResult component', () => {
     expect(text).toBeTruthy()
   })
 
-  it('should navigate to Search when pressing button and log event', () => {
+  it('should navigate to Search when pressing button and log event', async () => {
     const renderAPI = render(<NoFavoritesResult />)
     const button = renderAPI.getByText('Explorer les offres')
-    fireEvent.press(button)
+    await fireEvent.press(button)
     expect(navigate).toBeCalledWith(...getTabNavConfig('Search', { showResults: true }))
     expect(analytics.logDiscoverOffers).toHaveBeenCalledWith('favorites')
   })

--- a/src/features/home/atoms/tests/VenueTile.native.test.tsx
+++ b/src/features/home/atoms/tests/VenueTile.native.test.tsx
@@ -24,15 +24,15 @@ describe('VenueTile component', () => {
     expect(component).toMatchSnapshot()
   })
 
-  it('should navigate to the venue when clicking on the venue tile', () => {
+  it('should navigate to the venue when clicking on the venue tile', async () => {
     const { getByTestId } = render(<VenueTile {...props} />)
-    fireEvent.press(getByTestId('venueTile'))
+    await fireEvent.press(getByTestId('venueTile'))
     expect(navigate).toHaveBeenCalledWith('Venue', { id: venue.id })
   })
 
-  it('should log analytics event ConsultVenue when pressing on the venue tile', () => {
+  it('should log analytics event ConsultVenue when pressing on the venue tile', async () => {
     const { getByTestId } = render(<VenueTile {...props} />)
-    fireEvent.press(getByTestId('venueTile'))
+    await fireEvent.press(getByTestId('venueTile'))
     expect(analytics.logConsultVenue).toHaveBeenNthCalledWith(1, {
       venueId: venue.id,
       from: 'home',

--- a/src/features/home/atoms/tests/VenueTile.web.test.tsx
+++ b/src/features/home/atoms/tests/VenueTile.web.test.tsx
@@ -25,15 +25,15 @@ describe('VenueTile component', () => {
     expect(component).toMatchSnapshot()
   })
 
-  it('should navigate to the venue when clicking on the image', () => {
+  it('should navigate to the venue when clicking on the image', async () => {
     const { getByTestId } = render(<VenueTile {...props} />)
-    fireEvent.click(getByTestId('venueTile'))
+    await fireEvent.click(getByTestId('venueTile'))
     expect(navigate).toHaveBeenCalledWith('Venue', { id: venue.id })
   })
 
-  it('should log analytics event ConsultVenue when pressing on the venue tile', () => {
+  it('should log analytics event ConsultVenue when pressing on the venue tile', async () => {
     const { getByTestId } = render(<VenueTile {...props} />)
-    fireEvent.click(getByTestId('venueTile'))
+    await fireEvent.click(getByTestId('venueTile'))
     expect(analytics.logConsultVenue).toHaveBeenNthCalledWith(1, {
       venueId: venue.id,
       from: 'home',

--- a/src/features/identityCheck/components/__test__/DMSModal.native.test.tsx
+++ b/src/features/identityCheck/components/__test__/DMSModal.native.test.tsx
@@ -26,18 +26,18 @@ describe('<DMSModal/>', () => {
     expect(hideModalMock).toHaveBeenCalled()
   })
 
-  it('should open DSM french citizen when clicking on "Je suis de nationalité française" button', () => {
+  it('should open DSM french citizen when clicking on "Je suis de nationalité française" button', async () => {
     const { getByText } = render(<DMSModal visible={true} hideModal={hideModalMock} />)
     const frenchCitizenDMSButton = getByText('Je suis de nationalité française')
-    fireEvent.press(frenchCitizenDMSButton)
+    await fireEvent.press(frenchCitizenDMSButton)
     expect(analytics.logOpenDMSFrenchCitizenURL).toHaveBeenCalledTimes(1)
     expect(mockedOpenUrl).toBeCalledWith(env.DMS_FRENCH_CITIZEN_URL, undefined)
   })
 
-  it('should open DSM french citizen when clicking on "Je suis de nationalité étrangère" button', () => {
+  it('should open DSM french citizen when clicking on "Je suis de nationalité étrangère" button', async () => {
     const { getByText } = render(<DMSModal visible={true} hideModal={hideModalMock} />)
     const foreignCitizenDMSButton = getByText('Je suis de nationalité étrangère')
-    fireEvent.press(foreignCitizenDMSButton)
+    await fireEvent.press(foreignCitizenDMSButton)
     expect(analytics.logOpenDMSForeignCitizenURL).toHaveBeenCalledTimes(1)
     expect(mockedOpenUrl).toBeCalledWith(env.DMS_FOREIGN_CITIZEN_URL, undefined)
   })

--- a/src/features/identityCheck/components/__test__/FastEduconnectConnectionRequestModal.native.test.tsx
+++ b/src/features/identityCheck/components/__test__/FastEduconnectConnectionRequestModal.native.test.tsx
@@ -46,11 +46,11 @@ describe('<IdentityCheckEnd/>', () => {
     expect(hideModalMock).toHaveBeenCalled()
   })
 
-  it('should redirect to EduConnect when cliking on "Identification avec ÉduConnect" button', () => {
+  it('should redirect to EduConnect when cliking on "Identification avec ÉduConnect" button', async () => {
     const { getByText } = render(
       <FastEduconnectConnectionRequestModal visible={true} hideModal={hideModalMock} />
     )
-    fireEvent.press(getByText('Identification avec ÉduConnect'))
+    await fireEvent.press(getByText('Identification avec ÉduConnect'))
     expect(hideModalMock).toHaveBeenCalled()
     expect(mockDispatch).toHaveBeenNthCalledWith(1, {
       payload: IdentityCheckMethod.educonnect,
@@ -59,11 +59,11 @@ describe('<IdentityCheckEnd/>', () => {
     expect(navigate).toHaveBeenNthCalledWith(1, 'IdentityCheckEduConnect', undefined)
   })
 
-  it('should redirect to identity check Ubble or DMS when cliking on "Identification manuelle" button', () => {
+  it('should redirect to identity check Ubble or DMS when cliking on "Identification manuelle" button', async () => {
     const { getByText } = render(
       <FastEduconnectConnectionRequestModal visible={true} hideModal={hideModalMock} />
     )
-    fireEvent.press(getByText('Identification manuelle'))
+    await fireEvent.press(getByText('Identification manuelle'))
     expect(hideModalMock).toHaveBeenCalled()
     expect(mockDispatch).toHaveBeenNthCalledWith(1, {
       payload: IdentityCheckMethod.ubble,

--- a/src/features/navigation/RootNavigator/routes.ts
+++ b/src/features/navigation/RootNavigator/routes.ts
@@ -21,6 +21,7 @@ import { NotYetUnderageEligibility } from 'features/auth/signup/VerifyEligiblity
 import { AccountReactivationSuccess } from 'features/auth/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess'
 import { FraudulentAccount } from 'features/auth/suspendedAccount/FraudulentAccount/FraudulentAccount'
 import { SuspendedAccount } from 'features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount'
+import { SuspensionScreen } from 'features/auth/suspendedAccount/SuspensionScreen/SuspensionScreen'
 import { BookingDetails } from 'features/bookings/pages/BookingDetails'
 import { EndedBookings } from 'features/bookings/pages/EndedBookings'
 import { BookingConfirmation } from 'features/bookOffer/pages/BookingConfirmation'
@@ -196,18 +197,22 @@ export const routes: Route[] = [
     options: { title: t`Mentions légales` },
   },
   {
-    name: 'SuspendedAccount',
-    component: SuspendedAccount,
+    name: 'SuspensionScreen',
+    component: SuspensionScreen,
     path: 'compte-desactive',
     options: { title: t`Compte désactivé` },
-    secure: true,
+  },
+  {
+    name: 'SuspendedAccount',
+    component: SuspendedAccount,
+    path: 'compte-suspendu-a-la-demande',
+    options: { title: t`Compte désactivé` },
   },
   {
     name: 'FraudulentAccount',
     component: FraudulentAccount,
-    path: 'compte-suspendu',
+    path: 'compte-suspendu-pour-fraude',
     options: { title: t`Compte suspendu` },
-    secure: true,
   },
   {
     name: 'AccountReactivationSuccess',

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -107,6 +107,7 @@ export type RootStackParamList = {
     moduleName?: string
   }
   OfferDescription: { id: number }
+  SuspensionScreen: undefined
   ReinitializePassword: { email: string; token: string; expiration_timestamp: number }
   ResetPasswordEmailSent: { email: string }
   ResetPasswordExpiredLink: { email: string }

--- a/src/features/offer/atoms/__tests__/OfferTile.native.test.tsx
+++ b/src/features/offer/atoms/__tests__/OfferTile.native.test.tsx
@@ -43,7 +43,7 @@ describe('OfferTile component', () => {
   it('should navigate to the offer when clicking on the image', async () => {
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
     const { getByTestId } = render(reactQueryProviderHOC(<OfferTile {...props} />))
-    fireEvent.press(getByTestId('tileImage'))
+    await fireEvent.press(getByTestId('tileImage'))
     expect(navigate).toHaveBeenCalledWith('Offer', {
       id: offerId,
       from: 'home',
@@ -54,7 +54,7 @@ describe('OfferTile component', () => {
   it('Analytics - should log ConsultOffer that user opened the offer', async () => {
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
     const { getByTestId } = render(reactQueryProviderHOC(<OfferTile {...props} />))
-    fireEvent.press(getByTestId('tileImage'))
+    await fireEvent.press(getByTestId('tileImage'))
     expect(analytics.logConsultOffer).toHaveBeenCalledWith({
       offerId,
       from: 'home',
@@ -65,7 +65,7 @@ describe('OfferTile component', () => {
   it('should prepopulate react-query cache when clicking on offer', async () => {
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
     const { getByTestId } = render(reactQueryProviderHOC(<OfferTile {...props} />))
-    fireEvent.press(getByTestId('tileImage'))
+    await fireEvent.press(getByTestId('tileImage'))
 
     const queryHash = JSON.stringify(['offer', offerId])
     const query = queryCache.get(queryHash)

--- a/src/features/offer/atoms/__tests__/OfferTile.web.test.tsx
+++ b/src/features/offer/atoms/__tests__/OfferTile.web.test.tsx
@@ -42,10 +42,10 @@ describe('OfferTile component', () => {
     expect(renderAPI).toMatchSnapshot()
   })
 
-  it('should navigate to the offer when clicking on the image [WEB INTEGRATION REQUIRED]', () => {
+  it('should navigate to the offer when clicking on the image [WEB INTEGRATION REQUIRED]', async () => {
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
     const { getByTestId } = render(reactQueryProviderHOC(<OfferTile {...props} />))
-    fireEvent.click(getByTestId(`offre ${offer.name}`))
+    await fireEvent.click(getByTestId(`offre ${offer.name}`))
     expect(navigate).toHaveBeenCalledWith('Offer', {
       id: offerId,
       from: 'home',
@@ -53,10 +53,10 @@ describe('OfferTile component', () => {
     })
   })
 
-  it('Analytics - should log ConsultOffer that user opened the offer [WEB INTEGRATION REQUIRED]', () => {
+  it('Analytics - should log ConsultOffer that user opened the offer [WEB INTEGRATION REQUIRED]', async () => {
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
     const { getByTestId } = render(reactQueryProviderHOC(<OfferTile {...props} />))
-    fireEvent.click(getByTestId(`offre ${offer.name}`))
+    await fireEvent.click(getByTestId(`offre ${offer.name}`))
     expect(analytics.logConsultOffer).toHaveBeenCalledWith({
       offerId,
       from: 'home',
@@ -64,10 +64,10 @@ describe('OfferTile component', () => {
     })
   })
 
-  it('should prepopulate react-query cache when clicking on offer [WEB INTEGRATION REQUIRED]', () => {
+  it('should prepopulate react-query cache when clicking on offer [WEB INTEGRATION REQUIRED]', async () => {
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
     const { getByTestId } = render(reactQueryProviderHOC(<OfferTile {...props} />))
-    fireEvent.click(getByTestId(`offre ${offer.name}`))
+    await fireEvent.click(getByTestId(`offre ${offer.name}`))
 
     const queryHash = JSON.stringify(['offer', offerId])
     const query = queryCache.get(queryHash)

--- a/src/features/offer/components/__tests__/SignUpSignInChoiceOfferModal.native.test.tsx
+++ b/src/features/offer/components/__tests__/SignUpSignInChoiceOfferModal.native.test.tsx
@@ -17,24 +17,24 @@ describe('SignUpSignInChoiceOfferModal', () => {
     expect(getByText('Connecte-toi pour profiter de cette fonctionnalité')).toBeTruthy()
   })
 
-  it('go to login on click button', () => {
+  it('go to login on click button', async () => {
     const { getByText } = render(
       <SignUpSignInChoiceOfferModal visible={true} dismissModal={dismissModal} />
     )
 
     const button = getByText('Se connecter')
-    fireEvent.press(button)
+    await fireEvent.press(button)
 
     expect(navigate).toBeCalledWith('Login', undefined)
   })
 
-  it('go to signup on click button', () => {
+  it('go to signup on click button', async () => {
     const { getByText } = render(
       <SignUpSignInChoiceOfferModal visible={true} dismissModal={dismissModal} />
     )
 
     const button = getByText(`S'inscrire`)
-    fireEvent.press(button)
+    await fireEvent.press(button)
 
     expect(navigate).toBeCalledWith('SignupForm', undefined)
   })

--- a/src/features/profile/components/LoggedOutHeader.native.test.tsx
+++ b/src/features/profile/components/LoggedOutHeader.native.test.tsx
@@ -7,21 +7,21 @@ import { render, fireEvent } from 'tests/utils'
 import { LoggedOutHeader } from './LoggedOutHeader'
 
 describe('LoggedOutHeader', () => {
-  it('should navigate to the SignupForm page', () => {
+  it('should navigate to the SignupForm page', async () => {
     const { getByTestId } = render(<LoggedOutHeader />)
 
     const signupButton = getByTestId("S'inscrire")
 
-    fireEvent.press(signupButton)
+    await fireEvent.press(signupButton)
 
     expect(analytics.logProfilSignUp).toBeCalled()
     expect(navigate).toBeCalledWith('SignupForm', { preventCancellation: true })
   })
-  it('should navigate to the login page', () => {
+  it('should navigate to the login page', async () => {
     const { getByTestId } = render(<LoggedOutHeader />)
 
     const connectButton = getByTestId('Connecte-toi')
-    fireEvent.press(connectButton)
+    await fireEvent.press(connectButton)
 
     expect(navigate).toBeCalledWith('Login', { preventCancellation: true })
   })

--- a/src/features/profile/components/LoggedOutHeader.web.test.tsx
+++ b/src/features/profile/components/LoggedOutHeader.web.test.tsx
@@ -7,21 +7,21 @@ import { render, fireEvent } from 'tests/utils/web'
 import { LoggedOutHeader } from './LoggedOutHeader'
 
 describe('LoggedOutHeader', () => {
-  it('should navigate to the SignupForm page', () => {
+  it('should navigate to the SignupForm page', async () => {
     const { getByTestId } = render(<LoggedOutHeader />)
 
     const signupButton = getByTestId("S'inscrire")
 
-    fireEvent.click(signupButton)
+    await fireEvent.click(signupButton)
 
     expect(analytics.logProfilSignUp).toBeCalled()
     expect(navigate).toBeCalledWith('SignupForm', { preventCancellation: true })
   })
-  it('should navigate to the login page', () => {
+  it('should navigate to the login page', async () => {
     const { getByTestId } = render(<LoggedOutHeader />)
 
     const connectButton = getByTestId('Connecte-toi')
-    fireEvent.click(connectButton)
+    await fireEvent.click(connectButton)
 
     expect(navigate).toBeCalledWith('Login', { preventCancellation: true })
   })

--- a/src/features/search/atoms/Buttons/__tests__/Filter.native.test.tsx
+++ b/src/features/search/atoms/Buttons/__tests__/Filter.native.test.tsx
@@ -19,9 +19,9 @@ describe('Filter component', () => {
     expect(toJSON()).toMatchSnapshot()
   })
 
-  it('should navigate to Filter page on pressing', () => {
+  it('should navigate to Filter page on pressing', async () => {
     const { getByTestId } = render(<Filter />)
-    fireEvent.press(getByTestId('FilterButton'))
+    await fireEvent.press(getByTestId('FilterButton'))
     expect(navigate).toHaveBeenCalledWith('SearchFilter', undefined)
   })
 })

--- a/src/features/search/atoms/Buttons/__tests__/Filter.web.test.tsx
+++ b/src/features/search/atoms/Buttons/__tests__/Filter.web.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import waitForExpect from 'wait-for-expect'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 import { initialSearchState } from 'features/search/pages/reducer'
@@ -25,9 +26,11 @@ describe('Filter component', () => {
     expect(renderAPI).toMatchSnapshot()
   })
 
-  it('should navigate to Filter page on pressing', () => {
+  it('should navigate to Filter page on pressing', async () => {
     const { getByTestId } = render(<Filter />)
     fireEvent.click(getByTestId('FilterButton'))
-    expect(navigate).toHaveBeenCalledWith('SearchFilter', undefined)
+    await waitForExpect(() => {
+      expect(navigate).toHaveBeenCalledWith('SearchFilter', undefined)
+    })
   })
 })

--- a/src/features/search/atoms/__tests__/Hit.native.test.tsx
+++ b/src/features/search/atoms/__tests__/Hit.native.test.tsx
@@ -26,10 +26,10 @@ jest.mock('features/search/pages/SearchWrapper', () => ({
 }))
 
 describe('Hit component', () => {
-  it('should navigate to the offer when clicking on the hit', () => {
+  it('should navigate to the offer when clicking on the hit', async () => {
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
     const { getByTestId } = render(reactQueryProviderHOC(<Hit hit={hit} query="" />))
-    fireEvent.press(getByTestId('offerHit'))
+    await fireEvent.press(getByTestId('offerHit'))
     expect(analytics.logConsultOffer).toBeCalledTimes(1)
     expect(analytics.logConsultOffer).toHaveBeenCalledWith({
       offerId,

--- a/src/features/venue/atoms/__tests__/VenueOfferTile.native.test.tsx
+++ b/src/features/venue/atoms/__tests__/VenueOfferTile.native.test.tsx
@@ -41,7 +41,7 @@ describe('VenueOfferTile component', () => {
   it('should navigate to the offer when clicking on the image', async () => {
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
     const { getByTestId } = render(reactQueryProviderHOC(<VenueOfferTile {...props} />))
-    fireEvent.press(getByTestId('tileImage'))
+    await fireEvent.press(getByTestId('tileImage'))
     expect(navigate).toHaveBeenCalledWith('Offer', {
       id: offerId,
       from: 'venue',

--- a/src/features/venue/atoms/__tests__/VenueOfferTile.web.test.tsx
+++ b/src/features/venue/atoms/__tests__/VenueOfferTile.web.test.tsx
@@ -43,7 +43,7 @@ describe('VenueOfferTile component', () => {
   it('should navigate to the offer when clicking on the image', async () => {
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
     const { getByTestId } = render(reactQueryProviderHOC(<VenueOfferTile {...props} />))
-    fireEvent.click(getByTestId('categoryImageCaption'))
+    await fireEvent.click(getByTestId('categoryImageCaption'))
     expect(navigate).toHaveBeenCalledWith('Offer', {
       id: offerId,
       from: 'venue',

--- a/src/features/venue/components/__tests__/VenueOffers.native.test.tsx
+++ b/src/features/venue/components/__tests__/VenueOffers.native.test.tsx
@@ -70,9 +70,9 @@ describe('<VenueOffers />', () => {
     expect(queryByText('En voir plus')).toBeFalsy()
   })
 
-  it(`should set search state when clicking "En voir plus" button`, () => {
+  it(`should set search state when clicking "En voir plus" button`, async () => {
     const { getByText } = render(<VenueOffers venueId={venueId} />)
-    fireEvent.press(getByText('En voir plus'))
+    await fireEvent.press(getByText('En voir plus'))
     expect(navigate).toBeCalledWith('TabNavigator', {
       params: {
         ...defaultParams,

--- a/src/features/venue/components/__tests__/VenueOffers.web.test.tsx
+++ b/src/features/venue/components/__tests__/VenueOffers.web.test.tsx
@@ -71,9 +71,9 @@ describe('<VenueOffers />', () => {
     expect(queryByText('En voir plus')).toBeFalsy()
   })
 
-  it(`should set search state when clicking "En voir plus" button`, () => {
+  it(`should set search state when clicking "En voir plus" button`, async () => {
     const { getByText } = render(<VenueOffers venueId={venueId} />)
-    fireEvent.click(getByText('En voir plus'))
+    await fireEvent.click(getByText('En voir plus'))
     expect(navigate).toBeCalledWith('TabNavigator', {
       params: {
         ...defaultParams,
@@ -91,15 +91,15 @@ describe('<VenueOffers />', () => {
     })
   })
 
-  it(`should log analytics event VenueSeeMoreClicked when clicking "En voir plus" button`, () => {
+  it(`should log analytics event VenueSeeMoreClicked when clicking "En voir plus" button`, async () => {
     const { getByText } = render(<VenueOffers venueId={venueId} />)
-    fireEvent.click(getByText('En voir plus'))
+    await fireEvent.click(getByText('En voir plus'))
     expect(analytics.logVenueSeeMoreClicked).toHaveBeenNthCalledWith(1, venueId)
   })
 
-  it(`should log analytics event VenueSeeAllOffersClicked when clicking "Voir toutes les offres" button`, () => {
+  it(`should log analytics event VenueSeeAllOffersClicked when clicking "Voir toutes les offres" button`, async () => {
     const { getByText } = render(<VenueOffers venueId={venueId} />)
-    fireEvent.click(getByText('Voir toutes les offres'))
+    await fireEvent.click(getByText('Voir toutes les offres'))
     expect(analytics.logVenueSeeAllOffersClicked).toHaveBeenNthCalledWith(1, venueId)
   })
 })

--- a/src/libs/queryKeys.ts
+++ b/src/libs/queryKeys.ts
@@ -1,6 +1,7 @@
 export enum QueryKeys {
   ADDRESSES = 'addresses',
   ACCOUNT_SUSPENSION_DATE = 'accountSuspensionDate',
+  ACCOUNT_SUSPENSION_STATUS = 'accountSuspensionStatus',
   HOME_MODULE = 'homeModule',
   HOME_VENUES_MODULE = 'homeVenuesModule',
   BOOKINGS = 'bookings',

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -29,7 +29,11 @@ export const server = setupServer(
     (_req, res, ctx) => {
       return res(
         ctx.status(200),
-        ctx.json({ accessToken: 'access_token', refreshToken: 'refresh_token' })
+        ctx.json({
+          accessToken: 'access_token',
+          refreshToken: 'refresh_token',
+          isActive: true as boolean,
+        })
       )
     }
   ),

--- a/src/ui/components/touchableLink/TouchableLink.tsx
+++ b/src/ui/components/touchableLink/TouchableLink.tsx
@@ -66,13 +66,13 @@ export function TouchableLink<T extends ElementType = ElementType>({
     }
   }
 
-  function onClick(event: GestureResponderEvent) {
+  async function onClick(event: GestureResponderEvent) {
     Platform.OS === 'web' && event?.preventDefault()
     if (navigateBeforeOnPress) {
       handleNavigation()
     }
     if (onPress) {
-      onPress(event)
+      await onPress(event)
     }
     if (!navigateBeforeOnPress) {
       handleNavigation()


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-14577

Ces modifs permettent d'accéder aux écrans SuspendedAccount et FraudulentAccount sans être vraiment suspendu (depuis le cheat menu), et de rediriger un utilisateur suspendu vers le bon écran peu importe la page sur laquelle il se trouve

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
