### PR TITLE
(PC-16686) feat(OfflineMode): Use context to get network information

### DIFF
--- a/__mocks__/@react-native-community/netinfo.ts
+++ b/__mocks__/@react-native-community/netinfo.ts
@@ -5,3 +5,7 @@ export const useNetInfo: typeof actualUseNetInfo = jest.fn().mockReturnValue({
   isConnected: true,
   type: 'cellular',
 })
+
+export enum NetInfoStateType {
+  unknown = 'unknown',
+}

--- a/jest/jest.setup.ts
+++ b/jest/jest.setup.ts
@@ -79,6 +79,9 @@ jest.mock('libs/react-native-device-info/getUniqueId')
 
 jest.mock('libs/keychain')
 
+/* See the corresponding mock in libs/network/__mocks__ */
+jest.mock('libs/network/NetInfoWrapper')
+
 jest.mock('features/search/pages/SearchWrapper')
 
 jest.mock('features/favorites/pages/FavoritesWrapper')

--- a/src/App.native.test.tsx
+++ b/src/App.native.test.tsx
@@ -14,6 +14,7 @@ jest.mock('features/navigation/NavigationContainer/NavigationContainer', () => (
 jest.mock('libs/i18n', () => ({
   activate: jest.fn(),
 }))
+jest.unmock('libs/network/NetInfoWrapper')
 
 describe('<App /> with mocked RootNavigator', () => {
   it('should call startBatchNotification() to optin to notifications', async () => {

--- a/src/features/auth/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
+++ b/src/features/auth/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
@@ -10,7 +10,7 @@ import { useAppSettings } from 'features/auth/settings'
 import { navigateToHome } from 'features/navigation/helpers'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { captureMonitoringError } from 'libs/monitoring'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { ReCaptcha } from 'libs/recaptcha/ReCaptcha'
 import { BottomContentPage } from 'ui/components/BottomContentPage'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
@@ -27,7 +27,7 @@ import { Form } from 'ui/web/form/Form'
 export const ForgottenPassword: FunctionComponent = () => {
   const { data: settings, isLoading: areSettingsLoading } = useAppSettings()
   const { navigate, replace } = useNavigation<UseNavigationType>()
-  const networkInfo = useNetInfo()
+  const networkInfo = useNetInfoContext()
   const emailErrorMessageId = uuidv4()
 
   const [email, setEmail] = useState('')

--- a/src/features/auth/forgottenPassword/ForgottenPassword/tests/ForgottenPassword.native.test.tsx
+++ b/src/features/auth/forgottenPassword/ForgottenPassword/tests/ForgottenPassword.native.test.tsx
@@ -1,11 +1,10 @@
-// eslint-disable-next-line no-restricted-imports
-import * as netInfoModule from '@react-native-community/netinfo'
 import React from 'react'
 import waitForExpect from 'wait-for-expect'
 
 import { navigate, replace } from '__mocks__/@react-navigation/native'
 import { ForgottenPassword } from 'features/auth/forgottenPassword/ForgottenPassword/ForgottenPassword'
 import { captureMonitoringError } from 'libs/monitoring'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { requestPasswordResetFail, requestPasswordResetSuccess, server } from 'tests/server'
 import { simulateWebviewMessage, superFlushWithAct, fireEvent, render } from 'tests/utils'
@@ -16,6 +15,8 @@ jest.mock('features/navigation/helpers')
 jest.mock('features/auth/settings')
 
 jest.mock('libs/monitoring')
+
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 beforeEach(() => {
   simulateConnectedNetwork()
@@ -187,15 +188,15 @@ describe('<ForgottenPassword />', () => {
 })
 
 function simulateNoNetwork() {
-  jest.spyOn(netInfoModule, 'useNetInfo').mockReturnValue({
+  mockUseNetInfoContext.mockReturnValue({
     isConnected: false,
-  } as netInfoModule.NetInfoState)
+  })
 }
 
 function simulateConnectedNetwork() {
-  jest.spyOn(netInfoModule, 'useNetInfo').mockReturnValue({
+  mockUseNetInfoContext.mockReturnValue({
     isConnected: true,
-  } as netInfoModule.NetInfoState)
+  })
 }
 
 function renderForgottenPassword() {

--- a/src/features/auth/settings.ts
+++ b/src/features/auth/settings.ts
@@ -2,14 +2,14 @@ import { useQuery } from 'react-query'
 
 import { api } from 'api/api'
 import { SettingsResponse } from 'api/gen'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 
 // arbitrary. Should not change that often though
 const STALE_TIME_APP_SETTINGS = 5 * 60 * 1000
 
 export function useAppSettings() {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   return useQuery<SettingsResponse>(QueryKeys.SETTINGS, () => api.getnativev1settings(), {
     enabled: !!netInfo.isConnected && !!netInfo.isInternetReachable,
     staleTime: STALE_TIME_APP_SETTINGS,

--- a/src/features/auth/signup/AcceptCgu/AcceptCgu.native.test.tsx
+++ b/src/features/auth/signup/AcceptCgu/AcceptCgu.native.test.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import * as netInfoModule from '@react-native-community/netinfo'
 import React from 'react'
 import { Linking } from 'react-native'
 import waitForExpect from 'wait-for-expect'
@@ -10,6 +8,7 @@ import { contactSupport } from 'features/auth/support.services'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { env } from 'libs/environment'
 import { captureMonitoringError } from 'libs/monitoring'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { simulateWebviewMessage, fireEvent, render, superFlushWithAct, waitFor } from 'tests/utils'
 
@@ -19,16 +18,17 @@ jest.mock('features/auth/settings')
 jest.mock('libs/monitoring')
 const openUrl = jest.spyOn(NavigationHelpers, 'openUrl')
 
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 function simulateNoNetwork() {
-  jest.spyOn(netInfoModule, 'useNetInfo').mockReturnValue({
+  mockUseNetInfoContext.mockReturnValue({
     isConnected: false,
-  } as netInfoModule.NetInfoState)
+  })
 }
 
 function simulateConnectedNetwork() {
-  jest.spyOn(netInfoModule, 'useNetInfo').mockReturnValue({
+  mockUseNetInfoContext.mockReturnValue({
     isConnected: true,
-  } as netInfoModule.NetInfoState)
+  })
 }
 
 const props = { goToNextStep: jest.fn(), signUp: jest.fn() }

--- a/src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
+++ b/src/features/auth/signup/AcceptCgu/AcceptCgu.tsx
@@ -8,7 +8,7 @@ import { PreValidationSignupStepProps } from 'features/auth/signup/types'
 import { contactSupport } from 'features/auth/support.services'
 import { env } from 'libs/environment'
 import { captureMonitoringError } from 'libs/monitoring'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { ReCaptcha } from 'libs/recaptcha/ReCaptcha'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ButtonTertiary } from 'ui/components/buttons/ButtonTertiary'
@@ -20,7 +20,7 @@ import { Spacer, Typo } from 'ui/theme'
 
 export const AcceptCgu: FC<PreValidationSignupStepProps> = (props) => {
   const { data: settings, isLoading: areSettingsLoading } = useAppSettings()
-  const networkInfo = useNetInfo()
+  const networkInfo = useNetInfoContext()
   const checkCGUErrorId = uuidv4()
 
   const [isDoingReCaptchaChallenge, setIsDoingReCaptchaChallenge] = useState(false)

--- a/src/features/auth/signup/useNextSubscriptionStep.test.ts
+++ b/src/features/auth/signup/useNextSubscriptionStep.test.ts
@@ -4,7 +4,7 @@ import { IdentityCheckMethod, NextSubscriptionStepResponse, SubscriptionStep } f
 import { useAuthContext } from 'features/auth/AuthContext'
 import { useNextSubscriptionStep } from 'features/auth/signup/useNextSubscriptionStep'
 import { env } from 'libs/environment'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
 import { renderHook, waitFor } from 'tests/utils'
@@ -16,11 +16,11 @@ const mockUseAuthContext = useAuthContext as jest.MockedFunction<typeof useAuthC
 const allowedIdentityCheckMethods = [IdentityCheckMethod.ubble]
 
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 jest.unmock('react-query')
 describe('useNextSubscriptionStep', () => {
-  mockUseNetInfo.mockReturnValue({ isConnected: true, isInternetReachable: true })
+  mockUseNetInfoContext.mockReturnValue({ isConnected: true, isInternetReachable: true })
 
   it.each(Object.values(SubscriptionStep))(
     'should return expected step',
@@ -60,7 +60,7 @@ describe('useNextSubscriptionStep', () => {
   })
 
   it('should not fetch query if user is logged in and not connected', async () => {
-    mockUseNetInfo.mockReturnValueOnce({ isConnected: false, isInternetReachable: false })
+    mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false, isInternetReachable: false })
     mockNextStepRequest({
       allowedIdentityCheckMethods,
       nextSubscriptionStep: SubscriptionStep['email-validation'],

--- a/src/features/auth/signup/useNextSubscriptionStep.ts
+++ b/src/features/auth/signup/useNextSubscriptionStep.ts
@@ -3,12 +3,12 @@ import { useQuery } from 'react-query'
 import { api } from 'api/api'
 import { NextSubscriptionStepResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/AuthContext'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 
 export function useNextSubscriptionStep(setError?: (error: Error) => void) {
   const { isLoggedIn } = useAuthContext()
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   return useQuery<NextSubscriptionStepResponse | undefined>(
     QueryKeys.NEXT_SUBSCRIPTION_STEP,
     async () => {

--- a/src/features/auth/suspendedAccount/SuspendedAccount/useAccountSuspensionDate.ts
+++ b/src/features/auth/suspendedAccount/SuspendedAccount/useAccountSuspensionDate.ts
@@ -1,11 +1,11 @@
 import { useQuery } from 'react-query'
 
 import { api } from 'api/api'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 
 export function useAccountSuspensionDate() {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   return useQuery(
     QueryKeys.ACCOUNT_SUSPENSION_DATE,
     async () => {

--- a/src/features/auth/suspendedAccount/SuspensionScreen/useAccountSuspensionStatus.ts
+++ b/src/features/auth/suspendedAccount/SuspensionScreen/useAccountSuspensionStatus.ts
@@ -1,11 +1,11 @@
 import { useQuery } from 'react-query'
 
 import { api } from 'api/api'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 
 export function useAccountSuspensionStatus() {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
 
   return useQuery(
     QueryKeys.ACCOUNT_SUSPENSION_STATUS,

--- a/src/features/bookings/api/__tests__/queries.test.ts
+++ b/src/features/bookings/api/__tests__/queries.test.ts
@@ -3,7 +3,7 @@ import { rest } from 'msw'
 import { BookingsResponse } from 'api/gen'
 import { bookingsSnap } from 'features/bookings/api/bookingsSnap'
 import { env } from 'libs/environment'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
 import { renderHook, waitFor } from 'tests/utils'
@@ -21,14 +21,14 @@ server.use(
 )
 
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 jest.mock('features/auth/AuthContext', () => ({
   useAuthContext: jest.fn(() => ({ isLoggedIn: true })),
 }))
 
 describe('[API] booking queries', () => {
-  mockUseNetInfo.mockReturnValue({ isConnected: true, isInternetReachable: true })
+  mockUseNetInfoContext.mockReturnValue({ isConnected: true, isInternetReachable: true })
 
   describe('[Method] useEndedBookingFromOfferId', () => {
     it('should return an ended booking if existing', async () => {

--- a/src/features/bookings/api/queries.ts
+++ b/src/features/bookings/api/queries.ts
@@ -3,7 +3,7 @@ import { UseQueryResult } from 'react-query'
 import { api } from 'api/api'
 import { BookingReponse, BookingsResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/AuthContext'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 import { usePersistQuery } from 'libs/react-query/usePersistQuery'
 
@@ -12,7 +12,7 @@ const STALE_TIME_BOOKINGS = 5 * 60 * 1000
 
 export function useBookings(options = {}) {
   const { isLoggedIn } = useAuthContext()
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   return usePersistQuery<BookingsResponse>(QueryKeys.BOOKINGS, () => api.getnativev1bookings(), {
     enabled: !!netInfo.isConnected && !!netInfo.isInternetReachable && isLoggedIn,
     staleTime: STALE_TIME_BOOKINGS,

--- a/src/features/bookings/components/CancelBookingModal.native.test.tsx
+++ b/src/features/bookings/components/CancelBookingModal.native.test.tsx
@@ -7,7 +7,7 @@ import { bookingsSnap } from 'features/bookings/api/bookingsSnap'
 import { CancelBookingModal } from 'features/bookings/components/CancelBookingModal'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { analytics } from 'libs/firebase/analytics'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { fireEvent, render, useMutationFactory } from 'tests/utils'
 import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
 import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
@@ -37,10 +37,10 @@ jest.mock('ui/components/snackBar/SnackBarContext', () => ({
 }))
 
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 describe('<CancelBookingModal />', () => {
-  mockUseNetInfo.mockReturnValue({ isConnected: true })
+  mockUseNetInfoContext.mockReturnValue({ isConnected: true })
 
   it('should dismiss modal on press rightIconButton', () => {
     const booking = bookingsSnap.ongoing_bookings[0]
@@ -77,7 +77,7 @@ describe('<CancelBookingModal />', () => {
   })
 
   it('should showErrorSnackBar and close modal on press "Annuler ma réservation"', () => {
-    mockUseNetInfo.mockReturnValueOnce({ isConnected: false })
+    mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false })
     const booking = bookingsSnap.ongoing_bookings[0]
     const { getByText } = render(
       <CancelBookingModal visible dismissModal={mockDismissModal} booking={booking} />

--- a/src/features/bookings/components/CancelBookingModal.tsx
+++ b/src/features/bookings/components/CancelBookingModal.tsx
@@ -11,7 +11,7 @@ import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { useUserProfileInfo } from 'features/profile/api'
 import { isUserBeneficiary, isUserExBeneficiary } from 'features/profile/utils'
 import { analytics } from 'libs/firebase/analytics'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { formatToFrenchDecimal } from 'libs/parsers'
 import { convertCentsToEuros } from 'libs/parsers/pricesConversion'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
@@ -34,7 +34,7 @@ export const CancelBookingModal: FunctionComponent<Props> = ({
   dismissModal,
   booking,
 }) => {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   const { data: user } = useUserProfileInfo()
   const refundRule = getRefundRule(booking, user)
   const { navigate } = useNavigation<UseNavigationType>()

--- a/src/features/bookings/components/EndedBookingItem.tsx
+++ b/src/features/bookings/components/EndedBookingItem.tsx
@@ -8,7 +8,7 @@ import { BookingCancellationReasons } from 'api/gen'
 import { mergeOfferData } from 'features/offer/atoms/OfferTile'
 import { formatToSlashedFrenchDate } from 'libs/dates'
 import { analytics } from 'libs/firebase/analytics'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 import { useCategoryId } from 'libs/subcategories'
 import { tileAccessibilityLabel, TileContentType } from 'libs/tileAccessibilityLabel'
@@ -27,7 +27,7 @@ export const EndedBookingItem = ({ booking }: BookingItemProps) => {
   const { cancellationDate, cancellationReason, dateUsed, stock } = booking
   const categoryId = useCategoryId(stock.offer.subcategoryId)
   const queryClient = useQueryClient()
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   const { showErrorSnackBar } = useSnackBarContext()
 
   const endedBookingReason = getEndedBookingReason(cancellationReason, dateUsed)

--- a/src/features/bookings/components/NoBookingsView.test.tsx
+++ b/src/features/bookings/components/NoBookingsView.test.tsx
@@ -4,7 +4,7 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { SearchView } from 'features/search/types'
 import { analytics } from 'libs/firebase/analytics'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { fireEvent, render } from 'tests/utils'
 
@@ -19,23 +19,23 @@ jest.mock('features/search/pages/SearchWrapper', () => ({
 }))
 
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 describe('<NoBookingsView />', () => {
   it('should render online no bookings view when netInfo.isConnected is true', () => {
-    mockUseNetInfo.mockReturnValueOnce({ isConnected: true })
+    mockUseNetInfoContext.mockReturnValueOnce({ isConnected: true })
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
     const renderAPI = render(reactQueryProviderHOC(<NoBookingsView />))
     expect(renderAPI).toMatchSnapshot()
   })
   it('should render offline no bookings view when netInfo.isConnected is false', () => {
-    mockUseNetInfo.mockReturnValueOnce({ isConnected: false })
+    mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false })
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
     const renderAPI = render(reactQueryProviderHOC(<NoBookingsView />))
     expect(renderAPI).toMatchSnapshot()
   })
   it('should navigate to Search when pressing button and log event', async () => {
-    mockUseNetInfo.mockReturnValueOnce({ isConnected: true })
+    mockUseNetInfoContext.mockReturnValueOnce({ isConnected: true })
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
     const renderAPI = render(reactQueryProviderHOC(<NoBookingsView />))
     const button = renderAPI.getByText('Explorer les offres')

--- a/src/features/bookings/components/NoBookingsView.tsx
+++ b/src/features/bookings/components/NoBookingsView.tsx
@@ -5,14 +5,14 @@ import styled from 'styled-components/native'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { SearchView } from 'features/search/types'
 import { useLogBeforeNavToSearchResults } from 'features/search/utils/useLogBeforeNavToSearchResults'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { TouchableLink } from 'ui/components/touchableLink/TouchableLink'
 import { NoBookings } from 'ui/svg/icons/NoBookings'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
 export function NoBookingsView() {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   const onPressExploreOffers = useLogBeforeNavToSearchResults({ from: 'bookings' })
   const searchNavConfig = getTabNavConfig('Search', { view: SearchView.Landing })
 

--- a/src/features/bookings/components/OnGoingBookingsList.native.test.tsx
+++ b/src/features/bookings/components/OnGoingBookingsList.native.test.tsx
@@ -5,7 +5,7 @@ import { mocked } from 'ts-jest/utils'
 import { BookingsResponse, SubcategoriesResponseModelv2 } from 'api/gen'
 import { useBookings } from 'features/bookings/api/queries'
 import { analytics } from 'libs/firebase/analytics'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { useSubcategories } from 'libs/subcategories/useSubcategories'
 import { flushAllPromises, render, act } from 'tests/utils'
 import { showErrorSnackBar } from 'ui/components/snackBar/__mocks__/SnackBarContext'
@@ -32,13 +32,13 @@ mockUseSubcategories.mockReturnValue({
 } as UseQueryResult<SubcategoriesResponseModelv2, unknown>)
 
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 jest.mock('ui/components/snackBar/SnackBarContext', () =>
   jest.requireActual('ui/components/snackBar/__mocks__/SnackBarContext')
 )
 describe('<OnGoingBookingsList /> - Analytics', () => {
-  mockUseNetInfo.mockReturnValue({ isConnected: true, isInternetReachable: true })
+  mockUseNetInfoContext.mockReturnValue({ isConnected: true, isInternetReachable: true })
 
   const nativeEventMiddle = {
     layoutMeasurement: { height: 1000 },
@@ -71,7 +71,7 @@ describe('<OnGoingBookingsList /> - Analytics', () => {
       expect(flatList.props.onRefresh).toBeDefined()
     })
     it('should show snack bar error when trying to pull to refetch with message "Impossible de recharger tes réservations, connecte-toi à internet pour réessayer."', async () => {
-      mockUseNetInfo.mockReturnValueOnce({ isConnected: false, isInternetReachable: false })
+      mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false, isInternetReachable: false })
       const refetch = jest.fn()
       const loadingBookings = {
         data: {

--- a/src/features/bookings/components/OnGoingBookingsList.tsx
+++ b/src/features/bookings/components/OnGoingBookingsList.tsx
@@ -9,7 +9,7 @@ import { EndedBookingsSection } from 'features/bookings/pages/EndedBookingsSecti
 import { analytics, isCloseToBottom } from 'libs/firebase/analytics'
 import useFunctionOnce from 'libs/hooks/useFunctionOnce'
 import { useIsFalseWithDelay } from 'libs/hooks/useIsFalseWithDelay'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { useSubcategories } from 'libs/subcategories/useSubcategories'
 import {
   BookingHitPlaceholder,
@@ -30,7 +30,7 @@ const emptyBookings: Booking[] = []
 const ANIMATION_DURATION = 700
 
 export function OnGoingBookingsList() {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   const { data: bookings, isLoading, isFetching, refetch } = useBookings()
   const { bottom } = useSafeAreaInsets()
   const { isLoading: subcategoriesIsLoading } = useSubcategories()

--- a/src/features/bookings/pages/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails.native.test.tsx
@@ -12,7 +12,7 @@ import { openUrl } from 'features/navigation/helpers/openUrl'
 import { navigateFromRef } from 'features/navigation/navigationRef'
 import { analytics } from 'libs/firebase/analytics'
 import * as OpenItinerary from 'libs/itinerary/useOpenItinerary'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, flushAllPromisesWithAct, fireEvent, render } from 'tests/utils'
 import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
@@ -49,7 +49,7 @@ jest.mock('features/navigation/helpers/openUrl')
 const mockedOpenUrl = openUrl as jest.MockedFunction<typeof openUrl>
 
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 const mockShowErrorSnackBar = jest.fn()
 jest.mock('ui/components/snackBar/SnackBarContext', () => ({
@@ -63,7 +63,7 @@ jest.mock('ui/components/snackBar/SnackBarContext', () => ({
 allowConsole({ error: true }) // we allow it just for 1 test which is error throwing when no booking is found 404
 
 describe('BookingDetails', () => {
-  mockUseNetInfo.mockReturnValue({ isConnected: true })
+  mockUseNetInfoContext.mockReturnValue({ isConnected: true })
 
   afterEach(jest.restoreAllMocks)
 
@@ -221,7 +221,7 @@ describe('BookingDetails', () => {
   })
 
   it('should not redirect to the Offer and showSnackBarError when not connected', async () => {
-    mockUseNetInfo.mockReturnValueOnce({ isConnected: false })
+    mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false })
     const booking = bookingsSnap.ongoing_bookings[0]
     const { getByText } = renderBookingDetails(booking)
 

--- a/src/features/bookings/pages/BookingDetails.tsx
+++ b/src/features/bookings/pages/BookingDetails.tsx
@@ -24,7 +24,7 @@ import useFunctionOnce from 'libs/hooks/useFunctionOnce'
 import { SeeItineraryButton } from 'libs/itinerary/components/SeeItineraryButton'
 import { getGoogleMapsItineraryUrl } from 'libs/itinerary/openGoogleMapsItinerary'
 import { eventMonitoring, ScreenError } from 'libs/monitoring'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 import { useSubcategoriesMapping } from 'libs/subcategories'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
@@ -45,7 +45,7 @@ const emptyBookings: Booking[] = []
 
 export function BookingDetails() {
   const windowHeight = useWindowDimensions().height - blurImageHeight
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   const { params } = useRoute<UseRouteType<'BookingDetails'>>()
   const {
     status,

--- a/src/features/culturalSurvey/useCulturalSurvey.ts
+++ b/src/features/culturalSurvey/useCulturalSurvey.ts
@@ -5,7 +5,7 @@ import { CulturalSurveyAnswersRequest, CulturalSurveyQuestionsResponse } from 'a
 import { useAppSettings } from 'features/auth/settings'
 import { shouldShowCulturalSurvey } from 'features/culturalSurvey/helpers/utils'
 import { useUserProfileInfo } from 'features/profile/api'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 
 const STALE_TIME_CULTURAL_SURVEY_QUESTIONS = 5 * 60 * 1000
@@ -13,7 +13,7 @@ const STALE_TIME_CULTURAL_SURVEY_QUESTIONS = 5 * 60 * 1000
 export function useCulturalSurveyQuestions() {
   const { data: user } = useUserProfileInfo()
   const { data: settings } = useAppSettings()
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   const shouldRequestCulturalSurveyQuestions =
     shouldShowCulturalSurvey(user) && settings?.enableNativeCulturalSurvey
 

--- a/src/features/favorites/atoms/BicolorFavoriteCount.tsx
+++ b/src/features/favorites/atoms/BicolorFavoriteCount.tsx
@@ -5,7 +5,7 @@ import styled, { useTheme } from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/AuthContext'
 import { useFavoritesCount } from 'features/favorites/pages/useFavorites'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { BicolorFavorite } from 'ui/svg/icons/BicolorFavorite'
 import { BicolorFavoriteAuthed } from 'ui/svg/icons/BicolorFavoriteAuthed'
 import { Pastille } from 'ui/svg/icons/Pastille'
@@ -25,7 +25,7 @@ export const BicolorFavoriteCount: React.FC<BicolorIconInterface> = ({
     showTabBar,
     tabBar: { showLabels },
   } = useTheme()
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   const { isLoggedIn } = useAuthContext()
   const { data: favoritesCount } = useFavoritesCount()
   const scale = useScaleFavoritesAnimation(favoritesCount)

--- a/src/features/favorites/atoms/__tests__/BicolorFavoriteCount.native.test.tsx
+++ b/src/features/favorites/atoms/__tests__/BicolorFavoriteCount.native.test.tsx
@@ -5,7 +5,7 @@ import waitForExpect from 'wait-for-expect'
 import { FavoriteResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/AuthContext'
 import { env } from 'libs/environment'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
 import { render, superFlushWithAct } from 'tests/utils'
@@ -16,10 +16,10 @@ jest.mock('features/auth/AuthContext')
 const mockUseAuthContext = useAuthContext as jest.MockedFunction<typeof useAuthContext>
 
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 describe('BicolorFavoriteCount component', () => {
-  mockUseNetInfo.mockReturnValue({ isConnected: true })
+  mockUseNetInfoContext.mockReturnValue({ isConnected: true })
 
   it('should render non connected icon', async () => {
     const { queryByTestId } = await renderBicolorFavoriteCount({ isLoggedIn: false })
@@ -59,7 +59,7 @@ describe('BicolorFavoriteCount component', () => {
   })
 
   it('should not show nbFavorites within badge when offline', async () => {
-    mockUseNetInfo.mockReturnValueOnce({ isConnected: false })
+    mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false })
     const renderAPI = await renderBicolorFavoriteCount({ isLoggedIn: true, count: 10 })
     expect(renderAPI.queryByTestId('bicolor-favorite-count')).toBeFalsy()
   })

--- a/src/features/favorites/atoms/__tests__/BicolorFavoriteCount.web.test.tsx
+++ b/src/features/favorites/atoms/__tests__/BicolorFavoriteCount.web.test.tsx
@@ -5,7 +5,7 @@ import waitForExpect from 'wait-for-expect'
 import { FavoriteResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/AuthContext'
 import { env } from 'libs/environment'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
 import { render } from 'tests/utils/web'
@@ -16,10 +16,10 @@ jest.mock('features/auth/AuthContext')
 const mockUseAuthContext = useAuthContext as jest.MockedFunction<typeof useAuthContext>
 
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 describe('BicolorFavoriteCount component', () => {
-  mockUseNetInfo.mockReturnValue({ isConnected: true })
+  mockUseNetInfoContext.mockReturnValue({ isConnected: true })
 
   it('should render non connected icon', async () => {
     const { queryByTestId } = await renderBicolorFavoriteCount({ isLoggedIn: false })
@@ -55,7 +55,7 @@ describe('BicolorFavoriteCount component', () => {
   })
 
   it('should not show nbFavorites within badge when offline', async () => {
-    mockUseNetInfo.mockReturnValueOnce({ isConnected: false })
+    mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false })
     const renderAPI = await renderBicolorFavoriteCount({ isLoggedIn: true, count: 10 })
     expect(renderAPI.queryByTestId('bicolor-favorite-count')).toBeFalsy()
   })

--- a/src/features/favorites/pages/Favorites.tsx
+++ b/src/features/favorites/pages/Favorites.tsx
@@ -5,12 +5,12 @@ import styled from 'styled-components/native'
 import { useAuthContext } from 'features/auth/AuthContext'
 import { FavoritesResults } from 'features/favorites/components/FavoritesResults'
 import { NotConnectedFavorites } from 'features/favorites/components/NotConnectedFavorites'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { OfflinePage } from 'libs/network/OfflinePage'
-import { useNetInfo } from 'libs/network/useNetInfo'
 import { PageHeader } from 'ui/components/headers/PageHeader'
 
 export const Favorites: React.FC = () => {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   const { isLoggedIn } = useAuthContext()
 
   if (!netInfo.isConnected) {

--- a/src/features/favorites/pages/__tests__/Favorites.native.test.tsx
+++ b/src/features/favorites/pages/__tests__/Favorites.native.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { useAuthContext } from 'features/auth/AuthContext'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { cleanup, render } from 'tests/utils'
 
@@ -12,7 +12,7 @@ const mockSearchState = initialFavoritesState
 const mockDispatch = jest.fn()
 
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 jest.mock('features/favorites/pages/FavoritesWrapper', () => ({
   useFavoritesState: () => ({
@@ -25,7 +25,7 @@ jest.mock('features/auth/AuthContext')
 const mockUseAuthContext = useAuthContext as jest.MockedFunction<typeof useAuthContext>
 
 describe('Favorites component', () => {
-  mockUseNetInfo.mockReturnValue({ isConnected: true })
+  mockUseNetInfoContext.mockReturnValue({ isConnected: true })
 
   afterEach(async () => {
     await cleanup()
@@ -42,7 +42,7 @@ describe('Favorites component', () => {
   })
 
   it('should render offline page when not connected', () => {
-    mockUseNetInfo.mockReturnValueOnce({ isConnected: false })
+    mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false })
     const renderAPI = renderFavorites({ isLoggedIn: true })
     expect(renderAPI.queryByText('Pas de réseau internet')).toBeTruthy()
   })

--- a/src/features/favorites/pages/__tests__/useFavorites.test.tsx
+++ b/src/features/favorites/pages/__tests__/useFavorites.test.tsx
@@ -13,7 +13,7 @@ import { FavoritesWrapper } from 'features/favorites/pages/FavoritesWrapper'
 import { offerResponseSnap } from 'features/offer/api/snaps/offerResponseSnap'
 import { env } from 'libs/environment'
 import { EmptyResponse } from 'libs/fetch'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
 import { renderHook, waitFor, superFlushWithAct } from 'tests/utils'
@@ -26,7 +26,7 @@ allowConsole({ error: true })
 jest.mock('features/auth/AuthContext')
 const mockUseAuthContext = useAuthContext as jest.MockedFunction<typeof useAuthContext>
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 jest.unmock('react-query')
 const offerId = 116656
@@ -69,7 +69,7 @@ function simulateBackend(options: Options = defaultOptions) {
 }
 
 describe('useFavorites hook', () => {
-  mockUseNetInfo.mockReturnValue({ isConnected: true, isInternetReachable: true })
+  mockUseNetInfoContext.mockReturnValue({ isConnected: true, isInternetReachable: true })
 
   it('should retrieve favorite data when logged in', async () => {
     simulateBackend()
@@ -116,7 +116,7 @@ describe('useFavorites hook', () => {
   })
 
   it('should fail to fetch when logged in but offline', async () => {
-    mockUseNetInfo.mockReturnValueOnce({ isConnected: false, isInternetReachable: false })
+    mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false, isInternetReachable: false })
     mockUseAuthContext.mockReturnValueOnce({
       isLoggedIn: true,
       setIsLoggedIn: jest.fn(),

--- a/src/features/favorites/pages/useFavorites.ts
+++ b/src/features/favorites/pages/useFavorites.ts
@@ -10,7 +10,7 @@ import {
   SubcategoryIdEnum,
 } from 'api/gen'
 import { useAuthContext } from 'features/auth/AuthContext'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 
 export interface FavoriteMutationContext {
@@ -140,7 +140,7 @@ export function useAddFavorite({ onSuccess, onError }: AddFavorite) {
 const STALE_TIME_FAVORITES = 5 * 60 * 1000
 
 export function useFavorites() {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   const { isLoggedIn } = useAuthContext()
 
   return useQuery<PaginatedFavoritesResponse>(
@@ -152,7 +152,7 @@ export function useFavorites() {
 
 export function useFavoritesCount() {
   const { isLoggedIn } = useAuthContext()
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
 
   return useQuery(QueryKeys.FAVORITES_COUNT, () => api.getnativev1mefavoritescount(), {
     enabled: !!netInfo.isConnected && isLoggedIn,

--- a/src/features/home/api/useExcluOffer.ts
+++ b/src/features/home/api/useExcluOffer.ts
@@ -1,11 +1,11 @@
 import { useQuery } from 'react-query'
 
 import { api } from 'api/api'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 
 export const useExcluOffer = (id: number) => {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
 
   return useQuery(
     [QueryKeys.OFFER, id],

--- a/src/features/home/api/useOfferModule.ts
+++ b/src/features/home/api/useOfferModule.ts
@@ -12,7 +12,7 @@ import {
   useTransformOfferHits,
 } from 'libs/algolia/fetchAlgolia'
 import { useGeolocation } from 'libs/geolocation'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 import { SearchHit, useParseSearchParameters } from 'libs/search'
 
@@ -33,7 +33,7 @@ export const useOfferModule = ({
   const parseSearchParameters = useParseSearchParameters()
   const isUserUnderage = useIsUserUnderage()
   const { data: user } = useUserProfileInfo()
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   const parsedParameters = search.map(parseSearchParameters).filter(isSearchState)
 
   const { data, refetch } = useQuery(

--- a/src/features/home/api/useVenueModule.ts
+++ b/src/features/home/api/useVenueModule.ts
@@ -4,7 +4,7 @@ import { useQuery } from 'react-query'
 import { VenuesModule } from 'features/home/contentful'
 import { fetchMultipleVenues } from 'libs/algolia/fetchAlgolia/fetchMultipleVenues'
 import { useGeolocation } from 'libs/geolocation'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 import { VenueHit } from 'libs/search'
 
@@ -13,7 +13,7 @@ export const useVenueModule = ({
   moduleId,
 }: Pick<VenuesModule, 'search' | 'moduleId'>): VenueHit[] | undefined => {
   const { position } = useGeolocation()
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
 
   const { data, refetch } = useQuery(
     [QueryKeys.HOME_VENUES_MODULE, moduleId],

--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -27,8 +27,8 @@ import { UseRouteType } from 'features/navigation/RootNavigator'
 import { useABTestingContext } from 'libs/ABTesting'
 import { analytics, isCloseToBottom } from 'libs/firebase/analytics'
 import useFunctionOnce from 'libs/hooks/useFunctionOnce'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { OfflinePage } from 'libs/network/OfflinePage'
-import { useNetInfo } from 'libs/network/useNetInfo'
 import { Spinner } from 'ui/components/Spinner'
 import { getSpacing, Spacer } from 'ui/theme'
 
@@ -207,7 +207,7 @@ export const OnlineHome: FunctionComponent = () => {
 }
 
 export const Home: FunctionComponent = () => {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   if (netInfo.isConnected) {
     return <OnlineHome />
   }

--- a/src/features/home/pages/tests/Home.native.test.tsx
+++ b/src/features/home/pages/tests/Home.native.test.tsx
@@ -4,7 +4,7 @@ import { useRoute } from '__mocks__/@react-navigation/native'
 import { UserProfileResponse } from 'api/gen'
 import { env } from 'libs/environment'
 import { analytics } from 'libs/firebase/analytics'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { flushAllPromises, render } from 'tests/utils'
 
 import { Home } from '../Home'
@@ -28,14 +28,14 @@ jest.mock('features/home/api', () => ({
 }))
 
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 jest.mock('features/auth/AuthContext', () => ({
   useAuthContext: jest.fn(() => ({ isLoggedIn: true })),
 }))
 
 describe('Home component', () => {
-  mockUseNetInfo.mockReturnValue({ isConnected: true })
+  mockUseNetInfoContext.mockReturnValue({ isConnected: true })
 
   afterEach(jest.clearAllMocks)
   beforeEach(() => {
@@ -114,7 +114,7 @@ describe('Home component', () => {
   })
 
   it('should render offline page when not connected', () => {
-    mockUseNetInfo.mockReturnValueOnce({ isConnected: false })
+    mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false })
     const renderAPI = render(<Home />)
     expect(renderAPI.queryByText('Pas de réseau internet')).toBeTruthy()
   })

--- a/src/features/identityCheck/pages/profile/__test__/SetAddress.native.test.tsx
+++ b/src/features/identityCheck/pages/profile/__test__/SetAddress.native.test.tsx
@@ -5,7 +5,7 @@ import waitForExpect from 'wait-for-expect'
 
 import { initialIdentityCheckState as mockState } from 'features/identityCheck/context/reducer'
 import { SetAddress } from 'features/identityCheck/pages/profile/SetAddress'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { Properties } from 'libs/place'
 import { buildPlaceUrl } from 'libs/place/buildUrl'
 import * as fetchAddresses from 'libs/place/fetchAddresses'
@@ -47,10 +47,10 @@ jest.mock('ui/components/snackBar/SnackBarContext', () => ({
 }))
 
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 describe('<SetAddress/>', () => {
-  mockUseNetInfo.mockReturnValue({ isConnected: true, isInternetReachable: true })
+  mockUseNetInfoContext.mockReturnValue({ isConnected: true, isInternetReachable: true })
 
   it('should render correctly', () => {
     const renderAPI = renderSetAddresse()

--- a/src/features/navigation/TabBar/TabBarContainer.tsx
+++ b/src/features/navigation/TabBar/TabBarContainer.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { getShadow, getSpacing, Spacer } from 'ui/theme'
 
 import { useCustomSafeInsets } from '../../../ui/theme/useCustomSafeInsets'
 
 export const TabBarContainer = ({ children }: { children: React.ReactNode }) => {
   const { bottom } = useCustomSafeInsets()
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   return (
     <MainContainer>
       <RowContainer>

--- a/src/features/offer/pages/__tests__/OfferBody.deprecated.native.test.tsx
+++ b/src/features/offer/pages/__tests__/OfferBody.deprecated.native.test.tsx
@@ -2,7 +2,7 @@ import mockdate from 'mockdate'
 
 import { api } from 'api/api'
 import { analytics } from 'libs/firebase/analytics'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { act, cleanup, fireEvent } from 'tests/utils'
 
 import { offerId, renderOfferBodyPage } from './renderOfferPageTestUtil'
@@ -35,10 +35,10 @@ jest.mock('features/offer/services/useReasonsForReporting', () => ({
 }))
 
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 describe('<OfferBody />', () => {
-  mockUseNetInfo.mockReturnValue({ isConnected: true, isInternetReachable: true })
+  mockUseNetInfoContext.mockReturnValue({ isConnected: true, isInternetReachable: true })
 
   beforeAll(() => {
     mockdate.set(new Date(2021, 0, 1))
@@ -117,7 +117,7 @@ describe('<OfferBody />', () => {
   })
 
   it('should not request /native/v1/offers/reports if user is logged in and not connected', async () => {
-    mockUseNetInfo.mockReturnValueOnce({ isConnected: false, isInternetReachable: false })
+    mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false, isInternetReachable: false })
     await renderOfferBodyPage()
     expect(api.getnativev1offersreports).not.toBeCalled()
   })

--- a/src/features/offer/services/__tests__/useReasonsForReporting.test.ts
+++ b/src/features/offer/services/__tests__/useReasonsForReporting.test.ts
@@ -4,15 +4,17 @@ import { OfferReportReasons } from 'api/gen'
 import { useAuthContext } from 'features/auth/AuthContext'
 import { offerReportReasonSnap } from 'features/offer/api/snaps/offerReportReasonSnap'
 import { env } from 'libs/environment'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
 import { renderHook, waitFor } from 'tests/utils'
 
 import { useReasonsForReporting } from '../useReasonsForReporting'
 
-jest.mock('libs/network/useNetInfo')
 jest.mock('features/auth/AuthContext')
 const mockUseAuthContext = useAuthContext as jest.MockedFunction<typeof useAuthContext>
+
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 server.use(
   rest.get<OfferReportReasons>(
@@ -25,6 +27,7 @@ describe('useReasonsForReporting hook', () => {
   afterEach(jest.resetAllMocks)
 
   it('should retrieve reasons for reporting data when logged in', async () => {
+    mockUseNetInfoContext.mockImplementationOnce(() => ({ isConnected: true }))
     mockUseAuthContext.mockImplementationOnce(() => ({
       isLoggedIn: true,
       setIsLoggedIn: jest.fn(),
@@ -42,6 +45,7 @@ describe('useReasonsForReporting hook', () => {
   })
 
   it('should return null when not logged in', async () => {
+    mockUseNetInfoContext.mockImplementationOnce(() => ({ isConnected: true }))
     mockUseAuthContext.mockImplementationOnce(() => ({
       isLoggedIn: false,
       setIsLoggedIn: jest.fn(),

--- a/src/features/offer/services/useReasonsForReporting.ts
+++ b/src/features/offer/services/useReasonsForReporting.ts
@@ -2,14 +2,14 @@ import { useQuery } from 'react-query'
 
 import { api } from 'api/api'
 import { useAuthContext } from 'features/auth/AuthContext'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 
 const STALE_TIME_REPORT_OFFER_REASONS = 5 * 60 * 1000
 
 export const useReasonsForReporting = () => {
   const { isLoggedIn } = useAuthContext()
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   return useQuery(QueryKeys.REPORT_OFFER_REASONS, () => api.getnativev1offerreportreasons(), {
     enabled: !!netInfo.isConnected && isLoggedIn,
     staleTime: STALE_TIME_REPORT_OFFER_REASONS,

--- a/src/features/offer/services/useReportedOffers.ts
+++ b/src/features/offer/services/useReportedOffers.ts
@@ -3,13 +3,13 @@ import { useQuery } from 'react-query'
 import { api } from 'api/api'
 import { UserReportedOffersResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/AuthContext'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 
 const STALE_TIME_REPORTED_OFFERS = 5 * 60 * 1000
 
 export const useReportedOffers = () => {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   const { isLoggedIn } = useAuthContext()
 
   return useQuery<UserReportedOffersResponse>(

--- a/src/features/profile/api.ts
+++ b/src/features/profile/api.ts
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from 'react-query'
 import { api } from 'api/api'
 import { UserProfileResponse, UserProfileUpdateRequest } from 'api/gen'
 import { useAuthContext } from 'features/auth/AuthContext'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 import { usePersistQuery } from 'libs/react-query/usePersistQuery'
 
@@ -54,7 +54,7 @@ const STALE_TIME_USER_PROFILE = 5 * 60 * 1000
 
 export function useUserProfileInfo(options = {}) {
   const { isLoggedIn } = useAuthContext()
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
 
   return usePersistQuery<UserProfileResponse>(QueryKeys.USER_PROFILE, () => api.getnativev1me(), {
     enabled: !!netInfo.isConnected && isLoggedIn,

--- a/src/features/profile/pages/ChangeEmail/utils/useCheckHasCurrentEmailChange.ts
+++ b/src/features/profile/pages/ChangeEmail/utils/useCheckHasCurrentEmailChange.ts
@@ -1,11 +1,11 @@
 import { useQuery } from 'react-query'
 
 import { api } from 'api/api'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 
 export const useCheckHasCurrentEmailChange = () => {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
 
   const { data: currentEmailChangeTimestampResponse } = useQuery(
     QueryKeys.EMAIL_CHANGE_EXPIRATION_TIMESTAMP,

--- a/src/features/profile/pages/Profile.native.test.tsx
+++ b/src/features/profile/pages/Profile.native.test.tsx
@@ -18,7 +18,7 @@ import {
   GeoCoordinates,
   GEOLOCATION_USER_ERROR_MESSAGE,
 } from 'libs/geolocation'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { flushAllPromisesWithAct, render, act, fireEvent, cleanup } from 'tests/utils'
 
 import { Profile } from './Profile'
@@ -91,10 +91,10 @@ jest.mock('features/identityCheck/context/IdentityCheckContextProvider', () => (
 }))
 
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 describe('Profile component', () => {
-  mockUseNetInfo.mockReturnValue({ isConnected: true })
+  mockUseNetInfoContext.mockReturnValue({ isConnected: true })
 
   afterEach(() => {
     mockPermissionState = GeolocPermissionState.GRANTED
@@ -109,7 +109,7 @@ describe('Profile component', () => {
   })
 
   it('should render offline page when not connected', async () => {
-    mockUseNetInfo.mockReturnValueOnce({ isConnected: false })
+    mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false })
     const renderAPI = await renderProfile()
     expect(renderAPI.queryByText('Pas de réseau internet')).toBeTruthy()
   })

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -17,8 +17,8 @@ import { env } from 'libs/environment'
 import { analytics, isCloseToBottom } from 'libs/firebase/analytics'
 import { GeolocPermissionState, useGeolocation } from 'libs/geolocation'
 import useFunctionOnce from 'libs/hooks/useFunctionOnce'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { OfflinePage } from 'libs/network/OfflinePage'
-import { useNetInfo } from 'libs/network/useNetInfo'
 import { InputError } from 'ui/components/inputs/InputError'
 import { Section } from 'ui/components/Section'
 import { SectionRow } from 'ui/components/SectionRow'
@@ -258,7 +258,7 @@ const OnlineProfile: React.FC = () => {
 }
 
 export const Profile: React.FC = () => {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   if (netInfo.isConnected) {
     return <OnlineProfile />
   }

--- a/src/features/search/pages/Search.tsx
+++ b/src/features/search/pages/Search.tsx
@@ -17,8 +17,8 @@ import { SearchView } from 'features/search/types'
 import { AlgoliaSuggestionHit } from 'libs/algolia'
 import { client } from 'libs/algolia/fetchAlgolia/clients'
 import { env } from 'libs/environment'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { OfflinePage } from 'libs/network/OfflinePage'
-import { useNetInfo } from 'libs/network/useNetInfo'
 import { Spacer } from 'ui/theme'
 import { Form } from 'ui/web/form/Form'
 
@@ -71,7 +71,7 @@ const BodySearch = memo(function BodySearch({ view }: BodySearchProps) {
 })
 
 export function Search() {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   const { params } = useRoute<UseRouteType<'Search'>>()
   const { dispatch } = useSearch()
 

--- a/src/features/search/pages/__tests__/Search.native.test.tsx
+++ b/src/features/search/pages/__tests__/Search.native.test.tsx
@@ -9,7 +9,7 @@ import { SearchWrapper } from 'features/search/pages/SearchWrapper'
 import * as useShowResultsForCategory from 'features/search/pages/useShowResultsForCategory'
 import { SearchState, SearchView } from 'features/search/types'
 import * as useFilterCountAPI from 'features/search/utils/useFilterCount'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { SuggestedVenue } from 'libs/venue'
 import { mockedSuggestedVenues } from 'libs/venue/fixtures/mockedSuggestedVenues'
 import { render, fireEvent } from 'tests/utils'
@@ -60,7 +60,7 @@ jest.mock('features/search/pages/useSearchResults', () => ({
 }))
 
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 const mockSettings = jest.fn().mockReturnValue({ data: {} })
 jest.mock('features/auth/settings', () => ({
@@ -93,7 +93,7 @@ jest.spyOn(useFilterCountAPI, 'useFilterCount').mockReturnValue(3)
 jest.mock('algoliasearch')
 
 describe('Search component', () => {
-  mockUseNetInfo.mockReturnValue({ isConnected: true })
+  mockUseNetInfoContext.mockReturnValue({ isConnected: true })
 
   it('should render Search', () => {
     expect(render(<Search />)).toMatchSnapshot()
@@ -109,7 +109,7 @@ describe('Search component', () => {
 
   describe('When offline', () => {
     it('should display offline page', () => {
-      mockUseNetInfo.mockReturnValueOnce({ isConnected: false })
+      mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false })
       const renderAPI = render(<Search />)
       expect(renderAPI.queryByText('Pas de réseau internet')).toBeTruthy()
     })

--- a/src/features/venue/api/useVenueOffers.ts
+++ b/src/features/venue/api/useVenueOffers.ts
@@ -5,7 +5,7 @@ import { useIsUserUnderage } from 'features/profile/utils'
 import { useVenueSearchParameters } from 'features/venue/api/useVenueSearchParameters'
 import { useSearchAnalyticsState } from 'libs/algolia/analytics/SearchAnalyticsWrapper'
 import { fetchOffer, filterOfferHit, useTransformOfferHits } from 'libs/algolia/fetchAlgolia'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 import { SearchHit } from 'libs/search'
 
@@ -13,7 +13,7 @@ export const useVenueOffers = (venueId: number) => {
   const transformHits = useTransformOfferHits()
   const params = useVenueSearchParameters(venueId)
   const isUserUnderage = useIsUserUnderage()
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
 
   const { setCurrentQueryID } = useSearchAnalyticsState()
 

--- a/src/libs/network/NetInfoWrapper.tsx
+++ b/src/libs/network/NetInfoWrapper.tsx
@@ -1,12 +1,17 @@
 import { t } from '@lingui/macro'
 // eslint-disable-next-line no-restricted-imports
-import { useNetInfo } from '@react-native-community/netinfo'
-import { useEffect } from 'react'
+import { NetInfoState, NetInfoStateType } from '@react-native-community/netinfo'
+import React, { createContext, memo, useContext, useEffect } from 'react'
+import { Platform } from 'react-native'
 
+import { useNetInfo } from 'libs/network/useNetInfo'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 
-export function NetInfoWrapper({ children }: { children: JSX.Element }) {
-  // use the raw useNetInfo here which is null at start
+export const NetInfoWrapper = memo(function NetInfoWrapper({
+  children,
+}: {
+  children: JSX.Element
+}) {
   const networkInfo = useNetInfo()
   const { showInfoSnackBar } = useSnackBarContext()
 
@@ -20,5 +25,18 @@ export function NetInfoWrapper({ children }: { children: JSX.Element }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [networkInfo.isConnected])
 
-  return children
+  return <NetInfoContext.Provider value={networkInfo}>{children}</NetInfoContext.Provider>
+})
+
+const isWeb = Platform.OS === 'web'
+
+const NetInfoContext = createContext<NetInfoState>({
+  type: NetInfoStateType.unknown,
+  isConnected: isWeb ? true : null,
+  isInternetReachable: isWeb ? true : null,
+  details: null,
+} as NetInfoState)
+
+export function useNetInfoContext(): NetInfoState {
+  return useContext(NetInfoContext)
 }

--- a/src/libs/network/OfflineModeContainer.tsx
+++ b/src/libs/network/OfflineModeContainer.tsx
@@ -2,13 +2,13 @@ import { t } from '@lingui/macro'
 import React, { ReactNode, useState, useEffect, useRef } from 'react'
 import styled from 'styled-components/native'
 
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { getSpacing, Typo, Spacer } from 'ui/theme'
 
 const THIRTY_SECONDS = 15000
 
 export function OfflineModeContainer({ children }: { children: ReactNode }) {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   const [show, setShow] = useState(!netInfo.isConnected)
   const isInternetReachable = useRef(netInfo.isInternetReachable)
 

--- a/src/libs/network/__mocks__/NetInfoWrapper.tsx
+++ b/src/libs/network/__mocks__/NetInfoWrapper.tsx
@@ -1,0 +1,5 @@
+import { useNetInfoContext as actualUseNetInfoContext } from '../NetInfoWrapper'
+
+export const useNetInfoContext = jest.fn().mockReturnValue({
+  isConnected: true,
+}) as jest.MockedFunction<typeof actualUseNetInfoContext>

--- a/src/libs/network/__tests__/OfflineModeContainer.test.tsx
+++ b/src/libs/network/__tests__/OfflineModeContainer.test.tsx
@@ -1,16 +1,16 @@
 import React from 'react'
 import { View, Text } from 'react-native'
 
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { OfflineModeContainer } from 'libs/network/OfflineModeContainer'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
 import { render } from 'tests/utils'
 
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
 
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 describe('<OfflineModeContainer />', () => {
-  mockUseNetInfo.mockImplementation(() => ({ isConnected: false }))
+  mockUseNetInfoContext.mockImplementation(() => ({ isConnected: false }))
 
   it('should render children and show banner when offline at init when isConnected is false', () => {
     const renderAPI = renderOfflineModeContainer()
@@ -19,18 +19,21 @@ describe('<OfflineModeContainer />', () => {
   })
 
   it('should render children and not show banner when offline at init when isConnected is true', () => {
-    mockUseNetInfo.mockImplementationOnce(() => ({ isConnected: true }))
+    mockUseNetInfoContext.mockImplementationOnce(() => ({ isConnected: true }))
     const renderAPI = renderOfflineModeContainer()
     expect(renderAPI.queryByText('aucune connexion internet.')).toBeFalsy()
     expect(renderAPI.queryByText('Hello World')).toBeTruthy()
   })
 
   it('should not show "aucune connexion internet." at init, then show when isConnected is false, then hide when isConnected switch back to true', () => {
-    mockUseNetInfo.mockImplementationOnce(() => ({ isConnected: true, isInternetReachable: true }))
+    mockUseNetInfoContext.mockImplementationOnce(() => ({
+      isConnected: true,
+      isInternetReachable: true,
+    }))
     const renderAPI = render(jsx)
     expect(renderAPI.queryByText('aucune connexion internet.')).toBeFalsy()
 
-    mockUseNetInfo.mockImplementationOnce(() => ({
+    mockUseNetInfoContext.mockImplementationOnce(() => ({
       isConnected: false,
       isInternetReachable: false,
     }))

--- a/src/libs/place/useCities.ts
+++ b/src/libs/place/useCities.ts
@@ -1,6 +1,6 @@
 import { useQuery } from 'react-query'
 
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { SuggestedCity } from 'libs/place'
 import { fetchCities } from 'libs/place/fetchCities'
 import { QueryKeys } from 'libs/queryKeys'
@@ -19,7 +19,7 @@ export const CITIES_API_URL = 'https://geo.api.gouv.fr/communes'
 const STALE_TIME_CITIES = 5 * 60 * 1000
 
 export const useCities = (postalCode: string) => {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   return useQuery([QueryKeys.CITIES, postalCode], () => fetchCities(postalCode), {
     staleTime: STALE_TIME_CITIES,
     enabled: !!netInfo.isConnected && postalCode.length >= 5,

--- a/src/libs/place/usePlaces.ts
+++ b/src/libs/place/usePlaces.ts
@@ -1,13 +1,13 @@
 import { useQuery } from 'react-query'
 
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { fetchPlaces, SuggestedPlace } from 'libs/place'
 import { QueryKeys } from 'libs/queryKeys'
 
 const STALE_TIME_PLACES = 5 * 60 * 1000
 
 export const usePlaces = ({ query }: { query: string }) => {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   return useQuery<SuggestedPlace[]>(
     [QueryKeys.PLACES, query],
     () => fetchPlaces({ query, limit: 20 }),

--- a/src/libs/place/useVenues.ts
+++ b/src/libs/place/useVenues.ts
@@ -1,14 +1,14 @@
 import { useQuery } from 'react-query'
 
 import { fetchVenues } from 'libs/algolia/fetchAlgolia/fetchVenues'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 import { SuggestedVenue } from 'libs/venue'
 
 const STALE_TIME_VENUES = 5 * 60 * 1000
 
 export const useVenues = (query: string) => {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   return useQuery<SuggestedVenue[]>([QueryKeys.VENUES, query], () => fetchVenues(query), {
     staleTime: STALE_TIME_VENUES,
     enabled: !!netInfo.isConnected && query.length > 0,

--- a/src/libs/react-query/tests/usePersistQuery.native.test.tsx
+++ b/src/libs/react-query/tests/usePersistQuery.native.test.tsx
@@ -5,14 +5,14 @@ import { QueryFunction } from 'react-query/types/core/types'
 import waitForExpect from 'wait-for-expect'
 
 import { eventMonitoring } from 'libs/monitoring'
-import { useNetInfo as useNetInfoDefault } from 'libs/network/useNetInfo'
+import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, superFlushWithAct } from 'tests/utils'
 
 import { usePersistQuery } from '../usePersistQuery'
 
 jest.mock('libs/network/useNetInfo', () => jest.requireMock('@react-native-community/netinfo'))
-const mockUseNetInfo = useNetInfoDefault as jest.Mock
+const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 
 type TestData = {
   id: number
@@ -44,7 +44,7 @@ describe('usePersistQuery', () => {
 
   const queryFn: QueryFunction<TestData[]> = async () => onlineData
 
-  mockUseNetInfo.mockReturnValue({ isConnected: true })
+  mockUseNetInfoContext.mockReturnValue({ isConnected: true })
 
   afterEach(async () => {
     await AsyncStorage.removeItem(queryKey)

--- a/src/libs/react-query/usePersistQuery.ts
+++ b/src/libs/react-query/usePersistQuery.ts
@@ -4,7 +4,7 @@ import { useQuery, UseQueryOptions, UseQueryResult, QueryKey } from 'react-query
 import { QueryFunction } from 'react-query/types/core/types'
 
 import { eventMonitoring } from 'libs/monitoring'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 
 function useGetPersistData<TData, TQueryKey>(queryKey: TQueryKey) {
   const [persistData, setPersistData] = useState<TData | undefined>()
@@ -51,7 +51,7 @@ export function usePersistQuery<
   queryFn: QueryFunction<TQueryFnData, TQueryKey>,
   options?: Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'queryKey'>
 ): UsePersistQueryResult<TData, TError> {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   const persistData = useGetPersistData(queryKey)
 
   const query = useQuery<TQueryFnData, TError, TData, TQueryKey>(queryKey, queryFn, {

--- a/src/libs/react-query/usePrefetchQueries.ts
+++ b/src/libs/react-query/usePrefetchQueries.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 
 import { api } from 'api/api'
 import { getEntries } from 'features/home/api'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 import { queryClient } from 'libs/react-query/queryClient'
 
@@ -16,7 +16,7 @@ const prefetchQueries = async () => {
 }
 
 export const usePrefetchQueries = () => {
-  const { isConnected } = useNetInfo()
+  const { isConnected } = useNetInfoContext()
   useEffect(() => {
     if (isConnected) {
       prefetchQueries()

--- a/src/libs/subcategories/useSubcategories.ts
+++ b/src/libs/subcategories/useSubcategories.ts
@@ -2,7 +2,7 @@ import { useQuery } from 'react-query'
 
 import { api } from 'api/api'
 import { SubcategoriesResponseModelv2 } from 'api/gen'
-import { useNetInfo } from 'libs/network/useNetInfo'
+import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { QueryKeys } from 'libs/queryKeys'
 
 import { placeholderData } from './placeholderData'
@@ -10,7 +10,7 @@ import { placeholderData } from './placeholderData'
 const STALE_TIME_SUBCATEGORIES = 5 * 60 * 1000
 
 export const useSubcategories = () => {
-  const netInfo = useNetInfo()
+  const netInfo = useNetInfoContext()
   return useQuery<SubcategoriesResponseModelv2>(
     QueryKeys.SUBCATEGORIES,
     () => api.getnativev1subcategoriesv2(),


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16686

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
