### PR TITLE
(PC-17989) feat(ThematicHome): go back to home (without params) on press tab and go back button

### DIFF
--- a/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
@@ -78,13 +78,24 @@ exports[`Home N-1 should render correctly 1`] = `
               style={
                 Array [
                   Object {
-                    "paddingBottom": 8,
-                    "paddingHorizontal": 24,
-                    "paddingTop": 24,
+                    "marginBottom": 8,
+                    "marginHorizontal": 24,
+                    "marginTop": 24,
                   },
                 ]
               }
             >
+              <View
+                customHeight={16}
+                enable={true}
+                style={
+                  Array [
+                    Object {
+                      "height": 16,
+                    },
+                  ]
+                }
+              />
               <View
                 accessibilityLabel="Revenir en arrière"
                 accessibilityRole="button"

--- a/src/features/home/components/headers/ThematicHomeHeader.native.test.tsx
+++ b/src/features/home/components/headers/ThematicHomeHeader.native.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import { navigate } from '__mocks__/@react-navigation/native'
+import { ThematicHomeHeader } from 'features/home/components/headers/ThematicHomeHeader'
+import { navigateToHomeConfig } from 'features/navigation/helpers'
+import { fireEvent, render } from 'tests/utils'
+
+describe('ThematicHomeHeader', () => {
+  it('should navigate to home page on press go back button', () => {
+    const { getByTestId } = render(<ThematicHomeHeader headerTitle="toto" />)
+    const backButton = getByTestId('backButton')
+
+    fireEvent.press(backButton)
+
+    expect(navigate).toBeCalledWith(navigateToHomeConfig.screen, navigateToHomeConfig.params)
+  })
+})

--- a/src/features/home/components/headers/ThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/ThematicHomeHeader.tsx
@@ -14,6 +14,7 @@ export const ThematicHomeHeader: FunctionComponent<ThematicHomeHeaderProps> = ({
 }) => {
   return (
     <Container>
+      <Spacer.TopScreen />
       <BackButton />
       <Spacer.Column numberOfSpaces={6} />
       <Typo.Title1 numberOfLines={1}>{headerTitle}</Typo.Title1>
@@ -27,8 +28,8 @@ export const ThematicHomeHeader: FunctionComponent<ThematicHomeHeaderProps> = ({
   )
 }
 
-const Container = styled.View({
-  paddingHorizontal: getSpacing(6),
-  paddingTop: getSpacing(6),
-  paddingBottom: getSpacing(2),
-})
+const Container = styled.View(({ theme }) => ({
+  marginTop: getSpacing(6),
+  marginHorizontal: theme.contentPage.marginHorizontal,
+  marginBottom: getSpacing(2),
+}))

--- a/src/features/home/components/headers/ThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/ThematicHomeHeader.tsx
@@ -8,7 +8,7 @@ import { BackButton } from 'ui/components/headers/BackButton'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
 export interface ThematicHomeHeaderProps {
-  headerTitle: string
+  headerTitle?: string
   headerSubtitle?: string
 }
 export const ThematicHomeHeader: FunctionComponent<ThematicHomeHeaderProps> = ({
@@ -22,8 +22,12 @@ export const ThematicHomeHeader: FunctionComponent<ThematicHomeHeaderProps> = ({
     <Container>
       <Spacer.TopScreen />
       <BackButton onGoBack={onGoBack} />
-      <Spacer.Column numberOfSpaces={6} />
-      <Typo.Title1 numberOfLines={1}>{headerTitle}</Typo.Title1>
+      {headerTitle ? (
+        <React.Fragment>
+          <Spacer.Column numberOfSpaces={6} />
+          <Typo.Title1 numberOfLines={1}>{headerTitle}</Typo.Title1>
+        </React.Fragment>
+      ) : null}
       {headerSubtitle ? (
         <React.Fragment>
           <Spacer.Column numberOfSpaces={2} />

--- a/src/features/home/components/headers/ThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/ThematicHomeHeader.tsx
@@ -1,6 +1,9 @@
-import React, { FunctionComponent } from 'react'
+import { useNavigation } from '@react-navigation/native'
+import React, { FunctionComponent, useCallback } from 'react'
 import styled from 'styled-components/native'
 
+import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { homeNavConfig } from 'features/navigation/TabBar/helpers'
 import { BackButton } from 'ui/components/headers/BackButton'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
@@ -12,10 +15,13 @@ export const ThematicHomeHeader: FunctionComponent<ThematicHomeHeaderProps> = ({
   headerTitle,
   headerSubtitle,
 }) => {
+  const { navigate } = useNavigation<UseNavigationType>()
+  const onGoBack = useCallback(() => navigate(...homeNavConfig), [navigate])
+
   return (
     <Container>
       <Spacer.TopScreen />
-      <BackButton />
+      <BackButton onGoBack={onGoBack} />
       <Spacer.Column numberOfSpaces={6} />
       <Typo.Title1 numberOfLines={1}>{headerTitle}</Typo.Title1>
       {headerSubtitle ? (

--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -40,7 +40,7 @@ const Header = ({
   <ListHeaderContainer>
     {isThematicHome ? (
       <ThematicHomeHeader
-        headerTitle={thematicHeader?.title || ''}
+        headerTitle={thematicHeader?.title}
         headerSubtitle={thematicHeader?.subtitle}
       />
     ) : (

--- a/src/features/navigation/TabBar/TabBar.tsx
+++ b/src/features/navigation/TabBar/TabBar.tsx
@@ -22,7 +22,8 @@ export const TabBar: React.FC<Props> = ({ navigation }) => {
             canPreventDefault: true,
           })
           if (!event.defaultPrevented) {
-            navigation.navigate('TabNavigator', { screen: route.name, params: route.params })
+            const params = route.name === 'Home' ? undefined : route.params
+            navigation.navigate('TabNavigator', { screen: route.name, params })
           }
         }
         return (

--- a/src/features/navigation/TabBar/TabBar.tsx
+++ b/src/features/navigation/TabBar/TabBar.tsx
@@ -15,7 +15,7 @@ export const TabBar: React.FC<Props> = ({ navigation }) => {
     <TabBarContainer>
       {tabRoutes.map((route) => {
         const onPress = () => {
-          if (route.isSelected) return
+          if (route.isSelected && route.name !== 'Home') return
           const event = navigation.emit({
             type: 'tabPress',
             target: route.key,

--- a/src/features/navigation/TabBar/__tests__/TabBar.native.test.tsx
+++ b/src/features/navigation/TabBar/__tests__/TabBar.native.test.tsx
@@ -62,8 +62,7 @@ describe('TabBar', () => {
   })
 
   it('should display the 5 following tabs with Bookings selected', async () => {
-    // eslint-disable-next-line local-rules/independent-mocks
-    mockedUseTabNavigationContext.mockReturnValue({
+    mockedUseTabNavigationContext.mockReturnValueOnce({
       setTabNavigationState: jest.fn(),
       tabRoutes: DEFAULT_TAB_ROUTES.map((route) => ({
         ...route,
@@ -90,14 +89,32 @@ describe('TabBar', () => {
   })
 
   it('does not reset navigation when clicked on selected tab', async () => {
+    mockedUseTabNavigationContext.mockReturnValueOnce({
+      setTabNavigationState: jest.fn(),
+      tabRoutes: DEFAULT_TAB_ROUTES.map((route) => ({
+        ...route,
+        isSelected: route.name === 'Profile',
+      })),
+    })
+    const renderAPI = await renderTabBar()
+    expect(renderAPI.queryByTestId('Profile tab selected')).toBeTruthy()
+
+    const profileTab = renderAPI.getByTestId('Profile tab')
+    fireEvent.press(profileTab)
+
+    expect(navigation.emit).not.toHaveBeenCalled()
+    expect(navigation.navigate).not.toHaveBeenCalled()
+  })
+
+  it('should reset navigation when clicked on selected home tab', async () => {
     const renderAPI = await renderTabBar()
     expect(renderAPI.queryByTestId('Home tab selected')).toBeTruthy()
 
     const homeTab = renderAPI.getByTestId('Home tab')
     fireEvent.press(homeTab)
 
-    expect(navigation.emit).not.toBeCalled()
-    expect(navigation.navigate).not.toBeCalled()
+    expect(navigation.emit).toHaveBeenCalled()
+    expect(navigation.navigate).toHaveBeenCalled()
   })
 
   it('navigates to Profile on Profile tab click', async () => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17989

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

| Platform         | Before |
| :--------------- | :----: |
| iOS              |![Simulator Screen Shot - iPhone 13 - 2022-11-04 at 16 48 44](https://user-images.githubusercontent.com/22886846/200019108-4c68cda6-ff30-4a43-b85c-cb55a4f0d409.png)|
| Android          |<img width="295" alt="Capture d’écran 2022-11-04 à 16 48 32" src="https://user-images.githubusercontent.com/22886846/200019080-caddbffb-d11f-4305-a246-f0a95687c893.png">|
| Desktop - Chrome |<img width="1020" alt="Capture d’écran 2022-11-04 à 16 51 23" src="https://user-images.githubusercontent.com/22886846/200019340-4d662a40-2034-4211-a46f-69f25a6971c5.png">|

## Vidéos

**pour le clic sur la flèche de retour** :  https://user-images.githubusercontent.com/22886846/200019577-2e4465f8-f766-4a42-88bc-b31a3f640f5c.mov

**pour le clic sur l'onglet de la home depuis un autre onglet** : https://user-images.githubusercontent.com/22886846/200019822-d9ca43da-4d4c-4991-9189-ea8d3a5be7ed.mov

**pour le clic sur l'onglet de la home depuis une home thématique** : https://user-images.githubusercontent.com/22886846/200019983-8813532e-70de-4f19-8a42-cb4ca17dc8fc.mov



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
