### PR TITLE
(PC-16170) refactor(tests): remove @testing-library/react-hooks

### DIFF
--- a/doc/standards/testStrategy.md
+++ b/doc/standards/testStrategy.md
@@ -208,9 +208,10 @@ it('calls the API and returns the data', async () => {
   const { result, waitFor } = renderHook(useUserProfileInfo, {
     wrapper: ({ children }) => reactQueryProviderHOC(children),
   })
-  await waitFor(() => result.current.data !== undefined)
-  expect(result.current.data).toEqual(userProfileAPIResponse)
-  expect(userProfileApiMock).toHaveBeenCalledTimes(1)
+  await waitFor(() => {
+    expect(result.current.data).toEqual(userProfileAPIResponse)
+    expect(userProfileApiMock).toHaveBeenCalledTimes(1)
+  })
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -185,7 +185,6 @@
     "@svgr/webpack": "^5.5.0",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.0.0",
-    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/react-native": "10.1.1",
     "@types/amplitude-js": "^8.9.6",
     "@types/contentful-resolve-response": "^0.1.30",

--- a/src/features/auth/signup/SetBirthday/utils/useDatePickerErrorHandler.test.tsx
+++ b/src/features/auth/signup/SetBirthday/utils/useDatePickerErrorHandler.test.tsx
@@ -1,4 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks'
 import mockdate from 'mockdate'
 import * as styledComponentsNative from 'styled-components/native'
 
@@ -12,6 +11,7 @@ import {
   NOT_ELIGIBLE_YOUNGEST_AGE_DATE,
 } from 'features/auth/signup/SetBirthday/utils/fixtures'
 import { analytics } from 'libs/firebase/analytics'
+import { renderHook } from 'tests/utils'
 
 import { useDatePickerErrorHandler } from './useDatePickerErrorHandler'
 

--- a/src/features/auth/signup/useBeneficiaryValidationNavigation.test.ts
+++ b/src/features/auth/signup/useBeneficiaryValidationNavigation.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable local-rules/no-react-query-provider-hoc */
-import { act, renderHook } from '@testing-library/react-hooks'
 import { rest } from 'msw'
 import waitForExpect from 'wait-for-expect'
 
@@ -15,6 +14,7 @@ import { navigateToHome } from 'features/navigation/helpers'
 import { env } from 'libs/environment'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
+import { act, renderHook } from 'tests/utils'
 
 jest.mock('features/navigation/helpers')
 jest.mock('features/auth/settings')
@@ -27,6 +27,7 @@ describe('useBeneficiaryValidationNavigation', () => {
   it('should navigate to home if nextStep is null', async () => {
     const { result } = renderHook(useBeneficiaryValidationNavigation, {
       wrapper: ({ children }) => reactQueryProviderHOC(children),
+      initialProps: () => undefined,
     })
     await act(async () => result.current.navigateToNextBeneficiaryValidationStep())
 
@@ -44,6 +45,7 @@ describe('useBeneficiaryValidationNavigation', () => {
     })
     const { result } = renderHook(useBeneficiaryValidationNavigation, {
       wrapper: ({ children }) => reactQueryProviderHOC(children),
+      initialProps: () => undefined,
     })
     await act(async () => result.current.navigateToNextBeneficiaryValidationStep())
 
@@ -62,6 +64,7 @@ describe('useBeneficiaryValidationNavigation', () => {
     })
     const { result } = renderHook(useBeneficiaryValidationNavigation, {
       wrapper: ({ children }) => reactQueryProviderHOC(children),
+      initialProps: () => undefined,
     })
     await act(async () => result.current.navigateToNextBeneficiaryValidationStep())
 
@@ -79,6 +82,7 @@ describe('useBeneficiaryValidationNavigation', () => {
     })
     const { result } = renderHook(useBeneficiaryValidationNavigation, {
       wrapper: ({ children }) => reactQueryProviderHOC(children),
+      initialProps: () => undefined,
     })
     await act(async () => result.current.navigateToNextBeneficiaryValidationStep())
 
@@ -96,6 +100,7 @@ describe('useBeneficiaryValidationNavigation', () => {
     })
     const { result } = renderHook(useBeneficiaryValidationNavigation, {
       wrapper: ({ children }) => reactQueryProviderHOC(children),
+      initialProps: () => undefined,
     })
     await act(async () => result.current.navigateToNextBeneficiaryValidationStep())
 
@@ -115,6 +120,7 @@ describe('useBeneficiaryValidationNavigation', () => {
 
     const { result } = renderHook(useBeneficiaryValidationNavigation, {
       wrapper: ({ children }) => reactQueryProviderHOC(children),
+      initialProps: () => undefined,
     })
     await act(async () => result.current.navigateToNextBeneficiaryValidationStep())
 
@@ -134,6 +140,7 @@ it('should navigate to IdentityCheckUnavailable if nextStep is Maintenance and m
 
   const { result } = renderHook(useBeneficiaryValidationNavigation, {
     wrapper: ({ children }) => reactQueryProviderHOC(children),
+    initialProps: () => undefined,
   })
   await act(async () => result.current.navigateToNextBeneficiaryValidationStep())
 

--- a/src/features/auth/signup/useNextSubscriptionStep.test.ts
+++ b/src/features/auth/signup/useNextSubscriptionStep.test.ts
@@ -1,4 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { rest } from 'msw'
 
 import { IdentityCheckMethod, NextSubscriptionStepResponse, SubscriptionStep } from 'api/gen'
@@ -8,6 +7,7 @@ import { env } from 'libs/environment'
 import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
+import { renderHook, waitFor } from 'tests/utils'
 
 const setError = jest.fn()
 jest.mock('features/auth/AuthContext')
@@ -35,11 +35,12 @@ describe('useNextSubscriptionStep', () => {
         stepperIncludesPhoneValidation: false,
         hasIdentityCheckPending: false,
       })
-      const { result, waitFor } = renderNextSubscriptionStepHook()
-      await waitFor(() => result.current.isLoading === false)
+      const { result } = renderNextSubscriptionStepHook()
 
-      expect(result.current.data?.nextSubscriptionStep).toBe(expectedSubscriptionStep)
-      expect(setError).not.toBeCalled()
+      await waitFor(() => {
+        expect(result.current.data?.nextSubscriptionStep).toBe(expectedSubscriptionStep)
+        expect(setError).not.toBeCalled()
+      })
     }
   )
 
@@ -50,11 +51,12 @@ describe('useNextSubscriptionStep', () => {
       stepperIncludesPhoneValidation: false,
       hasIdentityCheckPending: false,
     })
-    const { result, waitFor } = renderNextSubscriptionStepHook()
-    await waitFor(() => result.current.isLoading === false)
+    const { result } = renderNextSubscriptionStepHook()
 
-    expect(setError).not.toBeCalled()
-    expect(result.current.data).toBeUndefined()
+    await waitFor(() => {
+      expect(setError).not.toBeCalled()
+      expect(result.current.data).toBeUndefined()
+    })
   })
 
   it('should not fetch query if user is logged in and not connected', async () => {
@@ -78,11 +80,12 @@ describe('useNextSubscriptionStep', () => {
       setIsLoggedIn: jest.fn(),
     })
     mockNextStepRequestError()
-    const { result, waitFor } = renderNextSubscriptionStepHook()
-    await waitFor(() => result.current.isLoading === false)
+    const { result } = renderNextSubscriptionStepHook()
 
-    expect(setError).toBeCalledTimes(1)
-    expect(result.current.data).toBeUndefined()
+    await waitFor(() => {
+      expect(setError).toBeCalledTimes(1)
+      expect(result.current.data).toBeUndefined()
+    })
   })
 })
 

--- a/src/features/auth/signup/useNextSubscriptionStep.test.ts
+++ b/src/features/auth/signup/useNextSubscriptionStep.test.ts
@@ -67,11 +67,12 @@ describe('useNextSubscriptionStep', () => {
       stepperIncludesPhoneValidation: false,
       hasIdentityCheckPending: false,
     })
-    const { result, waitFor } = renderNextSubscriptionStepHook()
-    await waitFor(() => result.current.isLoading === false)
+    const { result } = renderNextSubscriptionStepHook()
 
-    expect(setError).not.toBeCalled()
-    expect(result.current.data).toBeUndefined()
+    await waitFor(() => {
+      expect(setError).not.toBeCalled()
+      expect(result.current.data).toBeUndefined()
+    })
   })
 
   it('should set error and return undefined if request fails', async () => {

--- a/src/features/auth/suspendedAccount/SuspendedAccount/tests/useAccountSuspensionDate.test.ts
+++ b/src/features/auth/suspendedAccount/SuspendedAccount/tests/useAccountSuspensionDate.test.ts
@@ -1,10 +1,10 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { rest } from 'msw'
 
 import { useAccountSuspensionDate } from 'features/auth/suspendedAccount/SuspendedAccount/useAccountSuspensionDate'
 import { env } from 'libs/environment'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
+import { renderHook, waitFor } from 'tests/utils'
 
 const expectedResponse = { date: '2022-05-11T10:29:25.332786Z' }
 function simulateSuspensionDate200() {
@@ -26,10 +26,11 @@ function simulateSuspensionDateActiveAccount() {
 describe('useAccountSuspensionDate', () => {
   it('should return suspension date if it exists', async () => {
     simulateSuspensionDate200()
-    const { result, waitFor } = renderSuspensionDateHook()
+    const { result } = renderSuspensionDateHook()
 
-    await waitFor(() => result.current.data !== undefined)
-    expect(result.current.data?.date).toBe(expectedResponse.date)
+    await waitFor(() => {
+      expect(result.current.data?.date).toBe(expectedResponse.date)
+    })
   })
 
   it('should return undefined for unsuspended user', async () => {

--- a/src/features/auth/suspendedAccount/SuspendedAccount/tests/useAccountUnsuspend.test.ts
+++ b/src/features/auth/suspendedAccount/SuspendedAccount/tests/useAccountUnsuspend.test.ts
@@ -1,4 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { rest } from 'msw'
 import waitForExpect from 'wait-for-expect'
 
@@ -6,7 +5,7 @@ import { useAccountUnsuspend } from 'features/auth/suspendedAccount/SuspendedAcc
 import { env } from 'libs/environment'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
-import { superFlushWithAct } from 'tests/utils'
+import { renderHook, superFlushWithAct } from 'tests/utils'
 
 const onSuccess = jest.fn()
 const onError = jest.fn()

--- a/src/features/auth/suspendedAccount/SuspensionScreen/tests/useAccountSuspensionStatus.test.ts
+++ b/src/features/auth/suspendedAccount/SuspensionScreen/tests/useAccountSuspensionStatus.test.ts
@@ -1,4 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { rest } from 'msw'
 
 import { AccountState } from 'api/gen'
@@ -6,6 +5,7 @@ import { useAccountSuspensionStatus } from 'features/auth/suspendedAccount/Suspe
 import { env } from 'libs/environment'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
+import { renderHook, waitFor } from 'tests/utils'
 
 const expectedResponse = { status: AccountState.SUSPENDED }
 function simulateSuspensionStatus200() {
@@ -27,10 +27,11 @@ function simulateSuspensionStatusError() {
 describe('useAccountSuspensionStatus', () => {
   it('should return suspension status if it exists', async () => {
     simulateSuspensionStatus200()
-    const { result, waitFor } = renderSuspensionDateHook()
+    const { result } = renderSuspensionDateHook()
 
-    await waitFor(() => result.current.data !== undefined)
-    expect(result.current.data?.status).toBe(expectedResponse.status)
+    await waitFor(() => {
+      expect(result.current.data?.status).toBe(expectedResponse.status)
+    })
   })
 
   it('should return undefined if error', async () => {

--- a/src/features/bookOffer/components/__tests__/useMarkedDates.test.ts
+++ b/src/features/bookOffer/components/__tests__/useMarkedDates.test.ts
@@ -1,9 +1,9 @@
-import { renderHook } from '@testing-library/react-hooks'
 import mockdate from 'mockdate'
 
 import { useMarkedDates } from 'features/bookOffer/components/Calendar/useMarkedDates'
 import { BookingState, Step } from 'features/bookOffer/pages/reducer'
 import { notExpiredStock } from 'features/offer/services/useCtaWordingAndAction.testsFixtures'
+import { renderHook } from 'tests/utils'
 
 const mockBookingState: BookingState = {
   offerId: undefined,

--- a/src/features/bookOffer/services/__tests__/useModalContent.test.tsx
+++ b/src/features/bookOffer/services/__tests__/useModalContent.test.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { renderHook } from '@testing-library/react-hooks'
 import { Platform } from 'react-native'
 
 import { OfferResponse, SubcategoryIdEnum } from 'api/gen'
 import { mockOffer as baseOffer } from 'features/bookOffer/fixtures/offer'
 import { Step } from 'features/bookOffer/pages/reducer'
 import { notExpiredStock as baseStock } from 'features/offer/services/useCtaWordingAndAction.testsFixtures'
+import { renderHook } from 'tests/utils'
 
 import { useModalContent } from '../useModalContent'
 

--- a/src/features/bookOffer/services/__tests__/useReviewInAppInformation.test.ts
+++ b/src/features/bookOffer/services/__tests__/useReviewInAppInformation.test.ts
@@ -1,9 +1,8 @@
-import { renderHook } from '@testing-library/react-hooks'
 import mockdate from 'mockdate'
 
 import { useReviewInAppInformation } from 'features/bookOffer/services/useReviewInAppInformation'
 import { storage } from 'libs/storage'
-import { waitFor } from 'tests/utils'
+import { waitFor, renderHook } from 'tests/utils'
 
 const dateNow = 1634806274417
 const ONE_YEAR = 365 * 24 * 60 * 60 * 1000

--- a/src/features/bookings/api/__tests__/queries.test.ts
+++ b/src/features/bookings/api/__tests__/queries.test.ts
@@ -1,4 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { rest } from 'msw'
 
 import { BookingsResponse } from 'api/gen'
@@ -7,6 +6,7 @@ import { env } from 'libs/environment'
 import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
+import { renderHook, waitFor } from 'tests/utils'
 
 import { useOngoingOrEndedBooking } from '../queries'
 
@@ -29,37 +29,40 @@ describe('[API] booking queries', () => {
   describe('[Method] useOngoingOrEndedBooking', () => {
     it('should return ongoing_bookings when there is one', async () => {
       const booking = bookingsSnap.ongoing_bookings[0]
-      const { result, waitFor } = renderHook(() => useOngoingOrEndedBooking(booking.id), {
+      const { result } = renderHook(() => useOngoingOrEndedBooking(booking.id), {
         // eslint-disable-next-line local-rules/no-react-query-provider-hoc
         wrapper: ({ children }) => reactQueryProviderHOC(children),
       })
 
-      await waitFor(() => result.current.data !== undefined)
-      expect(result.current?.data?.id).toEqual(booking.id)
-      expect(result.current?.data?.stock.id).toEqual(booking.stock.id)
+      await waitFor(() => {
+        expect(result.current?.data?.id).toEqual(booking.id)
+        expect(result.current?.data?.stock.id).toEqual(booking.stock.id)
+      })
     })
 
     it('should return ended_bookings when there is one', async () => {
       const booking = bookingsSnap.ended_bookings[0]
-      const { result, waitFor } = renderHook(() => useOngoingOrEndedBooking(booking.id), {
+      const { result } = renderHook(() => useOngoingOrEndedBooking(booking.id), {
         // eslint-disable-next-line local-rules/no-react-query-provider-hoc
         wrapper: ({ children }) => reactQueryProviderHOC(children),
       })
 
-      await waitFor(() => result.current.data !== undefined)
-      expect(result.current?.data?.id).toEqual(booking.id)
-      expect(result.current?.data?.stock.id).toEqual(booking.stock.id)
+      await waitFor(() => {
+        expect(result.current?.data?.id).toEqual(booking.id)
+        expect(result.current?.data?.stock.id).toEqual(booking.stock.id)
+      })
     })
 
     it('should return null if no ongoing nor ended booking can be found', async () => {
       const bookingId = 1230912039
-      const { result, waitFor } = renderHook(() => useOngoingOrEndedBooking(bookingId), {
+      const { result } = renderHook(() => useOngoingOrEndedBooking(bookingId), {
         // eslint-disable-next-line local-rules/no-react-query-provider-hoc
         wrapper: ({ children }) => reactQueryProviderHOC(children),
       })
 
-      await waitFor(() => result.current.data === null)
-      expect(result.current.data).toBeNull()
+      await waitFor(() => {
+        expect(result.current.data).toBeNull()
+      })
     })
   })
 })

--- a/src/features/culturalSurvey/__tests__/useCulturalSurveyProgress.test.ts
+++ b/src/features/culturalSurvey/__tests__/useCulturalSurveyProgress.test.ts
@@ -1,8 +1,7 @@
-import { renderHook } from '@testing-library/react-hooks'
-
 import { CulturalSurveyQuestionEnum } from 'api/gen'
 import * as CulturalSurveyContextProviderModule from 'features/culturalSurvey/context/CulturalSurveyContextProvider'
 import { useCulturalSurveyProgress } from 'features/culturalSurvey/useCulturalSurveyProgress'
+import { renderHook } from 'tests/utils'
 
 import { ICulturalSurveyContext } from '../context/CulturalSurveyContextProvider'
 

--- a/src/features/favorites/pages/__tests__/useFavorites.test.tsx
+++ b/src/features/favorites/pages/__tests__/useFavorites.test.tsx
@@ -1,4 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { rest } from 'msw'
 import * as React from 'react'
 import { View } from 'react-native'
@@ -17,7 +16,7 @@ import { EmptyResponse } from 'libs/fetch'
 import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
-import { superFlushWithAct } from 'tests/utils'
+import { renderHook, waitFor, superFlushWithAct } from 'tests/utils'
 
 import { useFavorites, useRemoveFavorite, useAddFavorite, useFavorite } from '../useFavorites'
 
@@ -78,7 +77,7 @@ describe('useFavorites hook', () => {
       isLoggedIn: true,
       setIsLoggedIn: jest.fn(),
     })
-    const { result, waitFor } = renderHook(useFavorites, {
+    const { result } = renderHook(useFavorites, {
       wrapper: (props) =>
         // eslint-disable-next-line local-rules/no-react-query-provider-hoc
         reactQueryProviderHOC(
@@ -89,12 +88,12 @@ describe('useFavorites hook', () => {
     })
 
     expect(result.current.isFetching).toEqual(true)
-    await waitFor(() => result.current.isSuccess)
 
-    expect(result.current.isSuccess).toEqual(true)
-    expect(result.current.data?.favorites.length).toEqual(
-      paginatedFavoritesResponseSnap.favorites.length
-    )
+    await waitFor(() => {
+      expect(result.current.data?.favorites.length).toEqual(
+        paginatedFavoritesResponseSnap.favorites.length
+      )
+    })
   })
 
   it('should fail to fetch when not logged in', async () => {

--- a/src/features/home/api.test.ts
+++ b/src/features/home/api.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks'
+/* eslint-disable local-rules/no-react-query-provider-hoc */
 import { rest } from 'msw'
 
 import { processHomepageEntry } from 'features/home/contentful'
@@ -10,6 +10,7 @@ import {
 } from 'tests/fixtures/homepageEntries'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
+import { renderHook, waitFor } from 'tests/utils'
 
 import { getEntries, BASE_URL, PARAMS, useHomepageModules } from './api'
 
@@ -33,8 +34,7 @@ describe('Home api calls', () => {
 
   describe('useHomepageModules', () => {
     it('calls the API and returns the data', async () => {
-      const { result, waitFor } = renderHook(useHomepageModules, {
-        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+      const { result } = renderHook(useHomepageModules, {
         wrapper: ({ children }) => reactQueryProviderHOC(children),
       })
 
@@ -46,8 +46,7 @@ describe('Home api calls', () => {
     })
 
     it('calls the API and returns the data with specified entryId', async () => {
-      const { result, waitFor } = renderHook(() => useHomepageModules(entryId), {
-        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+      const { result } = renderHook(() => useHomepageModules(entryId), {
         wrapper: ({ children }) => reactQueryProviderHOC(children),
       })
 
@@ -59,8 +58,7 @@ describe('Home api calls', () => {
     })
 
     it('should log ConsultHome with specified entryId', async () => {
-      const { result, waitFor } = renderHook(() => useHomepageModules(entryId), {
-        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+      const { result } = renderHook(() => useHomepageModules(entryId), {
         wrapper: ({ children }) => reactQueryProviderHOC(children),
       })
 

--- a/src/features/home/api/tests/useAlgoliaRecommendedHits.test.ts
+++ b/src/features/home/api/tests/useAlgoliaRecommendedHits.test.ts
@@ -1,10 +1,9 @@
-import { renderHook } from '@testing-library/react-hooks'
-
 import { useAlgoliaRecommendedHits } from 'features/home/api/useAlgoliaRecommendedHits'
 import * as fetchOfferHitsAPI from 'libs/algolia/fetchAlgolia/fetchOfferHits'
 import * as filterOfferHitAPI from 'libs/algolia/fetchAlgolia/transformOfferHit'
 import { mockedAlgoliaResponse } from 'libs/algolia/mockedResponses/mockedAlgoliaResponse'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { renderHook, waitFor } from 'tests/utils'
 
 jest.mock('features/profile/api', () => ({
   useUserProfileInfo: jest.fn(() => ({ data: { firstName: 'Christophe', lastName: 'Dupont' } })),
@@ -24,32 +23,35 @@ describe('useAlgoliaRecommendedHits', () => {
     .mockImplementation(jest.fn())
 
   it('should fetch algolia when ids are provided', async () => {
-    const { waitForNextUpdate } = renderHook(() => useAlgoliaRecommendedHits(ids, 'abcd'), {
+    renderHook(() => useAlgoliaRecommendedHits(ids, 'abcd'), {
       // eslint-disable-next-line local-rules/no-react-query-provider-hoc
       wrapper: ({ children }) => reactQueryProviderHOC(children),
     })
-    await waitForNextUpdate()
-    expect(fetchAlgoliaHitsSpy).toHaveBeenCalledWith({ objectIds: ids, isUserUnderage: false })
+    await waitFor(() => {
+      expect(fetchAlgoliaHitsSpy).toHaveBeenCalledWith({ objectIds: ids, isUserUnderage: false })
+    })
   })
 
   it('should filter algolia hits', async () => {
-    const { waitForNextUpdate } = renderHook(() => useAlgoliaRecommendedHits(ids, 'abcd'), {
+    renderHook(() => useAlgoliaRecommendedHits(ids, 'abcd'), {
       // eslint-disable-next-line local-rules/no-react-query-provider-hoc
       wrapper: ({ children }) => reactQueryProviderHOC(children),
     })
-    await waitForNextUpdate()
-    expect(filterAlgoliaHitSpy).toHaveBeenCalledTimes(mockedAlgoliaResponse.hits.length)
+    await waitFor(() => {
+      expect(filterAlgoliaHitSpy).toHaveBeenCalledTimes(mockedAlgoliaResponse.hits.length)
+    })
   })
 
   it('should return undefined when algolia does not return any hit', async () => {
     jest.spyOn(fetchOfferHitsAPI, 'fetchOfferHits').mockResolvedValueOnce([])
-    const { waitForNextUpdate, result } = renderHook(() => useAlgoliaRecommendedHits(ids, 'abcd'), {
+    const { result } = renderHook(() => useAlgoliaRecommendedHits(ids, 'abcd'), {
       // eslint-disable-next-line local-rules/no-react-query-provider-hoc
       wrapper: ({ children }) => reactQueryProviderHOC(children),
     })
-    await waitForNextUpdate()
-    expect(result.current).toBeUndefined()
-    expect(filterAlgoliaHitSpy).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(result.current).toBeUndefined()
+      expect(filterAlgoliaHitSpy).not.toHaveBeenCalled()
+    })
   })
 
   it('should return undefined when ids are not provided', async () => {

--- a/src/features/home/api/tests/useHomeRecommendedHits.test.ts
+++ b/src/features/home/api/tests/useHomeRecommendedHits.test.ts
@@ -1,4 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { UseMutationResult } from 'react-query'
 
 import {
@@ -8,6 +7,7 @@ import {
 } from 'features/home/api/useHomeRecommendedHits'
 import { RecommendationParametersFields } from 'features/home/contentful'
 import { env } from 'libs/environment'
+import { renderHook } from 'tests/utils'
 
 import * as algoliaRecommendedHitsAPI from '../useAlgoliaRecommendedHits'
 import * as recommendedIdsAPI from '../useHomeRecommendedIdsMutation'

--- a/src/features/home/api/tests/useHomeRecommendedIdsMutation.test.ts
+++ b/src/features/home/api/tests/useHomeRecommendedIdsMutation.test.ts
@@ -1,8 +1,9 @@
-import { renderHook } from '@testing-library/react-hooks'
+/* eslint-disable local-rules/no-react-query-provider-hoc */
 import * as reactQueryAPI from 'react-query'
 
 import { eventMonitoring } from 'libs/monitoring'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { renderHook, waitFor } from 'tests/utils'
 
 import { useHomeRecommendedIdsMutation } from '../useHomeRecommendedIdsMutation'
 
@@ -12,7 +13,6 @@ describe('useHomeRecommendedIdsMutation', () => {
 
   it('should call useMutation', () => {
     renderHook(() => useHomeRecommendedIdsMutation('http://passculture.reco'), {
-      // eslint-disable-next-line local-rules/no-react-query-provider-hoc
       wrapper: ({ children }) => reactQueryProviderHOC(children),
     })
 
@@ -20,37 +20,33 @@ describe('useHomeRecommendedIdsMutation', () => {
   })
 
   it('should call fetch when mutate', async () => {
-    const { result, waitForNextUpdate } = renderHook(
-      () => useHomeRecommendedIdsMutation('http://passculture.reco'),
-      {
-        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-        wrapper: ({ children }) => reactQueryProviderHOC(children),
-      }
-    )
+    const { result } = renderHook(() => useHomeRecommendedIdsMutation('http://passculture.reco'), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
     result.current.mutate({})
-    await waitForNextUpdate()
-    expect(mockFetch).toHaveBeenCalledWith('http://passculture.reco', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-      body: JSON.stringify({}),
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('http://passculture.reco', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({}),
+      })
     })
   })
 
   it('should capture an exception when fetch call fails', async () => {
     mockFetch.mockRejectedValueOnce('some error')
-    const { result, waitForNextUpdate } = renderHook(
-      () => useHomeRecommendedIdsMutation('http://passculture.reco'),
-      {
-        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-        wrapper: ({ children }) => reactQueryProviderHOC(children),
-      }
-    )
+    const { result } = renderHook(() => useHomeRecommendedIdsMutation('http://passculture.reco'), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
     result.current.mutate({})
-    await waitForNextUpdate()
-    expect(eventMonitoring.captureException).toHaveBeenCalled()
+
+    await waitFor(() => {
+      expect(eventMonitoring.captureException).toHaveBeenCalled()
+    })
   })
 
   it('should return response body if fetch call succeeds', async () => {
@@ -63,15 +59,12 @@ describe('useHomeRecommendedIdsMutation', () => {
         status: 200,
       })
     )
-    const { result, waitForNextUpdate } = renderHook(
-      () => useHomeRecommendedIdsMutation('http://passculture.reco'),
-      {
-        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
-        wrapper: ({ children }) => reactQueryProviderHOC(children),
-      }
-    )
+    const { result } = renderHook(() => useHomeRecommendedIdsMutation('http://passculture.reco'), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
     result.current.mutate({})
-    await waitForNextUpdate()
-    expect(result.current.data).toEqual(body)
+    await waitFor(() => {
+      expect(result.current.data).toEqual(body)
+    })
   })
 })

--- a/src/features/home/api/tests/useShowSkeleton.test.ts
+++ b/src/features/home/api/tests/useShowSkeleton.test.ts
@@ -1,6 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks'
-
-import { act } from 'tests/utils'
+import { act, renderHook } from 'tests/utils'
 
 import { ANIMATION_DELAY, useShowSkeleton } from '../useShowSkeleton'
 
@@ -25,7 +23,7 @@ describe('useShowSkeleton', () => {
     const { result, rerender } = renderHook(useShowSkeleton)
 
     expect(result.current).toBeTruthy()
-    await act(async () => await rerender())
+    await act(async () => await rerender(1))
 
     expect(result.current).toBeTruthy()
     await act(async () => {

--- a/src/features/home/selectPlaylist.test.ts
+++ b/src/features/home/selectPlaylist.test.ts
@@ -1,10 +1,10 @@
-import { renderHook } from '@testing-library/react-hooks'
 import shuffle from 'lodash.shuffle'
 
 import { UserProfileResponse, UserRole } from 'api/gen'
 import { HomepageEntry, Tag } from 'features/home/contentful'
 import { useSelectPlaylist } from 'features/home/selectPlaylist'
 import { adaptedHomepageEntry as entry } from 'tests/fixtures/homepageEntries'
+import { renderHook } from 'tests/utils'
 
 const defaultUser: Partial<UserProfileResponse> = { roles: [UserRole.BENEFICIARY] }
 const underageUser = { ...defaultUser, roles: [UserRole.UNDERAGE_BENEFICIARY] }

--- a/src/features/identityCheck/api/__test__/api.test.ts
+++ b/src/features/identityCheck/api/__test__/api.test.ts
@@ -1,4 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { rest } from 'msw'
 
 import { PhoneValidationRemainingAttemptsRequest } from 'api/gen'
@@ -6,6 +5,7 @@ import { usePhoneValidationRemainingAttempts } from 'features/identityCheck/api/
 import { env } from 'libs/environment'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
+import { renderHook, waitFor } from 'tests/utils'
 
 const phoneValidationApiMock = jest.fn()
 const phoneValidationRemainingAttemptsAPIResponse: PhoneValidationRemainingAttemptsRequest = {
@@ -22,19 +22,20 @@ server.use(
 
 describe('usePhoneValidationRemainingAttempts', () => {
   it('calls the API and returns the data and isLastAttempt', async () => {
-    const { result, waitFor } = renderHook(usePhoneValidationRemainingAttempts, {
+    const { result } = renderHook(usePhoneValidationRemainingAttempts, {
       // eslint-disable-next-line local-rules/no-react-query-provider-hoc
       wrapper: ({ children }) => reactQueryProviderHOC(children),
     })
-    await waitFor(() => !!result.current.remainingAttempts)
 
-    expect(result.current.remainingAttempts).toEqual(
-      phoneValidationRemainingAttemptsAPIResponse.remainingAttempts
-    )
-    expect(result.current.counterResetDatetime).toEqual(
-      phoneValidationRemainingAttemptsAPIResponse.counterResetDatetime
-    )
-    expect(result.current.isLastAttempt).toEqual(false)
-    expect(phoneValidationApiMock).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(result.current.remainingAttempts).toEqual(
+        phoneValidationRemainingAttemptsAPIResponse.remainingAttempts
+      )
+      expect(result.current.counterResetDatetime).toEqual(
+        phoneValidationRemainingAttemptsAPIResponse.counterResetDatetime
+      )
+      expect(result.current.isLastAttempt).toEqual(false)
+      expect(phoneValidationApiMock).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/src/features/landscapePosition/tests/useIsLandscapePosition.web.test.tsx
+++ b/src/features/landscapePosition/tests/useIsLandscapePosition.web.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks'
+import { renderHook } from 'tests/utils'
 
 import { useIsLandscapePosition } from '../useIsLandscapePosition'
 

--- a/src/features/navigation/__tests__/useGoBack.native.test.ts
+++ b/src/features/navigation/__tests__/useGoBack.native.test.ts
@@ -1,6 +1,5 @@
-import { renderHook } from '@testing-library/react-hooks'
-
 import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { renderHook } from 'tests/utils'
 
 import { useGoBack } from '../useGoBack'
 

--- a/src/features/navigation/__tests__/useGoBack.web.test.ts
+++ b/src/features/navigation/__tests__/useGoBack.web.test.ts
@@ -1,6 +1,5 @@
-import { renderHook } from '@testing-library/react-hooks'
-
 import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { renderHook } from 'tests/utils'
 
 import { useGoBack } from '../useGoBack'
 

--- a/src/features/navigation/__tests__/useInitialScreenConfig.native.test.tsx
+++ b/src/features/navigation/__tests__/useInitialScreenConfig.native.test.tsx
@@ -1,4 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { rest } from 'msw'
 import React from 'react'
 import waitForExpect from 'wait-for-expect'
@@ -10,7 +9,7 @@ import { analytics } from 'libs/firebase/analytics'
 import { SplashScreenProvider } from 'libs/splashscreen'
 import { storage } from 'libs/storage'
 import { server } from 'tests/server'
-import { superFlushWithAct } from 'tests/utils'
+import { renderHook, superFlushWithAct } from 'tests/utils'
 
 import { useInitialScreen } from '../RootNavigator/useInitialScreenConfig'
 

--- a/src/features/offer/api/__tests__/useOffer.test.ts
+++ b/src/features/offer/api/__tests__/useOffer.test.ts
@@ -1,17 +1,18 @@
-import { renderHook } from '@testing-library/react-hooks'
-
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { renderHook, waitFor } from 'tests/utils'
 
 import { offerResponseSnap } from '../snaps/offerResponseSnap'
 import { useOffer } from '../useOffer'
 
 describe('useOffer', () => {
   it('should call API otherwise', async () => {
-    const { result, waitFor } = renderHook(() => useOffer({ offerId: offerResponseSnap.id }), {
+    const { result } = renderHook(() => useOffer({ offerId: offerResponseSnap.id }), {
       // eslint-disable-next-line local-rules/no-react-query-provider-hoc
       wrapper: ({ children }) => reactQueryProviderHOC(children),
     })
-    await waitFor(() => !result.current.isLoading)
-    expect(JSON.stringify(result.current.data)).toEqual(JSON.stringify(offerResponseSnap))
+
+    await waitFor(() => {
+      expect(JSON.stringify(result.current.data)).toEqual(JSON.stringify(offerResponseSnap))
+    })
   })
 })

--- a/src/features/offer/services/__tests__/useHasEnoughCredit.test.ts
+++ b/src/features/offer/services/__tests__/useHasEnoughCredit.test.ts
@@ -1,8 +1,8 @@
-import { renderHook } from '@testing-library/react-hooks'
 import mockdate from 'mockdate'
 
 import { ExpenseDomain, OfferResponse, UserProfileResponse } from 'api/gen'
 import { mockOffer } from 'features/bookOffer/fixtures/offer'
+import { renderHook } from 'tests/utils'
 
 import { hasEnoughCredit, useHasEnoughCredit } from '../useHasEnoughCredit'
 

--- a/src/features/offer/services/__tests__/useReasonsForReporting.test.ts
+++ b/src/features/offer/services/__tests__/useReasonsForReporting.test.ts
@@ -1,4 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { rest } from 'msw'
 
 import { OfferReportReasons } from 'api/gen'
@@ -7,6 +6,7 @@ import { offerReportReasonSnap } from 'features/offer/api/snaps/offerReportReaso
 import { env } from 'libs/environment'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
+import { renderHook, waitFor } from 'tests/utils'
 
 import { useReasonsForReporting } from '../useReasonsForReporting'
 
@@ -29,16 +29,16 @@ describe('useReasonsForReporting hook', () => {
       isLoggedIn: true,
       setIsLoggedIn: jest.fn(),
     }))
-    const { result, waitFor } = renderHook(useReasonsForReporting, {
+    const { result } = renderHook(useReasonsForReporting, {
       // eslint-disable-next-line local-rules/no-react-query-provider-hoc
       wrapper: ({ children }) => reactQueryProviderHOC(children),
     })
 
     expect(result.current.isFetching).toEqual(true)
-    await waitFor(() => result.current.isSuccess)
 
-    expect(result.current.isSuccess).toEqual(true)
-    expect(result.current.data?.reasons.length).toEqual(offerReportReasonSnap.reasons.length)
+    await waitFor(() => {
+      expect(result.current.data?.reasons.length).toEqual(offerReportReasonSnap.reasons.length)
+    })
   })
 
   it('should return null when not logged in', async () => {

--- a/src/features/profile/pages/ChangeEmail/utils/useValidateEmail.test.ts
+++ b/src/features/profile/pages/ChangeEmail/utils/useValidateEmail.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks'
+import { renderHook } from 'tests/utils'
 
 import { useIsCurrentUserEmail, useValidateEmail } from './useValidateEmail'
 

--- a/src/features/profile/tests/api.test.ts
+++ b/src/features/profile/tests/api.test.ts
@@ -1,4 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { rest } from 'msw'
 
 import { UserProfileResponse } from 'api/gen'
@@ -7,6 +6,7 @@ import { useUserProfileInfo } from 'features/profile/api'
 import { env } from 'libs/environment'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
+import { renderHook, waitFor } from 'tests/utils'
 
 const mockedUseAuthContext = useAuthContext as jest.Mock
 
@@ -49,22 +49,27 @@ jest.mock('libs/react-query/usePersistQuery', () => ({
 
 describe('useUserProfileInfo', () => {
   it('calls the API and returns the data', async () => {
-    const { result, waitFor } = renderHook(useUserProfileInfo, {
+    const { result } = renderHook(useUserProfileInfo, {
       // eslint-disable-next-line local-rules/no-react-query-provider-hoc
       wrapper: ({ children }) => reactQueryProviderHOC(children),
     })
-    await waitFor(() => !result.current.isLoading)
-    expect(result.current.data).toEqual(userProfileAPIResponse)
-    expect(userProfileApiMock).toHaveBeenCalledTimes(1)
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(userProfileAPIResponse)
+      expect(userProfileApiMock).toHaveBeenCalledTimes(1)
+    })
   })
 
   it("doesn't call the api if the user isn't logged in", async () => {
     mockedUseAuthContext.mockImplementationOnce(() => ({ isLoggedIn: false }))
-    const { result, waitFor } = renderHook(useUserProfileInfo, {
+    const { result } = renderHook(useUserProfileInfo, {
       // eslint-disable-next-line local-rules/no-react-query-provider-hoc
       wrapper: ({ children }) => reactQueryProviderHOC(children),
     })
-    await waitFor(() => !result.current.isLoading)
-    expect(userProfileApiMock).not.toHaveBeenCalled()
+
+    await waitFor(() => {
+      expect(userProfileApiMock).not.toHaveBeenCalled()
+      expect(result.current.data).toBeUndefined()
+    })
   })
 })

--- a/src/features/search/components/CategoriesButtons/useSortedSearchCategories.test.tsx
+++ b/src/features/search/components/CategoriesButtons/useSortedSearchCategories.test.tsx
@@ -1,5 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks'
-
+import { renderHook } from 'tests/utils'
 import { categoriesIcons } from 'ui/svg/icons/bicolor/exports/categoriesIcons'
 
 import { useSortedSearchCategories } from './useSortedSearchCategories'

--- a/src/features/search/pages/__tests__/useShowResults.test.ts
+++ b/src/features/search/pages/__tests__/useShowResults.test.ts
@@ -1,9 +1,7 @@
-import { renderHook } from '@testing-library/react-hooks'
-
 import { useRoute } from '__mocks__/@react-navigation/native'
 import { initialSearchState } from 'features/search/pages/reducer'
 import { useShowResults } from 'features/search/pages/useShowResults'
-import { waitFor } from 'tests/utils'
+import { renderHook, waitFor } from 'tests/utils'
 
 const mockSearchState = initialSearchState
 

--- a/src/features/search/pages/__tests__/useShowResultsForCategory.test.ts
+++ b/src/features/search/pages/__tests__/useShowResultsForCategory.test.ts
@@ -1,9 +1,8 @@
-import { renderHook } from '@testing-library/react-hooks'
-
 import { push } from '__mocks__/@react-navigation/native'
 import { SearchGroupNameEnum } from 'api/gen'
 import { LocationType } from 'features/search/enums'
 import { initialSearchState } from 'features/search/pages/reducer'
+import { renderHook } from 'tests/utils'
 
 import { useShowResultsForCategory } from '../useShowResultsForCategory'
 

--- a/src/features/search/pages/__tests__/useShowResultsWithStagedSearch.test.ts
+++ b/src/features/search/pages/__tests__/useShowResultsWithStagedSearch.test.ts
@@ -1,10 +1,9 @@
-import { renderHook } from '@testing-library/react-hooks'
-
+import { push } from '__mocks__/@react-navigation/native'
 import { SearchGroupNameEnum } from 'api/gen'
 import { LocationType } from 'features/search/enums'
 import { initialSearchState } from 'features/search/pages/reducer'
+import { renderHook } from 'tests/utils'
 
-import { push } from '../../../../../__mocks__/@react-navigation/native'
 import { usePushWithStagedSearch } from '../usePushWithStagedSearch'
 
 const mockSearchState = initialSearchState

--- a/src/features/search/sections/tests/Category.native.test.tsx
+++ b/src/features/search/sections/tests/Category.native.test.tsx
@@ -1,11 +1,10 @@
-import { renderHook } from '@testing-library/react-hooks'
 import React from 'react'
 
 import { SearchGroupNameEnum } from 'api/gen'
 import { CATEGORY_CRITERIA } from 'features/search/enums'
 import { initialSearchState } from 'features/search/pages/reducer'
 import { useSearchGroupLabelMapping } from 'libs/subcategories/mappings'
-import { fireEvent, render } from 'tests/utils'
+import { fireEvent, render, renderHook } from 'tests/utils'
 
 import { Category } from '../Category'
 

--- a/src/features/search/utils/tests/useFilterCount.test.ts
+++ b/src/features/search/utils/tests/useFilterCount.test.ts
@@ -1,4 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { mocked } from 'ts-jest/utils'
 
 import { LocationType } from 'features/search/enums'
@@ -7,6 +6,7 @@ import { initialSearchState } from 'features/search/pages/reducer'
 import { DEFAULT_TIME_RANGE, MAX_PRICE } from 'features/search/pages/reducer.helpers'
 import { SearchState } from 'features/search/types'
 import { useMaxPrice } from 'features/search/utils/useMaxPrice'
+import { renderHook } from 'tests/utils'
 
 import { useFilterCount } from '../useFilterCount'
 

--- a/src/features/search/utils/tests/useLogBeforeNavToSearchResults.test.ts
+++ b/src/features/search/utils/tests/useLogBeforeNavToSearchResults.test.ts
@@ -1,8 +1,7 @@
-import { renderHook } from '@testing-library/react-hooks'
-
 import { initialSearchState } from 'features/search/pages/reducer'
 import { useLogBeforeNavToSearchResults } from 'features/search/utils/useLogBeforeNavToSearchResults'
 import { analytics } from 'libs/firebase/analytics'
+import { renderHook } from 'tests/utils'
 
 const mockSearchState = initialSearchState
 const mockDispatch = jest.fn()

--- a/src/features/search/utils/tests/useMaxPrice.test.ts
+++ b/src/features/search/utils/tests/useMaxPrice.test.ts
@@ -1,4 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { UseQueryResult } from 'react-query'
 import { mocked } from 'ts-jest/utils'
 
@@ -6,6 +5,7 @@ import { UserProfileResponse } from 'api/gen'
 import { useUserProfileInfo } from 'features/profile/api'
 import { isUserExBeneficiary } from 'features/profile/utils'
 import { useMaxPrice } from 'features/search/utils/useMaxPrice'
+import { renderHook } from 'tests/utils'
 
 jest.mock('features/profile/api')
 jest.mock('features/profile/utils')

--- a/src/features/venue/api/__tests__/useVenueSearchParameters.test.ts
+++ b/src/features/venue/api/__tests__/useVenueSearchParameters.test.ts
@@ -1,10 +1,9 @@
-import { renderHook } from '@testing-library/react-hooks'
-
 import { VenueResponse } from 'api/gen'
 import { LocationType } from 'features/search/enums'
 import { useVenueSearchParameters } from 'features/venue/api/useVenueSearchParameters'
 import { venueResponseSnap as venue } from 'features/venue/fixtures/venueResponseSnap'
 import { GeoCoordinates } from 'libs/geolocation'
+import { renderHook } from 'tests/utils'
 
 let mockPosition: GeoCoordinates | null = null
 jest.mock('libs/geolocation', () => ({

--- a/src/features/venue/pages/__tests__/Venue.analytics.native.test.tsx
+++ b/src/features/venue/pages/__tests__/Venue.analytics.native.test.tsx
@@ -4,8 +4,7 @@ import { ReactTestInstance } from 'react-test-renderer'
 import { venueResponseSnap } from 'features/venue/fixtures/venueResponseSnap'
 import { VenueBody } from 'features/venue/pages/VenueBody'
 import { analytics } from 'libs/firebase/analytics'
-import { act, fireEvent } from 'tests/utils'
-import { render } from 'tests/utils'
+import { act, fireEvent, render } from 'tests/utils'
 
 const venueId = venueResponseSnap.id
 

--- a/src/libs/firebase/analytics/__tests__/useInit.test.ts
+++ b/src/libs/firebase/analytics/__tests__/useInit.test.ts
@@ -1,8 +1,8 @@
-import { renderHook } from '@testing-library/react-hooks'
 import mockdate from 'mockdate'
 
 import { analytics } from 'libs/firebase/analytics/analytics'
 import { useInit } from 'libs/firebase/analytics/useInit'
+import { renderHook } from 'tests/utils'
 
 const CURRENT_DATE = new Date('2020-12-02T00:00:01.000Z')
 const START_TWENTY_THREE_HOURS_IN_THE_PAST = new Date('2020-12-01T23:00:00.000Z')

--- a/src/libs/firebase/firestore/__tests__/ubbleETAMessage.native.test.ts
+++ b/src/libs/firebase/firestore/__tests__/ubbleETAMessage.native.test.ts
@@ -1,7 +1,6 @@
-import { renderHook } from '@testing-library/react-hooks'
-
 import firestore from 'libs/firebase/shims/firestore'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { renderHook, waitFor } from 'tests/utils'
 
 import { getUbbleETAMessage, useUbbleETAMessage } from '../ubbleETAMessage'
 
@@ -16,12 +15,14 @@ describe('[method] ubbleETAMessage', () => {
   })
 
   it('should retrieve the ubbleETAMessage', async () => {
-    const { result, waitFor } = renderHook(useUbbleETAMessage, {
+    const { result } = renderHook(useUbbleETAMessage, {
       // eslint-disable-next-line local-rules/no-react-query-provider-hoc
       wrapper: ({ children }) => reactQueryProviderHOC(children),
     })
-    await waitFor(() => typeof result.current.data === 'string')
-    // See __mocks__/@react-native-firebase/firestore
-    expect(result.current.data).toEqual('Environ 1 heure')
+
+    await waitFor(() => {
+      // See __mocks__/@react-native-firebase/firestore
+      expect(result.current.data).toEqual('Environ 1 heure')
+    })
   })
 })

--- a/src/libs/geolocation/GeolocationWrapper.test.tsx
+++ b/src/libs/geolocation/GeolocationWrapper.test.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable local-rules/independant-mocks */
-import { renderHook } from '@testing-library/react-hooks'
 import { mocked } from 'ts-jest/utils'
 import waitForExpect from 'wait-for-expect'
 
 import { checkGeolocPermission } from 'libs/geolocation/checkGeolocPermission'
 import { requestGeolocPermission } from 'libs/geolocation/requestGeolocPermission'
+import { renderHook } from 'tests/utils'
 
 import { GeolocPermissionState, GeolocPositionError } from './enums'
 import { GeolocationWrapper, useGeolocation } from './GeolocationWrapper'

--- a/src/libs/geolocation/tests.utils.ts
+++ b/src/libs/geolocation/tests.utils.ts
@@ -1,5 +1,6 @@
-import { act } from '@testing-library/react-hooks'
 import { GeoPosition } from 'react-native-geolocation-service'
+
+import { act } from 'tests/utils'
 
 export const EiffelTourCoordinates = {
   latitude: 48.85,

--- a/src/libs/itinerary/useItinerary.native.test.ts
+++ b/src/libs/itinerary/useItinerary.native.test.ts
@@ -1,11 +1,10 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { Alert, Platform } from 'react-native'
 import waitForExpect from 'wait-for-expect'
 
 import { getAvailableApps, navigate } from '__mocks__/react-native-launch-navigator'
 import { openGoogleMapsItinerary } from 'libs/itinerary/openGoogleMapsItinerary'
 import { useItinerary } from 'libs/itinerary/useItinerary'
-import { superFlushWithAct } from 'tests/utils'
+import { renderHook, superFlushWithAct } from 'tests/utils'
 import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
 
 const alertMock = jest.spyOn(Alert, 'alert')

--- a/src/libs/itinerary/useItinerary.web.test.ts
+++ b/src/libs/itinerary/useItinerary.web.test.ts
@@ -1,9 +1,8 @@
-import { renderHook } from '@testing-library/react-hooks'
 import waitForExpect from 'wait-for-expect'
 
 import { openGoogleMapsItinerary } from 'libs/itinerary/openGoogleMapsItinerary'
 import { useItinerary } from 'libs/itinerary/useItinerary'
-import { superFlushWithAct } from 'tests/utils'
+import { renderHook, superFlushWithAct } from 'tests/utils'
 import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
 
 jest.mock('libs/itinerary/openGoogleMapsItinerary')

--- a/src/libs/itinerary/useOpenItinerary.test.ts
+++ b/src/libs/itinerary/useOpenItinerary.test.ts
@@ -1,6 +1,5 @@
-import { renderHook } from '@testing-library/react-hooks'
-
 import * as Itinerary from 'libs/itinerary/useItinerary'
+import { renderHook } from 'tests/utils'
 
 import useOpenItinerary from './useOpenItinerary'
 

--- a/src/libs/notifications/useStartBatchNotification.native.test.ts
+++ b/src/libs/notifications/useStartBatchNotification.native.test.ts
@@ -1,6 +1,5 @@
-import { renderHook } from '@testing-library/react-hooks'
-
 import { BatchPush } from 'libs/react-native-batch'
+import { renderHook } from 'tests/utils'
 
 import { useStartBatchNotification } from './useStartBatchNotification'
 

--- a/src/libs/notifications/useStartBatchNotification.web.test.ts
+++ b/src/libs/notifications/useStartBatchNotification.web.test.ts
@@ -1,6 +1,5 @@
-import { renderHook } from '@testing-library/react-hooks'
-
 import { BatchPush } from 'libs/react-native-batch'
+import { renderHook } from 'tests/utils'
 
 import { useStartBatchNotification } from './useStartBatchNotification'
 

--- a/src/libs/search/__tests__/parseSearchParameters.test.ts
+++ b/src/libs/search/__tests__/parseSearchParameters.test.ts
@@ -1,4 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { GeoCoordinates } from 'react-native-geolocation-service'
 
 import { SearchParametersFields } from 'features/home/contentful'
@@ -6,6 +5,7 @@ import { LocationType } from 'features/search/enums'
 import { initialSearchState } from 'features/search/pages/reducer'
 import { useParseSearchParameters } from 'libs/search'
 import { useSubcategoryLabelMapping } from 'libs/subcategories/mappings'
+import { renderHook } from 'tests/utils'
 
 import { parseSearchParameters } from '../parseSearchParameters'
 

--- a/src/libs/subcategories/__tests__/mappings.test.ts
+++ b/src/libs/subcategories/__tests__/mappings.test.ts
@@ -1,5 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks'
-
 import {
   categoryIdMappingSnap,
   subcategoriesMappingSnap,
@@ -13,6 +11,7 @@ import {
   useSubcategoriesMapping,
 } from 'libs/subcategories/mappings'
 import { placeholderData } from 'libs/subcategories/placeholderData'
+import { renderHook } from 'tests/utils'
 
 const mockSubcategories = placeholderData.subcategories
 jest.mock('libs/subcategories/useSubcategories', () => ({

--- a/src/libs/subcategories/__tests__/useSubcategory.test.ts
+++ b/src/libs/subcategories/__tests__/useSubcategory.test.ts
@@ -1,7 +1,6 @@
-import { renderHook } from '@testing-library/react-hooks'
-
 import { SubcategoryIdEnum, CategoryIdEnum, SearchGroupNameEnum } from 'api/gen'
 import { useSubcategory } from 'libs/subcategories'
+import { renderHook } from 'tests/utils'
 
 describe('useSubcategory', () => {
   it.each`

--- a/src/libs/timer.native.test.ts
+++ b/src/libs/timer.native.test.ts
@@ -1,8 +1,6 @@
-import { renderHook } from '@testing-library/react-hooks'
-
 import * as Dates from 'libs/dates'
 import * as Timer from 'libs/timer'
-import { act } from 'tests/utils'
+import { act, renderHook } from 'tests/utils'
 
 describe('Timer', () => {
   describe('Undefined start time', () => {

--- a/src/ui/components/buttons/AppButton/AppButton.web.test.tsx
+++ b/src/ui/components/buttons/AppButton/AppButton.web.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
-import { render } from 'tests/utils/web'
-import { fireEvent } from 'tests/utils/web'
+import { render, fireEvent } from 'tests/utils/web'
 import { Close } from 'ui/svg/icons/Close'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
 import { Typo } from 'ui/theme'

--- a/src/ui/components/keyboard/useKeyboardEvents.native.test.ts
+++ b/src/ui/components/keyboard/useKeyboardEvents.native.test.ts
@@ -1,5 +1,6 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { Keyboard, KeyboardEvent, Platform, DeviceEventEmitter } from 'react-native'
+
+import { renderHook } from 'tests/utils'
 
 import { useKeyboardEvents } from './useKeyboardEvents'
 

--- a/src/ui/theme/customFocusOutline/__tests__/customFocusOutline.native.test.tsx
+++ b/src/ui/theme/customFocusOutline/__tests__/customFocusOutline.native.test.tsx
@@ -1,5 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks'
-
+import { renderHook } from 'tests/utils'
 import { theme } from 'theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 

--- a/src/ui/theme/customFocusOutline/__tests__/customFocusOutline.web.test.tsx
+++ b/src/ui/theme/customFocusOutline/__tests__/customFocusOutline.web.test.tsx
@@ -1,5 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks'
-
+import { renderHook } from 'tests/utils'
 import { theme } from 'theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 

--- a/src/ui/theme/getHoverStyle/__tests__/getHoverStyle.native.test.tsx
+++ b/src/ui/theme/getHoverStyle/__tests__/getHoverStyle.native.test.tsx
@@ -1,5 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks'
-
+import { renderHook } from 'tests/utils'
 import { theme } from 'theme'
 import { getHoverStyle } from 'ui/theme/getHoverStyle/getHoverStyle'
 

--- a/src/ui/theme/getHoverStyle/__tests__/getHoverStyle.web.test.tsx
+++ b/src/ui/theme/getHoverStyle/__tests__/getHoverStyle.web.test.tsx
@@ -1,5 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks'
-
+import { renderHook } from 'tests/utils'
 import { theme } from 'theme'
 import { getHoverStyle } from 'ui/theme/getHoverStyle/getHoverStyle'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5159,14 +5159,6 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
-  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    react-error-boundary "^3.1.0"
-
 "@testing-library/react-native@10.1.1":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-10.1.1.tgz#f5d1c634af797c890023713e69374fda010ca540"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16170

## Principaux changements
Plus besoin d'awaitFor le result.current.... avant les expects mais plutôt au niveau des expects. 
On utilise waitFor depuis testing library directement. 
Avant
``` 
import { renderHook } from '@testing-library/react-hooks'
...
 it('should return ....', async () => {
    const { result, waitFor } = rendeHook(() => useQuelqueChose())
    await waitFor(() => result.current.data !== undefined)
    expect(result.current....).toBe(...)
 })
```
Après 
```
import { renderHook, waitFor } from 'tests/utils'
...
 it('should return ....', async () => {
    const { result } = rendeHook(() => useQuelqueChose())
    await waitFor(() => {
       expect(result.current....).toBe(...)
    })
 })
```


## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
