### PR TITLE
(PC-17883) fix(Profile): align social media icons on the left in large devices

### DIFF
--- a/src/features/profile/components/SocialNetwork/SocialNetwork.stories.tsx
+++ b/src/features/profile/components/SocialNetwork/SocialNetwork.stories.tsx
@@ -1,0 +1,19 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+import React from 'react'
+
+import { SocialNetwork } from 'features/profile/components/SocialNetwork/SocialNetwork'
+import { theme } from 'theme'
+
+export default {
+  title: 'Features/Profile/SocialNetwork',
+  component: SocialNetwork,
+} as ComponentMeta<typeof SocialNetwork>
+
+// TODO(PC-17931): Fix those stories
+const Default: ComponentStory<typeof SocialNetwork> = () => <SocialNetwork />
+
+Default.parameters = {
+  chromatic: {
+    viewports: [theme.breakpoints.lg],
+  },
+}

--- a/src/features/profile/components/SocialNetwork/SocialNetwork.stories.tsx
+++ b/src/features/profile/components/SocialNetwork/SocialNetwork.stories.tsx
@@ -14,6 +14,6 @@ const Default: ComponentStory<typeof SocialNetwork> = () => <SocialNetwork />
 
 Default.parameters = {
   chromatic: {
-    viewports: [theme.breakpoints.lg],
+    viewports: [theme.breakpoints.md, theme.breakpoints.lg, theme.breakpoints.xl],
   },
 }

--- a/src/features/profile/components/SocialNetwork/SocialNetwork.tsx
+++ b/src/features/profile/components/SocialNetwork/SocialNetwork.tsx
@@ -29,8 +29,6 @@ export function SocialNetwork() {
   )
 }
 
-const paddingVertical = getSpacing(4)
-
 const NetworkRow = styled.View(({ theme }) => ({
   width: '100%',
   margin: theme.isDesktopViewport ? undefined : 'auto',
@@ -39,7 +37,7 @@ const NetworkRow = styled.View(({ theme }) => ({
 
 const NetworkRowContainer = styled.View({
   flexDirection: 'row',
-  paddingVertical,
+  paddingVertical: getSpacing(4),
   justifyContent: 'space-between',
 })
 

--- a/src/features/profile/components/SocialNetwork/SocialNetwork.tsx
+++ b/src/features/profile/components/SocialNetwork/SocialNetwork.tsx
@@ -33,7 +33,7 @@ const paddingVertical = getSpacing(4)
 
 const NetworkRow = styled.View(({ theme }) => ({
   width: '100%',
-  margin: 'auto',
+  margin: theme.isDesktopViewport ? undefined : 'auto',
   maxWidth: theme.contentPage.maxWidth,
 }))
 

--- a/src/features/profile/components/SocialNetwork/SocialNetwork.tsx
+++ b/src/features/profile/components/SocialNetwork/SocialNetwork.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { Li } from 'ui/components/Li'
+import { SocialNetworkCard } from 'ui/components/SocialNetworkCard'
+import { Ul } from 'ui/components/Ul'
+import { getSpacing } from 'ui/theme'
+
+export function SocialNetwork() {
+  return (
+    <NetworkRow>
+      <NetworkRowContainer>
+        <StyledUl>
+          <Li>
+            <SocialNetworkCard network="instagram" />
+          </Li>
+          <Li>
+            <SocialNetworkCard network="twitter" />
+          </Li>
+          <Li>
+            <SocialNetworkCard network="tiktok" />
+          </Li>
+          <Li>
+            <SocialNetworkCard network="facebook" />
+          </Li>
+        </StyledUl>
+      </NetworkRowContainer>
+    </NetworkRow>
+  )
+}
+
+const paddingVertical = getSpacing(4)
+
+const NetworkRow = styled.View(({ theme }) => ({
+  width: '100%',
+  margin: 'auto',
+  maxWidth: theme.contentPage.maxWidth,
+}))
+
+const NetworkRowContainer = styled.View({
+  flexDirection: 'row',
+  paddingVertical,
+  justifyContent: 'space-between',
+})
+
+const StyledUl = styled(Ul)({
+  flex: 1,
+  justifyContent: 'space-between',
+})

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -11,6 +11,7 @@ import { useUserProfileInfo } from 'features/profile/api'
 import { ProfileHeader } from 'features/profile/components/Header/ProfileHeader/ProfileHeader'
 import { ProfileContainer } from 'features/profile/components/reusables'
 import { SectionWithSwitch } from 'features/profile/components/SectionWithSwitch/SectionWithSwitch'
+import { SocialNetwork } from 'features/profile/components/SocialNetwork/SocialNetwork'
 import { env } from 'libs/environment'
 import { analytics, isCloseToBottom } from 'libs/firebase/analytics'
 import { GeolocPermissionState, useGeolocation } from 'libs/geolocation'
@@ -21,8 +22,7 @@ import { InputError } from 'ui/components/inputs/InputError'
 import { Li } from 'ui/components/Li'
 import { Section } from 'ui/components/Section'
 import { SectionRow } from 'ui/components/SectionRow'
-import { SocialNetworkCard } from 'ui/components/SocialNetworkCard'
-import { Ul, VerticalUl } from 'ui/components/Ul'
+import { VerticalUl } from 'ui/components/Ul'
 import { Bell } from 'ui/svg/icons/Bell'
 import { BicolorProfile } from 'ui/svg/icons/BicolorProfile'
 import { Confidentiality } from 'ui/svg/icons/Confidentiality'
@@ -209,24 +209,7 @@ const OnlineProfile: React.FC = () => {
           </VerticalUl>
         </Section>
         <Section title="Suivre pass Culture">
-          <NetworkRow>
-            <NetworkRowContainer>
-              <StyledUl>
-                <Li>
-                  <SocialNetworkCard network="instagram" />
-                </Li>
-                <Li>
-                  <SocialNetworkCard network="twitter" />
-                </Li>
-                <Li>
-                  <SocialNetworkCard network="tiktok" />
-                </Li>
-                <Li>
-                  <SocialNetworkCard network="facebook" />
-                </Li>
-              </StyledUl>
-            </NetworkRowContainer>
-          </NetworkRow>
+          <SocialNetwork />
         </Section>
         {!!isLoggedIn && (
           <Section>
@@ -272,21 +255,4 @@ const Row = styled(SectionRow).attrs({ iconSize: SECTION_ROW_ICON_SIZE })({
 const LogoMinistereContainer = styled.View({
   width: getSpacing(40),
   height: getSpacing(28),
-})
-
-const NetworkRow = styled.View(({ theme }) => ({
-  width: '100%',
-  margin: 'auto',
-  maxWidth: theme.contentPage.maxWidth,
-}))
-
-const NetworkRowContainer = styled.View({
-  flexDirection: 'row',
-  paddingVertical,
-  justifyContent: 'space-between',
-})
-
-const StyledUl = styled(Ul)({
-  flex: 1,
-  justifyContent: 'space-between',
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17883

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |<img width="386" alt="image" src="https://user-images.githubusercontent.com/114914696/196664295-06f89527-5f8d-41e3-b3eb-79d5a375aa63.png">|
| Android          |        | <img width="347" alt="image" src="https://user-images.githubusercontent.com/114914696/196664552-cee2e842-52ca-4ee5-afd2-79e5c27e9f74.png">|
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |<img width="1437" alt="image" src="https://user-images.githubusercontent.com/114914696/196664968-224be39c-d383-47f6-a601-fae4113bf771.png">|<img width="1438" alt="image" src="https://user-images.githubusercontent.com/114914696/196664717-50583049-492f-4ffd-a870-c86f17d38416.png">|
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
