### PR TITLE
(PC-18308) ci(e2e): added empty workflows

### DIFF
--- a/.github/workflows/e2e-android-chrome.yml
+++ b/.github/workflows/e2e-android-chrome.yml
@@ -1,0 +1,9 @@
+name: Tests e2e Android Chrome
+
+on:
+  workflow_dispatch:
+    inputs:
+      tbd:
+        description: "tbd"
+        required: false
+        type: string

--- a/.github/workflows/e2e-android-native.yml
+++ b/.github/workflows/e2e-android-native.yml
@@ -1,0 +1,9 @@
+name: Tests e2e Android Native
+
+on:
+  workflow_dispatch:
+    inputs:
+      tbd:
+        description: "tbd"
+        required: false
+        type: string

--- a/.github/workflows/e2e-desktop-chrome.yml
+++ b/.github/workflows/e2e-desktop-chrome.yml
@@ -1,0 +1,9 @@
+name: Tests e2e Desktop Chrome
+
+on:
+  workflow_dispatch:
+    inputs:
+      tbd:
+        description: "tbd"
+        required: false
+        type: string

--- a/.github/workflows/e2e-ios-native.yml
+++ b/.github/workflows/e2e-ios-native.yml
@@ -1,0 +1,9 @@
+name: Tests e2e iOS Native
+
+on:
+  workflow_dispatch:
+    inputs:
+      tbd:
+        description: "tbd"
+        required: false
+        type: string

--- a/.github/workflows/e2e-ios-safari.yml
+++ b/.github/workflows/e2e-ios-safari.yml
@@ -1,0 +1,9 @@
+name: Tests e2e iOS Safari
+
+on:
+  workflow_dispatch:
+    inputs:
+      tbd:
+        description: "tbd"
+        required: false
+        type: string


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18308

Ajout des fichiers suivant:
```
├── e2e-android-chrome.yml
├── e2e-android-native.yml
├── e2e-desktop-chrome.yml
├── e2e-ios-native.yml
├── e2e-ios-safari.yml
```
Le contenu est minimaliste, ex :  

```yml
name: Tests e2e Desktop Chrome

on:
  workflow_dispatch:
    inputs:
      tbd:
        description: "tbd"
        required: false
        type: string
```

Leur présence sur `master` est nécessaire pour débuter l'intégration.