### PR TITLE
(PC-15130) fix(search): categories buttons must keep search context

### DIFF
--- a/src/features/search/components/SearchBoxRework.tsx
+++ b/src/features/search/components/SearchBoxRework.tsx
@@ -36,7 +36,7 @@ export const SearchBoxRework: React.FC<Props> = ({
   accessibleHiddenTitle,
 }) => {
   const { navigate } = useNavigation<UseNavigationType>()
-  const { searchState: stagedSearchState } = useStagedSearch()
+  const { searchState: stagedSearchState, dispatch: stagedDispatch } = useStagedSearch()
   const { searchState, dispatch } = useSearch()
   const [query, setQuery] = useState<string>(searchState.query || '')
   const accessibilityDescribedBy = uuidv4()
@@ -55,6 +55,7 @@ export const SearchBoxRework: React.FC<Props> = ({
   const onPressArrowBack = () => {
     setQuery('')
     if (onFocusState) onFocusState(false)
+    stagedDispatch({ type: 'SET_QUERY', payload: '' })
     dispatch({ type: 'SET_QUERY', payload: '' })
     dispatch({ type: 'SHOW_RESULTS', payload: false })
     dispatch({ type: 'INIT' })

--- a/src/features/search/pages/__tests__/useShowResultsForCategory.test.ts
+++ b/src/features/search/pages/__tests__/useShowResultsForCategory.test.ts
@@ -1,13 +1,14 @@
 import { renderHook } from '@testing-library/react-hooks'
 
 import { SearchGroupNameEnum } from 'api/gen'
+import { LocationType } from 'features/search/enums'
 import { initialSearchState } from 'features/search/pages/reducer'
 
 import { useShowResultsForCategory } from '../useShowResultsForCategory'
 
 const mockSearchState = initialSearchState
 const mockDispatch = jest.fn()
-const mockStagedSearchState = initialSearchState
+let mockStagedSearchState = initialSearchState
 const mockStagedDispatch = jest.fn()
 jest.mock('features/search/pages/SearchWrapper', () => ({
   useSearch: () => ({
@@ -21,15 +22,14 @@ jest.mock('features/search/pages/SearchWrapper', () => ({
 }))
 
 describe('useShowResultsForCategory', () => {
-  it('should set category', () => {
-    const { result: resultCallback } = renderHook(useShowResultsForCategory)
-
-    resultCallback.current(SearchGroupNameEnum.SPECTACLE)
-
-    expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'SET_CATEGORY',
-      payload: [SearchGroupNameEnum.SPECTACLE],
-    })
+  beforeEach(() => {
+    mockStagedSearchState = {
+      ...initialSearchState,
+      locationFilter: { locationType: LocationType.EVERYWHERE },
+      priceRange: [0, 300],
+      query: 'Big flo et Oli',
+      offerCategories: [SearchGroupNameEnum.SPECTACLE], // initialize mock data with expected categories because dispatch is also a mock and won't change the mocked state
+    }
   })
 
   it('should set category in staged search', () => {
@@ -43,6 +43,17 @@ describe('useShowResultsForCategory', () => {
     })
   })
 
+  it('should set search state with staged search state and categories', () => {
+    const { result: resultCallback } = renderHook(useShowResultsForCategory)
+
+    resultCallback.current(SearchGroupNameEnum.SPECTACLE)
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'SET_STATE',
+      payload: mockStagedSearchState,
+    })
+  })
+
   it('should show results', () => {
     const { result: resultCallback } = renderHook(useShowResultsForCategory)
 
@@ -51,6 +62,17 @@ describe('useShowResultsForCategory', () => {
     expect(mockDispatch).toHaveBeenCalledWith({
       type: 'SHOW_RESULTS',
       payload: true,
+    })
+  })
+
+  it("should set category in search state after all because state isn't updated when dispatching multiple times", () => {
+    const { result: resultCallback } = renderHook(useShowResultsForCategory)
+
+    resultCallback.current(SearchGroupNameEnum.SPECTACLE)
+
+    expect(mockDispatch).toHaveBeenLastCalledWith({
+      type: 'SET_CATEGORY',
+      payload: [SearchGroupNameEnum.SPECTACLE],
     })
   })
 })

--- a/src/features/search/pages/__tests__/useShowResultsWithStagedSearch.test.ts
+++ b/src/features/search/pages/__tests__/useShowResultsWithStagedSearch.test.ts
@@ -1,0 +1,56 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import { SearchGroupNameEnum } from 'api/gen'
+import { LocationType } from 'features/search/enums'
+import { initialSearchState } from 'features/search/pages/reducer'
+
+import { useShowResultsWithStagedSearch } from '../useShowResultsWithStagedSearch'
+
+const mockSearchState = initialSearchState
+const mockDispatch = jest.fn()
+let mockStagedSearchState = initialSearchState
+const mockStagedDispatch = jest.fn()
+jest.mock('features/search/pages/SearchWrapper', () => ({
+  useSearch: () => ({
+    searchState: mockSearchState,
+    dispatch: mockDispatch,
+  }),
+  useStagedSearch: () => ({
+    searchState: mockStagedSearchState,
+    dispatch: mockStagedDispatch,
+  }),
+}))
+
+describe('useShowResultsWithStagedSearch', () => {
+  beforeEach(() => {
+    mockStagedSearchState = {
+      ...initialSearchState,
+      locationFilter: { locationType: LocationType.EVERYWHERE },
+      priceRange: [0, 300],
+      query: 'Big flo et Oli',
+      offerCategories: [SearchGroupNameEnum.SPECTACLE],
+    }
+  })
+
+  it('should set search state with staged search state', () => {
+    const { result: resultCallback } = renderHook(useShowResultsWithStagedSearch)
+
+    resultCallback.current()
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'SET_STATE',
+      payload: mockStagedSearchState,
+    })
+  })
+
+  it('should show results', () => {
+    const { result: resultCallback } = renderHook(useShowResultsWithStagedSearch)
+
+    resultCallback.current()
+
+    expect(mockDispatch).toHaveBeenLastCalledWith({
+      type: 'SHOW_RESULTS',
+      payload: true,
+    })
+  })
+})

--- a/src/features/search/pages/useShowResultsForCategory.ts
+++ b/src/features/search/pages/useShowResultsForCategory.ts
@@ -3,16 +3,19 @@ import { useCallback } from 'react'
 import { OnPressCategory } from 'features/search/components/CategoriesButtons'
 import { useSearch, useStagedSearch } from 'features/search/pages/SearchWrapper'
 
+import { useShowResultsWithStagedSearch } from './useShowResultsWithStagedSearch'
+
 export const useShowResultsForCategory = (): OnPressCategory => {
-  const { dispatch } = useSearch()
   const { dispatch: stagedDispatch } = useStagedSearch()
+  const showResultsWithStagedSearch = useShowResultsWithStagedSearch()
+  const { dispatch } = useSearch()
 
   return useCallback(
     (pressedCategory) => {
       stagedDispatch({ type: 'SET_CATEGORY', payload: [pressedCategory] })
+      showResultsWithStagedSearch()
       dispatch({ type: 'SET_CATEGORY', payload: [pressedCategory] })
-      dispatch({ type: 'SHOW_RESULTS', payload: true })
     },
-    [dispatch, stagedDispatch]
+    [stagedDispatch, dispatch, showResultsWithStagedSearch]
   )
 }

--- a/src/features/search/pages/useShowResultsWithStagedSearch.ts
+++ b/src/features/search/pages/useShowResultsWithStagedSearch.ts
@@ -1,0 +1,13 @@
+import { useCallback } from 'react'
+
+import { useSearch, useStagedSearch } from 'features/search/pages/SearchWrapper'
+
+export const useShowResultsWithStagedSearch = (): (() => void) => {
+  const { dispatch } = useSearch()
+  const { searchState: stagedSearchState } = useStagedSearch()
+
+  return useCallback(() => {
+    dispatch({ type: 'SET_STATE', payload: stagedSearchState })
+    dispatch({ type: 'SHOW_RESULTS', payload: true })
+  }, [dispatch, stagedSearchState])
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-15130

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.

