### PR TITLE
(PC-16119) fix(Offline): show banner when isInternetReachable stay false for more than 30secs

### DIFF
--- a/src/libs/network/OfflineModeContainer.tsx
+++ b/src/libs/network/OfflineModeContainer.tsx
@@ -1,21 +1,49 @@
 import { t } from '@lingui/macro'
-import React, { ReactNode } from 'react'
+import React, { ReactNode, useState, useEffect, useRef } from 'react'
 import styled from 'styled-components/native'
 
 import { useNetInfo } from 'libs/network/useNetInfo'
 import { getSpacing, Typo, Spacer } from 'ui/theme'
 
+const THIRTY_SECONDS = 30000
+
 export function OfflineModeContainer({ children }: { children: ReactNode }) {
   const netInfo = useNetInfo()
+  const [show, setShow] = useState(!netInfo.isConnected)
+  const isInternetReachable = useRef(netInfo.isInternetReachable)
+
+  useEffect(() => {
+    setShow(!netInfo.isConnected)
+  }, [netInfo.isConnected])
+
+  useEffect(() => {
+    isInternetReachable.current = netInfo.isInternetReachable
+    let timer: number | undefined
+    if (!isInternetReachable.current) {
+      timer = globalThis.setTimeout(() => {
+        if (!isInternetReachable.current) {
+          setShow(true)
+        }
+      }, THIRTY_SECONDS)
+    } else {
+      setShow(false)
+    }
+    return () => {
+      if (timer) {
+        globalThis.clearInterval(timer)
+      }
+    }
+  }, [netInfo.isInternetReachable])
+
   return (
     <FlexView>
       <FlexView>{children}</FlexView>
-      {!netInfo.isConnected && (
+      {show ? (
         <OfflineModeBanner>
           <OfflineModeBannerText>{t`aucune connexion internet.`}</OfflineModeBannerText>
           <Spacer.BottomScreen />
         </OfflineModeBanner>
-      )}
+      ) : null}
     </FlexView>
   )
 }

--- a/src/libs/network/__tests__/OfflineModeContainer.test.tsx
+++ b/src/libs/network/__tests__/OfflineModeContainer.test.tsx
@@ -12,18 +12,47 @@ const mockUseNetInfo = useNetInfoDefault as jest.Mock
 describe('<OfflineModeContainer />', () => {
   mockUseNetInfo.mockImplementation(() => ({ isConnected: false }))
 
-  it('should render children and show banner when offline', () => {
+  it('should render children and show banner when offline at init when isConnected is false', () => {
     const renderAPI = renderOfflineModeContainer()
     expect(renderAPI.queryByText('Hello World')).toBeTruthy()
     expect(renderAPI.queryByText('aucune connexion internet.')).toBeTruthy()
   })
-  it('should render children and not show banner when offline', () => {
+
+  it('should render children and not show banner when offline at init when isConnected is true', () => {
     mockUseNetInfo.mockImplementationOnce(() => ({ isConnected: true }))
     const renderAPI = renderOfflineModeContainer()
     expect(renderAPI.queryByText('aucune connexion internet.')).toBeFalsy()
     expect(renderAPI.queryByText('Hello World')).toBeTruthy()
   })
+
+  it('should not show "aucune connexion internet." at init, then show when isConnected is false, then hide when isConnected switch back to true', () => {
+    mockUseNetInfo.mockImplementationOnce(() => ({ isConnected: true, isInternetReachable: true }))
+    const renderAPI = render(jsx)
+    expect(renderAPI.queryByText('aucune connexion internet.')).toBeFalsy()
+
+    mockUseNetInfo.mockImplementationOnce(() => ({
+      isConnected: false,
+      isInternetReachable: false,
+    }))
+    renderAPI.rerender(
+      <OfflineModeContainer>
+        <View>
+          <Text>Hello World</Text>
+        </View>
+      </OfflineModeContainer>
+    )
+
+    expect(renderAPI.queryByText('aucune connexion internet.')).toBeTruthy()
+  })
 })
+
+const jsx = (
+  <OfflineModeContainer>
+    <View>
+      <Text>Hello World</Text>
+    </View>
+  </OfflineModeContainer>
+)
 
 function renderOfflineModeContainer() {
   return render(


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16119

Live demo  https://codesandbox.io/s/react-native-test-forked-7nc5zc

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [x] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [x] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
