### PR TITLE
(PC-19733) fix(SetEmail): Revert use of input with spelling help"

### DIFF
--- a/src/features/auth/signup/SetEmail/SetEmail.tsx
+++ b/src/features/auth/signup/SetEmail/SetEmail.tsx
@@ -63,13 +63,7 @@ export const SetEmail: FunctionComponent<PreValidationSignupStepProps> = (props)
 
   return (
     <Form.MaxWidth>
-      <EmailInputController
-        control={control}
-        name="email"
-        label="Adresse e-mail"
-        withSpellingHelp
-        autoFocus
-      />
+      <EmailInputController control={control} name="email" label="Adresse e-mail" autoFocus />
       <Spacer.Column numberOfSpaces={4} />
       <Controller
         control={control}

--- a/src/shared/forms/controllers/EmailInputController.tsx
+++ b/src/shared/forms/controllers/EmailInputController.tsx
@@ -3,7 +3,6 @@ import { Control, Controller, FieldPath, FieldValues } from 'react-hook-form'
 import { v4 as uuidv4 } from 'uuid'
 
 import { EmailInput, EmailInputProps } from 'ui/components/inputs/EmailInput/EmailInput'
-import { EmailInputWithSpellingHelp } from 'ui/components/inputs/EmailInputWithSpellingHelp/EmailInputWithSpellingHelp'
 import { InputError } from 'ui/components/inputs/InputError'
 
 const emailInputErrorId = uuidv4()
@@ -12,7 +11,6 @@ interface Props<TFieldValues extends FieldValues, TName>
   extends Omit<EmailInputProps, 'onEmailChange' | 'email'> {
   name: TName
   control: Control<TFieldValues>
-  withSpellingHelp?: boolean
 }
 
 export const EmailInputController = <
@@ -21,18 +19,15 @@ export const EmailInputController = <
 >({
   name,
   control,
-  withSpellingHelp,
   ...otherEmailInputProps
 }: PropsWithChildren<Props<TFieldValues, TName>>): ReactElement => {
-  const Input = withSpellingHelp ? EmailInputWithSpellingHelp : EmailInput
-
   return (
     <Controller
       control={control}
       name={name}
       render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => (
         <React.Fragment>
-          <Input
+          <EmailInput
             email={value}
             onEmailChange={onChange}
             onBlur={onBlur}


### PR DESCRIPTION
This reverts commit 64d9a86eb88fcb240e00f08130369948f1382740.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19733

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
