### PR TITLE
(PC-18334) fix(home): Use reusable components for page title and fix top margin

### DIFF
--- a/__snapshots__/features/home/pages/tests/Home.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/tests/Home.native.test.tsx.native-snap
@@ -65,21 +65,12 @@ exports[`Home component should render correctly without login modal 1`] = `
             }
           >
             <View
-              customHeight={16}
-              enable={true}
               style={
                 Array [
                   Object {
-                    "height": 16,
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                Array [
-                  Object {
+                    "marginBottom": 8,
                     "marginHorizontal": 24,
+                    "marginTop": 24,
                   },
                 ]
               }
@@ -91,16 +82,6 @@ exports[`Home component should render correctly without login modal 1`] = `
                   Array [
                     Object {
                       "height": 16,
-                    },
-                  ]
-                }
-              />
-              <View
-                numberOfSpaces={6}
-                style={
-                  Array [
-                    Object {
-                      "height": 24,
                     },
                   ]
                 }
@@ -120,16 +101,16 @@ exports[`Home component should render correctly without login modal 1`] = `
               >
                 Bienvenue !
               </Text>
-              <View
-                numberOfSpaces={2}
-                style={
-                  Array [
-                    Object {
-                      "height": 8,
-                    },
-                  ]
-                }
-              />
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "marginHorizontal": 24,
+                  },
+                ]
+              }
+            >
               <Text
                 style={
                   Array [

--- a/src/features/home/components/headers/HomeHeader.tsx
+++ b/src/features/home/components/headers/HomeHeader.tsx
@@ -12,6 +12,7 @@ import { isUserBeneficiary } from 'features/profile/utils'
 import { env } from 'libs/environment'
 import { useGeolocation, GeolocPermissionState } from 'libs/geolocation'
 import { formatToFrenchDecimal } from 'libs/parsers'
+import { PageTitle } from 'ui/components/PageTitle'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
@@ -47,7 +48,7 @@ export const HomeHeader: FunctionComponent = function () {
   }
 
   return (
-    <Container>
+    <React.Fragment>
       {!!env.FEATURE_FLIPPING_ONLY_VISIBLE_ON_TESTING && (
         <CheatCodeButtonContainer
           onPress={() => navigation.navigate(Platform.OS === 'web' ? 'Navigation' : 'CheatMenu')}
@@ -55,30 +56,24 @@ export const HomeHeader: FunctionComponent = function () {
           <Typo.Body>CheatMenu</Typo.Body>
         </CheatCodeButtonContainer>
       )}
-
-      <Spacer.TopScreen />
-      <Spacer.Column numberOfSpaces={6} />
-      <StyledTitle1>{welcomeTitle}</StyledTitle1>
-      <Spacer.Column numberOfSpaces={2} />
-      <Typo.Body>{getSubtitle()}</Typo.Body>
-      <Spacer.Column numberOfSpaces={6} />
-      {shouldDisplayGeolocationBloc ? (
-        <React.Fragment>
-          <GeolocationBanner />
-          <Spacer.Column numberOfSpaces={8} />
-        </React.Fragment>
-      ) : null}
-    </Container>
+      <PageTitle title={welcomeTitle} numberOfLines={2} />
+      <PageContent>
+        <Typo.Body>{getSubtitle()}</Typo.Body>
+        <Spacer.Column numberOfSpaces={6} />
+        {shouldDisplayGeolocationBloc ? (
+          <React.Fragment>
+            <GeolocationBanner />
+            <Spacer.Column numberOfSpaces={8} />
+          </React.Fragment>
+        ) : null}
+      </PageContent>
+    </React.Fragment>
   )
 }
 
-const Container = styled.View({
+const PageContent = styled.View({
   marginHorizontal: getSpacing(6),
 })
-
-const StyledTitle1 = styled(Typo.Title1).attrs({
-  numberOfLines: 2,
-})({})
 
 const CheatCodeButtonContainer = styled(TouchableOpacity)(({ theme }) => ({
   position: 'absolute',

--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -40,7 +40,6 @@ const keyExtractor = (item: ProcessedModule, index: number) =>
 const ListHeaderComponent = () => {
   return (
     <ListHeaderContainer>
-      <Spacer.TopScreen />
       <HomeHeader />
     </ListHeaderContainer>
   )
@@ -190,7 +189,6 @@ export const OnlineHome: FunctionComponent = () => {
           scrollEventThrottle={400}
           bounces={false}
           scrollEnabled={false}>
-          <Spacer.TopScreen />
           <HomeHeader />
           <HomeBodyPlaceholder />
           <Spacer.TabBar />


### PR DESCRIPTION
Il y avait un `Spacer.TopScreen` en trop ce qui ajoutait une marge qui décalait le titre de la home par rapport aux autres titres de l'app

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18334

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |    ![Simulator Screen Shot - iPhone 13 - 2022-11-04 at 10 33 14](https://user-images.githubusercontent.com/46637324/199940412-39bd1b86-da09-446d-a9ed-f24ca3000638.png) **Petit écran :** ![Simulator Screen Shot - iPhone 5s - 2022-11-04 at 10 33 15](https://user-images.githubusercontent.com/46637324/199940392-a391c138-b112-4c1f-b9ac-c28abfa383f8.png)    |   ![Simulator Screen Shot - iPhone 13 - 2022-11-04 at 10 32 39](https://user-images.githubusercontent.com/46637324/199940212-4bb1becc-cf27-42ee-af53-ab53aa0be54a.png) **Petit écran :** ![Simulator Screen Shot - iPhone 5s - 2022-11-04 at 10 32 33](https://user-images.githubusercontent.com/46637324/199940239-75219666-916b-4d68-baad-c5b52dc97750.png)  |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |   <img width="1440" alt="Capture d’écran 2022-11-04 à 10 33 05" src="https://user-images.githubusercontent.com/46637324/199940368-2b5331e1-80bd-4d9f-9b2a-4d0dc5450a23.png">     |    <img width="1440" alt="Capture d’écran 2022-11-04 à 10 32 50" src="https://user-images.githubusercontent.com/46637324/199940351-330438b3-9ab2-459d-bbbb-a5a66cb332a0.png">   |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
