### PR TITLE
(BSR) chore(SetPhoneNumber): replace flushAllPromise and act with waitFor

### DIFF
--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx
@@ -8,7 +8,7 @@ import { SetPhoneNumber } from 'features/identityCheck/pages/phoneValidation/Set
 import { amplitude } from 'libs/amplitude'
 import { analytics } from 'libs/firebase/analytics'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, flushAllPromisesWithAct, render, waitFor } from 'tests/utils'
+import { fireEvent, render, waitFor } from 'tests/utils'
 import { theme } from 'theme'
 import * as useModalAPI from 'ui/components/modals/useModal'
 
@@ -57,8 +57,9 @@ describe('SetPhoneNumber', () => {
     })
     const SetPhoneNumberPage = renderSetPhoneNumber()
 
-    await flushAllPromisesWithAct()
-    expect(SetPhoneNumberPage).toMatchSnapshot()
+    await waitFor(() => {
+      expect(SetPhoneNumberPage).toMatchSnapshot()
+    })
   })
 
   it('should show modal on first render', async () => {
@@ -80,7 +81,7 @@ describe('SetPhoneNumber', () => {
 
     const SetPhoneNumberPage = renderSetPhoneNumber()
     const remainingAttemptsText = SetPhoneNumberPage.getByText('1 demande')
-    await act(async () => {
+    await waitFor(() => {
       expect(remainingAttemptsText.props.style[0].color).toEqual(theme.colors.error)
     })
   })

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.web.test.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.web.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { render, checkAccessibilityFor, act } from 'tests/utils/web'
+import { render, checkAccessibilityFor, waitFor } from 'tests/utils/web'
 
 import { SetPhoneNumber } from './SetPhoneNumber'
 
@@ -38,7 +38,7 @@ describe('<SetPhoneNumber/>', () => {
     it('should not have basic accessibility issues', async () => {
       // eslint-disable-next-line local-rules/no-react-query-provider-hoc
       const { container } = render(reactQueryProviderHOC(<SetPhoneNumber />))
-      await act(async () => {
+      await waitFor(async () => {
         const results = await checkAccessibilityFor(container)
         expect(results).toHaveNoViolations()
       })


### PR DESCRIPTION
replace flushAllPromise and act with waitFor To be closer to the user experience and be less tied to implementation and react life cycle details
