### PR TITLE
(BSR) chore(api): Remove old feature flag from response

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -2023,11 +2023,6 @@ export interface SettingsResponse {
    */
   appEnableAutocomplete: boolean
   /**
-   * @type {boolean}
-   * @memberof SettingsResponse
-   */
-  appEnableCookiesV2: boolean
-  /**
    * @type {DepositAmountsByAge}
    * @memberof SettingsResponse
    */

--- a/src/features/auth/__mocks__/SettingsContext.tsx
+++ b/src/features/auth/__mocks__/SettingsContext.tsx
@@ -6,7 +6,6 @@ export const mockDefaultSettings: SettingsResponse = {
   accountCreationMinimumAge: 15,
   accountUnsuspensionLimit: 60,
   appEnableAutocomplete: true,
-  appEnableCookiesV2: true,
   displayDmsRedirection: true,
   enableFrontImageResizing: true,
   enableNativeCulturalSurvey: false,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18120

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
