### PR TITLE
(PC-19909) feat(analytics): add display tracker for thematic highlight module

### DIFF
--- a/src/features/home/components/modules/HomeModule.tsx
+++ b/src/features/home/components/modules/HomeModule.tsx
@@ -81,7 +81,7 @@ const UnmemoizedModule = ({
   if (isBusinessModule(item))
     return <BusinessModule {...item} homeEntryId={homeEntryId} index={index} moduleId={item.id} />
 
-  if (isThematicHighlightModule(item)) return <ThematicHighlightModule {...item} />
+  if (isThematicHighlightModule(item)) return <ThematicHighlightModule {...item} index={index} />
 
   if (isCategoryListModule(item))
     return <CategoryListModule {...item} homeEntryId={homeEntryId} index={index} />

--- a/src/features/home/components/modules/ThematicHighlightModule.native.test.tsx
+++ b/src/features/home/components/modules/ThematicHighlightModule.native.test.tsx
@@ -35,6 +35,31 @@ describe('ThematicHighlightModule', () => {
     expect(screen.queryByText(formattedThematicHighlightModule.title)).toBeNull()
   })
 
+  it('should log ModuleDisplayedOnHomePage event when seeing the module', () => {
+    render(<ThematicHighlightModule index={0} {...formattedThematicHighlightModule} />)
+
+    expect(analytics.logModuleDisplayedOnHomepage).toHaveBeenNthCalledWith(
+      1,
+      '5Z1FGtRGbE3d1Q5oqHMfe9',
+      'thematicHighlight',
+      0,
+      '6DCThxvbPFKAo04SVRZtwY'
+    )
+  })
+
+  it('should not log ModuleDisplayedOnHomePage event when the module is passed (so not displayed)', () => {
+    render(
+      <ThematicHighlightModule
+        index={0}
+        {...formattedThematicHighlightModule}
+        beginningDate={PASSED_DATE}
+        endingDate={PASSED_DATE}
+      />
+    )
+
+    expect(analytics.logModuleDisplayedOnHomepage).toHaveBeenCalledTimes(0)
+  })
+
   it('should log HighlightBlockClicked event when pressing', () => {
     render(<ThematicHighlightModule index={0} {...formattedThematicHighlightModule} />)
     const thematicHighlightModule = screen.getByText(formattedThematicHighlightModule.title)

--- a/src/features/home/components/modules/ThematicHighlightModule.native.test.tsx
+++ b/src/features/home/components/modules/ThematicHighlightModule.native.test.tsx
@@ -14,6 +14,7 @@ describe('ThematicHighlightModule', () => {
   it('should render if the ending date is not passed', () => {
     render(
       <ThematicHighlightModule
+        index={0}
         {...formattedThematicHighlightModule}
         beginningDate={CURRENT_DATE}
         endingDate={CURRENT_DATE}
@@ -25,6 +26,7 @@ describe('ThematicHighlightModule', () => {
   it('should not render if the ending date is passed', () => {
     render(
       <ThematicHighlightModule
+        index={0}
         {...formattedThematicHighlightModule}
         beginningDate={PASSED_DATE}
         endingDate={PASSED_DATE}
@@ -34,7 +36,7 @@ describe('ThematicHighlightModule', () => {
   })
 
   it('should log HighlightBlockClicked event when pressing', () => {
-    render(<ThematicHighlightModule {...formattedThematicHighlightModule} />)
+    render(<ThematicHighlightModule index={0} {...formattedThematicHighlightModule} />)
     const thematicHighlightModule = screen.getByText(formattedThematicHighlightModule.title)
 
     fireEvent.press(thematicHighlightModule)

--- a/src/features/home/components/modules/ThematicHighlightModule.stories.tsx
+++ b/src/features/home/components/modules/ThematicHighlightModule.stories.tsx
@@ -26,6 +26,7 @@ const Template: ComponentStory<typeof ThematicHighlightModule> = (props) => (
 )
 
 const defaultArgs = {
+  id: 'toto',
   title: 'Lorem ipsum',
   subtitle: 'Dolor sit amet',
   imageUrl:
@@ -33,6 +34,7 @@ const defaultArgs = {
   beginningDate: new Date('2022-12-21'),
   endingDate: new Date('2023-01-01'),
   thematicHomeEntryId: '351351',
+  index: 0,
 }
 
 export const Default = Template.bind({})

--- a/src/features/home/components/modules/ThematicHighlightModule.tsx
+++ b/src/features/home/components/modules/ThematicHighlightModule.tsx
@@ -31,7 +31,8 @@ export const ThematicHighlightModule: FunctionComponent<Props> = ({
   thematicHomeEntryId,
 }) => {
   const isAlreadyEnded = isBefore(endingDate, new Date())
-  if (isAlreadyEnded) return null
+  const shouldHideModule = isAlreadyEnded
+  if (shouldHideModule) return null
 
   const navigateTo = getNavigateToThematicHomeConfig(thematicHomeEntryId)
   const dateRange = computeDateRangeDisplay(beginningDate, endingDate)

--- a/src/features/home/components/modules/ThematicHighlightModule.tsx
+++ b/src/features/home/components/modules/ThematicHighlightModule.tsx
@@ -1,11 +1,12 @@
 import colorAlpha from 'color-alpha'
 import { isBefore } from 'date-fns'
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useEffect } from 'react'
 import LinearGradient from 'react-native-linear-gradient'
 import styled from 'styled-components/native'
 
 import { computeDateRangeDisplay } from 'features/home/components/modules/helpers/computeDateRangeDisplay'
 import { getNavigateToThematicHomeConfig } from 'features/navigation/helpers/getNavigateToThematicHomeConfig'
+import { ContentTypes } from 'libs/contentful'
 import { analytics } from 'libs/firebase/analytics'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
@@ -14,24 +15,41 @@ const TILE_HEIGHT = 244
 const TEXT_BACKGROUND_OPACITY = 0.67
 
 type Props = {
+  id: string
   title: string
   subtitle?: string
   imageUrl: string
   beginningDate: Date
   endingDate: Date
   thematicHomeEntryId: string
+  index: number
 }
 
 export const ThematicHighlightModule: FunctionComponent<Props> = ({
+  id,
   title,
   subtitle,
   imageUrl,
   beginningDate,
   endingDate,
   thematicHomeEntryId,
+  index,
 }) => {
   const isAlreadyEnded = isBefore(endingDate, new Date())
   const shouldHideModule = isAlreadyEnded
+
+  useEffect(() => {
+    !shouldHideModule &&
+      analytics.logModuleDisplayedOnHomepage(
+        id,
+        ContentTypes.THEMATIC_HIGHLIGHT,
+        index,
+        thematicHomeEntryId
+      )
+    // should send analytics event only once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   if (shouldHideModule) return null
 
   const navigateTo = getNavigateToThematicHomeConfig(thematicHomeEntryId)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19909

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

Dans Firebase DebugView, je vois un event avec le bon moduleType
<img width="300" alt="image" src="https://user-images.githubusercontent.com/26742386/214327850-16cf7302-e142-46d5-a750-928e01204a89.png">
