### PR TITLE
(PC-15998) feat(home):  add subcategories to recommendation playlists parameters

### DIFF
--- a/src/features/home/api/tests/useHomeRecommendedHits.test.ts
+++ b/src/features/home/api/tests/useHomeRecommendedHits.test.ts
@@ -7,6 +7,7 @@ import {
 } from 'features/home/api/useHomeRecommendedHits'
 import { RecommendationParametersFields } from 'features/home/contentful'
 import { env } from 'libs/environment'
+import { useSubcategoryLabelMapping } from 'libs/subcategories/mappings'
 import { renderHook } from 'tests/utils'
 
 import * as algoliaRecommendedHitsAPI from '../useAlgoliaRecommendedHits'
@@ -66,8 +67,9 @@ describe('getRecommendationEndpoint', () => {
 })
 
 describe('getRecommendationParameters', () => {
+  const subcategoryLabelMapping = useSubcategoryLabelMapping()
   it('should return empty parameters when no parameters are provided', () => {
-    const result = getRecommendationParameters(undefined)
+    const result = getRecommendationParameters(undefined, subcategoryLabelMapping)
     expect(result).toEqual({})
   })
 
@@ -80,14 +82,19 @@ describe('getRecommendationParameters', () => {
       priceMax: 10,
       endingDatetime: '2022-05-08T00:00+02:00',
       beginningDatetime: '2022-09-08T00:00+02:00',
+      subcategories: ['Achat instrument'],
     }
-    const recommendationParameters = getRecommendationParameters(parameters)
+    const recommendationParameters = getRecommendationParameters(
+      parameters,
+      subcategoryLabelMapping
+    )
     expect(recommendationParameters).toEqual({
       categories: ['CINEMA', 'COURS', 'LIVRE'],
       end_date: '2022-05-08T00:00+02:00',
       start_date: '2022-09-08T00:00+02:00',
       price_max: 10,
       isEvent: true,
+      subcategories: ['ACHAT_INSTRUMENT'],
     })
   })
 })

--- a/src/features/home/api/useHomeRecommendedIdsMutation.ts
+++ b/src/features/home/api/useHomeRecommendedIdsMutation.ts
@@ -13,6 +13,7 @@ export interface RecommendedIdsRequest {
   isEvent?: boolean
   categories?: string[]
   price_max?: number
+  subcategories?: string[]
 }
 
 export const useHomeRecommendedIdsMutation = (recommendationUrl: string) => {

--- a/src/features/home/contentful/contentful.ts
+++ b/src/features/home/contentful/contentful.ts
@@ -242,6 +242,7 @@ export interface RecommendationParametersFields {
   isFree?: boolean
   isEvent?: boolean
   priceMax?: number
+  subcategories?: string[]
 }
 
 // Taken from https://app.contentful.com/spaces/2bg01iqy0isv/content_types/homepageNatif/fields


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-15998

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots
<img width="721" alt="Capture d’écran 2022-07-28 à 15 47 22" src="https://user-images.githubusercontent.com/22886846/181521137-86320d08-3fc0-4797-9792-7d1a704d2e23.png">
<img width="749" alt="Capture d’écran 2022-07-28 à 15 39 35" src="https://user-images.githubusercontent.com/22886846/181520652-4ed55791-5f6b-475b-8c6e-afc4db0f5803.png">
<img width="752" alt="Capture d’écran 2022-07-28 à 15 39 39" src="https://user-images.githubusercontent.com/22886846/181520662-e2c665e8-196b-484c-bbf7-843a4c240c49.png">

Les id n'ont pas l'air d'être présent sur algolia donc les playlists ne peuvent pas s'afficher sur la home

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
