### PR TITLE
(PC-16239) feat(booking): show msg when no withdrawal type

### DIFF
--- a/src/features/bookings/helpers.test.ts
+++ b/src/features/bookings/helpers.test.ts
@@ -550,38 +550,51 @@ describe('getOfferRules', () => {
     )
   })
 
-  it('should return the correct message if isEvent and on site withdrawal type', () => {
-    const properties = {
-      hasActivationCode: false,
-      isDigital: false,
-      isPhysical: false,
-      isEvent: true,
+  it.each([WithdrawalTypeEnum.on_site, null])(
+    'should not return message if isEvent and %s withdrawal type',
+    (withdrawalType) => {
+      const properties = {
+        hasActivationCode: false,
+        isDigital: false,
+        isPhysical: false,
+        isEvent: true,
+      }
+      const newBooking = {
+        ...booking,
+        externalBookings: [],
+        stock: {
+          ...booking.stock,
+          offer: { ...booking.stock.offer, withdrawalType },
+        },
+      }
+      const offerRules = getOfferRules(properties, newBooking)
+      expect(offerRules).toEqual(
+        'Pour profiter de ta réservation, tu dois présenter ta carte d’identité et ce code à 6 caractères. N’oublie pas que tu n’as pas le droit de le revendre ou le céder.'
+      )
     }
-    const newBooking = { ...booking, externalBookings: [] }
-    const offerRules = getOfferRules(properties, newBooking)
-    expect(offerRules).toEqual(
-      'Pour profiter de ta réservation, tu dois présenter ta carte d’identité et ce code à 6 caractères. N’oublie pas que tu n’as pas le droit de le revendre ou le céder.'
-    )
-  })
+  )
 
-  it('should not return message if isEvent and not on site withdrawal type', () => {
-    const properties = {
-      hasActivationCode: false,
-      isDigital: false,
-      isPhysical: false,
-      isEvent: true,
+  it.each([WithdrawalTypeEnum.no_ticket, WithdrawalTypeEnum.by_email])(
+    'should not return message if isEvent and %s withdrawal type',
+    (withdrawalType) => {
+      const properties = {
+        hasActivationCode: false,
+        isDigital: false,
+        isPhysical: false,
+        isEvent: true,
+      }
+      const newBooking = {
+        ...booking,
+        externalBookings: [],
+        stock: {
+          ...booking.stock,
+          offer: { ...booking.stock.offer, withdrawalType },
+        },
+      }
+      const offerRules = getOfferRules(properties, newBooking)
+      expect(offerRules).toEqual('')
     }
-    const newBooking = {
-      ...booking,
-      externalBookings: [],
-      stock: {
-        ...booking.stock,
-        offer: { ...booking.stock.offer, withdrawalType: WithdrawalTypeEnum.no_ticket },
-      },
-    }
-    const offerRules = getOfferRules(properties, newBooking)
-    expect(offerRules).toEqual('')
-  })
+  )
 
   it('should return the correct message if externalBookingsInfos.length === 1', () => {
     const properties = {

--- a/src/features/bookings/helpers.ts
+++ b/src/features/bookings/helpers.ts
@@ -265,6 +265,9 @@ export function getOfferRules(
   const numberOfExternalBookings = booking?.externalBookings
     ? booking.externalBookings.length
     : undefined
+  const withdrawalTypeDisplay =
+    booking?.stock.offer.withdrawalType === WithdrawalTypeEnum.on_site ||
+    !booking?.stock.offer.withdrawalType
 
   if (hasActivationCode && activationCodeFeatureEnabled)
     return t`Ce code est ta preuve d’achat, il te permet d’accéder à ton offre\u00a0! N’oublie pas que tu n’as pas le droit de le revendre ou le céder.`
@@ -277,7 +280,7 @@ export function getOfferRules(
         'Pour profiter de ta réservation, tu dois présenter ta carte d’identité et ces QR codes. N’oublie pas que tu n’as pas le droit de les revendre ou les céder.',
     })
   }
-  if (isPhysical || (isEvent && booking?.stock.offer.withdrawalType === WithdrawalTypeEnum.on_site))
+  if (isPhysical || (isEvent && withdrawalTypeDisplay))
     return t`Pour profiter de ta réservation, tu dois présenter ta carte d’identité et ce code à 6 caractères. N’oublie pas que tu n’as pas le droit de le revendre ou le céder.`
   return ''
 }


### PR DESCRIPTION
for old offers

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16239
## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
