### PR TITLE
(PC-15909) fix(OfflineMode): added offline template on search when not connected

### DIFF
--- a/src/features/search/pages/Search.tsx
+++ b/src/features/search/pages/Search.tsx
@@ -3,11 +3,17 @@ import React from 'react'
 import { useAppSettings } from 'features/auth/settings'
 import { SearchLegacy } from 'features/search/pages/SearchLegacy'
 import { SearchRework } from 'features/search/pages/SearchRework'
+import { OfflinePage } from 'libs/network/OfflinePage'
+import { useNetInfo } from 'libs/network/useNetInfo'
 
 export function Search() {
+  const netInfo = useNetInfo()
   const { data: appSettings } = useAppSettings()
   const appEnableSearchHomepageRework = appSettings?.appEnableSearchHomepageRework ?? false
 
+  if (!netInfo.isConnected) {
+    return <OfflinePage />
+  }
   if (appEnableSearchHomepageRework) {
     return <SearchRework />
   }

--- a/src/features/search/pages/__tests__/Search.native.test.tsx
+++ b/src/features/search/pages/__tests__/Search.native.test.tsx
@@ -5,6 +5,7 @@ import { LocationType } from 'features/search/enums'
 import { initialSearchState } from 'features/search/pages/reducer'
 import { Search } from 'features/search/pages/Search'
 import { SearchState } from 'features/search/types'
+import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
 import { SuggestedVenue } from 'libs/venue'
 import { mockedSuggestedVenues } from 'libs/venue/fixtures/mockedSuggestedVenues'
 import { render, fireEvent } from 'tests/utils'
@@ -68,7 +69,12 @@ jest.mock('@react-navigation/native', () => ({
   useRoute: jest.fn().mockReturnValue({ params: {} }),
 }))
 
+jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
+const mockUseNetInfo = useNetInfoDefault as jest.Mock
+
 describe('Search component', () => {
+  mockUseNetInfo.mockReturnValue({ isConnected: true })
+
   it('should render Search', () => {
     expect(render(<Search />)).toMatchSnapshot()
   })
@@ -80,6 +86,14 @@ describe('Search component', () => {
       payload: {},
     })
     expect(mockDispatch).toBeCalledWith({ type: 'SHOW_RESULTS', payload: true })
+  })
+
+  describe('When offline', () => {
+    it('should display offline page', () => {
+      mockUseNetInfo.mockReturnValueOnce({ isConnected: false })
+      const renderAPI = render(<Search />)
+      expect(renderAPI.queryByText('Pas de réseau internet')).toBeTruthy()
+    })
   })
 
   describe('When rework feature flag is not activated', () => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-15909

Target branch is `PC-15704`

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **GitHub dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up-to-date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
