### PR TITLE
(PC-18858) feat(tests): use generic FakeTimers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -43,6 +43,7 @@ module.exports = {
     '<rootDir>/server/',
     '<rootDir>/e2e/',
   ],
+  timers: 'legacy',
   cacheDirectory: '.jest/cache',
   clearMocks: true,
   collectCoverageFrom: [

--- a/src/features/favorites/components/Favorite.native.test.tsx
+++ b/src/features/favorites/components/Favorite.native.test.tsx
@@ -1,6 +1,5 @@
 import { rest } from 'msw'
 import React from 'react'
-import waitForExpect from 'wait-for-expect'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 import { api } from 'api/api'
@@ -11,7 +10,7 @@ import { env } from 'libs/environment'
 import { EmptyResponse } from 'libs/fetch'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { server } from 'tests/server'
-import { act, fireEvent, render, cleanup, superFlushWithAct } from 'tests/utils'
+import { fireEvent, render, waitFor } from 'tests/utils'
 import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
 import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
 
@@ -67,15 +66,11 @@ jest.mock('features/favorites/context/FavoritesWrapper', () => ({
 }))
 
 describe('<Favorite /> component', () => {
-  beforeEach(() => jest.useFakeTimers())
-  afterEach(async () => {
-    jest.runOnlyPendingTimers()
-    cleanup()
-  })
-
   it('should navigate to the offer when clicking on the favorite', async () => {
     const { getByTestId } = renderFavorite()
+
     await fireEvent.press(getByTestId('favorite'))
+
     expect(navigate).toHaveBeenCalledWith('Offer', {
       from: 'favorites',
       id: favorite.offer.id,
@@ -94,13 +89,9 @@ describe('<Favorite /> component', () => {
     mockDistance = '10 km'
     const { getByText } = renderFavorite()
 
-    act(() => {
-      fireEvent.press(getByText('Supprimer'))
-      jest.advanceTimersByTime(1000)
-    })
-    await superFlushWithAct()
+    fireEvent.press(getByText('Supprimer'))
 
-    await waitForExpect(() => {
+    await waitFor(() => {
       expect(deleteFavoriteSpy).toHaveBeenNthCalledWith(1, favorite.id)
       expect(mockShowErrorSnackBar).not.toHaveBeenCalled()
     })
@@ -115,13 +106,9 @@ describe('<Favorite /> component', () => {
       favorite: { ...favorite, id, offer: { ...favorite.offer, id } },
     })
 
-    act(() => {
-      fireEvent.press(getByText('Supprimer'))
-      jest.advanceTimersByTime(1000)
-    })
-    await superFlushWithAct()
+    fireEvent.press(getByText('Supprimer'))
 
-    await waitForExpect(() => {
+    await waitFor(() => {
       expect(deleteFavoriteSpy).toHaveBeenNthCalledWith(1, id)
       expect(mockShowErrorSnackBar).toBeCalledWith({
         message: `L'offre n'a pas été retirée de tes favoris`,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18858

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
