### PR TITLE
(PC-15712) fix(OfflineMode): do not show favorites count when not connected

### DIFF
--- a/src/features/favorites/atoms/BicolorFavoriteCount.tsx
+++ b/src/features/favorites/atoms/BicolorFavoriteCount.tsx
@@ -5,6 +5,7 @@ import styled, { useTheme } from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/AuthContext'
 import { useFavoritesCount } from 'features/favorites/pages/useFavorites'
+import { useNetInfo } from 'libs/network/useNetInfo'
 import { BicolorFavorite } from 'ui/svg/icons/BicolorFavorite'
 import { BicolorFavoriteAuthed } from 'ui/svg/icons/BicolorFavoriteAuthed'
 import { Pastille } from 'ui/svg/icons/Pastille'
@@ -24,11 +25,12 @@ export const BicolorFavoriteCount: React.FC<BicolorIconInterface> = ({
     showTabBar,
     tabBar: { showLabels },
   } = useTheme()
+  const netInfo = useNetInfo()
   const { isLoggedIn } = useAuthContext()
   const { data: favoritesCount } = useFavoritesCount()
   const scale = useScaleFavoritesAnimation(favoritesCount)
 
-  if (!isLoggedIn || typeof favoritesCount === 'undefined') {
+  if (!netInfo.isConnected || !isLoggedIn || typeof favoritesCount === 'undefined') {
     return (
       <BicolorFavorite
         size={size}

--- a/src/features/favorites/atoms/__tests__/BicolorFavoriteCount.web.test.tsx
+++ b/src/features/favorites/atoms/__tests__/BicolorFavoriteCount.web.test.tsx
@@ -5,6 +5,7 @@ import waitForExpect from 'wait-for-expect'
 import { FavoriteResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/AuthContext'
 import { env } from 'libs/environment'
+import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
 import { render } from 'tests/utils/web'
@@ -14,7 +15,12 @@ import { BicolorFavoriteCount } from '../BicolorFavoriteCount'
 jest.mock('features/auth/AuthContext')
 const mockUseAuthContext = useAuthContext as jest.MockedFunction<typeof useAuthContext>
 
+jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
+const mockUseNetInfo = useNetInfoDefault as jest.Mock
+
 describe('BicolorFavoriteCount component', () => {
+  mockUseNetInfo.mockReturnValue({ isConnected: true })
+
   it('should render non connected icon', async () => {
     const { queryByTestId } = await renderBicolorFavoriteCount({ isLoggedIn: false })
     expect(queryByTestId('bicolor-favorite-count')).toBeFalsy()
@@ -46,6 +52,12 @@ describe('BicolorFavoriteCount component', () => {
     await waitForExpect(() => {
       expect(getByText('0')).toBeTruthy()
     })
+  })
+
+  it('should not show nbFavorites within badge when offline', async () => {
+    mockUseNetInfo.mockReturnValueOnce({ isConnected: false })
+    const renderAPI = await renderBicolorFavoriteCount({ isLoggedIn: true, count: 10 })
+    expect(renderAPI.queryByTestId('bicolor-favorite-count')).toBeFalsy()
   })
 })
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-15712

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **GitHub dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up-to-date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
