### PR TITLE
(PC-17485) refactor(SearchV2): remove duplicate offerType labels

### DIFF
--- a/__snapshots__/features/_marketingAndCommunication/atoms/__tests__/OfferTypeChoices.test.tsx.native-snap
+++ b/__snapshots__/features/_marketingAndCommunication/atoms/__tests__/OfferTypeChoices.test.tsx.native-snap
@@ -94,7 +94,7 @@ exports[`<OfferCategoryChoices /> should match snapshot 1`] = `
             ]
           }
         >
-          Offre numérique
+          Numérique
         </Text>
         <View
           numberOfSpaces={5}
@@ -177,7 +177,7 @@ exports[`<OfferCategoryChoices /> should match snapshot 1`] = `
             ]
           }
         >
-          Sortie
+          Sorties
         </Text>
         <View
           numberOfSpaces={5}
@@ -260,7 +260,7 @@ exports[`<OfferCategoryChoices /> should match snapshot 1`] = `
             ]
           }
         >
-          Offre physique
+          Bien physique
         </Text>
         <View
           numberOfSpaces={5}

--- a/__snapshots__/features/_marketingAndCommunication/atoms/__tests__/OfferTypeChoices.test.tsx.web-snap
+++ b/__snapshots__/features/_marketingAndCommunication/atoms/__tests__/OfferTypeChoices.test.tsx.web-snap
@@ -126,7 +126,7 @@ exports[`<OfferCategoryChoices /> should match snapshot 1`] = `
             }
           }
         >
-          Offre numérique
+          Numérique
         </div>
         <div
           className="css-view-1dbjc4n"
@@ -137,10 +137,10 @@ exports[`<OfferCategoryChoices /> should match snapshot 1`] = `
           }
         />
         <input
-          aria-label="Offre numérique"
+          aria-label="Numérique"
           checked={false}
           hidden={true}
-          name="Offre numérique"
+          name="Numérique"
           readOnly={true}
           type="checkbox"
         />
@@ -233,7 +233,7 @@ exports[`<OfferCategoryChoices /> should match snapshot 1`] = `
             }
           }
         >
-          Sortie
+          Sorties
         </div>
         <div
           className="css-view-1dbjc4n"
@@ -244,10 +244,10 @@ exports[`<OfferCategoryChoices /> should match snapshot 1`] = `
           }
         />
         <input
-          aria-label="Sortie"
+          aria-label="Sorties"
           checked={false}
           hidden={true}
-          name="Sortie"
+          name="Sorties"
           readOnly={true}
           type="checkbox"
         />
@@ -340,7 +340,7 @@ exports[`<OfferCategoryChoices /> should match snapshot 1`] = `
             }
           }
         >
-          Offre physique
+          Bien physique
         </div>
         <div
           className="css-view-1dbjc4n"
@@ -351,10 +351,10 @@ exports[`<OfferCategoryChoices /> should match snapshot 1`] = `
           }
         />
         <input
-          aria-label="Offre physique"
+          aria-label="Bien physique"
           checked={false}
           hidden={true}
-          name="Offre physique"
+          name="Bien physique"
           readOnly={true}
           type="checkbox"
         />

--- a/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
@@ -1111,7 +1111,7 @@ exports[`SearchFilter component should render correctly 1`] = `
                       ]
                     }
                   >
-                    Offre numérique
+                    Numérique
                   </Text>
                   <View
                     numberOfSpaces={5}
@@ -1194,7 +1194,7 @@ exports[`SearchFilter component should render correctly 1`] = `
                       ]
                     }
                   >
-                    Sortie
+                    Sorties
                   </Text>
                   <View
                     numberOfSpaces={5}
@@ -1277,7 +1277,7 @@ exports[`SearchFilter component should render correctly 1`] = `
                       ]
                     }
                   >
-                    Offre physique
+                    Bien physique
                   </Text>
                   <View
                     numberOfSpaces={5}

--- a/src/features/_marketingAndCommunication/atoms/OfferTypeChoices.tsx
+++ b/src/features/_marketingAndCommunication/atoms/OfferTypeChoices.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components/native'
 
 import { SelectionLabel } from 'features/search/atoms'
 import { OFFER_TYPES } from 'features/search/sections/OfferType'
+import { OfferTypes } from 'features/search/types'
 import { Li } from 'ui/components/Li'
 import { Ul } from 'ui/components/Ul'
 import { getSpacing } from 'ui/theme'
@@ -29,15 +30,15 @@ export const OfferTypeChoices = (props: Props) => {
   return (
     <BodyContainer>
       <StyledUl>
-        {OFFER_TYPES.map(([offerType, label]) => (
+        {OFFER_TYPES.filter(({ type }) => type).map(({ type, label }) => (
           <Li key={label}>
             <SelectionLabel
               label={label}
-              selected={offerTypes[offerType]}
+              selected={offerTypes[type as OfferTypes]}
               onPress={() => {
                 setOfferTypes((prevOfferTypes) => {
                   const nextOfferTypes = { ...prevOfferTypes }
-                  nextOfferTypes[offerType] = !nextOfferTypes[offerType]
+                  nextOfferTypes[type as OfferTypes] = !nextOfferTypes[type as OfferTypes]
                   props.onChange(nextOfferTypes)
                   return nextOfferTypes
                 })

--- a/src/features/_marketingAndCommunication/atoms/__tests__/OfferTypeChoices.test.tsx
+++ b/src/features/_marketingAndCommunication/atoms/__tests__/OfferTypeChoices.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { OfferTypeChoices } from 'features/_marketingAndCommunication/atoms/OfferTypeChoices'
+import { OfferType } from 'features/search/enums'
 import { render, fireEvent } from 'tests/utils'
 
 describe('<OfferCategoryChoices />', () => {
@@ -10,16 +11,17 @@ describe('<OfferCategoryChoices />', () => {
 
     expect(renderAPI).toMatchSnapshot()
   })
+
   it('should call onChange with proper offer types when toggling', () => {
     const onChange = jest.fn()
     const renderAPI = render(<OfferTypeChoices onChange={onChange} />)
-    fireEvent.press(renderAPI.getByText('Offre numérique'))
+    fireEvent.press(renderAPI.getByText(OfferType.DIGITAL))
     expect(onChange).toHaveBeenNthCalledWith(1, { isDigital: true, isEvent: false, isThing: false })
-    fireEvent.press(renderAPI.getByText('Sortie'))
+    fireEvent.press(renderAPI.getByText(OfferType.EVENT))
     expect(onChange).toHaveBeenNthCalledWith(2, { isDigital: true, isEvent: true, isThing: false })
-    fireEvent.press(renderAPI.getByText('Offre physique'))
+    fireEvent.press(renderAPI.getByText(OfferType.THING))
     expect(onChange).toHaveBeenNthCalledWith(3, { isDigital: true, isEvent: true, isThing: true })
-    fireEvent.press(renderAPI.getByText('Offre physique'))
+    fireEvent.press(renderAPI.getByText(OfferType.THING))
     expect(onChange).toHaveBeenNthCalledWith(4, { isDigital: true, isEvent: true, isThing: false })
   })
 })

--- a/src/features/search/pages/OfferTypeModal.tsx
+++ b/src/features/search/pages/OfferTypeModal.tsx
@@ -8,16 +8,14 @@ import { v4 as uuidv4 } from 'uuid'
 import { FilterSwitchWithLabel } from 'features/search/components/FilterSwitchWithLabel'
 import { SearchCustomModalHeader } from 'features/search/components/SearchCustomModalHeader'
 import { SearchFixedModalBottom } from 'features/search/components/SearchFixedModalBottom'
+import { OfferType } from 'features/search/enums'
 import { useSearch } from 'features/search/pages/SearchWrapper'
+import { OFFER_TYPES } from 'features/search/sections/OfferType'
 import { Form } from 'ui/components/Form'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { ModalSpacing } from 'ui/components/modals/enum'
 import { RadioButton } from 'ui/components/radioButtons/RadioButton'
 import { Separator } from 'ui/components/Separator'
-import { Numeric } from 'ui/svg/icons/bicolor/Numeric'
-import { Show } from 'ui/svg/icons/bicolor/Show'
-import { Thing } from 'ui/svg/icons/bicolor/Thing'
-import { BicolorLogo } from 'ui/svg/icons/BicolorLogo'
 import { Close } from 'ui/svg/icons/Close'
 import { Spacer } from 'ui/theme'
 
@@ -35,14 +33,6 @@ type Props = {
 
 const titleId = uuidv4()
 
-// TODO(alexis1993): rename to OFFER_TYPES when PC-17489 is merged
-export const RADIO_BUTTON_ITEMS = [
-  { label: 'Tous les types', icon: BicolorLogo },
-  { label: 'Numérique', icon: Numeric },
-  { label: 'Sorties', icon: Show },
-  { label: 'Bien physiques', icon: Thing },
-]
-
 const DEFAULT_HEIGHT_MODAL = 500
 
 export const OfferTypeModal: FunctionComponent<Props> = ({
@@ -52,7 +42,7 @@ export const OfferTypeModal: FunctionComponent<Props> = ({
   hideModal,
 }) => {
   const [heightModal, setHeightModal] = useState(DEFAULT_HEIGHT_MODAL)
-  const [radioButtonChoice, setRadioButtonChoice] = useState('Tous les types')
+  const [radioButtonChoice, setRadioButtonChoice] = useState(OfferType.ALL_TYPE)
   const { searchState } = useSearch()
   const { isDesktopViewport } = useTheme()
 
@@ -124,7 +114,7 @@ export const OfferTypeModal: FunctionComponent<Props> = ({
         onContentSizeChange={onContentSizeChange}>
         <Form.MaxWidth>
           <React.Fragment>
-            {RADIO_BUTTON_ITEMS.map(({ label, icon }) => (
+            {OFFER_TYPES.map(({ label, icon }) => (
               <View key={label}>
                 <RadioButton
                   onSelect={() => setRadioButtonChoice(label)}

--- a/src/features/search/pages/__tests__/OfferTypeModal.native.test.tsx
+++ b/src/features/search/pages/__tests__/OfferTypeModal.native.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 
-import { OfferTypeModal, RADIO_BUTTON_ITEMS } from 'features/search/pages/OfferTypeModal'
+import { OfferType } from 'features/search/enums'
+import { OfferTypeModal } from 'features/search/pages/OfferTypeModal'
 import { initialSearchState } from 'features/search/pages/reducer'
+import { OFFER_TYPES } from 'features/search/sections/OfferType'
 import { fireEvent, render } from 'tests/utils'
 
 const mockSearchState = initialSearchState
@@ -68,7 +70,7 @@ describe('OfferTypeModal component', () => {
     })
 
     it.each(
-      RADIO_BUTTON_ITEMS.filter((item) => item.label !== 'Tous les types').map(({ label }) => label)
+      OFFER_TYPES.filter((item) => item.label !== OfferType.ALL_TYPE).map(({ label }) => label)
     )(`should activate %s on press`, (label) => {
       const renderAPI = renderOfferTypeModal({
         hideOfferTypeModal,

--- a/src/features/search/sections/OfferType.tsx
+++ b/src/features/search/sections/OfferType.tsx
@@ -1,25 +1,33 @@
-import { t } from '@lingui/macro'
 import React from 'react'
 import styled from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
 
 import { SelectionLabel, TitleWithCount } from 'features/search/atoms'
+import { OfferType as OfferTypeEnum } from 'features/search/enums'
 import { useStagedSearch } from 'features/search/pages/SearchWrapper'
 import { SectionTitle } from 'features/search/sections/titles'
-import { SearchState } from 'features/search/types'
+import { OfferTypes } from 'features/search/types'
 import { useLogFilterOnce } from 'features/search/utils/useLogFilterOnce'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { AccordionItem } from 'ui/components/AccordionItem'
 import { Li } from 'ui/components/Li'
 import { Ul } from 'ui/components/Ul'
+import { Numeric } from 'ui/svg/icons/bicolor/Numeric'
+import { Show } from 'ui/svg/icons/bicolor/Show'
+import { Thing } from 'ui/svg/icons/bicolor/Thing'
+import { BicolorLogo } from 'ui/svg/icons/BicolorLogo'
+import { AccessibleBicolorIconInterface } from 'ui/svg/icons/types'
 import { getSpacing } from 'ui/theme'
 
-type OfferTypes = keyof SearchState['offerTypes']
-
-export const OFFER_TYPES: Array<[OfferTypes, string]> = [
-  ['isDigital', t`Offre numérique`],
-  ['isEvent', t`Sortie`],
-  ['isThing', t`Offre physique`],
+export const OFFER_TYPES: Array<{
+  type?: OfferTypes
+  icon: React.FC<AccessibleBicolorIconInterface>
+  label: OfferTypeEnum
+}> = [
+  { label: OfferTypeEnum.ALL_TYPE, icon: BicolorLogo },
+  { type: 'isDigital', label: OfferTypeEnum.DIGITAL, icon: Numeric },
+  { type: 'isEvent', label: OfferTypeEnum.EVENT, icon: Show },
+  { type: 'isThing', label: OfferTypeEnum.THING, icon: Thing },
 ]
 
 export const OfferType: React.FC = () => {
@@ -47,12 +55,12 @@ export const OfferType: React.FC = () => {
       accessibilityTitle={SectionTitle.OfferType}>
       <BodyContainer aria-labelledby={titleID} accessibilityRole={AccessibilityRole.GROUP}>
         <StyledUl>
-          {OFFER_TYPES.map(([offerType, label]) => (
+          {OFFER_TYPES.filter(({ type }) => type).map(({ type, label }) => (
             <Li key={label}>
               <SelectionLabel
                 label={label}
-                selected={offerTypes[offerType]}
-                onPress={onPress(offerType)}
+                selected={offerTypes[type as OfferTypes]}
+                onPress={onPress(type as OfferTypes)}
               />
             </Li>
           ))}

--- a/src/features/search/sections/tests/OfferType.native.test.tsx
+++ b/src/features/search/sections/tests/OfferType.native.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 
+import { OfferType as OfferTypeEnum } from 'features/search/enums'
 import { initialSearchState } from 'features/search/pages/reducer'
 import { fireEvent, render } from 'tests/utils'
 
-import { OfferType, OFFER_TYPES } from '../OfferType'
+import { OFFER_TYPES, OfferType } from '../OfferType'
 
 let mockSearchState = initialSearchState
 const mockStagedDispatch = jest.fn()
@@ -18,13 +19,13 @@ jest.mock('features/search/pages/SearchWrapper', () => ({
 describe('OfferType component', () => {
   it('should render all offer types', () => {
     const { queryByText } = render(<OfferType />)
-    OFFER_TYPES.forEach(([, label]) => {
+    OFFER_TYPES.filter(({ type }) => type).forEach(({ label }) => {
       expect(queryByText(label)).toBeTruthy()
     })
   })
   it('should dispatch OFFER_TYPE with correct offerType', () => {
     const { getByText } = render(<OfferType />)
-    fireEvent.press(getByText('Offre numérique'))
+    fireEvent.press(getByText(OfferTypeEnum.DIGITAL))
     expect(mockStagedDispatch).toHaveBeenCalledWith({
       type: 'OFFER_TYPE',
       payload: 'isDigital',

--- a/src/features/search/sections/tests/analytics.native.test.tsx
+++ b/src/features/search/sections/tests/analytics.native.test.tsx
@@ -2,6 +2,7 @@ import mockdate from 'mockdate'
 import React from 'react'
 import { ReactTestInstance } from 'react-test-renderer'
 
+import { OfferType } from 'features/search/enums'
 import { DATE_FILTER_OPTIONS } from 'features/search/enums'
 import { initialSearchState } from 'features/search/pages/reducer'
 import Section from 'features/search/sections'
@@ -54,8 +55,8 @@ describe('Analytics - logUseFilter', () => {
   })
   it('should log UseFilter once when selecting multiple offer types', () => {
     const { getByText } = render(<Section.OfferType />)
-    fireEvent.press(getByText('Offre numérique'))
-    fireEvent.press(getByText('Offre physique'))
+    fireEvent.press(getByText(OfferType.DIGITAL))
+    fireEvent.press(getByText(OfferType.THING))
     expect(analytics.logUseFilter).toHaveBeenCalledWith(SectionTitle.OfferType)
     expect(analytics.logUseFilter).toHaveBeenCalledTimes(1)
   })

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -49,3 +49,5 @@ export interface SearchState {
   minPrice?: string
   maxPrice?: string
 }
+
+export type OfferTypes = keyof SearchState['offerTypes']

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -743,15 +743,10 @@ msgstr "Offre digitale"
 msgid "Offre expirée"
 msgstr "Offre expirée"
 
-#: src/features/search/sections/OfferType.tsx
 #: src/libs/parsers/venueType.ts
 #: src/libs/parsers/venueType.ts
 msgid "Offre numérique"
 msgstr "Offre numérique"
-
-#: src/features/search/sections/OfferType.tsx
-msgid "Offre physique"
-msgstr "Offre physique"
 
 #: src/features/favorites/atoms/BookingButton.tsx
 #: src/features/favorites/atoms/BookingButton.tsx
@@ -1095,10 +1090,6 @@ msgstr "Signaler l'offre"
 #: src/ui/components/contact/ContactBlock.tsx
 msgid "Site internet"
 msgstr "Site internet"
-
-#: src/features/search/sections/OfferType.tsx
-msgid "Sortie"
-msgstr "Sortie"
 
 #: src/libs/parsers/venueType.ts
 #: src/libs/parsers/venueType.ts


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17485

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
