### PR TITLE
(PC-19213) ci(e2e): move manuel e2e to #alertes-qa-manuel

### DIFF
--- a/.github/workflows/e2e-android-app.yml
+++ b/.github/workflows/e2e-android-app.yml
@@ -68,6 +68,7 @@ jobs:
       SPECS: ${{ inputs.specs }}
       GITHUB_EVENT_NAME: ${{ github.event_name }}
       SLACK_WEB_HOOK_URL: ${{ secrets.E2E_SLACK_WEB_HOOK_URL }}
+      SLACK_WEB_HOOK_URL_MANUAL: ${{ secrets.E2E_SLACK_WEB_HOOK_URL_MANUAL }}
       # useful for Slack reports
       GITHUB_SERVER_URL: ${{ github.server_url }}
       GITHUB_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/e2e-android-browser.yml
+++ b/.github/workflows/e2e-android-browser.yml
@@ -56,6 +56,7 @@ jobs:
       SPECS: ${{ inputs.specs }}
       GITHUB_EVENT_NAME: ${{ github.event_name }}
       SLACK_WEB_HOOK_URL: ${{ secrets.E2E_SLACK_WEB_HOOK_URL }}
+      SLACK_WEB_HOOK_URL_MANUAL: ${{ secrets.E2E_SLACK_WEB_HOOK_URL_MANUAL }}
       # useful for Slack reports
       GITHUB_SERVER_URL: ${{ github.server_url }}
       GITHUB_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/e2e-browser-chrome.yml
+++ b/.github/workflows/e2e-browser-chrome.yml
@@ -44,6 +44,7 @@ jobs:
       SPECS: ${{ inputs.specs }}
       GITHUB_EVENT_NAME: ${{ github.event_name }}
       SLACK_WEB_HOOK_URL: ${{ secrets.E2E_SLACK_WEB_HOOK_URL }}
+      SLACK_WEB_HOOK_URL_MANUAL: ${{ secrets.E2E_SLACK_WEB_HOOK_URL_MANUAL }}
       # useful for Slack reports
       GITHUB_SERVER_URL: ${{ github.server_url }}
       GITHUB_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/e2e-browser-firefox.yml
+++ b/.github/workflows/e2e-browser-firefox.yml
@@ -44,6 +44,7 @@ jobs:
       SPECS: ${{ inputs.specs }}
       GITHUB_EVENT_NAME: ${{ github.event_name }}
       SLACK_WEB_HOOK_URL: ${{ secrets.E2E_SLACK_WEB_HOOK_URL }}
+      SLACK_WEB_HOOK_URL_MANUAL: ${{ secrets.E2E_SLACK_WEB_HOOK_URL_MANUAL }}
       # useful for Slack reports
       GITHUB_SERVER_URL: ${{ github.server_url }}
       GITHUB_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/e2e-browser-safari.yml
+++ b/.github/workflows/e2e-browser-safari.yml
@@ -44,6 +44,7 @@ jobs:
       SPECS: ${{ inputs.specs }}
       GITHUB_EVENT_NAME: ${{ github.event_name }}
       SLACK_WEB_HOOK_URL: ${{ secrets.E2E_SLACK_WEB_HOOK_URL }}
+      SLACK_WEB_HOOK_URL_MANUAL: ${{ secrets.E2E_SLACK_WEB_HOOK_URL_MANUAL }}
       # useful for Slack reports
       GITHUB_SERVER_URL: ${{ github.server_url }}
       GITHUB_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/e2e-ios-app.yml
+++ b/.github/workflows/e2e-ios-app.yml
@@ -56,6 +56,7 @@ jobs:
       SPECS: ${{ inputs.specs }}
       GITHUB_EVENT_NAME: ${{ github.event_name }}
       SLACK_WEB_HOOK_URL: ${{ secrets.E2E_SLACK_WEB_HOOK_URL }}
+      SLACK_WEB_HOOK_URL_MANUAL: ${{ secrets.E2E_SLACK_WEB_HOOK_URL_MANUAL }}
       # useful for Slack reports
       GITHUB_SERVER_URL: ${{ github.server_url }}
       GITHUB_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/e2e-ios-browser.yml
+++ b/.github/workflows/e2e-ios-browser.yml
@@ -53,6 +53,7 @@ jobs:
       SPECS: ${{ inputs.specs }}
       GITHUB_EVENT_NAME: ${{ github.event_name }}
       SLACK_WEB_HOOK_URL: ${{ secrets.E2E_SLACK_WEB_HOOK_URL }}
+      SLACK_WEB_HOOK_URL_MANUAL: ${{ secrets.E2E_SLACK_WEB_HOOK_URL_MANUAL }}
       # useful for Slack reports
       GITHUB_SERVER_URL: ${{ github.server_url }}
       GITHUB_RUN_ID: ${{ github.run_id }}

--- a/e2e/config/wdio.shared.conf.ts
+++ b/e2e/config/wdio.shared.conf.ts
@@ -13,6 +13,7 @@ const {
   /** Required CI env only */
   CI,
   SLACK_WEB_HOOK_URL,
+  SLACK_WEB_HOOK_URL_MANUAL,
   GITHUB_REF_NAME,
   GITHUB_EVENT_NAME,
   GITHUB_SERVER_URL,
@@ -34,6 +35,7 @@ const branchUrl = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY_OWNER_PART}/${GITHUB
 const commitUrl = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY_OWNER_PART}/${GITHUB_REPOSITORY_NAME_PART}/tree/${GITHUB_SHA_SHORT}`
 const actionUrl = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY_OWNER_PART}/${GITHUB_REPOSITORY_NAME_PART}/actions/runs/${GITHUB_RUN_ID}`
 const slackMessageTitle = `<${branchUrl}|${GITHUB_REF_NAME}>/<${commitUrl}|${GITHUB_SHA_SHORT}> ${ENVIRONMENT} - wdio ${GITHUB_REPOSITORY_NAME_PART} \`${NPM_LIFECYCLE_EVENT}\` <${actionUrl}|tests report> (${eventName})`
+const webHookUrl = eventName === 'Scheduled' ? SLACK_WEB_HOOK_URL : SLACK_WEB_HOOK_URL_MANUAL
 
 /**
  * All not needed configurations, for this boilerplate, are removed.
@@ -139,7 +141,7 @@ export const config: WebdriverIO.Config = {
     useSlackService && [
       slack,
       {
-        webHookUrl: SLACK_WEB_HOOK_URL,
+        webHookUrl,
         notifyOnlyOnFailure: false,
         messageTitle: slackMessageTitle,
       },


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19213

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
