### PR TITLE
(PC-16182) feat(wording): change wordings in two pages

### DIFF
--- a/src/features/auth/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
+++ b/src/features/auth/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
@@ -53,7 +53,7 @@ export const ReinitializePassword = () => {
 
   const { mutate: resetPassword, isLoading } = useResetPasswordMutation(() => {
     showSuccessSnackBar({
-      message: t`Ton mot de passe a été modifié\u00a0!`,
+      message: t`Ton mot de passe est modifié\u00a0!`,
       timeout: SNACK_BAR_TIME_OUT,
     })
     analytics.logHasChangedPassword('resetPassword')

--- a/src/features/profile/pages/AfterChangeEmailValidationBuffer/AfterChangeEmailValidationBuffer.tsx
+++ b/src/features/profile/pages/AfterChangeEmailValidationBuffer/AfterChangeEmailValidationBuffer.tsx
@@ -52,7 +52,7 @@ export function AfterChangeEmailValidationBuffer() {
     }
     delayedNavigate('Login')
     showSuccessSnackBar({
-      message: t`Ton adresse e-mail a été modifiée. Tu peux te reconnecter avec ta nouvelle adresse e-mail.`,
+      message: t`Ton adresse e-mail est modifiée. Tu peux te reconnecter avec ta nouvelle adresse e-mail.`,
       timeout: SNACK_BAR_TIME_OUT,
     })
   }

--- a/src/features/profile/pages/AfterChangeEmailValidationBuffer/__tests__/AfterChangeEmailValidationBuffer.native.test.tsx
+++ b/src/features/profile/pages/AfterChangeEmailValidationBuffer/__tests__/AfterChangeEmailValidationBuffer.native.test.tsx
@@ -72,7 +72,7 @@ describe('<AfterChangeEmailValidationBuffer/>', () => {
       expect(mockSignOut).toBeCalled()
       expect(mockShowSuccessSnackBar).toBeCalledWith({
         message:
-          'Ton adresse e-mail a été modifiée. Tu peux te reconnecter avec ta nouvelle adresse e-mail.',
+          'Ton adresse e-mail est modifiée. Tu peux te reconnecter avec ta nouvelle adresse e-mail.',
         timeout: 5000,
       })
       expect(navigate).toBeCalledWith('Login')

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -2860,8 +2860,8 @@ msgid "Titre de séjour, carte d'identité, ou passeport."
 msgstr "Titre de séjour, carte d'identité, ou passeport."
 
 #: src/features/profile/pages/AfterChangeEmailValidationBuffer/AfterChangeEmailValidationBuffer.tsx
-msgid "Ton adresse e-mail a été modifiée. Tu peux te reconnecter avec ta nouvelle adresse e-mail."
-msgstr "Ton adresse e-mail a été modifiée. Tu peux te reconnecter avec ta nouvelle adresse e-mail."
+msgid "Ton adresse e-mail est modifiée. Tu peux te reconnecter avec ta nouvelle adresse e-mail."
+msgstr "Ton adresse e-mail est modifiée. Tu peux te reconnecter avec ta nouvelle adresse e-mail."
 
 #: src/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.tsx
 msgid "Ton adresse e-mail n’a pas été modifiée. Le lien que tu reçois par e-mail expire 24h après sa réception."
@@ -2944,13 +2944,13 @@ msgstr "Ton inscription est en cours de vérification. Tu recevras une notificat
 msgid "Ton mot de passe"
 msgstr "Ton mot de passe"
 
-#: src/features/auth/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
-msgid "Ton mot de passe a été modifié !"
-msgstr "Ton mot de passe a été modifié !"
-
 #: src/features/profile/pages/ChangePassword/ChangePassword.tsx
 msgid "Ton mot de passe actuel"
 msgstr "Ton mot de passe actuel"
+
+#: src/features/auth/forgottenPassword/ReinitializePassword/ReinitializePassword.tsx
+msgid "Ton mot de passe est modifié !"
+msgstr "Ton mot de passe est modifié !"
 
 #: src/features/identityCheck/pages/profile/SetName.tsx
 msgid "Ton nom"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16182

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots


https://user-images.githubusercontent.com/44037911/180412498-f025e704-a317-4d7f-8720-d27d854c8075.mov



[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
