### PR TITLE
(PC-16469) feat(recommendation): log recommendation parameters on firebase

### DIFF
--- a/src/features/home/api/tests/useHomeRecommendedIdsMutation.test.ts
+++ b/src/features/home/api/tests/useHomeRecommendedIdsMutation.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable local-rules/no-react-query-provider-hoc */
 import * as reactQueryAPI from 'react-query'
 
+import { analytics } from 'libs/firebase/analytics'
 import { eventMonitoring } from 'libs/monitoring'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { renderHook, waitFor } from 'tests/utils'
@@ -65,6 +66,33 @@ describe('useHomeRecommendedIdsMutation', () => {
     result.current.mutate({})
     await waitFor(() => {
       expect(result.current.data).toEqual(body)
+    })
+  })
+
+  it('should log response body parameters on firebase when fetch call succeeds', async () => {
+    const params = {
+      reco_origin: 'cold_start',
+      model_name: 'awesome_model',
+      model_version: 'awesome_model_V202201010001',
+      geo_located: true,
+      ab_test: 'A',
+      filtered: true,
+    }
+    const body = { playlist_recommended_offers: ['102280', '102272', '102249', '102310'], params }
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(body), {
+        headers: {
+          'content-type': 'application/json',
+        },
+        status: 200,
+      })
+    )
+    const { result } = renderHook(() => useHomeRecommendedIdsMutation('http://passculture.reco'), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+    result.current.mutate({})
+    await waitFor(() => {
+      expect(analytics.setDefaultEventParameters).toHaveBeenCalledWith(params)
     })
   })
 })

--- a/src/features/home/api/useHomeRecommendedIdsMutation.ts
+++ b/src/features/home/api/useHomeRecommendedIdsMutation.ts
@@ -1,10 +1,19 @@
 import { useMutation } from 'react-query'
 
+import { analytics } from 'libs/firebase/analytics'
 import { eventMonitoring } from 'libs/monitoring'
 import { QueryKeys } from 'libs/queryKeys'
 
 export interface RecommendedIdsResponse {
   playlist_recommended_offers: string[]
+  params: {
+    reco_origin?: string
+    model_name?: string
+    model_version?: string
+    geo_located?: boolean
+    ab_test?: string
+    filtered?: boolean
+  }
 }
 
 export interface RecommendedIdsRequest {
@@ -33,6 +42,7 @@ export const useHomeRecommendedIdsMutation = (recommendationUrl: string) => {
           throw new Error('Failed to fetch recommendation')
         }
         const responseBody: RecommendedIdsResponse = await response.json()
+        analytics.setDefaultEventParameters(responseBody.params)
         return responseBody
       } catch (err) {
         eventMonitoring.captureException(new Error('Error with recommendation endpoint'), {

--- a/src/libs/firebase/analytics/provider.ts
+++ b/src/libs/firebase/analytics/provider.ts
@@ -19,7 +19,7 @@ export const analyticsProvider: AnalyticsProvider = {
   disableCollection() {
     firebaseAnalytics.setAnalyticsCollectionEnabled(false)
   },
-  setDefaultEventParameters(params: Record<string, string> | undefined) {
+  setDefaultEventParameters(params: Record<string, unknown> | undefined) {
     // only apply on native devices, does not exist on the Web
     if (Platform.OS !== 'web') {
       firebaseAnalytics.setDefaultEventParameters(params)

--- a/src/libs/firebase/analytics/types.ts
+++ b/src/libs/firebase/analytics/types.ts
@@ -7,7 +7,7 @@ export type LoginRoutineMethod = 'fromLogin' | 'fromSignup'
 export interface AnalyticsProvider {
   disableCollection: () => Promise<void> | void
   enableCollection: () => Promise<void> | void
-  setDefaultEventParameters: (params: Record<string, string> | undefined) => Promise<void> | void
+  setDefaultEventParameters: (params: Record<string, unknown> | undefined) => Promise<void> | void
   setUserId: (userId: number) => Promise<void> | void
   logScreenView: (screenName: string) => Promise<void> | void
   logLogin: ({ method }: { method: LoginRoutineMethod }) => Promise<void> | void


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16469

On utiliser la méthode `setDefaultEventParameters` pour que l'on puisse retrouver les infos de l'algo de reco sur les événements du type `ConsultOffer` ou `HasAddedOfferToFavorites`

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots


<img width="638" alt="Capture d’écran 2022-07-29 à 17 19 15" src="https://user-images.githubusercontent.com/22886846/181794758-94f3df36-1124-4f9f-8698-aa8ebfeeae1d.png">
<img width="609" alt="Capture d’écran 2022-07-29 à 17 20 20" src="https://user-images.githubusercontent.com/22886846/181794773-66cd1075-bd99-4a66-b932-fa48b012b92d.png">



[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
