### PR TITLE
(PC-16478) fix(Search): reset input does not work on the web

### DIFF
--- a/src/features/search/components/SearchBox.tsx
+++ b/src/features/search/components/SearchBox.tsx
@@ -56,9 +56,13 @@ export const SearchBox = function SearchBox({ searchInputID, accessibleHiddenTit
     setQuery(params?.query || '')
   }, [params?.query])
 
+  useEffect(() => {
+    if (params?.view === SearchView.Results) {
+      inputRef.current?.focus()
+    }
+  }, [params?.query, params?.view])
+
   const resetQuery = useCallback(() => {
-    inputRef.current?.focus()
-    setQuery('')
     pushWithStagedSearch({
       query: '',
       view: SearchView.Results,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16478

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
