### PR TITLE
(PC-17635) fix(ui): Adjust spacing between Submit and Authentication buttons

### DIFF
--- a/src/features/auth/login/Login.tsx
+++ b/src/features/auth/login/Login.tsx
@@ -250,7 +250,7 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
           disabled={shouldDisableLoginButton}
         />
       </Form.MaxWidth>
-      <Spacer.Column numberOfSpaces={4} />
+      <Spacer.Column numberOfSpaces={8} />
       <AuthenticationButton type="signup" />
     </BottomContentPage>
   )

--- a/src/features/auth/signup/SetEmail/SetEmail.tsx
+++ b/src/features/auth/signup/SetEmail/SetEmail.tsx
@@ -112,7 +112,7 @@ export const SetEmail: FunctionComponent<PreValidationSignupStepProps> = (props)
         isLoading={false}
         disabled={shouldDisableValidateButton}
       />
-      <Spacer.Column numberOfSpaces={4} />
+      <Spacer.Column numberOfSpaces={8} />
       <AuthenticationButton type="login" />
       <Spacer.Column numberOfSpaces={4} />
     </Form.MaxWidth>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17635

Apparemment les boutons étaient trop rapprochés ce qui causait des fausses manip de temps en temps

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |  ![simulator_screenshot_85085770-6276-4CE2-9181-9AAFC693CA5D](https://user-images.githubusercontent.com/46637324/198660481-431dda06-5cf4-4e3b-8263-5af04927d3b9.png) ![Simulator Screen Shot - iPhone 11 Pro Max - 2022-10-28 at 16 28 29](https://user-images.githubusercontent.com/46637324/198658971-c81bc0bd-96e8-4a63-a639-dc946cb2ac1c.png)     | ![Simulator Screen Shot - iPhone 11 Pro Max - 2022-10-28 at 16 53 13](https://user-images.githubusercontent.com/46637324/198660200-cf9904e7-0c9d-4312-9b23-2d1a090463b9.png) ![Simulator Screen Shot - iPhone 11 Pro Max - 2022-10-28 at 16 29 54](https://user-images.githubusercontent.com/46637324/198659210-3f875aec-5b36-472b-adf8-a2ae1110f526.png)   |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome | <img width="1188" alt="Capture d’écran 2022-10-28 à 16 55 08" src="https://user-images.githubusercontent.com/46637324/198661418-96b2a4ec-3cc5-48a2-bb83-969e7f117459.png"><img width="1189" alt="Capture d’écran 2022-10-28 à 16 54 55" src="https://user-images.githubusercontent.com/46637324/198661469-30c6799f-10b4-4818-80ce-036d163e723d.png">  |      <img width="1188" alt="Capture d’écran 2022-10-28 à 16 52 21" src="https://user-images.githubusercontent.com/46637324/198659768-7fb2e494-90b2-4511-974d-0e2c7c3480a2.png"><img width="1188" alt="Capture d’écran 2022-10-28 à 16 52 10" src="https://user-images.githubusercontent.com/46637324/198659843-1de0c7bb-70da-481b-9ac6-b642bd999034.png">   |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
