### PR TITLE
(PC-19294) feat(offer): add log on similar offer on scroll

### DIFF
--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -8,7 +8,7 @@ import { OfferBody } from 'features/offer/components/OfferBody/OfferBody'
 import { mockedAlgoliaResponse } from 'libs/algolia/__mocks__/mockedAlgoliaResponse'
 import { analytics } from 'libs/firebase/analytics'
 import { SearchHit } from 'libs/search'
-import { cleanup, fireEvent, render } from 'tests/utils'
+import { cleanup, fireEvent, render, waitFor } from 'tests/utils'
 
 jest.mock('react-query')
 jest.mock('features/auth/AuthContext')
@@ -83,6 +83,21 @@ describe('<OfferBody />', () => {
         fromOfferId: 1,
         id: 102280,
       })
+    })
+
+    it('should log analytics event logSimilarOfferPlaylistHorizontalScroll when scrolling on it', async () => {
+      const nativeEventMiddle = {
+        layoutMeasurement: { height: 296 },
+        contentOffset: { x: 50 }, // how far did we scroll
+        contentSize: { height: 296 },
+      }
+      const { getByTestId } = render(<OfferBody offerId={offerId} onScroll={onScroll} />)
+      const scrollView = getByTestId('offersModuleList')
+
+      await waitFor(() => {
+        scrollView.props.onScroll({ nativeEvent: nativeEventMiddle })
+      })
+      expect(analytics.logSimilarOfferPlaylistHorizontalScroll).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -51,6 +51,8 @@ const trackingOnHorizontalScroll = () => {
   return analytics.logSimilarOfferPlaylistHorizontalScroll()
 }
 
+const keyExtractor = (item: SearchHit) => item.objectID
+
 export const OfferBody: FunctionComponent<Props> = ({ offerId, onScroll }) => {
   const { data: offer } = useOffer({ offerId })
   const { user } = useAuthContext()
@@ -242,7 +244,7 @@ export const OfferBody: FunctionComponent<Props> = ({ offerId, onScroll }) => {
             itemWidth={itemWidth}
             itemHeight={itemHeight}
             renderItem={renderItem}
-            keyExtractor={(item) => item.objectID}
+            keyExtractor={keyExtractor}
             title="Ça peut aussi te plaire"
             onEndReached={trackingOnHorizontalScroll}
           />

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -47,6 +47,10 @@ interface Props {
   onScroll: () => void
 }
 
+const trackingOnHorizontalScroll = () => {
+  return analytics.logSimilarOfferPlaylistHorizontalScroll()
+}
+
 export const OfferBody: FunctionComponent<Props> = ({ offerId, onScroll }) => {
   const { data: offer } = useOffer({ offerId })
   const { user } = useAuthContext()
@@ -240,6 +244,7 @@ export const OfferBody: FunctionComponent<Props> = ({ offerId, onScroll }) => {
             renderItem={renderItem}
             keyExtractor={(item) => item.objectID}
             title="Ça peut aussi te plaire"
+            onEndReached={trackingOnHorizontalScroll}
           />
         </SectionWithDivider>
       )}

--- a/src/libs/firebase/analytics/__mocks__/analytics.ts
+++ b/src/libs/firebase/analytics/__mocks__/analytics.ts
@@ -122,6 +122,7 @@ export const analytics: typeof actualAnalytics = {
   logSignUpFromFavorite: jest.fn(),
   logSignUpFromOffer: jest.fn(),
   logSignUpTooYoung: jest.fn(),
+  logSimilarOfferPlaylistHorizontalScroll: jest.fn(),
   logStartDMSTransmission: jest.fn(),
   logTrySelectDeposit: jest.fn(),
   logUseFilter: jest.fn(),

--- a/src/libs/firebase/analytics/analytics.ts
+++ b/src/libs/firebase/analytics/analytics.ts
@@ -301,6 +301,8 @@ const logEventAnalytics = {
     analyticsProvider.logEvent(AnalyticsEvent.SIGN_UP_FROM_OFFER, { offerId }),
   logSignUpTooYoung: (age: number) =>
     analyticsProvider.logEvent(AnalyticsEvent.SIGN_UP_TOO_YOUNG, { age }),
+  logSimilarOfferPlaylistHorizontalScroll: () =>
+    analyticsProvider.logEvent(AnalyticsEvent.SIMILAR_OFFER_PLAYLIST_HORIZONTAL_SCROLL),
   logStartDMSTransmission: () => analyticsProvider.logEvent(AnalyticsEvent.START_DMS_TRANSMISSION),
   logTrySelectDeposit: (age: number) =>
     analyticsProvider.logEvent(AnalyticsEvent.TRY_SELECT_DEPOSIT, { age }),

--- a/src/libs/firebase/analytics/events.ts
+++ b/src/libs/firebase/analytics/events.ts
@@ -120,6 +120,7 @@ export enum AnalyticsEvent {
   SIGN_UP_FROM_FAVORITE = 'SignUpFromFavorite',
   SIGN_UP_FROM_OFFER = 'SignUpFromOffer',
   SIGN_UP_TOO_YOUNG = 'SignUpTooYoung',
+  SIMILAR_OFFER_PLAYLIST_HORIZONTAL_SCROLL = 'SimilarOfferPlaylistHorizontalScroll',
   START_DMS_TRANSMISSION = 'StartDMSTransmission',
   TRY_SELECT_DEPOSIT = 'TrySelectDeposit',
   USE_FILTER = 'UseFilter',


### PR DESCRIPTION
Cette PR a pour but de tracker des logs sur les offres similaires lorsqu'on scroll horizontalement visible sur Firebase.

Un test natif a été ajouté lorsqu'on scroll pour vérifier si l'event s'affiche correctement.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19294

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
