### PR TITLE
(PC-16790) refactor(phoneVal): replace old SetPhoneNumber paths with new

### DIFF
--- a/src/features/navigation/RootNavigator/identityCheckRoutes.ts
+++ b/src/features/navigation/RootNavigator/identityCheckRoutes.ts
@@ -60,29 +60,27 @@ export const identityCheckRoutes: GenericRoute<IdentityCheckRootStackParamList>[
   {
     name: 'SetPhoneNumberDeprecated',
     component: SetPhoneNumberDeprecated,
-    path: 'creation-compte/telephone',
+    path: 'validation-telephone/numero-cheatcodes-only',
     options: { title: t`Ton numéro de téléphone` },
     secure: true,
   },
   {
     name: 'SetPhoneNumber',
     component: SetPhoneNumber,
-    // TODO(PC-15247): exchange "path" names between Deprecated and New to maintain consistency in productio,.
-    path: 'validation-telephone/numero-cheatcodes-only',
+    path: 'creation-compte/telephone',
     options: { title: t`Ton numéro de téléphone` },
     secure: true,
   },
   {
     name: 'SetPhoneValidationCode',
     component: SetPhoneValidationCode,
-    // TODO(PC-15247): exchange "path" names between Deprecated and New to maintain consistency in productio,.
-    path: 'validation-telephone/code-cheatcodes-only',
+    path: 'creation-compte/code-de-validation-telephone',
     options: { title: t`Validation du numéro de téléphone` },
   },
   {
     name: 'SetPhoneValidationCodeDeprecated',
     component: SetPhoneValidationCodeDeprecated,
-    path: 'creation-compte/code-de-validation-telephone',
+    path: 'validation-telephone/code-cheatcodes-only',
     options: { title: t`Validation téléphone` },
   },
   // Profile


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16790

Exchange path names between deprecated and new SetPhoneNumber pages.

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
