### PR TITLE
(PC-20135) feat(home): show signup banner when user is not logged in

### DIFF
--- a/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
@@ -220,6 +220,172 @@ exports[`Home page should render correctly 1`] = `
                   ]
                 }
               />
+              <View
+                accessibilityRole="link"
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+              >
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "borderRadius": 7,
+                        "overflow": "hidden",
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    accessibilityIgnoresInvertColors={true}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "#eb0055",
+                          "justifyContent": "center",
+                          "width": "100%",
+                        },
+                      ]
+                    }
+                  >
+                    <Image
+                      source={
+                        Object {
+                          "uri": "",
+                        }
+                      }
+                      style={
+                        Array [
+                          Object {
+                            "bottom": 0,
+                            "left": 0,
+                            "position": "absolute",
+                            "right": 0,
+                            "top": 0,
+                          },
+                          Object {
+                            "height": undefined,
+                            "width": "100%",
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="module-background"
+                    />
+                    <View
+                      style={
+                        Array [
+                          Object {
+                            "alignItems": "center",
+                            "borderColor": "#90949D",
+                            "borderRadius": 7,
+                            "borderStyle": "solid",
+                            "borderWidth": 1,
+                            "flexDirection": "row",
+                            "padding": 16,
+                            "width": "100%",
+                          },
+                          undefined,
+                        ]
+                      }
+                    >
+                      <View
+                        style={
+                          Array [
+                            Object {
+                              "alignContent": "center",
+                              "marginRight": 16,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          height={32}
+                          width={32}
+                        >
+                          <Text>
+                            undefined-SVG-Mock
+                          </Text>
+                        </View>
+                      </View>
+                      <View
+                        style={
+                          Array [
+                            Object {
+                              "flexGrow": 1,
+                              "flexShrink": 1,
+                              "marginRight": 16,
+                              "textAlign": "start",
+                            },
+                          ]
+                        }
+                      >
+                        <Text
+                          style={
+                            Array [
+                              Object {
+                                "color": "#ffffff",
+                                "fontFamily": "Montserrat-Bold",
+                                "fontSize": 15,
+                                "lineHeight": 20,
+                              },
+                            ]
+                          }
+                        >
+                          Débloque ton crédit
+                        </Text>
+                        <Text
+                          style={
+                            Array [
+                              Object {
+                                "color": "#ffffff",
+                                "fontFamily": "Montserrat-Regular",
+                                "fontSize": 15,
+                                "lineHeight": 20,
+                              },
+                            ]
+                          }
+                        >
+                          Crée ton compte si tu as entre 15 et 18 ans !
+                        </Text>
+                      </View>
+                      <View>
+                        <View
+                          height={24}
+                          width={24}
+                        >
+                          <Text>
+                            undefined-SVG-Mock
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+              <View
+                numberOfSpaces={8}
+                style={
+                  Array [
+                    Object {
+                      "height": 32,
+                    },
+                  ]
+                }
+              />
             </View>
           </View>
         </View>

--- a/src/features/home/components/SignupBanner.native.test.tsx
+++ b/src/features/home/components/SignupBanner.native.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import { navigate } from '__mocks__/@react-navigation/native'
+import { SignupBanner } from 'features/home/components/SignupBanner'
+import { fireEvent, render, waitFor } from 'tests/utils'
+
+describe('SignupBanner', () => {
+  it('should redirect to signup form on press', async () => {
+    const { getByText } = render(<SignupBanner />)
+
+    fireEvent.press(getByText('Débloque ton crédit'))
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('SignupForm', undefined))
+  })
+})

--- a/src/features/home/components/SignupBanner.tsx
+++ b/src/features/home/components/SignupBanner.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { BannerWithBackground } from 'ui/components/ModuleBanner/BannerWithBackground'
+import { BicolorUnlock } from 'ui/svg/icons/BicolorUnlock'
+import { Spacer, Typo } from 'ui/theme'
+
+export const SignupBanner = () => {
+  return (
+    <React.Fragment>
+      <BannerWithBackground leftIcon={StyledBicolorUnlock} navigateTo={{ screen: 'SignupForm' }}>
+        <StyledButtonText>Débloque ton crédit</StyledButtonText>
+        <StyledBodyText>Crée ton compte si tu as entre 15 et 18 ans&nbsp;!</StyledBodyText>
+      </BannerWithBackground>
+      <Spacer.Column numberOfSpaces={8} />
+    </React.Fragment>
+  )
+}
+
+const StyledBicolorUnlock = styled(BicolorUnlock).attrs(({ theme }) => ({
+  color: theme.colors.white,
+  color2: theme.colors.white,
+}))``
+
+const StyledButtonText = styled(Typo.ButtonText)(({ theme }) => ({
+  color: theme.colors.white,
+}))
+
+const StyledBodyText = styled(Typo.Body)(({ theme }) => ({
+  color: theme.colors.white,
+}))

--- a/src/features/home/components/headers/HomeHeader.native.test.tsx
+++ b/src/features/home/components/headers/HomeHeader.native.test.tsx
@@ -49,6 +49,15 @@ jest.mock('features/auth/api/useNextSubscriptionStep', () => ({
   })),
 }))
 
+const mockLoggedInUser = () => {
+  mockUseAuthContext.mockReturnValueOnce({
+    isLoggedIn: true,
+    isUserLoading: false,
+    setIsLoggedIn: jest.fn(),
+    refetchUser: jest.fn(),
+  })
+}
+
 describe('HomeHeader', () => {
   it.each`
     usertype                     | user                                                                              | isLoggedIn | credit                                | subtitle
@@ -70,7 +79,7 @@ describe('HomeHeader', () => {
       credit: Credit
       subtitle: string
     }) => {
-      mockUseAuthContext.mockReturnValue({
+      mockUseAuthContext.mockReturnValueOnce({
         isLoggedIn: isLoggedIn,
         user,
         isUserLoading: false,
@@ -91,6 +100,7 @@ describe('HomeHeader', () => {
   })
 
   it('should display geolocation banner when geolocation is denied', () => {
+    mockLoggedInUser()
     mockUseGeolocation.mockReturnValueOnce({ permissionState: GeolocPermissionState.DENIED })
     mockedUseBeneficiaryValidationNavigation.mockReturnValueOnce({
       nextBeneficiaryValidationStepNavConfig: undefined,
@@ -102,6 +112,7 @@ describe('HomeHeader', () => {
   })
 
   it('should display geolocation banner when geolocation is never ask again', () => {
+    mockLoggedInUser()
     mockUseGeolocation.mockReturnValueOnce({
       permissionState: GeolocPermissionState.NEVER_ASK_AGAIN,
     })
@@ -156,6 +167,19 @@ describe('HomeHeader', () => {
     env.FEATURE_FLIPPING_ONLY_VISIBLE_ON_TESTING = false
     const { queryByText } = renderHomeHeader()
     expect(queryByText('CheatMenu')).toBeNull()
+  })
+
+  it('should display SignupBanner when user is not logged in', () => {
+    mockUseAuthContext.mockReturnValueOnce({
+      isLoggedIn: false,
+      isUserLoading: false,
+      setIsLoggedIn: jest.fn(),
+      refetchUser: jest.fn(),
+    })
+
+    const { getByText } = renderHomeHeader()
+
+    expect(getByText('Débloque ton crédit')).toBeTruthy()
   })
 })
 

--- a/src/features/home/components/headers/HomeHeader.tsx
+++ b/src/features/home/components/headers/HomeHeader.tsx
@@ -7,6 +7,7 @@ import { useNextSubscriptionStep } from 'features/auth/api/useNextSubscriptionSt
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useBeneficiaryValidationNavigation } from 'features/auth/helpers/useBeneficiaryValidationNavigation'
 import { GeolocationBanner } from 'features/home/components/GeolocationBanner'
+import { SignupBanner } from 'features/home/components/SignupBanner'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { isUserBeneficiary } from 'features/profile/helpers/isUserBeneficiary'
 import { env } from 'libs/environment'
@@ -59,6 +60,10 @@ export const HomeHeader: FunctionComponent = function () {
   const credit = useGetDepositAmountsByAge(user?.birthDate)
 
   const SystemBloc = useMemo(() => {
+    if (!isLoggedIn) {
+      return <SignupBanner />
+    }
+
     if (shouldDisplaySubscriptionBloc) {
       return (
         <React.Fragment>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-20135

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

## Screenshots

| Platform         | Before |
| :--------------- | :----: |
| iOS              |![Simulator Screen Shot - iPhone 13 mini - 2023-02-16 at 16 48 14](https://user-images.githubusercontent.com/22886846/219429638-df94d323-ce95-4ae9-8819-f73c71318b33.png)|
| Android          |<img width="412" alt="Capture d’écran 2023-02-16 à 17 55 04" src="https://user-images.githubusercontent.com/22886846/219434102-6d8f4162-e034-4858-86a8-1961324806de.png">|
| Desktop - Chrome |<img width="1722" alt="Capture d’écran 2023-02-16 à 16 47 54" src="https://user-images.githubusercontent.com/22886846/219429345-2b27a6ec-901f-4bd0-89b4-84d9bbc009ec.png">|
| Desktop - Safari |        |


https://user-images.githubusercontent.com/22886846/219429412-c3fba06b-f3ba-4fc6-9dfb-9bf88f841287.mp4


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
