### PR TITLE
(PC-18748) feat(contentful): add music type filter to OffersModule

### DIFF
--- a/src/features/home/fixtures/homepage.fixture.ts
+++ b/src/features/home/fixtures/homepage.fixture.ts
@@ -126,7 +126,7 @@ export const formattedOffersModule: OffersModule = {
       hitsPerPage: 10,
       minBookingsThreshold: 2,
       subcategories: ['Livre', 'Livre numérique, e-book'],
-      movieGenres: undefined,
+      movieGenres: ['ACTION', 'BOLLYWOOD'],
       musicTypes: ['Pop', 'Gospel'],
     },
   ],

--- a/src/features/home/fixtures/homepage.fixture.ts
+++ b/src/features/home/fixtures/homepage.fixture.ts
@@ -127,6 +127,7 @@ export const formattedOffersModule: OffersModule = {
       minBookingsThreshold: 2,
       subcategories: ['Livre', 'Livre numérique, e-book'],
       movieGenres: undefined,
+      musicTypes: ['Pop', 'Gospel'],
     },
   ],
   cover: undefined,

--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -67,6 +67,7 @@ export type OffersModuleParameters = {
   hitsPerPage: number
   minBookingsThreshold?: number
   movieGenres?: string[]
+  musicTypes?: string[]
 }
 
 export type BusinessModule = {

--- a/src/libs/contentful/adapters/modules/adaptOffersModule.native.test.ts
+++ b/src/libs/contentful/adapters/modules/adaptOffersModule.native.test.ts
@@ -46,6 +46,7 @@ describe('adaptOffersModule', () => {
           subcategories: ['Livre', 'Livre numérique, e-book'],
           minBookingsThreshold: 2,
           musicTypes: ['Pop', 'Gospel'],
+          movieGenres: ['ACTION', 'BOLLYWOOD'],
         },
         {
           title: 'Livre',

--- a/src/libs/contentful/adapters/modules/adaptOffersModule.native.test.ts
+++ b/src/libs/contentful/adapters/modules/adaptOffersModule.native.test.ts
@@ -45,6 +45,7 @@ describe('adaptOffersModule', () => {
           hitsPerPage: 10,
           subcategories: ['Livre', 'Livre numérique, e-book'],
           minBookingsThreshold: 2,
+          musicTypes: ['Pop', 'Gospel'],
         },
         {
           title: 'Livre',

--- a/src/libs/contentful/adapters/modules/adaptOffersModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptOffersModule.ts
@@ -19,6 +19,10 @@ const mapOffersCategories = (
   algoliaCategories: SearchParametersFields['algoliaCategories']
 ): OffersModuleParameters['categories'] => algoliaCategories?.fields?.categories
 
+const mapMusicTypes = (
+  musicTypes: SearchParametersFields['musicTypes']
+): OffersModuleParameters['musicTypes'] => musicTypes?.fields?.musicTypes
+
 const buildOffersParams = (
   firstParams: AlgoliaParameters,
   additionalParams: AlgoliaParameters[]
@@ -26,11 +30,20 @@ const buildOffersParams = (
   [firstParams, ...additionalParams]
     .filter((params) => params.fields && !isEmpty(params.fields))
     .map(
-      ({ fields: { algoliaSubcategories, algoliaCategories, movieGenres, ...otherFields } }) => ({
+      ({
+        fields: {
+          algoliaSubcategories,
+          algoliaCategories,
+          movieGenres,
+          musicTypes,
+          ...otherFields
+        },
+      }) => ({
         ...otherFields,
         subcategories: mapOffersSubcategories(algoliaSubcategories),
         movieGenres: mapOffersMovieGenres(movieGenres),
         categories: mapOffersCategories(algoliaCategories),
+        musicTypes: mapMusicTypes(musicTypes),
       })
     )
 

--- a/src/libs/contentful/fixtures/algoliaModules.fixture.ts
+++ b/src/libs/contentful/fixtures/algoliaModules.fixture.ts
@@ -1,4 +1,5 @@
 import { categoriesFixture } from 'libs/contentful/fixtures/categoriesFixture'
+import { movieGenresFixture } from 'libs/contentful/fixtures/movieGenres.fixture'
 import { musicTypesFixture } from 'libs/contentful/fixtures/musicTypes.fixture'
 import { subcategoriesFixture } from 'libs/contentful/fixtures/subcategoriesEntry.fixture'
 import { AlgoliaContentModel, AlgoliaParameters, ContentTypes } from 'libs/contentful/types'
@@ -40,6 +41,7 @@ export const algoliaNatifModuleFixture: AlgoliaContentModel = {
         minBookingsThreshold: 2,
         algoliaSubcategories: subcategoriesFixture,
         musicTypes: musicTypesFixture,
+        movieGenres: movieGenresFixture,
       },
     },
     displayParameters: {

--- a/src/libs/contentful/fixtures/algoliaModules.fixture.ts
+++ b/src/libs/contentful/fixtures/algoliaModules.fixture.ts
@@ -1,4 +1,5 @@
 import { categoriesFixture } from 'libs/contentful/fixtures/categoriesFixture'
+import { musicTypesFixture } from 'libs/contentful/fixtures/musicTypes.fixture'
 import { subcategoriesFixture } from 'libs/contentful/fixtures/subcategoriesEntry.fixture'
 import { AlgoliaContentModel, AlgoliaParameters, ContentTypes } from 'libs/contentful/types'
 
@@ -38,6 +39,7 @@ export const algoliaNatifModuleFixture: AlgoliaContentModel = {
         hitsPerPage: 10,
         minBookingsThreshold: 2,
         algoliaSubcategories: subcategoriesFixture,
+        musicTypes: musicTypesFixture,
       },
     },
     displayParameters: {

--- a/src/libs/contentful/fixtures/movieGenres.fixture.ts
+++ b/src/libs/contentful/fixtures/movieGenres.fixture.ts
@@ -1,0 +1,36 @@
+import { ContentTypes, MovieGenres } from 'libs/contentful/types'
+
+export const movieGenresFixture: MovieGenres = {
+  sys: {
+    space: {
+      sys: {
+        type: 'Link',
+        linkType: 'Space',
+        id: '2bg01iqy0isv',
+      },
+    },
+    id: '6booBIgPJz7cjVu4snM4bX',
+    type: 'Entry',
+    createdAt: '2023-01-26T17:16:34.643Z',
+    updatedAt: '2023-01-30T15:05:04.055Z',
+    environment: {
+      sys: {
+        id: 'testing',
+        type: 'Link',
+        linkType: 'Environment',
+      },
+    },
+    revision: 2,
+    contentType: {
+      sys: {
+        type: 'Link',
+        linkType: 'ContentType',
+        id: ContentTypes.MOVIE_GENRES,
+      },
+    },
+    locale: 'en-US',
+  },
+  fields: {
+    movieGenres: ['ACTION', 'BOLLYWOOD'],
+  },
+}

--- a/src/libs/contentful/fixtures/musicTypes.fixture.ts
+++ b/src/libs/contentful/fixtures/musicTypes.fixture.ts
@@ -1,0 +1,18 @@
+import { ContentTypes, MusicTypes } from 'libs/contentful/types'
+
+export const musicTypesFixture: MusicTypes = {
+  sys: {
+    space: { sys: { type: 'Link', linkType: 'Space', id: '2bg01iqy0isv' } },
+    id: '4Jbbbk8OjWbTozEA7qLsZK',
+    type: 'Entry',
+    createdAt: '2023-02-07T16:03:45.398Z',
+    updatedAt: '2023-02-07T16:23:57.923Z',
+    environment: { sys: { id: 'testing', type: 'Link', linkType: 'Environment' } },
+    revision: 2,
+    contentType: { sys: { type: 'Link', linkType: 'ContentType', id: ContentTypes.MUSIC_TYPES } },
+    locale: 'en-US',
+  },
+  fields: {
+    musicTypes: ['Pop', 'Gospel'],
+  },
+}

--- a/src/libs/contentful/types.ts
+++ b/src/libs/contentful/types.ts
@@ -17,6 +17,7 @@ export enum ContentTypes {
   CATEGORY_BLOCK = 'categoryBlock',
   CATEGORY_LIST = 'categoryList',
   MOVIE_GENRES = 'movieGenres',
+  MUSIC_TYPES = 'musicTypes',
 }
 
 export type Layout = 'two-items' | 'one-item-medium'
@@ -140,6 +141,10 @@ export interface MovieGenres {
   sys: Sys<typeof ContentTypes.MOVIE_GENRES>
   fields: MovieGenresFields
 }
+export interface MusicTypes {
+  sys: Sys<typeof ContentTypes.MUSIC_TYPES>
+  fields: MusicTypesFields
+}
 
 export interface ThematicHighlightParameters {
   sys: Sys<typeof ContentTypes.THEMATIC_HIGHLIGHT>
@@ -203,6 +208,7 @@ export interface SearchParametersFields {
   hitsPerPage: number
   minBookingsThreshold?: number
   movieGenres?: MovieGenres
+  musicTypes?: MusicTypes
 }
 
 // Taken from https://app.contentful.com/spaces/2bg01iqy0isv/environments/testing/content_types/venuesSearchParameters/fields
@@ -279,6 +285,10 @@ type CategoriesFields = {
 
 type MovieGenresFields = {
   movieGenres: string[]
+}
+
+type MusicTypesFields = {
+  musicTypes: string[]
 }
 
 export type ThematicHighlightFields = {

--- a/src/libs/search/parseSearchParameters.native.test.ts
+++ b/src/libs/search/parseSearchParameters.native.test.ts
@@ -33,7 +33,7 @@ const defaultSearchParameters = omit(
     hitsPerPage: null,
     priceRange: [0, 300],
     minBookingsThreshold: 0,
-    offerGenreTypes: undefined,
+    offerGenreTypes: [],
   },
   'offerIsFree'
 )
@@ -290,8 +290,11 @@ describe('parseSearchParameters', () => {
       expect(result).toBeUndefined()
     })
 
-    it('should return algolia parameters when a movieGenres list is provided', () => {
-      const parameters = { movieGenres: ['BOLLYWOOD'] } as OffersModuleParameters
+    it('should return algolia parameters when a movieGenres and a musicTypes lists are provided', () => {
+      const parameters = {
+        movieGenres: ['BOLLYWOOD'],
+        musicTypes: ['Gospel'],
+      } as OffersModuleParameters
 
       const result = parseSearchParameters(
         parameters,
@@ -301,7 +304,28 @@ describe('parseSearchParameters', () => {
       )
       expect(result).toStrictEqual({
         ...defaultSearchParameters,
-        offerGenreTypes: [{ key: 'MOVIE', name: 'BOLLYWOOD', value: 'Bollywood' }],
+        offerGenreTypes: [
+          { key: 'MOVIE', name: 'BOLLYWOOD', value: 'Bollywood' },
+          { key: 'MUSIC', name: 'Gospel', value: 'Gospel' },
+        ],
+      })
+    })
+
+    it('should return algolia parameters when a musicTypes list but no movieGenres are provided', () => {
+      const parameters = {
+        movieGenres: undefined,
+        musicTypes: ['Gospel'],
+      } as OffersModuleParameters
+
+      const result = parseSearchParameters(
+        parameters,
+        null,
+        subcategoryLabelMapping,
+        genreTypeMapping
+      )
+      expect(result).toStrictEqual({
+        ...defaultSearchParameters,
+        offerGenreTypes: [{ key: 'MUSIC', name: 'Gospel', value: 'Gospel' }],
       })
     })
   })

--- a/src/libs/search/parseSearchParameters.ts
+++ b/src/libs/search/parseSearchParameters.ts
@@ -54,7 +54,13 @@ export const parseSearchParameters = (
 
   const movieGenreTypes = parameters.movieGenres
     ? buildOfferGenreTypes(GenreType.MOVIE, parameters.movieGenres, genreTypeMapping)
-    : undefined
+    : []
+
+  const musicGenreTypes = parameters.musicTypes
+    ? buildOfferGenreTypes(GenreType.MUSIC, parameters.musicTypes, genreTypeMapping)
+    : []
+
+  const offerGenreTypes = movieGenreTypes?.concat(musicGenreTypes ?? [])
 
   return {
     beginningDatetime,
@@ -77,7 +83,7 @@ export const parseSearchParameters = (
     query: '',
     view: SearchView.Landing,
     minBookingsThreshold: parameters.minBookingsThreshold || 0,
-    offerGenreTypes: movieGenreTypes,
+    offerGenreTypes: offerGenreTypes,
   }
 }
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18748

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

<img width="611" alt="Capture d’écran 2023-02-07 à 18 51 25" src="https://user-images.githubusercontent.com/22886846/217325835-7b14dfdb-a460-4e9f-b6a9-804589dd3e4d.png">


Pas possible de tester l'apparition de la playlist sur la home car les offres qui remontent n'ont pas d'image mais le call à algolia retourne bien des résultats : 

<img width="898" alt="Capture d’écran 2023-02-07 à 17 27 28" src="https://user-images.githubusercontent.com/22886846/217324626-92df803f-298a-4087-8b34-710319137418.png">
<img width="898" alt="Capture d’écran 2023-02-07 à 17 27 40" src="https://user-images.githubusercontent.com/22886846/217324698-e6edd6d5-fd63-437c-acb9-3c4aa0ed16a7.png">


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
