### PR TITLE
(PC-16938) fix(Web): set version and revision in analytics

### DIFF
--- a/src/libs/firebase/analytics/provider.ts
+++ b/src/libs/firebase/analytics/provider.ts
@@ -1,5 +1,6 @@
 import { Platform } from 'react-native'
 
+import { env } from 'libs/environment'
 import {
   AGENT_TYPE,
   EVENT_PAGE_VIEW_NAME,
@@ -7,6 +8,8 @@ import {
 } from 'libs/firebase/analytics/constants'
 import { prepareLogEventParams } from 'libs/firebase/analytics/utils'
 import firebaseAnalyticsModule from 'libs/firebase/shims/analytics'
+
+import { version } from '../../../../package.json'
 
 import { AnalyticsProvider } from './types'
 
@@ -32,15 +35,18 @@ export const analyticsProvider: AnalyticsProvider = {
     firebaseAnalytics.logEvent(EVENT_PAGE_VIEW_NAME, {
       [EVENT_PAGE_VIEW_PARAM_KEY]: screenName,
       screen_class: screenName,
-      agentType: AGENT_TYPE,
     })
   },
   logLogin({ method }) {
-    firebaseAnalytics.logEvent('login', { method, agentType: AGENT_TYPE })
+    firebaseAnalytics.logEvent('login', { method })
   },
   logEvent(name, params) {
     const newParams = params ? prepareLogEventParams(params) : {}
     newParams['agentType'] = AGENT_TYPE
+    if (Platform.OS === 'web') {
+      newParams['app_version'] = version
+      newParams['app_revision'] = env.COMMIT_HASH
+    }
     return firebaseAnalytics.logEvent(name, newParams)
   },
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-16938

This PR is inspired from https://stackoverflow.com/a/61339074/2127277

However, it seems it may not work : https://stackoverflow.com/a/60206450/2127277

And params is not documented https://developers.google.com/tag-platform/gtagjs/reference/events so perhaps the first SO link is wrong

- `env.COMMIT_HASH` is set within the webpack config [here](https://github.com/pass-culture/pass-culture-app-native/blob/master/web/config/env.js#L101)
- `agentType` is already set in `logEvent`, no need to pass it again

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| Revision is in build | Analytics added |
| --: | ------: |
|  ![image](https://user-images.githubusercontent.com/77674046/185587367-5f93a81e-440f-4dbd-8e3f-cb2f38cf7252.png)  |       ![image](https://user-images.githubusercontent.com/77674046/185587553-52d34ca7-6227-4b48-acfd-bd70f1fdad7a.png)  |                 

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
