### PR TITLE
(PC-16541) ci(Web): reducing resource_class for build_web from large to medium+ (Revert)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -758,7 +758,7 @@ jobs:
   deploy-web-testing:
     executor: gcp
     working_directory: ~/pass-culture
-    resource_class: medium+
+    resource_class: large
     steps:
       - checkout
       - copy_assetlinks:
@@ -787,7 +787,7 @@ jobs:
   deploy-web-staging:
     executor: gcp
     working_directory: ~/pass-culture
-    resource_class: medium+
+    resource_class: large
     steps:
       - checkout
       - copy_assetlinks:
@@ -807,7 +807,7 @@ jobs:
   deploy-web-integration:
     executor: gcp
     working_directory: ~/pass-culture
-    resource_class: medium+
+    resource_class: large
     steps:
       - checkout
       - install_node_modules
@@ -825,7 +825,7 @@ jobs:
   deploy-web-prod:
     executor: gcp
     working_directory: ~/pass-culture
-    resource_class: medium+
+    resource_class: large
     steps:
       - checkout
       - copy_assetlinks:


### PR DESCRIPTION
This reverts commit 38c78daf88b930e58ea8b026a5e731845b58b841.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16541

Finalement, on ne peut pas réduire la RAM, ex de CI qui fail depuis ce commit : https://app.circleci.com/pipelines/github/pass-culture/pass-culture-app-native/17702/workflows/7a9e1fc6-6a90-4af1-918d-393c397ec297/jobs/64984

Donc je revert

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
## Screenshots

| [CI Failed](https://app.circleci.com/pipelines/github/pass-culture/pass-culture-app-native/17702/workflows/7a9e1fc6-6a90-4af1-918d-393c397ec297/jobs/64984) | 
| --: |
| ![image](https://user-images.githubusercontent.com/77674046/185145406-796ca882-3e4c-4a16-9ad5-ce160a199e84.png)    |


[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
