### PR TITLE
(PC-15708) fix(OfflineMode): show offline template on profil when net connected

### DIFF
--- a/src/features/profile/pages/Profile.native.test.tsx
+++ b/src/features/profile/pages/Profile.native.test.tsx
@@ -17,6 +17,7 @@ import {
   GeoCoordinates,
   GEOLOCATION_USER_ERROR_MESSAGE,
 } from 'libs/geolocation'
+import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
 import { flushAllPromises, render, act, fireEvent, cleanup } from 'tests/utils'
 
 import { Profile } from './Profile'
@@ -88,7 +89,12 @@ jest.mock('features/identityCheck/context/IdentityCheckContextProvider', () => (
   useIdentityCheckContext: () => ({ identification: { processing: false } }),
 }))
 
+jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
+const mockUseNetInfo = useNetInfoDefault as jest.Mock
+
 describe('Profile component', () => {
+  mockUseNetInfo.mockReturnValue({ isConnected: true })
+
   afterEach(() => {
     mockPermissionState = GeolocPermissionState.GRANTED
     mockPosition = DEFAULT_POSITION
@@ -99,6 +105,12 @@ describe('Profile component', () => {
   it('should render correctly', async () => {
     const renderAPI = await renderProfile()
     expect(renderAPI).toMatchSnapshot()
+  })
+
+  it('should render offline page when not connected', async () => {
+    mockUseNetInfo.mockReturnValueOnce({ isConnected: false })
+    const renderAPI = await renderProfile()
+    expect(renderAPI.queryByText('Pas de réseau internet')).toBeTruthy()
   })
 
   describe('user settings section', () => {

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -17,6 +17,8 @@ import { analytics, isCloseToBottom } from 'libs/analytics'
 import { env } from 'libs/environment'
 import { GeolocPermissionState, useGeolocation } from 'libs/geolocation'
 import useFunctionOnce from 'libs/hooks/useFunctionOnce'
+import { OfflinePage } from 'libs/network/OfflinePage'
+import { useNetInfo } from 'libs/network/useNetInfo'
 import { InputError } from 'ui/components/inputs/InputError'
 import { Section } from 'ui/components/Section'
 import { SectionRow } from 'ui/components/SectionRow'
@@ -39,7 +41,7 @@ import Package from '../../../../package.json'
 
 const DEBOUNCE_TOGGLE_DELAY_MS = 5000
 
-export const Profile: React.FC = () => {
+const OnlineProfile: React.FC = () => {
   const { dispatch: favoritesDispatch } = useFavoritesState()
   const { data: user } = useUserProfileInfo()
   const { isLoggedIn } = useAuthContext()
@@ -252,6 +254,14 @@ export const Profile: React.FC = () => {
       </ProfileContainer>
     </ScrollView>
   )
+}
+
+export const Profile: React.FC = () => {
+  const netInfo = useNetInfo()
+  if (!netInfo.isConnected) {
+    return <OfflinePage />
+  }
+  return <OnlineProfile />
 }
 
 const paddingVertical = getSpacing(4)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-15708

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Attached a **ticket number** or **GitHub dev name** for any added TODO / FIXME.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)
- [ ] Made sure translations file is up-to-date (`yarn translations:extract`)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
