### PR TITLE
(PC-18664) fix(home): move style to exclusivity module component

### DIFF
--- a/src/features/home/components/modules/exclusivity/ExclusivityModule.tsx
+++ b/src/features/home/components/modules/exclusivity/ExclusivityModule.tsx
@@ -26,11 +26,12 @@ const UnmemoizedExclusivityModule = ({ offerId, url, ...props }: ExclusivityModu
 
     return <ExclusivityBanner {...props} />
   }
+  const StyledExclusivityComponent = styled(ExclusivityComponent)({ paddingBottom: getSpacing(6) })
 
   return (
     <Row>
       <Spacer.Row numberOfSpaces={6} />
-      <ExclusivityComponent />
+      <StyledExclusivityComponent />
       <Spacer.Row numberOfSpaces={6} />
     </Row>
   )
@@ -40,5 +41,4 @@ export const ExclusivityModule = memo(UnmemoizedExclusivityModule)
 
 const Row = styled.View({
   flexDirection: 'row',
-  paddingBottom: getSpacing(6),
 })


### PR DESCRIPTION
so if the component is not displayed, the style isn't either

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18664

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [x] If my PR is a bugfix, I add the link: [Notion - Sur la Home, j’ai un “trou” blanc entre mes modules](https://www.notion.so/passcultureapp/Sur-la-Home-j-ai-un-trou-blanc-entre-mes-modules-a57bda603d7f4e1da79639dee4391ee1)

## Screenshots

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   | <img width="295" alt="image" src="https://user-images.githubusercontent.com/26742386/203020133-f755bc62-4d6b-4020-853e-8b9ae379c74a.png"> | <img width="295" alt="image" src="https://user-images.githubusercontent.com/26742386/203021831-dd90edce-f3b0-4576-b634-8abfd70f6ec2.png"> |
| Desktop - Chrome | <img width="1440" alt="image" src="https://user-images.githubusercontent.com/26742386/203020266-8d4da9c2-29c7-437e-98fe-bc8eabeb5291.png"> | <img width="1440" alt="image" src="https://user-images.githubusercontent.com/26742386/203021767-d862adf0-cd4c-4bef-94c1-1aa1cd871e4b.png"> |
