### PR TITLE
(PC-21120) feat(BookingCloseInformation): add booking close modale information when the booking is loading

### DIFF
--- a/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
+++ b/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
@@ -334,7 +334,7 @@ Object {
                     >
                       <button
                         aria-label="Fermer la modale"
-                        class="c0 c1 sc-iCfMLu c1"
+                        class="c0 c1 sc-gKclnd c1"
                         data-testid="Fermer la modale"
                         tabindex="0"
                         title="Fermer la modale"

--- a/src/features/bookOffer/components/BookingCloseInformation.native.test.tsx
+++ b/src/features/bookOffer/components/BookingCloseInformation.native.test.tsx
@@ -7,10 +7,6 @@ import { BookingCloseInformation } from './BookingCloseInformation'
 const mockHideModal = jest.fn()
 
 describe('BookingCloseInformation', () => {
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
   it('calls hideModal when the "J’ai compris" button is press', () => {
     render(<BookingCloseInformation visible hideModal={mockHideModal} />)
     const button = screen.getByText('J’ai compris')

--- a/src/features/bookOffer/components/BookingCloseInformation.native.test.tsx
+++ b/src/features/bookOffer/components/BookingCloseInformation.native.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+import { fireEvent, render, screen } from 'tests/utils'
+
+import { BookingCloseInformation } from './BookingCloseInformation'
+
+const mockHideModal = jest.fn()
+
+describe('BookingCloseInformation', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('calls hideModal when the "J’ai compris" button is press', () => {
+    render(<BookingCloseInformation visible hideModal={mockHideModal} />)
+    const button = screen.getByText('J’ai compris')
+    fireEvent.press(button)
+    expect(mockHideModal).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/bookOffer/components/BookingCloseInformation.tsx
+++ b/src/features/bookOffer/components/BookingCloseInformation.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import styled, { useTheme } from 'styled-components/native'
+
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { AppInformationModal } from 'ui/components/modals/AppInformationModal'
+import { BicolorInfo } from 'ui/svg/icons/BicolorInfo'
+import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { LINE_BREAK } from 'ui/theme/constants'
+
+interface Props {
+  visible: boolean
+  hideModal: VoidFunction
+}
+
+export const BookingCloseInformation = ({ visible, hideModal }: Props) => {
+  const theme = useTheme()
+  return (
+    <AppInformationModal
+      visible={visible}
+      title="Réservation en cours"
+      numberOfLinesTitle={2}
+      onCloseIconPress={hideModal}>
+      <React.Fragment>
+        <Spacer.Column numberOfSpaces={getSpacing(1)} />
+        <BicolorInfo size={theme.illustrations.sizes.medium} />
+        <Spacer.Column numberOfSpaces={getSpacing(2)} />
+        <ModalBodyText>
+          En quittant la réservation, elle ne sera pas annulée{LINE_BREAK}
+          {LINE_BREAK}Si elle est éligible à une annulation, tu pourras lʼannuler depuis lʼonglet
+          “Réservations”
+        </ModalBodyText>
+        <Spacer.Column numberOfSpaces={getSpacing(2)} />
+        <ButtonPrimary
+          wording="J’ai compris"
+          accessibilityLabel="J’ai compris, je ferme la pop-up "
+          onPress={hideModal}
+        />
+      </React.Fragment>
+    </AppInformationModal>
+  )
+}
+
+const ModalBodyText = styled(Typo.Body)({
+  textAlign: 'center',
+})

--- a/src/features/bookOffer/components/BookingDetails.tsx
+++ b/src/features/bookOffer/components/BookingDetails.tsx
@@ -1,12 +1,9 @@
-import { useNavigation, useRoute } from '@react-navigation/native'
 import React, { useEffect } from 'react'
 import { ActivityIndicator } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
 
-import { isApiError } from 'api/apiHelpers'
 import { OfferStockResponse } from 'api/gen'
-import { useBookOfferMutation } from 'features/bookOffer/api/useBookOfferMutation'
 import { BookingInformations } from 'features/bookOffer/components/BookingInformations'
 import { CancellationDetails } from 'features/bookOffer/components/CancellationDetails'
 import { DuoChoiceSelector } from 'features/bookOffer/components/DuoChoiceSelector'
@@ -15,28 +12,18 @@ import { useBookingContext } from 'features/bookOffer/context/useBookingContext'
 import { useBookingOffer } from 'features/bookOffer/helpers/useBookingOffer'
 import { useBookingStock } from 'features/bookOffer/helpers/useBookingStock'
 import { RotatingTextOptions, useRotatingText } from 'features/bookOffer/helpers/useRotatingText'
-import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { useIsUserUnderage } from 'features/profile/helpers/useIsUserUnderage'
-import { useLogOfferConversion } from 'libs/algolia/analytics/logOfferConversion'
-import { campaignTracker, CampaignEvents } from 'libs/campaign'
-import { analytics } from 'libs/firebase/analytics'
 import { formatToFrenchDecimal } from 'libs/parsers'
 import { useSubcategoriesMapping } from 'libs/subcategories'
 import { Banner } from 'ui/components/Banner'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
-import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { Error } from 'ui/svg/icons/Error'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
-interface Props {
+export interface BookingDetailsProps {
   stocks: OfferStockResponse[]
-}
-
-const errorCodeToMessage: Record<string, string> = {
-  INSUFFICIENT_CREDIT:
-    'Attention, ton crédit est insuffisant pour pouvoir réserver cette offre\u00a0!',
-  ALREADY_BOOKED: 'Attention, il est impossible de réserver plusieurs fois la même offre\u00a0!',
-  STOCK_NOT_BOOKABLE: 'Oups, cette offre n’est plus disponible\u00a0!',
+  onPressBookOffer: VoidFunction
+  isLoading?: boolean
 }
 
 const LOADING_MESSAGES: RotatingTextOptions[] = [
@@ -53,60 +40,23 @@ const LOADING_MESSAGES: RotatingTextOptions[] = [
   },
 ]
 
-export const BookingDetails: React.FC<Props> = ({ stocks }) => {
+export const BookingDetails: React.FC<BookingDetailsProps> = ({
+  stocks,
+  onPressBookOffer,
+  isLoading,
+}) => {
   const theme = useTheme()
-  const { navigate } = useNavigation<UseNavigationType>()
-  const { bookingState, dismissModal, dispatch } = useBookingContext()
+
+  const { bookingState, dispatch } = useBookingContext()
   const selectedStock = useBookingStock()
   const offer = useBookingOffer()
-  const { showErrorSnackBar } = useSnackBarContext()
+
   const isUserUnderage = useIsUserUnderage()
   const mapping = useSubcategoriesMapping()
-  const { quantity, offerId } = bookingState
+  const { quantity } = bookingState
   const accessibilityDescribedBy = uuidv4()
-  const route = useRoute<UseRouteType<'Offer'>>()
-  const { logOfferConversion } = useLogOfferConversion()
-
-  const isFromSearch = route.params?.from === 'search'
-  const fromOfferId = route.params?.fromOfferId
-  const algoliaOfferId = offerId?.toString()
 
   const isEvent = offer?.subcategoryId ? mapping[offer?.subcategoryId]?.isEvent : undefined
-
-  const { mutate, isLoading } = useBookOfferMutation({
-    onSuccess: ({ bookingId }) => {
-      dismissModal()
-      if (offerId) {
-        analytics.logBookingConfirmation(offerId, bookingId, fromOfferId)
-        isFromSearch && algoliaOfferId && logOfferConversion(algoliaOfferId)
-
-        if (!!selectedStock && !!offer)
-          campaignTracker.logEvent(CampaignEvents.COMPLETE_BOOK_OFFER, {
-            af_offer_id: offer.id,
-            af_booking_id: selectedStock.id,
-            af_price: selectedStock.price,
-            af_category: offer.subcategoryId,
-          })
-        navigate('BookingConfirmation', { offerId, bookingId })
-      }
-    },
-    onError: (error) => {
-      dismissModal()
-      let message = 'En raison d’une erreur technique, l’offre n’a pas pu être réservée'
-
-      if (isApiError(error)) {
-        const { content } = error as { content: { code: string } }
-        if (content && content.code && content.code in errorCodeToMessage) {
-          message = errorCodeToMessage[content.code]
-          if (typeof offerId === 'number') {
-            analytics.logBookingError(offerId, content.code)
-          }
-        }
-      }
-
-      showErrorSnackBar({ message, timeout: SNACK_BAR_TIME_OUT })
-    },
-  })
 
   const loadingMessage = useRotatingText(LOADING_MESSAGES, isLoading)
 
@@ -134,14 +84,12 @@ export const BookingDetails: React.FC<Props> = ({ stocks }) => {
   const priceInCents = quantity * selectedStock.price
   const formattedPriceWithEuro = formatToFrenchDecimal(priceInCents)
 
-  const onPressBookOffer = () => mutate({ quantity, stockId: selectedStock.id })
-
   const deductedAmount = `${formattedPriceWithEuro} seront déduits de ton crédit pass Culture`
 
   const isStockBookable = !(isUserUnderage && selectedStock.isForbiddenToUnderage)
 
   return isLoading ? (
-    <Center>
+    <Center testID="loadingScreen">
       <Spacer.Column numberOfSpaces={50} />
       <ActivityIndicator size="large" color={theme.colors.primary} />
       <Spacer.Column numberOfSpaces={4} />

--- a/src/features/bookOffer/components/BookingEventChoices.tsx
+++ b/src/features/bookOffer/components/BookingEventChoices.tsx
@@ -6,7 +6,6 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { BookDateChoice } from 'features/bookOffer/components/BookDateChoice'
 import { BookDuoChoice } from 'features/bookOffer/components/BookDuoChoice'
 import { BookHourChoice } from 'features/bookOffer/components/BookHourChoice'
-import { BookingDetails } from 'features/bookOffer/components/BookingDetails'
 import { BookPricesChoice } from 'features/bookOffer/components/BookPricesChoice'
 import { Step } from 'features/bookOffer/context/reducer'
 import { useBookingContext } from 'features/bookOffer/context/useBookingContext'
@@ -40,10 +39,6 @@ export const BookingEventChoices: React.FC<Props> = ({
 
   const validateOptions = () => {
     dispatch({ type: 'VALIDATE_OPTIONS' })
-  }
-
-  if (bookingState.step === Step.CONFIRMATION) {
-    return <BookingDetails stocks={stocks} />
   }
 
   // We only need those 2 informations to book an offer (and thus proceed to the next page)

--- a/src/features/bookOffer/components/BookingOfferModalHeader.tsx
+++ b/src/features/bookOffer/components/BookingOfferModalHeader.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { useModalContent } from 'features/bookOffer/helpers/useModalContent'
 import { ModalHeader } from 'ui/components/modals/ModalHeader'
 import { ModalLeftIconProps } from 'ui/components/modals/types'
 import { Close } from 'ui/svg/icons/Close'
@@ -10,16 +9,10 @@ import { getSpacing, Spacer } from 'ui/theme'
 type Props = {
   modalLeftIconProps: ModalLeftIconProps
   onClose: VoidFunction
-  isEndedUsedBooking?: boolean
+  title: string
 }
 
-export const BookingOfferModalHeader = ({
-  modalLeftIconProps,
-  onClose,
-  isEndedUsedBooking,
-}: Props) => {
-  const { title } = useModalContent(isEndedUsedBooking)
-
+export const BookingOfferModalHeader = ({ modalLeftIconProps, onClose, title }: Props) => {
   return (
     <HeaderContainer>
       <ModalHeader

--- a/src/features/bookOffer/helpers/useModalContent.test.tsx
+++ b/src/features/bookOffer/helpers/useModalContent.test.tsx
@@ -40,6 +40,8 @@ jest.mock('libs/subcategories/useSubcategories', () => ({
   }),
 }))
 
+const onPressBookOffer = jest.fn()
+
 describe('useModalContent', () => {
   it('show default modal if no information yet', () => {
     mockOffer = undefined
@@ -195,7 +197,7 @@ describe('useModalContent', () => {
     mockOffer.subcategoryId = SubcategoryIdEnum.CINE_PLEIN_AIR
     mockStep = Step.CONFIRMATION
 
-    const { result } = renderHook(() => useModalContent(true))
+    const { result } = renderHook(() => useModalContent(onPressBookOffer, undefined, true))
 
     expect((result.current.children as any).type.name).toBe('AlreadyBooked')
     expect(result.current.onLeftIconPress).toBeUndefined()

--- a/src/features/bookOffer/helpers/useModalContent.tsx
+++ b/src/features/bookOffer/helpers/useModalContent.tsx
@@ -52,13 +52,19 @@ const getBookingImpossibleModalContent = (): ModalContent => {
   }
 }
 
-const getNonEventModalContent = (stocks: OfferStockResponse[]): ModalContent => {
+const getNonEventModalContent = (
+  stocks: OfferStockResponse[],
+  onPressBookOffer: VoidFunction,
+  isLoading?: boolean
+): ModalContent => {
   return {
     title: 'Détails de la réservation',
     leftIconAccessibilityLabel: undefined,
     leftIcon: undefined,
     onLeftIconPress: undefined,
-    children: <BookingDetails stocks={stocks} />,
+    children: (
+      <BookingDetails stocks={stocks} isLoading={isLoading} onPressBookOffer={onPressBookOffer} />
+    ),
   }
 }
 
@@ -83,16 +89,24 @@ const getBookingStepModalContent = (
 
 const getBookingDetailsModalContent = (
   stocks: OfferStockResponse[],
-  modalLeftIconProps: ModalLeftIconProps
+  modalLeftIconProps: ModalLeftIconProps,
+  onPressBookOffer: VoidFunction,
+  isLoading?: boolean
 ): ModalContent => {
   return {
     title: 'Détails de la réservation',
     ...modalLeftIconProps,
-    children: <BookingDetails stocks={stocks} />,
+    children: (
+      <BookingDetails stocks={stocks} isLoading={isLoading} onPressBookOffer={onPressBookOffer} />
+    ),
   }
 }
 
-export const useModalContent = (isEndedUsedBooking?: boolean): ModalContent => {
+export const useModalContent = (
+  onPressBookOffer: VoidFunction,
+  isLoading?: boolean,
+  isEndedUsedBooking?: boolean
+): ModalContent => {
   const { bookingState, dispatch } = useBookingContext()
   const offer = useBookingOffer()
   const mapping = useSubcategoriesMapping()
@@ -124,7 +138,7 @@ export const useModalContent = (isEndedUsedBooking?: boolean): ModalContent => {
       return getBookingImpossibleModalContent()
     }
 
-    return getNonEventModalContent(stocks)
+    return getNonEventModalContent(stocks, onPressBookOffer, isLoading)
   }
 
   if (bookingState.step !== Step.CONFIRMATION) {
@@ -157,5 +171,10 @@ export const useModalContent = (isEndedUsedBooking?: boolean): ModalContent => {
       goToPreviousStep(enablePricesByCategories ? previousBookingState : Step.PRE_VALIDATION),
   }
 
-  return getBookingDetailsModalContent(stocks, bookingDetailsModalLeftIconProps)
+  return getBookingDetailsModalContent(
+    stocks,
+    bookingDetailsModalLeftIconProps,
+    onPressBookOffer,
+    isLoading
+  )
 }

--- a/src/features/bookOffer/pages/BookingOfferModal.native.test.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.native.test.tsx
@@ -1,16 +1,22 @@
 import React from 'react'
 
+import { navigate, useRoute } from '__mocks__/@react-navigation/native'
+import { ApiError } from 'api/apiHelpers'
 import { OfferResponse } from 'api/gen'
 import * as Auth from 'features/auth/context/AuthContext'
+import * as useBookOfferMutation from 'features/bookOffer/api/useBookOfferMutation'
 import { BookingState, Step } from 'features/bookOffer/context/reducer'
 import { mockOffer as baseOffer } from 'features/bookOffer/fixtures/offer'
 import { mockStocks } from 'features/bookOffer/fixtures/stocks'
 import { IBookingContext } from 'features/bookOffer/types'
 import { beneficiaryUser } from 'fixtures/user'
+import * as logOfferConversionAPI from 'libs/algolia/analytics/logOfferConversion'
+import { CampaignEvents, campaignTracker } from 'libs/campaign'
 import { analytics } from 'libs/firebase/analytics'
 import * as useFeatureFlag from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { placeholderData as mockSubcategoriesData } from 'libs/subcategories/placeholderData'
 import { fireEvent, render, screen } from 'tests/utils'
+import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
 
 import { BookingOfferModalComponent } from './BookingOfferModal'
 
@@ -57,6 +63,36 @@ jest.spyOn(Auth, 'useAuthContext').mockReturnValue({
 jest.mock('react-query')
 
 const useFeatureFlagSpy = jest.spyOn(useFeatureFlag, 'useFeatureFlag').mockReturnValue(false)
+
+const useBookOfferMutationSpy = jest.spyOn(useBookOfferMutation, 'useBookOfferMutation')
+
+const mockUseMutationSuccess = () => {
+  // @ts-ignore we don't use the other properties of UseMutationResult (such as failureCount)
+  useBookOfferMutationSpy.mockImplementation(({ onSuccess }) => ({
+    mutate: jest.fn(() => onSuccess({ bookingId: 1 })),
+  }))
+}
+
+const mockUseMutationError = (error?: ApiError) => {
+  // @ts-ignore we don't use the other properties of UseMutationResult (such as failureCount)
+  useBookOfferMutationSpy.mockImplementation(({ onError }) => ({
+    // @ts-ignore it's a mock
+    mutate: jest.fn(() => onError(error)),
+  }))
+}
+
+const logOfferConversionSpy = jest.fn()
+jest
+  .spyOn(logOfferConversionAPI, 'useLogOfferConversion')
+  .mockReturnValue({ logOfferConversion: logOfferConversionSpy })
+
+const mockShowErrorSnackBar = jest.fn()
+jest.mock('ui/components/snackBar/SnackBarContext', () => ({
+  useSnackBarContext: () => ({
+    showErrorSnackBar: jest.fn((props: SnackBarHelperSettings) => mockShowErrorSnackBar(props)),
+  }),
+  SNACK_BAR_TIME_OUT: 5000,
+}))
 
 describe('<BookingOfferModalComponent />', () => {
   it('should dismiss modal when click on rightIconButton and reset state', () => {
@@ -190,6 +226,160 @@ describe('<BookingOfferModalComponent />', () => {
     it('should not display modal without prices by categories', () => {
       render(<BookingOfferModalComponent visible offerId={20} />)
       expect(screen.queryByTestId('modalWithoutPricesByCategories')).toBeNull()
+    })
+  })
+
+  describe('when booking step is confirmation', () => {
+    beforeEach(() => {
+      mockUseBookingContext.mockReturnValue({
+        bookingState: {
+          offerId: mockOffer.id,
+          step: Step.CONFIRMATION,
+          quantity: 1,
+          stockId: mockOffer.stocks[0].id,
+        } as BookingState,
+        dismissModal: mockDismissModal,
+        dispatch: mockDispatch,
+      })
+      mockUseMutationSuccess()
+    })
+
+    describe('when booking validated', () => {
+      it('should dismiss the modal on success', () => {
+        render(<BookingOfferModalComponent visible offerId={20} />)
+        fireEvent.press(screen.getByText('Confirmer la réservation'))
+        expect(mockDismissModal).toHaveBeenCalledTimes(1)
+      })
+
+      it('should log confirmation booking when offer booked from a similar offer', () => {
+        useRoute.mockReturnValueOnce({
+          params: { fromOfferId: 1 },
+        })
+        render(<BookingOfferModalComponent visible offerId={20} />)
+        fireEvent.press(screen.getByText('Confirmer la réservation'))
+        expect(analytics.logBookingConfirmation).toHaveBeenCalledWith(20, 1, 1)
+      })
+
+      it('should log confirmation booking when offer not booked from a similar offer', () => {
+        render(<BookingOfferModalComponent visible offerId={20} />)
+        fireEvent.press(screen.getByText('Confirmer la réservation'))
+        expect(analytics.logBookingConfirmation).toHaveBeenCalledWith(20, 1, undefined)
+      })
+
+      it('should log conversion booking when is from search', () => {
+        useRoute.mockReturnValueOnce({
+          params: { from: 'search' },
+        })
+        render(<BookingOfferModalComponent visible offerId={20} />)
+
+        fireEvent.press(screen.getByText('Confirmer la réservation'))
+
+        expect(logOfferConversionSpy).toHaveBeenCalledWith('20')
+      })
+
+      it('should not log conversion booking when is not from search', async () => {
+        render(<BookingOfferModalComponent visible offerId={20} />)
+
+        fireEvent.press(screen.getByText('Confirmer la réservation'))
+
+        expect(logOfferConversionSpy).not.toHaveBeenCalled()
+      })
+
+      it('should log campaign tracker when booking is complete', () => {
+        render(<BookingOfferModalComponent visible offerId={mockOffer.id} />)
+        fireEvent.press(screen.getByText('Confirmer la réservation'))
+        expect(campaignTracker.logEvent).toHaveBeenCalledWith(CampaignEvents.COMPLETE_BOOK_OFFER, {
+          af_offer_id: mockOffer.id,
+          af_booking_id: mockOffer.stocks[0].id,
+          af_price: mockOffer.stocks[0].price,
+          af_category: mockOffer.subcategoryId,
+        })
+      })
+
+      it('should navigate to booking confirmation when booking is complete', () => {
+        render(<BookingOfferModalComponent visible offerId={20} />)
+        fireEvent.press(screen.getByText('Confirmer la réservation'))
+        expect(navigate).toHaveBeenCalledWith('BookingConfirmation', { offerId: 20, bookingId: 1 })
+      })
+    })
+
+    describe('when booking failed', () => {
+      beforeEach(() => {
+        mockUseBookingContext.mockReturnValue({
+          bookingState: {
+            offerId: mockOffer.id,
+            step: Step.CONFIRMATION,
+            quantity: 1,
+            stockId: mockOffer.stocks[0].id,
+          } as BookingState,
+          dismissModal: mockDismissModal,
+          dispatch: mockDispatch,
+        })
+      })
+
+      it('should dismiss the modal on error', () => {
+        mockUseMutationError({
+          content: {},
+          name: 'ApiError',
+          statusCode: 400,
+          message: 'erreur',
+        })
+        render(<BookingOfferModalComponent visible offerId={20} />)
+        fireEvent.press(screen.getByText('Confirmer la réservation'))
+
+        expect(mockDismissModal).toHaveBeenCalledTimes(1)
+      })
+
+      it('should log booking error when error is known', async () => {
+        mockUseMutationError({
+          content: { code: 'INSUFFICIENT_CREDIT' },
+          name: 'ApiError',
+          statusCode: 400,
+          message: 'erreur',
+        })
+        render(<BookingOfferModalComponent visible offerId={20} />)
+
+        fireEvent.press(screen.getByText('Confirmer la réservation'))
+
+        expect(analytics.logBookingError).toHaveBeenNthCalledWith(1, 20, 'INSUFFICIENT_CREDIT')
+      })
+
+      it('should log booking error when error is unknown', async () => {
+        mockUseMutationError({
+          content: {},
+          name: 'ApiError',
+          statusCode: 400,
+          message: 'erreur',
+        })
+        render(<BookingOfferModalComponent visible offerId={20} />)
+
+        fireEvent.press(screen.getByText('Confirmer la réservation'))
+
+        expect(analytics.logBookingError).not.toHaveBeenCalled()
+      })
+
+      it.each`
+        code                     | message
+        ${undefined}             | ${'En raison d’une erreur technique, l’offre n’a pas pu être réservée'}
+        ${'INSUFFICIENT_CREDIT'} | ${'Attention, ton crédit est insuffisant pour pouvoir réserver cette offre\u00a0!'}
+        ${'ALREADY_BOOKED'}      | ${'Attention, il est impossible de réserver plusieurs fois la même offre\u00a0!'}
+        ${'STOCK_NOT_BOOKABLE'}  | ${'Oups, cette offre n’est plus disponible\u00a0!'}
+      `(
+        'should show the error snackbar with message="$message" for errorCode="code" if booking an offer fails',
+        ({ code, message }: { code: string | undefined; message: string }) => {
+          mockUseMutationError({
+            content: { code },
+            name: 'ApiError',
+            statusCode: 400,
+            message: 'erreur',
+          })
+          render(<BookingOfferModalComponent visible offerId={20} />)
+
+          fireEvent.press(screen.getByText('Confirmer la réservation'))
+
+          expect(mockShowErrorSnackBar).toHaveBeenNthCalledWith(1, { timeout: 5000, message })
+        }
+      )
     })
   })
 })

--- a/src/features/bookOffer/pages/BookingOfferModal.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.tsx
@@ -135,15 +135,15 @@ export const BookingOfferModalComponent: React.FC<Props> = ({
 
   const {
     visible: bookingCloseInformationModalVisible,
-    showModal: showBookingCloseInformationModalVisible,
-    hideModal: hideBookingCloseInformationModalVisible,
+    showModal: showBookingCloseInformationModal,
+    hideModal: hideBookingCloseInformationModal,
   } = useModal(false)
 
   const onClose = useCallback(() => {
     dismissModal()
     dispatch({ type: 'RESET' })
     if (isLoading && title.includes('Détails de la réservation')) {
-      showBookingCloseInformationModalVisible()
+      showBookingCloseInformationModal()
     }
     if (enablePricesByCategories) analytics.logCancelBookingFunnel(step, offerId)
   }, [
@@ -154,7 +154,7 @@ export const BookingOfferModalComponent: React.FC<Props> = ({
     step,
     isLoading,
     title,
-    showBookingCloseInformationModalVisible,
+    showBookingCloseInformationModal,
   ])
 
   return enablePricesByCategories ? (
@@ -181,7 +181,7 @@ export const BookingOfferModalComponent: React.FC<Props> = ({
       </AppModal>
       <BookingCloseInformation
         visible={bookingCloseInformationModalVisible}
-        hideModal={hideBookingCloseInformationModalVisible}
+        hideModal={hideBookingCloseInformationModal}
       />
     </React.Fragment>
   ) : (

--- a/src/features/bookOffer/pages/BookingOfferModal.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.tsx
@@ -1,20 +1,30 @@
+import { useNavigation, useRoute } from '@react-navigation/native'
 import React, { useCallback, useEffect, useMemo } from 'react'
 import { useWindowDimensions } from 'react-native'
 import { useTheme } from 'styled-components/native'
 
+import { isApiError } from 'api/apiHelpers'
+import { useBookOfferMutation } from 'features/bookOffer/api/useBookOfferMutation'
+import { BookingCloseInformation } from 'features/bookOffer/components/BookingCloseInformation'
 import { BookingOfferModalFooter } from 'features/bookOffer/components/BookingOfferModalFooter'
 import { BookingOfferModalHeader } from 'features/bookOffer/components/BookingOfferModalHeader'
 import { BookingWrapper } from 'features/bookOffer/context/BookingWrapper'
 import { Step } from 'features/bookOffer/context/reducer'
 import { useBookingContext } from 'features/bookOffer/context/useBookingContext'
 import { getStockWithCategory } from 'features/bookOffer/helpers/bookingHelpers/bookingHelpers'
+import { useBookingStock } from 'features/bookOffer/helpers/useBookingStock'
 import { useModalContent } from 'features/bookOffer/helpers/useModalContent'
+import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { useOffer } from 'features/offer/api/useOffer'
+import { useLogOfferConversion } from 'libs/algolia/analytics/logOfferConversion'
+import { CampaignEvents, campaignTracker } from 'libs/campaign'
 import { analytics } from 'libs/firebase/analytics'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { ModalLeftIconProps } from 'ui/components/modals/types'
+import { useModal } from 'ui/components/modals/useModal'
+import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { Close } from 'ui/svg/icons/Close'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
@@ -24,6 +34,13 @@ interface Props {
   isEndedUsedBooking?: boolean
 }
 
+export const errorCodeToMessage: Record<string, string> = {
+  INSUFFICIENT_CREDIT:
+    'Attention, ton crédit est insuffisant pour pouvoir réserver cette offre\u00a0!',
+  ALREADY_BOOKED: 'Attention, il est impossible de réserver plusieurs fois la même offre\u00a0!',
+  STOCK_NOT_BOOKABLE: 'Oups, cette offre n’est plus disponible\u00a0!',
+}
+
 export const BookingOfferModalComponent: React.FC<Props> = ({
   visible,
   offerId,
@@ -31,8 +48,59 @@ export const BookingOfferModalComponent: React.FC<Props> = ({
 }) => {
   const { dismissModal, dispatch, bookingState } = useBookingContext()
   const { step } = bookingState
+  const { navigate } = useNavigation<UseNavigationType>()
+  const { logOfferConversion } = useLogOfferConversion()
+  const route = useRoute<UseRouteType<'Offer'>>()
+  const selectedStock = useBookingStock()
+  const { showErrorSnackBar } = useSnackBarContext()
+
+  const isFromSearch = route.params?.from === 'search'
+  const fromOfferId = route.params?.fromOfferId
+  const algoliaOfferId = offerId?.toString()
+
+  const { mutate, isLoading } = useBookOfferMutation({
+    onSuccess: ({ bookingId }) => {
+      dismissModal()
+      if (offerId) {
+        analytics.logBookingConfirmation(offerId, bookingId, fromOfferId)
+        isFromSearch && algoliaOfferId && logOfferConversion(algoliaOfferId)
+
+        if (!!selectedStock && !!offer)
+          campaignTracker.logEvent(CampaignEvents.COMPLETE_BOOK_OFFER, {
+            af_offer_id: offer.id,
+            af_booking_id: selectedStock.id,
+            af_price: selectedStock.price,
+            af_category: offer.subcategoryId,
+          })
+        navigate('BookingConfirmation', { offerId, bookingId })
+      }
+    },
+    onError: (error) => {
+      dismissModal()
+      let message = 'En raison d’une erreur technique, l’offre n’a pas pu être réservée'
+
+      if (isApiError(error)) {
+        const { content } = error as { content: { code: string } }
+        if (content && content.code && content.code in errorCodeToMessage) {
+          message = errorCodeToMessage[content.code]
+          if (typeof offerId === 'number') {
+            analytics.logBookingError(offerId, content.code)
+          }
+        }
+      }
+
+      showErrorSnackBar({ message, timeout: SNACK_BAR_TIME_OUT })
+    },
+  })
+
+  const onPressBookOffer = () => {
+    if (bookingState.quantity && bookingState.stockId) {
+      mutate({ quantity: bookingState.quantity, stockId: bookingState.stockId })
+    }
+  }
+
   const { title, leftIconAccessibilityLabel, leftIcon, onLeftIconPress, children } =
-    useModalContent(isEndedUsedBooking)
+    useModalContent(onPressBookOffer, isLoading, isEndedUsedBooking)
   const enablePricesByCategories = useFeatureFlag(RemoteStoreFeatureFlags.WIP_PRICES_BY_CATEGORIES)
 
   const { height } = useWindowDimensions()
@@ -65,33 +133,57 @@ export const BookingOfferModalComponent: React.FC<Props> = ({
   const shouldAddSpacerBetweenHeaderAndContent =
     !enablePricesByCategories || (enablePricesByCategories && step === Step.CONFIRMATION)
 
+  const {
+    visible: bookingCloseInformationModalVisible,
+    showModal: showBookingCloseInformationModalVisible,
+    hideModal: hideBookingCloseInformationModalVisible,
+  } = useModal(false)
+
   const onClose = useCallback(() => {
     dismissModal()
     dispatch({ type: 'RESET' })
+    if (isLoading && title.includes('Détails de la réservation')) {
+      showBookingCloseInformationModalVisible()
+    }
     if (enablePricesByCategories) analytics.logCancelBookingFunnel(step, offerId)
-  }, [dismissModal, dispatch, enablePricesByCategories, offerId, step])
+  }, [
+    dismissModal,
+    dispatch,
+    enablePricesByCategories,
+    offerId,
+    step,
+    isLoading,
+    title,
+    showBookingCloseInformationModalVisible,
+  ])
 
   return enablePricesByCategories ? (
-    <AppModal
-      testID="modalWithPricesByCategories"
-      noPadding
-      visible={visible}
-      title={title}
-      maxHeight={height - top}
-      modalSpacing={modal.spacing.MD}
-      customModalHeader={
-        <BookingOfferModalHeader
-          onClose={onClose}
-          modalLeftIconProps={modalLeftIconProps}
-          isEndedUsedBooking={isEndedUsedBooking}
-        />
-      }
-      fixedModalBottom={
-        <BookingOfferModalFooter hasPricesStep={hasPricesStep} isDuo={offer?.isDuo} />
-      }
-      shouldAddSpacerBetweenHeaderAndContent={shouldAddSpacerBetweenHeaderAndContent}>
-      {children}
-    </AppModal>
+    <React.Fragment>
+      <AppModal
+        testID="modalWithPricesByCategories"
+        noPadding
+        visible={visible}
+        title={title}
+        maxHeight={height - top}
+        modalSpacing={modal.spacing.MD}
+        customModalHeader={
+          <BookingOfferModalHeader
+            onClose={onClose}
+            modalLeftIconProps={modalLeftIconProps}
+            isEndedUsedBooking={isEndedUsedBooking}
+          />
+        }
+        fixedModalBottom={
+          <BookingOfferModalFooter hasPricesStep={hasPricesStep} isDuo={offer?.isDuo} />
+        }
+        shouldAddSpacerBetweenHeaderAndContent={shouldAddSpacerBetweenHeaderAndContent}>
+        {children}
+      </AppModal>
+      <BookingCloseInformation
+        visible={bookingCloseInformationModalVisible}
+        hideModal={hideBookingCloseInformationModalVisible}
+      />
+    </React.Fragment>
   ) : (
     <AppModal
       testID="modalWithoutPricesByCategories"

--- a/src/features/bookOffer/pages/BookingOfferModal.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.tsx
@@ -170,7 +170,7 @@ export const BookingOfferModalComponent: React.FC<Props> = ({
           <BookingOfferModalHeader
             onClose={onClose}
             modalLeftIconProps={modalLeftIconProps}
-            isEndedUsedBooking={isEndedUsedBooking}
+            title={title}
           />
         }
         fixedModalBottom={

--- a/src/ui/svg/icons/BicolorInfo.tsx
+++ b/src/ui/svg/icons/BicolorInfo.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import { Defs, LinearGradient, Path, Stop } from 'react-native-svg'
+import styled from 'styled-components/native'
+
+import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
+import { svgIdentifier } from 'ui/svg/utils'
+
+import { AccessibleIcon } from './types'
+
+const BicolorInfoSvg: React.FunctionComponent<AccessibleIcon> = ({
+  size,
+  color,
+  color2,
+  accessibilityLabel,
+  testID,
+}) => {
+  const { id: gradientId, fill: gradientFill } = svgIdentifier()
+  return (
+    <AccessibleSvg
+      width={size}
+      height={size}
+      viewBox="0 0 136 136"
+      accessibilityLabel={accessibilityLabel}
+      testID={testID}
+      fill={gradientFill}>
+      <Defs>
+        <LinearGradient id={gradientId} x1="28.841%" x2="71.159%" y1="0%" y2="100%">
+          <Stop offset="0%" stopColor={color} />
+          <Stop offset="100%" stopColor={color2} />
+        </LinearGradient>
+      </Defs>
+      <Path
+        fill={gradientFill}
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M68 13.9091C38.121 13.9091 13.9091 38.121 13.9091 68C13.9091 97.879 38.121 122.091 68 122.091C97.879 122.091 122.091 97.879 122.091 68C122.091 58.6732 119.722 49.8934 115.55 42.2192C114.836 40.9069 115.322 39.2648 116.634 38.5514C117.946 37.838 119.589 38.3235 120.302 39.6358C124.893 48.0807 127.5 57.7459 127.5 68C127.5 100.866 100.866 127.5 68 127.5C35.1336 127.5 8.5 100.866 8.5 68C8.5 35.1336 35.1336 8.5 68 8.5C78.1087 8.5 87.6621 11.0209 96.0012 15.5025C97.3169 16.2095 97.8103 17.8493 97.1032 19.1651C96.3961 20.4808 94.7563 20.9742 93.4406 20.2671C85.877 16.2023 77.2018 13.9091 68 13.9091ZM64.4583 92.7917C64.4583 90.8357 66.044 89.25 68 89.25C69.956 89.25 71.5417 90.8357 71.5417 92.7917C71.5417 94.7477 69.956 96.3333 68 96.3333C66.044 96.3333 64.4583 94.7477 64.4583 92.7917ZM70.8333 42.3619C70.8333 40.8733 69.5648 39.6667 68 39.6667C66.4352 39.6667 65.1667 40.8733 65.1667 42.3619V76.6381C65.1667 78.1266 66.4352 79.3333 68 79.3333C69.5648 79.3333 70.8333 78.1266 70.8333 76.6381V42.3619Z"
+      />
+    </AccessibleSvg>
+  )
+}
+
+export const BicolorInfo = styled(BicolorInfoSvg).attrs(({ color, color2, size, theme }) => ({
+  color: color ?? theme.colors.primary,
+  color2: color2 ?? theme.colors.secondary,
+  size: size ?? theme.icons.sizes.standard,
+}))``


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-21120

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |<img width="428" alt="Capture d’écran 2023-03-28 à 15 21 09" src="https://user-images.githubusercontent.com/62058919/228250231-4e38b691-57c3-496f-9160-8bf92da8c78b.png">|
| Android          |        |<img width="412" alt="Capture d’écran 2023-03-28 à 14 53 03" src="https://user-images.githubusercontent.com/62058919/228242322-0e064405-111a-4551-9827-bb699cf637e0.png">|
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |<img width="1282" alt="Capture d’écran 2023-03-28 à 14 58 28" src="https://user-images.githubusercontent.com/62058919/228243745-0b83e7d0-c1f3-404c-b069-6027728cd693.png">|
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
