### PR TITLE
(PC-16255) refactor(button): fix ButtonInsideText Android margin and font familly

### DIFF
--- a/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicy.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicy.native.test.tsx.native-snap
@@ -311,99 +311,101 @@ exports[`<PrivacyPolicy /> should render privacy policy 1`] = `
                     ]
                   }
                 />
-                <View
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onClick={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    Object {
-                      "marginVertical": -1.5,
-                      "opacity": 1,
-                      "userSelect": "auto",
-                    }
-                  }
-                >
+                <View>
                   <View
-                    icon={
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
                       Object {
-                        "$$typeof": Symbol(react.forward_ref),
-                        "attrs": Array [
-                          [Function],
-                        ],
-                        "inlineStyle": InlineStyle {
-                          "rules": Array [
-                            "",
-                          ],
-                        },
-                        "render": [Function],
-                        "shouldForwardProp": undefined,
-                        "styledComponentId": "StyledNativeComponent",
-                        "target": [Function],
-                        "withComponent": [Function],
+                        "opacity": 1,
+                        "top": 3,
+                        "userSelect": "auto",
                       }
                     }
-                    style={
-                      Array [
-                        Object {
-                          "paddingLeft": 25,
-                        },
-                      ]
-                    }
-                    typography="ButtonText"
                   >
                     <View
-                      style={
-                        Array [
-                          Object {
-                            "left": 0,
-                            "position": "absolute",
+                      icon={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "attrs": Array [
+                            [Function],
+                          ],
+                          "inlineStyle": InlineStyle {
+                            "rules": Array [
+                              "",
+                            ],
                           },
-                        ]
-                      }
-                    >
-                      <View
-                        height={20}
-                        testID="button-icon"
-                        width={20}
-                      >
-                        <Text>
-                          button-icon-SVG-Mock
-                        </Text>
-                      </View>
-                      <View
-                        numberOfSpaces={1}
-                        style={
-                          Array [
-                            Object {
-                              "width": 4,
-                            },
-                          ]
+                          "render": [Function],
+                          "shouldForwardProp": undefined,
+                          "styledComponentId": "StyledNativeComponent",
+                          "target": [Function],
+                          "withComponent": [Function],
                         }
-                      />
-                    </View>
-                    <Text
+                      }
                       style={
                         Array [
                           Object {
-                            "color": "#eb0055",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "fontWeight": "bold",
-                            "lineHeight": 20,
+                            "paddingLeft": 25,
                           },
                         ]
                       }
                       typography="ButtonText"
                     >
-                      Politique des cookies
-                    </Text>
+                      <View
+                        style={
+                          Array [
+                            Object {
+                              "left": 0,
+                              "position": "absolute",
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          height={20}
+                          testID="button-icon"
+                          width={20}
+                        >
+                          <Text>
+                            button-icon-SVG-Mock
+                          </Text>
+                        </View>
+                        <View
+                          numberOfSpaces={1}
+                          style={
+                            Array [
+                              Object {
+                                "width": 4,
+                              },
+                            ]
+                          }
+                        />
+                      </View>
+                      <Text
+                        style={
+                          Array [
+                            Object {
+                              "color": "#eb0055",
+                              "fontFamily": "Montserrat-Bold",
+                              "fontSize": 15,
+                              "fontWeight": "bold",
+                              "lineHeight": 20,
+                            },
+                          ]
+                        }
+                        typography="ButtonText"
+                      >
+                        Politique des cookies
+                      </Text>
+                    </View>
                   </View>
                 </View>
               </Text>

--- a/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicy.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicy.native.test.tsx.native-snap
@@ -396,7 +396,6 @@ exports[`<PrivacyPolicy /> should render privacy policy 1`] = `
                               "color": "#eb0055",
                               "fontFamily": "Montserrat-Bold",
                               "fontSize": 15,
-                              "fontWeight": "bold",
                               "lineHeight": 20,
                             },
                           ]

--- a/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicyModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicyModal.native.test.tsx.native-snap
@@ -311,99 +311,101 @@ exports[`<PrivacyPolicyModal /> should render correctly 1`] = `
                     ]
                   }
                 />
-                <View
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onClick={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    Object {
-                      "marginVertical": -1.5,
-                      "opacity": 1,
-                      "userSelect": "auto",
-                    }
-                  }
-                >
+                <View>
                   <View
-                    icon={
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
                       Object {
-                        "$$typeof": Symbol(react.forward_ref),
-                        "attrs": Array [
-                          [Function],
-                        ],
-                        "inlineStyle": InlineStyle {
-                          "rules": Array [
-                            "",
-                          ],
-                        },
-                        "render": [Function],
-                        "shouldForwardProp": undefined,
-                        "styledComponentId": "StyledNativeComponent",
-                        "target": [Function],
-                        "withComponent": [Function],
+                        "opacity": 1,
+                        "top": 3,
+                        "userSelect": "auto",
                       }
                     }
-                    style={
-                      Array [
-                        Object {
-                          "paddingLeft": 25,
-                        },
-                      ]
-                    }
-                    typography="ButtonText"
                   >
                     <View
-                      style={
-                        Array [
-                          Object {
-                            "left": 0,
-                            "position": "absolute",
+                      icon={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "attrs": Array [
+                            [Function],
+                          ],
+                          "inlineStyle": InlineStyle {
+                            "rules": Array [
+                              "",
+                            ],
                           },
-                        ]
-                      }
-                    >
-                      <View
-                        height={20}
-                        testID="button-icon"
-                        width={20}
-                      >
-                        <Text>
-                          button-icon-SVG-Mock
-                        </Text>
-                      </View>
-                      <View
-                        numberOfSpaces={1}
-                        style={
-                          Array [
-                            Object {
-                              "width": 4,
-                            },
-                          ]
+                          "render": [Function],
+                          "shouldForwardProp": undefined,
+                          "styledComponentId": "StyledNativeComponent",
+                          "target": [Function],
+                          "withComponent": [Function],
                         }
-                      />
-                    </View>
-                    <Text
+                      }
                       style={
                         Array [
                           Object {
-                            "color": "#eb0055",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "fontWeight": "bold",
-                            "lineHeight": 20,
+                            "paddingLeft": 25,
                           },
                         ]
                       }
                       typography="ButtonText"
                     >
-                      Politique des cookies
-                    </Text>
+                      <View
+                        style={
+                          Array [
+                            Object {
+                              "left": 0,
+                              "position": "absolute",
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          height={20}
+                          testID="button-icon"
+                          width={20}
+                        >
+                          <Text>
+                            button-icon-SVG-Mock
+                          </Text>
+                        </View>
+                        <View
+                          numberOfSpaces={1}
+                          style={
+                            Array [
+                              Object {
+                                "width": 4,
+                              },
+                            ]
+                          }
+                        />
+                      </View>
+                      <Text
+                        style={
+                          Array [
+                            Object {
+                              "color": "#eb0055",
+                              "fontFamily": "Montserrat-Bold",
+                              "fontSize": 15,
+                              "fontWeight": "bold",
+                              "lineHeight": 20,
+                            },
+                          ]
+                        }
+                        typography="ButtonText"
+                      >
+                        Politique des cookies
+                      </Text>
+                    </View>
                   </View>
                 </View>
               </Text>

--- a/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicyModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/firstLogin/PrivacyPolicy/PrivacyPolicyModal.native.test.tsx.native-snap
@@ -396,7 +396,6 @@ exports[`<PrivacyPolicyModal /> should render correctly 1`] = `
                               "color": "#eb0055",
                               "fontFamily": "Montserrat-Bold",
                               "fontSize": 15,
-                              "fontWeight": "bold",
                               "lineHeight": 20,
                             },
                           ]

--- a/__snapshots__/features/profile/components/ProfileHeader.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/ProfileHeader.native.test.tsx.native-snap
@@ -179,28 +179,20 @@ exports[`ProfileHeader should display the LoggedOutHeader if no user 1`] = `
         ]
       }
     />
-    <View
+    <Text
       style={
         Array [
           Object {
-            "flexDirection": "row",
+            "color": "#ffffff",
+            "fontFamily": "Montserrat-Regular",
+            "fontSize": 15,
+            "lineHeight": 20,
           },
         ]
       }
     >
-      <Text
-        style={
-          Array [
-            Object {
-              "color": "#ffffff",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
-            },
-          ]
-        }
-      >
-        Tu as déjà un compte ? 
+      Tu as déjà un compte ? 
+      <View>
         <View
           accessible={true}
           collapsable={false}
@@ -214,8 +206,8 @@ exports[`ProfileHeader should display the LoggedOutHeader if no user 1`] = `
           onStartShouldSetResponder={[Function]}
           style={
             Object {
-              "marginVertical": -1.5,
               "opacity": 1,
+              "top": 3,
               "userSelect": "auto",
             }
           }
@@ -248,8 +240,8 @@ exports[`ProfileHeader should display the LoggedOutHeader if no user 1`] = `
             </Text>
           </View>
         </View>
-      </Text>
-    </View>
+      </View>
+    </Text>
     <View
       numberOfSpaces={7}
       style={

--- a/__snapshots__/features/profile/components/ProfileHeader.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/ProfileHeader.native.test.tsx.native-snap
@@ -229,7 +229,6 @@ exports[`ProfileHeader should display the LoggedOutHeader if no user 1`] = `
                     "color": "#ffffff",
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
-                    "fontWeight": "bold",
                     "lineHeight": 20,
                   },
                 ]

--- a/__snapshots__/features/search/components/__tests__/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/components/__tests__/SearchResults.native.test.tsx.native-snap
@@ -179,63 +179,65 @@ exports[`SearchResults component should render correctly 1`] = `
               ]
             }
           >
-            Modifie ta recherche ou découvre toutes les offres 
-          </Text>
-          <View
-            numberOfSpaces={1}
-            style={
-              Array [
-                Object {
-                  "width": 4,
-                },
-              ]
-            }
-          />
-          <View
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Object {
-                "marginVertical": -1.5,
-                "opacity": 1,
-                "userSelect": "auto",
-              }
-            }
-          >
+            Modifie ta recherche ou découvre toutes les offres
             <View
+              numberOfSpaces={1}
               style={
                 Array [
-                  Object {},
+                  Object {
+                    "width": 4,
+                  },
                 ]
               }
-              typography="ButtonText"
-            >
-              <Text
+            />
+            <View>
+              <View
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
-                  Array [
-                    Object {
-                      "color": "#eb0055",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "fontWeight": "bold",
-                      "lineHeight": 20,
-                    },
-                  ]
+                  Object {
+                    "opacity": 1,
+                    "top": 3,
+                    "userSelect": "auto",
+                  }
                 }
-                typography="ButtonText"
               >
-                autour de toi
-              </Text>
+                <View
+                  style={
+                    Array [
+                      Object {},
+                    ]
+                  }
+                  typography="ButtonText"
+                >
+                  <Text
+                    style={
+                      Array [
+                        Object {
+                          "color": "#eb0055",
+                          "fontFamily": "Montserrat-Bold",
+                          "fontSize": 15,
+                          "fontWeight": "bold",
+                          "lineHeight": 20,
+                        },
+                      ]
+                    }
+                    typography="ButtonText"
+                  >
+                    autour de toi
+                  </Text>
+                </View>
+              </View>
             </View>
-          </View>
+          </Text>
         </Text>
         <View
           style={

--- a/__snapshots__/features/search/components/__tests__/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/components/__tests__/SearchResults.native.test.tsx.native-snap
@@ -225,7 +225,6 @@ exports[`SearchResults component should render correctly 1`] = `
                           "color": "#eb0055",
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
-                          "fontWeight": "bold",
                           "lineHeight": 20,
                         },
                       ]

--- a/src/features/profile/components/LoggedOutHeader.tsx
+++ b/src/features/profile/components/LoggedOutHeader.tsx
@@ -34,15 +34,13 @@ export function LoggedOutHeader() {
         />
         <Spacer.Column numberOfSpaces={5} />
         <LoginCta>
-          <Body>
-            {t`Tu as déjà un compte\u00a0?` + '\u00a0'}
-            <TouchableLink
-              as={StyledButtonInsideText}
-              navigateTo={{ screen: 'Login', params: { preventCancellation: true } }}
-              wording={t`Connecte-toi`}
-              {...accessibilityAndTestId(t`Connecte-toi`)}
-            />
-          </Body>
+          {t`Tu as déjà un compte\u00a0?` + '\u00a0'}
+          <TouchableLink
+            as={StyledButtonInsideText}
+            navigateTo={{ screen: 'Login', params: { preventCancellation: true } }}
+            wording={t`Connecte-toi`}
+            {...accessibilityAndTestId(t`Connecte-toi`)}
+          />
         </LoginCta>
         <Spacer.Column numberOfSpaces={7} />
       </HeaderContent>
@@ -60,10 +58,6 @@ const HeaderContent = styled.View({
   width: '100%',
 })
 
-const LoginCta = styled.View({
-  flexDirection: 'row',
-})
-
 const Description = styled(Typo.Body)(({ theme }) => ({
   textAlign: 'center',
   color: theme.colors.white,
@@ -73,7 +67,7 @@ const Title = styled(Typo.Title4).attrs(() => getHeadingAttrs(1))(({ theme }) =>
   color: theme.colors.white,
 }))
 
-const Body = styled(Typo.Body)(({ theme }) => ({
+const LoginCta = styled(Typo.Body)(({ theme }) => ({
   color: theme.colors.white,
 }))
 

--- a/src/features/search/atoms/NoSearchResult.tsx
+++ b/src/features/search/atoms/NoSearchResult.tsx
@@ -54,10 +54,10 @@ export const NoSearchResult: React.FC = () => {
       </DescriptionErrorTextContainer>
       <DescriptionErrorTextContainer>
         <DescriptionErrorText>
-          {t`Modifie ta recherche ou découvre toutes les offres` + ' '}
+          {t`Modifie ta recherche ou découvre toutes les offres`}
+          <Spacer.Row numberOfSpaces={1} />
+          <ButtonInsideText wording={t`autour de toi`} onPress={handlePressAroundMe} />
         </DescriptionErrorText>
-        <Spacer.Row numberOfSpaces={1} />
-        <ButtonInsideText wording={t`autour de toi`} onPress={handlePressAroundMe} />
       </DescriptionErrorTextContainer>
       <Spacer.Flex />
     </Container>

--- a/src/ui/components/buttons/buttonInsideText/ButtonInsideText.tsx
+++ b/src/ui/components/buttons/buttonInsideText/ButtonInsideText.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import { Platform } from 'react-native'
+import { View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { AppButtonEventNative } from 'ui/components/buttons/AppButton/types'
@@ -17,15 +19,22 @@ export function ButtonInsideText({
   testID,
 }: ButtonInsideTexteProps) {
   return (
-    <StyledTouchableOpacity
-      onPress={onPress as AppButtonEventNative}
-      onLongPress={onLongPress as AppButtonEventNative}
-      testID={testID}>
-      <ButtonInsideTextInner wording={wording} icon={Icon} color={color} typography={typography} />
-    </StyledTouchableOpacity>
+    <View>
+      <StyledTouchableOpacity
+        onPress={onPress as AppButtonEventNative}
+        onLongPress={onLongPress as AppButtonEventNative}
+        testID={testID}>
+        <ButtonInsideTextInner
+          wording={wording}
+          icon={Icon}
+          color={color}
+          typography={typography}
+        />
+      </StyledTouchableOpacity>
+    </View>
   )
 }
 
 const StyledTouchableOpacity = styled(TouchableOpacity)({
-  marginVertical: -getSpacing(1 / 3), // Hack for reset default TouchableOpacity margin vertical
+  top: getSpacing(Platform.OS === 'ios' ? 0.7 : 1), // Hack for reset default TouchableOpacity margin vertical
 })

--- a/src/ui/components/buttons/buttonInsideText/ButtonInsideTextInner.tsx
+++ b/src/ui/components/buttons/buttonInsideText/ButtonInsideTextInner.tsx
@@ -63,6 +63,5 @@ const StyledText = styled.Text<{
   icon?: FunctionComponent<IconInterface>
 }>(({ theme, typography, color }) => ({
   ...(typography === 'Caption' ? theme.typography.caption : theme.typography.buttonText),
-  fontWeight: 'bold',
   color: color ?? theme.colors.primary,
 }))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16255

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
| <img width="327" alt="Capture d’écran 2022-07-20 à 09 14 38" src="https://user-images.githubusercontent.com/62059034/179921880-55298580-cc92-4157-9874-7113275adb1d.png"> <img width="327" alt="Capture d’écran 2022-07-20 à 09 14 50" src="https://user-images.githubusercontent.com/62059034/179921891-3553a349-df49-4a15-b99d-438528e955f7.png"> <img width="325" alt="Capture d’écran 2022-07-20 à 09 15 02" src="https://user-images.githubusercontent.com/62059034/179921897-cbb7a5d8-2ea5-4912-b540-66adba2be783.png"> <img width="325" alt="Capture d’écran 2022-07-20 à 09 15 32" src="https://user-images.githubusercontent.com/62059034/179921900-e05d61a7-41de-48a5-afbc-7357c7370a04.png">  | <img width="340" alt="Capture d’écran 2022-07-20 à 09 21 15" src="https://user-images.githubusercontent.com/62059034/179922018-f7881f25-34c9-40ba-95d3-bf7b85012a6b.png"> <img width="336" alt="Capture d’écran 2022-07-20 à 09 21 44" src="https://user-images.githubusercontent.com/62059034/179922020-ff71d9d9-e9fc-4a0a-bcb0-c3857e2d2d5d.png"> <img width="337" alt="Capture d’écran 2022-07-20 à 09 22 08" src="https://user-images.githubusercontent.com/62059034/179922030-7e043bc9-558a-4ce4-bba4-f0de8b8b2403.png"> <img width="336" alt="Capture d’écran 2022-07-20 à 09 22 19" src="https://user-images.githubusercontent.com/62059034/179922031-0d16fec3-2fb1-4711-ac95-405c649928dd.png">        |       |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
