### PR TITLE
(PC-13914) feat(analytics): Log exclusivity module title on click instead of offer id

### DIFF
--- a/__snapshots__/features/home/contentful/processHomepageEntry.test.ts.native-snap
+++ b/__snapshots__/features/home/contentful/processHomepageEntry.test.ts.native-snap
@@ -12,6 +12,7 @@ Array [
     "id": 317,
     "image": "https://images.ctfassets.net/2bg01iqy0isv/2qTXOFUocq1HhgB7Wzl23K/a48ab7bedde13545231c0f843fbcfe10/image__3_.png",
     "moduleId": "KiG6rWuQYhHuGIBXZNeB2",
+    "title": "Exclusitivité du moment",
   },
   Offers {
     "display": Object {

--- a/__snapshots__/features/home/contentful/processHomepageEntry.test.ts.web-snap
+++ b/__snapshots__/features/home/contentful/processHomepageEntry.test.ts.web-snap
@@ -12,6 +12,7 @@ Array [
     "id": 317,
     "image": "https://images.ctfassets.net/2bg01iqy0isv/2qTXOFUocq1HhgB7Wzl23K/a48ab7bedde13545231c0f843fbcfe10/image__3_.png",
     "moduleId": "KiG6rWuQYhHuGIBXZNeB2",
+    "title": "Exclusitivité du moment",
   },
   Offers {
     "display": Object {

--- a/src/features/home/components/ExclusivityModule.tsx
+++ b/src/features/home/components/ExclusivityModule.tsx
@@ -14,6 +14,7 @@ import { MARGIN_DP, LENGTH_XL, RATIO_EXCLU, Spacer, getSpacing } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 
 export const ExclusivityModule = ({
+  title,
   alt,
   image,
   id,
@@ -26,8 +27,8 @@ export const ExclusivityModule = ({
 
   const handlePressExclu = useCallback(() => {
     if (typeof id !== 'number') return
-    analytics.logClickExclusivityBlock(id)
-    analytics.logConsultOffer({ offerId: id, from: 'exclusivity' })
+    analytics.logClickExclusivityBlock(title)
+    analytics.logConsultOffer({ offerId: id, moduleName: title, from: 'exclusivity' })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id])
 

--- a/src/features/home/components/tests/ExclusivityModule.native.test.tsx
+++ b/src/features/home/components/tests/ExclusivityModule.native.test.tsx
@@ -11,6 +11,7 @@ import { ExclusivityModule } from '../ExclusivityModule'
 jest.mock('features/search/utils/useMaxPrice', () => ({ useMaxPrice: jest.fn(() => 300) }))
 
 const props: ExclusivityPane = {
+  title: "Image d'Adèle",
   alt: "Image d'Adèle",
   image: 'https://fr.web.img6.acsta.net/medias/nmedia/18/96/46/01/20468669.jpg',
   id: mockOffer.id,
@@ -47,9 +48,10 @@ describe('ExclusivityModule component', () => {
   it('should log a click event when clicking on the image', () => {
     const { getByTestId } = renderExclusivityModule()
     fireEvent.press(getByTestId('imageExclu'))
-    expect(analytics.logClickExclusivityBlock).toHaveBeenCalledWith(mockOffer.id)
+    expect(analytics.logClickExclusivityBlock).toHaveBeenCalledWith(props.title)
     expect(analytics.logConsultOffer).toHaveBeenCalledWith({
       offerId: mockOffer.id,
+      moduleName: props.title,
       from: 'exclusivity',
     })
   })

--- a/src/features/home/components/tests/ExclusivityModule.web.test.tsx
+++ b/src/features/home/components/tests/ExclusivityModule.web.test.tsx
@@ -12,6 +12,7 @@ jest.mock('features/search/utils/useMaxPrice', () => ({ useMaxPrice: jest.fn(() 
 jest.mock('ui/theme/customFocusOutline/customFocusOutline')
 
 const props: ExclusivityPane = {
+  title: "Image d'Adèle",
   alt: "Image d'Adèle",
   image: 'https://fr.web.img6.acsta.net/medias/nmedia/18/96/46/01/20468669.jpg',
   id: mockOffer.id,
@@ -48,9 +49,10 @@ describe('ExclusivityModule component', () => {
   it('should log a click event when clicking on the image', () => {
     const { getByTestId } = renderExclusivityModule()
     fireEvent.click(getByTestId('imageExclu'))
-    expect(analytics.logClickExclusivityBlock).toHaveBeenCalledWith(mockOffer.id)
+    expect(analytics.logClickExclusivityBlock).toHaveBeenCalledWith(props.title)
     expect(analytics.logConsultOffer).toHaveBeenCalledWith({
       offerId: mockOffer.id,
+      moduleName: props.title,
       from: 'exclusivity',
     })
   })

--- a/src/features/home/contentful/moduleTypes.ts
+++ b/src/features/home/contentful/moduleTypes.ts
@@ -63,24 +63,28 @@ export class VenuesModule {
 }
 
 export class ExclusivityPane {
+  title: string
   alt: string
   image: string
   id: number
   moduleId: string
   display?: ExclusivityDisplayParametersFields
   constructor({
+    title,
     alt,
     image,
     id,
     moduleId,
     display,
   }: {
+    title: string
     alt: string
     image: string
     id: number
     moduleId: string
     display?: ExclusivityDisplayParametersFields
   }) {
+    this.title = title
     this.alt = alt
     this.image = image
     this.id = id

--- a/src/features/home/contentful/processHomepageEntry.ts
+++ b/src/features/home/contentful/processHomepageEntry.ts
@@ -58,13 +58,13 @@ const buildExclusivity = (
   fields: ExclusivityFields,
   moduleId: string
 ): ExclusivityPane | undefined => {
-  const { alt, offerId, image, displayParameters } = fields
+  const { title, alt, offerId, image, displayParameters } = fields
   const { fields: display = undefined } = displayParameters || {}
   const id = parseOfferId(offerId)
   if (typeof id !== 'number') return
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return new ExclusivityPane({ alt, image: buildImageUrl(image)!, id, moduleId, display })
+  return new ExclusivityPane({ title, alt, image: buildImageUrl(image)!, id, moduleId, display })
 }
 
 const buildVenuesPlaylist = (fields: VenuesFields, moduleId: string): VenuesModule | undefined => {

--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -66,7 +66,13 @@ const renderModule = ({ item, index }: { item: ProcessedModule; index: number })
 
   if (item instanceof ExclusivityPane)
     return (
-      <ExclusivityModule alt={item.alt} image={item.image} id={item.id} display={item.display} />
+      <ExclusivityModule
+        title={item.title}
+        alt={item.alt}
+        image={item.image}
+        id={item.id}
+        display={item.display}
+      />
     )
 
   if (item instanceof BusinessPane) return <BusinessModule module={item} />

--- a/src/libs/analytics/analytics.ts
+++ b/src/libs/analytics/analytics.ts
@@ -65,8 +65,8 @@ export const analytics = {
   }) => analyticsProvider.logEvent(AnalyticsEvent.CONSULT_OFFER, params),
   logConsultVenue: (params: { venueId: number; from: Referrals }) =>
     analyticsProvider.logEvent(AnalyticsEvent.CONSULT_VENUE, params),
-  logClickExclusivityBlock: (offerId: number) =>
-    analyticsProvider.logEvent(AnalyticsEvent.EXCLUSIVITY_BLOCK_CLICKED, { offerId }),
+  logClickExclusivityBlock: (moduleName: string) =>
+    analyticsProvider.logEvent(AnalyticsEvent.EXCLUSIVITY_BLOCK_CLICKED, { moduleName }),
   logClickSeeMore: (moduleName: string) =>
     analyticsProvider.logEvent(AnalyticsEvent.SEE_MORE_CLICKED, { moduleName }),
   logClickBusinessBlock: (moduleName: string) =>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-13914

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
