### PR TITLE
(PC-18085) ci(server): force usage of node 16 for server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ commands:
             - node-modules-proxy-v1-{{ checksum "yarn.lock" }}-{{ arch }}
       - run:
           name: Install Dependencies
-          command: yarn install --immutable --cwd server
+          command: nvm install 16 && nvm use 16 && yarn install --immutable --cwd server
       - save_cache:
           name: Save Node Modules
           key: node-modules-proxy-v1-{{ checksum "yarn.lock" }}-{{ arch }}
@@ -88,7 +88,7 @@ commands:
           name: Restore Tests cache
           keys:
             - jest-cache-proxy-{{ checksum "yarn.lock" }}-{{ arch }}
-      - run: yarn --cwd server test:unit:ci
+      - run: nvm use 16 && yarn --cwd server test:unit:ci
       - save_cache:
           name: Save Tests cache
           key: jest-cache-proxy-{{ checksum "yarn.lock" }}-{{ arch }}
@@ -443,6 +443,7 @@ commands:
         type: string
     steps:
       - checkout
+      - install_node_version
       - install_node_modules_proxy
       - authenticate_gcp:
           gcp_key_name: GCP_APP_NATIVE_KEY
@@ -450,7 +451,7 @@ commands:
           name: Deploy web proxy to <<parameters.env>>
           command: |
             if ./scripts/check_server_diff.sh; then
-              yarn --cwd server deploy:<<parameters.env>>
+              nvm use 16 && yarn --cwd server deploy:<<parameters.env>>
             fi
 
   notify-slack:
@@ -483,6 +484,7 @@ jobs:
     working_directory: ~/pass-culture
     steps:
       - checkout
+      - install_node_version
       - install_node_modules_proxy
 
   test-proxy:
@@ -490,13 +492,14 @@ jobs:
     working_directory: ~/pass-culture
     steps:
       - checkout
+      - install_node_version
       - install_node_modules_proxy
       - run:
           name: Linter
-          command: yarn --cwd server test:lint
+          command: nvm use 16 && yarn --cwd server test:lint
       - run:
           name: Typescript Type Check
-          command: yarn --cwd server test:types
+          command: nvm use 16 && yarn --cwd server test:types
       - unit_test_proxy
       - sonarcloud-scanner:
           directory: server

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/pass-culture/pass-culture-app-native.git"
   },
   "engines": {
-    "node": "18"
+    "node": "16"
   },
   "scripts": {
     "build": "tsc --build",


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18085

Force node16 on server temporary

This will be reverted in https://passculture.atlassian.net/browse/PC-18095

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
