### PR TITLE
(BSR) fix(system): ajout des paramètres d'activité pour que le lancement android ne…

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     ]
   },
   "scripts": {
-    "android": "react-native run-android --variant=developmentDebug",
-    "android:prod": "react-native run-android --variant=productionDebug",
-    "android:staging": "react-native run-android --variant=stagingDebug",
-    "android:testing": "react-native run-android --variant=apptestingDebug",
+    "android": " react-native run-android --variant=developmentDebug --appId=app.passculture.testing",
+    "android:prod": "react-native run-android --variant=productionDebug --appId=app.passculture.webapp",
+    "android:staging": "react-native run-android --variant=stagingDebug --appId=app.passculture.staging",
+    "android:testing": "react-native run-android --variant=apptestingDebug --appId=app.passculture.testing",
     "appcenter:install": "./scripts/appcenter-download-release.sh",
     "build": "SHOW_DUPLICATES_PLUGIN=${SHOW_DUPLICATES_PLUGIN:-true} node web/scripts/build.js",
     "build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     ]
   },
   "scripts": {
-    "android": " react-native run-android --variant=developmentDebug --appId=app.passculture.testing",
+    "android": "react-native run-android --variant=developmentDebug --appId=app.passculture.testing",
     "android:prod": "react-native run-android --variant=productionDebug --appId=app.passculture.webapp",
     "android:staging": "react-native run-android --variant=stagingDebug --appId=app.passculture.staging",
     "android:testing": "react-native run-android --variant=apptestingDebug --appId=app.passculture.testing",


### PR DESCRIPTION
Précédemment dans "pass Culture"...

`"android": " react-native run-android --variant=developmentDebug",`

Ce script se soldait par une erreur et un non lancement de l'app sur le device de test

J'ai ajouté le paramètre `--appId=app.passculture.N` pour les N environnements et vérifié qu'ils lançaient bien l'app

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [-] Written **unit tests** native (and web when implementation is different) for my feature.
- [-] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [-] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

