### PR TITLE
(PC-17620) fix(RootNavigator): add and testID to all app screens

### DIFF
--- a/src/features/navigation/RootNavigator/linking/__tests__/getScreenConfig.test.ts
+++ b/src/features/navigation/RootNavigator/linking/__tests__/getScreenConfig.test.ts
@@ -68,27 +68,27 @@ describe('getScreensAndConfig()', () => {
     expect(Screens.length).toBe(5)
     expect(Screens[0].props).toEqual({
       name: 'Offer',
-      component: expect.any(Function),
+      component: expect.any(Object),
       options: { title: 'Offer title' },
     })
     expect(Screens[1].props).toEqual({
       name: '_DeeplinkOnlyOffer1',
-      component: expect.any(Function),
+      component: expect.any(Object),
       options: { title: 'Offer title' },
     })
     expect(Screens[2].props).toEqual({
       name: '_DeeplinkOnlyOffer2',
-      component: expect.any(Function),
+      component: expect.any(Object),
       options: { title: 'Offer title' },
     })
     expect(Screens[3].props).toEqual({
       name: 'Login',
-      component: expect.any(Function),
+      component: expect.any(Object),
       options: { title: 'Login title' },
     })
     expect(Screens[4].props).toEqual({
       name: '_DeeplinkOnlyLogin1',
-      component: expect.any(Function),
+      component: expect.any(Object),
       options: { title: 'Login title' },
     })
   })

--- a/src/features/navigation/RootNavigator/linking/getScreenComponent.tsx
+++ b/src/features/navigation/RootNavigator/linking/getScreenComponent.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentType } from 'react'
 
 import { withAsyncErrorBoundary } from 'features/errors'
+import { withScreenWrapper } from 'features/navigation/RootNavigator/withScreenWrapper'
 import { TabRoute } from 'features/navigation/TabBar/types'
 
 import { Route } from '../types'
@@ -15,5 +16,6 @@ export function getScreenComponent(
   let component = route.component
   component = route.hoc ? route.hoc(component) : withAsyncErrorBoundary(component)
   if (route.secure) component = withAuthProtection(component)
+  component = withScreenWrapper(component, name)
   return <ScreenComponent key={name} name={name} component={component} options={route.options} />
 }

--- a/src/features/navigation/RootNavigator/withScreenWrapper.tsx
+++ b/src/features/navigation/RootNavigator/withScreenWrapper.tsx
@@ -1,8 +1,7 @@
 import React, { ComponentType, memo } from 'react'
 import styled from 'styled-components/native'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const withScreenWrapper = (Component: ComponentType<any>, name: string) => {
+export const withScreenWrapper = (Component: ComponentType, name: string) => {
   return memo(function ComponentWithScreenWrapper(props = {}) {
     return (
       <View testID={name}>

--- a/src/features/navigation/RootNavigator/withScreenWrapper.tsx
+++ b/src/features/navigation/RootNavigator/withScreenWrapper.tsx
@@ -1,0 +1,17 @@
+import React, { ComponentType, memo } from 'react'
+import styled from 'styled-components/native'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const withScreenWrapper = (Component: ComponentType<any>, name: string) => {
+  return memo(function ComponentWithScreenWrapper(props = {}) {
+    return (
+      <View testID={name}>
+        <Component {...props} />
+      </View>
+    )
+  })
+}
+
+const View = styled.View({
+  flex: 1,
+})


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-17620

Goal is to have a unique identifier for detecting when a screen is displayed in e2e tests

- We cannot wrap in `NavigationContainer`  with a `View` (it has to be `RootStack.Screen`)
- Settings each `testID` in existing screen is cumbersome

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
