### PR TITLE
(PC-15631) fix(AccountReactivation): Invalidate booking and favorite queries on account reactivation

### DIFF
--- a/src/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.native.test.tsx
+++ b/src/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.native.test.tsx
@@ -4,9 +4,9 @@ import { mocked } from 'ts-jest/utils'
 import waitForExpect from 'wait-for-expect'
 
 import { navigate } from '__mocks__/@react-navigation/native'
+import { queriesToInvalidateOnUnsuspend } from 'features/auth/suspendedAccount/SuspendedAccount/useAccountUnsuspend'
 import { navigateToHome, navigateToHomeConfig } from 'features/navigation/helpers'
 import { analytics } from 'libs/analytics'
-import { QueryKeys } from 'libs/queryKeys'
 import { fireEvent, render, useMutationFactory } from 'tests/utils'
 import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
 import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
@@ -63,8 +63,9 @@ describe('<SuspendedAccount />', () => {
 
     useMutationCallbacks.onSuccess()
     await waitForExpect(() => {
-      expect(queryClient.invalidateQueries).toHaveBeenCalledWith(QueryKeys.USER_PROFILE)
-      expect(queryClient.invalidateQueries).toHaveBeenCalledWith(QueryKeys.NEXT_SUBSCRIPTION_STEP)
+      queriesToInvalidateOnUnsuspend.forEach((queryKey) =>
+        expect(queryClient.invalidateQueries).toHaveBeenCalledWith(queryKey)
+      )
       expect(navigate).toHaveBeenCalledWith('AccountReactivationSuccess')
     })
   })

--- a/src/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.web.test.tsx
+++ b/src/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.web.test.tsx
@@ -4,9 +4,9 @@ import { mocked } from 'ts-jest/utils'
 import waitForExpect from 'wait-for-expect'
 
 import { navigate } from '__mocks__/@react-navigation/native'
+import { queriesToInvalidateOnUnsuspend } from 'features/auth/suspendedAccount/SuspendedAccount/useAccountUnsuspend'
 import { navigateToHome, navigateToHomeConfig } from 'features/navigation/helpers'
 import { analytics } from 'libs/analytics'
-import { QueryKeys } from 'libs/queryKeys'
 import { fireEvent, render, useMutationFactory } from 'tests/utils/web'
 import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
 import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
@@ -63,8 +63,9 @@ describe('<SuspendedAccount />', () => {
 
     useMutationCallbacks.onSuccess()
     await waitForExpect(() => {
-      expect(queryClient.invalidateQueries).toHaveBeenCalledWith(QueryKeys.USER_PROFILE)
-      expect(queryClient.invalidateQueries).toHaveBeenCalledWith(QueryKeys.NEXT_SUBSCRIPTION_STEP)
+      queriesToInvalidateOnUnsuspend.forEach((queryKey) =>
+        expect(queryClient.invalidateQueries).toHaveBeenCalledWith(queryKey)
+      )
       expect(navigate).toHaveBeenCalledWith('AccountReactivationSuccess')
     })
   })

--- a/src/features/auth/suspendedAccount/SuspendedAccount/useAccountUnsuspend.ts
+++ b/src/features/auth/suspendedAccount/SuspendedAccount/useAccountUnsuspend.ts
@@ -8,10 +8,17 @@ export function useAccountUnsuspend(onSuccess: () => void, onError: (error: unkn
 
   return useMutation(() => api.postnativev1accountunsuspend(), {
     onSuccess: () => {
-      queryClient.invalidateQueries(QueryKeys.USER_PROFILE)
-      queryClient.invalidateQueries(QueryKeys.NEXT_SUBSCRIPTION_STEP)
+      queriesToInvalidateOnUnsuspend.forEach((queryKey) => queryClient.invalidateQueries(queryKey))
       onSuccess()
     },
     onError,
   })
 }
+
+export const queriesToInvalidateOnUnsuspend: QueryKeys[] = [
+  QueryKeys.USER_PROFILE,
+  QueryKeys.NEXT_SUBSCRIPTION_STEP,
+  QueryKeys.FAVORITES,
+  QueryKeys.FAVORITES_COUNT,
+  QueryKeys.BOOKINGS,
+]


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-15631

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **GitHub dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up-to-date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
| https://user-images.githubusercontent.com/46637324/173512932-a71c6af5-7432-4706-98d5-56c9fa7cfdba.mp4 |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
