### PR TITLE
(PC-15284) fix(SignupEmailValidation): use replace instead of navigate to avoid navigation persistence

### DIFF
--- a/src/features/auth/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.tsx
+++ b/src/features/auth/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.tsx
@@ -15,12 +15,13 @@ import { useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 export function AfterSignupEmailValidationBuffer() {
   const { showInfoSnackBar } = useSnackBarContext()
 
-  const { navigate } = useNavigation<UseNavigationType>()
-  const delayedNavigate: typeof navigate = (...args: Parameters<typeof navigate>) => {
+  const { replace } = useNavigation<UseNavigationType>()
+  const delayedReplace: typeof replace = (...args: Parameters<typeof replace>) => {
     setTimeout(() => {
-      navigate(...args)
+      replace(...args)
     }, 2000)
   }
+
   const { params } = useRoute<UseRouteType<'AfterSignupEmailValidationBuffer'>>()
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -35,7 +36,7 @@ export function AfterSignupEmailValidationBuffer() {
 
   function beforeEmailValidation() {
     if (isTimestampExpired(params.expiration_timestamp)) {
-      delayedNavigate('SignupConfirmationExpiredLink', { email: params.email })
+      delayedReplace('SignupConfirmationExpiredLink', { email: params.email })
       return
     }
     validateEmail({
@@ -53,24 +54,24 @@ export function AfterSignupEmailValidationBuffer() {
       const user = await api.getnativev1me()
 
       if (user.isEligibleForBeneficiaryUpgrade) {
-        delayedNavigate('VerifyEligibility')
+        delayedReplace('VerifyEligibility')
         return
       }
       if (user.eligibilityStartDatetime && new Date(user.eligibilityStartDatetime) >= new Date()) {
-        delayedNavigate('NotYetUnderageEligibility', {
+        delayedReplace('NotYetUnderageEligibility', {
           eligibilityStartDatetime: user.eligibilityStartDatetime.toString(),
         })
         return
       }
-      delayedNavigate('AccountCreated')
+      delayedReplace('AccountCreated')
     } catch {
-      delayedNavigate('AccountCreated')
+      delayedReplace('AccountCreated')
     }
   }
 
   function onEmailValidationFailure() {
     showInfoSnackBar({ message: t`Ce lien de validation n'est plus valide` })
-    delayedNavigate(...homeNavConfig)
+    delayedReplace(...homeNavConfig)
   }
 
   return <LoadingPage />

--- a/src/features/auth/signup/AfterSignupEmailValidationBuffer/tests/AfterSignupEmailValidationBuffer.native.test.tsx
+++ b/src/features/auth/signup/AfterSignupEmailValidationBuffer/tests/AfterSignupEmailValidationBuffer.native.test.tsx
@@ -2,7 +2,7 @@ import mockdate from 'mockdate'
 import { rest } from 'msw'
 import React from 'react'
 
-import { navigate, useRoute } from '__mocks__/@react-navigation/native'
+import { navigate, replace, useRoute } from '__mocks__/@react-navigation/native'
 import { UserProfileResponse } from 'api/gen'
 import { homeNavConfig } from 'features/navigation/TabBar/helpers'
 import * as datesLib from 'libs/dates'
@@ -67,8 +67,8 @@ describe('<AfterSignupEmailValidationBuffer />', () => {
 
       await waitFor(() => {
         expect(loginRoutine).toBeCalledTimes(1)
-        expect(navigate).toBeCalledTimes(1)
-        expect(navigate).toHaveBeenCalledWith('AccountCreated')
+        expect(replace).toBeCalledTimes(1)
+        expect(replace).toHaveBeenCalledWith('AccountCreated')
       })
       loginRoutine.mockRestore()
     })
@@ -92,8 +92,8 @@ describe('<AfterSignupEmailValidationBuffer />', () => {
 
       await waitFor(() => {
         expect(loginRoutine).toBeCalledTimes(1)
-        expect(navigate).toBeCalledTimes(1)
-        expect(navigate).toHaveBeenCalledWith('VerifyEligibility')
+        expect(replace).toBeCalledTimes(1)
+        expect(replace).toHaveBeenCalledWith('VerifyEligibility')
       })
       loginRoutine.mockRestore()
     })
@@ -114,7 +114,7 @@ describe('<AfterSignupEmailValidationBuffer />', () => {
       renderPage()
 
       await waitFor(() => {
-        expect(navigate).toHaveBeenCalledWith('AccountCreated')
+        expect(replace).toHaveBeenCalledWith('AccountCreated')
       })
     })
 
@@ -135,7 +135,7 @@ describe('<AfterSignupEmailValidationBuffer />', () => {
       renderPage()
 
       await waitFor(() => {
-        expect(navigate).toHaveBeenCalledWith('NotYetUnderageEligibility', {
+        expect(replace).toHaveBeenCalledWith('NotYetUnderageEligibility', {
           eligibilityStartDatetime: '2021-12-01T00:00:00Z',
         })
       })
@@ -157,8 +157,8 @@ describe('<AfterSignupEmailValidationBuffer />', () => {
         expect(mockShowInfoSnackBar).toHaveBeenCalledWith({
           message: "Ce lien de validation n'est plus valide",
         })
-        expect(navigate).toBeCalledTimes(1)
-        expect(navigate).toHaveBeenCalledWith(...homeNavConfig)
+        expect(replace).toBeCalledTimes(1)
+        expect(replace).toHaveBeenCalledWith(...homeNavConfig)
       })
     })
   })
@@ -170,8 +170,8 @@ describe('<AfterSignupEmailValidationBuffer />', () => {
       renderPage()
 
       await waitFor(() => {
-        expect(navigate).toBeCalledTimes(1)
-        expect(navigate).toHaveBeenCalledWith('SignupConfirmationExpiredLink', {
+        expect(replace).toBeCalledTimes(1)
+        expect(replace).toHaveBeenCalledWith('SignupConfirmationExpiredLink', {
           email: 'john@wick.com',
         })
       })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-15284

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **GitHub dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up-to-date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
