### PR TITLE
(PC-17362) fix(SearchV2): SearchFilters use bicolor icon for location

### DIFF
--- a/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/__tests__/SearchFilter.native.test.tsx.native-snap
@@ -281,10 +281,11 @@ exports[`SearchFilter component should render correctly 1`] = `
       >
         <View
           height={24}
+          testID="BicolorLocationPointer"
           width={24}
         >
           <Text>
-            undefined-SVG-Mock
+            BicolorLocationPointer-SVG-Mock
           </Text>
         </View>
         <View

--- a/src/features/search/sections/Location.tsx
+++ b/src/features/search/sections/Location.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import styled from 'styled-components/native'
 
 import { FilterRow } from 'features/search/atoms/FilterRow'
 import { useLocationChoice } from 'features/search/components/locationChoice.utils'
@@ -7,7 +6,7 @@ import { LocationModal } from 'features/search/pages/LocationModal'
 import { useSearch } from 'features/search/pages/SearchWrapper'
 import { useLocationType } from 'features/search/pages/useLocationType'
 import { useModal } from 'ui/components/modals/useModal'
-import { LocationPointer } from 'ui/svg/icons/LocationPointer'
+import { BicolorLocationPointer as LocationPointer } from 'ui/svg/icons/BicolorLocationPointer'
 
 export function Location() {
   const { searchState } = useSearch()
@@ -23,7 +22,7 @@ export function Location() {
   return (
     <React.Fragment>
       <FilterRow
-        icon={LocationPointerStyledIcon}
+        icon={LocationPointer}
         title="Localisation"
         description={label}
         onPress={showLocationModal}
@@ -37,8 +36,3 @@ export function Location() {
     </React.Fragment>
   )
 }
-
-const LocationPointerStyledIcon = styled(LocationPointer).attrs(({ theme }) => ({
-  color: theme.colors.black,
-  color2: theme.colors.black,
-}))``


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17362

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |  ![image](https://user-images.githubusercontent.com/77674046/196900060-80a9704c-38ef-4a6d-b399-e38a21e4fb68.png)      |  ![image](https://user-images.githubusercontent.com/77674046/196899894-9fb8eb53-603f-4212-9c45-302eb5eeacdc.png)|
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
