### PR TITLE
(PC-19822) feat(Hit): display nativeCategory (subCatgeory) label instead of categeory label

### DIFF
--- a/src/features/search/components/Hit/Hit.tsx
+++ b/src/features/search/components/Hit/Hit.tsx
@@ -12,7 +12,6 @@ import { QueryKeys } from 'libs/queryKeys'
 import { SearchHit } from 'libs/search'
 import { useSubcategory } from 'libs/subcategories'
 import { useSearchGroupLabel } from 'libs/subcategories/useSearchGroupLabel'
-import { useSubcategories } from 'libs/subcategories/useSubcategories'
 import { tileAccessibilityLabel, TileContentType } from 'libs/tileAccessibilityLabel'
 import { OfferImage } from 'ui/components/tiles/OfferImage'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
@@ -32,8 +31,6 @@ export const Hit: React.FC<Props> = ({ hit, query, index, searchId }) => {
   const { categoryId, searchGroupName, nativeCategoryId } = useSubcategory(subcategoryId)
   const searchGroupLabel = useSearchGroupLabel(searchGroupName)
   const { logClickOnOffer } = useLogClickOnOffer()
-
-  const { data } = useSubcategories()
 
   const timestampsInMillis = dates?.map((timestampInSec) => timestampInSec * 1000)
   const offerId = +objectID
@@ -92,7 +89,7 @@ export const Hit: React.FC<Props> = ({ hit, query, index, searchId }) => {
           )}
         </Row>
         <Spacer.Column numberOfSpaces={1} />
-        <NativeCategoryValue nativeCategoryId={nativeCategoryId} data={data} />
+        <NativeCategoryValue nativeCategoryId={nativeCategoryId} />
         {!!formattedDate && <Body>{formattedDate}</Body>}
         <Spacer.Column numberOfSpaces={1} />
         <Typo.Caption>{formattedPrice}</Typo.Caption>

--- a/src/features/search/components/Hit/Hit.tsx
+++ b/src/features/search/components/Hit/Hit.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from 'react-query'
 import styled from 'styled-components/native'
 
 import { mergeOfferData } from 'features/offer/components/OfferTile/OfferTile'
-import { getNativeCategoryFromEnum } from 'features/search/helpers/categoriesHelpers/categoriesHelpers'
+import { NativeCategoryValue } from 'features/search/components/NativeCategoryValue/NativeCategoryValue'
 import { useLogClickOnOffer } from 'libs/algolia/analytics/logClickOnOffer'
 import { analytics } from 'libs/firebase/analytics'
 import { useDistance } from 'libs/geolocation/hooks/useDistance'
@@ -34,7 +34,6 @@ export const Hit: React.FC<Props> = ({ hit, query, index, searchId }) => {
   const { logClickOnOffer } = useLogClickOnOffer()
 
   const { data } = useSubcategories()
-  const nativeCategory = getNativeCategoryFromEnum(data, nativeCategoryId)
 
   const timestampsInMillis = dates?.map((timestampInSec) => timestampInSec * 1000)
   const offerId = +objectID
@@ -93,9 +92,7 @@ export const Hit: React.FC<Props> = ({ hit, query, index, searchId }) => {
           )}
         </Row>
         <Spacer.Column numberOfSpaces={1} />
-        <Body ellipsizeMode="tail" numberOfLines={1}>
-          {nativeCategory?.value}
-        </Body>
+        <NativeCategoryValue nativeCategoryId={nativeCategoryId} data={data} />
         {!!formattedDate && <Body>{formattedDate}</Body>}
         <Spacer.Column numberOfSpaces={1} />
         <Typo.Caption>{formattedPrice}</Typo.Caption>

--- a/src/features/search/components/Hit/Hit.tsx
+++ b/src/features/search/components/Hit/Hit.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from 'react-query'
 import styled from 'styled-components/native'
 
 import { mergeOfferData } from 'features/offer/components/OfferTile/OfferTile'
+import { getNativeCategoryFromEnum } from 'features/search/helpers/categoriesHelpers/categoriesHelpers'
 import { useLogClickOnOffer } from 'libs/algolia/analytics/logClickOnOffer'
 import { analytics } from 'libs/firebase/analytics'
 import { useDistance } from 'libs/geolocation/hooks/useDistance'
@@ -11,6 +12,7 @@ import { QueryKeys } from 'libs/queryKeys'
 import { SearchHit } from 'libs/search'
 import { useSubcategory } from 'libs/subcategories'
 import { useSearchGroupLabel } from 'libs/subcategories/useSearchGroupLabel'
+import { useSubcategories } from 'libs/subcategories/useSubcategories'
 import { tileAccessibilityLabel, TileContentType } from 'libs/tileAccessibilityLabel'
 import { OfferImage } from 'ui/components/tiles/OfferImage'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
@@ -27,9 +29,12 @@ export const Hit: React.FC<Props> = ({ hit, query, index, searchId }) => {
   const { subcategoryId, dates, prices } = offer
   const queryClient = useQueryClient()
   const distanceToOffer = useDistance(_geoloc)
-  const { categoryId, searchGroupName } = useSubcategory(subcategoryId)
+  const { categoryId, searchGroupName, nativeCategoryId } = useSubcategory(subcategoryId)
   const searchGroupLabel = useSearchGroupLabel(searchGroupName)
   const { logClickOnOffer } = useLogClickOnOffer()
+
+  const { data } = useSubcategories()
+  const nativeCategory = getNativeCategoryFromEnum(data, nativeCategoryId)
 
   const timestampsInMillis = dates?.map((timestampInSec) => timestampInSec * 1000)
   const offerId = +objectID
@@ -89,7 +94,7 @@ export const Hit: React.FC<Props> = ({ hit, query, index, searchId }) => {
         </Row>
         <Spacer.Column numberOfSpaces={1} />
         <Body ellipsizeMode="tail" numberOfLines={1}>
-          {searchGroupLabel}
+          {nativeCategory?.value}
         </Body>
         {!!formattedDate && <Body>{formattedDate}</Body>}
         <Spacer.Column numberOfSpaces={1} />

--- a/src/features/search/components/NativeCategoryValue/NativeCategoryValue.native.test.tsx
+++ b/src/features/search/components/NativeCategoryValue/NativeCategoryValue.native.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import { NativeCategoryIdEnumv2, SubcategoriesResponseModelv2 } from 'api/gen'
+import { NativeCategoryValue } from 'features/search/components/NativeCategoryValue/NativeCategoryValue'
+import { render } from 'tests/utils'
+
+describe('<NativeCategoryValue />', () => {
+  it('should render the native category value when data and nativeCategoryId are passed', () => {
+    const data = {
+      nativeCategories: [
+        { genreType: 'MUSIC', name: 'CD_VINYLES', value: 'CD, vinyles' },
+        { genreType: 'MUSIC', name: 'MUSIQUE_EN_LIGNE', value: 'Musique en ligne' },
+      ],
+    } as SubcategoriesResponseModelv2
+    const nativeCategoryId = NativeCategoryIdEnumv2.MUSIQUE_EN_LIGNE
+
+    const { getByText } = render(
+      <NativeCategoryValue data={data} nativeCategoryId={nativeCategoryId} />
+    )
+
+    expect(getByText('Musique en ligne')).toBeTruthy()
+  })
+
+  it('should not render anything when no data are passed', () => {
+    const nativeCategoryId = NativeCategoryIdEnumv2.MUSIQUE_EN_LIGNE
+    const { queryByTestId } = render(
+      <NativeCategoryValue data={undefined} nativeCategoryId={nativeCategoryId} />
+    )
+
+    expect(queryByTestId('native-category-value')).toBeNull()
+  })
+})

--- a/src/features/search/components/NativeCategoryValue/NativeCategoryValue.native.test.tsx
+++ b/src/features/search/components/NativeCategoryValue/NativeCategoryValue.native.test.tsx
@@ -1,46 +1,28 @@
 import React from 'react'
 
-import { NativeCategoryIdEnumv2, SubcategoriesResponseModelv2 } from 'api/gen'
+import { NativeCategoryIdEnumv2 } from 'api/gen'
 import { NativeCategoryValue } from 'features/search/components/NativeCategoryValue/NativeCategoryValue'
+import { placeholderData as mockData } from 'libs/subcategories/placeholderData'
 import { render } from 'tests/utils'
+
+jest.mock('libs/subcategories/useSubcategories', () => ({
+  useSubcategories: () => ({
+    data: mockData,
+  }),
+}))
 
 describe('<NativeCategoryValue />', () => {
   it('should render the native category value when data and nativeCategoryId are passed', () => {
-    const data = {
-      nativeCategories: [
-        { genreType: 'MUSIC', name: 'CD_VINYLES', value: 'CD, vinyles' },
-        { genreType: 'MUSIC', name: 'MUSIQUE_EN_LIGNE', value: 'Musique en ligne' },
-      ],
-    } as SubcategoriesResponseModelv2
     const nativeCategoryId = NativeCategoryIdEnumv2.MUSIQUE_EN_LIGNE
 
-    const { getByText } = render(
-      <NativeCategoryValue data={data} nativeCategoryId={nativeCategoryId} />
-    )
+    const { getByText } = render(<NativeCategoryValue nativeCategoryId={nativeCategoryId} />)
 
     expect(getByText('Musique en ligne')).toBeTruthy()
   })
 
-  it('should render anything when no data are passed', () => {
-    const nativeCategoryId = NativeCategoryIdEnumv2.MUSIQUE_EN_LIGNE
-    const { queryByTestId } = render(
-      <NativeCategoryValue data={undefined} nativeCategoryId={nativeCategoryId} />
-    )
-
-    expect(queryByTestId('native-category-value')).toBeNull()
-  })
-
   it('should render anything when UNKNOW nativeCategoryId are passed', () => {
-    const data = {
-      nativeCategories: [
-        { genreType: 'MUSIC', name: 'CD_VINYLES', value: 'CD, vinyles' },
-        { genreType: 'MUSIC', name: 'MUSIQUE_EN_LIGNE', value: 'Musique en ligne' },
-      ],
-    } as SubcategoriesResponseModelv2
     const nativeCategoryId = 'UNKNOWN' as NativeCategoryIdEnumv2
-    const { queryByTestId } = render(
-      <NativeCategoryValue data={data} nativeCategoryId={nativeCategoryId} />
-    )
+    const { queryByTestId } = render(<NativeCategoryValue nativeCategoryId={nativeCategoryId} />)
 
     expect(queryByTestId('native-category-value')).toBeNull()
   })

--- a/src/features/search/components/NativeCategoryValue/NativeCategoryValue.native.test.tsx
+++ b/src/features/search/components/NativeCategoryValue/NativeCategoryValue.native.test.tsx
@@ -21,10 +21,25 @@ describe('<NativeCategoryValue />', () => {
     expect(getByText('Musique en ligne')).toBeTruthy()
   })
 
-  it('should not render anything when no data are passed', () => {
+  it('should render anything when no data are passed', () => {
     const nativeCategoryId = NativeCategoryIdEnumv2.MUSIQUE_EN_LIGNE
     const { queryByTestId } = render(
       <NativeCategoryValue data={undefined} nativeCategoryId={nativeCategoryId} />
+    )
+
+    expect(queryByTestId('native-category-value')).toBeNull()
+  })
+
+  it('should render anything when UNKNOW nativeCategoryId are passed', () => {
+    const data = {
+      nativeCategories: [
+        { genreType: 'MUSIC', name: 'CD_VINYLES', value: 'CD, vinyles' },
+        { genreType: 'MUSIC', name: 'MUSIQUE_EN_LIGNE', value: 'Musique en ligne' },
+      ],
+    } as SubcategoriesResponseModelv2
+    const nativeCategoryId = 'UNKNOWN' as NativeCategoryIdEnumv2
+    const { queryByTestId } = render(
+      <NativeCategoryValue data={data} nativeCategoryId={nativeCategoryId} />
     )
 
     expect(queryByTestId('native-category-value')).toBeNull()

--- a/src/features/search/components/NativeCategoryValue/NativeCategoryValue.tsx
+++ b/src/features/search/components/NativeCategoryValue/NativeCategoryValue.tsx
@@ -1,16 +1,17 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { NativeCategoryIdEnumv2, SubcategoriesResponseModelv2 } from 'api/gen'
+import { NativeCategoryIdEnumv2 } from 'api/gen'
 import { getNativeCategoryFromEnum } from 'features/search/helpers/categoriesHelpers/categoriesHelpers'
+import { useSubcategories } from 'libs/subcategories/useSubcategories'
 import { Typo } from 'ui/theme'
 
 interface NativeCategoryValueProps {
   nativeCategoryId: NativeCategoryIdEnumv2
-  data?: SubcategoriesResponseModelv2
 }
 
-export const NativeCategoryValue = ({ nativeCategoryId, data }: NativeCategoryValueProps) => {
+export const NativeCategoryValue = ({ nativeCategoryId }: NativeCategoryValueProps) => {
+  const { data } = useSubcategories()
   const { value } = getNativeCategoryFromEnum(data, nativeCategoryId) || {}
 
   return value ? (

--- a/src/features/search/components/NativeCategoryValue/NativeCategoryValue.tsx
+++ b/src/features/search/components/NativeCategoryValue/NativeCategoryValue.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { NativeCategoryIdEnumv2, SubcategoriesResponseModelv2 } from 'api/gen'
+import { getNativeCategoryValue } from 'features/search/helpers/categoriesHelpers/categoriesHelpers'
+import { Typo } from 'ui/theme'
+
+interface NativeCategoryValueProps {
+  nativeCategoryId: NativeCategoryIdEnumv2
+  data: SubcategoriesResponseModelv2 | undefined
+}
+
+export const NativeCategoryValue = ({ nativeCategoryId, data }: NativeCategoryValueProps) => {
+  const nativeCategoryValue = getNativeCategoryValue(data, nativeCategoryId)
+
+  return (nativeCategoryValue?.length ?? 0) > 0 ? (
+    <Body ellipsizeMode="tail" numberOfLines={1} testID="native-category-value">
+      {nativeCategoryValue}
+    </Body>
+  ) : null
+}
+
+const Body = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/search/components/NativeCategoryValue/NativeCategoryValue.tsx
+++ b/src/features/search/components/NativeCategoryValue/NativeCategoryValue.tsx
@@ -2,20 +2,20 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { NativeCategoryIdEnumv2, SubcategoriesResponseModelv2 } from 'api/gen'
-import { getNativeCategoryValue } from 'features/search/helpers/categoriesHelpers/categoriesHelpers'
+import { getNativeCategoryFromEnum } from 'features/search/helpers/categoriesHelpers/categoriesHelpers'
 import { Typo } from 'ui/theme'
 
 interface NativeCategoryValueProps {
   nativeCategoryId: NativeCategoryIdEnumv2
-  data: SubcategoriesResponseModelv2 | undefined
+  data?: SubcategoriesResponseModelv2
 }
 
 export const NativeCategoryValue = ({ nativeCategoryId, data }: NativeCategoryValueProps) => {
-  const nativeCategoryValue = getNativeCategoryValue(data, nativeCategoryId)
+  const { value } = getNativeCategoryFromEnum(data, nativeCategoryId) || {}
 
-  return (nativeCategoryValue?.length ?? 0) > 0 ? (
+  return value ? (
     <Body ellipsizeMode="tail" numberOfLines={1} testID="native-category-value">
-      {nativeCategoryValue}
+      {value}
     </Body>
   ) : null
 }

--- a/src/features/search/helpers/categoriesHelpers/categoriesHelpers.ts
+++ b/src/features/search/helpers/categoriesHelpers/categoriesHelpers.ts
@@ -63,6 +63,16 @@ export function getSearchGroupsFromEnumArray(
 }
 
 /**
+ * Returns a `NativeCategoryResponseModelv2` value from a `NativeCategoryIdEnumv2`.
+ */
+export function getNativeCategoryValue(
+  data: SubcategoriesResponseModelv2 | undefined,
+  enumValue: NativeCategoryIdEnumv2
+) {
+  return data?.nativeCategories.find((nativeCategory) => nativeCategory.name === enumValue)?.value
+}
+
+/**
  * Returns a `NativeCategoryResponseModelv2` from a `NativeCategoryIdEnumv2`.
  */
 export function getNativeCategoryFromEnum(

--- a/src/features/search/helpers/categoriesHelpers/categoriesHelpers.ts
+++ b/src/features/search/helpers/categoriesHelpers/categoriesHelpers.ts
@@ -63,16 +63,6 @@ export function getSearchGroupsFromEnumArray(
 }
 
 /**
- * Returns a `NativeCategoryResponseModelv2` value from a `NativeCategoryIdEnumv2`.
- */
-export function getNativeCategoryValue(
-  data: SubcategoriesResponseModelv2 | undefined,
-  enumValue: NativeCategoryIdEnumv2
-) {
-  return data?.nativeCategories.find((nativeCategory) => nativeCategory.name === enumValue)?.value
-}
-
-/**
  * Returns a `NativeCategoryResponseModelv2` from a `NativeCategoryIdEnumv2`.
  */
 export function getNativeCategoryFromEnum(

--- a/src/features/search/helpers/categoriesHelpers/categoriesHelpers.ts
+++ b/src/features/search/helpers/categoriesHelpers/categoriesHelpers.ts
@@ -66,10 +66,10 @@ export function getSearchGroupsFromEnumArray(
  * Returns a `NativeCategoryResponseModelv2` from a `NativeCategoryIdEnumv2`.
  */
 export function getNativeCategoryFromEnum(
-  data: SubcategoriesResponseModelv2,
+  data: SubcategoriesResponseModelv2 | undefined,
   enumValue: NativeCategoryIdEnumv2
 ) {
-  return data.nativeCategories.find((nativeCategory) => nativeCategory.name === enumValue)
+  return data?.nativeCategories.find((nativeCategory) => nativeCategory.name === enumValue)
 }
 
 /**


### PR DESCRIPTION
Cette PR a pour but de changer l'affichage des intitulés de résultats de recherche d'offres, qui aujourd'hui affiche les sous catégories. On affiche désormais les sous-catégories.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19822

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |![Capture d’écran 2023-01-24 à 13 26 32](https://user-images.githubusercontent.com/62058919/214291442-41591ade-8bea-43e1-9cf5-fd7e910ed38e.png)|![Capture d’écran 2023-01-24 à 13 24 00](https://user-images.githubusercontent.com/62058919/214291005-5bd19959-63c1-4983-8358-26011dbb75a1.png)|
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
