### PR TITLE
(PC-17108) fix(Bookings): completedUrl instead of stock.offer.url

### DIFF
--- a/__snapshots__/features/bookings/pages/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails.native.test.tsx.native-snap
@@ -314,6 +314,7 @@ exports[`BookingDetails should render correctly 1`] = `
                 Object {
                   "cancellationDate": null,
                   "cancellationReason": null,
+                  "completedUrl": "https://example.com",
                   "confirmationDate": "2021-03-15T23:01:37.925926",
                   "dateUsed": null,
                   "expirationDate": null,
@@ -333,7 +334,6 @@ exports[`BookingDetails should render correctly 1`] = `
                       "isPermanent": false,
                       "name": "Avez-vous déjà vu ?",
                       "subcategoryId": "EVENEMENT_PATRIMOINE",
-                      "url": "https://example.com",
                       "venue": Object {
                         "city": "Drancy",
                         "coordinates": Object {

--- a/src/features/bookings/components/BookingDetailsTicketContent.native.test.tsx
+++ b/src/features/bookings/components/BookingDetailsTicketContent.native.test.tsx
@@ -11,11 +11,11 @@ describe('BookingDetailsTicketContent', () => {
   const booking = {
     ...originalBooking,
     activationCode: { code: 'someCode' },
+    completedUrl: 'https://example.com',
     stock: {
       ...originalBooking.stock,
       offer: {
         ...originalBooking.stock.offer,
-        url: 'https://example.com',
       },
     },
   }

--- a/src/features/bookings/components/BookingDetailsTicketContent.tsx
+++ b/src/features/bookings/components/BookingDetailsTicketContent.tsx
@@ -27,10 +27,10 @@ export const BookingDetailsTicketContent: FunctionComponent<BookingDetailsTicket
   activationCodeFeatureEnabled,
   externalBookings,
 }) => {
+  const { completedUrl } = booking
   const { offer, beginningDatetime } = booking.stock
   const {
     id: offerId,
-    url: offerUrl,
     name: offerName,
     subcategoryId: offerSubcategory,
     extraData,
@@ -52,12 +52,12 @@ export const BookingDetailsTicketContent: FunctionComponent<BookingDetailsTicket
     <TicketCode withdrawalType={withdrawalType || undefined} code={booking.activationCode.code} />
   )
 
-  const accessExternalOfferButton = offerUrl ? (
+  const accessExternalOfferButton = completedUrl ? (
     <TouchableLink
       as={ButtonWithLinearGradient}
       wording={t`Accéder à l'offre`}
       icon={ExternalSite}
-      externalNav={{ url: offerUrl, params: { analyticsData: { offerId } } }}
+      externalNav={{ url: completedUrl, params: { analyticsData: { offerId } } }}
     />
   ) : null
 

--- a/src/features/bookings/pages/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails.native.test.tsx
@@ -85,7 +85,7 @@ describe('BookingDetails', () => {
 
   it('should render correctly', async () => {
     const booking = cloneDeep(bookingsSnap.ongoing_bookings[0])
-    booking.stock.offer.url = 'https://example.com'
+    booking.completedUrl = 'https://example.com'
     const { toJSON } = renderBookingDetails(booking)
     expect(toJSON()).toMatchSnapshot()
   })
@@ -100,13 +100,13 @@ describe('BookingDetails', () => {
     it('should display offer link button if offer is digital and open url on press', async () => {
       const booking = cloneDeep(bookingsSnap.ongoing_bookings[0])
       booking.stock.offer.isDigital = true
-      booking.stock.offer.url = 'https://example.com'
+      booking.completedUrl = 'https://example.com'
 
       const { getByText } = renderBookingDetails(booking)
       const offerButton = getByText("Accéder à l'offre")
       await fireEvent.press(offerButton)
 
-      expect(mockedOpenUrl).toHaveBeenCalledWith(booking.stock.offer.url, {
+      expect(mockedOpenUrl).toHaveBeenCalledWith(booking.completedUrl, {
         analyticsData: {
           offerId: booking.stock.offer.id,
         },


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17108

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
