### PR TITLE
(PC-18908) fix(search): only free offers when min & max prices at 0

### DIFF
--- a/src/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx
+++ b/src/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx
@@ -95,6 +95,37 @@ describe('<PriceModal/>', () => {
       })
     })
 
+    it('when pressing on search button with minimum and maximum prices entered at 0', async () => {
+      const { getByPlaceholderText, getByText } = renderSearchPrice()
+
+      const minPriceInput = getByPlaceholderText('0')
+      await act(async () => {
+        fireEvent(minPriceInput, 'onChangeText', '0')
+      })
+
+      const maxPriceInput = getByPlaceholderText('80')
+      await act(async () => {
+        fireEvent(maxPriceInput, 'onChangeText', '0')
+      })
+
+      const searchButton = getByText('Rechercher')
+      await act(async () => {
+        fireEvent.press(searchButton)
+      })
+
+      const expectedSearchParams = {
+        ...mockSearchState,
+        minPrice: '0',
+        maxPrice: '0',
+        offerIsFree: true,
+        view: SearchView.Results,
+      }
+      expect(navigate).toHaveBeenCalledWith('TabNavigator', {
+        params: expectedSearchParams,
+        screen: 'Search',
+      })
+    })
+
     it('when pressing search button with only free offers search toggle activated', async () => {
       const { getByTestId, getByText } = renderSearchPrice()
 

--- a/src/features/search/pages/modals/PriceModal/PriceModal.tsx
+++ b/src/features/search/pages/modals/PriceModal/PriceModal.tsx
@@ -86,7 +86,8 @@ export const PriceModal: FunctionComponent<Props> = ({
 
   function search(values: PriceModalFormData) {
     const offerIsFree =
-      values.isOnlyFreeOffersSearch || (values.maxPrice === '0' && values.minPrice === '')
+      values.isOnlyFreeOffersSearch ||
+      (values.maxPrice === '0' && (values.minPrice === '' || values.minPrice === '0'))
     let additionalSearchState: SearchState = {
       ...searchState,
       priceRange: null,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18908

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
