### PR TITLE
(BSR) refactor(tests): remove useless clear mocks

### DIFF
--- a/doc/standards/testStrategy.md
+++ b/doc/standards/testStrategy.md
@@ -185,8 +185,6 @@ const mockUseAuthContext = useAuthContext as jest.MockedFunction<typeof useAuthC
 mockUseAuthContext.mockReturnValue({ isLoggedIn, setIsLoggedIn: jest.fn() })
 ```
 
-Don't forget to use `afterEach(jest.clearAllMocks)` to clear mocks after each test.
-
 #### Navigation
 
 To test our `navigate` call, we can do:

--- a/src/features/_marketingAndCommunication/atoms/__tests__/DeepLinkItem.web.test.tsx
+++ b/src/features/_marketingAndCommunication/atoms/__tests__/DeepLinkItem.web.test.tsx
@@ -41,8 +41,6 @@ describe('<DeeplinkItem />', () => {
     })
   })
 
-  afterEach(jest.clearAllMocks)
-
   it('should copy the universal link to clipboard', () => {
     const renderAPI = render(<DeeplinkItem deeplink={deeplink} />)
 

--- a/src/features/auth/signup/SetEmail/SetEmail.native.test.tsx
+++ b/src/features/auth/signup/SetEmail/SetEmail.native.test.tsx
@@ -7,9 +7,6 @@ import { act, fireEvent, render } from 'tests/utils'
 const props = { goToNextStep: jest.fn(), signUp: jest.fn() }
 
 describe('<SetEmail />', () => {
-  beforeEach(jest.clearAllMocks)
-  afterAll(jest.clearAllMocks)
-
   it('should display disabled validate button when email input is not filled', () => {
     const { getByText } = render(<SetEmail {...props} />)
 

--- a/src/features/auth/signup/SetPassword/SetPassword.native.test.tsx
+++ b/src/features/auth/signup/SetPassword/SetPassword.native.test.tsx
@@ -10,9 +10,6 @@ jest.mock('features/auth/settings')
 const props = { goToNextStep: jest.fn(), signUp: jest.fn() }
 
 describe('SetPassword Page', () => {
-  beforeEach(jest.clearAllMocks)
-  afterAll(jest.clearAllMocks)
-
   it('should enable the submit button when password is correct', async () => {
     const { getByPlaceholderText, getByTestId } = render(<SetPassword {...props} />)
 

--- a/src/features/auth/signup/SignupForm.native.test.tsx
+++ b/src/features/auth/signup/SignupForm.native.test.tsx
@@ -43,9 +43,6 @@ const defaultProps = {
 } as StackScreenProps<RootStackParamList, 'SignupForm'>
 
 describe('<SignupForm />', () => {
-  beforeEach(jest.clearAllMocks)
-  afterAll(jest.clearAllMocks)
-
   it('should display 4 step dots with the first one as current step', () => {
     const { getAllByTestId } = render(<SignupForm {...defaultProps} />)
     const dots = getAllByTestId('dot-icon')

--- a/src/features/bookings/helpers/getBookingLabels.test.ts
+++ b/src/features/bookings/helpers/getBookingLabels.test.ts
@@ -5,8 +5,6 @@ import { getBookingLabels } from 'features/bookings/helpers'
 import { Booking } from 'features/bookings/types'
 
 describe('getBookingLabels', () => {
-  beforeEach(jest.clearAllMocks)
-
   it('should return the correct dateLabel for permanent bookings', () => {
     const booking = bookingsSnap.ongoing_bookings[0]
     const properties = { isPermanent: true }

--- a/src/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx
@@ -11,7 +11,6 @@ jest.mock('features/culturalSurvey/useGetNextQuestion')
 jest.mock('features/navigation/helpers')
 jest.mock('features/culturalSurvey/context/CulturalSurveyContextProvider')
 describe('CulturalSurveyIntro page', () => {
-  afterEach(jest.clearAllMocks)
   it('should render the page with correct layout', () => {
     const CulturalSurveyIntroPage = render(<CulturalSurveyIntro />)
     expect(CulturalSurveyIntroPage).toMatchSnapshot()

--- a/src/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx
@@ -6,7 +6,6 @@ import { render, fireEvent } from 'tests/utils'
 
 jest.mock('features/navigation/helpers')
 describe('CulturalSurveyThanksPage page', () => {
-  afterEach(jest.clearAllMocks)
   it('should render the page with correct layout', () => {
     const CulturalSurveyThanksPage = render(<CulturalSurveyThanks />)
     expect(CulturalSurveyThanksPage).toMatchSnapshot()

--- a/src/features/home/components/modules/RecommendationModule.native.test.tsx
+++ b/src/features/home/components/modules/RecommendationModule.native.test.tsx
@@ -20,8 +20,6 @@ jest.mock('features/home/api/useHomeRecommendedHits', () => ({
 }))
 
 describe('RecommendationModule', () => {
-  afterEach(jest.clearAllMocks)
-
   it('should trigger logEvent "ModuleDisplayedOnHomepage" when shouldModuleBeDisplayed is true', () => {
     render(
       <RecommendationModule

--- a/src/features/home/pages/Home.native.test.tsx
+++ b/src/features/home/pages/Home.native.test.tsx
@@ -62,8 +62,6 @@ describe('Home component', () => {
   })
   mockUseNetInfoContext.mockReturnValue({ isConnected: true })
 
-  afterEach(jest.clearAllMocks)
-
   it('should render skeleton when there are no modules to display', () => {
     mockUseHomepageData.mockReturnValueOnce({
       modules: [],

--- a/src/features/identityCheck/pages/profile/SetSchoolType.native.test.tsx
+++ b/src/features/identityCheck/pages/profile/SetSchoolType.native.test.tsx
@@ -43,8 +43,6 @@ const mockUseIdentityCheckContext = useSubscriptionContext as jest.Mock
 jest.mock('react-query')
 
 describe('<SetSchoolType />', () => {
-  beforeEach(jest.clearAllMocks)
-
   it('shoud render a list of middle school types if profile.status is middleSchoolStudent', () => {
     mockUseIdentityCheckContext.mockImplementationOnce(() => ({
       dispatch: jest.fn(),

--- a/src/features/identityCheck/pages/profile/SetStatus.native.test.tsx
+++ b/src/features/identityCheck/pages/profile/SetStatus.native.test.tsx
@@ -44,8 +44,6 @@ jest.mock('features/identityCheck/api/api', () => {
 const mockUseIsUserUnderage = useIsUserUnderage as jest.Mock
 
 describe('<SetStatus/>', () => {
-  beforeEach(jest.clearAllMocks)
-
   it('should render correctly', () => {
     mockUseIsUserUnderage.mockReturnValueOnce(true)
     const renderAPI = render(<SetStatus />)

--- a/src/features/identityCheck/useSubscriptionSteps.test.tsx
+++ b/src/features/identityCheck/useSubscriptionSteps.test.tsx
@@ -37,8 +37,6 @@ const useFeatureFlagSpy = jest.spyOn(useFeatureFlag, 'useFeatureFlag')
 useFeatureFlagSpy.mockReturnValue(false)
 
 describe('useSubscriptionSteps', () => {
-  beforeEach(jest.clearAllMocks)
-
   it('should return 3 steps if stepperIncludesPhoneValidation is false', () => {
     const steps = useSubscriptionSteps()
     expect(steps.length).toEqual(3)

--- a/src/features/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx
+++ b/src/features/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx
@@ -19,8 +19,6 @@ const hideModal = jest.fn()
 const visible = true
 
 describe('<FinishSubscriptionModal />', () => {
-  beforeEach(jest.clearAllMocks)
-
   it('should render correctly with undefined deposit amount', () => {
     mockDepositAmounts = undefined
     const renderAPI = render(

--- a/src/features/search/pages/modals/OfferTypeModal/OfferTypeModal.native.test.tsx
+++ b/src/features/search/pages/modals/OfferTypeModal/OfferTypeModal.native.test.tsx
@@ -38,8 +38,6 @@ mockUseAuthContext.mockReturnValue({
 const hideOfferTypeModal = jest.fn()
 
 describe('<OfferTypeModal/>', () => {
-  afterEach(jest.clearAllMocks)
-
   describe('modal header', () => {
     it('should have header when viewport width is mobile', () => {
       const isDesktopViewport = false

--- a/src/libs/geolocation/GeolocationWrapper.test.tsx
+++ b/src/libs/geolocation/GeolocationWrapper.test.tsx
@@ -29,10 +29,8 @@ const MOCK_POSITION = { latitude: 90, longitude: 90 }
 
 describe('useGeolocation()', () => {
   beforeEach(() => {
-    jest.clearAllMocks()
     mockGetPositionSuccess()
   })
-  afterAll(jest.clearAllMocks)
 
   it('should call onSubmit() and onAcceptance() when requestGeolocPermission() returns GRANTED', async () => {
     mockPermissionResult(GeolocPermissionState.GRANTED)

--- a/src/libs/itinerary/openGoogleMapsItinerary.test.ts
+++ b/src/libs/itinerary/openGoogleMapsItinerary.test.ts
@@ -8,8 +8,6 @@ jest.mock('features/navigation/helpers')
 const mockOpenUrl = mocked(openUrl)
 
 describe('openGoogleMapsItinerary()', () => {
-  afterEach(jest.clearAllMocks)
-
   it('should open the correct encoded url with address', () => {
     const address = '12 rue duhesme 75018 Paris'
     openGoogleMapsItinerary(address)


### PR DESCRIPTION
Remove useless jest.clearMocks(), as it is run by default after each test, thanks to `clearMocks: true` in jest.config.js