### PR TITLE
(PC-16233) feat(algolia): add algolia tracking to mobile

### DIFF
--- a/src/libs/algolia/analytics/__tests__/logClickOnOffer.test.ts
+++ b/src/libs/algolia/analytics/__tests__/logClickOnOffer.test.ts
@@ -19,7 +19,7 @@ describe('logClickOnOffer', () => {
     await logClickOnOffer('abc123')({ objectID: 'object123', position: 0 })
 
     expect(mockAlgoliaSearchInsights).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
-      eventName: 'Product Clicked',
+      eventName: 'Offer Clicked',
       index: 'algoliaOffersIndexName',
       objectIDs: ['object123'],
       positions: [1],

--- a/src/libs/algolia/analytics/initAlgoliaAnalytics.ts
+++ b/src/libs/algolia/analytics/initAlgoliaAnalytics.ts
@@ -1,4 +1,5 @@
 import AlgoliaSearchInsights from 'search-insights'
+import { v1 as uuid } from 'uuid'
 
 import { env } from 'libs/environment'
 
@@ -6,6 +7,7 @@ export const initAlgoliaAnalytics = () => {
   AlgoliaSearchInsights('init', {
     appId: env.ALGOLIA_APPLICATION_ID,
     apiKey: env.ALGOLIA_SEARCH_API_KEY,
-    useCookie: true,
   })
+
+  AlgoliaSearchInsights('setUserToken', uuid())
 }

--- a/src/libs/algolia/analytics/logClickOnOffer.ts
+++ b/src/libs/algolia/analytics/logClickOnOffer.ts
@@ -6,23 +6,6 @@ import { env } from 'libs/environment'
 import { captureMonitoringError } from 'libs/monitoring'
 import { getCookiesConsent } from 'libs/trackingConsent/consent'
 
-type LogClickOnProductArgs = {
-  index: string
-  queryID: string
-  objectIDs: string[]
-  positions: number[]
-}
-
-const logClickOnProduct = ({ index, queryID, objectIDs, positions }: LogClickOnProductArgs) => {
-  AlgoliaSearchInsights('clickedObjectIDsAfterSearch', {
-    eventName: 'Product Clicked',
-    index,
-    queryID,
-    objectIDs,
-    positions,
-  })
-}
-
 export const logClickOnOffer =
   (currentQueryID?: string) =>
   async ({ objectID, position }: { objectID: string; position: number }) => {
@@ -36,7 +19,8 @@ export const logClickOnOffer =
       return
     }
 
-    logClickOnProduct({
+    AlgoliaSearchInsights('clickedObjectIDsAfterSearch', {
+      eventName: 'Product Clicked',
       index: env.ALGOLIA_OFFERS_INDEX_NAME,
       queryID: currentQueryID,
       objectIDs: [objectID],

--- a/src/libs/algolia/analytics/logClickOnOffer.ts
+++ b/src/libs/algolia/analytics/logClickOnOffer.ts
@@ -20,7 +20,7 @@ export const logClickOnOffer =
     }
 
     AlgoliaSearchInsights('clickedObjectIDsAfterSearch', {
-      eventName: 'Product Clicked',
+      eventName: 'Offer Clicked',
       index: env.ALGOLIA_OFFERS_INDEX_NAME,
       queryID: currentQueryID,
       objectIDs: [objectID],


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16233

Le tracking Algolia ne fonctionne pas sur mobile car nous utilisons une fonctionnalité d'Algolia, qui génère un userToken et le stocke dans un cookie. Or il n'y a pas de cookie sur mobile (confirmé par le support: https://support.algolia.com/hc/en-us/requests/504416) 
En suivant une des recommandations du support, on génère alors un userToken en début de session (un uuid), qui sera utilisé dans les events envoyés plus tard. Ce token n'étant pas stocké, il ne durera que le temps de la session, mais cela n'a pas l'air d'avoir d'impact avec les fonctionnalités qu'on utilise du tracking algolia (confirmé par le support: "Though if you wish the users remain anonymous between sessions, generating a new one each session would be acceptable")

## Checklist

I have:
- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
