### PR TITLE
(PC-17895) fix(ubbleFlow): navigate explicitly to stepper after identitycheck end

### DIFF
--- a/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.test.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { navigate } from '__mocks__/@react-navigation/native'
 import { NextSubscriptionStepResponse, SubscriptionStep } from 'api/gen'
 import { nextSubscriptionStepFixture as mockStep } from 'features/identityCheck/__mocks__/nextSubscriptionStepFixture'
 import { IdentityCheckEnd } from 'features/identityCheck/pages/identification/ubble/IdentityCheckEnd'
@@ -34,11 +35,11 @@ describe('<IdentityCheckEnd/>', () => {
     expect(renderAPI).toMatchSnapshot()
   })
 
-  it('should navigate to next screen after timeout if nextSubscriptionStep is not null', () => {
+  it('should navigate to stepper after timeout if nextSubscriptionStep is not null', () => {
     render(<IdentityCheckEnd />)
-    expect(mockNavigateToNextScreen).not.toHaveBeenCalled()
+    expect(navigate).not.toHaveBeenCalled()
     jest.advanceTimersByTime(3000)
-    expect(mockNavigateToNextScreen).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledWith('IdentityCheckStepper')
   })
 
   it('should navigate to home after timeout if nextSubscriptionStep is null', () => {

--- a/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.tsx
@@ -1,18 +1,21 @@
+import { useNavigation } from '@react-navigation/native'
 import React, { useEffect } from 'react'
 
 import { useNextSubscriptionStep } from 'features/auth/signup/useNextSubscriptionStep'
-import { useIdentityCheckNavigation } from 'features/identityCheck/useIdentityCheckNavigation'
 import { navigateToHome } from 'features/navigation/helpers'
+import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { EmailSent } from 'ui/svg/icons/EmailSent'
 
 export const IdentityCheckEnd = () => {
   const { data: subscription } = useNextSubscriptionStep()
-  const { navigateToNextScreen } = useIdentityCheckNavigation()
+  const { navigate } = useNavigation<UseNavigationType>()
+
+  const navigateToStepper = () => navigate('IdentityCheckStepper')
 
   useEffect(() => {
     const timeout = setTimeout(
-      !subscription?.nextSubscriptionStep ? navigateToHome : navigateToNextScreen,
+      !subscription?.nextSubscriptionStep ? navigateToHome : navigateToStepper,
       3000
     )
     return () => clearTimeout(timeout)

--- a/src/features/identityCheck/pages/identification/ubble/UbbleWebview.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/UbbleWebview.tsx
@@ -1,12 +1,13 @@
+import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 import { WebView } from 'react-native-webview'
 import styled from 'styled-components/native'
 
 import { IdentityCheckMethod } from 'api/gen'
 import { REDIRECT_URL_UBBLE, useIdentificationUrl } from 'features/identityCheck/api/api'
-import { useIdentityCheckNavigation } from 'features/identityCheck/useIdentityCheckNavigation'
 import { parseUrlParams } from 'features/identityCheck/utils/parseUrlParams'
 import { navigateToHome } from 'features/navigation/helpers'
+import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { analytics } from 'libs/firebase/analytics'
 import { LoadingPage } from 'ui/components/LoadingPage'
 import { Spacer } from 'ui/theme'
@@ -16,7 +17,7 @@ const ORIGIN_WHITELIST = ['*']
 
 export const UbbleWebview: React.FC = () => {
   const identificationUrl = useIdentificationUrl()
-  const { navigateToNextScreen } = useIdentityCheckNavigation()
+  const { navigate } = useNavigation<UseNavigationType>()
 
   function onNavigationStateChange({ url }: { url: string }) {
     const parsedUrlParams = parseUrlParams(url)
@@ -31,7 +32,7 @@ export const UbbleWebview: React.FC = () => {
       navigateToHome()
     } else if (url.includes(REDIRECT_URL_UBBLE)) {
       analytics.logIdentityCheckSuccess({ method: IdentityCheckMethod.ubble })
-      navigateToNextScreen()
+      navigate('IdentityCheckEnd')
     }
   }
 

--- a/src/features/identityCheck/pages/identification/ubble/UbbleWebview.web.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/UbbleWebview.web.tsx
@@ -1,9 +1,10 @@
+import { useNavigation } from '@react-navigation/native'
 import React, { useEffect } from 'react'
 
 import { IdentityCheckMethod } from 'api/gen'
 import { REDIRECT_URL_UBBLE, useIdentificationUrl } from 'features/identityCheck/api/api'
-import { useIdentityCheckNavigation } from 'features/identityCheck/useIdentityCheckNavigation'
 import { navigateToHome } from 'features/navigation/helpers'
+import { UseNavigationType } from 'features/navigation/RootNavigator'
 import { analytics } from 'libs/firebase/analytics'
 import { Helmet } from 'libs/react-helmet/Helmet'
 import { LoadingPage } from 'ui/components/LoadingPage'
@@ -26,7 +27,7 @@ interface AbortEvent {
 // https://ubbleai.github.io/developer-documentation/#webview-integration
 export const UbbleWebview: React.FC = () => {
   const identificationUrl = useIdentificationUrl()
-  const { navigateToNextScreen } = useIdentityCheckNavigation()
+  const { navigate } = useNavigation<UseNavigationType>()
 
   useEffect(() => {
     if (!identificationUrl) return
@@ -40,7 +41,7 @@ export const UbbleWebview: React.FC = () => {
           onComplete({ redirectUrl }: CompleteEvent) {
             analytics.logIdentityCheckSuccess({ method: IdentityCheckMethod.ubble })
             ubbleIDV.destroy()
-            if (redirectUrl.includes(REDIRECT_URL_UBBLE)) navigateToNextScreen()
+            if (redirectUrl.includes(REDIRECT_URL_UBBLE)) navigate('IdentityCheckEnd')
           },
           onAbort({ redirectUrl, returnReason: reason }: AbortEvent) {
             analytics.logIdentityCheckAbort({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17895

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

Même problème que cette PR https://github.com/pass-culture/pass-culture-app-native/pull/3768 mais sur la page IdentityCheckEnd

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
