### PR TITLE
(PC-16526) fix(header): no header when user disconnected

### DIFF
--- a/src/features/home/components/HomeHeader.tsx
+++ b/src/features/home/components/HomeHeader.tsx
@@ -4,6 +4,7 @@ import React, { FunctionComponent } from 'react'
 import { Platform } from 'react-native'
 import styled from 'styled-components/native'
 
+import { useAuthContext } from 'features/auth/AuthContext'
 import { useAvailableCredit } from 'features/home/services/useAvailableCredit'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { useUserProfileInfo } from 'features/profile/api'
@@ -19,17 +20,19 @@ export const HomeHeader: FunctionComponent = function () {
   const { data: userInfos } = useUserProfileInfo()
   const availableCredit = useAvailableCredit()
   const { top } = useCustomSafeInsets()
+  const { isLoggedIn } = useAuthContext()
 
-  const welcomeTitle = userInfos?.firstName
-    ? t({
-        id: 'hello name',
-        values: { name: userInfos?.firstName },
-        message: 'Bonjour {name}',
-      })
-    : t`Bienvenue\u00a0!`
+  const welcomeTitle =
+    userInfos?.firstName && isLoggedIn
+      ? t({
+          id: 'hello name',
+          values: { name: userInfos?.firstName },
+          message: 'Bonjour {name}',
+        })
+      : t`Bienvenue\u00a0!`
 
   let subtitle = t`Toute la culture à portée de main`
-  if (userInfos?.isBeneficiary && availableCredit) {
+  if (userInfos?.isBeneficiary && availableCredit && isLoggedIn) {
     subtitle = availableCredit.isExpired
       ? t`Ton crédit est expiré`
       : t({

--- a/src/features/home/pages/tests/Home.native.test.tsx
+++ b/src/features/home/pages/tests/Home.native.test.tsx
@@ -30,6 +30,10 @@ jest.mock('features/home/api', () => ({
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
 const mockUseNetInfo = useNetInfoDefault as jest.Mock
 
+jest.mock('features/auth/AuthContext', () => ({
+  useAuthContext: jest.fn(() => ({ isLoggedIn: true })),
+}))
+
 describe('Home component', () => {
   mockUseNetInfo.mockReturnValue({ isConnected: true })
 

--- a/src/features/profile/components/ProfileHeader.native.test.tsx
+++ b/src/features/profile/components/ProfileHeader.native.test.tsx
@@ -52,6 +52,10 @@ jest.mock('features/profile/api')
 jest.mock('features/profile/utils')
 const mockedisUserUnderageBeneficiary = mocked(isUserUnderageBeneficiary, true)
 
+jest.mock('features/auth/AuthContext', () => ({
+  useAuthContext: jest.fn(() => ({ isLoggedIn: true })),
+}))
+
 describe('ProfileHeader', () => {
   beforeEach(() => {
     mockdate.set('2021-07-01T00:00:00Z')

--- a/src/features/profile/components/ProfileHeader.tsx
+++ b/src/features/profile/components/ProfileHeader.tsx
@@ -2,6 +2,7 @@ import { t } from '@lingui/macro'
 import React from 'react'
 
 import { UserProfileResponse } from 'api/gen'
+import { useAuthContext } from 'features/auth/AuthContext'
 import { isUserUnderageBeneficiary } from 'features/profile/utils'
 import { formatToSlashedFrenchDate } from 'libs/dates'
 import { formatToHour } from 'libs/parsers'
@@ -36,8 +37,10 @@ const getDisplayedExpirationDate = (expirationDate: Date, isUnderageBeneficiary:
 export function ProfileHeader(props: ProfileHeaderProps) {
   const { user } = props
   const isUnderageBeneficiary = isUserUnderageBeneficiary(user)
+  const { isLoggedIn } = useAuthContext()
 
-  if (!user) {
+  // Not use user? because it's already tested here
+  if (!isLoggedIn || !user) {
     return <LoggedOutHeader />
   }
   const depositExpirationDate = user.depositExpirationDate

--- a/src/features/profile/components/ProfileHeader.web.test.tsx
+++ b/src/features/profile/components/ProfileHeader.web.test.tsx
@@ -36,6 +36,10 @@ const exBeneficiaryUser: UserProfileResponse = {
   depositExpirationDate: '2020-01-01T03:04:05',
 }
 
+jest.mock('features/auth/AuthContext', () => ({
+  useAuthContext: jest.fn(() => ({ isLoggedIn: true })),
+}))
+
 describe('ProfileHeader', () => {
   beforeEach(() => {
     mockdate.set('2021-07-01T00:00:00Z')


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16526

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
