### PR TITLE
(BSR) feat(AccessbilityList): move the separator inside the Li element

### DIFF
--- a/__snapshots__/features/identityCheck/pages/identification/identificationStart/SelectIDOrigin.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/identificationStart/SelectIDOrigin.native.test.tsx.native-snap
@@ -467,17 +467,17 @@ exports[`SelectIDOrigin should render correctly 1`] = `
                       </View>
                     </View>
                   </View>
+                  <View
+                    numberOfSpaces={6}
+                    style={
+                      Array [
+                        Object {
+                          "height": 24,
+                        },
+                      ]
+                    }
+                  />
                 </View>
-                <View
-                  numberOfSpaces={6}
-                  style={
-                    Array [
-                      Object {
-                        "height": 24,
-                      },
-                    ]
-                  }
-                />
                 <View
                   accessibilityRole="none"
                   style={

--- a/__snapshots__/features/identityCheck/pages/identification/identificationStart/SelectIDStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/identificationStart/SelectIDStatus.native.test.tsx.native-snap
@@ -562,17 +562,17 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
                       </View>
                     </View>
                   </View>
+                  <View
+                    numberOfSpaces={6}
+                    style={
+                      Array [
+                        Object {
+                          "height": 24,
+                        },
+                      ]
+                    }
+                  />
                 </View>
-                <View
-                  numberOfSpaces={6}
-                  style={
-                    Array [
-                      Object {
-                        "height": 24,
-                      },
-                    ]
-                  }
-                />
                 <View
                   accessibilityRole="none"
                   style={
@@ -703,17 +703,17 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
                       </View>
                     </View>
                   </View>
+                  <View
+                    numberOfSpaces={6}
+                    style={
+                      Array [
+                        Object {
+                          "height": 24,
+                        },
+                      ]
+                    }
+                  />
                 </View>
-                <View
-                  numberOfSpaces={6}
-                  style={
-                    Array [
-                      Object {
-                        "height": 24,
-                      },
-                    ]
-                  }
-                />
                 <View
                   accessibilityRole="none"
                   style={

--- a/__snapshots__/features/identityCheck/pages/identification/identificationStart/SelectPhoneStatus.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/identificationStart/SelectPhoneStatus.web.test.tsx.web-snap
@@ -261,11 +261,11 @@ Object {
                             </div>
                           </div>
                         </div>
+                        <div
+                          class="css-view-1dbjc4n"
+                          style="height: 24px;"
+                        />
                       </li>
-                      <div
-                        class="css-view-1dbjc4n"
-                        style="height: 24px;"
-                      />
                       <li
                         class="css-reset-4rbku5 css-view-1dbjc4n"
                         role="listitem"
@@ -587,11 +587,11 @@ Object {
                           </div>
                         </div>
                       </div>
+                      <div
+                        class="css-view-1dbjc4n"
+                        style="height: 24px;"
+                      />
                     </li>
-                    <div
-                      class="css-view-1dbjc4n"
-                      style="height: 24px;"
-                    />
                     <li
                       class="css-reset-4rbku5 css-view-1dbjc4n"
                       role="listitem"

--- a/src/ui/components/accessibility/AccessibilityList.tsx
+++ b/src/ui/components/accessibility/AccessibilityList.tsx
@@ -19,8 +19,10 @@ export const AccessibilityList: FunctionComponent<AccessibilityListProps> = ({
       {items.map((item, index) => {
         return (
           <React.Fragment key={index}>
-            <Li>{item}</Li>
-            {index < itemListLength - 1 && Separator}
+            <Li>
+              {item}
+              {index < itemListLength - 1 && Separator}
+            </Li>
           </React.Fragment>
         )
       })}


### PR DESCRIPTION
Lists should only have <Li /> elements as children for accessibility matters