### PR TITLE
(PC-15491) fix(QPI): flush answers on submit success, avoid cached answers

### DIFF
--- a/src/features/culturalSurvey/context/reducer.ts
+++ b/src/features/culturalSurvey/context/reducer.ts
@@ -32,6 +32,11 @@ export const culturalSurveyReducer: React.Reducer<CulturalSurveyState, Action> =
         answers: answers,
       }
     }
+    case 'FLUSH_ANSWERS':
+      return {
+        ...state,
+        answers: [],
+      }
     default:
       return { ...state }
   }

--- a/src/features/culturalSurvey/context/types.ts
+++ b/src/features/culturalSurvey/context/types.ts
@@ -25,3 +25,6 @@ export type Action =
         answers: CulturalSurveyAnswerEnum[]
       }
     }
+  | {
+      type: 'FLUSH_ANSWERS'
+    }

--- a/src/features/culturalSurvey/pages/CulturalSurveyQuestions.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyQuestions.tsx
@@ -76,6 +76,9 @@ export const CulturalSurveyQuestions = ({ route }: CulturalSurveyQuestionsProps)
     throw new Error('should have questions to show')
   }
   const onSuccess = () => {
+    dispatch({
+      type: 'FLUSH_ANSWERS',
+    })
     navigate('CulturalSurveyThanks')
   }
 

--- a/src/features/culturalSurvey/pages/__tests__/CulturalSurveyQuestions.native.test.tsx
+++ b/src/features/culturalSurvey/pages/__tests__/CulturalSurveyQuestions.native.test.tsx
@@ -61,7 +61,7 @@ describe('CulturalSurveysQuestions page', () => {
     })
   })
 
-  it('should navigate to CulturalSurveyThanks if on lastQuestion and API call is successful', async () => {
+  it('should flush answers and navigate to CulturalSurveyThanks if on lastQuestion and API call is successful', async () => {
     mockUseGetNextQuestionReturnValue = {
       isCurrentQuestionLastQuestion: true,
       nextQuestion: CulturalSurveyQuestionEnum.SPECTACLES,
@@ -69,6 +69,7 @@ describe('CulturalSurveysQuestions page', () => {
     const QuestionsPage = render(<CulturalSurveyQuestions {...navigationProps} />)
     const NextQuestionButton = QuestionsPage.getByTestId('next-cultural-survey-question')
     fireEvent.press(NextQuestionButton)
+    expect(dispatch).toHaveBeenCalledWith({ type: 'FLUSH_ANSWERS' })
     expect(navigate).toHaveBeenCalledWith('CulturalSurveyThanks')
   })
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-15491

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
