### PR TITLE
(PC-19097) feat(identityCheck): retour UX icon + separator

### DIFF
--- a/__snapshots__/features/identityCheck/pages/identification/identificationStart/SelectIDStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/identificationStart/SelectIDStatus.native.test.tsx.native-snap
@@ -254,9 +254,6 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
               style={
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "flexDirection": "column",
-                    "height": "100%",
                     "marginHorizontal": 4,
                     "marginVertical": 32,
                   },

--- a/src/features/identityCheck/pages/identification/identificationStart/SelectIDOrigin.tsx
+++ b/src/features/identityCheck/pages/identification/identificationStart/SelectIDOrigin.tsx
@@ -56,7 +56,7 @@ const SelectIDOriginContent: FunctionComponent = () => {
       <Spacer.Column numberOfSpaces={7} />
       <SecondButtonList
         label="J’ai un titre de séjour, une carte d’identité ou un passeport étranger."
-        leftIcon={BicolorEarth}
+        leftIcon={StyledBicolorEarth}
         navigateTo={{ screen: 'DMSIntroduction', params: { isForeignDMSInformation: true } }}
         onBeforeNavigate={() =>
           amplitude.logEvent('set_id_origin_clicked', { type: IDOrigin.FOREIGN })
@@ -65,6 +65,11 @@ const SelectIDOriginContent: FunctionComponent = () => {
     </Container>
   )
 }
+
+const StyledBicolorEarth = styled(BicolorEarth).attrs(({ theme }) => ({
+  color: theme.colors.black,
+  color2: theme.colors.black,
+}))``
 
 const Container = styled.View({
   marginHorizontal: getSpacing(1),

--- a/src/features/identityCheck/pages/identification/identificationStart/SelectIDStatus.tsx
+++ b/src/features/identityCheck/pages/identification/identificationStart/SelectIDStatus.tsx
@@ -88,9 +88,6 @@ const SelectIDStatusContent: FunctionComponent = () => {
 }
 
 const Container = styled.View({
-  flexDirection: 'column',
-  height: '100%',
-  alignItems: 'center',
   marginHorizontal: getSpacing(1),
   marginVertical: getSpacing(8),
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19097

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS selectIDStatus             | <img width="362" alt="image" src="https://user-images.githubusercontent.com/89008469/214589465-9e434980-5e03-43d2-b097-9d3b7bcbaa9f.png"> | <img width="389" alt="image" src="https://user-images.githubusercontent.com/89008469/214588831-255fd8ab-c98d-47cf-82a9-f9effd7e1883.png"> |
| iOS selectIDOrigin          | <img width="361" alt="image" src="https://user-images.githubusercontent.com/89008469/214589410-b1a151a8-d250-4c9f-8b98-80f23dfbcbfb.png"> | <img width="367" alt="image" src="https://user-images.githubusercontent.com/89008469/214588944-acaa9dbb-f43a-47a6-b5ad-d037dc4693b5.png"> |
| Desktop - Chrome selectIDStatus   | <img width="1044" alt="image" src="https://user-images.githubusercontent.com/89008469/214589633-ee91d310-8918-4b6e-8e4c-62949232b4cf.png"> | <img width="1043" alt="image" src="https://user-images.githubusercontent.com/89008469/214589147-ad281822-dc7d-4c8b-ad81-4e1c1d4dd168.png"> |
| Desktop - Chrome selectIDOrigin | <img width="1049" alt="image" src="https://user-images.githubusercontent.com/89008469/214589699-560583e6-5d9f-408b-a6d7-1622394b6a3e.png"> | <img width="695" alt="image" src="https://user-images.githubusercontent.com/89008469/214589266-9f812e18-ccca-4aed-8e52-3566ce5f322c.png"> |
| Android - selectIDStatus | <img width="439" alt="image" src="https://user-images.githubusercontent.com/89008469/214594778-a1fbaa69-a82d-4130-84b7-b7df36527420.png"> | <img width="441" alt="image" src="https://user-images.githubusercontent.com/89008469/214594220-d0a96f85-dbf9-4b76-a959-09ea42af8e67.png"> |
| Android - selectIDOrigin | <img width="439" alt="image" src="https://user-images.githubusercontent.com/89008469/214594860-e11424ce-3ee7-4572-9158-7c62c09eaf5a.png"> | <img width="438" alt="image" src="https://user-images.githubusercontent.com/89008469/214594318-a082d83c-f767-4715-818e-28a473a49ecd.png"> |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
