### PR TITLE
(PC-18073) feat: add scroll to top when pressing home tab

### DIFF
--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -1,5 +1,5 @@
-import { useFocusEffect, useRoute } from '@react-navigation/native'
-import React, { FunctionComponent, useCallback, useEffect, useState } from 'react'
+import { useFocusEffect, useRoute, useScrollToTop } from '@react-navigation/native'
+import React, { FunctionComponent, useCallback, useEffect, useRef, useState } from 'react'
 import {
   FlatList,
   NativeScrollEvent,
@@ -84,6 +84,9 @@ export const OnlineHome: FunctionComponent = () => {
 
   const modulesToDisplay = Platform.OS === 'web' ? modules : modules.slice(0, maxIndex)
 
+  const scrollRef = useRef<FlatList>(null)
+  useScrollToTop(scrollRef)
+
   const onScroll = useCallback(
     ({ nativeEvent }: NativeSyntheticEvent<NativeScrollEvent>) => {
       if (isCloseToBottom({ ...nativeEvent, padding: theme.minScreenHeight * 2 })) {
@@ -140,6 +143,7 @@ export const OnlineHome: FunctionComponent = () => {
       )}
       <HomeBodyLoadingContainer hide={showSkeleton}>
         <FlatList
+          ref={scrollRef}
           testID="homeBodyScrollView"
           scrollEventThrottle={1000}
           onScroll={onScroll}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18073

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

Tested on iOS and Android: 
https://user-images.githubusercontent.com/26742386/200611116-153f64e8-99c9-419e-8218-39608d37fec2.mov

Not available on web as we reload the page (so it's scrolled to the top in the end)