### PR TITLE
(PC-19814) ci(e2e): added openDeepLink that support iOS/Android/Web

### DIFF
--- a/e2e/tests/pc/helpers/Browser.ts
+++ b/e2e/tests/pc/helpers/Browser.ts
@@ -1,0 +1,13 @@
+class Browser {
+  async url(url: string) {
+    const p = await browser.url(url)
+    await browser.execute(() => {
+      // @ts-ignore due to a bug with safaridriver not setting navigation.webdriver
+      // this is only necessary for iOS Safari browser
+      globalThis.window.webdriver = true
+    })
+    return p
+  }
+}
+
+export default new Browser()

--- a/e2e/tests/pc/helpers/FirstLaunch.ts
+++ b/e2e/tests/pc/helpers/FirstLaunch.ts
@@ -6,6 +6,7 @@ import AgeSelection from '../features/onboarding/AgeSelection'
 import AgeInformation from '../features/onboarding/AgeInformation'
 import OnboardingWelcome from '../features/onboarding/OnboardingWelcome'
 import OnboardingGeolocation from '../features/onboarding/OnboardingGeolocation'
+import Browser from './Browser'
 
 class FirstLaunch {
   retries = 2
@@ -13,11 +14,7 @@ class FirstLaunch {
 
   async init(tabBar: TabBar) {
     if (flags.isWeb) {
-      await browser.url('/')
-      await browser.execute(() => {
-        // @ts-ignore due to a bug with safaridriver not setting navigation.webdriver, this is only necessary for iOS Safari browser
-        globalThis.window.webdriver = true
-      })
+      await Browser.url('/')
     }
     if (!flags.isWeb && flags.isIOS) {
       // This while loop will take care of the DoNotTrack and Notification Alert

--- a/e2e/tests/pc/helpers/utils/deeplink.ts
+++ b/e2e/tests/pc/helpers/utils/deeplink.ts
@@ -1,0 +1,89 @@
+import { flags } from './platform'
+import Browser from '../Browser'
+import { env } from '../../../../config/environment/env'
+
+/**
+ * Create a cross platform solution for opening a deep link
+ */
+export async function openDeepLinkUrl(deeplinkUrl: string) {
+  const canBeFdlUrl = new URL(deeplinkUrl)
+  const url = new URL(
+    canBeFdlUrl.search.startsWith('?link=')
+      ? decodeURIComponent(canBeFdlUrl.search.replace(/^\?link=/, ''))
+      : canBeFdlUrl.href
+  )
+  const forcedHostUrl = new URL(
+    url.host.startsWith('localhost') ||
+    url.host.startsWith('192.168') ||
+    url.host.startsWith('10.0')
+      ? url.href.replace(url.origin, `https://app.${env.ENVIRONMENT}.passculture.team`)
+      : url.href
+  )
+
+  if (flags.isWeb) {
+    // On the web, open as it is
+    return await Browser.url(url.href)
+  }
+
+  if (driver.isAndroid) {
+    // Life is so much easier
+    return driver.execute('mobile:deepLink', {
+      url: forcedHostUrl.href,
+      package: `app.passculture.${env.ENVIRONMENT}/com.passculture.MainActivity`,
+    })
+  }
+
+  // We can use `driver.url` on iOS simulators, but not on iOS real devices. The reason is that iOS real devices
+  // open Siri when you call `driver.url('')` to use a deep link. This means that real devices need to have a different implementation
+  // then iOS simslink
+  // iOS sims and real devices can be distinguished by their UDID. Based on these sources there is a diff in the UDIDS
+  // - https://blog.diawi.com/2018/10/15/2018-apple-devices-and-their-new-udid-format/
+  // - https://www.theiphonewiki.com/wiki/UDID
+  // iOS sims have more than 1 `-` in the UDID and the UDID is being
+  const simulatorRegex = new RegExp('(.*-.*){2,}')
+
+  // Check if we are a simulator
+  if ('udid' in driver.capabilities && simulatorRegex.test(driver.capabilities.udid as string)) {
+    await driver.url(forcedHostUrl.href)
+  } else {
+    // Else we are a real device and we need to take some extra steps
+    // Launch Safari to open the deep link
+    await driver.execute('mobile: launchApp', { bundleId: 'com.apple.mobilesafari' })
+
+    // Add the deep link url in Safari in the `URL`-field
+    // This can be 2 different elements, or the button, or the text field
+    // Use the predicate string because  the accessibility label will return 2 different types
+    // of elements making it flaky to use. With predicate string we can be more precise
+    const addressBarSelector = 'label == "Address" OR name == "URL"'
+    const urlFieldSelector = 'type == "XCUIElementTypeTextField" && name CONTAINS "URL"'
+    const addressBar = $(`-ios predicate string:${addressBarSelector}`)
+    const urlField = $(`-ios predicate string:${urlFieldSelector}`)
+
+    // Wait for the url button to appear and click on it so the text field will appear
+    // iOS 13 now has the keyboard open by default because the URL field has focus when opening the Safari browser
+    if (!(await driver.isKeyboardShown())) {
+      await addressBar.waitForDisplayed()
+      await addressBar.click()
+    }
+
+    // Submit the url and add a break
+    await urlField.setValue(`${forcedHostUrl.href}\uE007`)
+  }
+
+  /**
+   * PRO TIP:
+   * if you started the iOS device with `autoAcceptAlerts:true` in the capabilities then Appium will auto accept the alert that should
+   * be shown now. You can then comment out the code below
+   */
+  // Wait for the notification and accept it
+  // When using an iOS simulator you will only get the pop-up once, all the other times it won't be shown
+  try {
+    const openSelector = "type == 'XCUIElementTypeButton' && name CONTAINS 'Open'"
+    const openButton = $(`-ios predicate string:${openSelector}`)
+    // Assumption is made that the alert will be seen within 2 seconds, if not it did not appear
+    await openButton.waitForDisplayed({ timeout: 2000 })
+    await openButton.click()
+  } catch (e) {
+    // ignore
+  }
+}

--- a/e2e/tests/pc/helpers/utils/deeplink.ts
+++ b/e2e/tests/pc/helpers/utils/deeplink.ts
@@ -6,11 +6,11 @@ import { env } from '../../../../config/environment/env'
  * Create a cross platform solution for opening a deep link
  */
 export async function openDeepLinkUrl(deeplinkUrl: string) {
-  const canBeFdlUrl = new URL(deeplinkUrl)
+  const canBeFirebaseDynamicLink = new URL(deeplinkUrl)
   const url = new URL(
-    canBeFdlUrl.search.startsWith('?link=')
-      ? decodeURIComponent(canBeFdlUrl.search.replace(/^\?link=/, ''))
-      : canBeFdlUrl.href
+    canBeFirebaseDynamicLink.search.startsWith('?link=')
+      ? decodeURIComponent(canBeFirebaseDynamicLink.search.replace(/^\?link=/, ''))
+      : canBeFirebaseDynamicLink.href
   )
   const forcedHostUrl = new URL(
     url.host.startsWith('localhost') ||


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19814

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
