### PR TITLE
(PC-18727) feat(Contentful): add a music types field for recommended playlist

### DIFF
--- a/src/features/home/api/helpers/buildRecommendationOfferTypesList.native.test.ts
+++ b/src/features/home/api/helpers/buildRecommendationOfferTypesList.native.test.ts
@@ -4,8 +4,9 @@ describe('buildOfferTypesList', () => {
   it('should return an empty offerTypeList', () => {
     const bookTypes = undefined
     const movieGenres = undefined
+    const musicTypes = undefined
 
-    const offerTypeList = buildRecommendationOfferTypesList({ bookTypes, movieGenres })
+    const offerTypeList = buildRecommendationOfferTypesList({ bookTypes, movieGenres, musicTypes })
 
     const expectedOffertTypeList: typeof offerTypeList = []
     expect(offerTypeList).toEqual(expectedOffertTypeList)
@@ -13,14 +14,17 @@ describe('buildOfferTypesList', () => {
   it('should return a formatted offerTypeList', () => {
     const bookTypes = ['art', 'cuisine']
     const movieGenres = ['ACTION', 'ART']
+    const musicTypes = ['pop', 'Gospel']
 
-    const offerTypeList = buildRecommendationOfferTypesList({ bookTypes, movieGenres })
+    const offerTypeList = buildRecommendationOfferTypesList({ bookTypes, movieGenres, musicTypes })
 
     const expectedOffertTypeList = [
       { key: 'BOOK', value: 'art' },
       { key: 'BOOK', value: 'cuisine' },
       { key: 'MOVIE', value: 'ACTION' },
       { key: 'MOVIE', value: 'ART' },
+      { key: 'MUSIC', value: 'pop' },
+      { key: 'MUSIC', value: 'Gospel' },
     ]
     expect(offerTypeList).toEqual(expectedOffertTypeList)
   })

--- a/src/features/home/api/helpers/buildRecommendationOfferTypesList.ts
+++ b/src/features/home/api/helpers/buildRecommendationOfferTypesList.ts
@@ -5,9 +5,11 @@ import { RecommendedIdsRequest } from 'libs/recommendation/types'
 export const buildRecommendationOfferTypesList = ({
   bookTypes,
   movieGenres,
+  musicTypes,
 }: {
   bookTypes: RecommendedOffersParameters['bookTypes']
   movieGenres: RecommendedOffersParameters['movieGenres']
+  musicTypes: RecommendedOffersParameters['musicTypes']
 }): RecommendedIdsRequest['offerTypeList'] => {
   let offerTypesList: RecommendedIdsRequest['offerTypeList'] = []
 
@@ -21,9 +23,16 @@ export const buildRecommendationOfferTypesList = ({
       value: movieGenre,
     })
   )
+  const formattedMusicTypes: RecommendedIdsRequest['offerTypeList'] = musicTypes?.map(
+    (movieGenre) => ({
+      key: GenreType.MUSIC,
+      value: movieGenre,
+    })
+  )
 
   offerTypesList = offerTypesList?.concat(formattedBookTypes ?? [])
   offerTypesList = offerTypesList?.concat(formattedMovieGenres ?? [])
+  offerTypesList = offerTypesList?.concat(formattedMusicTypes ?? [])
 
   return offerTypesList
 }

--- a/src/features/home/api/useHomeRecommendedHits.native.test.ts
+++ b/src/features/home/api/useHomeRecommendedHits.native.test.ts
@@ -84,6 +84,7 @@ describe('getRecommendationParameters', () => {
       subcategories: ['Achat instrument'],
       bookTypes: ['Carrière/Concours', 'Scolaire & Parascolaire', 'Gestion/entreprise'],
       movieGenres: ['ACTION', 'SPY'],
+      musicTypes: ['Pop'],
     }
     const recommendationParameters = getRecommendationParameters(
       parameters,
@@ -103,6 +104,7 @@ describe('getRecommendationParameters', () => {
         { key: 'BOOK', value: 'Gestion/entreprise' },
         { key: 'MOVIE', value: 'ACTION' },
         { key: 'MOVIE', value: 'SPY' },
+        { key: 'MUSIC', value: 'Pop' },
       ],
     })
   })

--- a/src/features/home/api/useHomeRecommendedHits.ts
+++ b/src/features/home/api/useHomeRecommendedHits.ts
@@ -30,6 +30,7 @@ export function getRecommendationParameters(
   const offertTypeValue = buildRecommendationOfferTypesList({
     bookTypes: parameters.bookTypes,
     movieGenres: parameters.movieGenres,
+    musicTypes: parameters.musicTypes,
   })
   return {
     categories: (parameters?.categories || []).map(getCategoriesFacetFilters),

--- a/src/features/home/fixtures/homepage.fixture.ts
+++ b/src/features/home/fixtures/homepage.fixture.ts
@@ -84,6 +84,7 @@ export const formattedRecommendedOffersModule: RecommendedOffersModule = {
     isRecoShuffled: false,
     bookTypes: ['Carrière/Concours', 'Scolaire & Parascolaire', 'Gestion/entreprise'],
     movieGenres: ['ACTION', 'BOLLYWOOD'],
+    musicTypes: ['Pop', 'Gospel'],
   },
 }
 

--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -145,6 +145,7 @@ export type RecommendedOffersParameters = {
   modelEndpoint?: string
   bookTypes?: string[]
   movieGenres?: string[]
+  musicTypes?: string[]
 }
 
 export type ThematicHighlightModule = {

--- a/src/libs/contentful/adapters/modules/adaptRecommendationModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptRecommendationModule.ts
@@ -19,6 +19,9 @@ const mapBookTypes = (recoCategories: RecommendationParametersFields['bookTypes'
 const mapMovieGenres = (recoCategories: RecommendationParametersFields['movieGenres']) =>
   recoCategories?.fields?.movieGenres
 
+const mapMusicTypes = (recoCategories: RecommendationParametersFields['musicTypes']) =>
+  recoCategories?.fields?.musicTypes
+
 const buildRecommendationParams = (
   recommendationParams: RecommendationParameters
 ): RecommendedOffersModule['recommendationParameters'] => {
@@ -27,11 +30,13 @@ const buildRecommendationParams = (
     recommendationCategories,
     bookTypes,
     movieGenres,
+    musicTypes,
     title: _title,
     ...otherFields
   } = recommendationParams.fields
   return {
     ...otherFields,
+    musicTypes: mapMusicTypes(musicTypes),
     movieGenres: mapMovieGenres(movieGenres),
     bookTypes: mapBookTypes(bookTypes),
     subcategories: mapRecommendationSubcategories(recommendationSubcategories),

--- a/src/libs/contentful/fixtures/recommendationNatifModule.fixture.ts
+++ b/src/libs/contentful/fixtures/recommendationNatifModule.fixture.ts
@@ -1,6 +1,7 @@
 import { bookTypesFixture } from 'libs/contentful/fixtures/bookTypes.fixture'
 import { categoriesFixture } from 'libs/contentful/fixtures/categoriesFixture'
 import { movieGenresFixture } from 'libs/contentful/fixtures/movieGenres.fixture'
+import { musicTypesFixture } from 'libs/contentful/fixtures/musicTypes.fixture'
 import { subcategoriesFixture } from 'libs/contentful/fixtures/subcategoriesEntry.fixture'
 import { ContentTypes, RecommendationContentModel } from 'libs/contentful/types'
 
@@ -119,6 +120,7 @@ export const recommendationNatifModuleFixture: RecommendationContentModel = {
         isRecoShuffled: false,
         bookTypes: bookTypesFixture,
         movieGenres: movieGenresFixture,
+        musicTypes: musicTypesFixture,
       },
     },
   },

--- a/src/libs/contentful/types.ts
+++ b/src/libs/contentful/types.ts
@@ -302,6 +302,7 @@ export interface RecommendationParametersFields {
   modelEndpoint?: string
   bookTypes?: BookTypes
   movieGenres?: MovieGenres
+  musicTypes?: MusicTypes
 }
 
 type SubcategoriesFields = {

--- a/src/libs/recommendation/types.ts
+++ b/src/libs/recommendation/types.ts
@@ -28,3 +28,4 @@ export interface RecommendedIdsRequest {
 type OfferTypeValue =
   | { key: GenreType.BOOK; value: string }
   | { key: GenreType.MOVIE; value: string }
+  | { key: GenreType.MUSIC; value: string }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-18727

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| Contentful Playlist reco avec musicTypes              | <img width="950" alt="image" src="https://user-images.githubusercontent.com/89008469/223495632-9433975d-9ac5-40f5-b974-76585afe66d7.png"> | <img width="591" alt="image" src="https://user-images.githubusercontent.com/89008469/223495454-100d1d7d-62de-4f7a-a4d7-268878882fe1.png"> |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
