### PR TITLE
(PC-20133) fix(thematicHighlight): use the whole length for the title's background

### DIFF
--- a/src/features/home/components/modules/ThematicHighlightModule.tsx
+++ b/src/features/home/components/modules/ThematicHighlightModule.tsx
@@ -109,7 +109,7 @@ const DateRangeCaption = styled(Typo.Hint)(({ theme }) => ({
   color: theme.colors.white,
 }))
 
-const TextContainer = styled.View({ position: 'absolute', bottom: 0 })
+const TextContainer = styled.View({ position: 'absolute', bottom: 0, left: 0, right: 0 })
 
 const Gradient = styled(LinearGradient).attrs(({ theme }) => ({
   colors: [


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-20133

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [x] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" on Notion
--> (https://www.notion.so/passcultureapp/Sur-la-Home-pour-un-module-Temps-Fort-l-opacit-sous-le-titre-se-coupe-net-4d01ae2a6df1476282c6f1ead047833d)

## Screenshots

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              | <img width="511" alt="image" src="https://user-images.githubusercontent.com/26742386/214816176-0355d2e2-1595-406c-bb08-71abe3595535.png"> | <img width="511" alt="image" src="https://user-images.githubusercontent.com/26742386/214816236-b260f07e-bc73-417d-b7cb-2b91586f7ac7.png"> |
| Phone - Chrome   | <img width="375" alt="image" src="https://user-images.githubusercontent.com/26742386/214817219-18462364-a3b9-4c34-9157-7317ff51c89c.png"> | <img width="377" alt="image" src="https://user-images.githubusercontent.com/26742386/214817327-562076fa-8dc7-4435-96fc-12539ddeb031.png"> |
| Desktop - Chrome | <img width="1440" alt="image" src="https://user-images.githubusercontent.com/26742386/214817130-c9313080-9319-444b-87f9-a42db3d32ec9.png"> | <img width="1440" alt="image" src="https://user-images.githubusercontent.com/26742386/214817029-73e2d538-3abb-4a75-b57a-2592ac2a317a.png"> |
