### PR TITLE
(PC-20952) feat(bookOffer): dismiss modal when there is an error on booking confirmation

### DIFF
--- a/src/features/bookOffer/components/BookingDetails.tsx
+++ b/src/features/bookOffer/components/BookingDetails.tsx
@@ -74,6 +74,7 @@ export const BookingDetails: React.FC<Props> = ({ stocks }) => {
       }
     },
     onError: (error) => {
+      dismissModal()
       let message = 'En raison d’une erreur technique, l’offre n’a pas pu être réservée'
 
       if (isApiError(error)) {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-20952

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |<img width="418" alt="Capture d’écran 2023-03-17 à 12 43 11" src="https://user-images.githubusercontent.com/78556024/225896254-e4a2a45c-3996-4c48-8f7d-3a3f8d522c40.png">|<img width="456" alt="Capture d’écran 2023-03-17 à 09 34 16" src="https://user-images.githubusercontent.com/78556024/225896291-6d475588-76df-4fbe-b8bf-69486a638ab0.png">|
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
