### PR TITLE
(PC-20067) feat(resetPassword): fix blank space display on ios and android

### DIFF
--- a/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -658,21 +658,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                                           ]
                                         }
                                       >
-                                        L’e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams !
-                                      </Text>
-                                      <Text
-                                        style={
-                                          Array [
-                                            Object {
-                                              "color": "#161617",
-                                              "fontFamily": "Montserrat-Regular",
-                                              "fontSize": 15,
-                                              "lineHeight": 20,
-                                            },
-                                          ]
-                                        }
-                                      >
-                                         Si l’e-mail n’arrive pas, tu peux :
+                                        L’e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams ! Si l’e-mail n’arrive pas, tu peux :
                                       </Text>
                                     </Text>
                                     <View

--- a/src/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.tsx
+++ b/src/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.tsx
@@ -39,9 +39,9 @@ export const ResetPasswordEmailSent: FunctionComponent<Props> = ({ route }) => {
           <Spacer.Column numberOfSpaces={5} />
           <CenteredText>
             <Typo.Body>
-              L’e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams&nbsp;!
+              L’e-mail peut prendre quelques minutes à arriver. Pense à vérifier tes spams&nbsp;! Si
+              l’e-mail n’arrive pas, tu peux&nbsp;:
             </Typo.Body>
-            <Typo.Body> Si l’e-mail n’arrive pas, tu peux&nbsp;:</Typo.Body>
           </CenteredText>
           <Spacer.Column numberOfSpaces={5} />
           <ExternalTouchableLink


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-20067

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |<img width="351" alt="Capture d’écran 2023-01-26 à 16 53 36" src="https://user-images.githubusercontent.com/59031393/214883861-f6cc9c11-337b-4742-9f2e-061c9d0ddfc6.png">|
| Phone - Chrome   |        |<img width="326" alt="Capture d’écran 2023-01-26 à 16 53 56" src="https://user-images.githubusercontent.com/59031393/214883793-0330f026-92d5-4dbd-be57-0a0a7a18ebb0.png">|
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |<img width="1439" alt="Capture d’écran 2023-01-26 à 16 54 18" src="https://user-images.githubusercontent.com/59031393/214883686-97e000a4-f9de-4bf3-9837-83b513ca25aa.png">|
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
