### PR TITLE
(PC-17486) fix(searchV2): display duo offer when user is benificiary

### DIFF
--- a/src/features/search/components/__tests__/SearchResults.native.test.tsx
+++ b/src/features/search/components/__tests__/SearchResults.native.test.tsx
@@ -197,23 +197,6 @@ describe('SearchResults component', () => {
     expect(isInverseLayout).toBeFalsy()
   })
 
-  it('should open for desktop the type filter modal when clicking on the type filter button', async () => {
-    const { getByTestId } = render(<SearchResults />, {
-      theme: {
-        isDesktopViewport: true,
-      },
-    })
-    const typeButton = getByTestId('typeButton')
-
-    await act(async () => {
-      fireEvent.press(typeButton)
-    })
-
-    const isInverseLayout = getByTestId('inverseLayout')
-
-    expect(isInverseLayout).toBeTruthy()
-  })
-
   it.each`
     type               | params
     ${'duo offer'}     | ${{ offerIsDuo: true }}

--- a/src/features/search/pages/OfferTypeModal.tsx
+++ b/src/features/search/pages/OfferTypeModal.tsx
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { useUserProfileInfo } from 'features/profile/api'
 import { FilterSwitchWithLabel } from 'features/search/components/FilterSwitchWithLabel'
 import { SearchCustomModalHeader } from 'features/search/components/SearchCustomModalHeader'
 import { SearchFixedModalBottom } from 'features/search/components/SearchFixedModalBottom'
@@ -51,6 +52,7 @@ export const OfferTypeModal: FunctionComponent<Props> = ({
   const logUseFilter = useLogFilterOnce(SectionTitle.OfferType)
   const [heightModal, setHeightModal] = useState(DEFAULT_HEIGHT_MODAL)
   const { searchState } = useSearch()
+  const { data: user } = useUserProfileInfo()
   const [offerTypes, setOfferTypes] = useState(searchState.offerTypes)
   const { isDesktopViewport } = useTheme()
   const { navigate } = useNavigation<UseNavigationType>()
@@ -112,6 +114,8 @@ export const OfferTypeModal: FunctionComponent<Props> = ({
     return entry ? entry[0] : undefined
   }, [offerTypes])
 
+  const hasDisplayDuoOffer = !!user?.isBeneficiary && !!user?.domainsCredit?.all?.remaining
+
   return (
     <AppModal
       visible={isVisible}
@@ -168,21 +172,23 @@ export const OfferTypeModal: FunctionComponent<Props> = ({
           <Spacer.Column numberOfSpaces={6} />
           <Separator />
           <Spacer.Column numberOfSpaces={6} />
-          <Controller
-            control={control}
-            name="offerIsDuo"
-            render={({ field: { value } }) => (
-              <React.Fragment>
-                <FilterSwitchWithLabel
-                  isActive={value}
-                  toggle={toggleLimitDuoOfferSearch}
-                  label="Uniquement les offres duo"
-                  testID="limitDuoOfferSearch"
-                />
-                <Spacer.Column numberOfSpaces={6} />
-              </React.Fragment>
-            )}
-          />
+          {!!hasDisplayDuoOffer && (
+            <Controller
+              control={control}
+              name="offerIsDuo"
+              render={({ field: { value } }) => (
+                <React.Fragment>
+                  <FilterSwitchWithLabel
+                    isActive={value}
+                    toggle={toggleLimitDuoOfferSearch}
+                    label="Uniquement les offres duo"
+                    testID="limitDuoOfferSearch"
+                  />
+                  <Spacer.Column numberOfSpaces={6} />
+                </React.Fragment>
+              )}
+            />
+          )}
         </Form.MaxWidth>
       </StyledScrollView>
     </AppModal>

--- a/src/features/search/sections/tests/OfferType.native.test.tsx
+++ b/src/features/search/sections/tests/OfferType.native.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { OfferType as OfferTypeEnum } from 'features/search/enums'
 import { initialSearchState } from 'features/search/pages/reducer'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render } from 'tests/utils'
 
 import { OfferType } from '../OfferType'
@@ -16,7 +17,7 @@ jest.mock('features/search/pages/SearchWrapper', () => ({
 
 describe('OfferType component', () => {
   it('should have no description when no selection', () => {
-    const { queryByText } = render(<OfferType />)
+    const { queryByText } = renderOfferType()
     expect(queryByText("Type d'offre")).toBeTruthy()
     expect(queryByText(OfferTypeEnum.EVENT)).toBeFalsy()
     expect(queryByText(`${OfferTypeEnum.EVENT} DUO`)).toBeFalsy()
@@ -35,7 +36,7 @@ describe('OfferType component', () => {
         },
       },
     })
-    const { queryByText } = render(<OfferType />)
+    const { queryByText } = renderOfferType()
     expect(queryByText(OfferTypeEnum.EVENT)).toBeTruthy()
     expect(queryByText(`${OfferTypeEnum.EVENT} DUO`)).toBeFalsy()
     expect(queryByText(OfferTypeEnum.THING)).toBeFalsy()
@@ -53,7 +54,7 @@ describe('OfferType component', () => {
         },
       },
     })
-    const { queryByText } = render(<OfferType />)
+    const { queryByText } = renderOfferType()
     expect(queryByText(OfferTypeEnum.EVENT)).toBeFalsy()
     expect(queryByText(`${OfferTypeEnum.EVENT} DUO`)).toBeTruthy()
     expect(queryByText(OfferTypeEnum.THING)).toBeFalsy()
@@ -71,7 +72,7 @@ describe('OfferType component', () => {
         },
       },
     })
-    const { queryByText } = render(<OfferType />)
+    const { queryByText } = renderOfferType()
     expect(queryByText(OfferTypeEnum.EVENT)).toBeFalsy()
     expect(queryByText(`${OfferTypeEnum.EVENT} DUO`)).toBeFalsy()
     expect(queryByText(OfferTypeEnum.THING)).toBeTruthy()
@@ -89,10 +90,15 @@ describe('OfferType component', () => {
         },
       },
     })
-    const { queryByText } = render(<OfferType />)
+    const { queryByText } = renderOfferType()
     expect(queryByText(OfferTypeEnum.EVENT)).toBeFalsy()
     expect(queryByText(`${OfferTypeEnum.EVENT} DUO`)).toBeFalsy()
     expect(queryByText(OfferTypeEnum.THING)).toBeFalsy()
     expect(queryByText(OfferTypeEnum.DIGITAL)).toBeTruthy()
   })
 })
+
+function renderOfferType() {
+  // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+  return render(reactQueryProviderHOC(<OfferType />))
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17486

## Checklist

I have:

- [x] Made sure the title of my PR follows the [convention](1) `($jira) $type($scope): $summary`.
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets.
- [ ] Added new reusable components to **AppComponents** page and communicate to the team on slack.
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](2)

## Screenshots

| iOS | Android | Mobile - Chrome | Desktop - Chrome | Desktop - Safari |
| --: | ------: | --------------: | ---------------: | ---------------: |
|     |         |                 |                  |                  |

[1]: https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/standards/pr-title.md
[2]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
