### PR TITLE
(PC-16541) ci(Web): reducing resource_class for build_web from large to medium+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -758,7 +758,7 @@ jobs:
   deploy-web-testing:
     executor: gcp
     working_directory: ~/pass-culture
-    resource_class: large
+    resource_class: medium+
     steps:
       - checkout
       - copy_assetlinks:
@@ -787,7 +787,7 @@ jobs:
   deploy-web-staging:
     executor: gcp
     working_directory: ~/pass-culture
-    resource_class: large
+    resource_class: medium+
     steps:
       - checkout
       - copy_assetlinks:
@@ -807,7 +807,7 @@ jobs:
   deploy-web-integration:
     executor: gcp
     working_directory: ~/pass-culture
-    resource_class: large
+    resource_class: medium+
     steps:
       - checkout
       - install_node_modules
@@ -825,7 +825,7 @@ jobs:
   deploy-web-prod:
     executor: gcp
     working_directory: ~/pass-culture
-    resource_class: large
+    resource_class: medium+
     steps:
       - checkout
       - copy_assetlinks:


### PR DESCRIPTION
Following the bundle web optimization, we will try to hold the resource_class to the minimum of ram needed, until our app grows and we'll increased it again later.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16541

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
