### PR TITLE
(BSR) chore(jest): use fake timers by default

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -51,4 +51,5 @@ module.exports = {
   ],
   coveragePathIgnorePatterns: ['\\.web\\.(test|spec)', '/node_modules/', '/src/environment'],
   collectCoverage: false,
+  timers: 'legacy',
 }


### PR DESCRIPTION
https://jestjs.io/fr/docs/26.x/timer-mocks

Cf. guilde Test de BAM : 
> On ne veut pas que ces fonctions dépendent du temps pour plusieurs raisons : 
> - Ca induit un risque de tests non déterministes (flaky tests). En effet, si ces fonctions dépendent du temps, alors selon le temps d’exécution du test on pourrait avoir certains callbacks appelés dans des setTimeout par exemple qui pourraient être appelés ou non.
> - Pour réduire le temps des tests : si le temps des timers est long, on n’a pas envie d’attendre qu’ils soient finis autrement on aurait des tests trop long
> - Pour que tous les process en cours soient terminés quand on quitte le test : si ce n’est pas le cas, Jest va print un warning nous disant qu’un des process n’est pas terminé et qu’il n’a pas pu quitter normalement. Ca peut causer des problèmes au niveau du temps d’exécution d’une suite de tests, voire potentiellement d’isolation des tests

Warning: L’utilisation de fake timers peut causer des problèmes lorsque l’on utilise rntl (react-native-testing-library) : si vous utiliser des fake timers modern, alors waitFor va systématique timeout, ainsi que tous les utilitaires asynchrones de la librairie. C’est expliqué dans la [documentation de rntl](https://github.com/callstack/react-native-testing-library#custom-jest-preset).

> We generally advise to use the "react-native" preset when testing with this library. However, if you use ["modern" Fake Timers](https://jestjs.io/blog/2020/05/05/jest-26#new-fake-timers) (default since Jest 27), you'll need to apply our custom Jest preset or awaiting promises, like `waitFor`, will timeout. 
> 
> This is a [[known issue](https://github.com/facebook/react-native/issues/29303)](https://github.com/facebook/react-native/issues/29303). It happens because React Native's Jest preset overrides native Promise. Our preset restores it to defaults, which is not a problem in most apps out there.

Pour corriger ce problème, il faut soit utiliser des fake timers legacy, soit appliquer le preset de rntl