### PR TITLE
(PC-20054) feat(home): display thematic home title for old dynamic links

### DIFF
--- a/src/features/home/components/headers/HomeHeader.tsx
+++ b/src/features/home/components/headers/HomeHeader.tsx
@@ -32,7 +32,7 @@ export const HomeHeader: FunctionComponent = function () {
   const { data: subscription } = useNextSubscriptionStep()
 
   const shouldDisplayGeolocationBloc = permissionState !== GeolocPermissionState.GRANTED
-  const shouldDisplaySubscritpionBloc =
+  const shouldDisplaySubscriptionBloc =
     subscription?.nextSubscriptionStep && !!nextBeneficiaryValidationStepNavConfig
 
   const welcomeTitle =
@@ -59,7 +59,7 @@ export const HomeHeader: FunctionComponent = function () {
   const credit = useGetDepositAmountsByAge(user?.birthDate)
 
   const SystemBloc = useMemo(() => {
-    if (shouldDisplaySubscritpionBloc) {
+    if (shouldDisplaySubscriptionBloc) {
       return (
         <React.Fragment>
           <BannerWithBackground
@@ -83,7 +83,7 @@ export const HomeHeader: FunctionComponent = function () {
 
     return null
   }, [
-    shouldDisplaySubscritpionBloc,
+    shouldDisplaySubscriptionBloc,
     nextBeneficiaryValidationStepNavConfig,
     shouldDisplayGeolocationBloc,
     credit,

--- a/src/features/home/pages/Home.native.test.tsx
+++ b/src/features/home/pages/Home.native.test.tsx
@@ -36,6 +36,21 @@ describe('Home page', () => {
 
     expect(screen).toMatchSnapshot()
   })
+
+  // TODO(PC-20066): remove test for transitional home header split
+  it('should render a thematic home header if available', () => {
+    useRoute.mockReturnValueOnce({ params: { entryId: 'fake-entry-id' } })
+    mockUseHomepageData.mockReturnValueOnce({
+      modules: [formattedVenuesModule],
+      id: 'fakeEntryId',
+      thematicHeader: {
+        title: 'title',
+      },
+    })
+    renderHome()
+
+    expect(screen.queryByText('title')).toBeTruthy()
+  })
 })
 
 function renderHome() {

--- a/src/features/home/pages/Home.native.test.tsx
+++ b/src/features/home/pages/Home.native.test.tsx
@@ -4,7 +4,7 @@ import { useRoute } from '__mocks__/@react-navigation/native'
 import { useHomepageData } from 'features/home/api/useHomepageData'
 import { formattedVenuesModule } from 'features/home/fixtures/homepage.fixture'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { render } from 'tests/utils'
+import { render, screen } from 'tests/utils'
 
 import { Home } from './Home'
 
@@ -32,13 +32,14 @@ describe('Home page', () => {
       modules: [formattedVenuesModule],
       id: 'fakeEntryId',
     })
-    const home = renderHome()
-    expect(home).toMatchSnapshot()
+    renderHome()
+
+    expect(screen).toMatchSnapshot()
   })
 })
 
 function renderHome() {
-  return render(<Home />, {
+  render(<Home />, {
     // eslint-disable-next-line local-rules/no-react-query-provider-hoc
     wrapper: ({ children }) => reactQueryProviderHOC(children),
   })

--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -4,20 +4,37 @@ import styled from 'styled-components/native'
 
 import { useHomepageData } from 'features/home/api/useHomepageData'
 import { HomeHeader } from 'features/home/components/headers/HomeHeader'
+import { ThematicHomeHeader } from 'features/home/components/headers/ThematicHomeHeader'
 import { GenericHome } from 'features/home/pages/GenericHome'
 import { UseRouteType } from 'features/navigation/RootNavigator/types'
 
-const Header = () => (
+const Header = ({ thematicHeader }: { thematicHeader?: { title?: string; subtitle?: string } }) => (
   <ListHeaderContainer>
-    <HomeHeader />
+    {
+      // TODO(PC-20066): remove transitional home header split
+      thematicHeader?.title ? (
+        <ThematicHomeHeader
+          headerTitle={thematicHeader.title}
+          headerSubtitle={thematicHeader.subtitle}
+        />
+      ) : (
+        <HomeHeader />
+      )
+    }
   </ListHeaderContainer>
 )
 
 export const Home: FunctionComponent = () => {
   const { params } = useRoute<UseRouteType<'Home'>>()
-  const { modules, id } = useHomepageData(params?.entryId) || {}
+  const { modules, id, thematicHeader } = useHomepageData(params?.entryId) || {}
 
-  return <GenericHome modules={modules} homeId={id} Header={<Header />} />
+  return (
+    <GenericHome
+      modules={modules}
+      homeId={id}
+      Header={<Header thematicHeader={thematicHeader} />}
+    />
+  )
 }
 
 const ListHeaderContainer = styled.View({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-20054

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Home N-1 with new deeplink | Home N-1 with old deeplink |
| :--------------- | :----: | :---: |
| Desktop - Chrome | <img width="1440" alt="image" src="https://user-images.githubusercontent.com/26742386/214352701-40e93a52-96eb-466d-8117-2897cb9a5ffa.png"> | <img width="1440" alt="image" src="https://user-images.githubusercontent.com/26742386/214352893-ba3f3762-b80c-43fa-8e26-844e62f5b467.png"> |
| Mobile - Chrome | <img width="375" alt="image" src="https://user-images.githubusercontent.com/26742386/214353313-90edc4f1-f848-42dd-94f7-ebbbdd99fd81.png"> | <img width="375" alt="image" src="https://user-images.githubusercontent.com/26742386/214353584-18f98d7b-2364-4c47-aba7-7ca2a8ca2b35.png"> |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
