### PR TITLE
(BSR) docs(codeStructure): improve architecture standard

### DIFF
--- a/doc/standards/codeStructure.md
+++ b/doc/standards/codeStructure.md
@@ -2,6 +2,7 @@
 
 ### Why
 
+- the code structure follows a screaming architecture
 - developers can quickly find what they are looking for in the code
 - avoid code duplication
 - it makes it easier to work on a part of the project without knowing the other parts
@@ -19,23 +20,38 @@ features
       \
         |- api
           \
-            |- user
-              \
-                |- login.ts ===> caller, adapter
-                |- otherCall.ts
-        |- components ==> UI components specific to the feature
+            |- __mocks__
+            |- login.ts ===> caller, adapter
+            |- login.test.ts
+            |- otherCall.ts
+            |- otherCall.test.ts
+        |- components ==> feature-specific UI components
           \
-            |- Component1.tsx
-            |- Component1.test.tsx
+            |- Component1
+              \
+                |- Component1.tsx
+                |- Component1.test.tsx
+                |- Component1.stories.tsx
             |- ...
-        |- pages ==> feature specific pages
-        |- services ==> utils or data tranform functions
-        fixturesTests.ts ==> data for testing (API call responses mocks)
+        |- pages ==> feature-specific pages
+          \
+            |- Page1
+              \
+                |- Page1.tsx
+                |- Page1.test.tsx
+            |- ...
+        |- helpers ==> utils or data transform functions
+        |- fixtures
+          \
+            |- fixture1.ts ==> data for testing (for example API call responses mocks)
+            |- ...
+        |- enums.ts
+        |- types.ts
     |- register
     |- homepage
     |- search
 
-libs
+libs ===> external modules implementations or reusable helpers
   \
     |- analytics
     |- pushNotification
@@ -43,17 +59,30 @@ libs
     |- geolocation
     |- ...
 
+theme ==> theme object used in styled-components
+
 ui
-\
- |- components ===> independent components (reusables)
- |- theme
- |- assets
+  \
+    |- animations ==> lottie animations
+    |- components ===> independent and stateless components (reusables)
+      \
+        |- Component1
+          \
+            |- Component1.tsx
+            |- Component1.test.tsx
+            |- Component1.stories.tsx
+    |- hooks
+    |- svg ==> logos and icons
+    |- styleGuide ==> theme constants and typography components
 ```
 
-### Mistakes to avoid
+
+### Guidelines
 
 - Do not put component into `ui/components` if it is used only once in the app
+- Put stories and tests next to corresponding page or component in dedicated subdirectory
 
-### Ressources
+
+### Resources
 
 - ADR: https://www.notion.so/ADR-sur-la-structure-du-projet-315ca5b83d134d938074855b509f611a


### PR DESCRIPTION
### But de la PR

- Actuellement la codebase suit partiellement le standard décrit ici, mais certaines parties semblent désorganisées. Le but de la PR est d'améliorer le standard d'archi du projet, trancher sur certains points (par exemple où mettre les tests: /tests ? /__test__? /__tests__?) et avoir une structure de code propre et lisible.


### Changements

- Je propose de placer les tests directements à côté des composants/pages testés et de supprimer les dossiers /tests, /__test__, /__tests__...
- On a un dossier /theme et un sous-dossier /ui/theme. Cela porte un peu à confusion, je propose de renommer le sous-dossier /ui/theme en /ui/styleguide mais si vous avez d'autres idées n'hésitez pas

### Next steps

- Ajouter des TODO pour corriger la structure de code actuelle
- s'assurer que tous les devs sont formés à ce sujet
- intégrer la lecture ou un point de formation à ce sujet dans l'onboarding des nouveaux dev
- définir des indicateurs à suivre pour s'assurer que la qualité de la code base ne décroit pas
