### PR TITLE
(PC-15707) feat(OfflineMode): use not connected template on favorite

### DIFF
--- a/src/features/favorites/pages/Favorites.tsx
+++ b/src/features/favorites/pages/Favorites.tsx
@@ -5,12 +5,19 @@ import styled from 'styled-components/native'
 import { useAuthContext } from 'features/auth/AuthContext'
 import { FavoritesResults } from 'features/favorites/components/FavoritesResults'
 import { NotConnectedFavorites } from 'features/favorites/components/NotConnectedFavorites'
+import { OfflinePage } from 'libs/network/OfflinePage'
+import { useNetInfo } from 'libs/network/useNetInfo'
 import SvgPageHeader from 'ui/components/headers/SvgPageHeader'
 
 export const Favorites: React.FC = () => {
+  const netInfo = useNetInfo()
   const { isLoggedIn } = useAuthContext()
 
-  if (!isLoggedIn) return <NotConnectedFavorites />
+  if (!netInfo.isConnected) {
+    return <OfflinePage />
+  } else if (!isLoggedIn) {
+    return <NotConnectedFavorites />
+  }
 
   return (
     <Container>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-15707

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **GitHub dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up-to-date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
