### PR TITLE
(PC-19412) ci(e2e): add logging even if failure

### DIFF
--- a/.github/workflows/e2e-android-app.yml
+++ b/.github/workflows/e2e-android-app.yml
@@ -198,6 +198,18 @@ jobs:
       - run: nohup adb logcat > logcat.log &
         name: Capture logcat
 
+      - name: Slack failure notification
+        if: ${{ env.WDIO_DEMO == 'false' && failure() }}
+        env:
+          BRANCH_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/tree/${{ env.GITHUB_REF_NAME }}
+          COMMIT_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/tree/${{ env.GITHUB_SHA_SHORT }}
+          ACTION_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/actions/runs/${{ env.GITHUB_RUN_ID }}
+          SLACK_WEBHOOK: ${{ env.GITHUB_EVENT_NAME == 'schedule' && env.SLACK_WEB_HOOK_URL || env.SLACK_WEB_HOOK_URL_MANUAL }}
+          EVENT_NAME: ${{ env.GITHUB_EVENT_NAME == 'schedule' && 'Scheduled' || 'Manually' }}
+        run: |
+          slackMessageTitle="<${BRANCH_URL}|${{ env.GITHUB_REF_NAME }}>/<${COMMIT_URL}|${{ env.GITHUB_SHA_SHORT }}> ${{ env.ENVIRONMENT }} - wdio ${{ env.GITHUB_REPOSITORY_NAME_PART }} \`e2e:android.app\` <${ACTION_URL}|action> (${EVENT_NAME})"
+          curl -X POST -H 'Content-type: application/json' --data "{\"text\":\":x: *CI NOK: ${slackMessageTitle}* :x:\"}"  "$SLACK_WEBHOOK"
+
       - uses: reactivecircus/android-emulator-runner@v2
         name: e2e_api${{ matrix.apiLevel }}
         with:

--- a/.github/workflows/e2e-android-browser.yml
+++ b/.github/workflows/e2e-android-browser.yml
@@ -150,6 +150,18 @@ jobs:
       - run: nohup adb logcat > logcat.log &
         name: Capture logcat
 
+      - name: Slack failure notification
+        if: ${{ env.WDIO_DEMO == 'false' && failure() }}
+        env:
+          BRANCH_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/tree/${{ env.GITHUB_REF_NAME }}
+          COMMIT_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/tree/${{ env.GITHUB_SHA_SHORT }}
+          ACTION_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/actions/runs/${{ env.GITHUB_RUN_ID }}
+          SLACK_WEBHOOK: ${{ env.GITHUB_EVENT_NAME == 'schedule' && env.SLACK_WEB_HOOK_URL || env.SLACK_WEB_HOOK_URL_MANUAL }}
+          EVENT_NAME: ${{ env.GITHUB_EVENT_NAME == 'schedule' && 'Scheduled' || 'Manually' }}
+        run: |
+          slackMessageTitle="<${BRANCH_URL}|${{ env.GITHUB_REF_NAME }}>/<${COMMIT_URL}|${{ env.GITHUB_SHA_SHORT }}> ${{ env.ENVIRONMENT }} - wdio ${{ env.GITHUB_REPOSITORY_NAME_PART }} \`e2e:browser.chrome\` <${ACTION_URL}|action> (${EVENT_NAME})"
+          curl -X POST -H 'Content-type: application/json' --data "{\"text\":\":x: *CI NOK: ${slackMessageTitle}* :x:\"}"  "$SLACK_WEBHOOK"
+
       - uses: reactivecircus/android-emulator-runner@v2
         name: e2e_api${{ matrix.apiLevel }}
         with:

--- a/.github/workflows/e2e-browser-chrome.yml
+++ b/.github/workflows/e2e-browser-chrome.yml
@@ -108,6 +108,18 @@ jobs:
             sleep 5
           done
 
+      - name: Slack failure notification
+        if: ${{ env.WDIO_DEMO == 'false' && failure() }}
+        env:
+          BRANCH_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/tree/${{ env.GITHUB_REF_NAME }}
+          COMMIT_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/tree/${{ env.GITHUB_SHA_SHORT }}
+          ACTION_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/actions/runs/${{ env.GITHUB_RUN_ID }}
+          SLACK_WEBHOOK: ${{ env.GITHUB_EVENT_NAME == 'schedule' && env.SLACK_WEB_HOOK_URL || env.SLACK_WEB_HOOK_URL_MANUAL }}
+          EVENT_NAME: ${{ env.GITHUB_EVENT_NAME == 'schedule' && 'Scheduled' || 'Manually' }}
+        run: |
+          slackMessageTitle="<${BRANCH_URL}|${{ env.GITHUB_REF_NAME }}>/<${COMMIT_URL}|${{ env.GITHUB_SHA_SHORT }}> ${{ env.ENVIRONMENT }} - wdio ${{ env.GITHUB_REPOSITORY_NAME_PART }} \`e2e:browser.chrome\` <${ACTION_URL}|action> (${EVENT_NAME})"
+          curl -X POST -H 'Content-type: application/json' --data "{\"text\":\":x: *CI NOK: ${slackMessageTitle}* :x:\"}"  "$SLACK_WEBHOOK"
+
       - run: ENVIRONMENT="${{ env.ENVIRONMENT }}" yarn e2e:browser.chrome
 
       - name: Save chromedriver output

--- a/.github/workflows/e2e-browser-firefox.yml
+++ b/.github/workflows/e2e-browser-firefox.yml
@@ -108,6 +108,18 @@ jobs:
             sleep 5
           done
 
+      - name: Slack failure notification
+        if: ${{ env.WDIO_DEMO == 'false' && failure() }}
+        env:
+          BRANCH_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/tree/${{ env.GITHUB_REF_NAME }}
+          COMMIT_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/tree/${{ env.GITHUB_SHA_SHORT }}
+          ACTION_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/actions/runs/${{ env.GITHUB_RUN_ID }}
+          SLACK_WEBHOOK: ${{ env.GITHUB_EVENT_NAME == 'schedule' && env.SLACK_WEB_HOOK_URL || env.SLACK_WEB_HOOK_URL_MANUAL }}
+          EVENT_NAME: ${{ env.GITHUB_EVENT_NAME == 'schedule' && 'Scheduled' || 'Manually' }}
+        run: |
+          slackMessageTitle="<${BRANCH_URL}|${{ env.GITHUB_REF_NAME }}>/<${COMMIT_URL}|${{ env.GITHUB_SHA_SHORT }}> ${{ env.ENVIRONMENT }} - wdio ${{ env.GITHUB_REPOSITORY_NAME_PART }} \`e2e:browser.firefox\` <${ACTION_URL}|action> (${EVENT_NAME})"
+          curl -X POST -H 'Content-type: application/json' --data "{\"text\":\":x: *CI NOK: ${slackMessageTitle}* :x:\"}"  "$SLACK_WEBHOOK"
+
       - run: ENVIRONMENT="${{ env.ENVIRONMENT }}" yarn e2e:browser.firefox
 
       - name: Save geckodriver output

--- a/.github/workflows/e2e-browser-safari.yml
+++ b/.github/workflows/e2e-browser-safari.yml
@@ -106,6 +106,18 @@ jobs:
             sleep 5
           done
 
+      - name: Slack failure notification
+        if: ${{ env.WDIO_DEMO == 'false' && failure() }}
+        env:
+          BRANCH_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/tree/${{ env.GITHUB_REF_NAME }}
+          COMMIT_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/tree/${{ env.GITHUB_SHA_SHORT }}
+          ACTION_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/actions/runs/${{ env.GITHUB_RUN_ID }}
+          SLACK_WEBHOOK: ${{ env.GITHUB_EVENT_NAME == 'schedule' && env.SLACK_WEB_HOOK_URL || env.SLACK_WEB_HOOK_URL_MANUAL }}
+          EVENT_NAME: ${{ env.GITHUB_EVENT_NAME == 'schedule' && 'Scheduled' || 'Manually' }}
+        run: |
+          slackMessageTitle="<${BRANCH_URL}|${{ env.GITHUB_REF_NAME }}>/<${COMMIT_URL}|${{ env.GITHUB_SHA_SHORT }}> ${{ env.ENVIRONMENT }} - wdio ${{ env.GITHUB_REPOSITORY_NAME_PART }} \`e2e:browser.safari\` <${ACTION_URL}|action> (${EVENT_NAME})"
+          curl -X POST -H 'Content-type: application/json' --data "{\"text\":\":x: *CI NOK: ${slackMessageTitle}* :x:\"}"  "$SLACK_WEBHOOK"
+
       - run: ENVIRONMENT="${{ env.ENVIRONMENT }}" yarn e2e:browser.safari
 
       - name: Save safaridriver output

--- a/.github/workflows/e2e-ios-app.yml
+++ b/.github/workflows/e2e-ios-app.yml
@@ -124,6 +124,18 @@ jobs:
             fi
           done
 
+      - name: Slack failure notification
+        if: ${{ env.WDIO_DEMO == 'false' && failure() }}
+        env:
+          BRANCH_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/tree/${{ env.GITHUB_REF_NAME }}
+          COMMIT_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/tree/${{ env.GITHUB_SHA_SHORT }}
+          ACTION_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/actions/runs/${{ env.GITHUB_RUN_ID }}
+          SLACK_WEBHOOK: ${{ env.GITHUB_EVENT_NAME == 'schedule' && env.SLACK_WEB_HOOK_URL || env.SLACK_WEB_HOOK_URL_MANUAL }}
+          EVENT_NAME: ${{ env.GITHUB_EVENT_NAME == 'schedule' && 'Scheduled' || 'Manually' }}
+        run: |
+          slackMessageTitle="<${BRANCH_URL}|${{ env.GITHUB_REF_NAME }}>/<${COMMIT_URL}|${{ env.GITHUB_SHA_SHORT }}> ${{ env.ENVIRONMENT }} - wdio ${{ env.GITHUB_REPOSITORY_NAME_PART }} \`e2e:ios.app\` <${ACTION_URL}|action> (${EVENT_NAME})"
+          curl -X POST -H 'Content-type: application/json' --data "{\"text\":\":x: *CI NOK: ${slackMessageTitle}* :x:\"}"  "$SLACK_WEBHOOK"
+
       - name: Run functional tests
         run: ENVIRONMENT="${{ env.ENVIRONMENT }}" IOS_DEVICE_NAME="${{ matrix.model }}" IOS_PLATFORM_VERSION="${{ matrix.osVersion }}" APPIUM_APP=${{ env.IOS_IPA_PATH }} yarn e2e:ios.app
 

--- a/.github/workflows/e2e-ios-browser.yml
+++ b/.github/workflows/e2e-ios-browser.yml
@@ -154,6 +154,18 @@ jobs:
             fi
           done
 
+      - name: Slack failure notification
+        if: ${{ env.WDIO_DEMO == 'false' && failure() }}
+        env:
+          BRANCH_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/tree/${{ env.GITHUB_REF_NAME }}
+          COMMIT_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/tree/${{ env.GITHUB_SHA_SHORT }}
+          ACTION_URL: ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}/actions/runs/${{ env.GITHUB_RUN_ID }}
+          SLACK_WEBHOOK: ${{ env.GITHUB_EVENT_NAME == 'schedule' && env.SLACK_WEB_HOOK_URL || env.SLACK_WEB_HOOK_URL_MANUAL }}
+          EVENT_NAME: ${{ env.GITHUB_EVENT_NAME == 'schedule' && 'Scheduled' || 'Manually' }}
+        run: |
+          slackMessageTitle="<${BRANCH_URL}|${{ env.GITHUB_REF_NAME }}>/<${COMMIT_URL}|${{ env.GITHUB_SHA_SHORT }}> ${{ env.ENVIRONMENT }} - wdio ${{ env.GITHUB_REPOSITORY_NAME_PART }} \`e2e:ios.browser\` <${ACTION_URL}|action> (${EVENT_NAME})"
+          curl -X POST -H 'Content-type: application/json' --data "{\"text\":\":x: *CI NOK: ${slackMessageTitle}* :x:\"}"  "$SLACK_WEBHOOK"
+
       - run: ENVIRONMENT="${{ env.ENVIRONMENT }}" IOS_DEVICE_NAME="${{ matrix.model }}" IOS_PLATFORM_VERSION="${{ matrix.osVersion }}" yarn e2e:ios.browser
         name: Run functional tests
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19412

When failure happen before running test, nos report goes up to slack, this fix it.

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
