### PR TITLE
(PC-17201) fix(Search): exclude objectIDs from previous page to prevent duplicate

### DIFF
--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildFilters.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildFilters.ts
@@ -1,0 +1,9 @@
+export const buildFilters = ({ excludedObjectIds }: { excludedObjectIds?: string[] }) => {
+  let filters = ''
+  if (excludedObjectIds && excludedObjectIds.length > 0) {
+    filters = excludedObjectIds
+      .map((objectId, index) => `${index > 0 ? 'AND ' : ''}NOT objectID:${objectId}`)
+      .join(' ')
+  }
+  return filters.length > 0 ? { filters } : {}
+}

--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildOfferSearchParameters.ts.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildOfferSearchParameters.ts.ts
@@ -1,4 +1,5 @@
 import { SearchState } from 'features/search/types'
+import { buildFilters } from 'libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildFilters'
 import { buildGeolocationParameter } from 'libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildGeolocationParameter'
 import { GeoCoordinates } from 'libs/geolocation'
 
@@ -27,7 +28,8 @@ export const buildOfferSearchParameters = (
     tags = [],
     minPrice = '',
     maxPrice = '',
-  }: SearchState & { objectIds?: string[] },
+    excludedObjectIds = [],
+  }: SearchState & { objectIds?: string[]; excludedObjectIds?: string[] },
   userLocation: GeoCoordinates | null,
   isUserUnderage: boolean
 ) => ({
@@ -53,4 +55,5 @@ export const buildOfferSearchParameters = (
     maxPrice,
   }),
   ...buildGeolocationParameter(locationFilter, userLocation),
+  ...buildFilters({ excludedObjectIds }),
 })

--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/tests/buildFilters.test.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/tests/buildFilters.test.ts
@@ -1,0 +1,26 @@
+import { buildFilters } from '../buildFilters'
+
+describe('buildFilters', () => {
+  describe('without filter', () => {
+    it('should return an object if no parameters are passed', () => {
+      expect(buildFilters({})).toEqual({})
+    })
+  })
+
+  describe('with filter', () => {
+    describe('excludedObjectIds', () => {
+      it('should return filters that excludes objectID when excludedObjectIds is not empty', () => {
+        expect(
+          buildFilters({ excludedObjectIds: ['你好', 'привет', 'xαίρετε', 'สวัสดี'] })
+        ).toEqual({
+          filters:
+            'NOT objectID:你好 AND NOT objectID:привет AND NOT objectID:xαίρετε AND NOT objectID:สวัสดี',
+        })
+      })
+
+      it('should return filters that excludes objectID when excludedObjectIds is empty', () => {
+        expect(buildFilters({ excludedObjectIds: [] })).toEqual({})
+      })
+    })
+  })
+})

--- a/src/libs/algolia/fetchAlgolia/fetchOffer.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchOffer.ts
@@ -16,6 +16,7 @@ type FetchOfferArgs = {
   userLocation: GeoCoordinates | null
   isUserUnderage: boolean
   storeQueryID?: (queryID?: string) => void
+  excludedObjectIds?: string[]
 }
 
 export const fetchOffer = async ({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17201

## Description

Il c'est avéré que algolia d'une page à l'autre quand on scroll dans les résultats de recherche, retourne des offres déjà reçu.

Ceci à pour conséquence d'avoir des duplicates key dans la `FlatList`, ceci est vérifiable en modifiant le `useMemo` pour obtenir `hits` dans `useSearchResults.ts` par ceci:

```tsx
  const hits = useMemo(
    () => {
      if (data?.pages) {
        const allIDs = flatten(data?.pages.map((page) => page.hits.map((h) => h.objectID)))
        const map = new Map()
        allIDs.forEach((id) => {
          if (map.get(id)) {
            console.log('duplicate', id, 'in page', data?.pages[data?.pages.length - 1].page)
          }
          map.set(id, true)
        })
      }
      return flatten(data?.pages.map((page) => page.hits.map(transformHits))).filter(
        (hit) => typeof hit.offer.subcategoryId !== 'undefined'
      ) as SearchHit[]
    },
    // eslint-disable-next-line react-hooks/exhaustive-deps
    [data?.pages]
  )
```

La raison est que l'index peut évoluer et donc on ne peut pas esperé ne pas avoir de duplicate d'une page à l'autre dans le cas ou ça se décaler un peu (en général 1 ou 2 duplicate par page après un long scroll).

La solution proposé par algolia était d'exclure avec [`filters`](https://www.algolia.com/doc/api-reference/api-parameters/filters/) les `objectID` d'une page reçu pour la page précédente ce qui devrait permettre d'éviter ce bug, le format étant par exemple :

```json
{
  "filters":"NOT objectID:5009222 AND NOT objectID:4423600 AND NOT objectID:6987389"
}
```



## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
