### PR TITLE
(PC-17482) fix(FilterSwitch): show checked icon when not disabled and active

### DIFF
--- a/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
@@ -684,7 +684,16 @@ exports[`Profile component should render correctly 1`] = `
                                       "width": 28,
                                     }
                                   }
-                                />
+                                >
+                                  <View
+                                    height={16}
+                                    width={16}
+                                  >
+                                    <Text>
+                                      undefined-SVG-Mock
+                                    </Text>
+                                  </View>
+                                </View>
                               </View>
                             </View>
                           </View>

--- a/src/ui/components/FilterSwitch.tsx
+++ b/src/ui/components/FilterSwitch.tsx
@@ -6,6 +6,7 @@ import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { HiddenAccessibleText } from 'ui/components/HiddenAccessibleText'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { useSpaceBarAction } from 'ui/hooks/useSpaceBarAction'
+import { Check as CheckIcon } from 'ui/svg/icons/Check'
 import { Lock as LockIcon } from 'ui/svg/icons/Lock'
 import { getShadow, getSpacing } from 'ui/theme'
 import { HiddenCheckbox } from 'ui/web/inputs/HiddenCheckbox'
@@ -66,6 +67,7 @@ const FilterSwitch: FunctionComponent<FilterSwitchProps> = (props) => {
         <StyledBackgroundColor active={active}>
           <StyledToggle style={{ marginLeft }} disabled={disabled}>
             {!!disabled && <Lock />}
+            {!!active && !disabled ? <Check /> : null}
           </StyledToggle>
         </StyledBackgroundColor>
       </TouchableOpacity>
@@ -116,6 +118,12 @@ const Lock = styled(LockIcon).attrs(({ theme }) => ({
   color: theme.colors.greyDark,
   size: theme.icons.sizes.extraSmall,
   accessibilityLabel: 'Désactivé',
+}))``
+
+const Check = styled(CheckIcon).attrs(({ theme }) => ({
+  color: theme.colors.greenValid,
+  size: theme.icons.sizes.extraSmall,
+  accessibilityLabel: 'Activé',
 }))``
 
 const propsAreEqual = (


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17482

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |  ![image](https://user-images.githubusercontent.com/77674046/193562347-a5204a6e-d466-4518-986e-95dabf3e9e6c.png)
      |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
