### PR TITLE
(PC-16810) fix(notification): add break before load batch url

### DIFF
--- a/src/features/navigation/RootNavigator/linking/getInitialUrl.ios.ts
+++ b/src/features/navigation/RootNavigator/linking/getInitialUrl.ios.ts
@@ -10,6 +10,10 @@ export async function getInitialURL(): Promise<string> {
   if (dynamicLinkUrl) {
     return dynamicLinkUrl.url
   }
+  // Little break for react-navigation loading
+  // Issue opened to remove it : https://github.com/react-navigation/react-navigation/issues/10752
+  // TODO(PC-16812): https://passculture.atlassian.net/browse/PC-16812
+  await new Promise((r) => setTimeout(r, 500))
   const url = await BatchPush.getInitialURL()
   if (url) {
     return url


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16810

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
