### PR TITLE
(PC-18688) feat(HomeHeader): use the same display condition as the system bloc on the NonBeneficiaryHeader Component

### DIFF
--- a/src/features/home/components/headers/HomeHeader.native.test.tsx
+++ b/src/features/home/components/headers/HomeHeader.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import { SubscriptionStatus, UserProfileResponse, YoungStatusType } from 'api/gen'
 import * as Auth from 'features/auth/AuthContext'
+import { useBeneficiaryValidationNavigation } from 'features/auth/signup/useBeneficiaryValidationNavigation'
 import { Credit, useAvailableCredit } from 'features/home/services/useAvailableCredit'
 import { nonBeneficiaryUser } from 'fixtures/user'
 import { GeolocPermissionState, useGeolocation } from 'libs/geolocation'
@@ -14,6 +15,10 @@ import { HomeHeader } from './HomeHeader'
 const mockUseAuthContext = jest.spyOn(Auth, 'useAuthContext')
 
 jest.mock('features/auth/signup/useBeneficiaryValidationNavigation')
+const mockedUseBeneficiaryValidationNavigation =
+  useBeneficiaryValidationNavigation as jest.MockedFunction<
+    typeof useBeneficiaryValidationNavigation
+  >
 jest.mock('features/home/services/useAvailableCredit')
 const mockUseAvailableCredit = useAvailableCredit as jest.MockedFunction<typeof useAvailableCredit>
 
@@ -72,6 +77,10 @@ describe('HomeHeader', () => {
 
   it('should display geolocation banner when geolocation is denied', () => {
     mockUseGeolocation.mockReturnValueOnce({ permissionState: GeolocPermissionState.DENIED })
+    mockedUseBeneficiaryValidationNavigation.mockReturnValueOnce({
+      nextBeneficiaryValidationStepNavConfig: undefined,
+      navigateToNextBeneficiaryValidationStep: jest.fn(),
+    })
     const { queryByText } = renderHomeHeader()
 
     expect(queryByText('Géolocalise-toi')).toBeTruthy()
@@ -80,6 +89,10 @@ describe('HomeHeader', () => {
   it('should display geolocation banner when geolocation is never ask again', () => {
     mockUseGeolocation.mockReturnValueOnce({
       permissionState: GeolocPermissionState.NEVER_ASK_AGAIN,
+    })
+    mockedUseBeneficiaryValidationNavigation.mockReturnValueOnce({
+      nextBeneficiaryValidationStepNavConfig: undefined,
+      navigateToNextBeneficiaryValidationStep: jest.fn(),
     })
     const { queryByText } = renderHomeHeader()
 

--- a/src/features/home/components/headers/HomeHeader.tsx
+++ b/src/features/home/components/headers/HomeHeader.tsx
@@ -3,7 +3,6 @@ import React, { FunctionComponent, useMemo } from 'react'
 import { Platform } from 'react-native'
 import styled from 'styled-components/native'
 
-import { SubscriptionStatus } from 'api/gen'
 import { useAuthContext } from 'features/auth/AuthContext'
 import { useBeneficiaryValidationNavigation } from 'features/auth/signup/useBeneficiaryValidationNavigation'
 import { GeolocationBanner } from 'features/home/components/GeolocationBanner'
@@ -28,11 +27,10 @@ export const HomeHeader: FunctionComponent = function () {
   const { top } = useCustomSafeInsets()
   const { isLoggedIn, user } = useAuthContext()
   const { permissionState } = useGeolocation()
+  const { nextBeneficiaryValidationStepNavConfig } = useBeneficiaryValidationNavigation()
 
   const shouldDisplayGeolocationBloc = permissionState !== GeolocPermissionState.GRANTED
-  const shouldDisplaySubscritpionBloc =
-    user?.status.subscriptionStatus === SubscriptionStatus.has_to_complete_subscription
-  const { nextBeneficiaryValidationStepNavConfig } = useBeneficiaryValidationNavigation()
+  const shouldDisplaySubscritpionBloc = !!nextBeneficiaryValidationStepNavConfig
 
   const welcomeTitle =
     user?.firstName && isLoggedIn ? `Bonjour ${user.firstName}` : 'Bienvenue\u00a0!'
@@ -58,7 +56,7 @@ export const HomeHeader: FunctionComponent = function () {
   const credit = useGetDepositAmountsByAge(user?.birthDate)
 
   const SystemBloc = useMemo(() => {
-    if (shouldDisplaySubscritpionBloc && !!nextBeneficiaryValidationStepNavConfig) {
+    if (shouldDisplaySubscritpionBloc) {
       return (
         <React.Fragment>
           <BannerWithBackground


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18688

## Checklist


I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              | https://user-images.githubusercontent.com/89008469/207348773-f13a7a30-8fe4-4b29-8501-73412034a65d.mp4 | https://user-images.githubusercontent.com/89008469/207346934-4eeeff13-07cc-47bb-833c-a13ce78ed9dc.mp4 |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
