### PR TITLE
(PC-19987) feat(logCategoryBlock): fix the params so they can be seen on firebase console

### DIFF
--- a/src/features/cheatcodes/pages/AppComponents/AppComponents.tsx
+++ b/src/features/cheatcodes/pages/AppComponents/AppComponents.tsx
@@ -784,6 +784,8 @@ export const AppComponents: FunctionComponent = () => {
             id="123"
             title={'En ce moment sur le pass'}
             categoryBlockList={categoryBlockList}
+            homeEntryId="homeEntryId"
+            index={1}
           />
         </AccordionItem>
         <Spacer.Column numberOfSpaces={5} />

--- a/src/features/home/components/modules/HomeModule.tsx
+++ b/src/features/home/components/modules/HomeModule.tsx
@@ -6,7 +6,7 @@ import {
   OffersModule,
   VenuesModule,
 } from 'features/home/components'
-import { CategoryListModule as CategoryListComponent } from 'features/home/components/modules/categories/CategoryListModule'
+import { CategoryListModule } from 'features/home/components/modules/categories/CategoryListModule'
 import { RecommendationModule } from 'features/home/components/modules/RecommendationModule'
 import { ThematicHighlightModule } from 'features/home/components/modules/ThematicHighlightModule'
 import {
@@ -84,7 +84,7 @@ const UnmemoizedModule = ({
   if (isThematicHighlightModule(item)) return <ThematicHighlightModule {...item} />
 
   if (isCategoryListModule(item))
-    return <CategoryListComponent {...item} homeEntryId={homeEntryId} index={index} />
+    return <CategoryListModule {...item} homeEntryId={homeEntryId} index={index} />
 
   return <React.Fragment></React.Fragment>
 }

--- a/src/features/home/components/modules/HomeModule.tsx
+++ b/src/features/home/components/modules/HomeModule.tsx
@@ -83,7 +83,8 @@ const UnmemoizedModule = ({
 
   if (isThematicHighlightModule(item)) return <ThematicHighlightModule {...item} />
 
-  if (isCategoryListModule(item)) return <CategoryListComponent {...item} />
+  if (isCategoryListModule(item))
+    return <CategoryListComponent {...item} homeEntryId={homeEntryId} index={index} />
 
   return <React.Fragment></React.Fragment>
 }

--- a/src/features/home/components/modules/categories/CategoryListModule.native.test.tsx
+++ b/src/features/home/components/modules/categories/CategoryListModule.native.test.tsx
@@ -2,13 +2,38 @@ import React from 'react'
 
 import { CategoryListModule } from 'features/home/components/modules/categories/CategoryListModule'
 import { categoryBlockList } from 'features/home/fixtures/categoryBlockList.fixture'
+import { ContentTypes } from 'libs/contentful'
 import { analytics } from 'libs/firebase/analytics'
 import { fireEvent, render } from 'tests/utils'
 
 describe('CategoryListModule', () => {
+  it('should call analytics when the module is displayed', () => {
+    render(
+      <CategoryListModule
+        id="123"
+        title="module"
+        categoryBlockList={categoryBlockList}
+        index={1}
+        homeEntryId="homeEntryId"
+      />
+    )
+
+    expect(analytics.logModuleDisplayedOnHomepage).toHaveBeenCalledWith(
+      '123',
+      ContentTypes.CATEGORY_LIST,
+      1,
+      'homeEntryId'
+    )
+  })
   it('should call analytics when a categoryBlock is clicked', () => {
     const categoryListModule = render(
-      <CategoryListModule id="123" title="module" categoryBlockList={categoryBlockList} />
+      <CategoryListModule
+        id="123"
+        title="module"
+        categoryBlockList={categoryBlockList}
+        index={1}
+        homeEntryId="homeEntryId"
+      />
     )
 
     const bloc = categoryListModule.getByText('Toto au cinéma')

--- a/src/features/home/components/modules/categories/CategoryListModule.stories.tsx
+++ b/src/features/home/components/modules/categories/CategoryListModule.stories.tsx
@@ -23,6 +23,8 @@ export const CategoryListWithThreeBlocks: ComponentStory<typeof CategoryListModu
     id="123"
     title={'En ce moment sur le pass'}
     categoryBlockList={categoryBlockList.slice(1)}
+    homeEntryId="homeEntryId"
+    index={1}
   />
 )
 CategoryListWithThreeBlocks.storyName = 'CategoryListWithThreeBlocks'
@@ -32,6 +34,8 @@ export const CategoryListWithFourBlocks: ComponentStory<typeof CategoryListModul
     id="123"
     title={'En ce moment sur le pass'}
     categoryBlockList={categoryBlockList}
+    homeEntryId="homeEntryId"
+    index={1}
   />
 )
 CategoryListWithFourBlocks.storyName = 'CategoryListWithFourBlocks'

--- a/src/features/home/components/modules/categories/CategoryListModule.tsx
+++ b/src/features/home/components/modules/categories/CategoryListModule.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { FlatList } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
@@ -8,6 +8,7 @@ import {
   getMobileColorFilter,
 } from 'features/home/components/modules/categories/helpers/getColorFilter'
 import { CategoryBlock as CategoryBlockData } from 'features/home/types'
+import { ContentTypes } from 'libs/contentful'
 import { analytics } from 'libs/firebase/analytics'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
@@ -15,6 +16,8 @@ type CategoryListProps = {
   id: string
   title: string
   categoryBlockList: CategoryBlockData[]
+  index: number
+  homeEntryId: string | undefined
 }
 
 const DESKTOP_COLUMNS = 4
@@ -33,7 +36,17 @@ const keyExtractor = (_item: CategoryBlockData, index: number) => `category_bloc
 
 const ListFooterComponent = () => <Footer />
 
-export const CategoryListModule = ({ id, title, categoryBlockList }: CategoryListProps) => {
+export const CategoryListModule = ({
+  id,
+  title,
+  categoryBlockList,
+  index,
+  homeEntryId,
+}: CategoryListProps) => {
+  useEffect(() => {
+    analytics.logModuleDisplayedOnHomepage(id, ContentTypes.CATEGORY_LIST, index, homeEntryId)
+  }, [id, homeEntryId, index])
+
   const theme = useTheme()
   const numColumns = theme.isDesktopViewport ? DESKTOP_COLUMNS : MOBILE_COLUMNS
 

--- a/src/libs/firebase/analytics/analytics.ts
+++ b/src/libs/firebase/analytics/analytics.ts
@@ -65,7 +65,7 @@ const logEventAnalytics = {
     moduleID: string
     moduleListID: string
     toEntryId: string
-  }) => analyticsProvider.logEvent(AnalyticsEvent.CATEGORY_BLOCK_CLICKED, { params }),
+  }) => analyticsProvider.logEvent(AnalyticsEvent.CATEGORY_BLOCK_CLICKED, params),
   logChangeSearchLocation: (params: ChangeSearchLocationParam, searchId?: string) =>
     analyticsProvider.logEvent(AnalyticsEvent.CHANGE_SEARCH_LOCATION, {
       type: params.type,


### PR DESCRIPTION
Ticket : https://passculture.atlassian.net/browse/PC-19987

Fix the logCategoryBlockClicked function so the event params are transmitted to firebase.
On the right screenshot you can see the moduleID, moduleListID ans toEntryId params

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| firebase logCategoryBlockClicked            | <img width="329" alt="image" src="https://user-images.githubusercontent.com/89008469/213412424-ff4fa67c-1c1f-4e56-ab42-58fea26821d0.png"> | <img width="335" alt="image" src="https://user-images.githubusercontent.com/89008469/213411581-282c087f-4b2d-432c-ad68-b5fc77e9053c.png"> |
| firebase logModuleDisplayedOnHome        |  | <img width="350" alt="image" src="https://user-images.githubusercontent.com/89008469/213427521-d697758c-9a7b-4ec5-a41a-01c8b504ad32.png"> |





[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
