### PR TITLE
(PC-17254) fix(ChangePassword): improve formik form

### DIFF
--- a/src/features/profile/pages/ChangePassword/schema/changePasswordSchema.test.ts
+++ b/src/features/profile/pages/ChangePassword/schema/changePasswordSchema.test.ts
@@ -1,0 +1,103 @@
+import { ValidationError } from 'yup'
+
+import { PASSWORD_MIN_LENGTH } from 'features/auth/components/PasswordSecurityRules'
+
+import { changePasswordSchema } from './changePasswordSchema'
+
+describe('changePasswordSchema', () => {
+  describe('should validate', () => {
+    it('validate a form with all required values', async () => {
+      const values = {
+        currentPassword: 'user@AZERTY123',
+        newPassword: 'user@AZERTY123',
+        confirmedPassword: 'user@AZERTY123',
+      }
+      const result = await changePasswordSchema.validate(values)
+      expect(result).toEqual(values)
+    })
+  })
+
+  describe('should invalidate', () => {
+    it.each([
+      ['userAZERTY123', 'user@AZERTY123', 'user@AZERTY123'],
+      ['user@AZERTY123', 'userAZERTY123', 'userAZERTY123'],
+    ])(
+      'should fail due to missing special character { currentPassword: $currentPassword, newPassword: $newPassword, confirmedPassword: $confirmedPassword }',
+      async (currentPassword, newPassword, confirmedPassword) => {
+        const result = changePasswordSchema.validate({
+          currentPassword,
+          newPassword,
+          confirmedPassword,
+        })
+        await expect(result).rejects.toEqual(
+          new ValidationError('1 Caractère spécial (!@#$%^&*...)')
+        )
+      }
+    )
+
+    it('should fail due to non identical newPassword and confirmedPassword', async () => {
+      const result = changePasswordSchema.validate({
+        currentPassword: 'user@AZERTY123',
+        newPassword: 'abc',
+        confirmedPassword: 'def',
+      })
+      await expect(result).rejects.toEqual(
+        new ValidationError('Les mots de passe ne concordent pas')
+      )
+    })
+
+    it.each([
+      [
+        {
+          currentPassword: 'abc',
+          newPassword: 'user@AZERTY123',
+          confirmedPassword: 'user@AZERTY123',
+        },
+        {
+          currentPassword: 'user@AZERTY123',
+          newPassword: 'abc',
+          confirmedPassword: 'abc',
+        },
+      ],
+    ])(`should fail due to not being ${PASSWORD_MIN_LENGTH} character length`, async (values) => {
+      const result = changePasswordSchema.validate(values)
+      await expect(result).rejects.toEqual(new ValidationError('12 Caractères'))
+    })
+
+    it.each([
+      [
+        {
+          currentPassword: 'user@azerty123',
+          newPassword: 'user@AZERTY123',
+          confirmedPassword: 'user@AZERTY123',
+        },
+        {
+          currentPassword: 'user@AZERTY123',
+          newPassword: 'user@azerty123',
+          confirmedPassword: 'user@azerty123',
+        },
+      ],
+    ])('should fail due to not have 1 uppercase character', async (values) => {
+      const result = changePasswordSchema.validate(values)
+      await expect(result).rejects.toEqual(new ValidationError('1 Majuscule'))
+    })
+
+    it.each([
+      [
+        {
+          currentPassword: 'user@AZERTYyyyy',
+          newPassword: 'user@AZERTY123',
+          confirmedPassword: 'user@AZERTY123',
+        },
+        {
+          currentPassword: 'user@AZERTY123',
+          newPassword: 'user@AZERTYyyy',
+          confirmedPassword: 'user@AZERTYyyy',
+        },
+      ],
+    ])('should fail due to not have 1 number character', async (values) => {
+      const result = changePasswordSchema.validate(values)
+      await expect(result).rejects.toEqual(new ValidationError('1 Chiffre'))
+    })
+  })
+})

--- a/src/features/profile/pages/ChangePassword/schema/changePasswordSchema.ts
+++ b/src/features/profile/pages/ChangePassword/schema/changePasswordSchema.ts
@@ -1,0 +1,29 @@
+import { object, ref, string } from 'yup'
+
+import {
+  CAPITAL_REGEX,
+  LOWERCASE_REGEX,
+  NUMBER_REGEX,
+  PASSWORD_MIN_LENGTH,
+  SPECIAL_CHARACTER_REGEX,
+} from 'features/auth/components/PasswordSecurityRules'
+
+export const changePasswordSchema = object().shape({
+  currentPassword: string()
+    .min(PASSWORD_MIN_LENGTH, '12 Caractères')
+    .required()
+    .matches(CAPITAL_REGEX, '1 Majuscule')
+    .matches(LOWERCASE_REGEX, '1 Minuscule')
+    .matches(NUMBER_REGEX, '1 Chiffre')
+    .matches(SPECIAL_CHARACTER_REGEX, '1 Caractère spécial (!@#$%^&*...)'),
+  newPassword: string()
+    .min(PASSWORD_MIN_LENGTH, '12 Caractères')
+    .required('required')
+    .matches(CAPITAL_REGEX, '1 Majuscule')
+    .matches(LOWERCASE_REGEX, '1 Minuscule')
+    .matches(NUMBER_REGEX, '1 Chiffre')
+    .matches(SPECIAL_CHARACTER_REGEX, '1 Caractère spécial (!@#$%^&*...)'),
+  confirmedPassword: string()
+    .oneOf([ref('newPassword'), null], 'Les mots de passe ne concordent pas')
+    .required(),
+})


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17254


## Note

- Au niveau des `onChange`, la page reflow avec ou sans `useCallback`, je n'ai pas trouvé comment éviter ça, je vais faire un 2nd POC avec `react-hook-form` : https://react-hook-form.com/

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
