### PR TITLE
(PC-15705) fix(BicolorBrokenConnection): remove BrokenConnection icon…

### DIFF
--- a/src/features/cheatcodes/pages/AppComponents/illustrationsExports.ts
+++ b/src/features/cheatcodes/pages/AppComponents/illustrationsExports.ts
@@ -1,5 +1,4 @@
 import { BicolorBrokenConnection } from 'ui/svg/BicolorBrokenConnection'
-import { BrokenConnection } from 'ui/svg/BicolorBrokenConnection'
 import { BicolorCircledCheck } from 'ui/svg/icons/BicolorCircledCheck'
 import { BicolorEmailSent } from 'ui/svg/icons/BicolorEmailSent'
 import { BicolorError } from 'ui/svg/icons/BicolorError'
@@ -37,7 +36,6 @@ export const BicolorIllustrations = {
 }
 
 export const UniqueColorIllustrations = {
-  BrokenConnection,
   BirthdayCake,
   CalendarIllustration,
   EmailSent,

--- a/src/features/errors/pages/AsyncErrorBoundary.tsx
+++ b/src/features/errors/pages/AsyncErrorBoundary.tsx
@@ -13,7 +13,7 @@ import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { GenericErrorPage } from 'ui/components/GenericErrorPage'
 import { Touchable } from 'ui/components/touchable/Touchable'
-import { BrokenConnection } from 'ui/svg/BicolorBrokenConnection'
+import { BicolorBrokenConnection } from 'ui/svg/BicolorBrokenConnection'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { getSpacing, Typo } from 'ui/theme'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
@@ -114,3 +114,8 @@ const StyledBody = styled(Typo.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))
+
+const BrokenConnection = styled(BicolorBrokenConnection).attrs(({ theme }) => ({
+  color: theme.colors.white,
+  color2: theme.colors.white,
+}))``

--- a/src/features/home/components/NoContentError.tsx
+++ b/src/features/home/components/NoContentError.tsx
@@ -8,7 +8,7 @@ import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { Helmet } from 'libs/react-helmet/Helmet'
 import { ButtonSecondaryWhite } from 'ui/components/buttons/ButtonSecondaryWhite'
 import { GenericErrorPage } from 'ui/components/GenericErrorPage'
-import { BrokenConnection } from 'ui/svg/BicolorBrokenConnection'
+import { BicolorBrokenConnection } from 'ui/svg/BicolorBrokenConnection'
 import { MagnifyingGlass } from 'ui/svg/icons/MagnifyingGlass'
 import { Typo } from 'ui/theme'
 
@@ -49,3 +49,8 @@ const BodyText = styled(Typo.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))
+
+const BrokenConnection = styled(BicolorBrokenConnection).attrs(({ theme }) => ({
+  color: theme.colors.white,
+  color2: theme.colors.white,
+}))``

--- a/src/ui/svg/BicolorBrokenConnection.tsx
+++ b/src/ui/svg/BicolorBrokenConnection.tsx
@@ -38,9 +38,3 @@ export const BicolorBrokenConnection = styled(BicolorBrokenConnectionSvg).attrs(
     size: size ?? theme.illustrations.sizes.medium,
   })
 )``
-
-export const BrokenConnection = styled(BicolorBrokenConnectionSvg).attrs(({ size, theme }) => ({
-  color: theme.colors.black,
-  color2: theme.colors.black,
-  size: size ?? theme.illustrations.sizes.medium,
-}))``


### PR DESCRIPTION
… and use BicolorBrokenConnection with unique color

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-15705

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Added a **screenshot** for UI tickets.

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |       <img width="1792" alt="Capture d’écran 2022-06-20 à 11 58 42" src="https://user-images.githubusercontent.com/62059034/174579857-7aa9bad4-d909-4901-8eb8-34bd58be87aa.png">  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md