### PR TITLE
(PC-18833) fix(home): propagate style to exclusivity components

### DIFF
--- a/src/features/home/components/modules/exclusivity/ExclusivityBanner.tsx
+++ b/src/features/home/components/modules/exclusivity/ExclusivityBanner.tsx
@@ -12,6 +12,7 @@ const UnmemoizedExclusivityBanner = ({
   moduleId,
   homeEntryId,
   index,
+  style,
 }: ExclusivityBannerProps) => {
   useEffect(() => {
     analytics.logModuleDisplayedOnHomepage(moduleId, ContentTypes.EXCLUSIVITY, index, homeEntryId)
@@ -19,7 +20,7 @@ const UnmemoizedExclusivityBanner = ({
   }, [moduleId, homeEntryId])
 
   return (
-    <ImageContainer testID="exclusivity-banner">
+    <ImageContainer style={style} testID="exclusivity-banner">
       <ExclusivityImage imageURL={imageURL} alt={alt} />
     </ImageContainer>
   )

--- a/src/features/home/components/modules/exclusivity/ExclusivityExternalLink.tsx
+++ b/src/features/home/components/modules/exclusivity/ExclusivityExternalLink.tsx
@@ -19,6 +19,7 @@ const UnmemoizedExclusivityExternalLink = ({
   homeEntryId,
   index,
   url,
+  style,
 }: ExclusivityExternalLinkProps) => {
   const [isFocus, setIsFocus] = useState(false)
   useEffect(() => {
@@ -36,6 +37,7 @@ const UnmemoizedExclusivityExternalLink = ({
       onBlur={onBlur}
       isFocus={isFocus}
       externalNav={{ url }}
+      style={style}
       testID="exclusivity-external-link">
       <ExclusivityImage imageURL={imageURL} alt={alt} />
     </StyledTouchableLink>

--- a/src/features/home/components/modules/exclusivity/ExclusivityModule.tsx
+++ b/src/features/home/components/modules/exclusivity/ExclusivityModule.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from 'react'
+import { ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
 
 import { ExclusivityBanner } from 'features/home/components/modules/exclusivity/ExclusivityBanner'
@@ -10,23 +11,26 @@ import { getSpacing, Spacer } from 'ui/theme'
 export interface ExclusivityModuleProps extends ExclusivityPane {
   homeEntryId: string | undefined
   index: number
+  style?: ViewStyle
 }
 
 export type ExclusivityBannerProps = Omit<ExclusivityModuleProps, 'offerId' | 'url'>
 
 const UnmemoizedExclusivityModule = ({ offerId, url, ...props }: ExclusivityModuleProps) => {
-  const ExclusivityComponent = () => {
+  const ExclusivityComponent = ({ style }: { style?: ViewStyle }) => {
     if (offerId !== undefined) {
-      return <ExclusivityOffer offerId={offerId} {...props} />
+      return <ExclusivityOffer offerId={offerId} {...props} style={style} />
     }
 
     if (url !== undefined) {
-      return <ExclusivityExternalLink url={url} {...props} />
+      return <ExclusivityExternalLink url={url} {...props} style={style} />
     }
 
-    return <ExclusivityBanner {...props} />
+    return <ExclusivityBanner {...props} style={style} />
   }
-  const StyledExclusivityComponent = styled(ExclusivityComponent)({ paddingBottom: getSpacing(6) })
+  const StyledExclusivityComponent = styled(ExclusivityComponent)({
+    marginBottom: getSpacing(6),
+  })
 
   return (
     <Row>

--- a/src/features/home/components/modules/exclusivity/ExclusivityOffer.tsx
+++ b/src/features/home/components/modules/exclusivity/ExclusivityOffer.tsx
@@ -22,6 +22,7 @@ const UnmemoizedExclusivityOffer = ({
   display,
   homeEntryId,
   index,
+  style,
 }: ExclusivityOfferProps) => {
   const [isFocus, setIsFocus] = useState(false)
   const shouldDisplayExcluOffer = useShouldDisplayExcluOffer(display, offerId)
@@ -63,7 +64,8 @@ const UnmemoizedExclusivityOffer = ({
       onBlur={onBlur}
       isFocus={isFocus}
       testID="link-exclusivity-offer"
-      disabled={offerId === undefined}>
+      disabled={offerId === undefined}
+      style={style}>
       <ExclusivityImage imageURL={imageURL} alt={alt} />
     </StyledTouchableLink>
   )


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18833

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS (part 1) |        | <img width="511" alt="image" src="https://user-images.githubusercontent.com/26742386/203753971-031ec4a4-6a70-4673-afcc-af3934977465.png"> |
| iOS (part 2) |        | <img width="511" alt="image" src="https://user-images.githubusercontent.com/26742386/203754010-19384fab-34ca-46c2-adc7-882f009cde55.png"> |
| Phone - Chrome   | <img width="294" alt="image" src="https://user-images.githubusercontent.com/26742386/203753492-8957f1b3-b646-4d1c-910a-284abedfbe27.png">> | <img width="294" alt="image" src="https://user-images.githubusercontent.com/26742386/203753354-2c94c600-8d91-4552-b344-46c22764ac64.png"> |
