### PR TITLE
(PC-17311) fix(search): category after reset general filters

### DIFF
--- a/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
@@ -801,20 +801,6 @@ exports[`SearchFilter component should render correctly 1`] = `
             >
               Catégorie
             </Text>
-            <Text
-              numberOfLines={1}
-              style={
-                Array [
-                  Object {
-                    "color": "#696A6F",
-                    "flexShrink": 1,
-                    "fontFamily": "Montserrat-SemiBold",
-                    "fontSize": 12,
-                    "lineHeight": 16,
-                  },
-                ]
-              }
-            />
           </View>
           <View
             style={

--- a/__snapshots__/features/search/sections/tests/Category.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/sections/tests/Category.native.test.tsx.native-snap
@@ -77,20 +77,6 @@ Array [
         >
           Catégorie
         </Text>
-        <Text
-          numberOfLines={1}
-          style={
-            Array [
-              Object {
-                "color": "#696A6F",
-                "flexShrink": 1,
-                "fontFamily": "Montserrat-SemiBold",
-                "fontSize": 12,
-                "lineHeight": 16,
-              },
-            ]
-          }
-        />
       </View>
       <View
         style={

--- a/src/features/search/atoms/FilterRow.tsx
+++ b/src/features/search/atoms/FilterRow.tsx
@@ -27,7 +27,7 @@ export const FilterRow = ({ icon: Icon, title, description, captionId, onPress }
         <Spacer.Row numberOfSpaces={2} />
         <TextContainer>
           <Title numberOfLines={1}>{title}</Title>
-          <Description numberOfLines={1}>{description}</Description>
+          {!!description && <Description numberOfLines={1}>{description}</Description>}
         </TextContainer>
         <Spacer.Flex />
         <ArrowNext />

--- a/src/features/search/pages/Categories.tsx
+++ b/src/features/search/pages/Categories.tsx
@@ -1,5 +1,5 @@
 import { useNavigation } from '@react-navigation/native'
-import React, { FunctionComponent, useCallback } from 'react'
+import React, { FunctionComponent, useCallback, useEffect } from 'react'
 import { useTheme } from 'styled-components'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -39,6 +39,10 @@ export const Categories: FunctionComponent<Props> = ({
     searchState?.offerCategories?.[0] || SearchGroupNameEnumv2.NONE
   )
   const { isDesktopViewport } = useTheme()
+
+  useEffect(() => {
+    setSelectedCategory(searchState?.offerCategories?.[0] || SearchGroupNameEnumv2.NONE)
+  }, [searchState?.offerCategories, setSelectedCategory])
 
   const onSelectCategory = (category: SearchGroupNameEnumv2) => () => {
     setSelectedCategory(category)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17311

## Checklist

I have:

- [ ] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|<img width="387" alt="Capture d’écran 2022-09-19 à 17 32 47" src="https://user-images.githubusercontent.com/78556024/191055816-ca5cd7fb-bae1-4a84-b561-0ed9daf826ee.png"> <img width="396" alt="Capture d’écran 2022-09-19 à 17 32 58" src="https://user-images.githubusercontent.com/78556024/191055826-8dd3fc29-a819-4bdb-b141-ebedc07d6922.png">|         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
