### PR TITLE
(PC-17368) fix(AccountSuspension): Display specific screen for users in banned countries

### DIFF
--- a/__snapshots__/features/errors/pages/tests/BannedCountry.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/tests/BannedCountry.native.test.tsx.native-snap
@@ -1,0 +1,234 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BannedCountryError should render correctly 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+      },
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "flexBasis": 0,
+          "flexDirection": "column",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "justifyContent": "center",
+          "maxWidth": 360,
+          "paddingHorizontal": 16,
+        },
+      ]
+    }
+  >
+    <View
+      customHeight={16}
+      enable={true}
+      style={
+        Array [
+          Object {
+            "height": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+        ]
+      }
+    />
+    <View
+      numberOfSpaces={10}
+      style={
+        Array [
+          Object {
+            "height": 40,
+          },
+        ]
+      }
+    />
+    <View
+      height={156}
+      width={200}
+    >
+      <Text>
+        undefined-SVG-Mock
+      </Text>
+    </View>
+    <View
+      numberOfSpaces={5}
+      style={
+        Array [
+          Object {
+            "height": 20,
+          },
+        ]
+      }
+    />
+    <Text
+      fontSize={24}
+      noBackground={true}
+      style={
+        Array [
+          Object {
+            "color": "#161617",
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 24,
+            "lineHeight": 28,
+          },
+          Object {
+            "textAlign": "center",
+          },
+        ]
+      }
+    >
+      Pas en France ?
+    </Text>
+    <View
+      numberOfSpaces={5}
+      style={
+        Array [
+          Object {
+            "height": 20,
+          },
+        ]
+      }
+    />
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#161617",
+            "fontFamily": "Montserrat-Regular",
+            "fontSize": 15,
+            "lineHeight": 20,
+            "textAlign": "center",
+          },
+        ]
+      }
+    >
+      Pour des raisons de sécurité, l’usage du pass Culture est interdit dans certains pays ou en cas d’utilisation d’un VPN.
+    </Text>
+    <View
+      numberOfSpaces={10}
+      style={
+        Array [
+          Object {
+            "height": 40,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "alignSelf": "stretch",
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+        ]
+      }
+    >
+      <View
+        accessibilityLabel="Réessayer"
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#eb0055",
+            "borderRadius": 24,
+            "flexDirection": "row",
+            "justifyContent": "center",
+            "maxWidth": 500,
+            "minHeight": 48,
+            "opacity": 1,
+            "paddingBottom": 2,
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "paddingTop": 2,
+            "userSelect": "auto",
+            "width": "100%",
+          }
+        }
+        testID="Réessayer"
+      >
+        <Text
+          adjustsFontSizeToFit={false}
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "color": "#ffffff",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 15,
+                "lineHeight": 20,
+                "marginLeft": 0,
+                "maxWidth": "100%",
+              },
+            ]
+          }
+        >
+          Réessayer
+        </Text>
+      </View>
+    </View>
+    <View
+      numberOfSpaces={10}
+      style={
+        Array [
+          Object {
+            "height": 40,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+        ]
+      }
+    />
+    <View
+      customHeight={8}
+      enable={true}
+      style={
+        Array [
+          Object {
+            "height": 8,
+          },
+        ]
+      }
+    />
+  </View>
+</View>
+`;

--- a/src/api/__tests__/apiHelpers.test.ts
+++ b/src/api/__tests__/apiHelpers.test.ts
@@ -17,10 +17,16 @@ import { DefaultApi } from '../gen'
 
 const api = new DefaultApi({})
 
-const respondWith = async (body: unknown, status = 200, statusText?: string): Promise<Response> => {
+const respondWith = async (
+  body: unknown,
+  status = 200,
+  statusText?: string,
+  headers?: HeadersInit
+): Promise<Response> => {
   return new Response(JSON.stringify(body), {
     headers: {
       'content-type': 'application/json',
+      ...headers,
     },
     status,
     statusText,
@@ -298,6 +304,17 @@ describe('[api] helpers', () => {
       const result = await handleGeneratedApiResponse(response)
 
       expect(navigateFromRef).toBeCalledWith('SuspensionScreen')
+      expect(result).toEqual({})
+    })
+
+    it('should navigate to banned country screen when status is 403 (forbidden) with country ban header', async () => {
+      const response = await respondWith('', 403, undefined, {
+        'x-country-ban': 'CountryName',
+      })
+
+      const result = await handleGeneratedApiResponse(response)
+
+      expect(navigateFromRef).toBeCalledWith('BannedCountryError')
       expect(result).toEqual({})
     })
 

--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -182,6 +182,11 @@ export async function handleGeneratedApiResponse(response: Response): Promise<an
   }
 
   if (response.status === 403) {
+    const bannedCountry = response.headers.get('x-country-ban')
+    if (bannedCountry) {
+      navigateFromRef('BannedCountryError')
+      return {}
+    }
     navigateFromRef('SuspensionScreen')
     return {}
   }

--- a/src/features/cheatcodes/pages/Navigation/Navigation.tsx
+++ b/src/features/cheatcodes/pages/Navigation/Navigation.tsx
@@ -254,6 +254,12 @@ export function Navigation(): JSX.Element {
               }
             />
           </Row>
+          <Row half>
+            <ButtonPrimary
+              wording="Banned Country Error"
+              onPress={() => navigate('BannedCountryError')}
+            />
+          </Row>
         </StyledContainer>
         <Spacer.BottomScreen />
       </ScrollView>

--- a/src/features/errors/pages/BannedCountryError.tsx
+++ b/src/features/errors/pages/BannedCountryError.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { useQueryClient } from 'react-query'
+import styled from 'styled-components/native'
+
+import { navigateToHomeConfig } from 'features/navigation/helpers'
+import { pushFromRef } from 'features/navigation/navigationRef'
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { GenericErrorPage } from 'ui/components/GenericErrorPage'
+import { BicolorBrokenConnection } from 'ui/svg/BicolorBrokenConnection'
+import { Typo } from 'ui/theme'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+
+export const BannedCountryError = () => {
+  const queryClient = useQueryClient()
+
+  const onPress = () => {
+    queryClient.clear()
+    pushFromRef(navigateToHomeConfig.screen, navigateToHomeConfig.params)
+  }
+
+  return (
+    <GenericErrorPage
+      noBackground
+      title="Pas en France&nbsp;?"
+      icon={BicolorBrokenConnection}
+      buttons={[
+        <ButtonPrimary key={1} buttonHeight="tall" wording="Réessayer" onPress={onPress} />,
+      ]}>
+      <StyledBody>
+        Pour des raisons de sécurité, l’usage du pass Culture est interdit dans certains pays ou en
+        cas d’utilisation d’un VPN.
+      </StyledBody>
+    </GenericErrorPage>
+  )
+}
+
+const StyledBody = styled(Typo.Body).attrs(() => getHeadingAttrs(2))({
+  textAlign: 'center',
+})

--- a/src/features/errors/pages/tests/BannedCountry.native.test.tsx
+++ b/src/features/errors/pages/tests/BannedCountry.native.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import { BannedCountryError } from 'features/errors/pages/BannedCountryError'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { render } from 'tests/utils'
+
+describe('BannedCountryError', () => {
+  it('should render correctly', () => {
+    const renderAPI = render(<BannedCountryError />, {
+      // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+    expect(renderAPI).toMatchSnapshot()
+  })
+})

--- a/src/features/navigation/RootNavigator/routes.ts
+++ b/src/features/navigation/RootNavigator/routes.ts
@@ -30,6 +30,7 @@ import { NavigationNotScreensPages } from 'features/cheatcodes/pages/NavigationN
 import { NavigationProfile } from 'features/cheatcodes/pages/NavigationProfile'
 import { EighteenBirthday } from 'features/eighteenBirthday/pages/EighteenBirthday'
 import { withAsyncErrorBoundary } from 'features/errors'
+import { BannedCountryError } from 'features/errors/pages/BannedCountryError'
 import { FavoritesSorts } from 'features/favorites/pages/FavoritesSorts'
 import { CulturalSurvey } from 'features/firstLogin/CulturalSurvey'
 import { FirstTutorial } from 'features/firstTutorial/pages/FirstTutorial/FirstTutorial'
@@ -151,6 +152,12 @@ export const routes: Route[] = [
     },
   },
   { name: 'AppComponents', component: AppComponents, path: 'composants-app' },
+  {
+    name: 'BannedCountryError',
+    component: BannedCountryError,
+    hoc: withAsyncErrorBoundary,
+    path: 'erreur-pays',
+  },
   {
     name: 'ChangeEmailExpiredLink',
     component: ChangeEmailExpiredLink,

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -91,6 +91,7 @@ export type RootStackParamList = {
   }
   AfterSignupEmailValidationBuffer: { token: string; expiration_timestamp: number; email: string }
   AppComponents: undefined
+  BannedCountryError: undefined
   ChangePassword: undefined
   ChangeEmail: undefined
   ChangeEmailExpiredLink: undefined

--- a/src/ui/components/GenericErrorPage.tsx
+++ b/src/ui/components/GenericErrorPage.tsx
@@ -13,6 +13,7 @@ type Props = {
   icon?: FunctionComponent<IconInterface>
   title: string
   buttons?: Array<ReactNode>
+  noBackground?: boolean
 }
 
 export const GenericErrorPage: FunctionComponent<Props> = ({
@@ -22,13 +23,14 @@ export const GenericErrorPage: FunctionComponent<Props> = ({
   icon,
   title,
   buttons,
+  noBackground,
 }) => {
   const { isTouch } = useTheme()
   const Icon =
     !!icon &&
     styled(icon).attrs(({ theme }) => ({
       size: theme.illustrations.sizes.fullPage,
-      color: theme.colors.white,
+      color: noBackground ? undefined : theme.colors.white,
     }))``
 
   return (
@@ -38,7 +40,7 @@ export const GenericErrorPage: FunctionComponent<Props> = ({
           <meta name="robots" content="noindex" />
         </Helmet>
       )}
-      <Background />
+      {!noBackground && <Background />}
       {header}
       <Content>
         <Spacer.TopScreen />
@@ -50,7 +52,7 @@ export const GenericErrorPage: FunctionComponent<Props> = ({
             <Spacer.Column numberOfSpaces={spacingMatrix.afterIcon} />
           </React.Fragment>
         )}
-        <StyledTitle>{title}</StyledTitle>
+        <StyledTitle noBackground={noBackground}>{title}</StyledTitle>
         <Spacer.Column numberOfSpaces={spacingMatrix.afterTitle} />
         {children}
         <Spacer.Column numberOfSpaces={spacingMatrix.afterChildren} />
@@ -85,10 +87,12 @@ const spacingMatrix = {
   bottom: 10,
 }
 
-const StyledTitle = styled(Typo.Title2).attrs(() => getHeadingAttrs(1))(({ theme }) => ({
-  color: theme.colors.white,
-  textAlign: 'center',
-}))
+const StyledTitle = styled(Typo.Title2).attrs(() => getHeadingAttrs(1))<{ noBackground?: boolean }>(
+  ({ theme, noBackground }) => ({
+    color: noBackground ? undefined : theme.colors.white,
+    textAlign: 'center',
+  })
+)
 
 const Content = styled.View({
   flexDirection: 'column',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17368

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|   ![Simulator Screen Shot - iPhone 13 - 2022-09-22 at 15 07 41](https://user-images.githubusercontent.com/46637324/191755518-466a9659-4a97-4c7d-9c50-6fa0bbefd148.png)  |         |                 |         
<img width="1045" alt="Capture d’écran 2022-09-22 à 15 07 57" src="https://user-images.githubusercontent.com/46637324/191755497-c3f94b99-6e18-419a-9559-6b5c6274ab51.png">        |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
