### PR TITLE
(PC-15156) feat(login): show help message when user is forced to login because of refresh token expiration

### DIFF
--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -74,7 +74,7 @@ export const safeFetch = async (
   const accessTokenStatus = getAccessTokenStatus(token)
 
   if (accessTokenStatus === 'unknown') {
-    return Promise.resolve(NeedsAuthenticationResponse)
+    return NeedsAuthenticationResponse
   }
 
   // If the token is expired, we refresh it before calling the backend
@@ -82,12 +82,12 @@ export const safeFetch = async (
     try {
       const { result: newAccessToken, error } = await refreshAccessToken(api)
       if (error === REFRESH_TOKEN_IS_EXPIRED_ERROR) {
-        return Promise.resolve(RefreshTokenExpiredResponse)
+        return RefreshTokenExpiredResponse
       }
 
       if (error) {
         eventMonitoring.captureException(new Error(`safeFetch ${error}`))
-        return Promise.resolve(NeedsAuthenticationResponse)
+        return NeedsAuthenticationResponse
       }
 
       runtimeOptions = {
@@ -102,7 +102,7 @@ export const safeFetch = async (
       // But the access token is expired and cannot be refreshed.
       // In this case, we cleared the access token and we need to login again
       eventMonitoring.captureException(new Error(`safeFetch ${error}`))
-      return Promise.resolve(NeedsAuthenticationResponse)
+      return NeedsAuthenticationResponse
     }
   }
 

--- a/src/features/auth/login/Login.tsx
+++ b/src/features/auth/login/Login.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro'
 import { useNavigation, useRoute } from '@react-navigation/native'
-import React, { FunctionComponent, memo, useCallback, useState } from 'react'
+import React, { FunctionComponent, memo, useCallback, useEffect, useState } from 'react'
 import { Keyboard } from 'react-native'
 import styled from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
@@ -29,6 +29,7 @@ import { isValueEmpty } from 'ui/components/inputs/helpers'
 import { InputError } from 'ui/components/inputs/InputError'
 import { PasswordInput } from 'ui/components/inputs/PasswordInput'
 import { ModalHeader } from 'ui/components/modals/ModalHeader'
+import { useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { Close } from 'ui/svg/icons/Close'
 import { Key } from 'ui/svg/icons/Key'
@@ -58,10 +59,20 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
   const shouldDisableLoginButton = isValueEmpty(email) || isValueEmpty(password) || isLoading
   const emailInputErrorId = uuidv4()
   const culturalSurveyRoute = useCulturalSurveyRoute()
+  const { showInfoSnackBar } = useSnackBarContext()
 
   const { params } = useRoute<UseRouteType<'Login'>>()
   const { navigate } = useNavigation<UseNavigationType>()
   const { goBack } = useGoBack(...homeNavConfig)
+
+  useEffect(() => {
+    if (params?.displayForcedLoginHelpMessage) {
+      showInfoSnackBar({
+        message:
+          'Pour sécuriser ton pass Culture, tu dois confirmer tes identifiants tous les 30 jours.',
+      })
+    }
+  }, [params?.displayForcedLoginHelpMessage, showInfoSnackBar])
 
   function onEmailChange(mail: string) {
     if (emailErrorMessage) {

--- a/src/features/auth/login/Login.web.test.tsx
+++ b/src/features/auth/login/Login.web.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { SafeAreaProvider } from 'react-native-safe-area-context'
+
+import { useRoute } from '__mocks__/@react-navigation/native'
+import { render } from 'tests/utils/web'
+import { SnackBarProvider } from 'ui/components/snackBar/SnackBarContext'
+
+import { AuthContext } from '../AuthContext'
+
+import { Login } from './Login'
+
+jest.mock('react-query')
+
+const mockIdentityCheckDispatch = jest.fn()
+jest.mock('features/identityCheck/context/IdentityCheckContextProvider', () => ({
+  useIdentityCheckContext: jest.fn(() => ({ dispatch: mockIdentityCheckDispatch })),
+}))
+
+describe('<Login/>', () => {
+  it('should display forced login help message when the query param is given', () => {
+    useRoute.mockReturnValueOnce({ params: { displayForcedLoginHelpMessage: true } })
+    const { queryByRole } = renderLogin()
+
+    const snackBar = queryByRole('status')
+
+    expect(snackBar).toHaveTextContent(
+      'Pour sécuriser ton pass Culture, tu dois confirmer tes identifiants tous les 30 jours.'
+    )
+  })
+
+  it('should not display the login help message when the query param is not given', () => {
+    useRoute.mockReturnValueOnce({})
+    const { queryByRole } = renderLogin()
+
+    const snackBar = queryByRole('status')
+
+    expect(snackBar).not.toHaveTextContent(
+      'Pour sécuriser ton pass Culture, tu dois confirmer tes identifiants tous les 30 jours.'
+    )
+  })
+})
+
+function renderLogin() {
+  return render(
+    <SafeAreaProvider>
+      <SnackBarProvider>
+        <AuthContext.Provider value={{ isLoggedIn: true, setIsLoggedIn: jest.fn() }}>
+          <Login />
+        </AuthContext.Provider>
+      </SnackBarProvider>
+    </SafeAreaProvider>
+  )
+}

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -102,6 +102,7 @@ export type RootStackParamList = {
   FraudulentAccount: undefined
   Login?: {
     preventCancellation?: boolean
+    displayForcedLoginHelpMessage?: boolean
   }
   Navigation: undefined
   NavigationAccountSuspension: undefined

--- a/src/features/navigation/screenParamsUtils.ts
+++ b/src/features/navigation/screenParamsUtils.ts
@@ -46,6 +46,7 @@ export const screenParamsParser: ParamsParsers = {
 
   Login: {
     preventCancellation: parseObject,
+    displayForcedLoginHelpMessage: parseObject,
   },
   Offer: {
     id: Number,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-15156

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots


https://user-images.githubusercontent.com/22886846/185447436-f98c7e3c-22d9-43e2-8eab-de765130c362.mov


[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
