### PR TITLE
(PC-16143) fix(Search): back reset default search expect locationFilter

### DIFF
--- a/src/features/search/components/SearchBox.tsx
+++ b/src/features/search/components/SearchBox.tsx
@@ -60,12 +60,21 @@ export const SearchBox: React.FC<Props> = ({
 
   const onPressArrowBack = useCallback(() => {
     if (onFocusState) onFocusState(false)
-    stagedDispatch({ type: 'SET_QUERY', payload: '' })
-    showResultsWithStagedSearch({
-      query: '',
-      showResults: false,
+    stagedDispatch({
+      type: 'SET_STATE',
+      payload: { locationFilter },
     })
-  }, [onFocusState, showResultsWithStagedSearch, stagedDispatch])
+    showResultsWithStagedSearch(
+      {
+        query: '',
+        showResults: false,
+        locationFilter,
+      },
+      {
+        reset: true,
+      }
+    )
+  }, [locationFilter, onFocusState, showResultsWithStagedSearch, stagedDispatch])
 
   const onPressLocationButton = useCallback(() => {
     navigate('LocationFilter')

--- a/src/features/search/components/__tests__/SearchBox.native.test.tsx
+++ b/src/features/search/components/__tests__/SearchBox.native.test.tsx
@@ -140,11 +140,19 @@ describe('SearchBox component', () => {
     await fireEvent(searchInput, 'onChangeText', 'Some text')
 
     await fireEvent.press(previousButton)
+
+    expect(mockStagedDispatch).toBeCalledWith({
+      type: 'SET_STATE',
+      payload: {
+        locationFilter: mockStagedSearchState.locationFilter,
+      },
+    })
     expect(push).toBeCalledWith(
       ...getTabNavConfig('Search', {
-        ...mockStagedSearchState,
+        ...initialSearchState,
         query: '',
         showResults: false,
+        locationFilter: mockStagedSearchState.locationFilter,
       })
     )
   })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16143

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
