### PR TITLE
(PC-19088) feat(ci): Use github action to deploy soft testing

### DIFF
--- a/.github/workflows/.sentryclirc
+++ b/.github/workflows/.sentryclirc
@@ -1,0 +1,7 @@
+[defaults]
+url=https://sentry.passculture.team/
+org=sentry
+project=application-native
+
+[auth]
+token={{.token}}

--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -5,25 +5,7 @@ on:
 
 jobs:
   yarn-install:
-    runs-on: [self-hosted, linux, X64]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - name: Setup yarn
-        run: npm install -g yarn
-      - uses: actions/cache@v3
-        id: yarn-modules-cache
-        with:
-          path: |
-            node_modules
-            ~/.cache/yarn
-          key: v1-yarn-dependency-cache-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            v1-yarn-dependency-cache-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install --immutable
-        if: steps.yarn-modules-cache.outputs.cache-hit != 'true'
+    uses: ./.github/workflows/dev_on_workflow_install.yml
   yarn-linter:
     needs: yarn-install
     uses: ./.github/workflows/dev_on_workflow_linter_ts.yml
@@ -32,6 +14,18 @@ jobs:
     uses: ./.github/workflows/dev_on_workflow_tester.yml
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
   yarn-storybook:
     needs: yarn-linter
     uses: ./.github/workflows/dev_on_workflow_storybook.yml
+  sentry-on-deploy:
+    needs: yarn-tester
+    if: github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/dev_on_workflow_sentry_on_deploy.yml
+    with:
+      ENV: "testing"
+    secrets:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      ANDROID_APPCENTER_API_TOKEN: ${{ secrets.ANDROID_TESTING_APPCENTER_API_TOKEN }}
+      IOS_APPCENTER_API_TOKEN: ${{ secrets.IOS_TESTING_APPCENTER_API_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/dev_on_workflow_install.yml
+++ b/.github/workflows/dev_on_workflow_install.yml
@@ -1,0 +1,32 @@
+name: Install runtime environment and dependencies
+
+on:
+  workflow_call:
+
+jobs:
+  yarn-install:
+    runs-on: [self-hosted, linux, X64]
+    container:
+      image: node:18
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        id: yarn-modules-cache
+        with:
+          path: |
+            node_modules
+            ~/.cache/yarn
+          key: v1-yarn-dependency-cache-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            v1-yarn-dependency-cache-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn install --immutable
+        if: steps.yarn-modules-cache.outputs.cache-hit != 'true'
+  bundle-install:
+    runs-on: [self-hosted, linux, X64]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Install Gem dependencies
+        run: bundle install --path=vendor/bundle

--- a/.github/workflows/dev_on_workflow_linter_ts.yml
+++ b/.github/workflows/dev_on_workflow_linter_ts.yml
@@ -10,13 +10,10 @@ concurrency:
 jobs:
   yarn_lint:
     runs-on: [self-hosted, linux, x64]
+    container:
+      image: node:18
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-      - name: Setup yarn
-        run: npm install -g yarn
       - uses: actions/cache@v3
         with:
           path: |
@@ -29,13 +26,13 @@ jobs:
 
   yarn_typescript:
     runs-on: [self-hosted, linux, x64]
+    container:
+      image: node:18
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-      - name: Setup yarn
-        run: npm install -g yarn
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/dev_on_workflow_sentry_on_deploy.yml
+++ b/.github/workflows/dev_on_workflow_sentry_on_deploy.yml
@@ -1,0 +1,86 @@
+name: Install runtime environment and dependencies
+
+on:
+  workflow_call:
+    inputs:
+      ENV:
+        type: string
+        required: true
+    secrets:
+      SENTRY_AUTH_TOKEN:
+        required: true
+      ANDROID_APPCENTER_API_TOKEN:
+        required: true
+      IOS_APPCENTER_API_TOKEN:
+        required: true
+      SLACK_BOT_TOKEN:
+        required: true
+
+jobs:
+  sentry_and_deploy:
+    runs-on: [self-hosted, linux, X64]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Setup yarn
+        run: npm install -g yarn
+      - uses: actions/cache@v3
+        id: yarn-modules-cache
+        with:
+          path: |
+            node_modules
+            ~/.cache/yarn
+          key: v1-yarn-dependency-cache-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            v1-yarn-dependency-cache-${{ hashFiles('**/yarn.lock') }}
+      - name: 'Render Template'
+        id: render_template
+        uses: chuhlomin/render-template@v1.6
+        with:
+          template: .sentryclirc
+          vars: |
+            token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          #  - name: Deploy android for ${{ inputs.ENV }}
+          #    run: |
+          #      bundle exec fastlane android deploy codepush: --env ${{ inputs.ENV }}
+          #    env:
+          #      ANDROID_APPCENTER_API_TOKEN: ${{ secrets.ANDROID_APPCENTER_API_TOKEN }}
+          #  - name: Deploy ios App for ${{ inputs.ENV }}
+          #    run: |
+          #      bundle exec fastlane ios deploy codepush: --env ${{ inputs.ENV }}
+          #    env:
+          #      IOS_APPCENTER_API_TOKEN: ${{ secrets.IOS_APPCENTER_API_TOKEN }}
+      - uses: technote-space/workflow-conclusion-action@v3
+        if: ${{ always() }}
+      - name: Post to a Slack channel
+        id: slack
+        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          # channel #alertes-deploiement-native
+          channel-id: "C0309RP8K42"
+          payload: |
+            {
+              "attachments": [
+                  {
+                      "mrkdwn_in": ["text"],
+                      "color": "${{ fromJSON('["#36a64f", "#A30002"]')[ env.WORKFLOW_CONCLUSION == 'failure'] }}",
+                      "author_name": "${{github.actor}}",
+                      "author_link": "https://github.com/${{github.actor}}",
+                      "author_icon": "https://github.com/${{github.actor}}.png",
+                      "title": "PCAPPNATIVE Deployment",
+                      "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
+                      "text": "Le déploiement sur `${{ inputs.ENV }}` a échoué :boom:"
+                  }
+              ],
+              "unfurl_links": false,
+              "unfurl_media": false
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+

--- a/.github/workflows/dev_on_workflow_tester.yml
+++ b/.github/workflows/dev_on_workflow_tester.yml
@@ -5,6 +5,8 @@ on:
     secrets:
       SONAR_TOKEN:
         required: true
+      SLACK_BOT_TOKEN:
+        required: true
 
 concurrency:
   group: ${{ github.ref }}
@@ -13,15 +15,12 @@ concurrency:
 env:
   JEST_JUNIT_OUTPUT_DIR: ./reports/junit/
 jobs:
-  yarn_tester_web:
+  yarn_test_web:
     runs-on: [self-hosted, linux, X64]
+    container:
+      image: node:16
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - name: Setup yarn
-        run: npm install -g yarn
       - uses: actions/cache@v3
         with:
           path: |
@@ -40,13 +39,10 @@ jobs:
 
   yarn_test_native:
     runs-on: [self-hosted, linux, X64]
+    container:
+      image: node:16
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - name: Setup yarn
-        run: npm install -g yarn
       - uses: actions/cache@v3
         with:
           path: |
@@ -71,13 +67,10 @@ jobs:
           projectBaseDir: .
   yarn_test_proxy:
     runs-on: [self-hosted, linux, X64]
+    container:
+      image: node:16
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - name: Setup yarn
-        run: npm install -g yarn
       - uses: actions/cache@v3
         with:
           path: |
@@ -90,9 +83,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: .jest/cache
-          key: v1-yarn-test-native-cache-${{ hashFiles('**/yarn.lock') }}
+          key: v1-yarn-test-proxy-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            v1-yarn-test-native-cache-${{ hashFiles('**/yarn.lock') }}
+            v1-yarn-test-proxy-${{ hashFiles('**/yarn.lock') }}
       - run: yarn --cwd server test:unit:ci 
       - name: SonarCloud scan
         uses: SonarSource/sonarcloud-github-action@master
@@ -101,3 +94,39 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           projectBaseDir: server
+  slack_notify:
+    runs-on: [self-hosted, linux, X64]
+    if: ${{ always() && github.ref == 'refs/heads/master' }}
+    needs:
+      - yarn_test_native
+      - yarn_test_proxy
+      - yarn_test_web
+    steps:
+      - uses: technote-space/workflow-conclusion-action@v3
+        if: ${{ always() }}
+      - name: Post to a Slack channel
+        id: slack
+        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          # channel #alertes-deploiement-native
+          channel-id: "C0309RP8K42"
+          payload: |
+            {
+              "attachments": [
+                  {
+                      "mrkdwn_in": ["text"],
+                      "color": "${{ fromJSON('["#36a64f", "#A30002"]')[ env.WORKFLOW_CONCLUSION == 'failure'] }}",
+                      "author_name": "${{github.actor}}",
+                      "author_link": "https://github.com/${{github.actor}}",
+                      "author_icon": "https://github.com/${{github.actor}}.png",
+                      "title": "PCAPPNATIVE Deployment",
+                      "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
+                      "text": "Les tests sur master ont échoué :boom:"
+                  }
+              ],
+              "unfurl_links": false,
+              "unfurl_media": false
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19088

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).


## Purpose

+ Use as much as possible github workflow to avoid duplicate code
+ Push the use of specific container when we can
+ Config sentry cli
+ Run bundle to publish for android and ios (currently comment to avoid duplicate push with circle)
+ Use slack notify to add a message when test are ok on master and deploy ok (will not run for the moment to avoid spam)
