### PR TITLE
(BSR) chore(deploy): prevent staging patches to be launched from the master branch

### DIFF
--- a/scripts/appcenter-download-release.sh
+++ b/scripts/appcenter-download-release.sh
@@ -17,7 +17,7 @@ APPCENTER_DISTRIBUTION_GROUP_NAME="Collaborators"
 
 GITHUB_APP_NATIVE_RAW_REPOSITORY_URL="https://raw.githubusercontent.com/pass-culture/pass-culture-app-native"
 
-function help () {
+function help() {
   echo "Description:"
   echo
   echo "      Quickly uninstall, download and reinstall an APK from AppCenter."
@@ -70,8 +70,8 @@ function android() {
       curl -sS \
         -H "X-API-Token: ${X_API_TOKEN}" \
         -H "accept: application/json" \
-        "${APPCENTER_API_URL}/apps/pass-Culture/${app_name}/releases" \
-        | jq 'map(select(.short_version == "'"${TARGET_VERSION}"'").id)[0]'
+        "${APPCENTER_API_URL}/apps/pass-Culture/${app_name}/releases" |
+        jq 'map(select(.short_version == "'"${TARGET_VERSION}"'").id)[0]'
     )" || die "Cannot retrieve AppCenter Release ID"
     echo "Fetched ${APPCENTER_PLATFORM} AppCenter Release ID ${releaseId} for application version ${TARGET_VERSION} (${APPCENTER_ENVIRONMENT}) with success"
   else

--- a/scripts/check_branch.sh
+++ b/scripts/check_branch.sh
@@ -2,19 +2,17 @@
 
 set -e
 
-check_branch(){
-  CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+check_branch() {
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo $CURRENT_BRANCH
-  if [ "$CURRENT_BRANCH" != "master" ];
-  then
+  if [ "$CURRENT_BRANCH" != "master" ]; then
     read -p "Are you sure you want to deploy this branch? (Yy/Nn)" -n 1 -r
-    echo    # step a new line
-    if [[ $REPLY =~ ^[Yy]$ ]]
-    then
-       echo "YOU ARE DEPLOYING $CURRENT_BRANCH"
+    echo # step a new line
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      echo "YOU ARE DEPLOYING $CURRENT_BRANCH"
     else
-     echo "Deployment aborted, checkout master to deploy"
-     exit 1
+      echo "Deployment aborted, checkout master to deploy"
+      exit 1
     fi
   else
     git pull

--- a/scripts/check_diff.sh
+++ b/scripts/check_diff.sh
@@ -2,12 +2,12 @@
 
 set -e
 
-check_diff(){
+check_diff() {
   base_sha=$(curl -s -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/pass-culture/pass-culture-app-native/pulls?state=closed" | jq --arg sha "$CIRCLE_SHA1" -r '.[]|select(.merge_commit_sha == $sha).base.sha')
   filter='^(src|web|public|.circleci)/'
   echo "Diff $base_sha..$CIRCLE_SHA1"
 
-  if git diff --name-only "$base_sha..$CIRCLE_SHA1" | grep -E -v "$filter" ; then
+  if git diff --name-only "$base_sha..$CIRCLE_SHA1" | grep -E -v "$filter"; then
     echo "Running build hard"
     exit 0
   else

--- a/scripts/check_server_diff.sh
+++ b/scripts/check_server_diff.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-check_server_diff(){
-  CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+check_server_diff() {
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo $CURRENT_BRANCH
   if [ "$CURRENT_BRANCH" != "master" ]; then
     echo "Require manual deploy"
@@ -14,7 +14,7 @@ check_server_diff(){
   filter='^(server)/'
   echo "Diff $base_sha..$CIRCLE_SHA1"
 
-  if git diff --name-only "$base_sha..$CIRCLE_SHA1" | grep -E "$filter" ; then
+  if git diff --name-only "$base_sha..$CIRCLE_SHA1" | grep -E "$filter"; then
     echo "Running server deploy"
     exit 0
   else

--- a/scripts/create_and_push_tag_from_package_json_version.sh
+++ b/scripts/create_and_push_tag_from_package_json_version.sh
@@ -2,14 +2,12 @@
 
 set -e
 
-
-create_and_push_tag_from_package_json_version(){
+create_and_push_tag_from_package_json_version() {
   TAG_PREFIX="$1"
   source ./scripts/get_version.sh
   git tag --annotate "${TAG_PREFIX}${VERSION}" --message "v${VERSION}"
   git push origin "${TAG_PREFIX}${VERSION}"
 }
-
 
 # $1 is the tag used to trigger the ci deployment (see .circleci/config.yml)
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,25 +8,27 @@ GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NO_COLOR='\033[0m'
 
-PROJECT_DIR="$( dirname "${BASH_SOURCE[0]}" )/.."
-CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+PROJECT_DIR="$(dirname "${BASH_SOURCE[0]}")/.."
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 . "${PROJECT_DIR}/scripts/upload_sourcemaps_to_sentry.sh"
 
 invalid_option_val() {
-  echo >&2 "Invalid option value \"$OPTARG\""; print_usage; exit 1;
-}
-
-error(){
-  echo -e >&2 "${RED}$1${NO_COLOR}"
+  echo >&2 "Invalid option value \"$OPTARG\""
+  print_usage
   exit 1
 }
 
-success(){
+error() {
+  echo -e "${RED}$1${NO_COLOR}" >&2
+  exit 1
+}
+
+success() {
   echo -e "✅  ${GREEN}$1${NO_COLOR}"
 }
 
-warn(){
+warn() {
   echo -e "⚠️  ${YELLOW}$1${NO_COLOR}"
 
   if [ $DEV -eq 0 ]; then
@@ -34,7 +36,7 @@ warn(){
   fi
 }
 
-print_usage(){
+print_usage() {
   echo "Usage : ./scripts/deploy [-e <env>] [-t hard|soft] [-o ios|android] [-h]
 
 Options:
@@ -51,18 +53,16 @@ APP_OS="ios and android"
 
 DEPLOY_TYPE="soft"
 
-check_environment(){
-  CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
-  CURRENT_TAG=`git tag --points-at HEAD`
+check_environment() {
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  CURRENT_TAG=$(git tag --points-at HEAD)
 
   # If we are not on master, we can still deploy if we have a valid tag
   # The CI jobs are based on a tag (not a branch)
   HARD_DEPLOY_TESTING_TAG_REGEX="(testing\/)?v[0-9]+(\.[0-9]+){2}"
 
-  if [[ "$APP_ENV" == "testing" && "$CURRENT_BRANCH" != "master" ]];
-  then
-    if [[ $CURRENT_TAG =~ $HARD_DEPLOY_TESTING_TAG_REGEX ]];
-    then
+  if [[ "$APP_ENV" == "testing" && "$CURRENT_BRANCH" != "master" ]]; then
+    if [[ $CURRENT_TAG =~ $HARD_DEPLOY_TESTING_TAG_REGEX ]]; then
       success "Not on master but tag found. Deploying to $APP_ENV."
     else
       warn "Wrong branch, checkout master or create tag to deploy to $APP_ENV."
@@ -72,9 +72,8 @@ check_environment(){
   fi
 }
 
-check_dependency(){
-  if ! which jq >/dev/null
-  then
+check_dependency() {
+  if ! which jq >/dev/null; then
     error "Please install jq at: https://stedolan.github.io/jq/download/"
     exit 1
   fi
@@ -82,12 +81,18 @@ check_dependency(){
 
 while getopts ":e:o:t:h:d" opt; do
   case $opt in
-    e) APP_ENV="$OPTARG" ;;
-    o) if [[ $OPTARG =~ ^(ios|android)$ ]]; then APP_OS="$OPTARG"; else invalid_option_val; fi;;
-    t) if [[ $OPTARG =~ ^(hard|soft)$ ]]; then DEPLOY_TYPE="$OPTARG"; else invalid_option_val; fi;;
-    h) print_usage; exit;;
-    d) DEV=1 ;;
-    \?) error "Invalid option -$OPTARG"; exit 1;;
+  e) APP_ENV="$OPTARG" ;;
+  o) if [[ $OPTARG =~ ^(ios|android)$ ]]; then APP_OS="$OPTARG"; else invalid_option_val; fi ;;
+  t) if [[ $OPTARG =~ ^(hard|soft)$ ]]; then DEPLOY_TYPE="$OPTARG"; else invalid_option_val; fi ;;
+  h)
+    print_usage
+    exit
+    ;;
+  d) DEV=1 ;;
+  \?)
+    error "Invalid option -$OPTARG"
+    exit 1
+    ;;
   esac
 done
 

--- a/scripts/deploy_new_production_version.sh
+++ b/scripts/deploy_new_production_version.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-error(){
+error() {
   echo "$1"
   exit 1
 }
@@ -13,4 +13,3 @@ git checkout $1
 
 git tag prod-hard-deploy-$1
 git push origin prod-hard-deploy-$1
-

--- a/scripts/deploy_new_version.sh
+++ b/scripts/deploy_new_version.sh
@@ -6,4 +6,21 @@ set -e
 
 # $1 is the tag used to trigger the ci deployment (see .circleci/config.yml)
 # $2 is upgrade level (major, minor or patch)
+
+if [ "$1" = "patch/v" ]; then
+    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$CURRENT_BRANCH" == "master" ]; then
+        echo # step a new line
+        echo "It seems you are deploying master to patch staging"
+        echo
+        echo "You should be checking out the staging tag already released: git checkout <your_tag> (either v1.X.Y or patch/v1.X.Y)"
+        echo
+        echo "Then cherry-pick the commits you need for your patch, and run yarn trigger:staging:deploy:patch"
+        echo
+        echo "Aborting deployment"
+        echo
+        exit 1
+    fi
+fi
+
 ./scripts/update_app_version.sh "$1" "$2"

--- a/scripts/get_version.sh
+++ b/scripts/get_version.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-VERSION=`yarn --silent json -f package.json version`
+VERSION=$(yarn --silent json -f package.json version)

--- a/scripts/print_project_version.sh
+++ b/scripts/print_project_version.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
-print_usage(){
+print_usage() {
   echo "Usage : ./scripts/print_project_version.sh <path_to_project_root_dir>" >&2
 }
 
 if [ "$#" -ne 1 ]; then
- echo "One argument should be provided" >&2
- print_usage
- exit 1
+  echo "One argument should be provided" >&2
+  print_usage
+  exit 1
 fi
 
 VERSION=$(jq -r '.version' "${1}/package.json")
 BUILD=$(jq -r '.build' "${1}/package.json")
 
-echo "VERSION=$VERSION" >> "${1}/ios/react-native-config.xcconfig"
-echo "BUILD=$BUILD" >> "${1}/ios/react-native-config.xcconfig"
+echo "VERSION=$VERSION" >>"${1}/ios/react-native-config.xcconfig"
+echo "BUILD=$BUILD" >>"${1}/ios/react-native-config.xcconfig"
 
 exit 0

--- a/scripts/release_staging_minor.sh
+++ b/scripts/release_staging_minor.sh
@@ -2,11 +2,9 @@
 
 set -e
 
-# When releasing a staging minor, all we do is getting the version from 
+# When releasing a staging minor, all we do is getting the version from
 # the package.json and pushing the corresponding tag to trigger the CI.
-
 
 ./scripts/check_branch.sh
 
 ./scripts/create_and_push_tag_from_package_json_version.sh "v"
-

--- a/scripts/transition_jira_ticket.sh
+++ b/scripts/transition_jira_ticket.sh
@@ -2,7 +2,7 @@
 
 JIRA_TICKET_ID=$(git log --oneline | head -1 | grep -oP "PC-\d+" | head -1)
 JIRA_TRANSITION_ID="81" # revue PM
-CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 [[ "$CURRENT_BRANCH" != "master" ]] && echo "Not on master branch, exiting" && exit 0
 

--- a/scripts/update_app_version.sh
+++ b/scripts/update_app_version.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-update_app_version(){
+update_app_version() {
   yarn version --"$2" --no-git-tag-version
 
   source ./scripts/get_version.sh
@@ -12,13 +12,11 @@ update_app_version(){
   git commit -m "v${VERSION}"
   ./scripts/create_and_push_tag_from_package_json_version.sh "$1"
 
-  CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
-  if [ "$CURRENT_BRANCH" = "master" ]
-  then
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  if [ "$CURRENT_BRANCH" = "master" ]; then
     git push
   fi
 }
-
 
 # $1 is the tag used to trigger the ci deployment (see .circleci/config.yml)
 # $2 is upgrade level (major, minor or patch)

--- a/scripts/update_build_number_from_package_json_version.sh
+++ b/scripts/update_build_number_from_package_json_version.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-
-update_build_number_from_package_json_version(){
+update_build_number_from_package_json_version() {
   # We have to increment the build number because it is used as the versionCode
   # in app/build.gradle: versionCode (packageJson.build as Integer) and the
   # Play Store requires this value to be strictly increasing. Otherwise, we get this error:
@@ -23,7 +22,7 @@ update_build_number_from_package_json_version(){
   #   1.137.1  => 10 000 000 + 137 000 + 001 => 10137001
 
   source ./scripts/get_version.sh
-  SEMVER=( ${VERSION//./ } )
+  SEMVER=(${VERSION//./ })
   MAJOR=${SEMVER[0]}
   MINOR=${SEMVER[1]}
   PATCH=${SEMVER[2]}

--- a/scripts/upload_sourcemaps_to_sentry.sh
+++ b/scripts/upload_sourcemaps_to_sentry.sh
@@ -4,7 +4,7 @@ set -e
 
 SOURCEMAPS_DIR="sourcemaps"
 
-create_sourcemaps(){
+create_sourcemaps() {
   APP_OS="$1"
   SOURCEMAPS_NAME="$2"
 
@@ -57,12 +57,12 @@ create_sourcemaps(){
   fi
 }
 
-upload_sourcemaps(){
+upload_sourcemaps() {
   APP_OS="$1"
   APP_ENV="$2"
   CODE_PUSH_LABEL="$3"
-  VERSION=`jq -r .version package.json`
-  BUILD=`jq -r .build package.json`
+  VERSION=$(jq -r .version package.json)
+  BUILD=$(jq -r .build package.json)
 
   echo "APP_OS: ${APP_OS}"
   echo "APP_ENV: ${APP_ENV}"
@@ -98,7 +98,6 @@ upload_sourcemaps(){
     fi
   fi
 
-
   DIST="${BUILD}-${APP_OS}"
   echo "RELEASE: ${RELEASE}"
   echo "DIST: ${DIST}"
@@ -111,4 +110,3 @@ upload_sourcemaps(){
 
   echo "✅ Successfully uploaded sources maps"
 }
-


### PR DESCRIPTION
## Description

Problème rencontré :

Aujourd’hui, pas d’impossibilité technique de lancer un patch de staging si on est positionné sur master.

Cas de reproduction possible :

- On a fait une MES le jeudi `v1.X.Y`, testing passe donc à `testing/v1.(X+1).0`
- On se rend compte qu’on voudrait cherry pick de nombreux commits différents pour patcher la v1.X.Y → on se dit qu’il vaut mieux embarquer tout `master`
- On se place sur `master` et on lance `yarn trigger:staging:deploy:patch`
- Conséquence :
    - comme la commande de tag se base sur la version du package.json et que le package.json de master correspond à la version de testing, on pose un tag `v1.(X+1).1` qui se déploie en staging. La mineure de staging est donc à nouveau alignée avec testing, alors qu’elle doit avoir une mineure de retard.

## Solution envisagée

Cette PR empêche le lancement de la commande `yarn trigger:staging:deploy:patch` si l'utilisateur est positionné sur `master`
