### PR TITLE
(PC-19371) feat(selectHomepageEntry): display home pre reservation 18

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -470,6 +470,11 @@ export interface BookingsResponse {
    */
   ended_bookings: Array<BookingReponse>
   /**
+   * @type {boolean}
+   * @memberof BookingsResponse
+   */
+  hasBookingsAfter18: boolean
+  /**
    * @type {Array<BookingReponse>}
    * @memberof BookingsResponse
    */

--- a/src/features/bookings/components/OnGoingBookingsList.native.test.tsx
+++ b/src/features/bookings/components/OnGoingBookingsList.native.test.tsx
@@ -57,6 +57,7 @@ describe('<OnGoingBookingsList /> - Analytics', () => {
         data: {
           ended_bookings: [],
           ongoing_bookings: [],
+          hasBookingsAfter18: false,
         } as BookingsResponse,
         isLoading: false,
         isFetching: false,
@@ -76,6 +77,7 @@ describe('<OnGoingBookingsList /> - Analytics', () => {
         data: {
           ended_bookings: [],
           ongoing_bookings: [],
+          hasBookingsAfter18: false,
         } as BookingsResponse,
         isLoading: false,
         isFetching: false,

--- a/src/features/bookings/fixtures/bookingsSnap.ts
+++ b/src/features/bookings/fixtures/bookingsSnap.ts
@@ -128,9 +128,11 @@ export const bookingsSnap: BookingsResponse = {
       ],
     },
   ],
+  hasBookingsAfter18: true,
 }
 
 export const emptyBookingsSnap: BookingsResponse = {
   ended_bookings: [],
   ongoing_bookings: [],
+  hasBookingsAfter18: true,
 }

--- a/src/features/home/helpers/selectHomepageEntry.ts
+++ b/src/features/home/helpers/selectHomepageEntry.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react'
 
 import { UserProfileResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/AuthContext'
+import { useBookings } from 'features/bookings/api'
 import { useUserHasBookings } from 'features/bookings/api/useUserHasBookings'
 import { Homepage } from 'features/home/types'
 import { isUserBeneficiary18 } from 'features/profile/helpers/isUserBeneficiary18'
@@ -31,6 +32,7 @@ export const useSelectHomepageEntry = (
 ): ((homepageList: Homepage[]) => Homepage | undefined) => {
   const { isLoggedIn, user } = useAuthContext()
   const userHasBookings = useUserHasBookings()
+  const { data: userBookings } = useBookings()
   const {
     homeEntryIdNotConnected,
     homeEntryIdGeneral,
@@ -76,7 +78,7 @@ export const useSelectHomepageEntry = (
 
       const credit = getAvailableCredit(user)
       if (user?.eligibility === 'age-18' || (isUserBeneficiary18(user) && !credit.isExpired)) {
-        if (userHasBookings) {
+        if (userBookings?.hasBookingsAfter18) {
           return homepageList.find(({ id }) => id === homeEntryId_18) || defaultHomepageEntry
         }
         return (
@@ -97,6 +99,7 @@ export const useSelectHomepageEntry = (
       homeEntryId_15_17,
       isLoggedIn,
       userHasBookings,
+      userBookings,
     ]
   )
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19371

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

Tests effectués : 
- Si beneficiaire 18 ans sans resa => homeEntryId : 62Th0gKULQPyTR9kJkXbnd (Page d'accueil 18 - sans réservation)
- Si beneficiaire 18 ans avec resa => homeEntryId : a7y5X9eAxgL4RLMSCD3Wn (Page d'accueil 18 - avec réservation)