### PR TITLE
(PC-16537) fix(Search): show results view after submitting reinitialized filters

### DIFF
--- a/src/features/search/atoms/Buttons/__tests__/ShowResults.native.test.tsx
+++ b/src/features/search/atoms/Buttons/__tests__/ShowResults.native.test.tsx
@@ -1,10 +1,16 @@
 import React from 'react'
 
-import { render } from 'tests/utils'
+import { navigate } from '__mocks__/@react-navigation/native'
+import { SearchWrapper } from 'features/search/pages/SearchWrapper'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { render, fireEvent } from 'tests/utils'
 
 import { ShowResults } from '../ShowResults'
 
 let mockData = { pages: [{ nbHits: 0 }] }
+
+jest.unmock('features/search/pages/SearchWrapper')
+
 jest.mock('features/search/pages/useSearchResults', () => ({
   useStagedSearchResults: () => ({
     data: mockData,
@@ -22,12 +28,53 @@ describe('<ShowResults />', () => {
     ${1200} | ${'Afficher les 999+ résultats'} | ${false}
   `(
     'should display the correct translation ($expected) and be disabled=$disabled',
-    ({ nbHits, expected, disabled }) => {
+    async ({ nbHits, expected, disabled }) => {
       mockData = { pages: [{ nbHits }] }
-      const { getByText, getByTestId } = render(<ShowResults />)
-      getByText(expected)
+      const { getByText } = render(
+        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+        reactQueryProviderHOC(
+          <SearchWrapper>
+            <ShowResults />
+          </SearchWrapper>
+        )
+      )
 
-      expect(getByTestId(expected))[disabled ? 'toBeDisabled' : 'toBeEnabled']()
+      expect(await getByText(expected))[disabled ? 'toBeDisabled' : 'toBeEnabled']()
     }
   )
+
+  it('should call navigate with searchState.view = "Results"', async () => {
+    mockData = { pages: [{ nbHits: 1 }] }
+    const { findByTestId } = render(
+      // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+      reactQueryProviderHOC(
+        <SearchWrapper>
+          <ShowResults />
+        </SearchWrapper>
+      )
+    )
+    const button = await findByTestId('Afficher 1 résultat')
+    await fireEvent.press(button)
+    expect(navigate).toBeCalledWith('TabNavigator', {
+      params: {
+        beginningDatetime: null,
+        date: null,
+        endingDatetime: null,
+        hitsPerPage: 20,
+        locationFilter: { locationType: 'EVERYWHERE' },
+        offerCategories: [],
+        offerIsDuo: false,
+        offerIsFree: false,
+        offerIsNew: false,
+        offerSubcategories: [],
+        offerTypes: { isDigital: false, isEvent: false, isThing: false },
+        priceRange: [0, 300],
+        query: '',
+        tags: [],
+        timeRange: null,
+        view: 'Results',
+      },
+      screen: 'Search',
+    })
+  })
 })

--- a/src/features/search/pages/SearchWrapper.tsx
+++ b/src/features/search/pages/SearchWrapper.tsx
@@ -4,7 +4,7 @@ import React, { memo, useContext, useEffect, useMemo, useReducer } from 'react'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { Action, initialSearchState, searchReducer } from 'features/search/pages/reducer'
-import { SearchState } from 'features/search/types'
+import { SearchState, SearchView } from 'features/search/types'
 import { useMaxPrice } from 'features/search/utils/useMaxPrice'
 import { useGeolocation } from 'libs/geolocation'
 
@@ -75,8 +75,8 @@ export const useCommit = (): { commit: () => void } => {
 
   return {
     commit() {
-      dispatch({ type: 'SET_STATE', payload: stagedSearchState })
-      navigate(...getTabNavConfig('Search', stagedSearchState))
+      dispatch({ type: 'SET_STATE', payload: { ...stagedSearchState, view: SearchView.Results } })
+      navigate(...getTabNavConfig('Search', { ...stagedSearchState, view: SearchView.Results }))
     },
   }
 }

--- a/src/features/search/pages/SearchWrapper.tsx
+++ b/src/features/search/pages/SearchWrapper.tsx
@@ -70,12 +70,12 @@ export const useStagedSearch = (): Pick<ISearchContext, 'searchState' | 'dispatc
 
 export const useCommit = (): { commit: () => void } => {
   const { navigate } = useNavigation<UseNavigationType>()
-  const { dispatch } = useSearch()
   const { searchState: stagedSearchState } = useStagedSearch()
 
   return {
     commit() {
-      dispatch({ type: 'SET_STATE', payload: { ...stagedSearchState, view: SearchView.Results } })
+      // ReinitializeFilters when pressed will call SET_STATE and use initialSearchState.view,
+      // so we force it until full removal of searchState
       navigate(...getTabNavConfig('Search', { ...stagedSearchState, view: SearchView.Results }))
     },
   }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16537

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [x] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [x] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
