### PR TITLE
(PC-16252) fix(SearchV2): navigate instead of push on Native apps

### DIFF
--- a/src/features/search/atoms/__tests__/NoSearchResult.native.test.tsx
+++ b/src/features/search/atoms/__tests__/NoSearchResult.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { push, useRoute } from '__mocks__/@react-navigation/native'
+import { navigate, useRoute } from '__mocks__/@react-navigation/native'
 import { LocationType } from 'features/search/enums'
 import { initialSearchState } from 'features/search/pages/reducer'
 import { MAX_RADIUS } from 'features/search/pages/reducer.helpers'
@@ -40,8 +40,8 @@ describe('NoSearchResult component', () => {
   it('should dispatch the right actions when pressing "autour de toi" - no location', () => {
     const button = render(<NoSearchResult />).getByText('autour de toi')
     fireEvent.press(button)
-    expect(push).toHaveBeenCalledTimes(1)
-    expect(push).toHaveBeenLastCalledWith('TabNavigator', {
+    expect(navigate).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenLastCalledWith('TabNavigator', {
       screen: 'Search',
       params: {
         ...initialSearchState,
@@ -57,8 +57,8 @@ describe('NoSearchResult component', () => {
     mockPosition = { latitude: 2, longitude: 40 }
     const button = render(<NoSearchResult />).getByText('autour de toi')
     fireEvent.press(button)
-    expect(push).toHaveBeenCalledTimes(1)
-    expect(push).toHaveBeenLastCalledWith('TabNavigator', {
+    expect(navigate).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenLastCalledWith('TabNavigator', {
       screen: 'Search',
       params: {
         ...initialSearchState,

--- a/src/features/search/components/__tests__/SearchBox.native.test.tsx
+++ b/src/features/search/components/__tests__/SearchBox.native.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
-import { navigate, push } from '__mocks__/@react-navigation/native'
+import { navigate } from '__mocks__/@react-navigation/native'
 import { SearchGroupNameEnum } from 'api/gen'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { LocationType } from 'features/search/enums'
@@ -68,7 +68,7 @@ describe('SearchBox component', () => {
     fireEvent(searchInput, 'onSubmitEditing', { nativeEvent: { text: 'jazzaza' } })
 
     expect(analytics.logSearchQuery).toBeCalledWith('jazzaza')
-    expect(push).toBeCalledWith(
+    expect(navigate).toBeCalledWith(
       ...getTabNavConfig('Search', {
         ...initialSearchState,
         query: 'jazzaza',
@@ -122,7 +122,7 @@ describe('SearchBox component', () => {
     const resetIcon = getByTestId('resetSearchInput')
     await fireEvent.press(resetIcon)
 
-    expect(push).toBeCalledWith(
+    expect(navigate).toBeCalledWith(
       ...getTabNavConfig('Search', {
         ...mockStagedSearchState,
         query: '',
@@ -147,7 +147,7 @@ describe('SearchBox component', () => {
         locationFilter: mockStagedSearchState.locationFilter,
       },
     })
-    expect(push).toBeCalledWith(
+    expect(navigate).toBeCalledWith(
       ...getTabNavConfig('Search', {
         ...initialSearchState,
         query: '',
@@ -172,7 +172,7 @@ describe('SearchBox component', () => {
 
     fireEvent(searchInput, 'onSubmitEditing', { nativeEvent: { text: 'jazzaza' } })
 
-    expect(push).toBeCalledWith(
+    expect(navigate).toBeCalledWith(
       ...getTabNavConfig('Search', {
         ...initialSearchState,
         query: 'jazzaza',

--- a/src/features/search/pages/__tests__/useShowResultsForCategory.test.ts
+++ b/src/features/search/pages/__tests__/useShowResultsForCategory.test.ts
@@ -1,4 +1,4 @@
-import { push } from '__mocks__/@react-navigation/native'
+import { navigate } from '__mocks__/@react-navigation/native'
 import { SearchGroupNameEnum } from 'api/gen'
 import { LocationType } from 'features/search/enums'
 import { initialSearchState } from 'features/search/pages/reducer'
@@ -48,7 +48,7 @@ describe('useShowResultsForCategory', () => {
 
     resultCallback.current(SearchGroupNameEnum.SPECTACLE)
 
-    expect(push).toBeCalledWith('TabNavigator', {
+    expect(navigate).toBeCalledWith('TabNavigator', {
       params: {
         beginningDatetime: null,
         date: null,

--- a/src/features/search/pages/__tests__/useShowResultsWithStagedSearch.test.ts
+++ b/src/features/search/pages/__tests__/useShowResultsWithStagedSearch.test.ts
@@ -1,4 +1,6 @@
-import { push } from '__mocks__/@react-navigation/native'
+import { Platform } from 'react-native'
+
+import { navigate as mockNavigate, push as mockPush } from '__mocks__/@react-navigation/native'
 import { SearchGroupNameEnum } from 'api/gen'
 import { LocationType } from 'features/search/enums'
 import { initialSearchState } from 'features/search/pages/reducer'
@@ -6,6 +8,7 @@ import { renderHook } from 'tests/utils'
 
 import { usePushWithStagedSearch } from '../usePushWithStagedSearch'
 
+const push = Platform.OS === 'web' ? mockPush : mockNavigate
 const mockSearchState = initialSearchState
 const mockDispatch = jest.fn()
 let mockStagedSearchState = initialSearchState

--- a/src/features/search/pages/usePushWithStagedSearch.web.ts
+++ b/src/features/search/pages/usePushWithStagedSearch.web.ts
@@ -9,11 +9,11 @@ import { SearchState } from 'features/search/types'
 
 export const usePushWithStagedSearch = () => {
   const { searchState: stagedSearchState } = useStagedSearch()
-  const { navigate } = useNavigation<UseNavigationType>()
+  const { push } = useNavigation<UseNavigationType>()
 
   return useCallback(
     (partialSearchState?: Partial<SearchState>, options: { reset?: boolean } = {}) => {
-      navigate(
+      push(
         ...getTabNavConfig('Search', {
           ...stagedSearchState,
           ...(options.reset ? initialSearchState : {}),
@@ -21,6 +21,6 @@ export const usePushWithStagedSearch = () => {
         })
       )
     },
-    [navigate, stagedSearchState]
+    [push, stagedSearchState]
   )
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16252

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
