### PR TITLE
(PC-20029) feat(contentful): use data from thematic highlight info

### DIFF
--- a/src/libs/contentful/adapters/modules/adaptThematicHighlightModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptThematicHighlightModule.ts
@@ -5,15 +5,17 @@ import { ThematicHighlightContentModel } from 'libs/contentful/types'
 export const adaptThematicHighlightModule = (
   module: ThematicHighlightContentModel
 ): ThematicHighlightModule => {
-  const imageUrl = buildImageUrl(module.fields.image?.fields.file.url)
+  const thematicHighlightInfo = module.fields.thematicHighlightInfo.fields
+  const imageUrl = buildImageUrl(thematicHighlightInfo.image?.fields.file.url)
+
   return {
     id: module.sys.id,
     type: HomepageModuleType.ThematicHighlightModule,
-    title: module.fields.displayedTitle,
-    subtitle: module.fields.displayedSubtitle,
+    title: thematicHighlightInfo.displayedTitle,
+    subtitle: thematicHighlightInfo.displayedSubtitle,
     imageUrl,
-    beginningDate: new Date(module.fields.beginningDatetime),
-    endingDate: new Date(module.fields.endingDatetime),
+    beginningDate: new Date(thematicHighlightInfo.beginningDatetime),
+    endingDate: new Date(thematicHighlightInfo.endingDatetime),
     thematicHomeEntryId: module.fields.thematicHomeEntryId,
   }
 }

--- a/src/libs/contentful/adapters/modules/adaptThematicHighlightModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptThematicHighlightModule.ts
@@ -6,7 +6,7 @@ export const adaptThematicHighlightModule = (
   module: ThematicHighlightContentModel
 ): ThematicHighlightModule => {
   const thematicHighlightInfo = module.fields.thematicHighlightInfo.fields
-  const imageUrl = buildImageUrl(thematicHighlightInfo.image?.fields.file.url)
+  const imageUrl = buildImageUrl(thematicHighlightInfo.image.fields.file.url)
 
   return {
     id: module.sys.id,

--- a/src/libs/contentful/fixtures/thematicHighlightInfo.fixture.ts
+++ b/src/libs/contentful/fixtures/thematicHighlightInfo.fixture.ts
@@ -1,0 +1,79 @@
+import { ContentTypes, ThematicHighlightInfo } from 'libs/contentful/types'
+
+export const thematicHighlightInfoFixture: ThematicHighlightInfo = {
+  sys: {
+    space: {
+      sys: {
+        type: 'Link',
+        linkType: 'Space',
+        id: '2bg01iqy0isv',
+      },
+    },
+    id: '3IJm1DTZ0wBEmZl6jR2Z4K',
+    type: 'Entry',
+    createdAt: '2023-02-17T15:00:14.663Z',
+    updatedAt: '2023-02-17T15:00:20.329Z',
+    environment: {
+      sys: {
+        id: 'testing',
+        type: 'Link',
+        linkType: 'Environment',
+      },
+    },
+    revision: 2,
+    contentType: {
+      sys: {
+        type: 'Link',
+        linkType: 'ContentType',
+        id: ContentTypes.THEMATIC_HIGHLIGHT_INFO,
+      },
+    },
+    locale: 'en-US',
+  },
+  fields: {
+    title: 'Temps fort',
+    displayedTitle: 'Temps très fort',
+    displayedSubtitle: 'Avec son sous-titre',
+    image: {
+      sys: {
+        space: {
+          sys: {
+            type: 'Link',
+            linkType: 'Space',
+            id: '2bg01iqy0isv',
+          },
+        },
+        id: '6kYYW8Uwad2ZlLUmw1k4ax',
+        type: 'Asset',
+        createdAt: '2020-11-12T12:51:58.409Z',
+        updatedAt: '2020-11-12T12:51:58.409Z',
+        environment: {
+          sys: {
+            id: 'testing',
+            type: 'Link',
+            linkType: 'Environment',
+          },
+        },
+        revision: 1,
+        locale: 'en-US',
+      },
+      fields: {
+        title: 'Découvre Versailles',
+        file: {
+          url: '//images.ctfassets.net/2bg01iqy0isv/6kYYW8Uwad2ZlLUmw1k4ax/9e1261e7010f4419506dc821b2d0bea8/be697ba0-3439-42fa-8f54-b917e988db66.jpeg',
+          details: {
+            size: 321635,
+            image: {
+              width: 1600,
+              height: 1200,
+            },
+          },
+          fileName: 'be697ba0-3439-42fa-8f54-b917e988db66.jpeg',
+          contentType: 'image/jpeg',
+        },
+      },
+    },
+    beginningDatetime: '2022-12-22T00:00+01:00',
+    endingDatetime: '2023-01-15T00:00+01:00',
+  },
+}

--- a/src/libs/contentful/fixtures/thematicHighlightModule.fixture.ts
+++ b/src/libs/contentful/fixtures/thematicHighlightModule.fixture.ts
@@ -1,3 +1,4 @@
+import { thematicHighlightInfoFixture } from 'libs/contentful/fixtures/thematicHighlightInfo.fixture'
 import { ContentTypes, ThematicHighlightContentModel } from 'libs/contentful/types'
 
 export const thematicHighlightModuleFixture: ThematicHighlightContentModel = {
@@ -32,49 +33,7 @@ export const thematicHighlightModuleFixture: ThematicHighlightContentModel = {
   },
   fields: {
     title: 'Temps fort Hugo',
-    displayedTitle: 'Temps très fort',
-    displayedSubtitle: 'Avec son sous-titre',
-    image: {
-      sys: {
-        space: {
-          sys: {
-            type: 'Link',
-            linkType: 'Space',
-            id: '2bg01iqy0isv',
-          },
-        },
-        id: '6kYYW8Uwad2ZlLUmw1k4ax',
-        type: 'Asset',
-        createdAt: '2020-11-12T12:51:58.409Z',
-        updatedAt: '2020-11-12T12:51:58.409Z',
-        environment: {
-          sys: {
-            id: 'testing',
-            type: 'Link',
-            linkType: 'Environment',
-          },
-        },
-        revision: 1,
-        locale: 'en-US',
-      },
-      fields: {
-        title: 'Découvre Versailles',
-        file: {
-          url: '//images.ctfassets.net/2bg01iqy0isv/6kYYW8Uwad2ZlLUmw1k4ax/9e1261e7010f4419506dc821b2d0bea8/be697ba0-3439-42fa-8f54-b917e988db66.jpeg',
-          details: {
-            size: 321635,
-            image: {
-              width: 1600,
-              height: 1200,
-            },
-          },
-          fileName: 'be697ba0-3439-42fa-8f54-b917e988db66.jpeg',
-          contentType: 'image/jpeg',
-        },
-      },
-    },
-    beginningDatetime: '2022-12-22T00:00+01:00',
-    endingDatetime: '2023-01-15T00:00+01:00',
     thematicHomeEntryId: '6DCThxvbPFKAo04SVRZtwY',
+    thematicHighlightInfo: thematicHighlightInfoFixture,
   },
 }

--- a/src/libs/contentful/types.ts
+++ b/src/libs/contentful/types.ts
@@ -13,6 +13,7 @@ export enum ContentTypes {
   SUBCATEGORIES = 'subcategories',
   CATEGORIES = 'categories',
   THEMATIC_HIGHLIGHT = 'thematicHighlight',
+  THEMATIC_HIGHLIGHT_INFO = 'thematic_highlight_info',
   VENUES_PLAYLIST = 'venuesPlaylist',
   VENUES_PARAMETERS = 'venuesParameters',
   CATEGORY_BLOCK = 'categoryBlock',
@@ -156,6 +157,11 @@ export interface ShowTypes {
 export interface BookTypes {
   sys: Sys<typeof ContentTypes.BOOK_TYPES>
   fields: BookTypesFields
+}
+
+export interface ThematicHighlightInfo {
+  sys: Sys<typeof ContentTypes.THEMATIC_HIGHLIGHT_INFO>
+  fields: ThematicHighlightInfoFields
 }
 
 export interface ThematicHighlightParameters {
@@ -314,13 +320,19 @@ type BookTypesFields = {
 
 export type ThematicHighlightFields = {
   title: string
+  thematicHighlightInfo: ThematicHighlightInfo
+  thematicHomeEntryId: string
+}
+
+export type ThematicHighlightInfoFields = {
+  title: string
   displayedTitle: string
   displayedSubtitle?: string
   image: Image
   beginningDatetime: string
   endingDatetime: string
-  thematicHomeEntryId: string
 }
+
 export interface CategoryListFields {
   title: string
   categoryBlockList: CategoryBlockContentModel[]


### PR DESCRIPTION
so that it can be reused in thematic highlight homes in a future ticket

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-20029

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion](1)

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/26742386/220084319-0f471aea-c399-4bcf-9a6c-e4eda50011d4.png">
