### PR TITLE
(PC-16720) fix(Date): remove duplicate unecessary date lib moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "amplitude-js": "^8.16.1",
     "color-alpha": "^1.1.3",
     "contentful-resolve-response": "^1.3.0",
+    "date-fns": "^2.29.1",
     "firebase": "^9.6.11",
     "geojson": "^0.5.0",
     "highlight-words-core": "^1.2.2",

--- a/patches/react-native-calendars+1.1284.0.patch
+++ b/patches/react-native-calendars+1.1284.0.patch
@@ -196,3 +196,17 @@ index d85e6a9..14505be 100644
            {monthYear}
          </Text>
          {renderWeekDaysNames()}
+diff --git a/node_modules/react-native-calendars/src/momentResolver.js b/node_modules/react-native-calendars/src/momentResolver.js
+index ed4d962..8551a2d 100644
+--- a/node_modules/react-native-calendars/src/momentResolver.js
++++ b/node_modules/react-native-calendars/src/momentResolver.js
+@@ -1,8 +1,5 @@
+ let moment;
+ // Moment is an optional dependency
+ export const getMoment = () => {
+-    if (!moment) {
+-        moment = require('moment');
+-    }
+-    return moment;
++    throw new Error('react-native-calendars was patch-package to remove moment. See PC-16720')
+ };

--- a/src/features/bookOffer/components/Calendar/Calendar.tsx
+++ b/src/features/bookOffer/components/Calendar/Calendar.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro'
-import moment from 'moment'
+import { format } from 'date-fns'
 import React from 'react'
 import { Calendar as RNCalendar, LocaleConfig } from 'react-native-calendars'
 import { DateData, Theme } from 'react-native-calendars/src/types'
@@ -77,7 +77,7 @@ const RNCalendarTheme = {
 
 export const Calendar: React.FC<Props> = ({ stocks, userRemainingCredit, offerId }) => {
   const markedDates = useMarkedDates(stocks, userRemainingCredit || 0)
-  const minDate = getMinAvailableDate(markedDates) || moment(new Date()).format('YYYY-MM-DD')
+  const minDate = getMinAvailableDate(markedDates) || format(new Date(), 'yyyy-dd-MM')
   const selectDay = useSelectDay()
 
   return (

--- a/src/features/identityCheck/pages/identification/IdentityCheckValidation.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckValidation.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro'
-import moment from 'moment'
+import { parse, format } from 'date-fns'
 import React from 'react'
 import styled from 'styled-components/native'
 
@@ -16,7 +16,7 @@ export function IdentityCheckValidation() {
   const { navigateToNextScreen } = useIdentityCheckNavigation()
 
   const birthDate = identification.birthDate
-    ? moment(identification.birthDate, 'YYYY-MM-DD').format('DD/MM/YYYY')
+    ? format(parse(identification.birthDate, 'yyyy-MM-dd', new Date()), 'dd/MM/yyyy')
     : ''
 
   const navigateToNextEduConnectStep = async () => {

--- a/src/features/identityCheck/pages/identification/IdentityCheckValidation.web.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckValidation.web.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro'
 import { useFocusEffect, useNavigation, useRoute } from '@react-navigation/native'
-import moment from 'moment'
+import { parse, format } from 'date-fns'
 import React, { useCallback } from 'react'
 import styled from 'styled-components/native'
 
@@ -22,7 +22,7 @@ export function IdentityCheckValidation() {
   const { dispatch, identification } = useIdentityCheckContext()
 
   const birthDate = identification.birthDate
-    ? moment(identification.birthDate, 'YYYY-MM-DD').format('DD/MM/YYYY')
+    ? format(parse(identification.birthDate, 'yyyy-MM-dd', new Date()), 'dd/MM/yyyy')
     : ''
 
   const navigateToNextEduConnectStep = () => {

--- a/src/features/search/components/CalendarPicker.web.tsx
+++ b/src/features/search/components/CalendarPicker.web.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro'
-import moment from 'moment'
+import { format } from 'date-fns'
 import React, { useState, useMemo, useRef, useEffect } from 'react'
 import Picker from 'react-mobile-picker'
 import { Calendar as RNCalendar, LocaleConfig } from 'react-native-calendars'
@@ -70,7 +70,7 @@ export const CalendarPicker: React.FC<Props> = ({
     [fontFamily, colors]
   )
 
-  const minDate = moment(new Date()).format('YYYY-MM-DD')
+  const minDate = format(new Date(), 'yyyy-MM-dd')
   const ref = useRef<Node>(null)
   const [markedDates, setMarkedDates] = useState<{
     [name: string]: { selected: boolean; accessibilityLabel: string }
@@ -161,7 +161,7 @@ export const CalendarPicker: React.FC<Props> = ({
           <RNCalendar
             minDate={minDate}
             style={RN_CALENDAR_STYLE}
-            current={moment(selectedDate).format('YYYY-MM-DD')}
+            current={format(selectedDate, 'yyyy-MM-dd')}
             firstDay={1}
             enableSwipeMonths={true}
             renderHeader={(date) => <MonthHeader date={date as unknown as Date} />}

--- a/src/features/search/utils/isBeforeToday.ts
+++ b/src/features/search/utils/isBeforeToday.ts
@@ -1,12 +1,7 @@
+import { isBefore } from 'date-fns'
+
 export const isBeforeToday = (year: number, month: number, day: number) => {
-  const now = new Date()
-  const currentYear = now.getFullYear()
-  const currentMonth = now.getMonth()
-  const currentDate = now.getDate()
-
-  const isBeforeCurrentYear = year < currentYear
-  const isBeforeCurrentMonth = month < currentMonth && currentYear === year
-  const isBeforeCurrentDay = day < currentDate && currentMonth === month && currentYear === year
-
-  return isBeforeCurrentYear || isBeforeCurrentMonth || isBeforeCurrentDay
+  const today = new Date(new Date().setHours(0, 0, 0, 0))
+  const dateToCompare = new Date(new Date(year, month, day).setHours(0, 0, 0, 0))
+  return isBefore(dateToCompare, today)
 }

--- a/src/features/search/utils/tests/isBeforeToday.test.ts
+++ b/src/features/search/utils/tests/isBeforeToday.test.ts
@@ -6,15 +6,15 @@ mockdate.set(new Date('2022-07-14T00:00:00Z'))
 
 describe('isBeforeToday', () => {
   it('should return false if later than today', () => {
-    expect(isBeforeToday(2022, 6, 14)).toBe(false)
+    expect(isBeforeToday(2022, 6, 14)).toBeFalsy()
   })
   it('should return true if one year before', () => {
-    expect(isBeforeToday(2021, 6, 14)).toBe(true)
+    expect(isBeforeToday(2021, 6, 14)).toBeTruthy()
   })
   it('should return true if one month before', () => {
-    expect(isBeforeToday(2022, 5, 14)).toBe(true)
+    expect(isBeforeToday(2022, 5, 14)).toBeTruthy()
   })
   it('should return true if one day before', () => {
-    expect(isBeforeToday(2022, 6, 12)).toBe(true)
+    expect(isBeforeToday(2022, 6, 12)).toBeTruthy()
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10299,6 +10299,11 @@ date-fns@^2.16.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.27.0.tgz#e1ff3c3ddbbab8a2eaadbb6106be2929a5a2d92b"
   integrity sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q==
 
+date-fns@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.1.tgz#9667c2615525e552b5135a3116b95b1961456e60"
+  integrity sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw==
+
 dayjs@^1.8.15:
   version "1.10.7"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.7.tgz#2cf5f91add28116748440866a0a1d26f3a6ce468"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16720

## How 

En plus de la suppression de l’usage de `moment` (au profit de `date-fns`) dans 4 sources à nous: 

- `src/features/bookOffer/components/Calendar/Calendar.tsx`
- `src/features/identityCheck/pages/identification/IdentityCheckValidation.tsx`
- `src/features/identityCheck/pages/identification/IdentityCheckValidation.web.tsx`
- `src/features/search/components/CalendarPicker.web.tsx`

Pour supprimer `moment`, nous devons modifier `react-native-calendars`, j’ai ouvert une issue sur leur repo GitHub :  https://github.com/wix/react-native-calendars/issues/1968

Aussi `moment` était importé mais non présent dans les dépendances de notre `package.json`, donc il n'était pas nécessaire de le supprimer.

## Formattage/Parsing

Exemple de format/parse du fait qu'on change de lib de date : https://codesandbox.io/s/gracious-meitner-ht3ldd?file=/src/index.js

## Avant

```bash
  936.77 KB           build/static/js/2.47d76d4b.chunk.js
  554.26 KB           build/static/js/main.55c4641e.chunk.js
  6.29 KB               build/static/js/4.a2b0c1f4.chunk.js
  3.16 KB               build/static/js/5.fca6be2f.chunk.js
  1.73 KB               build/static/js/6.ac1862e3.chunk.js
  1.42 KB               build/static/js/3.5dfc00f1.chunk.js
  1.22 KB               build/static/js/runtime-main.d52a7a1a.js
```

## Après

```bash
  917.85 KB  build/static/js/2.18a8e603.chunk.js
  553.93 KB  build/static/js/main.f5153a57.chunk.js
  6.29 KB    build/static/js/4.0f496c75.chunk.js
  3.16 KB    build/static/js/5.88b315c0.chunk.js
  1.73 KB    build/static/js/6.f192cb3e.chunk.js
  1.42 KB    build/static/js/3.4f05c1d8.chunk.js
  1.22 KB    build/static/js/runtime-main.53529d99.js
```

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |   ![image](https://user-images.githubusercontent.com/77674046/183653948-29872ffa-1a9f-47a1-9d9d-e8f13be4019d.png)      |        ![image](https://user-images.githubusercontent.com/77674046/183654031-50ac78de-bd40-4d98-974b-61056a3905d7.png)         |          ![image](https://user-images.githubusercontent.com/77674046/183654291-85edf462-8846-41be-a2e8-94a1666b3ec2.png)        |                  |




[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
