### PR TITLE
(PC-20600) fix(MessagingApps): Separate webUrl from share url

### DIFF
--- a/__mocks__/react-native-share.ts
+++ b/__mocks__/react-native-share.ts
@@ -4,4 +4,5 @@ export default {
 
 export enum Social {
   Snapchat = 'Snapchat',
+  Whatsapp = 'Whatsapp',
 }

--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -1,7 +1,7 @@
 import mockdate from 'mockdate'
 import React from 'react'
 import { Share as NativeShare } from 'react-native'
-import Share from 'react-native-share'
+import Share, { Social } from 'react-native-share'
 
 import { push } from '__mocks__/@react-navigation/native'
 import { mockOffer } from 'features/bookOffer/fixtures/offer'
@@ -184,6 +184,24 @@ describe('<OfferBody />', () => {
 
       expect(mockShareSingle).toHaveBeenCalledWith({
         social: Network.snapchat,
+        message: `Retrouve "${mockOffer.name}" chez "${mockOffer.venue.name}" sur le pass Culture`,
+        url: getOfferUrl(offerId),
+      })
+    })
+
+    it('should open social medium on share button press with offer url even when web url is defined', async () => {
+      mockCheckInstalledApps.mockResolvedValueOnce({
+        [Network.whatsapp]: true,
+      })
+      render(<OfferBody offerId={offerId} onScroll={onScroll} />)
+
+      await act(async () => {
+        const socialMediumButton = await screen.findByText(`Envoyer sur ${[Network.whatsapp]}`)
+        fireEvent.press(socialMediumButton)
+      })
+
+      expect(mockShareSingle).toHaveBeenCalledWith({
+        social: Social.Whatsapp,
         message: `Retrouve "${mockOffer.name}" chez "${mockOffer.venue.name}" sur le pass Culture`,
         url: getOfferUrl(offerId),
       })

--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -183,7 +183,7 @@ describe('<OfferBody />', () => {
       })
 
       expect(mockShareSingle).toHaveBeenCalledWith({
-        social: Network.snapchat,
+        social: Social.Snapchat,
         message: `Retrouve "${mockOffer.name}" chez "${mockOffer.venue.name}" sur le pass Culture`,
         url: getOfferUrl(offerId),
       })

--- a/src/features/offer/components/shareMessagingOffer/InstalledMessagingApps.tsx
+++ b/src/features/offer/components/shareMessagingOffer/InstalledMessagingApps.tsx
@@ -37,6 +37,7 @@ export const InstalledMessagingApps = ({ offerId }: { offerId: number }) => {
           shouldEncodeURI,
           supportsURL = true,
           isNative,
+          webUrl,
           ...options
         } = mapNetworkToSocial[network]
         // Message has to be concatenated with url if url option is not supported, and in web
@@ -44,7 +45,7 @@ export const InstalledMessagingApps = ({ offerId }: { offerId: number }) => {
 
         const onPress = async () => {
           analytics.logShare({ type: 'Offer', id: offerId, from: 'offer', social: options.social })
-          if (isWeb) await Linking.openURL(options.url + encodeURIComponent(message))
+          if (isWeb && webUrl) await Linking.openURL(webUrl + encodeURIComponent(message))
           else if (isNative && options.url) await Linking.openURL(options.url + message)
           else {
             await Share.shareSingle({
@@ -67,18 +68,23 @@ export const InstalledMessagingApps = ({ offerId }: { offerId: number }) => {
 
 const mapNetworkToSocial: Record<
   Network,
-  ShareSingleOptions & { shouldEncodeURI?: boolean; supportsURL?: boolean; isNative?: boolean }
+  ShareSingleOptions & {
+    shouldEncodeURI?: boolean
+    supportsURL?: boolean
+    isNative?: boolean
+    webUrl?: string
+  }
 > = {
   [Network.instagram]: { social: Social.Instagram, supportsURL: false, shouldEncodeURI: true },
   [Network.messenger]: { social: Social.Messenger },
   [Network.snapchat]: { social: Social.Snapchat },
   [Network.whatsapp]: {
     social: Social.Whatsapp,
-    url: isWeb ? 'https://api.whatsapp.com/send?text=' : undefined,
+    webUrl: 'https://api.whatsapp.com/send?text=',
   },
   [Network.telegram]: {
     social: Social.Telegram,
-    url: isWeb ? 'https://telegram.me/share/msg?url=' : undefined,
+    webUrl: 'https://telegram.me/share/msg?url=',
   },
   [Network.viber]: {
     social: Social.Viber,
@@ -92,6 +98,6 @@ const mapNetworkToSocial: Record<
   },
   [Network.twitter]: {
     social: Social.Twitter,
-    url: isWeb ? 'https://twitter.com/intent/tweet?text=' : undefined,
+    webUrl: 'https://twitter.com/intent/tweet?text=',
   },
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-20600

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |   [TestIOS.mov](https://user-images.githubusercontent.com/46637324/220690301-6fc903d4-494b-4c68-8f6f-eaca4b93b3c5.mov)   |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |   [TestWeb.mov](https://user-images.githubusercontent.com/46637324/220689342-8fe0845d-225f-4f81-b474-987b9fa7fd4c.mov)    |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
