### PR TITLE
(PC-17865) fix(Search): fix iOS modal not opening

### DIFF
--- a/src/features/search/pages/LocationModal.tsx
+++ b/src/features/search/pages/LocationModal.tsx
@@ -18,10 +18,12 @@ import { SearchState, SearchView } from 'features/search/types'
 import { useLogFilterOnce } from 'features/search/utils/useLogFilterOnce'
 import { analytics } from 'libs/firebase/analytics'
 import { GeolocPermissionState, useGeolocation } from 'libs/geolocation'
+import { GeolocationActivationModal } from 'libs/geolocation/components/GeolocationActivationModal'
 import { Form } from 'ui/components/Form'
 import { InputError } from 'ui/components/inputs/InputError'
 import { Slider } from 'ui/components/inputs/Slider'
 import { AppModal } from 'ui/components/modals/AppModal'
+import { useModal } from 'ui/components/modals/useModal'
 import { RadioButton } from 'ui/components/radioButtons/RadioButton'
 import { Separator } from 'ui/components/Separator'
 import { BicolorAroundMe as AroundMe } from 'ui/svg/icons/BicolorAroundMe'
@@ -71,8 +73,14 @@ export const LocationModal: FunctionComponent<Props> = ({
     positionError,
     permissionState,
     requestGeolocPermission,
-    showGeolocPermissionModal,
+    onPressGeolocPermissionModalButton,
   } = useGeolocation()
+
+  const {
+    showModal: showGeolocPermissionModal,
+    hideModal: hideGeolocPermissionModal,
+    visible: isGeolocPermissionModalVisible,
+  } = useModal(false)
   const logChangeRadius = useLogFilterOnce(SectionTitle.Radius)
 
   const getLocationChoice = useCallback(() => {
@@ -284,6 +292,11 @@ export const LocationModal: FunctionComponent<Props> = ({
                 visible={!!positionError}
                 messageId={positionError?.message}
                 numberOfSpacesTop={1}
+              />
+              <GeolocationActivationModal
+                isGeolocPermissionModalVisible={isGeolocPermissionModalVisible}
+                hideGeolocPermissionModal={hideGeolocPermissionModal}
+                onPressGeolocPermissionModalButton={onPressGeolocPermissionModalButton}
               />
             </React.Fragment>
           )}

--- a/src/libs/geolocation/GeolocationWrapper.tsx
+++ b/src/libs/geolocation/GeolocationWrapper.tsx
@@ -26,6 +26,7 @@ const GeolocationContext = React.createContext<IGeolocationContext>({
   },
   triggerPositionUpdate: () => null,
   showGeolocPermissionModal: () => null,
+  onPressGeolocPermissionModalButton: () => null,
 })
 
 export const GeolocationWrapper = memo(function GeolocationWrapper({
@@ -117,10 +118,10 @@ export const GeolocationWrapper = memo(function GeolocationWrapper({
 
   useAppStateChange(contextualCheckPermission, undefined, [])
 
-  function onPressGeolocPermissionModalButton() {
+  const onPressGeolocPermissionModalButton = useCallback(() => {
     Linking.openSettings()
     hideGeolocPermissionModal()
-  }
+  }, [hideGeolocPermissionModal])
 
   const value = useMemo(
     () => ({
@@ -130,6 +131,7 @@ export const GeolocationWrapper = memo(function GeolocationWrapper({
       requestGeolocPermission: contextualRequestGeolocPermission,
       triggerPositionUpdate,
       showGeolocPermissionModal,
+      onPressGeolocPermissionModalButton,
     }),
     [
       contextualRequestGeolocPermission,
@@ -138,6 +140,7 @@ export const GeolocationWrapper = memo(function GeolocationWrapper({
       positionError,
       showGeolocPermissionModal,
       triggerPositionUpdate,
+      onPressGeolocPermissionModalButton,
     ]
   )
   return (

--- a/src/libs/geolocation/__mocks__/index.ts
+++ b/src/libs/geolocation/__mocks__/index.ts
@@ -10,6 +10,7 @@ export type { GeoCoordinates, GeolocationError, IGeolocationContext } from '../t
 export const requestGeolocPermission = jest.fn()
 export const triggerPositionUpdate = jest.fn()
 export const showGeolocPermissionModal = jest.fn()
+export const onPressGeolocPermissionModalButton = jest.fn()
 
 const geolocationContext: IGeolocationContext = {
   position: { longitude: 90, latitude: 90 },
@@ -18,6 +19,7 @@ const geolocationContext: IGeolocationContext = {
   requestGeolocPermission,
   triggerPositionUpdate,
   showGeolocPermissionModal,
+  onPressGeolocPermissionModalButton,
 }
 
 export const useGeolocation = jest.fn().mockReturnValue(geolocationContext)

--- a/src/libs/geolocation/types.ts
+++ b/src/libs/geolocation/types.ts
@@ -25,4 +25,5 @@ export type IGeolocationContext = {
   requestGeolocPermission: (params?: RequestGeolocPermissionParams) => Promise<void>
   triggerPositionUpdate: () => void
   showGeolocPermissionModal: () => void
+  onPressGeolocPermissionModalButton: () => void
 }

--- a/src/ui/components/modals/AppModal.tsx
+++ b/src/ui/components/modals/AppModal.tsx
@@ -35,7 +35,7 @@ type Props = {
   shouldScrollToEnd?: boolean
 } & ModalIconProps
 
-// Without this, the margin is recomputed with arbitraty values
+// Without this, the margin is recomputed with arbitrary values
 const modalStyles = { margin: 'auto' }
 
 const DESKTOP_FULLSCREEN_RATIO = 0.75


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17865

Tried portal and nested modal

Nested modal requires no lib but to have twice the modal rendered, which is not a problem since it was already available as a component.

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |    ![image](https://user-images.githubusercontent.com/77674046/195380172-caabd29a-9cb4-4dae-a227-652adb2ac0ec.png)   |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |   ![image](https://user-images.githubusercontent.com/77674046/195380325-d01aad00-ff1b-44c0-b7ad-b48e4b7f34da.png)    |
| Desktop - Safari |        |       |



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
