### PR TITLE
(PC-18972) fix(android): avoid crash when re-entering the app

### DIFF
--- a/android/app/src/main/java/com/passculture/MainActivity.java
+++ b/android/app/src/main/java/com/passculture/MainActivity.java
@@ -24,7 +24,7 @@ public class MainActivity extends ReactActivity {
     protected void onCreate(Bundle savedInstanceState) {
         SplashScreen.show(this, R.id.lottie);
         SplashScreen.setAnimationFinished(true); // We want the animation dialog to be forced to close when hide is called, so we use this
-        super.onCreate(savedInstanceState);
+        super.onCreate(null); // known fix for react-native-screens: https://github.com/software-mansion/react-native-screens#android
     }
 
     // @batch.com/react-native-plugin (https://doc.batch.com/react-native/sdk-integration#configure-onnewintent)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18972

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web). -> **only on Android**
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [x] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" -> https://www.notion.so/Android-crash-en-re-rentrant-sur-l-app-3170c0b4ee534da698877fef720177da

<img src="https://user-images.githubusercontent.com/26742386/204605933-bdaf904f-985a-4990-9c58-131ca5f9deb5.gif" width=300 />
