### PR TITLE
(PC-19233) fix(categoryBlock): use white underline on hover

### DIFF
--- a/src/features/home/components/modules/categories/CategoryBlock.tsx
+++ b/src/features/home/components/modules/categories/CategoryBlock.tsx
@@ -59,6 +59,8 @@ const ImageBackground = styled.ImageBackground({
   flex: 1,
 })
 
-const StyledInternalTouchableLink = styled(InternalTouchableLink)({
+const StyledInternalTouchableLink = styled(InternalTouchableLink).attrs(({ theme }) => ({
+  hoverUnderlineColor: theme.colors.white,
+}))({
   height: getSpacing(18),
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19233

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| Desktop - Chrome | <img width="97" alt="image" src="https://user-images.githubusercontent.com/26742386/212287212-02a2185f-a1b2-4c38-88dc-81a103434ef9.png"> | <img width="94" alt="image" src="https://user-images.githubusercontent.com/26742386/212288226-66151314-6e02-4136-a514-ebda8c2c17a3.png"> |
