### PR TITLE
(PC-17198) feat(cookies): Store utm params only when user consents

### DIFF
--- a/src/libs/amplitude/amplitude.web.ts
+++ b/src/libs/amplitude/amplitude.web.ts
@@ -1,6 +1,7 @@
 import Amplitude from 'amplitude-js'
 
 import { env } from 'libs/environment'
+import { storage } from 'libs/storage'
 
 import { AmplitudeClient } from './types'
 
@@ -10,6 +11,7 @@ export const amplitude = (): AmplitudeClient => {
     ampInstance.init(env.AMPLITUDE_API_KEY, undefined, {
       serverZone: 'EU',
       serverZoneBasedApi: true,
+      saveEvents: !ampInstance.options.optOut,
     })
   }
   return {
@@ -21,6 +23,9 @@ export const amplitude = (): AmplitudeClient => {
     },
     disableCollection() {
       ampInstance.setOptOut(true)
+      storage.getAllKeys().then((keys) => {
+        keys?.forEach((key) => key.startsWith('amplitude_unsent') && storage.clear(key))
+      })
     },
   }
 }

--- a/src/libs/storage.ts
+++ b/src/libs/storage.ts
@@ -19,6 +19,7 @@ export type StorageKey =
 
 export const storage = {
   clear,
+  getAllKeys,
   readObject,
   readString,
   readMultiString,
@@ -94,6 +95,14 @@ async function saveObject(storageKey: StorageKey, value: unknown): Promise<void>
 async function clear(storageKey: StorageKey): Promise<void> {
   try {
     await AsyncStorage.removeItem(storageKey)
+  } catch (error) {
+    if (error instanceof Error) onAsyncStorageError(error)
+  }
+}
+
+async function getAllKeys(): Promise<readonly StorageKey[] | void> {
+  try {
+    return (await AsyncStorage.getAllKeys()) as StorageKey[]
   } catch (error) {
     if (error instanceof Error) onAsyncStorageError(error)
   }

--- a/src/libs/utm/getUtmParamsConsent.test.ts
+++ b/src/libs/utm/getUtmParamsConsent.test.ts
@@ -1,0 +1,83 @@
+import mockdate from 'mockdate'
+
+import { ALL_OPTIONAL_COOKIES, COOKIES_BY_CATEGORY } from 'features/cookies/CookiesPolicy'
+import { useCookies } from 'features/cookies/helpers/useCookies'
+import { storage } from 'libs/storage'
+import { getUtmParamsConsent } from 'libs/utm/getUtmParamsConsent'
+import { act, flushAllPromisesWithAct, renderHook } from 'tests/utils'
+
+const COOKIES_CONSENT_KEY = 'cookies_consent'
+const Today = new Date(2022, 9, 29)
+mockdate.set(Today)
+
+describe('getUtmParamsConsent', () => {
+  beforeEach(() => {
+    storage.clear(COOKIES_CONSENT_KEY)
+  })
+
+  it('should return true for all params if cookies are accepted', async () => {
+    const { result } = renderHook(useCookies)
+    const { setCookiesConsent } = result.current
+
+    act(() => {
+      setCookiesConsent({
+        mandatory: COOKIES_BY_CATEGORY.essential,
+        accepted: ALL_OPTIONAL_COOKIES,
+        refused: [],
+      })
+    })
+    await flushAllPromisesWithAct()
+    const paramsConsent = await getUtmParamsConsent()
+
+    expect(paramsConsent).toEqual({
+      acceptedTrafficCampaign: true,
+      acceptedTrafficMedium: true,
+      acceptedTrafficSource: true,
+      acceptedCampaignDate: true,
+    })
+  })
+
+  it('should return false for all params if cookies are refused', async () => {
+    const { result } = renderHook(useCookies)
+    const { setCookiesConsent } = result.current
+
+    act(() => {
+      setCookiesConsent({
+        mandatory: COOKIES_BY_CATEGORY.essential,
+        accepted: [],
+        refused: ALL_OPTIONAL_COOKIES,
+      })
+    })
+    await flushAllPromisesWithAct()
+    const paramsConsent = await getUtmParamsConsent()
+
+    expect(paramsConsent).toEqual({
+      acceptedTrafficCampaign: false,
+      acceptedTrafficMedium: false,
+      acceptedTrafficSource: false,
+      acceptedCampaignDate: false,
+    })
+  })
+
+  it('should return true for all params if customization cookies are accepted', async () => {
+    const { result } = renderHook(useCookies)
+    const { setCookiesConsent } = result.current
+
+    act(() => {
+      setCookiesConsent({
+        mandatory: COOKIES_BY_CATEGORY.essential,
+        accepted: COOKIES_BY_CATEGORY.customization,
+        refused: [...COOKIES_BY_CATEGORY.marketing, ...COOKIES_BY_CATEGORY.performance],
+      })
+    })
+    await flushAllPromisesWithAct()
+    const paramsConsent = await getUtmParamsConsent()
+
+    expect(paramsConsent).toEqual({
+      acceptedTrafficCampaign: true,
+      acceptedTrafficMedium: true,
+      acceptedTrafficSource: true,
+      acceptedCampaignDate: true,
+    })
+  })
+})

--- a/src/libs/utm/getUtmParamsConsent.ts
+++ b/src/libs/utm/getUtmParamsConsent.ts
@@ -1,0 +1,19 @@
+import { CookieNameEnum } from 'features/cookies/enums'
+import { getCookiesChoice } from 'features/cookies/helpers/useCookies'
+
+export const getUtmParamsConsent = async () => {
+  const cookiesChoice = await getCookiesChoice()
+  const acceptedCookies = cookiesChoice?.consent.accepted || []
+
+  const acceptedTrafficCampaign = acceptedCookies.includes(CookieNameEnum.TRAFFIC_CAMPAIGN)
+  const acceptedTrafficMedium = acceptedCookies.includes(CookieNameEnum.TRAFFIC_MEDIUM)
+  const acceptedTrafficSource = acceptedCookies.includes(CookieNameEnum.TRAFFIC_SOURCE)
+  const acceptedCampaignDate = acceptedCookies.includes(CookieNameEnum.CAMPAIGN_DATE)
+
+  return {
+    acceptedTrafficCampaign,
+    acceptedTrafficMedium,
+    acceptedTrafficSource,
+    acceptedCampaignDate,
+  }
+}

--- a/src/libs/utm/storeUtmParams.test.ts
+++ b/src/libs/utm/storeUtmParams.test.ts
@@ -1,0 +1,92 @@
+import mockdate from 'mockdate'
+
+import { ALL_OPTIONAL_COOKIES, COOKIES_BY_CATEGORY } from 'features/cookies/CookiesPolicy'
+import { CookieNameEnum } from 'features/cookies/enums'
+import { useCookies } from 'features/cookies/helpers/useCookies'
+import { storage } from 'libs/storage'
+import { storeUtmParams } from 'libs/utm/storeUtmParams'
+import { act, flushAllPromisesWithAct, renderHook } from 'tests/utils'
+
+const COOKIES_CONSENT_KEY = 'cookies_consent'
+const Today = new Date(2022, 9, 29)
+mockdate.set(Today)
+const expectedParams = { campaign: 'campaign', medium: 'medium', source: 'source' }
+
+describe('storeUtmParams', () => {
+  beforeEach(() => {
+    storage.clear(COOKIES_CONSENT_KEY)
+    storage.clear(CookieNameEnum.TRAFFIC_CAMPAIGN)
+    storage.clear(CookieNameEnum.TRAFFIC_MEDIUM)
+    storage.clear(CookieNameEnum.TRAFFIC_SOURCE)
+    storage.clear(CookieNameEnum.CAMPAIGN_DATE)
+  })
+
+  it('should save utmParams to storage if cookies are accepted', async () => {
+    const { result } = renderHook(useCookies)
+    const { setCookiesConsent } = result.current
+
+    act(() => {
+      setCookiesConsent({
+        mandatory: COOKIES_BY_CATEGORY.essential,
+        accepted: ALL_OPTIONAL_COOKIES,
+        refused: [],
+      })
+    })
+    await flushAllPromisesWithAct()
+    await storeUtmParams(expectedParams)
+    const utmParams = await getUtmParamsFromStorage()
+
+    expect(utmParams).toEqual({ ...expectedParams, campaignDate: Today.valueOf().toString() })
+  })
+
+  it('should not save utmParams to storage if cookies are accepted', async () => {
+    const { result } = renderHook(useCookies)
+    const { setCookiesConsent } = result.current
+
+    act(() => {
+      setCookiesConsent({
+        mandatory: COOKIES_BY_CATEGORY.essential,
+        accepted: [],
+        refused: ALL_OPTIONAL_COOKIES,
+      })
+    })
+    await flushAllPromisesWithAct()
+    await storeUtmParams(expectedParams)
+    const utmParams = await getUtmParamsFromStorage()
+
+    expect(utmParams).toEqual({ campaign: null, medium: null, source: null, campaignDate: null })
+  })
+
+  it('should save utmParams if customization cookies are accepted', async () => {
+    const { result } = renderHook(useCookies)
+    const { setCookiesConsent } = result.current
+
+    act(() => {
+      setCookiesConsent({
+        mandatory: COOKIES_BY_CATEGORY.essential,
+        accepted: COOKIES_BY_CATEGORY.customization,
+        refused: [...COOKIES_BY_CATEGORY.marketing, ...COOKIES_BY_CATEGORY.performance],
+      })
+    })
+    await flushAllPromisesWithAct()
+    await storeUtmParams(expectedParams)
+    const utmParams = await getUtmParamsFromStorage()
+
+    expect(utmParams).toEqual({ ...expectedParams, campaignDate: Today.valueOf().toString() })
+  })
+})
+
+const getUtmParamsFromStorage = async () => {
+  const [campaign, medium, source, campaignDate] = await storage.readMultiString([
+    CookieNameEnum.TRAFFIC_CAMPAIGN,
+    CookieNameEnum.TRAFFIC_MEDIUM,
+    CookieNameEnum.TRAFFIC_SOURCE,
+    CookieNameEnum.CAMPAIGN_DATE,
+  ])
+  return {
+    campaign: campaign[1],
+    medium: medium[1],
+    source: source[1],
+    campaignDate: campaignDate[1],
+  }
+}

--- a/src/libs/utm/storeUtmParams.ts
+++ b/src/libs/utm/storeUtmParams.ts
@@ -1,15 +1,21 @@
 import { storage, StorageKey } from 'libs/storage'
+import { getUtmParamsConsent } from 'libs/utm/getUtmParamsConsent'
 import { UtmParams } from 'libs/utm/types'
 
 export async function storeUtmParams({ campaign, medium, source }: UtmParams) {
+  const {
+    acceptedTrafficCampaign,
+    acceptedTrafficMedium,
+    acceptedTrafficSource,
+    acceptedCampaignDate,
+  } = await getUtmParamsConsent()
+
   const multiString: Array<[StorageKey, string]> = []
-  if (campaign) multiString.push(['traffic_campaign', campaign])
-  if (medium) multiString.push(['traffic_medium', medium])
-  if (source) multiString.push(['traffic_source', source])
+  if (campaign && acceptedTrafficCampaign) multiString.push(['traffic_campaign', campaign])
+  if (medium && acceptedTrafficMedium) multiString.push(['traffic_medium', medium])
+  if (source && acceptedTrafficSource) multiString.push(['traffic_source', source])
+  if (acceptedCampaignDate) multiString.push(['campaign_date', new Date().valueOf().toString()])
   if (multiString.length) {
-    await storage.saveMultiString([
-      ...multiString,
-      ['campaign_date', new Date().valueOf().toString()],
-    ])
+    await storage.saveMultiString(multiString)
   }
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17198

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
