### PR TITLE
(BSR) chore(api): add script to allow generating codegen on silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ If the backend changes the api schema, you will need to update it:
 
 - pull the `swagger-codegen-cli-v3` image: `docker pull swaggerapi/swagger-codegen-cli-v3`
 - run: `yarn generate:api:client`
+- or run `yarn generate:api:client:silicon` on Apple Silicon chips
 
 If the file `src/api/gen/.swagger-codegen/VERSION` changes, make sure you locally have the desired version of `swagger-codegen-cli`, otherwise run `docker pull swaggerapi/swagger-codegen-cli-v3:3.0.24`
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "chromatic": "chromatic --exit-zero-on-changes --exit-once-uploaded",
     "fix:lint": "eslint . --ext .js,.ts,.tsx,.mjs --fix",
     "generate:api:client": "SWAGGER_CODEGEN_CLI_VERSION=3.0.30 ./scripts/generate_api_client.sh",
+    "generate:api:client:silicon": "SWAGGER_CODEGEN_CLI_VERSION=3.0.32 ./scripts/generate_api_client_silicon.sh",
     "ios:prod": "react-native run-ios --scheme PassCulture-Production",
     "ios:staging": "react-native run-ios --scheme PassCulture-Staging",
     "ios:testing": "react-native run-ios --scheme PassCulture-Testing",

--- a/scripts/generate_api_client_silicon.sh
+++ b/scripts/generate_api_client_silicon.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
+# This file uses custom Docker image to handle generating api.ts until this PR is merged
+# https://github.com/swagger-api/swagger-codegen/pull/11772
+
 docker run \
     --network="host" \
     --rm \
     --volume "${PWD}:/local" \
-    "swaggerapi/swagger-codegen-cli-v3:${SWAGGER_CODEGEN_CLI_VERSION:-'latest'}" generate \
+    "parsertongue/swagger-codegen-cli:${SWAGGER_CODEGEN_CLI_VERSION:-'latest'}" generate \
         --input-spec https://backend.testing.passculture.team/native/v1/openapi.json `# schema location` \
         --lang typescript-fetch `# client type` \
         --config /local/swagger_codegen/swagger_codegen_config.json `# swagger codegen config` \


### PR DESCRIPTION
Les développeurs sous puces Apple Silicon ne peuvent pas lancer `generate:api:client`.

J'ai donc créé un script `generate:api:client:silicon` pour remédier à cela en attendant que [cette PR](https://github.com/swagger-api/swagger-codegen/pull/11772) de chez Swagger soit mergée.