### PR TITLE
(PC-17895) fix(ubbleFlow): fix navigation from ubble webview to identity check end

### DIFF
--- a/src/features/identityCheck/pages/identification/ubble/UbbleWebview.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/UbbleWebview.tsx
@@ -1,12 +1,13 @@
+import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 import { WebView } from 'react-native-webview'
 import styled from 'styled-components/native'
 
 import { IdentityCheckMethod } from 'api/gen'
 import { REDIRECT_URL_UBBLE, useIdentificationUrl } from 'features/identityCheck/api/api'
-import { useIdentityCheckNavigation } from 'features/identityCheck/useIdentityCheckNavigation'
 import { parseUrlParams } from 'features/identityCheck/utils/parseUrlParams'
 import { navigateToHome } from 'features/navigation/helpers'
+import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { analytics } from 'libs/firebase/analytics'
 import { LoadingPage } from 'ui/components/LoadingPage'
 import { Spacer } from 'ui/theme'
@@ -16,7 +17,7 @@ const ORIGIN_WHITELIST = ['*']
 
 export const UbbleWebview: React.FC = () => {
   const identificationUrl = useIdentificationUrl()
-  const { navigateToNextScreen } = useIdentityCheckNavigation()
+  const { navigate } = useNavigation<UseNavigationType>()
 
   function onNavigationStateChange({ url }: { url: string }) {
     const parsedUrlParams = parseUrlParams(url)
@@ -31,7 +32,7 @@ export const UbbleWebview: React.FC = () => {
       navigateToHome()
     } else if (url.includes(REDIRECT_URL_UBBLE)) {
       analytics.logIdentityCheckSuccess({ method: IdentityCheckMethod.ubble })
-      navigateToNextScreen()
+      navigate('IdentityCheckEnd')
     }
   }
 

--- a/src/features/identityCheck/pages/identification/ubble/UbbleWebview.web.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/UbbleWebview.web.tsx
@@ -1,9 +1,10 @@
+import { useNavigation } from '@react-navigation/native'
 import React, { useEffect } from 'react'
 
 import { IdentityCheckMethod } from 'api/gen'
 import { REDIRECT_URL_UBBLE, useIdentificationUrl } from 'features/identityCheck/api/api'
-import { useIdentityCheckNavigation } from 'features/identityCheck/useIdentityCheckNavigation'
 import { navigateToHome } from 'features/navigation/helpers'
+import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { analytics } from 'libs/firebase/analytics'
 import { Helmet } from 'libs/react-helmet/Helmet'
 import { LoadingPage } from 'ui/components/LoadingPage'
@@ -26,7 +27,7 @@ interface AbortEvent {
 // https://ubbleai.github.io/developer-documentation/#webview-integration
 export const UbbleWebview: React.FC = () => {
   const identificationUrl = useIdentificationUrl()
-  const { navigateToNextScreen } = useIdentityCheckNavigation()
+  const { navigate } = useNavigation<UseNavigationType>()
 
   useEffect(() => {
     if (!identificationUrl) return
@@ -40,7 +41,7 @@ export const UbbleWebview: React.FC = () => {
           onComplete({ redirectUrl }: CompleteEvent) {
             analytics.logIdentityCheckSuccess({ method: IdentityCheckMethod.ubble })
             ubbleIDV.destroy()
-            if (redirectUrl.includes(REDIRECT_URL_UBBLE)) navigateToNextScreen()
+            if (redirectUrl.includes(REDIRECT_URL_UBBLE)) navigate('IdentityCheckEnd')
           },
           onAbort({ redirectUrl, returnReason: reason }: AbortEvent) {
             analytics.logIdentityCheckAbort({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17895

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Description du bug
https://passcultureteam.slack.com/archives/C01APVCG22J/p1665751452342409
Après avoir complété le parcours ubble, avec le nouveau flux activé, la navigation de la webview vers la page "ta pièce d'identité a été transmise" plante et on se retrouve sur un écran blanc.
<img width="1257" alt="Capture d’écran 2022-10-14 à 16 33 33" src="https://user-images.githubusercontent.com/22886846/195872712-18a02e70-95bb-43bb-b0e6-f716ca0e6225.png">


Le fix consiste à **naviguer explicitement vers la page IdentityCheckEnd** plutôt que d'utiliser le hook useIdentityCheckNavigation qui se retrouve perdu avec le nouveau flux.

Des tests en local on montré que le fix corrige le nouveau flux, et ne casse pas l'ancien (j'ai oublié de faire un screenshot)


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
