### PR TITLE
(PC-15797) fix(AccountReactivation): use replace instead of navigate to redirect to success screen

### DIFF
--- a/src/features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount.tsx
+++ b/src/features/auth/suspendedAccount/SuspendedAccount/SuspendedAccount.tsx
@@ -27,14 +27,14 @@ const addDaysToDate = (date: Date, days: number) => {
 }
 
 export const SuspendedAccount = () => {
-  const { navigate } = useNavigation<UseNavigationType>()
+  const { replace } = useNavigation<UseNavigationType>()
   const { data: settings } = useAppSettings()
   const { data: accountSuspensionDate } = useAccountSuspensionDate()
   const signOut = useLogoutRoutine()
   const { showErrorSnackBar } = useSnackBarContext()
 
   function onAccountUnsuspendSuccess() {
-    navigate('AccountReactivationSuccess')
+    replace('AccountReactivationSuccess')
   }
 
   function onAccountUnsuspendFailure() {

--- a/src/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.native.test.tsx
+++ b/src/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.native.test.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from 'react-query'
 import { mocked } from 'ts-jest/utils'
 import waitForExpect from 'wait-for-expect'
 
-import { navigate } from '__mocks__/@react-navigation/native'
+import { navigate, replace } from '__mocks__/@react-navigation/native'
 import { queriesToInvalidateOnUnsuspend } from 'features/auth/suspendedAccount/SuspendedAccount/useAccountUnsuspend'
 import { navigateToHome, navigateToHomeConfig } from 'features/navigation/helpers'
 import { analytics } from 'libs/analytics'
@@ -66,7 +66,7 @@ describe('<SuspendedAccount />', () => {
       queriesToInvalidateOnUnsuspend.forEach((queryKey) =>
         expect(queryClient.invalidateQueries).toHaveBeenCalledWith(queryKey)
       )
-      expect(navigate).toHaveBeenCalledWith('AccountReactivationSuccess')
+      expect(replace).toHaveBeenCalledWith('AccountReactivationSuccess')
     })
   })
 

--- a/src/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.web.test.tsx
+++ b/src/features/auth/suspendedAccount/SuspendedAccount/tests/SuspendedAccount.web.test.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from 'react-query'
 import { mocked } from 'ts-jest/utils'
 import waitForExpect from 'wait-for-expect'
 
-import { navigate } from '__mocks__/@react-navigation/native'
+import { navigate, replace } from '__mocks__/@react-navigation/native'
 import { queriesToInvalidateOnUnsuspend } from 'features/auth/suspendedAccount/SuspendedAccount/useAccountUnsuspend'
 import { navigateToHome, navigateToHomeConfig } from 'features/navigation/helpers'
 import { analytics } from 'libs/analytics'
@@ -66,7 +66,7 @@ describe('<SuspendedAccount />', () => {
       queriesToInvalidateOnUnsuspend.forEach((queryKey) =>
         expect(queryClient.invalidateQueries).toHaveBeenCalledWith(queryKey)
       )
-      expect(navigate).toHaveBeenCalledWith('AccountReactivationSuccess')
+      expect(replace).toHaveBeenCalledWith('AccountReactivationSuccess')
     })
   })
 

--- a/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.tsx
+++ b/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.tsx
@@ -23,13 +23,13 @@ import { Li } from 'ui/web/list/Li'
 import { VerticalUl } from 'ui/web/list/Ul'
 
 export function ConfirmDeleteProfile() {
-  const { navigate } = useNavigation<UseNavigationType>()
+  const { replace } = useNavigation<UseNavigationType>()
 
   const signOut = useLogoutRoutine()
   const { showErrorSnackBar } = useSnackBarContext()
 
   async function onAccountSuspendSuccess() {
-    navigate('DeleteProfileSuccess')
+    replace('DeleteProfileSuccess')
     await signOut()
   }
 

--- a/src/features/profile/pages/DeleteProfile/__tests__/ConfirmDeleteProfile.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/__tests__/ConfirmDeleteProfile.native.test.tsx
@@ -3,7 +3,7 @@ import { useMutation } from 'react-query'
 import { mocked } from 'ts-jest/utils'
 import waitForExpect from 'wait-for-expect'
 
-import { navigate } from '__mocks__/@react-navigation/native'
+import { replace } from '__mocks__/@react-navigation/native'
 import { mockGoBack } from 'features/navigation/__mocks__/useGoBack'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { analytics } from 'libs/analytics'
@@ -53,8 +53,8 @@ describe('ConfirmDeleteProfile component', () => {
     useMutationCallbacks.onSuccess()
 
     await waitForExpect(() => {
-      expect(navigate).toBeCalledTimes(1)
-      expect(navigate).toHaveBeenCalledWith('DeleteProfileSuccess')
+      expect(replace).toBeCalledTimes(1)
+      expect(replace).toHaveBeenCalledWith('DeleteProfileSuccess')
       expect(mockSignOut).toBeCalled()
     })
   })

--- a/src/features/profile/pages/DeleteProfile/__tests__/ConfirmDeleteProfile.web.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/__tests__/ConfirmDeleteProfile.web.test.tsx
@@ -3,7 +3,7 @@ import { useMutation } from 'react-query'
 import { mocked } from 'ts-jest/utils'
 import waitForExpect from 'wait-for-expect'
 
-import { navigate } from '__mocks__/@react-navigation/native'
+import { replace } from '__mocks__/@react-navigation/native'
 import { mockGoBack } from 'features/navigation/__mocks__/useGoBack'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { analytics } from 'libs/analytics'
@@ -53,8 +53,8 @@ describe('ConfirmDeleteProfile component', () => {
     useMutationCallbacks.onSuccess()
 
     await waitForExpect(() => {
-      expect(navigate).toBeCalledTimes(1)
-      expect(navigate).toHaveBeenCalledWith('DeleteProfileSuccess')
+      expect(replace).toBeCalledTimes(1)
+      expect(replace).toHaveBeenCalledWith('DeleteProfileSuccess')
       expect(mockSignOut).toBeCalled()
     })
   })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-15797

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **GitHub dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up-to-date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
