### PR TITLE
(PC-19243) fix(ios): add permission for location

### DIFF
--- a/ios/PassCulture/Info.plist
+++ b/ios/PassCulture/Info.plist
@@ -80,18 +80,18 @@
 			</dict>
 		</dict>
 	</dict>
-	<key>NSUserTrackingUsageDescription</key>
-	<string>Pour vous offrir les meilleurs offres et une expérience personnalisée</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Cette application peut vérifier ton identité avec une photo.</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Cette application peut vérifier ton identité avec une photo de votre galerie.</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>Cette application a besoin de ta géolocalisation pour te montrer des offres proche de toi.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Cette application a besoin de ta géolocalisation pour te montrer des offres proche de toi.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Cette application peut vérifier ton identité avec de l'audio</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Cette application peut vérifier ton identité avec une photo de votre galerie.</string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>Pour vous offrir les meilleurs offres et une expérience personnalisée</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Montserrat-Bold.ttf</string>

--- a/ios/PassCulture/Info.plist
+++ b/ios/PassCulture/Info.plist
@@ -82,6 +82,8 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>Cette application peut vérifier ton identité avec une photo.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Cette application a besoin de ta géolocalisation pour te montrer des offres proche de toi.</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>Cette application a besoin de ta géolocalisation pour te montrer des offres proche de toi.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19243

J'ai bien testé sur un simulateur, ça build bien et je n'ai pas plus de modale de permission (j'ai toujours celle de géoloc comme avant)

Normalement, c'est 3 clés sont nécessaires seulement pour utiliser la géoloc en background (ce que nous ne faisons pas, ce qui se voit du fait qu'on a pas la capability BackgroundMode), mais Apple détecte de façon erronée que nous avons besoin de ces clés, donc on les rajoute quand même.