### PR TITLE
(PC-19089) feat(ci): Use github action to deploy hard testing

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -1,4 +1,4 @@
-name: Validate dev branch
+name: Initiate workflow
 
 on:
   push:
@@ -18,11 +18,24 @@ jobs:
   yarn-storybook:
     needs: yarn-linter
     uses: ./.github/workflows/dev_on_workflow_storybook.yml
-  sentry-on-deploy:
+  soft-deploy-testing:
     needs: yarn-tester
     if: github.ref == 'refs/heads/master'
-    uses: ./.github/workflows/dev_on_workflow_sentry_on_deploy.yml
+    uses: ./.github/workflows/dev_on_workflow_environment_deploy.yml
     with:
+      TYPE: "soft"
+      ENV: "testing"
+    secrets:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      ANDROID_APPCENTER_API_TOKEN: ${{ secrets.ANDROID_TESTING_APPCENTER_API_TOKEN }}
+      IOS_APPCENTER_API_TOKEN: ${{ secrets.IOS_TESTING_APPCENTER_API_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  hard-deploy-testing:
+    needs: yarn-tester
+    if: startsWith(github.ref, 'refs/tags/testing')
+    uses: ./.github/workflows/dev_on_workflow_environment_deploy.yml
+    with:
+      TYPE: "hard"
       ENV: "testing"
     secrets:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/dev_on_workflow_environment_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_deploy.yml
@@ -6,6 +6,9 @@ on:
       ENV:
         type: string
         required: true
+      TYPE:
+        type: string
+        required: true
     secrets:
       SENTRY_AUTH_TOKEN:
         required: true
@@ -45,16 +48,30 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          #  - name: Deploy android for ${{ inputs.ENV }}
+      - name: Deploy soft android for ${{ inputs.ENV }}
+        if:  ${{ inputs.TYPE == 'soft' }}
+        run: echo ${{ inputs.TYPE }}
           #    run: |
           #      bundle exec fastlane android deploy codepush: --env ${{ inputs.ENV }}
           #    env:
           #      ANDROID_APPCENTER_API_TOKEN: ${{ secrets.ANDROID_APPCENTER_API_TOKEN }}
-          #  - name: Deploy ios App for ${{ inputs.ENV }}
+      - name: Deploy soft ios App for ${{ inputs.ENV }}
+        if:  ${{ inputs.TYPE == 'soft' }}
+        run: echo ${{ inputs.TYPE }}
           #    run: |
           #      bundle exec fastlane ios deploy codepush: --env ${{ inputs.ENV }}
           #    env:
           #      IOS_APPCENTER_API_TOKEN: ${{ secrets.IOS_APPCENTER_API_TOKEN }}
+      - name: Deploy hard android for ${{ inputs.ENV }}
+        if: ${{ inputs.TYPE == 'hard'}}
+        run: echo ${{ inputs.TYPE }}
+        #     run: |
+        #       bundle exec fastlane android deploy --env "${APP_ENV}" --verbose
+      - name: Deploy hard ios for ${{ inputs.ENV }}
+        if: ${{ inputs.TYPE == 'hard'}}
+        run: echo ${{ inputs.TYPE }}
+        # run: |
+        #   bundle exec fastlane ios deploy --env "${APP_ENV}" --verbose
       - uses: technote-space/workflow-conclusion-action@v3
         if: ${{ always() }}
       - name: Post to a Slack channel


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Purpose
Add a distinction between soft and hard deploy for environment testing, for the moment it will only echo the environment to avoid building twice with circleci