### PR TITLE
(PC-17516) fix(Notifications): fix illustration size on modal

### DIFF
--- a/src/features/notifications/askNotificationsModal/components/AskNotificationsModal.tsx
+++ b/src/features/notifications/askNotificationsModal/components/AskNotificationsModal.tsx
@@ -2,7 +2,6 @@ import React, { FunctionComponent, useCallback } from 'react'
 import styled from 'styled-components/native'
 
 import { analytics } from 'libs/firebase/analytics'
-import { theme } from 'theme'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { AppInformationModal } from 'ui/components/modals/AppInformationModal'
 import { BicolorRingingBell } from 'ui/svg/BicolorRingingBell'
@@ -31,7 +30,7 @@ export const AskNotificiationsModal: FunctionComponent<Props> = ({ visible, onHi
       onCloseIconPress={dismissNotifications}
       visible={visible}>
       <Spacer.Column numberOfSpaces={4} />
-      <BicolorRingingBell size={theme.illustrations.sizes.fullPage} />
+      <RingingBell />
       <Spacer.Column numberOfSpaces={4} />
       <StyledBody>
         Offres personnalisées, invitations spéciales, concours...
@@ -47,3 +46,7 @@ export const AskNotificiationsModal: FunctionComponent<Props> = ({ visible, onHi
 const StyledBody = styled(Typo.Body)({
   textAlign: 'center',
 })
+
+const RingingBell = styled(BicolorRingingBell).attrs(({ theme }) => ({
+  size: theme.illustrations.sizes.fullPage,
+}))``

--- a/src/features/notifications/askNotificationsModal/components/AskNotificationsModal.tsx
+++ b/src/features/notifications/askNotificationsModal/components/AskNotificationsModal.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent, useCallback } from 'react'
 import styled from 'styled-components/native'
 
 import { analytics } from 'libs/firebase/analytics'
+import { theme } from 'theme'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { AppInformationModal } from 'ui/components/modals/AppInformationModal'
 import { BicolorRingingBell } from 'ui/svg/BicolorRingingBell'
@@ -30,7 +31,7 @@ export const AskNotificiationsModal: FunctionComponent<Props> = ({ visible, onHi
       onCloseIconPress={dismissNotifications}
       visible={visible}>
       <Spacer.Column numberOfSpaces={4} />
-      <BicolorRingingBell />
+      <BicolorRingingBell size={theme.illustrations.sizes.fullPage} />
       <Spacer.Column numberOfSpaces={4} />
       <StyledBody>
         Offres personnalisées, invitations spéciales, concours...


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17516

## Checklist

I have:

- [X] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |<img width="333" alt="image" src="https://user-images.githubusercontent.com/68000368/194509119-868f0fe7-d508-4f02-a91b-95ecb1095ff2.png">| <img width="328" alt="image" src="https://user-images.githubusercontent.com/68000368/194508952-d67dc591-6e00-4c9f-b79b-91bdf477443c.png">|
| Android          |<img width="403" alt="image" src="https://user-images.githubusercontent.com/68000368/194509169-7f7ef14e-472f-41ef-8018-156047002ed1.png">|<img width="406" alt="image" src="https://user-images.githubusercontent.com/68000368/194508350-15473bf6-6ba5-4247-9236-34b037238fd5.png">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
