### PR TITLE
(PC-21145) fix(bookOffer): duo icon color choice

### DIFF
--- a/src/features/bookOffer/components/DuoChoice.tsx
+++ b/src/features/bookOffer/components/DuoChoice.tsx
@@ -29,6 +29,7 @@ export const DuoChoice: React.FC<Props> = ({
   const StyledIcon = styled(Icon).attrs(({ theme }) => ({
     size: theme.icons.sizes.small,
     color: getTextColor(theme, selected, disabled),
+    color2: getTextColor(theme, selected, disabled),
   }))``
 
   const accessibilityLabel = `${title} ${price}`


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-21145

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome | <img width="258" alt="CleanShot 2023-03-24 at 10 53 17@2x" src="https://user-images.githubusercontent.com/114916654/227488572-6601abb7-6d51-4501-9dd4-641db4aa01c6.png"> | <img width="244" alt="CleanShot 2023-03-24 at 10 54 12@2x" src="https://user-images.githubusercontent.com/114916654/227488714-2e957295-2974-4488-bf61-1cbf762daae6.png"> |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
