### PR TITLE
(PC-16351) fix(AppModal): disable animationOut for BookingOfferModal, ArchiveBookingModal, CancelBookingModal

### DIFF
--- a/src/features/bookOffer/pages/BookingOfferModal.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.tsx
@@ -43,6 +43,7 @@ export const BookingOfferModalComponent: React.FC<Props> = ({
 
   return (
     <AppModal
+      animationOutTiming={1}
       visible={visible}
       title={title}
       {...modalLeftIconProps}

--- a/src/features/bookings/components/ArchiveBookingModal.tsx
+++ b/src/features/bookings/components/ArchiveBookingModal.tsx
@@ -46,6 +46,7 @@ export const ArchiveBookingModal = (props: ArchiveBookingModalProps) => {
 
   return (
     <AppModal
+      animationOutTiming={1}
       visible={props.visible}
       title={t`Tu es sur le point d'archiver`}
       leftIconAccessibilityLabel={undefined}

--- a/src/features/bookings/components/CancelBookingModal.tsx
+++ b/src/features/bookings/components/CancelBookingModal.tsx
@@ -73,6 +73,7 @@ export const CancelBookingModal: FunctionComponent<Props> = ({
 
   return (
     <AppModal
+      animationOutTiming={1}
       visible={visible}
       title={t`Tu es sur le point d'annuler`}
       leftIconAccessibilityLabel={undefined}

--- a/src/ui/components/modals/AppModal.tsx
+++ b/src/ui/components/modals/AppModal.tsx
@@ -16,6 +16,7 @@ import { ModalHeader } from './ModalHeader'
 import { ModalIconProps } from './types'
 
 type Props = {
+  animationOutTiming?: number
   title: string
   visible: boolean
   titleNumberOfLines?: number
@@ -28,6 +29,7 @@ type Props = {
 const modalStyles = { margin: 'auto' }
 
 export const AppModal: FunctionComponent<Props> = ({
+  animationOutTiming,
   title,
   visible,
   leftIconAccessibilityLabel,
@@ -103,6 +105,7 @@ export const AppModal: FunctionComponent<Props> = ({
 
   return (
     <StyledModal
+      animationOutTiming={animationOutTiming}
       style={modalStyles}
       supportedOrientations={['portrait', 'landscape']}
       statusBarTranslucent


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16351

## Description

Due to navigation when action success on those modal, it is preferable to prevent overlap of the modal after navigation, to totally disable the `slideOutDown` animation by setting the `animationOutTiming` to `0`

Read more: https://github.com/react-native-modal/react-native-modal

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
