### PR TITLE
(PC-19779) fix(search): reset native category & genre when pressing suggestion

### DIFF
--- a/src/features/search/components/SearchAutocompleteItem/SearchAutocompleteItem.tsx
+++ b/src/features/search/components/SearchAutocompleteItem/SearchAutocompleteItem.tsx
@@ -49,6 +49,8 @@ export const SearchAutocompleteItem: React.FC<Props> = ({ hit, sendEvent, should
       view: SearchView.Results,
       searchId,
       isAutocomplete: true,
+      offerGenreTypes: undefined,
+      offerNativeCategories: undefined,
       ...(!!shouldFilteredOnCategory && { offerCategories: [categories[0].value] }),
     }
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19779

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
