### PR TITLE
(PC-19687) ci(e2e): fix not allowed pattern for artifact

### DIFF
--- a/e2e/config/wdio.shared.conf.ts
+++ b/e2e/config/wdio.shared.conf.ts
@@ -209,10 +209,9 @@ export const config: WebdriverIO.Config = {
         .toISOString()
         .replace(/[^0-9]/g, '')
         .slice(0, -5)
-      const filePath = `${screenshotsPath}/${timestamp}_${test.parent}_${test.title.replace(
-        / /g,
-        '-'
-      )}.png`
+      const filePath = `${screenshotsPath}/${timestamp}_${test.parent}_${test.title
+        .replace(/ /g, '-')
+        .replace(/"|:|<|>|\||\*|\?|\\r|\\n/g, '_')}.png`
       await browser.saveScreenshot(filePath)
     }
   },


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19687

Exemple d'échec: https://github.com/pass-culture/pass-culture-app-native/actions/runs/3873041069/jobs/6602593942

Erreur:

```bash
Starting artifact upload
For more detailed logs during the artifact upload process, enable step-debugging: https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging
Artifact name is valid!
Error: Artifact path is not valid: /screenshots/202301091139_profile registration_should-click-on-"Créer-un-compte".png. Contains the following character:  Double quote "
          
Invalid characters include:  Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?, Carriage return \r, Line feed \n
```