### PR TITLE
(PC-15471) fix(recommendation): do not fetch endpoint when user is not connected

### DIFF
--- a/src/features/home/api/tests/useAlgoliaRecommendedHits.test.ts
+++ b/src/features/home/api/tests/useAlgoliaRecommendedHits.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import { useAlgoliaRecommendedHits } from 'features/home/api/useAlgoliaRecommendedHits'
+import * as fetchAlgoliaAPI from 'libs/algolia/fetchAlgolia/fetchAlgolia'
+import * as filterAlgoliaHitAPI from 'libs/algolia/fetchAlgolia/transformAlgoliaHit'
+import { mockedAlgoliaResponse } from 'libs/algolia/mockedResponses/mockedAlgoliaResponse'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+
+jest.mock('features/profile/api', () => ({
+  useUserProfileInfo: jest.fn(() => ({ data: { firstName: 'Christophe', lastName: 'Dupont' } })),
+}))
+
+jest.mock('features/auth/settings')
+
+const ids = ['102280', '102272', '102249', '102310']
+describe('useAlgoliaRecommendedHits', () => {
+  const mockFetchAlgoliaHits = jest.fn().mockResolvedValue(mockedAlgoliaResponse.hits)
+  const fetchAlgoliaHitsSpy = jest
+    .spyOn(fetchAlgoliaAPI, 'fetchAlgoliaHits')
+    .mockImplementation(mockFetchAlgoliaHits)
+
+  const filterAlgoliaHitSpy = jest
+    .spyOn(filterAlgoliaHitAPI, 'filterAlgoliaHit')
+    .mockImplementation(jest.fn())
+
+  it('should fetch algolia when ids are provided', async () => {
+    const { waitForNextUpdate } = renderHook(() => useAlgoliaRecommendedHits(ids, 'abcd'), {
+      // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+    await waitForNextUpdate()
+    expect(fetchAlgoliaHitsSpy).toHaveBeenCalledWith(ids, false)
+  })
+
+  it('should filter algolia hits', async () => {
+    const { waitForNextUpdate } = renderHook(() => useAlgoliaRecommendedHits(ids, 'abcd'), {
+      // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+    await waitForNextUpdate()
+    expect(filterAlgoliaHitSpy).toHaveBeenCalledTimes(mockedAlgoliaResponse.hits.length)
+  })
+
+  it('should return undefined when algolia does not return any hit', async () => {
+    jest
+      .spyOn(fetchAlgoliaAPI, 'fetchAlgoliaHits')
+      .mockImplementationOnce(jest.fn().mockResolvedValue(undefined))
+    const { waitForNextUpdate, result } = renderHook(() => useAlgoliaRecommendedHits(ids, 'abcd'), {
+      // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+    await waitForNextUpdate()
+    expect(result.current).toBeUndefined()
+    expect(filterAlgoliaHitSpy).not.toHaveBeenCalled()
+  })
+
+  it('should return undefined when ids are not provided', async () => {
+    const { result } = renderHook(() => useAlgoliaRecommendedHits([], 'abcd'), {
+      // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+    expect(result.current).toBeUndefined()
+  })
+})

--- a/src/features/home/api/tests/useAlgoliaRecommendedHits.test.ts
+++ b/src/features/home/api/tests/useAlgoliaRecommendedHits.test.ts
@@ -42,9 +42,7 @@ describe('useAlgoliaRecommendedHits', () => {
   })
 
   it('should return undefined when algolia does not return any hit', async () => {
-    jest
-      .spyOn(fetchAlgoliaAPI, 'fetchAlgoliaHits')
-      .mockImplementationOnce(jest.fn().mockResolvedValue(undefined))
+    jest.spyOn(fetchAlgoliaAPI, 'fetchAlgoliaHits').mockResolvedValueOnce([])
     const { waitForNextUpdate, result } = renderHook(() => useAlgoliaRecommendedHits(ids, 'abcd'), {
       // eslint-disable-next-line local-rules/no-react-query-provider-hoc
       wrapper: ({ children }) => reactQueryProviderHOC(children),

--- a/src/features/home/api/tests/useHomeRecommendedHits.test.ts
+++ b/src/features/home/api/tests/useHomeRecommendedHits.test.ts
@@ -1,84 +1,63 @@
-import { renderHook, cleanup } from '@testing-library/react-hooks'
-import { rest } from 'msw'
-
-import { RecommendationParametersFields } from 'features/home/contentful'
-import * as AlgoliaModule from 'libs/algolia/fetchAlgolia/fetchAlgolia'
-import { mockedAlgoliaResponse } from 'libs/algolia/mockedResponses/mockedAlgoliaResponse'
-import { env } from 'libs/environment'
-import { queryCache, reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { server } from 'tests/server'
-import { waitFor } from 'tests/utils'
+import { renderHook } from '@testing-library/react-hooks'
+import { UseMutationResult } from 'react-query'
 
 import {
-  useHomeRecommendedHits,
   getRecommendationEndpoint,
   getRecommendationParameters,
-} from '../useHomeRecommendedHits'
+  useHomeRecommendedHits,
+} from 'features/home/api/useHomeRecommendedHits'
+import { RecommendationParametersFields } from 'features/home/contentful'
+import { env } from 'libs/environment'
 
-const mockUserId = 30
-jest.mock('features/profile/api', () => ({
-  useUserProfileInfo: jest.fn(() => ({ data: { id: mockUserId } })),
-}))
-jest.mock('features/auth/settings')
+import * as algoliaRecommendedHitsAPI from '../useAlgoliaRecommendedHits'
+import * as recommendedIdsAPI from '../useHomeRecommendedIdsMutation'
 
-const objectIds = mockedAlgoliaResponse.hits.map(({ objectID }) => objectID)
-
-const fetchHits = jest.fn().mockResolvedValue(mockedAlgoliaResponse.hits)
-jest.spyOn(AlgoliaModule, 'fetchAlgoliaHits').mockImplementation(fetchHits)
-
-const endpoint = getRecommendationEndpoint(mockUserId, null) as string
+const mockUserId = 1234
+const position = {
+  latitude: 6,
+  longitude: 22,
+}
+const mockModuleId = 'abcd'
 
 describe('useHomeRecommendedHits', () => {
-  beforeEach(() => {
-    server.use(
-      rest.post(endpoint, (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json({ playlist_recommended_offers: objectIds }))
-      )
-    )
+  const mutate = jest.fn()
+  jest
+    .spyOn(recommendedIdsAPI, 'useHomeRecommendedIdsMutation')
+    .mockReturnValue({ mutate } as unknown as UseMutationResult<
+      recommendedIdsAPI.RecommendedIdsResponse,
+      unknown,
+      recommendedIdsAPI.RecommendedIdsRequest,
+      unknown
+    >)
+
+  const algoliaSpy = jest
+    .spyOn(algoliaRecommendedHitsAPI, 'useAlgoliaRecommendedHits')
+    .mockImplementation(jest.fn())
+
+  it('should not call recommendation mutation when user is not connected', () => {
+    renderHook(() => useHomeRecommendedHits(undefined, position, mockModuleId))
+    expect(mutate).not.toHaveBeenCalled()
   })
 
-  afterEach(async () => {
-    await cleanup()
+  it('should call recommendation mutation when user is connected', () => {
+    renderHook(() => useHomeRecommendedHits(mockUserId, position, mockModuleId))
+    expect(mutate).toHaveBeenCalled()
   })
 
-  it('should not make any call if there is no recommendation module', async () => {
-    renderHook(() => useHomeRecommendedHits(undefined, null, 'abcd'), {
-      // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-      wrapper: ({ children }) => reactQueryProviderHOC(children),
-    })
-
-    await waitFor(() => {
-      expect(fetchHits).not.toHaveBeenCalled()
-      expect(queryCache.get('recommendationOfferIds')).toBeUndefined()
-      expect(queryCache.get('recommendationHits')).toBeUndefined()
-    })
-  })
-
-  it('calls fetchAlgolia with params and returns data', async () => {
-    const { result } = renderHook(() => useHomeRecommendedHits(mockUserId, null, 'abcd'), {
-      // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-      wrapper: ({ children }) => reactQueryProviderHOC(children),
-    })
-    const isUserUnderage = false
-    await waitFor(() => {
-      expect(result.current).toHaveLength(4)
-      expect(fetchHits).toHaveBeenCalledTimes(1)
-      expect(fetchHits).toHaveBeenCalledWith(objectIds, isUserUnderage)
-    })
+  it('should call algolia hook', () => {
+    renderHook(() => useHomeRecommendedHits(undefined, position, mockModuleId))
+    expect(algoliaSpy).toHaveBeenCalled()
+    renderHook(() => useHomeRecommendedHits(mockUserId, position, mockModuleId))
+    expect(algoliaSpy).toHaveBeenCalled()
   })
 })
 
 describe('getRecommendationEndpoint', () => {
-  it('should return undefined if no user id is provided', () => {
+  it('should return undefined when no user id is provided', () => {
     const endpoint = getRecommendationEndpoint(undefined, null)
     expect(endpoint).toBeUndefined()
   })
-
-  it('should return endpoint with latitude and longitude query params if position is provided', () => {
-    const position = {
-      latitude: 6,
-      longitude: 22,
-    }
+  it('should return endpoint with latitude and longitude query params when position is provided', () => {
     const endpoint = getRecommendationEndpoint(mockUserId, position)
     expect(endpoint).toEqual(
       `${env.RECOMMENDATION_ENDPOINT}/playlist_recommendation/${mockUserId}?token=${env.RECOMMENDATION_TOKEN}&longitude=${position.longitude}&latitude=${position.latitude}`
@@ -92,7 +71,7 @@ describe('getRecommendationParameters', () => {
     expect(result).toEqual({})
   })
 
-  it('should return parameters with mapped categories if provided', () => {
+  it('should return parameters with mapped categories when parameters are provided', () => {
     const parameters: RecommendationParametersFields = {
       title: 'some parameters',
       categories: ['Cinéma', 'Cours, ateliers', 'Livres'],

--- a/src/features/home/api/tests/useHomeRecommendedIdsMutation.test.ts
+++ b/src/features/home/api/tests/useHomeRecommendedIdsMutation.test.ts
@@ -1,0 +1,77 @@
+import { renderHook } from '@testing-library/react-hooks'
+import * as reactQueryAPI from 'react-query'
+
+import { eventMonitoring } from 'libs/monitoring'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+
+import { useHomeRecommendedIdsMutation } from '../useHomeRecommendedIdsMutation'
+
+describe('useHomeRecommendedIdsMutation', () => {
+  const mockFetch = jest.spyOn(global, 'fetch')
+  const mockUseMutation = jest.spyOn(reactQueryAPI, 'useMutation')
+
+  it('should call useMutation', () => {
+    renderHook(() => useHomeRecommendedIdsMutation('http://passculture.reco'), {
+      // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+
+    expect(mockUseMutation).toHaveBeenCalled()
+  })
+
+  it('should call fetch when mutate', async () => {
+    const { result, waitForNextUpdate } = renderHook(
+      () => useHomeRecommendedIdsMutation('http://passculture.reco'),
+      {
+        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+        wrapper: ({ children }) => reactQueryProviderHOC(children),
+      }
+    )
+    result.current.mutate({})
+    await waitForNextUpdate()
+    expect(mockFetch).toHaveBeenCalledWith('http://passculture.reco', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({}),
+    })
+  })
+
+  it('should capture an exception when fetch call fails', async () => {
+    mockFetch.mockRejectedValueOnce('some error')
+    const { result, waitForNextUpdate } = renderHook(
+      () => useHomeRecommendedIdsMutation('http://passculture.reco'),
+      {
+        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+        wrapper: ({ children }) => reactQueryProviderHOC(children),
+      }
+    )
+    result.current.mutate({})
+    await waitForNextUpdate()
+    expect(eventMonitoring.captureException).toHaveBeenCalled()
+  })
+
+  it('should return response body if fetch call succeeds', async () => {
+    const body = { playlist_recommended_offers: ['102280', '102272', '102249', '102310'] }
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(body), {
+        headers: {
+          'content-type': 'application/json',
+        },
+        status: 200,
+      })
+    )
+    const { result, waitForNextUpdate } = renderHook(
+      () => useHomeRecommendedIdsMutation('http://passculture.reco'),
+      {
+        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+        wrapper: ({ children }) => reactQueryProviderHOC(children),
+      }
+    )
+    result.current.mutate({})
+    await waitForNextUpdate()
+    expect(result.current.data).toEqual(body)
+  })
+})

--- a/src/features/home/api/useAlgoliaRecommendedHits.ts
+++ b/src/features/home/api/useAlgoliaRecommendedHits.ts
@@ -25,7 +25,7 @@ export const useAlgoliaRecommendedHits = (
   )
 
   return useMemo(() => {
-    if (!hits) return
+    if (!hits || hits.length === 0) return
 
     return (hits as IncompleteSearchHit[])
       .filter(filterAlgoliaHit)

--- a/src/features/home/api/useAlgoliaRecommendedHits.ts
+++ b/src/features/home/api/useAlgoliaRecommendedHits.ts
@@ -1,0 +1,34 @@
+import { useMemo } from 'react'
+import { useQuery } from 'react-query'
+
+import { useIsUserUnderage } from 'features/profile/utils'
+import {
+  fetchAlgoliaHits,
+  filterAlgoliaHit,
+  useTransformAlgoliaHits,
+} from 'libs/algolia/fetchAlgolia'
+import { QueryKeys } from 'libs/queryKeys'
+import { IncompleteSearchHit, SearchHit } from 'libs/search'
+
+export const useAlgoliaRecommendedHits = (
+  ids: string[],
+  moduleId: string
+): SearchHit[] | undefined => {
+  const isUserUnderage = useIsUserUnderage()
+  const transformHits = useTransformAlgoliaHits()
+
+  const moduleQueryKey = moduleId
+  const { data: hits } = useQuery(
+    [QueryKeys.RECOMMENDATION_HITS, moduleQueryKey],
+    async () => await fetchAlgoliaHits(ids, isUserUnderage),
+    { enabled: ids.length > 0 }
+  )
+
+  return useMemo(() => {
+    if (!hits) return
+
+    return (hits as IncompleteSearchHit[])
+      .filter(filterAlgoliaHit)
+      .map(transformHits) as SearchHit[]
+  }, [hits, transformHits])
+}

--- a/src/features/home/api/useHomeRecommendedIdsMutation.ts
+++ b/src/features/home/api/useHomeRecommendedIdsMutation.ts
@@ -1,0 +1,44 @@
+import { useMutation } from 'react-query'
+
+import { eventMonitoring } from 'libs/monitoring'
+import { QueryKeys } from 'libs/queryKeys'
+
+export interface RecommendedIdsResponse {
+  playlist_recommended_offers: string[]
+}
+
+export interface RecommendedIdsRequest {
+  start_date?: string
+  end_date?: string
+  isEvent?: boolean
+  categories?: string[]
+  price_max?: number
+}
+
+export const useHomeRecommendedIdsMutation = (recommendationUrl: string) => {
+  return useMutation(
+    QueryKeys.RECOMMENDATION_OFFER_IDS,
+    async (parameters: RecommendedIdsRequest) => {
+      try {
+        const response = await fetch(recommendationUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          body: JSON.stringify(parameters),
+        })
+        if (!response.ok) {
+          throw new Error('Failed to fetch recommendation')
+        }
+        const responseBody: RecommendedIdsResponse = await response.json()
+        return responseBody
+      } catch (err) {
+        eventMonitoring.captureException(new Error('Error with recommendation endpoint'), {
+          extra: { url: recommendationUrl },
+        })
+        return { playlist_recommended_offers: [] }
+      }
+    }
+  )
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-15471

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.

## Screenshots

### Avant: on faisait une requête à /undefined au lieu de l'endpoint de recommendation quand l'utilisateur n'est pas connecté
<img width="839" alt="Capture d’écran 2022-06-22 à 18 31 26" src="https://user-images.githubusercontent.com/22886846/175089029-123b6d6f-f28f-4f0a-a5e1-b824f3ad498a.png">

### Maintenant: plus de requête si l'utilisateur n'est pas connecté
<img width="830" alt="Capture d’écran 2022-06-22 à 18 32 28" src="https://user-images.githubusercontent.com/22886846/175089269-47ea1784-0520-473e-923d-0158077671a9.png">

### La requête est toujours bien exécutée si l'utilisateur se connecte
<img width="854" alt="Capture d’écran 2022-06-22 à 18 32 58" src="https://user-images.githubusercontent.com/22886846/175089502-56a64a39-7f9f-4783-87d7-c1c14aa107f8.png">


[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
