### PR TITLE
(PC-15248) feat(AccountSuspension): Logout user when quitting suspension screen (PC-14854)

### DIFF
--- a/src/features/auth/login/Login.native.test.tsx
+++ b/src/features/auth/login/Login.native.test.tsx
@@ -225,7 +225,7 @@ describe('<Login/>', () => {
     fireEvent.changeText(passwordInput, 'mypassword')
 
     fireEvent.press(renderAPI.getByText('Se connecter'))
-    await act(flushAllPromises)
+    await superFlushWithAct()
 
     await waitForExpect(() => {
       expect(navigate).toHaveBeenNthCalledWith(1, 'SuspensionScreen')

--- a/src/features/auth/login/Login.tsx
+++ b/src/features/auth/login/Login.tsx
@@ -93,6 +93,7 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
       }
 
       if (settings?.allowAccountReactivation && !isActive) {
+        setIsLoading(false)
         return navigate('SuspensionScreen')
       }
 

--- a/src/features/auth/suspendedAccount/SuspensionScreen/SuspensionScreen.tsx
+++ b/src/features/auth/suspendedAccount/SuspensionScreen/SuspensionScreen.tsx
@@ -1,7 +1,8 @@
 import { useFocusEffect } from '@react-navigation/native'
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect } from 'react'
 
 import { AccountState } from 'api/gen'
+import { useLogoutRoutine } from 'features/auth/AuthContext'
 import { useAppSettings } from 'features/auth/settings'
 import { FraudulentAccount } from 'features/auth/suspendedAccount/FraudulentAccount/FraudulentAccount'
 import { SuspendedAccount } from 'features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount'
@@ -13,6 +14,7 @@ export const SuspensionScreen = () => {
   const { data: settings } = useAppSettings()
   const { data: accountSuspensionStatus, isLoading } = useAccountSuspensionStatus()
   const suspensionStatus = accountSuspensionStatus?.status
+  const signOut = useLogoutRoutine()
 
   useFocusEffect(
     useCallback(() => {
@@ -27,6 +29,12 @@ export const SuspensionScreen = () => {
       }
     }, [settings, suspensionStatus])
   )
+
+  useEffect(() => {
+    return () => {
+      signOut()
+    }
+  }, [signOut])
 
   if (isLoading) {
     return <LoadingPage />

--- a/src/features/auth/suspendedAccount/SuspensionScreen/tests/SuspensionScreen.test.tsx
+++ b/src/features/auth/suspendedAccount/SuspensionScreen/tests/SuspensionScreen.test.tsx
@@ -24,7 +24,10 @@ jest.mock('features/auth/settings', () => ({
     data: mockSettings,
   })),
 }))
-jest.mock('features/auth/AuthContext')
+const mockSignOut = jest.fn()
+jest.mock('features/auth/AuthContext', () => ({
+  useLogoutRoutine: jest.fn(() => mockSignOut.mockResolvedValueOnce(jest.fn())),
+}))
 
 describe('<SuspensionsScreen />', () => {
   it('should display SuspendedAccount component if account is suspended upon user request', async () => {
@@ -45,6 +48,15 @@ describe('<SuspensionsScreen />', () => {
 
     await waitForExpect(() => {
       expect(navigateToHome).toBeCalled()
+    })
+  })
+
+  it('should call sign out function on component unmount', async () => {
+    const { unmount } = render(<SuspensionScreen />)
+
+    unmount()
+    await waitForExpect(() => {
+      expect(mockSignOut).toBeCalled()
     })
   })
 


### PR DESCRIPTION
Link to JIRA ticket: 
https://passculture.atlassian.net/browse/PC-15248
https://passculture.atlassian.net/browse/PC-14854

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **github dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up to date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
