### PR TITLE
(PC-18526) feat(identityCheck): fix illustration UserError color for …

### DIFF
--- a/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.test.ts
+++ b/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.test.ts
@@ -4,7 +4,7 @@ import {
   useNotEligibleEduConnectErrorData,
 } from 'features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData'
 import { renderHook } from 'tests/utils'
-import { UserError } from 'ui/svg/BicolorUserError'
+import { UserErrorWhite } from 'ui/svg/BicolorUserError'
 import { Email } from 'ui/svg/icons/Email'
 
 jest.mock('features/auth/signup/useBeneficiaryValidationNavigation')
@@ -15,7 +15,7 @@ describe('useNotEligibleEduConnectErrorData', () => {
   const mockSetError = jest.fn()
 
   const expectedDuplicatedUserData = {
-    Illustration: UserError,
+    Illustration: UserErrorWhite,
     title: 'As-tu déja un compte\u00a0?',
     description:
       "Ton compte ÉduConnect est déjà rattaché à un compte pass Culture. Vérifie que tu n'as pas déjà créé un compte avec une autre adresse e-mail.\n\nTu peux contacter le support pour plus d'informations.",
@@ -29,7 +29,7 @@ describe('useNotEligibleEduConnectErrorData', () => {
   }
 
   const expectedUserAgeNotValidErrorData = {
-    Illustration: UserError,
+    Illustration: UserErrorWhite,
     title: 'Oh non\u00a0!',
     description:
       'La date de naissance enregistrée dans ÉduConnect semble indiquer que tu n’as pas l’âge requis pour obtenir l’aide de l’État.\n\nS’il y a une erreur sur ta date de naissance, contacte ton établissement pour modifier ton profil ÉduConnect.',
@@ -38,7 +38,7 @@ describe('useNotEligibleEduConnectErrorData', () => {
   }
 
   const expectedInvalidInformationErrorData = {
-    Illustration: UserError,
+    Illustration: UserErrorWhite,
     title: 'Oh non\u00a0!',
     description:
       'Il semblerait que les informations que tu nous as communiquées ne soient pas correctes.\n\nRefais une demande en vérifiant ton identité avec ta pièce d’identité.',
@@ -54,7 +54,7 @@ describe('useNotEligibleEduConnectErrorData', () => {
   }
 
   const expectedUserTypeNotStudentErrorData = {
-    Illustration: UserError,
+    Illustration: UserErrorWhite,
     title: 'Qui est-ce\u00a0?',
     description:
       'Les informations provenant d’ÉduConnect indiquent que vous êtes le représentant légal d’un jeune scolarisé.\n\nL’usage du pass Culture est strictement nominatif. Le compte doit être créé et utilisé par un jeune éligible, de 15 à 18 ans. L’identification doit se faire au nom du futur bénéficiaire. ',

--- a/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.ts
+++ b/src/features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData.ts
@@ -6,7 +6,7 @@ import { useBeneficiaryValidationNavigation } from 'features/auth/signup/useBene
 import { contactSupport } from 'features/auth/support.services'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { ExternalNavigationProps, TouchableLinkProps } from 'ui/components/touchableLink/types'
-import { UserError } from 'ui/svg/BicolorUserError'
+import { UserErrorWhite } from 'ui/svg/BicolorUserError'
 import { Email } from 'ui/svg/icons/Email'
 import { MaintenanceCone } from 'ui/svg/icons/MaintenanceCone'
 import { IconInterface } from 'ui/svg/icons/types'
@@ -40,7 +40,7 @@ export type NotEligibleEduConnectErrorData = {
 }
 
 const UserAgeNotValidErrorData: NotEligibleEduConnectErrorData = {
-  Illustration: UserError,
+  Illustration: UserErrorWhite,
   title: 'Oh non\u00a0!',
   description:
     'La date de naissance enregistrée dans ÉduConnect semble indiquer que tu n’as pas l’âge requis pour obtenir l’aide de l’État.' +
@@ -53,7 +53,7 @@ const UserAgeNotValidErrorData: NotEligibleEduConnectErrorData = {
 const getInvalidInformationErrorData = (
   navigateTo: TouchableLinkProps['navigateTo']
 ): NotEligibleEduConnectErrorData => ({
-  Illustration: UserError,
+  Illustration: UserErrorWhite,
   title: 'Oh non\u00a0!',
   description:
     'Il semblerait que les informations que tu nous as communiquées ne soient pas correctes.' +
@@ -71,7 +71,7 @@ const getUserTypeNotStudentErrorData = (
   onPrimaryButtonPress: () => void,
   navigateTo: TouchableLinkProps['navigateTo']
 ): NotEligibleEduConnectErrorData => ({
-  Illustration: UserError,
+  Illustration: UserErrorWhite,
   title: 'Qui est-ce\u00a0?',
   description:
     'Les informations provenant d’ÉduConnect indiquent que vous êtes le représentant légal d’un jeune scolarisé.' +
@@ -95,7 +95,7 @@ const GenericErrorData: NotEligibleEduConnectErrorData = {
 }
 
 const DuplicateUserErrorData: NotEligibleEduConnectErrorData = {
-  Illustration: UserError,
+  Illustration: UserErrorWhite,
   title: 'As-tu déja un compte\u00a0?',
   description:
     "Ton compte ÉduConnect est déjà rattaché à un compte pass Culture. Vérifie que tu n'as pas déjà créé un compte avec une autre adresse e-mail.\n\nTu peux contacter le support pour plus d'informations.",

--- a/src/ui/svg/BicolorUserError.tsx
+++ b/src/ui/svg/BicolorUserError.tsx
@@ -53,8 +53,8 @@ export const BicolorUserError = styled(BicolorUserErrorSvg).attrs(({ size, theme
   size: size ?? theme.illustrations.sizes.medium,
 }))``
 
-export const UserError = styled(BicolorUserErrorSvg).attrs(({ color, size, theme }) => ({
-  color: color ?? theme.colors.black,
-  color2: color ?? theme.colors.black,
+export const UserErrorWhite = styled(BicolorUserErrorSvg).attrs(({ size, theme }) => ({
+  color: theme.colors.white,
+  color2: theme.colors.white,
   size: size ?? theme.illustrations.sizes.medium,
 }))``


### PR DESCRIPTION
…useNotEligibleEduConnectErrorData

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18526

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |  ![Capture d’écran 2022-11-10 à 11 05 08](https://user-images.githubusercontent.com/62059034/201065755-47ef9a2e-6e07-453b-8d81-fd8115c688a7.png) ![Capture d’écran 2022-11-10 à 11 05 44](https://user-images.githubusercontent.com/62059034/201065737-a69da175-e276-459c-b0f2-922f7f629280.png) ![Capture d’écran 2022-11-10 à 11 05 30](https://user-images.githubusercontent.com/62059034/201065743-86ced8be-c600-4dd2-bc2b-66bf4597d8be.png) ![Capture d’écran 2022-11-10 à 11 05 18](https://user-images.githubusercontent.com/62059034/201065749-8b0670df-b08a-4084-a028-c532daeed840.png)  |  ![Capture d’écran 2022-11-10 à 11 03 31](https://user-images.githubusercontent.com/62059034/201065962-37377f0f-a23e-4454-bbfb-f954293d77fe.png) ![Capture d’écran 2022-11-10 à 11 02 28](https://user-images.githubusercontent.com/62059034/201066175-c5a2a8bf-d9f2-45e3-97c5-56d6e911b63a.png)  ![Capture d’écran 2022-11-10 à 11 02 08](https://user-images.githubusercontent.com/62059034/201066326-7ac8e03b-06ec-4171-814d-d743dc055c36.png) ![Capture d’écran 2022-11-10 à 11 04 35](https://user-images.githubusercontent.com/62059034/201066775-1ad345a8-1688-481d-b9ce-c613dbd68480.png)  |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
