### PR TITLE
(PC-17493) chore(navigation): reorganise navigation helpers tests

### DIFF
--- a/src/features/navigation/helpers/isAppUrl.native.test.ts
+++ b/src/features/navigation/helpers/isAppUrl.native.test.ts
@@ -1,0 +1,15 @@
+import { isAppUrl } from './isAppUrl'
+
+jest.mock('features/navigation/navigationRef')
+jest.mock('features/navigation/RootNavigator/linking')
+
+describe('isAppUrl', () => {
+  it('should return false if url does not start with linking prefixes', () => {
+    const url = isAppUrl('https://notavalidprefix')
+    expect(url).toEqual(false)
+  })
+  it('should return true if url starts with linking prefixes', () => {
+    const url = isAppUrl('https://mockValidPrefix1')
+    expect(url).toEqual(true)
+  })
+})

--- a/src/features/navigation/helpers/navigateToBooking.native.test.ts
+++ b/src/features/navigation/helpers/navigateToBooking.native.test.ts
@@ -1,0 +1,13 @@
+import { navigateFromRef } from 'features/navigation/navigationRef'
+
+import { navigateToBooking } from './navigateToBooking'
+
+jest.mock('features/navigation/navigationRef')
+
+describe('[Method] navigateToBooking', () => {
+  it('should navigate to BookingDetails', async () => {
+    const bookingId = 37815152
+    navigateToBooking(bookingId)
+    expect(navigateFromRef).toBeCalledWith('BookingDetails', { id: bookingId })
+  })
+})

--- a/src/features/navigation/helpers/openUrl.native.test.ts
+++ b/src/features/navigation/helpers/openUrl.native.test.ts
@@ -52,7 +52,7 @@ describe('openUrl', () => {
     expect(navigateFromRef).toBeCalledWith('PageNotFound', undefined)
   })
 
-  it('should log analytics when shouldLogEvent is true', async () => {
+  it('should log analytics when shouldLogEvent is true (default behavior)', async () => {
     openURLSpy.mockResolvedValueOnce(undefined)
     const link = 'https://www.google.com'
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17493

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

L'event OpenExternalUrl remonte bien sur firebase. Étant donné que l'on teste déjà le comportement de tracking sur les liens externes, j'en ai profité pour refacto les tests helpers.test.ts de la feature navigation

<img width="607" alt="Capture d’écran 2022-10-19 à 17 55 31" src="https://user-images.githubusercontent.com/22886846/196890625-03fd8597-5207-4f54-bc2c-44bcb99ac584.png">


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
