### PR TITLE
(PC-17491) feat(IntroDMS): add tracker to DMS nav button press (#3748)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -530,7 +530,6 @@ jobs:
           steps:
             - notify-slack:
                 channel: shérif
-      - sonarcloud-scanner
 
   test-web:
     executor: node
@@ -546,6 +545,7 @@ jobs:
           steps:
             - notify-slack:
                 channel: shérif
+      - sonarcloud-scanner
 
   notify-hard-testing-release:
     executor: node
@@ -983,7 +983,9 @@ workflows:
           filters:
             tags:
               only: /.*/
-          context: Slack
+          context:
+            - SonarCloud
+            - Slack
       - deploy-soft-testing:
           filters:
             branches:

--- a/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DMSIntroduction should render foreign version correctly 1`] = `
+exports[`DMSIntroduction foreign version should render correctly 1`] = `
 Array [
   <View
     accessibilityRole="button"
@@ -536,7 +536,7 @@ Array [
 ]
 `;
 
-exports[`DMSIntroduction should render french version correctly 1`] = `
+exports[`DMSIntroduction french version should render correctly 1`] = `
 Array [
   <View
     accessibilityRole="button"

--- a/src/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx
@@ -4,56 +4,79 @@ import { useRoute } from '__mocks__/@react-navigation/native'
 import { DMSIntroduction } from 'features/identityCheck/pages/identification/dms/DMSIntroduction'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { env } from 'libs/environment'
-import { fireEvent, render } from 'tests/utils'
+import { analytics } from 'libs/firebase/analytics'
+import { fireEvent, render, waitFor } from 'tests/utils'
 
 const openUrl = jest.spyOn(NavigationHelpers, 'openUrl')
 
 describe('DMSIntroduction', () => {
-  it('should render french version correctly', () => {
-    useRoute.mockReturnValueOnce({
-      params: {
-        isForeignDMSInformation: false,
-      },
+  describe('french version', () => {
+    beforeEach(() => {
+      useRoute.mockReturnValueOnce({
+        params: {
+          isForeignDMSInformation: false,
+        },
+      })
     })
-    const DMSIntroductionFR = render(<DMSIntroduction />)
-    expect(DMSIntroductionFR).toMatchSnapshot()
+
+    it('should render correctly', () => {
+      const DMSIntroductionFR = render(<DMSIntroduction />)
+      expect(DMSIntroductionFR).toMatchSnapshot()
+    })
+
+    it('should open french dms link when pressing "Aller sur demarches-simplifiees.fr" button', async () => {
+      const { getByText } = render(<DMSIntroduction />)
+      const button = getByText('Aller sur demarches-simplifiees.fr')
+
+      fireEvent.press(button)
+
+      await waitFor(() => {
+        expect(openUrl).toHaveBeenCalledWith(env.DMS_FRENCH_CITIZEN_URL, undefined)
+      })
+    })
+
+    it('should log french DMS event when pressing "Aller sur demarches-simplifiees.fr" button', () => {
+      const { getByText } = render(<DMSIntroduction />)
+
+      const button = getByText('Aller sur demarches-simplifiees.fr')
+      fireEvent.press(button)
+
+      expect(analytics.logOpenDMSFrenchCitizenURL).toHaveBeenCalled()
+    })
   })
 
-  it('should render foreign version correctly', () => {
-    useRoute.mockReturnValueOnce({
-      params: {
-        isForeignDMSInformation: true,
-      },
+  describe('foreign version', () => {
+    beforeEach(() => {
+      useRoute.mockReturnValueOnce({
+        params: {
+          isForeignDMSInformation: true,
+        },
+      })
     })
-    const DMSIntroductionFR = render(<DMSIntroduction />)
-    expect(DMSIntroductionFR).toMatchSnapshot()
-  })
 
-  it('should open foreign dms link on press "Aller sur demarches-simplifiees.fr" when foreign route param is true', () => {
-    useRoute.mockReturnValueOnce({
-      params: {
-        isForeignDMSInformation: true,
-      },
+    it('should render correctly', () => {
+      const DMSIntroductionFR = render(<DMSIntroduction />)
+      expect(DMSIntroductionFR).toMatchSnapshot()
     })
-    const { getByText } = render(<DMSIntroduction />)
-    const button = getByText('Aller sur demarches-simplifiees.fr')
 
-    fireEvent.press(button)
+    it('should open foreign dms link when pressing "Aller sur demarches-simplifiees.fr" button', async () => {
+      const { getByText } = render(<DMSIntroduction />)
+      const button = getByText('Aller sur demarches-simplifiees.fr')
 
-    expect(openUrl).toHaveBeenCalledWith(env.DMS_FOREIGN_CITIZEN_URL, undefined)
-  })
+      fireEvent.press(button)
 
-  it('should open french dms link on press "Aller sur demarches-simplifiees.fr" when foreign route param is false', () => {
-    useRoute.mockReturnValueOnce({
-      params: {
-        isForeignDMSInformation: false,
-      },
+      await waitFor(() => {
+        expect(openUrl).toHaveBeenCalledWith(env.DMS_FOREIGN_CITIZEN_URL, undefined)
+      })
     })
-    const { getByText } = render(<DMSIntroduction />)
-    const button = getByText('Aller sur demarches-simplifiees.fr')
 
-    fireEvent.press(button)
+    it('should log foreign DMS event when pressing "Aller sur demarches-simplifiees.fr" button', () => {
+      const { getByText } = render(<DMSIntroduction />)
 
-    expect(openUrl).toHaveBeenCalledWith(env.DMS_FRENCH_CITIZEN_URL, undefined)
+      const button = getByText('Aller sur demarches-simplifiees.fr')
+      fireEvent.press(button)
+
+      expect(analytics.logOpenDMSForeignCitizenURL).toHaveBeenCalled()
+    })
   })
 })

--- a/src/features/identityCheck/pages/identification/dms/DMSIntroduction.tsx
+++ b/src/features/identityCheck/pages/identification/dms/DMSIntroduction.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 
 import { UseRouteType } from 'features/navigation/RootNavigator'
 import { env } from 'libs/environment'
+import { analytics } from 'libs/firebase/analytics'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { InformationWithIcon } from 'ui/components/InformationWithIcon'
 import { Li } from 'ui/components/Li'
@@ -43,9 +44,15 @@ export const DMSIntroduction = (): JSX.Element => {
           { icon: BicolorProfile, label: selfieLabel },
         ]
 
-  const DMSUrl = params.isForeignDMSInformation
-    ? env.DMS_FOREIGN_CITIZEN_URL
-    : env.DMS_FRENCH_CITIZEN_URL
+  const toDMSWebsiteButtonProps = params?.isForeignDMSInformation
+    ? {
+        externalNav: { url: env.DMS_FOREIGN_CITIZEN_URL },
+        onBeforeNavigate: analytics.logOpenDMSForeignCitizenURL,
+      }
+    : {
+        externalNav: { url: env.DMS_FRENCH_CITIZEN_URL },
+        onBeforeNavigate: analytics.logOpenDMSFrenchCitizenURL,
+      }
 
   return (
     <GenericInfoPageWhite
@@ -72,9 +79,7 @@ export const DMSIntroduction = (): JSX.Element => {
           wording="Aller sur demarches-simplifiees.fr"
           icon={ExternalSite}
           as={ButtonPrimary}
-          externalNav={{
-            url: DMSUrl,
-          }}
+          {...toDMSWebsiteButtonProps}
         />
       </LinkContainer>
     </GenericInfoPageWhite>


### PR DESCRIPTION
* feat: add tracker to DMS nav button press

* refactor: split tests in two describes() one for the french version, one for the foreign version

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
