### PR TITLE
(PC-18018) fix(SearchV2): LocationModal close when opening settings

### DIFF
--- a/src/features/search/pages/LocationModal.tsx
+++ b/src/features/search/pages/LocationModal.tsx
@@ -96,7 +96,7 @@ export const LocationModal: FunctionComponent<Props> = ({
     positionError,
     permissionState,
     requestGeolocPermission,
-    onPressGeolocPermissionModalButton,
+    onPressGeolocPermissionModalButton: onPressGeolocPermissionModalButtonDefault,
   } = useGeolocation()
 
   const {
@@ -104,6 +104,12 @@ export const LocationModal: FunctionComponent<Props> = ({
     hideModal: hideGeolocPermissionModal,
     visible: isGeolocPermissionModalVisible,
   } = useModal(false)
+
+  const onPressGeolocPermissionModalButton = useCallback(() => {
+    hideGeolocPermissionModal()
+    onPressGeolocPermissionModalButtonDefault()
+  }, [hideGeolocPermissionModal, onPressGeolocPermissionModalButtonDefault])
+
   const [isSearchInputFocused, setIsSearchInputFocused] = useState(false)
 
   const logChangeRadius = useLogFilterOnce(SectionTitle.Radius)

--- a/src/features/search/pages/__tests__/LocationModal.native.test.tsx
+++ b/src/features/search/pages/__tests__/LocationModal.native.test.tsx
@@ -36,6 +36,8 @@ let mockPermissionState = GeolocPermissionState.GRANTED
 let mockPositionError: GeolocationError | null = null
 const mockTriggerPositionUpdate = jest.fn()
 const mockShowGeolocPermissionModal = jest.fn()
+const mockHideGeolocPermissionModal = jest.fn()
+const mockOnPressGeolocPermissionModalButton = jest.fn()
 
 jest.mock('libs/geolocation/GeolocationWrapper', () => ({
   useGeolocation: () => ({
@@ -44,6 +46,8 @@ jest.mock('libs/geolocation/GeolocationWrapper', () => ({
     positionError: mockPositionError,
     triggerPositionUpdate: mockTriggerPositionUpdate,
     showGeolocPermissionModal: mockShowGeolocPermissionModal,
+    hideGeolocPermissionModal: mockHideGeolocPermissionModal,
+    onPressGeolocPermissionModalButton: mockOnPressGeolocPermissionModalButton,
   }),
 }))
 
@@ -309,6 +313,29 @@ describe('LocationModal component', () => {
       fireEvent.press(radioButton)
     })
     expect(queryByTestId('slider')).toBeTruthy()
+  })
+
+  it('should show then hide geolocation activation modal if GeolocPermissionState is NEVER_ASK_AGAIN and user choose AROUND_ME then click to open settings', async () => {
+    const geolocationModalText =
+      'Retrouve toutes les offres autour de chez toi en activant les données de localisation.'
+    mockPosition = null
+    mockPermissionState = GeolocPermissionState.NEVER_ASK_AGAIN
+    const { queryByText, getByTestId, getByText } = renderLocationModal({ hideLocationModal })
+    expect(queryByText(geolocationModalText)).toBeFalsy()
+
+    const radioButton = getByTestId(RadioButtonLocation.AROUND_ME)
+    await act(async () => {
+      fireEvent.press(radioButton)
+    })
+
+    expect(queryByText(geolocationModalText)).toBeTruthy()
+
+    const openSettingsButton = getByText('Activer la géolocalisation')
+    await act(async () => {
+      fireEvent.press(openSettingsButton)
+    })
+
+    expect(queryByText(geolocationModalText)).toBeFalsy()
   })
 
   it('should not change location filter on Autour de moi radio button press when position is null', async () => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18018

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
