### PR TITLE
(PC-19697) fix(ui): Center page with tabBar taken into account

### DIFF
--- a/__snapshots__/features/favorites/components/NotConnectedFavorites.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/components/NotConnectedFavorites.test.tsx.native-snap
@@ -323,12 +323,12 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
     }
   />
   <View
-    flex={1.5}
+    flex={2}
     style={
       Array [
         Object {
           "flexBasis": 0,
-          "flexGrow": 1.5,
+          "flexGrow": 2,
           "flexShrink": 1,
         },
       ]

--- a/src/features/favorites/components/NotConnectedFavorites.tsx
+++ b/src/features/favorites/components/NotConnectedFavorites.tsx
@@ -16,7 +16,8 @@ export const NotConnectedFavorites = () => (
     titleComponent={StyledTitle4}
     subtitleComponent={CenteredText}
     icon={BicolorUserFavorite}
-    separateIconFromTitle={false}>
+    separateIconFromTitle={false}
+    mobileBottomFlex={2}>
     <Row>
       <ButtonContainer>
         <InternalTouchableLink


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19697

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS small phone  (iPhone 5s)           |    ![Simulator Screen Shot - iPhone 5s - 2023-01-25 at 09 06 14](https://user-images.githubusercontent.com/46637324/214510755-a152b40c-2c02-47a3-893a-a7fe62db8069.png)    |  ![Simulator Screen Shot - iPhone 5s - 2023-01-25 at 08 59 37](https://user-images.githubusercontent.com/46637324/214510366-10f2a693-9913-4c87-9414-f6ee4e01536b.png)     |
| iOS big phone   (iPhone 13)          |  ![Simulator Screen Shot - iPhone 13 - 2023-01-25 at 09 06 13](https://user-images.githubusercontent.com/46637324/214510743-506c440e-45ca-49b4-a6dc-fb75e86cf0fc.png)     |     ![Simulator Screen Shot - iPhone 13 - 2023-01-25 at 08 59 35](https://user-images.githubusercontent.com/46637324/214510381-8215c12c-7dc8-43d8-92f9-c3125410df14.png)  |
| Android          |   ![Screenshot_20230125_090608](https://user-images.githubusercontent.com/46637324/214510728-d96561ee-fc8d-4c43-b81e-29a55bfc4963.png)     |    ![Screenshot_20230125_090025](https://user-images.githubusercontent.com/46637324/214510287-002119cc-a83a-4427-ac32-904d7b779740.png)   |
| Desktop - Chrome (pas de changement) |   <img width="1440" alt="Capture d’écran 2023-01-25 à 09 05 24" src="https://user-images.githubusercontent.com/46637324/214510571-6e68848e-d001-492f-ae1c-a3edf60d6572.png">      |    <img width="1440" alt="Capture d’écran 2023-01-25 à 09 05 24" src="https://user-images.githubusercontent.com/46637324/214510571-6e68848e-d001-492f-ae1c-a3edf60d6572.png">   |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
