### PR TITLE
(PC-20807) feat(DMSRedirection): fix DMS redirection after 3 KO Ubble

### DIFF
--- a/src/features/profile/components/Badges/SubscriptionMessageBadge.tsx
+++ b/src/features/profile/components/Badges/SubscriptionMessageBadge.tsx
@@ -18,7 +18,6 @@ import { Spacer } from 'ui/theme'
 type Props = {
   subscriptionMessage: SubscriptionMessage
 }
-
 const CallToAction = ({ subscriptionMessage }: Props) => {
   const { callToActionTitle, callToActionLink, callToActionIcon } =
     subscriptionMessage.callToAction || {}
@@ -47,6 +46,7 @@ const CallToAction = ({ subscriptionMessage }: Props) => {
         <ExternalTouchableLink
           as={ButtonQuaternarySecondary}
           externalNav={{ url: callToActionLink }}
+          openInNewWindow={false}
           icon={ExternalSiteFilled}
           {...sharedButtonProps}
         />


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-20807

When 3 KO ubble occur, the backend send a subscription message to the front with an error message and a redirection url to dms (app screen). 
Few month ago a a prop 'openInNewWindow' as been add to the ExternalTouchableLink with a default value set to true. Therefore, if no counter specification, an externalTouchableLink should open an external url. In our case, the openNewWindow prop wasn't set, which caused the link opening failure