### PR TITLE
(PC-16664) fix(lottie): play animation after app in background for all lottie animations

### DIFF
--- a/src/features/recreditBirthdayNotification/pages/components/RecreditBirthdayNotification.tsx
+++ b/src/features/recreditBirthdayNotification/pages/components/RecreditBirthdayNotification.tsx
@@ -58,14 +58,13 @@ export const RecreditBirthdayNotification = () => {
     analytics.logScreenView('BirthdayNotification')
   }, [])
 
-  const showAnimation = useCallback(() => {
+  const playAnimation = useCallback(() => {
     const lottieAnimation = animationRef.current
     if (lottieAnimation) lottieAnimation.play(0, 62)
   }, [animationRef])
 
-  const onAppBecomeActive = () => showAnimation()
-  useAppStateChange(onAppBecomeActive, undefined)
-  useEffect(() => showAnimation, [showAnimation])
+  useAppStateChange(playAnimation, undefined)
+  useEffect(playAnimation, [playAnimation])
 
   return (
     <GenericInfoPageWhite animation={TutorialPassLogo} title={t`Bonne nouvelle\u00a0!`}>

--- a/src/features/recreditBirthdayNotification/pages/components/RecreditBirthdayNotification.tsx
+++ b/src/features/recreditBirthdayNotification/pages/components/RecreditBirthdayNotification.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro'
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { useTheme } from 'styled-components/native'
 
 import {
@@ -12,6 +12,7 @@ import {
 import { useAvailableCredit } from 'features/home/services/useAvailableCredit'
 import { navigateToHome } from 'features/navigation/helpers'
 import { useUserProfileInfo, useResetRecreditAmountToShow } from 'features/profile/api'
+import { useAppStateChange } from 'libs/appState'
 import { analytics } from 'libs/firebase/analytics'
 import LottieView from 'libs/lottie'
 import { formatToFrenchDecimal } from 'libs/parsers'
@@ -57,11 +58,14 @@ export const RecreditBirthdayNotification = () => {
     analytics.logScreenView('BirthdayNotification')
   }, [])
 
-  useEffect(() => {
-    if (animationRef.current) {
-      animationRef.current.play(0, 62)
-    }
+  const showAnimation = useCallback(() => {
+    const lottieAnimation = animationRef.current
+    if (lottieAnimation) lottieAnimation.play(0, 62)
   }, [animationRef])
+
+  const onAppBecomeActive = () => showAnimation()
+  useAppStateChange(onAppBecomeActive, undefined)
+  useEffect(() => showAnimation, [showAnimation])
 
   return (
     <GenericInfoPageWhite animation={TutorialPassLogo} title={t`Bonne nouvelle\u00a0!`}>

--- a/src/ui/components/GenericInfoPage.tsx
+++ b/src/ui/components/GenericInfoPage.tsx
@@ -75,7 +75,13 @@ export const GenericInfoPage: FunctionComponent<Props> = ({
         ) : (
           !!animation && (
             <React.Fragment>
-              <StyledLottieView source={animation} autoPlay loop={false} size={ANIMATION_SIZE} />
+              <StyledLottieView
+                source={animation}
+                autoPlay
+                loop={false}
+                size={ANIMATION_SIZE}
+                progress={1}
+              />
               <Spacer.Column numberOfSpaces={spacingMatrix.afterLottieAnimation} />
             </React.Fragment>
           )

--- a/src/ui/components/GenericInfoPageWhite.tsx
+++ b/src/ui/components/GenericInfoPageWhite.tsx
@@ -79,16 +79,15 @@ export const GenericInfoPageWhite: React.FC<Props> = ({
     })
   }, [subtitleComponent])
 
-  const showAnimation = useCallback(() => {
+  const playAnimation = useCallback(() => {
     const lottieAnimation = animationRef.current
     if (animation && lottieAnimation) {
       lottieAnimation.play(0, 62)
     }
   }, [animation])
 
-  const onAppBecomeActive = () => showAnimation()
-  useAppStateChange(onAppBecomeActive, undefined)
-  useEffect(() => showAnimation(), [showAnimation])
+  useAppStateChange(playAnimation, undefined)
+  useEffect(playAnimation, [playAnimation])
 
   return (
     <React.Fragment>

--- a/src/ui/components/GenericInfoPageWhite.tsx
+++ b/src/ui/components/GenericInfoPageWhite.tsx
@@ -1,10 +1,11 @@
 import { t } from '@lingui/macro'
-import React, { useEffect, useMemo, useRef } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 import styled, { useTheme } from 'styled-components/native'
 
 import { RootNavigateParams } from 'features/navigation/RootNavigator'
 import { homeNavConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
+import { useAppStateChange } from 'libs/appState'
 import LottieView from 'libs/lottie'
 import { useMediaQuery } from 'libs/react-responsive/useMediaQuery'
 import { AnimationObject } from 'ui/animations/type'
@@ -78,11 +79,16 @@ export const GenericInfoPageWhite: React.FC<Props> = ({
     })
   }, [subtitleComponent])
 
-  useEffect(() => {
-    if (animation && animationRef.current) {
-      animationRef.current.play(0, 62)
+  const showAnimation = useCallback(() => {
+    const lottieAnimation = animationRef.current
+    if (animation && lottieAnimation) {
+      lottieAnimation.play(0, 62)
     }
-  }, [animationRef, animation])
+  }, [animation])
+
+  const onAppBecomeActive = () => showAnimation()
+  useAppStateChange(onAppBecomeActive, undefined)
+  useEffect(() => showAnimation(), [showAnimation])
 
   return (
     <React.Fragment>

--- a/src/ui/components/achievements/components/GenericAchievementCard.tsx
+++ b/src/ui/components/achievements/components/GenericAchievementCard.tsx
@@ -75,7 +75,7 @@ export const GenericAchievementCard: FunctionComponent<AchievementCardProps> = (
     )
   }
 
-  const showAnimation = useCallback(() => {
+  const playAnimation = useCallback(() => {
     const lottieAnimation = animationRef.current
     if (!lottieAnimation) return
     if (props.index === props.activeIndex) {
@@ -89,9 +89,8 @@ export const GenericAchievementCard: FunctionComponent<AchievementCardProps> = (
     }
   }, [props.activeIndex, props.index, props.pauseAnimationOnRenderAtFrame])
 
-  const onAppBecomeActive = () => showAnimation()
-  useAppStateChange(onAppBecomeActive, undefined)
-  useEffect(() => showAnimation(), [showAnimation])
+  useAppStateChange(playAnimation, undefined)
+  useEffect(playAnimation, [playAnimation])
 
   didFadeIn = false
   useEffect(() => {

--- a/src/ui/components/achievements/components/GenericAchievementCard.tsx
+++ b/src/ui/components/achievements/components/GenericAchievementCard.tsx
@@ -1,10 +1,11 @@
 import { t } from '@lingui/macro'
-import React, { FunctionComponent, RefObject, useEffect, useMemo } from 'react'
+import React, { FunctionComponent, RefObject, useCallback, useEffect, useMemo } from 'react'
 import { View } from 'react-native'
 import * as Animatable from 'react-native-animatable'
 import Swiper from 'react-native-web-swiper'
 import styled, { useTheme } from 'styled-components/native'
 
+import { useAppStateChange } from 'libs/appState'
 import { analytics } from 'libs/firebase/analytics'
 import LottieView from 'libs/lottie'
 import { MonitoringError } from 'libs/monitoring'
@@ -70,12 +71,11 @@ export const GenericAchievementCard: FunctionComponent<AchievementCardProps> = (
         activeIndex={props.activeIndex}
         lastIndex={props.lastIndex}
         
-Those props are provided by the GenericAchievementCard and must be passed down to the GenericAchievementCard from within your custom Card component!`
+      Those props are provided by the GenericAchievementCard and must be passed down to the GenericAchievementCard from within your custom Card component!`
     )
   }
 
-  didFadeIn = false
-  useEffect(() => {
+  const showAnimation = useCallback(() => {
     const lottieAnimation = animationRef.current
     if (!lottieAnimation) return
     if (props.index === props.activeIndex) {
@@ -87,8 +87,13 @@ Those props are provided by the GenericAchievementCard and must be passed down t
         lottieAnimation.pause()
       }
     }
-  }, [props.pauseAnimationOnRenderAtFrame, animationRef, props.index, props.activeIndex])
+  }, [props.activeIndex, props.index, props.pauseAnimationOnRenderAtFrame])
 
+  const onAppBecomeActive = () => showAnimation()
+  useAppStateChange(onAppBecomeActive, undefined)
+  useEffect(() => showAnimation(), [showAnimation])
+
+  didFadeIn = false
   useEffect(() => {
     const button = animatedButtonRef?.current
     if (button?.fadeIn) {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16664

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|    ![Simulator Screen Recording - iPhone 12 - 2022-08-11 at 15 52 12](https://user-images.githubusercontent.com/62059034/184150646-997ec9d8-fb67-49ab-8729-a9f65f1e1f2e.gif) ![Simulator Screen Recording - iPhone 12 - 2022-08-11 at 15 55 03](https://user-images.githubusercontent.com/62059034/184150676-be39e8cb-3844-4cf7-ab8d-c95366b6676f.gif) ![Simulator Screen Recording - iPhone 12 - 2022-08-11 at 15 55 37](https://user-images.githubusercontent.com/62059034/184150686-c9290622-b44e-409d-8faf-3c198a73c2cf.gif) ![Simulator Screen Recording - iPhone 12 - 2022-08-11 at 15 58 34](https://user-images.githubusercontent.com/62059034/184150692-c4b7876b-560f-4921-94e0-abb7b15e7f22.gif)   |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
