### PR TITLE
(PC-18151) fix(keychain): Fix android crash for API 22 and lower

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -32,3 +32,6 @@
   **[] $VALUES;
   public *;
 }
+
+# react-native-keychain
+-keep class com.facebook.crypto.** { *; }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18151

Je pense qu'à la mise à jour de la librairie `react-native-keychain`, cette modification n'a pas été incluse, ce qui causait un crash pour les Android API 21 et 22 :

> <img width="809" alt="Capture d’écran 2022-10-24 à 13 50 43" src="https://user-images.githubusercontent.com/46637324/197519288-ce9dcd35-6dd5-4ad7-857d-9285af550e70.png">


## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
