### PR TITLE
(PC-20493) fix(firebase): Return null for app instance id in web since it is not supported

### DIFF
--- a/src/libs/firebase/analytics/__tests__/provider.native.test.ts
+++ b/src/libs/firebase/analytics/__tests__/provider.native.test.ts
@@ -1,0 +1,7 @@
+import { analytics } from 'libs/firebase/analytics'
+
+describe('analytics - getAppInstanceId', () => {
+  it('should be user pseudo id', async () => {
+    expect(await analytics.getAppInstanceId()).toEqual('firebase_pseudo_id')
+  })
+})

--- a/src/libs/firebase/analytics/__tests__/provider.web.test.ts
+++ b/src/libs/firebase/analytics/__tests__/provider.web.test.ts
@@ -1,0 +1,10 @@
+import { analytics } from 'libs/firebase/analytics'
+
+jest.unmock('libs/firebase/analytics/analytics')
+jest.unmock('libs/firebase/analytics/provider')
+
+describe('analytics - getAppInstanceId', () => {
+  it('should be null', async () => {
+    expect(await analytics.getAppInstanceId()).toBeNull()
+  })
+})

--- a/src/libs/firebase/analytics/provider.ts
+++ b/src/libs/firebase/analytics/provider.ts
@@ -24,6 +24,7 @@ export const analyticsProvider: AnalyticsProvider = {
     firebaseAnalytics.setAnalyticsCollectionEnabled(false)
   },
   getAppInstanceId() {
+    if (Platform.OS === 'web') return new Promise((resolve) => resolve(null))
     return firebaseAnalytics.getAppInstanceId()
   },
   setDefaultEventParameters(params: Record<string, unknown> | undefined) {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-20493

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
