### PR TITLE
(PC-20476) feat(ci): check linter and typescript throught ci

### DIFF
--- a/.github/workflows/dev_on_workflow_linter_ts.yaml
+++ b/.github/workflows/dev_on_workflow_linter_ts.yaml
@@ -1,0 +1,33 @@
+name: Verify code lint and typescript 
+
+on:
+  workflow_call:
+
+jobs:
+  yarn_lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            ~/.cache/yarn
+          key: v1-yarn-dependency-cache-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            v1-yarn-dependency-cache-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn test:lint
+
+  yarn_typescript:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            ~/.cache/yarn
+          key: v1-yarn-dependency-cache-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            v1-yarn-dependency-cache-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn test:types


### PR DESCRIPTION
### Purpose

The purpose of this PR is to make a linter (and typescript checker) on github-actions.
This workflow will not run for the moment, until we create a dev-on-push-workflow-main.yml with this type of code

```
name: Validate dev branch

on:
  push:

jobs:
  yarn-install:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - uses: actions/setup-node@v3
        with:
          node-version: 16
          cache: 'yarn'
      - uses: actions/cache@v3
        id: yarn-modules-cache
        with:
          path: |
            node_modules
            ~/.cache/yarn
          key: v1-yarn-dependency-cache-${{ hashFiles('**/yarn.lock') }}
          restore-keys: |
            v1-yarn-dependency-cache-${{ hashFiles('**/yarn.lock') }}
            v1-yarn-dependency-cache-
      - run: yarn install --immutable
        if: steps.yarn-modules-cache.outputs.cache-hit != 'true'
  yarn-linter:
    needs: yarn-install
    uses:  ./.github/workflows/dev_on_workflow_linter_ts.yaml
```

### Why don't implement it now ?
Because we don't want to run the two same jobs on too different CI (Circle and github) to avoid waste of ressources