### PR TITLE
(PC-19293) feat(offer): Add log on Offer on scroll vertical when reaching similar offers

### DIFF
--- a/src/features/offer/pages/Offer/Offer.native.test.tsx
+++ b/src/features/offer/pages/Offer/Offer.native.test.tsx
@@ -69,7 +69,7 @@ describe('<Offer />', () => {
       const { getByTestId } = await renderOfferPage()
       const scrollView = getByTestId('offer-container')
 
-      await act(async () => await fireEvent.scroll(scrollView, nativeEventBottom))
+      fireEvent.scroll(scrollView, nativeEventBottom)
 
       expect(analytics.logSimilarOfferPlaylistVerticalScroll).toHaveBeenCalledTimes(1)
     })
@@ -78,7 +78,7 @@ describe('<Offer />', () => {
       const { getByTestId } = await renderOfferPage()
       const scrollView = getByTestId('offer-container')
 
-      await act(async () => await fireEvent.scroll(scrollView, nativeEventTop))
+      fireEvent.scroll(scrollView, nativeEventTop)
 
       expect(analytics.logSimilarOfferPlaylistVerticalScroll).toHaveBeenCalledTimes(0)
     })

--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -52,7 +52,7 @@ export const Offer: FunctionComponent = () => {
       if (isCloseToBottom(nativeEvent)) {
         logConsultWholeOffer()
       }
-      // The log event is trigger when the similar offer playlist is visible
+      // The log event is triggered when the similar offer playlist is visible
       if (isCloseToBottom({ ...nativeEvent, padding: 300 })) {
         logSimilarOfferPlaylistVerticalScroll()
       }

--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 
 import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { useOffer } from 'features/offer/api/useOffer'
+import { useSimilarOffers } from 'features/offer/api/useSimilarOffers'
 import { BottomBanner } from 'features/offer/components/BottomBanner/BottomBanner'
 import { OfferBody } from 'features/offer/components/OfferBody/OfferBody'
 import { OfferHeader } from 'features/offer/components/OfferHeader/OfferHeader'
@@ -36,9 +37,24 @@ export const Offer: FunctionComponent = () => {
     }
   })
 
+  const { data: offer } = useOffer({ offerId })
+  const similarOffers = useSimilarOffers(offerId, offer?.venue.coordinates)
+  const hasSimilarOffers = similarOffers && similarOffers.length > 0
+
+  const logSimilarOfferPlaylistVerticalScroll = useFunctionOnce(() => {
+    if (hasSimilarOffers) {
+      return analytics.logSimilarOfferPlaylistVerticalScroll()
+    }
+  })
+
   const { headerTransition, onScroll } = useOpacityTransition({
     listener: ({ nativeEvent }) => {
-      if (isCloseToBottom(nativeEvent)) logConsultWholeOffer()
+      if (isCloseToBottom(nativeEvent)) {
+        logConsultWholeOffer()
+      }
+      if (isCloseToBottom({ ...nativeEvent, padding: 300 })) {
+        logSimilarOfferPlaylistVerticalScroll()
+      }
     },
   })
 

--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -52,6 +52,7 @@ export const Offer: FunctionComponent = () => {
       if (isCloseToBottom(nativeEvent)) {
         logConsultWholeOffer()
       }
+      // The log event is trigger when the similar offer playlist is visible
       if (isCloseToBottom({ ...nativeEvent, padding: 300 })) {
         logSimilarOfferPlaylistVerticalScroll()
       }

--- a/src/libs/firebase/analytics/__mocks__/analytics.ts
+++ b/src/libs/firebase/analytics/__mocks__/analytics.ts
@@ -123,6 +123,7 @@ export const analytics: typeof actualAnalytics = {
   logSignUpFromOffer: jest.fn(),
   logSignUpTooYoung: jest.fn(),
   logSimilarOfferPlaylistHorizontalScroll: jest.fn(),
+  logSimilarOfferPlaylistVerticalScroll: jest.fn(),
   logStartDMSTransmission: jest.fn(),
   logTrySelectDeposit: jest.fn(),
   logUseFilter: jest.fn(),

--- a/src/libs/firebase/analytics/analytics.ts
+++ b/src/libs/firebase/analytics/analytics.ts
@@ -303,6 +303,8 @@ const logEventAnalytics = {
     analyticsProvider.logEvent(AnalyticsEvent.SIGN_UP_TOO_YOUNG, { age }),
   logSimilarOfferPlaylistHorizontalScroll: () =>
     analyticsProvider.logEvent(AnalyticsEvent.SIMILAR_OFFER_PLAYLIST_HORIZONTAL_SCROLL),
+  logSimilarOfferPlaylistVerticalScroll: () =>
+    analyticsProvider.logEvent(AnalyticsEvent.SIMILAR_OFFER_PLAYLIST_VERTICAL_SCROLL),
   logStartDMSTransmission: () => analyticsProvider.logEvent(AnalyticsEvent.START_DMS_TRANSMISSION),
   logTrySelectDeposit: (age: number) =>
     analyticsProvider.logEvent(AnalyticsEvent.TRY_SELECT_DEPOSIT, { age }),

--- a/src/libs/firebase/analytics/events.ts
+++ b/src/libs/firebase/analytics/events.ts
@@ -121,6 +121,7 @@ export enum AnalyticsEvent {
   SIGN_UP_FROM_OFFER = 'SignUpFromOffer',
   SIGN_UP_TOO_YOUNG = 'SignUpTooYoung',
   SIMILAR_OFFER_PLAYLIST_HORIZONTAL_SCROLL = 'SimilarOfferPlaylistHorizontalScroll',
+  SIMILAR_OFFER_PLAYLIST_VERTICAL_SCROLL = 'SimilarOfferPlaylistVerticalScroll',
   START_DMS_TRANSMISSION = 'StartDMSTransmission',
   TRY_SELECT_DEPOSIT = 'TrySelectDeposit',
   USE_FILTER = 'UseFilter',


### PR DESCRIPTION
Cette PR a pour but de tracker des logs sur les offres similaires lorsqu'on scroll verticalement jusqu'à atteindre le bas de la page d'une offre, ces logs seront visible sur Firebase.

Deux test natif ont été ajouté : 
- lorsqu'on scroll bien jusqu'au bas de la page d'une offre, l'event s'affiche correctement .
- lorsqu'on ne scroll pas jusqu'au bas de la page l'event ne s'affiche pas.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19293

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
