### PR TITLE
(BSR) chore(deps): remove unused package cli-table

### DIFF
--- a/package.json
+++ b/package.json
@@ -346,7 +346,6 @@
     "@sentry/utils": "7.8.*",
     "ansi-regex": "^5.0.1",
     "browserslist": "^4.16.5",
-    "cli-table": "0.3.6",
     "color-name": "1.1.*",
     "glob-parent": "^5.1.2",
     "immer": "^9.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9970,13 +9970,6 @@ cli-table3@0.6.1, cli-table3@^0.6.1:
   optionalDependencies:
     colors "1.4.0"
 
-cli-table@0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.6.tgz#e9d6aa859c7fe636981fd3787378c2a20bce92fc"
-  integrity sha512-ZkNZbnZjKERTY5NwC2SeMeLeifSPq/pubeRoTpdr3WchLlnZg6hEgvHkK5zL7KNFdd9PmHN8lxrENUwI3cE8vQ==
-  dependencies:
-    colors "1.0.3"
-
 cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
@@ -10181,11 +10174,6 @@ colorette@^2.0.14:
   version "2.0.16"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
-
-colors@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
-  integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
 colors@1.4.0:
   version "1.4.0"


### PR DESCRIPTION

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Contexte

Renovate propose de bumper la version de cli-table mais la lib n'a pas l'air d'être réellement utilisée, elle avait été introduite dans ce commit https://github.com/pass-culture/pass-culture-app-native/commit/9775326e3eb56090579e0c6462c61ecad600e1e7 qui bumpait lingui. On n'utilise plus lingui donc on peut sans doute supprimer cli-table

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
