### PR TITLE
(PC-16256) build(metro): set blacklistRE in rn-cli.config.js

### DIFF
--- a/rn-cli.config.js
+++ b/rn-cli.config.js
@@ -1,4 +1,12 @@
+const blacklist = require('react-native/packager/blacklist')
+
 module.exports = {
+  getBlacklistRE(platform) {
+    return blacklist(platform, [
+      /build\/.*/,
+      /server\/.*/,
+    ]);
+  },
   getTransformModulePath() {
     return require.resolve('react-native-typescript-transformer');
   },


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16256

To prevent refreshing the native while starting the web app of development.


## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
