### PR TITLE
(PC-15261) feat(header): hide QuickAccess button if no tabNav or Nav

### DIFF
--- a/src/features/navigation/RootNavigator/RootNavigator.tsx
+++ b/src/features/navigation/RootNavigator/RootNavigator.tsx
@@ -4,6 +4,7 @@ import { useTheme } from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
 
 import { PrivacyPolicy } from 'features/firstLogin/PrivacyPolicy/PrivacyPolicy'
+import { useCurrentRoute } from 'features/navigation/helpers'
 import { AccessibleTabBar } from 'features/navigation/RootNavigator/Header/AccessibleTabBar'
 import { NAVIGATOR_SCREEN_OPTIONS } from 'features/navigation/RootNavigator/navigationOptions'
 import { RootScreenNames } from 'features/navigation/RootNavigator/types'
@@ -40,16 +41,19 @@ export const RootNavigator: React.ComponentType = () => {
 
   const initialScreen = useInitialScreen()
 
+  const currentRoute = useCurrentRoute()
+  const showHeaderQuickAccess = currentRoute && currentRoute.name === 'TabNavigator'
+  const headerWithQuickAccess = showHeaderQuickAccess ? (
+    <QuickAccess href={`#${tabBarId}`} title={t`Accéder au menu de navigation`} />
+  ) : null
+
   if (!initialScreen) {
     return <LoadingPage />
   }
+
   return (
     <TabNavigationStateProvider>
-      {showTabBar ? (
-        <QuickAccess href={`#${tabBarId}`} title={t`Accéder au menu de navigation`} />
-      ) : (
-        <Header mainId={mainId} />
-      )}
+      {showTabBar ? headerWithQuickAccess : <Header mainId={mainId} />}
       <Main id={mainId}>
         <RootStackNavigator initialRouteName={initialScreen} />
       </Main>

--- a/src/features/navigation/__tests__/RootNavigator.native.test.tsx
+++ b/src/features/navigation/__tests__/RootNavigator.native.test.tsx
@@ -27,6 +27,10 @@ jest.mock('features/navigation/RootNavigator/useInitialScreenConfig', () => ({
   useInitialScreen: () => 'TabNavigator',
 }))
 
+jest.mock('features/navigation/helpers', () => ({
+  useCurrentRoute: () => ({ name: 'TabNavigator', key: 'key' }),
+}))
+
 jest.mock('libs/splashscreen')
 const mockUseSplashScreenContext = mocked(useSplashScreenContext)
 
@@ -62,6 +66,18 @@ describe('<RootNavigator />', () => {
       expect(privacyPolicyTitle).toBeTruthy()
     })
     renderAPI.unmount()
+  })
+
+  it('should not display quick access button in native', async () => {
+    // eslint-disable-next-line local-rules/independant-mocks
+    mockUseSplashScreenContext.mockReturnValue({ isSplashScreenHidden: true })
+
+    const renderAPI = await renderRootNavigator()
+    const quickAccessButton = renderAPI.queryByText('Accéder au menu de navigation')
+
+    await waitForExpect(() => {
+      expect(quickAccessButton).toBeNull()
+    })
   })
 })
 

--- a/src/features/navigation/__tests__/RootNavigator.web.test.tsx
+++ b/src/features/navigation/__tests__/RootNavigator.web.test.tsx
@@ -36,10 +36,7 @@ jest.mock('libs/splashscreen')
 const mockUseSplashScreenContext = mocked(useSplashScreenContext)
 
 // eslint-disable-next-line local-rules/no-allow-console
-allowConsole({
-  warn: true,
-  error: true,
-})
+allowConsole({ error: true })
 
 describe('<RootNavigator />', () => {
   beforeEach(() => {
@@ -72,6 +69,32 @@ describe('<RootNavigator />', () => {
     })
     renderAPI.unmount()
   })
+
+  it('should display quick access button if show tabBar and current route is TabNavigator', async () => {
+    // eslint-disable-next-line local-rules/independant-mocks
+    mockUseSplashScreenContext.mockReturnValue({ isSplashScreenHidden: true })
+
+    const renderAPI = await renderRootNavigator()
+    const quickAccessButton = renderAPI.queryByText('Accéder au menu de navigation')
+
+    await waitForExpect(() => {
+      expect(quickAccessButton).toBeTruthy()
+    })
+  })
+
+  it('should not display quick access button if current route is not TabNavigator', async () => {
+    // eslint-disable-next-line local-rules/independant-mocks
+    mockUseSplashScreenContext.mockReturnValue({ isSplashScreenHidden: true })
+    // eslint-disable-next-line local-rules/independant-mocks
+    mockUseCurrentRoute.mockReturnValue({ name: 'Offer', key: 'key' })
+
+    const renderAPI = await renderRootNavigator()
+    const quickAccessButton = renderAPI.queryByText('Accéder au menu de navigation')
+
+    await waitForExpect(() => {
+      expect(quickAccessButton).toBeNull()
+    })
+  })
 })
 
 describe('ForceUpdate display logic', () => {
@@ -81,6 +104,8 @@ describe('ForceUpdate display logic', () => {
 
   it('should display force update page when global variable is set', async () => {
     await storage.saveObject('has_accepted_cookie', false)
+    // eslint-disable-next-line local-rules/independant-mocks
+    mockUseCurrentRoute.mockReturnValue({ name: 'TabNavigator', key: 'key' })
     mockedUseMustUpdateApp.mockReturnValueOnce(true)
 
     const rootNavigator = await renderRootNavigator()


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-15261

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md