### PR TITLE
(PC-19246) feat(onboarding): Redirect to new onboarding instead of tutorials

### DIFF
--- a/e2e/tests/pc/helpers/FirstLaunch.ts
+++ b/e2e/tests/pc/helpers/FirstLaunch.ts
@@ -1,10 +1,10 @@
 import { flags } from './utils/platform'
 import CookiesConsent from '../features/cookies/CookiesConsent'
-import FirstTutorial from '../features/firstTutorial/FirstTutorial'
 import NativeAlert from './NativeAlert'
 import { TabBar } from '../features/navigation/TabBar'
 import AgeSelection from '../features/onboarding/AgeSelection'
 import AgeInformation from '../features/onboarding/AgeInformation'
+import OnboardingWelcome from '../features/onboarding/OnboardingWelcome'
 
 class FirstLaunch {
   retries = 2
@@ -30,8 +30,8 @@ class FirstLaunch {
       }
     }
     await CookiesConsent.randomChoice()
-    await FirstTutorial.proceed()
     if (!flags.isWeb) {
+      await OnboardingWelcome.proceed()
       await AgeSelection.randomChoiceAge()
       await AgeInformation.proceed()
     }

--- a/src/features/navigation/RootNavigator/useInitialScreenConfig.tsx
+++ b/src/features/navigation/RootNavigator/useInitialScreenConfig.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import { Platform } from 'react-native'
 
 import { api } from 'api/api'
 import { useAuthContext } from 'features/auth/AuthContext'
@@ -65,14 +66,14 @@ async function getInitialScreen({
 
   try {
     const hasSeenTutorials = !!(await storage.readObject('has_seen_tutorials'))
-    if (hasSeenTutorials) {
+    if (hasSeenTutorials || Platform.OS === 'web') {
       return homeNavConfig[0]
     }
   } catch {
     return homeNavConfig[0]
   }
 
-  return 'FirstTutorial'
+  return 'OnboardingWelcome'
 }
 
 function triggerInitialScreenNameAnalytics(screenName: RootScreenNames) {

--- a/src/features/navigation/__tests__/useInitialScreenConfig.native.test.tsx
+++ b/src/features/navigation/__tests__/useInitialScreenConfig.native.test.tsx
@@ -44,7 +44,7 @@ describe('useInitialScreen()', () => {
     ${true}          | ${null}             | ${true}  | ${{ needsToFillCulturalSurvey: true, showEligibleCard: true, recreditAmountToShow: 3000 }}   | ${true}                      | ${'RecreditBirthdayNotification'} | ${'RecreditBirthdayNotification'}
     ${true}          | ${true}             | ${false} | ${{ needsToFillCulturalSurvey: true, showEligibleCard: false, recreditAmountToShow: null }}  | ${true}                      | ${'TabNavigator'}                 | ${'Home'}
     ${true}          | ${true}             | ${false} | ${{ needsToFillCulturalSurvey: false, showEligibleCard: true, recreditAmountToShow: null }}  | ${true}                      | ${'TabNavigator'}                 | ${'Home'}
-    ${null}          | ${true}             | ${false} | ${{ needsToFillCulturalSurvey: false, showEligibleCard: false, recreditAmountToShow: null }} | ${true}                      | ${'FirstTutorial'}                | ${'FirstTutorial'}
+    ${null}          | ${true}             | ${false} | ${{ needsToFillCulturalSurvey: false, showEligibleCard: false, recreditAmountToShow: null }} | ${true}                      | ${'OnboardingWelcome'}            | ${'OnboardingWelcome'}
   `(
     `should return $expectedScreen when 
       - has_seen_tutorials = $hasSeenTutorials 

--- a/src/features/navigation/__tests__/useInitialScreenConfig.web.test.tsx
+++ b/src/features/navigation/__tests__/useInitialScreenConfig.web.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+
+import { analytics } from 'libs/firebase/analytics'
+import { SplashScreenProvider } from 'libs/splashscreen'
+import { storage } from 'libs/storage'
+import { renderHook, waitFor } from 'tests/utils'
+
+import { useInitialScreen } from '../RootNavigator/useInitialScreenConfig'
+
+jest.mock('features/auth/settings', () => ({
+  useAppSettings: jest.fn(() => ({
+    data: {
+      enableNativeCulturalSurvey: false,
+    },
+  })),
+}))
+
+const wrapper = (props: { children: unknown }) => (
+  <SplashScreenProvider>{props.children as JSX.Element}</SplashScreenProvider>
+)
+
+describe('useInitialScreen()', () => {
+  afterAll(async () => {
+    await storage.clear('has_seen_tutorials')
+    await storage.clear('has_seen_eligible_card')
+  })
+
+  it('should redirect to Home if user has not seen tutorials', async () => {
+    const { result } = renderHook(useInitialScreen, { wrapper })
+
+    await waitFor(() => {
+      expect(result.current).toEqual('TabNavigator')
+      expect(analytics.logScreenView).toBeCalledTimes(1)
+      expect(analytics.logScreenView).toBeCalledWith('Home')
+    })
+  })
+})

--- a/src/features/onboarding/pages/OnboardingWelcome.native.test.tsx
+++ b/src/features/onboarding/pages/OnboardingWelcome.native.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 import { OnboardingWelcome } from 'features/onboarding/pages/OnboardingWelcome'
+import { storage } from 'libs/storage'
 import { fireEvent, render, waitFor } from 'tests/utils'
 
 describe('OnboardingWelcome', () => {
@@ -30,5 +31,23 @@ describe('OnboardingWelcome', () => {
     await waitFor(() => {
       expect(navigate).toHaveBeenCalledWith('Login', { preventCancellation: true })
     })
+  })
+
+  it('should set has_seen_tutorials to true in local storage when "C’est parti !" is clicked', async () => {
+    const { getByText } = render(<OnboardingWelcome />)
+
+    const button = getByText('C’est parti\u00a0!')
+    fireEvent.press(button)
+
+    expect(await storage.readObject('has_seen_tutorials')).toBeTruthy()
+  })
+
+  it('should set has_seen_tutorials to true in local storage when "Se connecter" is clicked', async () => {
+    const { getByText } = render(<OnboardingWelcome />)
+
+    const loginButton = getByText('Se connecter')
+    fireEvent.press(loginButton)
+
+    expect(await storage.readObject('has_seen_tutorials')).toBeTruthy()
   })
 })

--- a/src/features/onboarding/pages/OnboardingWelcome.tsx
+++ b/src/features/onboarding/pages/OnboardingWelcome.tsx
@@ -5,10 +5,13 @@ import styled from 'styled-components/native'
 
 import { AuthenticationButton } from 'features/auth/components/AuthenticationButton/AuthenticationButton'
 import { WELCOME_BACKGROUND_SOURCE } from 'features/onboarding/components/welcomeBackground'
+import { storage } from 'libs/storage'
 import { ButtonWithLinearGradient } from 'ui/components/buttons/buttonWithLinearGradient/ButtonWithLinearGradient'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
+
+const setHasSeenTutorials = () => storage.saveObject('has_seen_tutorials', true)
 
 export const OnboardingWelcome: FunctionComponent = () => (
   <Container>
@@ -29,9 +32,10 @@ export const OnboardingWelcome: FunctionComponent = () => (
         icon={PlainArrowNext}
         iconAfterWording
         navigateTo={{ screen: 'AgeSelection' }}
+        onBeforeNavigate={setHasSeenTutorials}
       />
       <Spacer.Column numberOfSpaces={4} />
-      <StyledAuthenticationButton type="login" />
+      <StyledAuthenticationButton type="login" onAdditionalPress={setHasSeenTutorials} />
       <Spacer.BottomScreen />
     </Content>
   </Container>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19246

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
