### PR TITLE
(PC-18521) fix(position): increase position cache time in web

### DIFF
--- a/src/libs/geolocation/getPosition.web.ts
+++ b/src/libs/geolocation/getPosition.web.ts
@@ -4,7 +4,7 @@ import { GeoCoordinates } from './types'
 const GET_POSITION_SETTINGS = {
   enableHighAccuracy: false,
   timeout: 20000,
-  maximumAge: 10000,
+  maximumAge: 60000,
 }
 
 // @ts-expect-error: older versions of Safari and Firefox may use the non-standard name of `PositionError`:


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18521

**Vu avec la data**: pour garder la position précise de l'utilisateur on a décidé d'augmenter le temps de cache de la position en web (pas de spam depuis l'app) plutôt que d'arrondir la position de l'utilisateur et perdre en précision.


## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

Avant:
https://user-images.githubusercontent.com/22886846/207003129-fe3fbffc-f9a3-4eb1-8baa-a0d3686211f3.mov




[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
