### PR TITLE
(PC-17529) ci(authentication): Use gsutil for rsync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,7 +395,7 @@ commands:
     steps:
       - run: |
           set +eo pipefail
-          gcloud alpha storage rsync -r ./build gs://<< parameters.bucket_name >>
+          gsutil rsync -r ./build gs://<< parameters.bucket_name >>
 
   invalidate-cache:
     description: Invalidate Cache asynchronously


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17529

`gcloud alpha storage` ne supporte pas la commande `rsync`, donc on repasse sur `gsutil` qui fonctionne maintenant avec Workload Identity.