### PR TITLE
(PC-12372) feat(EduConnectErrors): Create a Duplicate User error screen

### DIFF
--- a/src/features/auth/support.services.ts
+++ b/src/features/auth/support.services.ts
@@ -1,6 +1,7 @@
 import { env } from 'libs/environment'
 import { analytics } from 'libs/firebase/analytics'
 import { eventMonitoring } from 'libs/monitoring'
+import { ExternalNavigationProps } from 'ui/components/touchableLink/types'
 
 class ContactSupportError extends Error {
   name = 'ContactSupportError'
@@ -11,7 +12,7 @@ class ContactSupportError extends Error {
 
 const subject = encodeURI('Confirmation de numéro de téléphone')
 
-export const contactSupport = {
+export const contactSupport: Record<string, ExternalNavigationProps['externalNav']> = {
   forGenericQuestion: {
     url: `mailto:${env.SUPPORT_EMAIL_ADDRESS}`,
     params: { shouldLogEvent: false },

--- a/src/features/cheatcodes/pages/NavigationSignUp/NavigationIdentityCheck/NavigationIdentityCheck.tsx
+++ b/src/features/cheatcodes/pages/NavigationSignUp/NavigationIdentityCheck/NavigationIdentityCheck.tsx
@@ -93,6 +93,10 @@ export function NavigationIdentityCheck(): JSX.Element {
           title={'UserTypeNotStudent Error'}
           onPress={() => trigger(EduConnectErrorMessageEnum.UserTypeNotStudent)}
         />
+        <LinkToComponent
+          title={'DuplicateUser Error'}
+          onPress={() => trigger(EduConnectErrorMessageEnum.DuplicateUser)}
+        />
 
         <LinkToComponent
           title={'Generic Error'}

--- a/src/features/identityCheck/pages/identification/educonnect/IdentityCheckEduConnectForm.tsx
+++ b/src/features/identityCheck/pages/identification/educonnect/IdentityCheckEduConnectForm.tsx
@@ -49,6 +49,7 @@ export const IdentityCheckEduConnectForm = () => {
   const onNavigationStateChange = (event: WebViewNavigation) => {
     // PC Api detected an error after EduConnect authentication
     const isError = event.url.includes('educonnect/erreur')
+
     if (isError) {
       if (event.url.includes('UserAgeNotValid18YearsOld')) {
         setError(new EduConnectError(EduConnectErrorMessageEnum.UserAgeNotValid18YearsOld))
@@ -56,6 +57,8 @@ export const IdentityCheckEduConnectForm = () => {
         setError(new EduConnectError(EduConnectErrorMessageEnum.UserAgeNotValid))
       } else if (event.url.includes('UserTypeNotStudent')) {
         setError(new EduConnectError(EduConnectErrorMessageEnum.UserTypeNotStudent))
+      } else if (event.url.includes('DuplicateUser')) {
+        setError(new EduConnectError(EduConnectErrorMessageEnum.DuplicateUser))
       } else {
         setError(new Error(EduConnectErrorMessageEnum.UnknownErrorCode))
       }

--- a/src/features/identityCheck/pages/identification/educonnect/IdentityCheckEduConnectForm.tsx
+++ b/src/features/identityCheck/pages/identification/educonnect/IdentityCheckEduConnectForm.tsx
@@ -57,7 +57,7 @@ export const IdentityCheckEduConnectForm = () => {
         setError(new EduConnectError(EduConnectErrorMessageEnum.UserAgeNotValid))
       } else if (event.url.includes('UserTypeNotStudent')) {
         setError(new EduConnectError(EduConnectErrorMessageEnum.UserTypeNotStudent))
-      } else if (event.url.includes('DuplicateUser')) {
+      } else if (event.url.includes('DuplicateUser') || event.url.includes('DuplicateINE')) {
         setError(new EduConnectError(EduConnectErrorMessageEnum.DuplicateUser))
       } else {
         setError(new Error(EduConnectErrorMessageEnum.UnknownErrorCode))

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/EduConnectErrors.ts
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/EduConnectErrors.ts
@@ -17,6 +17,8 @@ export const EduConnectErrors = withEduConnectErrorBoundary(() => {
     throw new EduConnectError(EduConnectErrorMessageEnum.UserAgeNotValid)
   } else if (params?.code === 'UserTypeNotStudent') {
     throw new EduConnectError(EduConnectErrorMessageEnum.UserTypeNotStudent)
+  } else if (params?.code === 'DuplicateUser') {
+    throw new EduConnectError(EduConnectErrorMessageEnum.DuplicateUser)
   } else {
     throw new Error(EduConnectErrorMessageEnum.UnknownErrorCode)
   }

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/EduConnectErrors.ts
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/EduConnectErrors.ts
@@ -17,7 +17,7 @@ export const EduConnectErrors = withEduConnectErrorBoundary(() => {
     throw new EduConnectError(EduConnectErrorMessageEnum.UserAgeNotValid)
   } else if (params?.code === 'UserTypeNotStudent') {
     throw new EduConnectError(EduConnectErrorMessageEnum.UserTypeNotStudent)
-  } else if (params?.code === 'DuplicateUser') {
+  } else if (params?.code === 'DuplicateUser' || params?.code === 'DuplicateINE') {
     throw new EduConnectError(EduConnectErrorMessageEnum.DuplicateUser)
   } else {
     throw new Error(EduConnectErrorMessageEnum.UnknownErrorCode)

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { TextProps, TextStyle } from 'react-native'
 import styled from 'styled-components/native'
 
-import { computePrimaryButtonToDisplay } from 'features/identityCheck/pages/identification/errors/hooks/computePrimaryButtonToDisplay'
+import { computePrimaryButtonToDisplay } from 'features/identityCheck/pages/identification/errors/eduConnect/computePrimaryButtonToDisplay'
 import { navigateToHomeConfig } from 'features/navigation/helpers'
 import { analytics } from 'libs/firebase/analytics'
 import { ScreenErrorProps } from 'libs/monitoring/errors'

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
@@ -27,8 +27,9 @@ export const NotEligibleEduConnect = ({
     descriptionAlignment,
     Illustration,
     primaryButtonText,
-    isGoHomeTertiaryButtonVisible = false,
     onPrimaryButtonPress,
+    primaryButtonIcon,
+    isGoHomeTertiaryButtonVisible = false,
     navigateTo,
   } = useNotEligibleEduConnectErrorData(message, setError)
 
@@ -77,6 +78,7 @@ export const NotEligibleEduConnect = ({
           wording={primaryButtonText ?? "Retourner à l'accueil"}
           navigateTo={navigateTo ?? navigateToHomeConfig}
           onPress={onPrimaryButtonPress}
+          icon={primaryButtonIcon}
         />,
         !!isGoHomeTertiaryButtonVisible && goBackToHomeTertiaryButton,
       ].filter(Boolean)}>

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
@@ -26,11 +26,8 @@ export const NotEligibleEduConnect = ({
     description,
     descriptionAlignment,
     Illustration,
-    primaryButtonText,
-    onPrimaryButtonPress,
-    primaryButtonIcon,
+    primaryButton,
     isGoHomeTertiaryButtonVisible = false,
-    navigateTo,
   } = useNotEligibleEduConnectErrorData(message, setError)
 
   useEffect(
@@ -75,10 +72,10 @@ export const NotEligibleEduConnect = ({
         <TouchableLink
           key={1}
           as={ButtonPrimaryWhite}
-          wording={primaryButtonText ?? "Retourner à l'accueil"}
-          navigateTo={navigateTo ?? navigateToHomeConfig}
-          onPress={onPrimaryButtonPress}
-          icon={primaryButtonIcon}
+          wording={primaryButton?.primaryButtonText ?? "Retourner à l'accueil"}
+          navigateTo={primaryButton?.navigateTo ?? navigateToHomeConfig}
+          onPress={primaryButton?.onPrimaryButtonPress}
+          icon={primaryButton?.primaryButtonIcon}
         />,
         !!isGoHomeTertiaryButtonVisible && goBackToHomeTertiaryButton,
       ].filter(Boolean)}>

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
@@ -21,12 +21,11 @@ export const NotEligibleEduConnect = ({
 }: ScreenErrorProps) => {
   const timer = useRef<number>()
   const [error, setError] = useState<Error | undefined>()
-
   const {
     title,
     description,
     descriptionAlignment,
-    Icon,
+    Illustration,
     primaryButtonText,
     isGoHomeTertiaryButtonVisible = false,
     onPrimaryButtonPress,
@@ -70,7 +69,7 @@ export const NotEligibleEduConnect = ({
   return (
     <GenericInfoPage
       title={title}
-      icon={Icon}
+      icon={Illustration}
       buttons={[
         <TouchableLink
           key={1}

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
@@ -2,68 +2,18 @@ import React, { useEffect, useRef, useState } from 'react'
 import { TextProps, TextStyle } from 'react-native'
 import styled from 'styled-components/native'
 
+import { computePrimaryButtonToDisplay } from 'features/identityCheck/pages/identification/errors/hooks/computePrimaryButtonToDisplay'
 import { navigateToHomeConfig } from 'features/navigation/helpers'
 import { analytics } from 'libs/firebase/analytics'
 import { ScreenErrorProps } from 'libs/monitoring/errors'
 import { Helmet } from 'libs/react-helmet/Helmet'
-import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { ButtonTertiaryWhite } from 'ui/components/buttons/ButtonTertiaryWhite'
 import { GenericInfoPage } from 'ui/components/GenericInfoPage'
 import { TouchableLink } from 'ui/components/touchableLink/TouchableLink'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
 import { Typo } from 'ui/theme'
 
-import {
-  NotEligibleEduConnectErrorData,
-  useNotEligibleEduConnectErrorData,
-} from '../hooks/useNotEligibleEduConnectErrorData'
-
-const PrimaryButtonToDisplay = ({
-  button,
-}: {
-  button: NotEligibleEduConnectErrorData['primaryButton'] | undefined
-}): React.ReactNode => {
-  if (!button) {
-    return (
-      <TouchableLink
-        key={1}
-        as={ButtonPrimaryWhite}
-        wording="Retourner à l'accueil"
-        navigateTo={navigateToHomeConfig}
-      />
-    )
-  }
-
-  const { text: primaryButtonText, icon: primaryButtonIcon, onPress: onPrimaryButtonPress } = button
-
-  if ('navigateTo' in button && button.navigateTo) {
-    return (
-      <TouchableLink
-        key={1}
-        as={ButtonPrimaryWhite}
-        wording={primaryButtonText}
-        navigateTo={button.navigateTo}
-        icon={primaryButtonIcon}
-        onPress={onPrimaryButtonPress}
-      />
-    )
-  }
-
-  if ('externalNav' in button && button.externalNav) {
-    return (
-      <TouchableLink
-        key={1}
-        as={ButtonPrimaryWhite}
-        wording={primaryButtonText}
-        icon={primaryButtonIcon}
-        onPress={onPrimaryButtonPress}
-        externalNav={button.externalNav}
-      />
-    )
-  }
-
-  return null
-}
+import { useNotEligibleEduConnectErrorData } from '../hooks/useNotEligibleEduConnectErrorData'
 
 export const NotEligibleEduConnect = ({
   error: { message },
@@ -114,12 +64,14 @@ export const NotEligibleEduConnect = ({
     />
   )
 
+  const primaryButton = computePrimaryButtonToDisplay({ button: primaryButtonProps })
+
   return (
     <GenericInfoPage
       title={title}
       icon={Illustration}
       buttons={[
-        PrimaryButtonToDisplay({ button: primaryButtonProps }),
+        primaryButton,
         !!isGoHomeTertiaryButtonVisible && goBackToHomeTertiaryButton,
       ].filter(Boolean)}>
       <Helmet>

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
@@ -21,13 +21,14 @@ export const NotEligibleEduConnect = ({
 }: ScreenErrorProps) => {
   const timer = useRef<number>()
   const [error, setError] = useState<Error | undefined>()
+
   const {
     title,
     description,
     descriptionAlignment,
     Icon,
     primaryButtonText,
-    tertiaryButtonVisible = false,
+    isGoHomeTertiaryButtonVisible = false,
     onPrimaryButtonPress,
     navigateTo,
   } = useNotEligibleEduConnectErrorData(message, setError)
@@ -54,6 +55,18 @@ export const NotEligibleEduConnect = ({
 
   const helmetTitle = `Page erreur\u00a0: ${title} | pass Culture`
 
+  const goBackToHomeTertiaryButton = (
+    <TouchableLink
+      key={2}
+      as={ButtonTertiaryWhite}
+      icon={PlainArrowPrevious}
+      wording="Retourner à l'accueil"
+      navigateTo={navigateToHomeConfig}
+      onPress={onAbandon}
+      navigateBeforeOnPress
+    />
+  )
+
   return (
     <GenericInfoPage
       title={title}
@@ -66,17 +79,7 @@ export const NotEligibleEduConnect = ({
           navigateTo={navigateTo ?? navigateToHomeConfig}
           onPress={onPrimaryButtonPress}
         />,
-        !!tertiaryButtonVisible && (
-          <TouchableLink
-            key={2}
-            as={ButtonTertiaryWhite}
-            icon={PlainArrowPrevious}
-            wording="Retourner à l’accueil"
-            navigateTo={navigateToHomeConfig}
-            onPress={onAbandon}
-            navigateBeforeOnPress
-          />
-        ),
+        !!isGoHomeTertiaryButtonVisible && goBackToHomeTertiaryButton,
       ].filter(Boolean)}>
       <Helmet>
         <title>{helmetTitle}</title>

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
@@ -13,7 +13,57 @@ import { TouchableLink } from 'ui/components/touchableLink/TouchableLink'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
 import { Typo } from 'ui/theme'
 
-import { useNotEligibleEduConnectErrorData } from '../hooks/useNotEligibleEduConnectErrorData'
+import {
+  NotEligibleEduConnectErrorData,
+  useNotEligibleEduConnectErrorData,
+} from '../hooks/useNotEligibleEduConnectErrorData'
+
+const PrimaryButtonToDisplay = ({
+  button,
+}: {
+  button: NotEligibleEduConnectErrorData['primaryButton'] | undefined
+}): React.ReactNode => {
+  if (!button) {
+    return (
+      <TouchableLink
+        key={1}
+        as={ButtonPrimaryWhite}
+        wording="Retourner à l'accueil"
+        navigateTo={navigateToHomeConfig}
+      />
+    )
+  }
+
+  const { text: primaryButtonText, icon: primaryButtonIcon, onPress: onPrimaryButtonPress } = button
+
+  if ('navigateTo' in button && button.navigateTo) {
+    return (
+      <TouchableLink
+        key={1}
+        as={ButtonPrimaryWhite}
+        wording={primaryButtonText}
+        navigateTo={button.navigateTo}
+        icon={primaryButtonIcon}
+        onPress={onPrimaryButtonPress}
+      />
+    )
+  }
+
+  if ('externalNav' in button && button.externalNav) {
+    return (
+      <TouchableLink
+        key={1}
+        as={ButtonPrimaryWhite}
+        wording={primaryButtonText}
+        icon={primaryButtonIcon}
+        onPress={onPrimaryButtonPress}
+        externalNav={button.externalNav}
+      />
+    )
+  }
+
+  return null
+}
 
 export const NotEligibleEduConnect = ({
   error: { message },
@@ -26,7 +76,7 @@ export const NotEligibleEduConnect = ({
     description,
     descriptionAlignment,
     Illustration,
-    primaryButton,
+    primaryButton: primaryButtonProps,
     isGoHomeTertiaryButtonVisible = false,
   } = useNotEligibleEduConnectErrorData(message, setError)
 
@@ -69,14 +119,7 @@ export const NotEligibleEduConnect = ({
       title={title}
       icon={Illustration}
       buttons={[
-        <TouchableLink
-          key={1}
-          as={ButtonPrimaryWhite}
-          wording={primaryButton?.primaryButtonText ?? "Retourner à l'accueil"}
-          navigateTo={primaryButton?.navigateTo ?? navigateToHomeConfig}
-          onPress={primaryButton?.onPrimaryButtonPress}
-          icon={primaryButton?.primaryButtonIcon}
-        />,
+        PrimaryButtonToDisplay({ button: primaryButtonProps }),
         !!isGoHomeTertiaryButtonVisible && goBackToHomeTertiaryButton,
       ].filter(Boolean)}>
       <Helmet>

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/computePrimaryButtonToDisplay.test.tsx
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/computePrimaryButtonToDisplay.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+
+import { contactSupport } from 'features/auth/__mocks__/support.services'
+import { computePrimaryButtonToDisplay } from 'features/identityCheck/pages/identification/errors/eduConnect/computePrimaryButtonToDisplay'
+import { navigateToHomeConfig } from 'features/navigation/helpers/__mocks__'
+import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
+import { TouchableLink } from 'ui/components/touchableLink/TouchableLink'
+import { Email } from 'ui/svg/icons/Email'
+
+describe('computePrimaryButtonToDisplay', () => {
+  const defaultPrimaryButton = (
+    <TouchableLink
+      key={1}
+      as={ButtonPrimaryWhite}
+      wording="Retourner à l'accueil"
+      navigateTo={navigateToHomeConfig}
+    />
+  )
+
+  const navigateToButtonProps = {
+    text: 'Réessayer de m’identifier',
+    navigateTo: { screen: 'IdentityCheckEduConnectForm' },
+  }
+
+  const navigateToPrimaryButton = (
+    <TouchableLink
+      key={1}
+      as={ButtonPrimaryWhite}
+      wording="Réessayer de m’identifier"
+      navigateTo={{ screen: 'IdentityCheckEduConnectForm' }}
+    />
+  )
+
+  const externalNavPrimaryButton = (
+    <TouchableLink
+      key={1}
+      as={ButtonPrimaryWhite}
+      wording="Contacter le support"
+      icon={Email}
+      externalNav={contactSupport.forGenericQuestion}
+    />
+  )
+
+  const externalNavButtonProps = {
+    text: 'Contacter le support',
+    icon: Email,
+    externalNav: contactSupport.forGenericQuestion,
+  }
+
+  it.each`
+    buttonProps               | expectedButton
+    ${undefined}              | ${defaultPrimaryButton}
+    ${navigateToButtonProps}  | ${navigateToPrimaryButton}
+    ${externalNavButtonProps} | ${externalNavPrimaryButton}
+  `(
+    'should return the correct button depending on the given button props',
+    ({ buttonProps, expectedButton }) => {
+      const primaryButton = computePrimaryButtonToDisplay({ button: buttonProps })
+
+      expect(primaryButton).toEqual(expectedButton)
+    }
+  )
+})

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/computePrimaryButtonToDisplay.tsx
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/computePrimaryButtonToDisplay.tsx
@@ -23,6 +23,9 @@ export const computePrimaryButtonToDisplay = ({
 
   const { text: primaryButtonText, icon: primaryButtonIcon, onPress: onPrimaryButtonPress } = button
 
+  // If button props are given + a navigateTo prop is defined :
+  // 'navigateTo' in button => 'navigateTo' key exists in the button object
+  // button.navigateTo => 'navigateTo' value is not null nor undefined
   if ('navigateTo' in button && button.navigateTo) {
     return (
       <TouchableLink

--- a/src/features/identityCheck/pages/identification/errors/hooks/computePrimaryButtonToDisplay.tsx
+++ b/src/features/identityCheck/pages/identification/errors/hooks/computePrimaryButtonToDisplay.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+
+import { NotEligibleEduConnectErrorData } from 'features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData'
+import { navigateToHomeConfig } from 'features/navigation/helpers'
+import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
+import { TouchableLink } from 'ui/components/touchableLink/TouchableLink'
+
+export const computePrimaryButtonToDisplay = ({
+  button,
+}: {
+  button?: NotEligibleEduConnectErrorData['primaryButton']
+}): React.ReactNode => {
+  if (!button) {
+    return (
+      <TouchableLink
+        key={1}
+        as={ButtonPrimaryWhite}
+        wording="Retourner à l'accueil"
+        navigateTo={navigateToHomeConfig}
+      />
+    )
+  }
+
+  const { text: primaryButtonText, icon: primaryButtonIcon, onPress: onPrimaryButtonPress } = button
+
+  if ('navigateTo' in button && button.navigateTo) {
+    return (
+      <TouchableLink
+        key={1}
+        as={ButtonPrimaryWhite}
+        wording={primaryButtonText}
+        navigateTo={button.navigateTo}
+        icon={primaryButtonIcon}
+        onPress={onPrimaryButtonPress}
+      />
+    )
+  }
+
+  if ('externalNav' in button && button.externalNav) {
+    return (
+      <TouchableLink
+        key={1}
+        as={ButtonPrimaryWhite}
+        wording={primaryButtonText}
+        icon={primaryButtonIcon}
+        onPress={onPrimaryButtonPress}
+        externalNav={button.externalNav}
+      />
+    )
+  }
+
+  return null
+}

--- a/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.test.ts
+++ b/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.test.ts
@@ -1,0 +1,85 @@
+import { contactSupport } from 'features/auth/support.services'
+import {
+  EduConnectErrorMessageEnum,
+  useNotEligibleEduConnectErrorData,
+} from 'features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData'
+import { renderHook } from 'tests/utils'
+import { Email } from 'ui/svg/icons/Email'
+import { UserError } from 'ui/svg/icons/UserError'
+
+jest.mock('features/auth/signup/useBeneficiaryValidationNavigation')
+
+jest.mock('features/auth/support.services')
+
+describe('useNotEligibleEduConnectErrorData', () => {
+  const mockSetError = jest.fn()
+
+  const expectedDuplicatedUserData = {
+    Illustration: UserError,
+    title: 'As-tu déja un compte\u00a0?',
+    description:
+      "Ton compte ÉduConnect est déjà rattaché à un compte pass Culture. Vérifie que tu n'as pas déjà créé un compte avec une autre adresse e-mail.\n\nTu peux contacter le support pour plus d'informations.",
+    descriptionAlignment: 'center',
+    primaryButton: {
+      text: 'Contacter le support',
+      icon: Email,
+      externalNav: contactSupport.forGenericQuestion,
+    },
+    isGoHomeTertiaryButtonVisible: true,
+  }
+
+  const expectedUserAgeNotValidErrorData = {
+    Illustration: UserError,
+    title: 'Oh non\u00a0!',
+    description:
+      'La date de naissance enregistrée dans ÉduConnect semble indiquer que tu n’as pas l’âge requis pour obtenir l’aide du Gouvernement.\n\nS’il y a une erreur sur ta date de naissance, contacte ton établissement pour modifier ton profil ÉduConnect.',
+    titleAlignment: 'center',
+    descriptionAlignment: 'center',
+  }
+
+  const expectedInvalidInformationErrorData = {
+    Illustration: UserError,
+    title: 'Oh non\u00a0!',
+    description:
+      'Il semblerait que les informations que tu nous as communiquées ne soient pas correctes.\n\nRefais une demande en vérifiant ton identité avec ta pièce d’identité.',
+    descriptionAlignment: 'center',
+    primaryButton: {
+      text: 'Vérifier mon identité',
+      navigateTo: {
+        params: undefined,
+        screen: '',
+      },
+    },
+    isGoHomeTertiaryButtonVisible: true,
+  }
+
+  const expectedUserTypeNotStudentErrorData = {
+    Illustration: UserError,
+    title: 'Qui est-ce\u00a0?',
+    description:
+      'Les informations provenant d’ÉduConnect indiquent que vous êtes le représentant légal d’un jeune scolarisé.\n\nL’usage du pass Culture est strictement nominatif. Le compte doit être créé et utilisé par un jeune éligible, de 15 à 18 ans. L’identification doit se faire au nom du futur bénéficiaire. ',
+    descriptionAlignment: 'center',
+    primaryButton: {
+      text: 'Réessayer de m’identifier',
+      onPress: expect.any(Function),
+      navigateTo: { screen: 'IdentityCheckEduConnectForm' },
+    },
+    isGoHomeTertiaryButtonVisible: true,
+  }
+  it.each`
+    eduConnectError                                         | expectedData
+    ${EduConnectErrorMessageEnum.DuplicateUser}             | ${expectedDuplicatedUserData}
+    ${EduConnectErrorMessageEnum.UserAgeNotValid}           | ${expectedUserAgeNotValidErrorData}
+    ${EduConnectErrorMessageEnum.UserAgeNotValid18YearsOld} | ${expectedInvalidInformationErrorData}
+    ${EduConnectErrorMessageEnum.UserTypeNotStudent}        | ${expectedUserTypeNotStudentErrorData}
+  `(
+    'should return the correct dataset if the eduConnect error is : $eduConnectError',
+    ({ eduConnectError, expectedData }) => {
+      const {
+        result: { current: data },
+      } = renderHook(() => useNotEligibleEduConnectErrorData(eduConnectError, mockSetError))
+
+      expect(data).toEqual(expectedData)
+    }
+  )
+})

--- a/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.ts
+++ b/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.ts
@@ -5,6 +5,7 @@ import { TextStyle } from 'react-native'
 import { useBeneficiaryValidationNavigation } from 'features/auth/signup/useBeneficiaryValidationNavigation'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { TouchableLinkProps } from 'ui/components/touchableLink/types'
+import { Email } from 'ui/svg/icons/Email'
 import { MaintenanceCone } from 'ui/svg/icons/MaintenanceCone'
 import { IconInterface } from 'ui/svg/icons/types'
 import { UserError } from 'ui/svg/icons/UserError'
@@ -83,6 +84,18 @@ const GenericErrorData: NotEligibleEduConnectErrorData = {
   descriptionAlignment: 'center',
 }
 
+const DuplicateUserErrorData: NotEligibleEduConnectErrorData = {
+  Illustration: UserError,
+  title: 'As-tu déja un compte\u00a0?',
+  description:
+    "Ton compte ÉduConnect est déjà rattaché à un compte pass Culture. Vérifie que tu n'as pas déjà créé un compte avec une autre adresse e-mail.\n\nTu peux contacter le support pour plus d'informations.",
+  descriptionAlignment: 'center',
+
+  primaryButtonText: 'Contacter le support',
+  primaryButtonIcon: Email,
+  isGoHomeTertiaryButtonVisible: true,
+}
+
 export function useNotEligibleEduConnectErrorData(
   message: EduConnectErrorMessageEnum | string,
   setError: (error: Error | undefined) => void
@@ -103,6 +116,9 @@ export function useNotEligibleEduConnectErrorData(
         },
         { screen: 'IdentityCheckEduConnectForm' }
       )
+
+    case EduConnectErrorMessageEnum.DuplicateUser:
+      return DuplicatedUserErrorData
 
     default:
       return GenericErrorData

--- a/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.ts
+++ b/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.ts
@@ -3,8 +3,9 @@ import { FunctionComponent } from 'react'
 import { TextStyle } from 'react-native'
 
 import { useBeneficiaryValidationNavigation } from 'features/auth/signup/useBeneficiaryValidationNavigation'
+import { contactSupport } from 'features/auth/support.services'
 import { UseNavigationType } from 'features/navigation/RootNavigator'
-import { TouchableLinkProps } from 'ui/components/touchableLink/types'
+import { ExternalNavigationProps, TouchableLinkProps } from 'ui/components/touchableLink/types'
 import { Email } from 'ui/svg/icons/Email'
 import { MaintenanceCone } from 'ui/svg/icons/MaintenanceCone'
 import { IconInterface } from 'ui/svg/icons/types'
@@ -20,18 +21,21 @@ export enum EduConnectErrorMessageEnum {
   GenericError = 'GenericError',
 }
 
-type NotEligibleEduConnectErrorData = {
+export type NotEligibleEduConnectErrorData = {
   Illustration: FunctionComponent<IconInterface>
   title: string
   description: string
   titleAlignment?: Exclude<TextStyle['textAlign'], 'auto'>
   descriptionAlignment?: Exclude<TextStyle['textAlign'], 'auto'>
   primaryButton?: {
-    primaryButtonText?: string
-    primaryButtonIcon?: FunctionComponent<IconInterface>
-    onPrimaryButtonPress?: () => void
-    navigateTo?: TouchableLinkProps['navigateTo']
-  }
+    text: string
+    icon?: FunctionComponent<IconInterface>
+    onPress?: () => void
+  } & (
+    | { navigateTo: TouchableLinkProps['navigateTo'] }
+    | { externalNav: ExternalNavigationProps['externalNav'] }
+  )
+
   isGoHomeTertiaryButtonVisible?: boolean
 }
 
@@ -57,7 +61,7 @@ const getInvalidInformationErrorData = (
     'Refais une demande en vérifiant ton identité avec ta pièce d’identité.',
   descriptionAlignment: 'center',
   primaryButton: {
-    primaryButtonText: 'Vérifier mon identité',
+    text: 'Vérifier mon identité',
     navigateTo,
   },
   isGoHomeTertiaryButtonVisible: true,
@@ -75,8 +79,8 @@ const getUserTypeNotStudentErrorData = (
     'L’usage du pass Culture est strictement nominatif. Le compte doit être créé et utilisé par un jeune éligible, de 15 à 18 ans. L’identification doit se faire au nom du futur bénéficiaire. ',
   descriptionAlignment: 'center',
   primaryButton: {
-    primaryButtonText: "Réessayer de m'identifier",
-    onPrimaryButtonPress,
+    text: 'Réessayer de m’identifier',
+    onPress: onPrimaryButtonPress,
     navigateTo,
   },
   isGoHomeTertiaryButtonVisible: true,
@@ -97,8 +101,9 @@ const DuplicateUserErrorData: NotEligibleEduConnectErrorData = {
     "Ton compte ÉduConnect est déjà rattaché à un compte pass Culture. Vérifie que tu n'as pas déjà créé un compte avec une autre adresse e-mail.\n\nTu peux contacter le support pour plus d'informations.",
   descriptionAlignment: 'center',
   primaryButton: {
-    primaryButtonText: 'Contacter le support',
-    primaryButtonIcon: Email,
+    text: 'Contacter le support',
+    icon: Email,
+    externalNav: contactSupport.forGenericQuestion,
   },
   isGoHomeTertiaryButtonVisible: true,
 }
@@ -125,7 +130,7 @@ export function useNotEligibleEduConnectErrorData(
       )
 
     case EduConnectErrorMessageEnum.DuplicateUser:
-      return DuplicatedUserErrorData
+      return DuplicateUserErrorData
 
     default:
       return GenericErrorData

--- a/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.ts
+++ b/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.ts
@@ -26,6 +26,7 @@ type NotEligibleEduConnectErrorData = {
   titleAlignment?: Exclude<TextStyle['textAlign'], 'auto'>
   descriptionAlignment?: Exclude<TextStyle['textAlign'], 'auto'>
   primaryButtonText?: string
+  primaryButtonIcon?: FunctionComponent<IconInterface>
   isGoHomeTertiaryButtonVisible?: boolean
   onPrimaryButtonPress?: () => void
   navigateTo?: TouchableLinkProps['navigateTo']

--- a/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.ts
+++ b/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.ts
@@ -11,6 +11,7 @@ import { UserError } from 'ui/svg/icons/UserError'
 import { DOUBLE_LINE_BREAK } from 'ui/theme/constants'
 
 export enum EduConnectErrorMessageEnum {
+  DuplicateUser = 'DuplicateUser',
   UserAgeNotValid18YearsOld = 'UserAgeNotValid18YearsOld',
   UserAgeNotValid = 'UserAgeNotValid',
   UserTypeNotStudent = 'UserTypeNotStudent',

--- a/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.ts
+++ b/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.ts
@@ -26,7 +26,7 @@ type NotEligibleEduConnectErrorData = {
   titleAlignment?: Exclude<TextStyle['textAlign'], 'auto'>
   descriptionAlignment?: Exclude<TextStyle['textAlign'], 'auto'>
   primaryButtonText?: string
-  tertiaryButtonVisible?: boolean
+  isGoHomeTertiaryButtonVisible?: boolean
   onPrimaryButtonPress?: () => void
   navigateTo?: TouchableLinkProps['navigateTo']
 }
@@ -53,7 +53,7 @@ const getInvalidInformationErrorData = (
     'Refais une demande en vérifiant ton identité avec ta pièce d’identité.',
   descriptionAlignment: 'center',
   primaryButtonText: 'Vérifier mon identité',
-  tertiaryButtonVisible: true,
+  isGoHomeTertiaryButtonVisible: true,
   navigateTo,
 })
 
@@ -68,8 +68,8 @@ const getUserTypeNotStudentErrorData = (
     DOUBLE_LINE_BREAK +
     'L’usage du pass Culture est strictement nominatif. Le compte doit être créé et utilisé par un jeune éligible, de 15 à 18 ans. L’identification doit se faire au nom du futur bénéficiaire. ',
   descriptionAlignment: 'center',
-  primaryButtonText: 'Réessayer de m’identifier',
-  tertiaryButtonVisible: true,
+  primaryButtonText: "Réessayer de m'identifier",
+  isGoHomeTertiaryButtonVisible: true,
   onPrimaryButtonPress,
   navigateTo,
 })

--- a/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.ts
+++ b/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.ts
@@ -20,7 +20,7 @@ export enum EduConnectErrorMessageEnum {
 }
 
 type NotEligibleEduConnectErrorData = {
-  Icon: FunctionComponent<IconInterface>
+  Illustration: FunctionComponent<IconInterface>
   title: string
   description: string
   titleAlignment?: Exclude<TextStyle['textAlign'], 'auto'>
@@ -32,7 +32,7 @@ type NotEligibleEduConnectErrorData = {
 }
 
 const UserAgeNotValidErrorData: NotEligibleEduConnectErrorData = {
-  Icon: UserError,
+  Illustration: UserError,
   title: 'Oh non\u00a0!',
   description:
     'La date de naissance enregistrée dans ÉduConnect semble indiquer que tu n’as pas l’âge requis pour obtenir l’aide du Gouvernement.' +
@@ -45,7 +45,7 @@ const UserAgeNotValidErrorData: NotEligibleEduConnectErrorData = {
 const getInvalidInformationErrorData = (
   navigateTo: TouchableLinkProps['navigateTo']
 ): NotEligibleEduConnectErrorData => ({
-  Icon: UserError,
+  Illustration: UserError,
   title: 'Oh non\u00a0!',
   description:
     'Il semblerait que les informations que tu nous as communiquées ne soient pas correctes.' +
@@ -61,7 +61,7 @@ const getUserTypeNotStudentErrorData = (
   onPrimaryButtonPress: () => void,
   navigateTo: TouchableLinkProps['navigateTo']
 ): NotEligibleEduConnectErrorData => ({
-  Icon: UserError,
+  Illustration: UserError,
   title: 'Qui est-ce\u00a0?',
   description:
     'Les informations provenant d’ÉduConnect indiquent que vous êtes le représentant légal d’un jeune scolarisé.' +
@@ -75,9 +75,9 @@ const getUserTypeNotStudentErrorData = (
 })
 
 const GenericErrorData: NotEligibleEduConnectErrorData = {
-  Icon: MaintenanceCone,
+  Illustration: MaintenanceCone,
   title: 'Oups\u00a0!',
-  description: 'Une erreur s’est produite pendant le chargement',
+  description: "Une erreur s'est produite pendant le chargement",
   titleAlignment: 'center',
   descriptionAlignment: 'center',
 }

--- a/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.ts
+++ b/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.ts
@@ -26,11 +26,13 @@ type NotEligibleEduConnectErrorData = {
   description: string
   titleAlignment?: Exclude<TextStyle['textAlign'], 'auto'>
   descriptionAlignment?: Exclude<TextStyle['textAlign'], 'auto'>
-  primaryButtonText?: string
-  primaryButtonIcon?: FunctionComponent<IconInterface>
+  primaryButton?: {
+    primaryButtonText?: string
+    primaryButtonIcon?: FunctionComponent<IconInterface>
+    onPrimaryButtonPress?: () => void
+    navigateTo?: TouchableLinkProps['navigateTo']
+  }
   isGoHomeTertiaryButtonVisible?: boolean
-  onPrimaryButtonPress?: () => void
-  navigateTo?: TouchableLinkProps['navigateTo']
 }
 
 const UserAgeNotValidErrorData: NotEligibleEduConnectErrorData = {
@@ -54,9 +56,11 @@ const getInvalidInformationErrorData = (
     DOUBLE_LINE_BREAK +
     'Refais une demande en vérifiant ton identité avec ta pièce d’identité.',
   descriptionAlignment: 'center',
-  primaryButtonText: 'Vérifier mon identité',
+  primaryButton: {
+    primaryButtonText: 'Vérifier mon identité',
+    navigateTo,
+  },
   isGoHomeTertiaryButtonVisible: true,
-  navigateTo,
 })
 
 const getUserTypeNotStudentErrorData = (
@@ -70,10 +74,12 @@ const getUserTypeNotStudentErrorData = (
     DOUBLE_LINE_BREAK +
     'L’usage du pass Culture est strictement nominatif. Le compte doit être créé et utilisé par un jeune éligible, de 15 à 18 ans. L’identification doit se faire au nom du futur bénéficiaire. ',
   descriptionAlignment: 'center',
-  primaryButtonText: "Réessayer de m'identifier",
+  primaryButton: {
+    primaryButtonText: "Réessayer de m'identifier",
+    onPrimaryButtonPress,
+    navigateTo,
+  },
   isGoHomeTertiaryButtonVisible: true,
-  onPrimaryButtonPress,
-  navigateTo,
 })
 
 const GenericErrorData: NotEligibleEduConnectErrorData = {
@@ -90,9 +96,10 @@ const DuplicateUserErrorData: NotEligibleEduConnectErrorData = {
   description:
     "Ton compte ÉduConnect est déjà rattaché à un compte pass Culture. Vérifie que tu n'as pas déjà créé un compte avec une autre adresse e-mail.\n\nTu peux contacter le support pour plus d'informations.",
   descriptionAlignment: 'center',
-
-  primaryButtonText: 'Contacter le support',
-  primaryButtonIcon: Email,
+  primaryButton: {
+    primaryButtonText: 'Contacter le support',
+    primaryButtonIcon: Email,
+  },
   isGoHomeTertiaryButtonVisible: true,
 }
 

--- a/src/ui/components/touchableLink/types.ts
+++ b/src/ui/components/touchableLink/types.ts
@@ -35,11 +35,10 @@ type AsProps = {
   as?: ElementType // Component that will be used to render the link
 } & Record<string, unknown>
 
-export type TouchableLinkProps =
-  | (InternalNavigationProps | ExternalNavigationProps) & {
-      navigateBeforeOnPress?: boolean // If true, triggers navigation before onPress function
-      highlight?: boolean // If true, uses TouchableHighlight instead of TouchableOpacity to render component
-      hoverUnderlineColor?: ColorsEnum // Color to be used for underline effect on hover. Black if not specified
-      isOnPressDebounced?: boolean
-    } & TouchableOpacityProps &
-      AsProps
+export type TouchableLinkProps = (InternalNavigationProps | ExternalNavigationProps) & {
+  navigateBeforeOnPress?: boolean // If true, triggers navigation before onPress function
+  highlight?: boolean // If true, uses TouchableHighlight instead of TouchableOpacity to render component
+  hoverUnderlineColor?: ColorsEnum // Color to be used for underline effect on hover. Black if not specified
+  isOnPressDebounced?: boolean
+} & TouchableOpacityProps &
+  AsProps


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-12372

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
| <img width="352" alt="image" src="https://user-images.githubusercontent.com/89008469/192488367-2190bc0d-36f8-408e-aeda-73801868b09f.png"> |         |                 |                  |                  |
