### PR TITLE
(PC-17986) feat(ThematicHomeHeader): add missing subtilte to the header

### DIFF
--- a/src/features/cheatcodes/pages/ThematicHomeHeaderCheatcode/ThematicHomeHeaderCheatcode.tsx
+++ b/src/features/cheatcodes/pages/ThematicHomeHeaderCheatcode/ThematicHomeHeaderCheatcode.tsx
@@ -7,7 +7,7 @@ import { getSpacing } from 'ui/theme'
 export const ThematicHomeHeaderCheatcode: FunctionComponent = () => {
   return (
     <Container>
-      <ThematicHomeHeader headerTitle="Le plein de cinéma" />
+      <ThematicHomeHeader headerTitle="Le plein de cinéma" headerSubtitle="La playlist cinéma" />
     </Container>
   )
 }

--- a/src/features/home/components/headers/ThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/ThematicHomeHeader.tsx
@@ -6,14 +6,24 @@ import { Spacer, Typo } from 'ui/theme'
 
 export interface ThematicHomeHeaderProps {
   headerTitle: string
+  headerSubtitle?: string
 }
-export const ThematicHomeHeader: FunctionComponent<ThematicHomeHeaderProps> = ({ headerTitle }) => {
+export const ThematicHomeHeader: FunctionComponent<ThematicHomeHeaderProps> = ({
+  headerTitle,
+  headerSubtitle,
+}) => {
   return (
     <View>
       <Spacer.TopScreen />
       <BackButton />
       <Spacer.Column numberOfSpaces={6} />
       <Typo.Title1 numberOfLines={1}>{headerTitle}</Typo.Title1>
+      {headerSubtitle ? (
+        <React.Fragment>
+          <Spacer.Column numberOfSpaces={2} />
+          <Typo.Body numberOfLines={1}>{headerSubtitle}</Typo.Body>
+        </React.Fragment>
+      ) : null}
     </View>
   )
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17986

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        | <img width="545" alt="image" src="https://user-images.githubusercontent.com/89008469/199220946-d40c64e0-cd3b-4205-83fd-1778b44a3778.png"> |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        | <img width="1496" alt="image" src="https://user-images.githubusercontent.com/89008469/199220885-65ba7f01-fae9-4c0e-9a28-a9bcf8b9f073.png"> |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
