### PR TITLE
(PC-20641) feat(contentful): move category block info to its own content model

### DIFF
--- a/src/libs/contentful/adapters/modules/adaptCategoryListModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptCategoryListModule.ts
@@ -12,9 +12,12 @@ export const adaptCategoryListModule = (module: CategoryListContentModel): Categ
 }
 
 const adaptCategoryBlock = (CategoryBlockList: CategoryBlockContentModel[]): CategoryBlock[] =>
-  CategoryBlockList.filter((categoryBlock) => categoryBlock.fields).map((bloc) => ({
-    id: bloc.sys.id,
-    image: bloc.fields.image ? buildImageUrl(bloc.fields.image.fields.file.url) : undefined,
-    homeEntryId: bloc.fields.homeEntryId,
-    title: bloc.fields.title,
-  }))
+  CategoryBlockList.filter((categoryBlock) => categoryBlock.fields).map((bloc) => {
+    const { displayedTitle: title, image } = bloc.fields.thematicCategoryInfo.fields
+    return {
+      id: bloc.sys.id,
+      image: image ? buildImageUrl(image.fields.file.url) : undefined,
+      homeEntryId: bloc.fields.homeEntryId,
+      title: title,
+    }
+  })

--- a/src/libs/contentful/fixtures/categoryList.fixture.ts
+++ b/src/libs/contentful/fixtures/categoryList.fixture.ts
@@ -65,7 +65,7 @@ export const categoryListFixture: CategoryListContentModel = {
         },
         fields: {
           title: 'Livres',
-          image: {
+          thematicCategoryInfo: {
             sys: {
               space: {
                 sys: {
@@ -74,10 +74,10 @@ export const categoryListFixture: CategoryListContentModel = {
                   id: '2bg01iqy0isv',
                 },
               },
-              id: '1uTePwMo6qxJo7bMM7VLeX',
-              type: 'Asset',
-              createdAt: '2022-11-10T17:15:29.312Z',
-              updatedAt: '2022-11-10T17:19:54.202Z',
+              id: '2xEmftUxdtnfw2touSs6pr',
+              type: 'Entry',
+              createdAt: '2023-02-27T15:48:23.465Z',
+              updatedAt: '2023-02-27T15:48:23.465Z',
               environment: {
                 sys: {
                   id: 'testing',
@@ -85,23 +85,58 @@ export const categoryListFixture: CategoryListContentModel = {
                   linkType: 'Environment',
                 },
               },
-              revision: 3,
+              revision: 1,
+              contentType: {
+                sys: {
+                  type: 'Link',
+                  linkType: 'ContentType',
+                  id: ContentTypes.THEMATIC_CATEGORY_INFO,
+                },
+              },
               locale: 'en-US',
             },
             fields: {
-              title: 'wefrac',
-              description: '',
-              file: {
-                url: '//images.ctfassets.net/2bg01iqy0isv/1uTePwMo6qxJo7bMM7VLeX/fdea7eb6fd7ab2003a5f1eeaba2565e9/17-insta-1080x1350_560x800.jpg',
-                details: {
-                  size: 100095,
-                  image: {
-                    width: 560,
-                    height: 800,
+              title: 'Livres',
+              displayedTitle: 'Livres',
+              image: {
+                sys: {
+                  space: {
+                    sys: {
+                      type: 'Link',
+                      linkType: 'Space',
+                      id: '2bg01iqy0isv',
+                    },
+                  },
+                  id: '1uTePwMo6qxJo7bMM7VLeX',
+                  type: 'Asset',
+                  createdAt: '2022-11-10T17:15:29.312Z',
+                  updatedAt: '2022-11-10T17:19:54.202Z',
+                  environment: {
+                    sys: {
+                      id: 'testing',
+                      type: 'Link',
+                      linkType: 'Environment',
+                    },
+                  },
+                  revision: 3,
+                  locale: 'en-US',
+                },
+                fields: {
+                  title: 'wefrac',
+                  description: '',
+                  file: {
+                    url: '//images.ctfassets.net/2bg01iqy0isv/1uTePwMo6qxJo7bMM7VLeX/fdea7eb6fd7ab2003a5f1eeaba2565e9/17-insta-1080x1350_560x800.jpg',
+                    details: {
+                      size: 100095,
+                      image: {
+                        width: 560,
+                        height: 800,
+                      },
+                    },
+                    fileName: '17-insta-1080x1350_560x800.jpg',
+                    contentType: 'image/jpeg',
                   },
                 },
-                fileName: '17-insta-1080x1350_560x800.jpg',
-                contentType: 'image/jpeg',
               },
             },
           },
@@ -140,7 +175,7 @@ export const categoryListFixture: CategoryListContentModel = {
         },
         fields: {
           title: 'Cinéma',
-          image: {
+          thematicCategoryInfo: {
             sys: {
               space: {
                 sys: {
@@ -149,10 +184,10 @@ export const categoryListFixture: CategoryListContentModel = {
                   id: '2bg01iqy0isv',
                 },
               },
-              id: '1IujqyX9w3ugcGGbKlolbp',
-              type: 'Asset',
-              createdAt: '2022-05-03T09:58:15.614Z',
-              updatedAt: '2022-10-21T09:51:46.381Z',
+              id: '7rOeUTyjb7O2IFUio8Yn5j',
+              type: 'Entry',
+              createdAt: '2023-02-27T15:47:57.604Z',
+              updatedAt: '2023-02-27T15:47:57.604Z',
               environment: {
                 sys: {
                   id: 'testing',
@@ -160,23 +195,58 @@ export const categoryListFixture: CategoryListContentModel = {
                   linkType: 'Environment',
                 },
               },
-              revision: 7,
+              revision: 1,
+              contentType: {
+                sys: {
+                  type: 'Link',
+                  linkType: 'ContentType',
+                  id: ContentTypes.THEMATIC_CATEGORY_INFO,
+                },
+              },
               locale: 'en-US',
             },
             fields: {
-              title: 'Test Sab',
-              description: 'dqqddsds',
-              file: {
-                url: '//images.ctfassets.net/2bg01iqy0isv/1IujqyX9w3ugcGGbKlolbp/d11cdb6d0dee5e6d3fb2b072031a01e7/i107848-eduquer-un-chaton.jpeg',
-                details: {
-                  size: 378517,
-                  image: {
-                    width: 1000,
-                    height: 667,
+              title: 'Chasse au trésor - Cinéma',
+              displayedTitle: 'Cinéma',
+              image: {
+                sys: {
+                  space: {
+                    sys: {
+                      type: 'Link',
+                      linkType: 'Space',
+                      id: '2bg01iqy0isv',
+                    },
+                  },
+                  id: '1IujqyX9w3ugcGGbKlolbp',
+                  type: 'Asset',
+                  createdAt: '2022-05-03T09:58:15.614Z',
+                  updatedAt: '2022-10-21T09:51:46.381Z',
+                  environment: {
+                    sys: {
+                      id: 'testing',
+                      type: 'Link',
+                      linkType: 'Environment',
+                    },
+                  },
+                  revision: 7,
+                  locale: 'en-US',
+                },
+                fields: {
+                  title: 'Test Sab',
+                  description: 'dqqddsds',
+                  file: {
+                    url: '//images.ctfassets.net/2bg01iqy0isv/1IujqyX9w3ugcGGbKlolbp/d11cdb6d0dee5e6d3fb2b072031a01e7/i107848-eduquer-un-chaton.jpeg',
+                    details: {
+                      size: 378517,
+                      image: {
+                        width: 1000,
+                        height: 667,
+                      },
+                    },
+                    fileName: 'i107848-eduquer-un-chaton.jpeg',
+                    contentType: 'image/jpeg',
                   },
                 },
-                fileName: 'i107848-eduquer-un-chaton.jpeg',
-                contentType: 'image/jpeg',
               },
             },
           },

--- a/src/libs/contentful/types.ts
+++ b/src/libs/contentful/types.ts
@@ -12,6 +12,7 @@ export enum ContentTypes {
   RECOMMENDATION_PARAMETERS = 'recommendation_parameters',
   SUBCATEGORIES = 'subcategories',
   CATEGORIES = 'categories',
+  THEMATIC_CATEGORY_INFO = 'thematicCategoryInfo',
   THEMATIC_HIGHLIGHT = 'thematicHighlight',
   THEMATIC_HIGHLIGHT_INFO = 'thematic_highlight_info',
   VENUES_PLAYLIST = 'venuesPlaylist',
@@ -157,6 +158,11 @@ export interface ShowTypes {
 export interface BookTypes {
   sys: Sys<typeof ContentTypes.BOOK_TYPES>
   fields: BookTypesFields
+}
+
+export interface ThematicCategoryInfo {
+  sys: Sys<typeof ContentTypes.THEMATIC_CATEGORY_INFO>
+  fields: ThematicCategoryInfoFields
 }
 
 export interface ThematicHighlightInfo {
@@ -318,6 +324,13 @@ type BookTypesFields = {
   bookTypes: string[]
 }
 
+export type ThematicCategoryInfoFields = {
+  title: string
+  displayedTitle: string
+  displayedSubtitle?: string
+  image: Image
+}
+
 export type ThematicHighlightFields = {
   title: string
   thematicHighlightInfo: ThematicHighlightInfo
@@ -346,7 +359,7 @@ export interface CategoryBlockContentModel {
 export interface CategoryBlockFields {
   title: string
   homeEntryId: string
-  image?: Image
+  thematicCategoryInfo: ThematicCategoryInfo
 }
 
 export interface Image {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-20641

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

<img width="759" alt="image" src="https://user-images.githubusercontent.com/26742386/221842368-89a48e11-d5ba-4c12-94bb-574fa7648bb3.png">

<img width="1021" alt="image" src="https://user-images.githubusercontent.com/26742386/221842677-0a42397f-2083-47d2-a835-245757c0f717.png">

<img width="938" alt="image" src="https://user-images.githubusercontent.com/26742386/221842795-cef24300-0650-40cb-b1ff-095d03b2cb20.png">

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
