### PR TITLE
(PC-18773) feat(amplitude): add amplitude logs on identification and confirmation screens

### DIFF
--- a/src/features/identityCheck/pages/confirmation/IdentityCheckHonor.tsx
+++ b/src/features/identityCheck/pages/confirmation/IdentityCheckHonor.tsx
@@ -1,5 +1,5 @@
 import { useNavigation } from '@react-navigation/native'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useQueryClient } from 'react-query'
 import styled, { useTheme } from 'styled-components/native'
 
@@ -12,6 +12,7 @@ import { PageWithHeader } from 'features/identityCheck/components/layout/PageWit
 import { useSubscriptionNavigation } from 'features/identityCheck/useSubscriptionNavigation'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { useUserProfileInfo } from 'features/profile/api'
+import { amplitude } from 'libs/amplitude'
 import { QueryKeys } from 'libs/queryKeys'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
@@ -19,6 +20,9 @@ import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { getSpacing, Spacer } from 'ui/theme'
 
 export const IdentityCheckHonor = () => {
+  useEffect(() => {
+    amplitude.logEvent('screen_view_identity_check_honor')
+  }, [])
   const theme = useTheme()
   const { navigateToNextScreen } = useSubscriptionNavigation()
   const { showErrorSnackBar } = useSnackBarContext()

--- a/src/features/identityCheck/pages/confirmation/__test__/IdentityCheckHonor.test.tsx
+++ b/src/features/identityCheck/pages/confirmation/__test__/IdentityCheckHonor.test.tsx
@@ -8,7 +8,8 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { UserProfileResponse } from 'api/gen'
 import { IdentityCheckHonor } from 'features/identityCheck/pages/confirmation/IdentityCheckHonor'
 import { beneficiaryUser, nonBeneficiaryUser } from 'fixtures/user'
-import { act, fireEvent, render, useMutationFactory } from 'tests/utils'
+import { amplitude } from 'libs/amplitude'
+import { act, fireEvent, render, useMutationFactory, waitFor } from 'tests/utils'
 
 jest.mock('react-query')
 
@@ -94,5 +95,13 @@ describe('<IdentityCheckHonor/>', () => {
     await waitForExpect(() => {
       expect(mockNavigateToNextScreen).toHaveBeenCalledTimes(1)
     })
+  })
+
+  it('should send a amplitude event when the screen is mounted', async () => {
+    render(<IdentityCheckHonor />)
+
+    await waitFor(() =>
+      expect(amplitude.logEvent).toHaveBeenNthCalledWith(1, 'screen_view_identity_check_honor')
+    )
   })
 })

--- a/src/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { useRoute } from '__mocks__/@react-navigation/native'
 import { DMSIntroduction } from 'features/identityCheck/pages/identification/dms/DMSIntroduction'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
+import { amplitude } from 'libs/amplitude'
 import { env } from 'libs/environment'
 import { analytics } from 'libs/firebase/analytics'
 import { fireEvent, render, waitFor } from 'tests/utils'
@@ -10,6 +11,13 @@ import { fireEvent, render, waitFor } from 'tests/utils'
 const openUrl = jest.spyOn(NavigationHelpers, 'openUrl')
 
 describe('DMSIntroduction', () => {
+  it('should send a amplitude event when the screen is mounted', async () => {
+    render(<DMSIntroduction />)
+
+    await waitFor(() =>
+      expect(amplitude.logEvent).toHaveBeenNthCalledWith(1, 'screen_view_dms_introduction')
+    )
+  })
   describe('french version', () => {
     beforeEach(() => {
       useRoute.mockReturnValueOnce({

--- a/src/features/identityCheck/pages/identification/dms/DMSIntroduction.tsx
+++ b/src/features/identityCheck/pages/identification/dms/DMSIntroduction.tsx
@@ -1,8 +1,9 @@
 import { useRoute } from '@react-navigation/native'
-import React, { FC } from 'react'
+import React, { FC, useEffect } from 'react'
 import styled from 'styled-components/native'
 
 import { UseRouteType } from 'features/navigation/RootNavigator/types'
+import { amplitude } from 'libs/amplitude'
 import { env } from 'libs/environment'
 import { analytics } from 'libs/firebase/analytics'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
@@ -21,6 +22,9 @@ import { LogoDMS } from 'ui/svg/LogoDMS'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
 export const DMSIntroduction = (): JSX.Element => {
+  useEffect(() => {
+    amplitude.logEvent('screen_view_dms_introduction')
+  }, [])
   const { params } = useRoute<UseRouteType<'DMSIntroduction'>>()
 
   const timeLabel = '10 minutes de ton temps'

--- a/src/features/identityCheck/pages/identification/identificationStart/ComeBackLater.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/identificationStart/ComeBackLater.native.test.tsx
@@ -3,7 +3,8 @@ import React from 'react'
 import { ComeBackLater } from 'features/identityCheck/pages/identification/identificationStart/ComeBackLater'
 import { navigateToHomeConfig } from 'features/navigation/helpers'
 import { navigateFromRef } from 'features/navigation/navigationRef'
-import { fireEvent, render } from 'tests/utils'
+import { amplitude } from 'libs/amplitude'
+import { fireEvent, render, waitFor } from 'tests/utils'
 
 jest.mock('features/navigation/helpers')
 jest.mock('features/navigation/navigationRef')
@@ -24,6 +25,13 @@ describe('ComeBackLater', () => {
     expect(navigateFromRef).toHaveBeenCalledWith(
       navigateToHomeConfig.screen,
       navigateToHomeConfig.params
+    )
+  })
+  it('should send a amplitude event when the screen is mounted', async () => {
+    render(<ComeBackLater />)
+
+    await waitFor(() =>
+      expect(amplitude.logEvent).toHaveBeenNthCalledWith(1, 'screen_view_come_back_later')
     )
   })
 })

--- a/src/features/identityCheck/pages/identification/identificationStart/ComeBackLater.tsx
+++ b/src/features/identityCheck/pages/identification/identificationStart/ComeBackLater.tsx
@@ -1,8 +1,9 @@
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useEffect } from 'react'
 import { View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { navigateToHomeConfig } from 'features/navigation/helpers'
+import { amplitude } from 'libs/amplitude'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { TouchableLink } from 'ui/components/touchableLink/TouchableLink'
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
@@ -10,6 +11,10 @@ import { BicolorIdCardInvalid } from 'ui/svg/icons/BicolorIdCardInvalid'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
 export const ComeBackLater: FunctionComponent = () => {
+  useEffect(() => {
+    amplitude.logEvent('screen_view_come_back_later')
+  }, [])
+
   return (
     <GenericInfoPageWhite
       icon={BicolorIdCardInvalid}

--- a/src/features/identityCheck/pages/identification/identificationStart/ExpiredOrLostID.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/identificationStart/ExpiredOrLostID.native.test.tsx
@@ -4,7 +4,8 @@ import { ExpiredOrLostID } from 'features/identityCheck/pages/identification/ide
 import { navigateToHomeConfig } from 'features/navigation/helpers'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { navigateFromRef } from 'features/navigation/navigationRef'
-import { fireEvent, render } from 'tests/utils'
+import { amplitude } from 'libs/amplitude'
+import { fireEvent, render, waitFor } from 'tests/utils'
 
 jest.mock('features/navigation/navigationRef')
 const openUrl = jest.spyOn(NavigationHelpers, 'openUrl')
@@ -29,5 +30,13 @@ describe('ExpiredOrLostID', () => {
     fireEvent.press(getByText('Demander un renouvellement'))
 
     expect(openUrl).toHaveBeenCalledWith('https://ants.gouv.fr/', undefined)
+  })
+
+  it('should send a amplitude event when the screen is mounted', async () => {
+    render(<ExpiredOrLostID />)
+
+    await waitFor(() =>
+      expect(amplitude.logEvent).toHaveBeenNthCalledWith(1, 'screen_view_expired_or_lost_id')
+    )
   })
 })

--- a/src/features/identityCheck/pages/identification/identificationStart/ExpiredOrLostID.tsx
+++ b/src/features/identityCheck/pages/identification/identificationStart/ExpiredOrLostID.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { navigateToHomeConfig } from 'features/navigation/helpers'
+import { amplitude } from 'libs/amplitude'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
 import { TouchableLink } from 'ui/components/touchableLink/TouchableLink'
@@ -14,6 +15,10 @@ import { getSpacing, Spacer, Typo } from 'ui/theme'
 const ANTS_URL = 'https://ants.gouv.fr/'
 
 export const ExpiredOrLostID = (): JSX.Element => {
+  useEffect(() => {
+    amplitude.logEvent('screen_view_expired_or_lost_id')
+  }, [])
+
   return (
     <GenericInfoPageWhite
       icon={StyledBicolorIdCardError}

--- a/src/features/identityCheck/pages/identification/identificationStart/SelectIDOrigin.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/identificationStart/SelectIDOrigin.native.test.tsx
@@ -3,7 +3,8 @@ import React from 'react'
 import { navigate } from '__mocks__/@react-navigation/native'
 import { initialSubscriptionState as mockState } from 'features/identityCheck/context/reducer'
 import { SelectIDOrigin } from 'features/identityCheck/pages/identification/identificationStart/SelectIDOrigin'
-import { fireEvent, render } from 'tests/utils'
+import { amplitude } from 'libs/amplitude'
+import { fireEvent, render, waitFor } from 'tests/utils'
 
 jest.mock('features/identityCheck/context/SubscriptionContextProvider', () => ({
   useSubscriptionContext: jest.fn(() => ({
@@ -33,5 +34,13 @@ describe('SelectIDOrigin', () => {
     fireEvent.press(HeroButtonListForeign)
 
     expect(navigate).toHaveBeenCalledWith('DMSIntroduction', { isForeignDMSInformation: true })
+  })
+
+  it('should send a amplitude event when the screen is mounted', async () => {
+    render(<SelectIDOrigin />)
+
+    await waitFor(() =>
+      expect(amplitude.logEvent).toHaveBeenNthCalledWith(1, 'screen_view_select_id_origin')
+    )
   })
 })

--- a/src/features/identityCheck/pages/identification/identificationStart/SelectIDOrigin.tsx
+++ b/src/features/identityCheck/pages/identification/identificationStart/SelectIDOrigin.tsx
@@ -1,9 +1,10 @@
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useEffect } from 'react'
 import { Platform, Text } from 'react-native'
 import styled from 'styled-components/native'
 
 import { HeroButtonList } from 'features/identityCheck/components/HeroButtonList'
 import { PageWithHeader } from 'features/identityCheck/components/layout/PageWithHeader'
+import { amplitude } from 'libs/amplitude'
 import { AccessibilityList } from 'ui/components/accessibility/AccessibilityList'
 import { BicolorEarth } from 'ui/svg/icons/BicolorEarth'
 import { BicolorFrance } from 'ui/svg/icons/BicolorFrance'
@@ -11,6 +12,9 @@ import { BicolorIdCardWithMagnifyingGlass } from 'ui/svg/icons/BicolorIdCardWith
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
 export const SelectIDOrigin: FunctionComponent = () => {
+  useEffect(() => {
+    amplitude.logEvent('screen_view_select_id_origin')
+  }, [])
   return <PageWithHeader title={'Identification'} scrollChildren={<SelectIDOriginContent />} />
 }
 

--- a/src/features/identityCheck/pages/identification/identificationStart/SelectIDStatus.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/identificationStart/SelectIDStatus.native.test.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 import { SelectIDStatus } from 'features/identityCheck/pages/identification/identificationStart/SelectIDStatus'
-import { fireEvent, render } from 'tests/utils'
+import { amplitude } from 'libs/amplitude'
+import { fireEvent, render, waitFor } from 'tests/utils'
 
 describe('SelectIDStatus', () => {
   it('should render SelectIDStatus page correctly', () => {
@@ -35,5 +36,13 @@ describe('SelectIDStatus', () => {
     fireEvent.press(button)
 
     expect(navigate).toHaveBeenCalledWith('ExpiredOrLostID', undefined)
+  })
+
+  it('should send a amplitude event when the screen is mounted', async () => {
+    render(<SelectIDStatus />)
+
+    await waitFor(() =>
+      expect(amplitude.logEvent).toHaveBeenNthCalledWith(1, 'screen_view_select_id_status')
+    )
   })
 })

--- a/src/features/identityCheck/pages/identification/identificationStart/SelectIDStatus.tsx
+++ b/src/features/identityCheck/pages/identification/identificationStart/SelectIDStatus.tsx
@@ -1,9 +1,10 @@
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useEffect } from 'react'
 import { Text } from 'react-native'
 import styled from 'styled-components/native'
 
 import { HeroButtonList } from 'features/identityCheck/components/HeroButtonList'
 import { PageWithHeader } from 'features/identityCheck/components/layout/PageWithHeader'
+import { amplitude } from 'libs/amplitude'
 import { AccessibilityList } from 'ui/components/accessibility/AccessibilityList'
 import { Emoji } from 'ui/components/Emoji'
 import { BicolorIdCard } from 'ui/svg/icons/BicolorIdCard'
@@ -12,6 +13,9 @@ import { BicolorNoId } from 'ui/svg/icons/BicolorNoId'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
 export const SelectIDStatus: FunctionComponent = () => {
+  useEffect(() => {
+    amplitude.logEvent('screen_view_select_id_status')
+  }, [])
   return <PageWithHeader title="Identification" scrollChildren={<SelectIDStatusContent />} />
 }
 

--- a/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.test.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.test.tsx
@@ -5,7 +5,8 @@ import { NextSubscriptionStepResponse, SubscriptionStep } from 'api/gen'
 import { nextSubscriptionStepFixture as mockStep } from 'features/identityCheck/__mocks__/nextSubscriptionStepFixture'
 import { IdentityCheckEnd } from 'features/identityCheck/pages/identification/ubble/IdentityCheckEnd'
 import { navigateToHome } from 'features/navigation/helpers'
-import { render } from 'tests/utils'
+import { amplitude } from 'libs/amplitude'
+import { render, waitFor } from 'tests/utils'
 
 jest.mock('features/navigation/helpers')
 const mockNavigateToNextScreen = jest.fn()
@@ -51,5 +52,13 @@ describe('<IdentityCheckEnd/>', () => {
     expect(navigateToHome).not.toHaveBeenCalled()
     jest.advanceTimersByTime(3000)
     expect(navigateToHome).toHaveBeenCalledTimes(1)
+  })
+
+  it('should send a amplitude event when the screen is mounted', async () => {
+    render(<IdentityCheckEnd />)
+
+    await waitFor(() =>
+      expect(amplitude.logEvent).toHaveBeenNthCalledWith(1, 'screen_view_identity_check_end')
+    )
   })
 })

--- a/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.tsx
@@ -4,6 +4,7 @@ import React, { useEffect } from 'react'
 import { useNextSubscriptionStep } from 'features/auth/signup/useNextSubscriptionStep'
 import { navigateToHome } from 'features/navigation/helpers'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { amplitude } from 'libs/amplitude'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { EmailSent } from 'ui/svg/icons/EmailSent'
 
@@ -12,6 +13,10 @@ export const IdentityCheckEnd = () => {
   const { navigate } = useNavigation<UseNavigationType>()
 
   const navigateToStepper = () => navigate('IdentityCheckStepper')
+
+  useEffect(() => {
+    amplitude.logEvent('screen_view_identity_check_end')
+  }, [])
 
   useEffect(() => {
     const timeout = setTimeout(


### PR DESCRIPTION

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18773

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/89008469/204830378-b857145e-e811-48b3-935b-7ad4f69ff22e.png">
