### PR TITLE
(PC-15797) fix(AccountSuspension): Use navigate instead of replace in AccountSuspension

### DIFF
--- a/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.tsx
+++ b/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.tsx
@@ -23,13 +23,13 @@ import { Li } from 'ui/web/list/Li'
 import { VerticalUl } from 'ui/web/list/Ul'
 
 export function ConfirmDeleteProfile() {
-  const { replace } = useNavigation<UseNavigationType>()
+  const { navigate } = useNavigation<UseNavigationType>()
 
   const signOut = useLogoutRoutine()
   const { showErrorSnackBar } = useSnackBarContext()
 
   async function onAccountSuspendSuccess() {
-    replace('DeleteProfileSuccess')
+    navigate('DeleteProfileSuccess')
     await signOut()
   }
 

--- a/src/features/profile/pages/DeleteProfile/__tests__/ConfirmDeleteProfile.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/__tests__/ConfirmDeleteProfile.native.test.tsx
@@ -3,7 +3,7 @@ import { useMutation } from 'react-query'
 import { mocked } from 'ts-jest/utils'
 import waitForExpect from 'wait-for-expect'
 
-import { replace } from '__mocks__/@react-navigation/native'
+import { navigate } from '__mocks__/@react-navigation/native'
 import { mockGoBack } from 'features/navigation/__mocks__/useGoBack'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { analytics } from 'libs/analytics'
@@ -53,8 +53,8 @@ describe('ConfirmDeleteProfile component', () => {
     useMutationCallbacks.onSuccess()
 
     await waitForExpect(() => {
-      expect(replace).toBeCalledTimes(1)
-      expect(replace).toHaveBeenCalledWith('DeleteProfileSuccess')
+      expect(navigate).toBeCalledTimes(1)
+      expect(navigate).toHaveBeenCalledWith('DeleteProfileSuccess')
       expect(mockSignOut).toBeCalled()
     })
   })

--- a/src/features/profile/pages/DeleteProfile/__tests__/ConfirmDeleteProfile.web.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/__tests__/ConfirmDeleteProfile.web.test.tsx
@@ -3,7 +3,7 @@ import { useMutation } from 'react-query'
 import { mocked } from 'ts-jest/utils'
 import waitForExpect from 'wait-for-expect'
 
-import { replace } from '__mocks__/@react-navigation/native'
+import { navigate } from '__mocks__/@react-navigation/native'
 import { mockGoBack } from 'features/navigation/__mocks__/useGoBack'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { analytics } from 'libs/analytics'
@@ -53,8 +53,8 @@ describe('ConfirmDeleteProfile component', () => {
     useMutationCallbacks.onSuccess()
 
     await waitForExpect(() => {
-      expect(replace).toBeCalledTimes(1)
-      expect(replace).toHaveBeenCalledWith('DeleteProfileSuccess')
+      expect(navigate).toBeCalledTimes(1)
+      expect(navigate).toHaveBeenCalledWith('DeleteProfileSuccess')
       expect(mockSignOut).toBeCalled()
     })
   })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-15797

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **GitHub dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up-to-date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
