### PR TITLE
(PC-19324) feat(contentful): handle is free and price min parameters

### DIFF
--- a/src/features/home/api/useHomeRecommendedHits.native.test.ts
+++ b/src/features/home/api/useHomeRecommendedHits.native.test.ts
@@ -64,7 +64,6 @@ describe('getRecommendationParameters', () => {
     const parameters: RecommendationParametersFields = {
       title: 'some parameters',
       categories: ['Arts & loisirs créatifs', 'Bibliothèques, Médiathèques', 'Cartes jeunes'],
-      isFree: true,
       isEvent: true,
       isDuo: true,
       priceMax: 10,
@@ -80,7 +79,7 @@ describe('getRecommendationParameters', () => {
       categories: ['ARTS_LOISIRS_CREATIFS', 'BIBLIOTHEQUES_MEDIATHEQUE', 'CARTES_JEUNES'],
       end_date: '2022-05-08T00:00+00:00',
       start_date: '2022-09-08T00:00+00:00',
-      price_max: 0,
+      price_max: 10,
       isEvent: true,
       isDuo: true,
       subcategories: ['ACHAT_INSTRUMENT'],

--- a/src/features/home/api/useHomeRecommendedHits.ts
+++ b/src/features/home/api/useHomeRecommendedHits.ts
@@ -29,6 +29,7 @@ export function getRecommendationParameters(
     categories: (parameters?.categories || []).map(getCategoriesFacetFilters),
     end_date: endingDatetime,
     isEvent: parameters?.isEvent,
+    price_min: parameters?.priceMin,
     price_max: parameters?.priceMax,
     start_date: beginningDatetime,
     subcategories: (parameters?.subcategories || []).map(

--- a/src/features/home/api/useHomeRecommendedHits.ts
+++ b/src/features/home/api/useHomeRecommendedHits.ts
@@ -29,7 +29,7 @@ export function getRecommendationParameters(
     categories: (parameters?.categories || []).map(getCategoriesFacetFilters),
     end_date: endingDatetime,
     isEvent: parameters?.isEvent,
-    price_max: parameters?.isFree ? 0 : parameters?.priceMax,
+    price_max: parameters?.priceMax,
     start_date: beginningDatetime,
     subcategories: (parameters?.subcategories || []).map(
       (subcategoryLabel) => subcategoryLabelMapping[subcategoryLabel]

--- a/src/features/home/api/useHomeRecommendedHits.ts
+++ b/src/features/home/api/useHomeRecommendedHits.ts
@@ -19,7 +19,7 @@ export function getRecommendationParameters(
 ): Omit<RecommendedIdsRequest, 'endpointUrl'> {
   if (!parameters) return {}
   const eventDuringNextXDays = parameters.eventDuringNextXDays
-    ? parseInt(parameters.eventDuringNextXDays)
+    ? parameters.eventDuringNextXDays
     : undefined
   const { beginningDatetime, endingDatetime } = computeBeginningAndEndingDatetimes({
     ...parameters,

--- a/src/features/home/fixtures/homepage.fixture.ts
+++ b/src/features/home/fixtures/homepage.fixture.ts
@@ -65,9 +65,23 @@ export const formattedVenuesModule: VenuesModule = {
 
 export const formattedRecommendedOffersModule: RecommendedOffersModule = {
   type: HomepageModuleType.RecommendedOffersModule,
-  id: '3sAqNrRMXUOES7tFyRFFO8',
-  displayParameters: { title: 'Nos recos', layout: 'two-items', minOffers: 1 },
-  recommendationParameters: undefined,
+  id: '2TD5BEKL2zUGLhfzhkWhwL',
+  displayParameters: { title: 'Tes évènements en ligne', layout: 'two-items', minOffers: 1 },
+  recommendationParameters: {
+    categories: ['Livres'],
+    beginningDatetime: '2021-01-01T00:00+00:00',
+    endingDatetime: '2024-01-01T00:00+00:00',
+    upcomingWeekendEvent: true,
+    eventDuringNextXDays: 5,
+    currentWeekEvent: true,
+    newestOnly: false,
+    isEvent: true,
+    priceMin: 0.99,
+    priceMax: 99.99,
+    subcategories: ['Livre'],
+    isDuo: false,
+    isRecoShuffled: false,
+  },
 }
 
 export const formattedThematicHighlightModule: ThematicHighlightModule = {

--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -108,7 +108,7 @@ type RecommendedOffersParameters = {
   beginningDatetime?: string
   endingDatetime?: string
   upcomingWeekendEvent?: boolean
-  eventDuringNextXDays?: string
+  eventDuringNextXDays?: number
   currentWeekEvent?: boolean
   newestOnly?: boolean
   isFree?: boolean

--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -60,7 +60,6 @@ export type OffersModuleParameters = {
   eventDuringNextXDays?: number
   upcomingWeekendEvent?: boolean
   currentWeekEvent?: boolean
-  isFree?: boolean
   priceMin?: number
   priceMax?: number
   isDuo?: boolean

--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -111,7 +111,6 @@ type RecommendedOffersParameters = {
   eventDuringNextXDays?: number
   currentWeekEvent?: boolean
   newestOnly?: boolean
-  isFree?: boolean
   isEvent?: boolean
   priceMax?: number
   subcategories?: string[]

--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -112,6 +112,7 @@ type RecommendedOffersParameters = {
   currentWeekEvent?: boolean
   newestOnly?: boolean
   isEvent?: boolean
+  priceMin?: number
   priceMax?: number
   subcategories?: string[]
   isDuo?: boolean

--- a/src/features/search/helpers/useFilterCount/useFilterCount.ts
+++ b/src/features/search/helpers/useFilterCount/useFilterCount.ts
@@ -17,7 +17,7 @@ export const useFilterCount = (searchState: SearchState): number => {
     // Prix
     +(priceRange[0] > 0 || priceRange[1] < maxPrice) +
     // Uniquement les offres gratuites
-    +searchState.offerIsFree +
+    +(searchState.offerIsFree ?? false) +
     // Uniquement les offres duo
     +searchState.offerIsDuo +
     // Uniquement les nouveautés

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -44,7 +44,7 @@ export interface SearchState {
   offerNativeCategories?: NativeCategoryIdEnumv2[]
   offerSubcategories: SubcategoryIdEnumv2[]
   offerIsDuo: boolean
-  offerIsFree: boolean
+  offerIsFree?: boolean
   offerIsNew: boolean
   offerTypes: {
     isDigital: boolean

--- a/src/libs/contentful/adapters/modules/adaptRecommendationModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptRecommendationModule.ts
@@ -1,3 +1,5 @@
+import omit from 'lodash/omit'
+
 import { HomepageModuleType, RecommendedOffersModule } from 'features/home/types'
 import { RecommendationContentModel } from 'libs/contentful/types'
 
@@ -7,5 +9,5 @@ export const adaptRecommendationModule = (
   type: HomepageModuleType.RecommendedOffersModule,
   id: modules.sys.id,
   displayParameters: modules.fields.displayParameters.fields,
-  recommendationParameters: modules.fields.recommendationParameters?.fields,
+  recommendationParameters: omit(modules.fields.recommendationParameters?.fields, 'title'),
 })

--- a/src/libs/contentful/fixtures/homepageNatifEntry.fixture.ts
+++ b/src/libs/contentful/fixtures/homepageNatifEntry.fixture.ts
@@ -1,3 +1,4 @@
+import { recommendationNatifModuleFixture } from 'libs/contentful/fixtures/recommendationNatifModule.fixture'
 import { ContentTypes, HomepageNatifEntry } from 'libs/contentful/types'
 
 export const homepageNatifEntryFixture: HomepageNatifEntry = {
@@ -195,38 +196,7 @@ export const homepageNatifEntryFixture: HomepageNatifEntry = {
           offerId: '123456789',
         },
       },
-      {
-        sys: {
-          space: { sys: { type: 'Link', linkType: 'Space', id: '2bg01iqy0isv' } },
-          id: '3sAqNrRMXUOES7tFyRFFO8',
-          type: 'Entry',
-          createdAt: '2022-07-13T12:28:35.922Z',
-          updatedAt: '2022-12-06T09:31:04.217Z',
-          environment: { sys: { id: 'testing', type: 'Link', linkType: 'Environment' } },
-          revision: 3,
-          contentType: { sys: { type: 'Link', linkType: 'ContentType', id: 'recommendation' } },
-          locale: 'en-US',
-        },
-        fields: {
-          title: 'Nos recos',
-          displayParameters: {
-            sys: {
-              space: { sys: { type: 'Link', linkType: 'Space', id: '2bg01iqy0isv' } },
-              id: '5zr0sGoxz6mSgkPDgk0pY9',
-              type: 'Entry',
-              createdAt: '2022-07-13T12:28:32.262Z',
-              updatedAt: '2022-12-06T09:31:38.064Z',
-              environment: { sys: { id: 'testing', type: 'Link', linkType: 'Environment' } },
-              revision: 3,
-              contentType: {
-                sys: { type: 'Link', linkType: 'ContentType', id: ContentTypes.DISPLAY_PARAMETERS },
-              },
-              locale: 'en-US',
-            },
-            fields: { title: 'Nos recos', layout: 'two-items', minOffers: 1 },
-          },
-        },
-      },
+      recommendationNatifModuleFixture,
       {
         sys: {
           space: { sys: { type: 'Link', linkType: 'Space', id: '2bg01iqy0isv' } },

--- a/src/libs/contentful/fixtures/recommendationNatifModule.fixture.ts
+++ b/src/libs/contentful/fixtures/recommendationNatifModule.fixture.ts
@@ -2,33 +2,118 @@ import { ContentTypes, RecommendationContentModel } from 'libs/contentful/types'
 
 export const recommendationNatifModuleFixture: RecommendationContentModel = {
   sys: {
-    space: { sys: { type: 'Link', linkType: 'Space', id: '2bg01iqy0isv' } },
-    id: '3sAqNrRMXUOES7tFyRFFO8',
+    space: {
+      sys: {
+        type: 'Link',
+        linkType: 'Space',
+        id: '2bg01iqy0isv',
+      },
+    },
+    id: '2TD5BEKL2zUGLhfzhkWhwL',
     type: 'Entry',
-    createdAt: '2022-07-13T12:28:35.922Z',
-    updatedAt: '2022-12-06T09:31:04.217Z',
-    environment: { sys: { id: 'testing', type: 'Link', linkType: 'Environment' } },
-    revision: 3,
-    contentType: { sys: { type: 'Link', linkType: 'ContentType', id: 'recommendation' } },
+    createdAt: '2022-11-28T11:13:39.608Z',
+    updatedAt: '2022-11-28T11:13:39.608Z',
+    environment: {
+      sys: {
+        id: 'testing',
+        type: 'Link',
+        linkType: 'Environment',
+      },
+    },
+    revision: 1,
+    contentType: {
+      sys: {
+        type: 'Link',
+        linkType: 'ContentType',
+        id: 'recommendation',
+      },
+    },
     locale: 'en-US',
   },
   fields: {
-    title: 'Nos recos',
+    title: 'Tes évènements en ligne',
     displayParameters: {
       sys: {
-        space: { sys: { type: 'Link', linkType: 'Space', id: '2bg01iqy0isv' } },
-        id: '5zr0sGoxz6mSgkPDgk0pY9',
+        space: {
+          sys: {
+            type: 'Link',
+            linkType: 'Space',
+            id: '2bg01iqy0isv',
+          },
+        },
+        id: '5dPoY40tY3KBg0x8suDOHz',
         type: 'Entry',
-        createdAt: '2022-07-13T12:28:32.262Z',
-        updatedAt: '2022-12-06T09:31:38.064Z',
-        environment: { sys: { id: 'testing', type: 'Link', linkType: 'Environment' } },
-        revision: 3,
+        createdAt: '2022-11-28T11:12:49.720Z',
+        updatedAt: '2022-11-28T11:12:49.720Z',
+        environment: {
+          sys: {
+            id: 'testing',
+            type: 'Link',
+            linkType: 'Environment',
+          },
+        },
+        revision: 1,
         contentType: {
-          sys: { type: 'Link', linkType: 'ContentType', id: ContentTypes.DISPLAY_PARAMETERS },
+          sys: {
+            type: 'Link',
+            linkType: 'ContentType',
+            id: ContentTypes.DISPLAY_PARAMETERS,
+          },
         },
         locale: 'en-US',
       },
-      fields: { title: 'Nos recos', layout: 'two-items', minOffers: 1 },
+      fields: {
+        title: 'Tes évènements en ligne',
+        layout: 'two-items',
+        minOffers: 1,
+      },
+    },
+    recommendationParameters: {
+      sys: {
+        space: {
+          sys: {
+            type: 'Link',
+            linkType: 'Space',
+            id: '2bg01iqy0isv',
+          },
+        },
+        id: 'K0Tq2rnfKKNYCsnFyybsG',
+        type: 'Entry',
+        createdAt: '2022-11-28T11:13:32.371Z',
+        updatedAt: '2023-01-04T14:17:12.840Z',
+        environment: {
+          sys: {
+            id: 'testing',
+            type: 'Link',
+            linkType: 'Environment',
+          },
+        },
+        revision: 3,
+        contentType: {
+          sys: {
+            type: 'Link',
+            linkType: 'ContentType',
+            id: ContentTypes.RECOMMENDATION_PARAMETERS,
+          },
+        },
+        locale: 'en-US',
+      },
+      fields: {
+        title: 'Tes évènements en ligne',
+        isEvent: true,
+        beginningDatetime: '2021-01-01T00:00+00:00',
+        endingDatetime: '2024-01-01T00:00+00:00',
+        upcomingWeekendEvent: true,
+        eventDuringNextXDays: 5,
+        currentWeekEvent: true,
+        priceMin: 0.99,
+        priceMax: 99.99,
+        categories: ['Livres'],
+        newestOnly: false,
+        isDuo: false,
+        subcategories: ['Livre'],
+        isRecoShuffled: false,
+      },
     },
   },
 }

--- a/src/libs/contentful/types.ts
+++ b/src/libs/contentful/types.ts
@@ -240,7 +240,7 @@ export interface RecommendationParametersFields {
   beginningDatetime?: string
   endingDatetime?: string
   upcomingWeekendEvent?: boolean
-  eventDuringNextXDays?: string
+  eventDuringNextXDays?: number
   currentWeekEvent?: boolean
   newestOnly?: boolean
   isFree?: boolean

--- a/src/libs/contentful/types.ts
+++ b/src/libs/contentful/types.ts
@@ -244,6 +244,7 @@ export interface RecommendationParametersFields {
   currentWeekEvent?: boolean
   newestOnly?: boolean
   isEvent?: boolean
+  priceMin?: number
   priceMax?: number
   subcategories?: string[]
   isDuo?: boolean

--- a/src/libs/contentful/types.ts
+++ b/src/libs/contentful/types.ts
@@ -243,7 +243,6 @@ export interface RecommendationParametersFields {
   eventDuringNextXDays?: number
   currentWeekEvent?: boolean
   newestOnly?: boolean
-  isFree?: boolean
   isEvent?: boolean
   priceMax?: number
   subcategories?: string[]

--- a/src/libs/contentful/types.ts
+++ b/src/libs/contentful/types.ts
@@ -179,7 +179,6 @@ export interface SearchParametersFields {
   eventDuringNextXDays?: number
   upcomingWeekendEvent?: boolean
   currentWeekEvent?: boolean
-  isFree?: boolean
   priceMin?: number
   priceMax?: number
   isDuo?: boolean

--- a/src/libs/recommendation/types.ts
+++ b/src/libs/recommendation/types.ts
@@ -16,6 +16,7 @@ export interface RecommendedIdsRequest {
   end_date?: string
   isEvent?: boolean
   categories?: string[]
+  price_min?: number
   price_max?: number
   subcategories?: string[]
   isDuo?: boolean

--- a/src/libs/search/parseSearchParameters.test.ts
+++ b/src/libs/search/parseSearchParameters.test.ts
@@ -1,3 +1,4 @@
+import omit from 'lodash/omit'
 import mockdate from 'mockdate'
 import { GeoCoordinates } from 'react-native-geolocation-service'
 
@@ -14,11 +15,14 @@ import { parseSearchParameters } from './parseSearchParameters'
 jest.mock('features/profile/api/useUpdateProfileMutation')
 mockdate.set(new Date('2020-10-01T00:00+00:00'))
 
-const defaultSearchParameters = {
-  ...initialSearchState,
-  hitsPerPage: null,
-  priceRange: [0, 300],
-}
+const defaultSearchParameters = omit(
+  {
+    ...initialSearchState,
+    hitsPerPage: null,
+    priceRange: [0, 300],
+  },
+  'offerIsFree'
+)
 
 describe('parseSearchParameters', () => {
   const subcategoryLabelMapping = useSubcategoryLabelMapping()
@@ -59,6 +63,7 @@ describe('parseSearchParameters', () => {
 
   it('should return parsed algolia parameters with tags when provided', () => {
     const parameters = {
+      title: 'title',
       tags: ['offre du 14 juillet spéciale pass culture', 'offre de la pentecôte'],
       hitsPerPage: 5,
       isDuo: true,
@@ -66,7 +71,6 @@ describe('parseSearchParameters', () => {
       isDigital: true,
       isEvent: true,
       isThing: true,
-      isFree: true,
       beginningDatetime: '2020-10-01T00:00+00:00',
       endingDatetime: '2020-10-02T00:00+00:00',
       upcomingWeekendEvent: true,
@@ -85,7 +89,6 @@ describe('parseSearchParameters', () => {
         isEvent: true,
         isThing: true,
       },
-      offerIsFree: true,
       beginningDatetime: '2020-10-01T00:00+00:00',
       endingDatetime: '2020-10-02T00:00+00:00',
     })

--- a/src/libs/search/parseSearchParameters.ts
+++ b/src/libs/search/parseSearchParameters.ts
@@ -57,7 +57,6 @@ export const parseSearchParameters = (
     offerCategories,
     offerSubcategories,
     offerIsDuo: parameters.isDuo || false,
-    offerIsFree: parameters.isFree || false,
     offerIsNew: parameters.newestOnly || false,
     offerTypes: {
       isDigital: parameters.isDigital || false,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19324

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

### Algolia
Pour remplacer isFree, on utilise priceMax = 0, ce qui donne : 
<img width="304" alt="image" src="https://user-images.githubusercontent.com/26742386/211298240-3bbb16ed-e309-4c9e-a5bf-328045ec4a74.png">
qui retourne bien des résultats
<img width="357" alt="image" src="https://user-images.githubusercontent.com/26742386/211298506-83be05cb-6c87-4055-b750-5e00fa35e872.png">

### API de reco
isFree ne remonte pas, et priceMax et priceMin remonte bien (pas d'offres proposées, je pense à cause du manque d'offre dispo pour les tests de l'API de reco)
<img width="168" alt="image" src="https://user-images.githubusercontent.com/26742386/211299467-c02dff78-5b07-4334-9b3c-a7bc9e8f666a.png">


[PC-19324]: https://passculture.atlassian.net/browse/PC-19324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ