### PR TITLE
(PC-20198) fix(Android): allow clear text traffic from 10.0.2.2

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
-  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/icon" android:roundIcon="@mipmap/icon_round" android:allowBackup="false" android:theme="@style/AppTheme" android:requestLegacyExternalStorage="true">
+  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/icon" android:roundIcon="@mipmap/icon_round" android:allowBackup="false" android:theme="@style/AppTheme" android:requestLegacyExternalStorage="true" android:networkSecurityConfig="@xml/network_security_config">
     <activity android:name=".MainActivity" android:label="@string/app_name" android:screenOrientation="portrait" android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">10.0.2.2</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-20198

During e2e workflow android.app , it is necessary to allow clear text traffic from `10.0.2.2`, 

1. Create an `xml` directory in : `android/app/src/main/res/`

```bash
mkdir -p android/app/src/main/res/xml
```

2. Create file in `android/app/src/main/res/network_security_config.xml`:


```xml
<?xml version="1.0" encoding="utf-8"?>
<network-security-config>
    <domain-config cleartextTrafficPermitted="true">
        <domain includeSubdomains="true">10.0.2.2</domain>
    </domain-config>
</network-security-config>
```

3. Edited `AndroidManifest.xml` by adding `android:networkSecurityConfig="@xml/network_security_config"` in `application`.

Source : https://medium.com/livefront/how-to-connect-your-android-emulator-to-a-local-web-service-47c380bff350


## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
