### PR TITLE
(PC-20469) chore(deps): update react-native-device-info from 8.1.0 to…

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "react-native-code-push": "^7.0.4",
     "react-native-country-picker-modal": "^2.0.0",
     "react-native-date-picker": "^4.2.2",
-    "react-native-device-info": "^8.1.0",
+    "react-native-device-info": "^10.3.0",
     "react-native-email-link": "^1.10.0",
     "react-native-fast-image": "^8.6.3",
     "react-native-geolocation-service": "5.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20589,10 +20589,10 @@ react-native-date-picker@^4.2.2:
   resolved "https://registry.yarnpkg.com/react-native-date-picker/-/react-native-date-picker-4.2.2.tgz#07fb8a9021fb48ef9a20b043d33c14e858220883"
   integrity sha512-x0jxWbJXKDXivRDwsUx58tKOxe719XoVqqq6UzMSYSsTiPL2i13r7PyDxop3f3et/62qbcMgeswl+/CLdX6+Eg==
 
-react-native-device-info@^8.1.0:
-  version "8.4.8"
-  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-8.4.8.tgz#fc92ae423e47db6cfbf30c30012e09cee63727fa"
-  integrity sha512-92676ZWHZHsPM/EW1ulgb2MuVfjYfMWRTWMbLcrCsipkcMaZ9Traz5mpsnCS7KZpsOksnvUinzDIjsct2XGc6Q==
+react-native-device-info@^10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-10.3.0.tgz#6bab64d84d3415dd00cc446c73ec5e2e61fddbe7"
+  integrity sha512-/ziZN1sA1REbJTv5mQZ4tXggcTvSbct+u5kCaze8BmN//lbxcTvWsU6NQd4IihLt89VkbX+14IGc9sVApSxd/w==
 
 react-native-email-link@^1.10.0:
   version "1.12.2"


### PR DESCRIPTION
… 10.3.0

Les breakings change ne nous concernent pas : 
- [Release note v10.0.0
](https://github.com/react-native-device-info/react-native-device-info/releases/tag/v10.0.0)
- [Release note v9.0.0
](https://github.com/react-native-device-info/react-native-device-info/releases/tag/v9.0.0)

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-20469

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots
Toujours la récupération de l'unique ID du device : 
![Capture d’écran 2023-02-13 à 14 21 51](https://user-images.githubusercontent.com/62059034/218470269-997e9571-180f-4db3-8ccc-ed7f61379d77.png)
