### PR TITLE
(PC-19699) fix(recommendation): improve geolocation typing to fix recommendation api call

### DIFF
--- a/src/features/favorites/components/FavoritesResults.tsx
+++ b/src/features/favorites/components/FavoritesResults.tsx
@@ -18,7 +18,7 @@ import {
   sortByIdDesc,
 } from 'features/favorites/helpers/sorts'
 import { FavoriteSortBy } from 'features/favorites/types'
-import { useGeolocation, GeoCoordinates } from 'libs/geolocation'
+import { useGeolocation, Position } from 'libs/geolocation'
 import { useIsFalseWithDelay } from 'libs/hooks/useIsFalseWithDelay'
 import { storage } from 'libs/storage'
 import { useAvailableCredit } from 'shared/user/useAvailableCredit'
@@ -31,11 +31,7 @@ import { TAB_BAR_COMP_HEIGHT } from 'ui/theme/constants'
 
 const keyExtractor = (item: FavoriteResponse) => item.id.toString()
 
-function applySortBy(
-  list: Array<FavoriteResponse>,
-  sortBy: FavoriteSortBy,
-  position: GeoCoordinates | null
-) {
+function applySortBy(list: Array<FavoriteResponse>, sortBy: FavoriteSortBy, position: Position) {
   if (!list) {
     // fix concurrency sentry/issues/288586
     return []

--- a/src/features/favorites/helpers/sorts.ts
+++ b/src/features/favorites/helpers/sorts.ts
@@ -27,7 +27,7 @@ export function sortByIdDesc(a: FavoriteResponse, b: FavoriteResponse) {
 
 export function sortByDistanceAroundMe(position: Position) {
   return (a: FavoriteResponse, b: FavoriteResponse) => {
-    if (position === null) return 0
+    if (!position) return 0
 
     let aCoordinate, bCoordinate
     if (a.offer.coordinates?.latitude && a.offer.coordinates?.longitude) {

--- a/src/features/favorites/helpers/sorts.ts
+++ b/src/features/favorites/helpers/sorts.ts
@@ -1,5 +1,5 @@
 import { FavoriteResponse } from 'api/gen'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 import { computeDistanceInMeters } from 'libs/parsers'
 
 function getOfferPrice({ offer }: FavoriteResponse): number | null {
@@ -25,7 +25,7 @@ export function sortByIdDesc(a: FavoriteResponse, b: FavoriteResponse) {
   return b.id - a.id
 }
 
-export function sortByDistanceAroundMe(position: GeoCoordinates | null) {
+export function sortByDistanceAroundMe(position: Position) {
   return (a: FavoriteResponse, b: FavoriteResponse) => {
     if (position === null) return 0
 

--- a/src/features/favorites/pages/FavoritesSorts.native.test.tsx
+++ b/src/features/favorites/pages/FavoritesSorts.native.test.tsx
@@ -11,6 +11,7 @@ import {
   GeolocationError,
   GeoCoordinates,
   GEOLOCATION_USER_ERROR_MESSAGE,
+  Position,
 } from 'libs/geolocation'
 import { fireEvent, render, waitFor } from 'tests/utils'
 
@@ -20,7 +21,7 @@ jest.mock('features/favorites/context/FavoritesWrapper', () =>
 
 const DEFAULT_POSITION = { latitude: 66, longitude: 66 } as GeoCoordinates
 let mockPermissionState = GeolocPermissionState.GRANTED
-let mockPosition: GeoCoordinates | null = DEFAULT_POSITION
+let mockPosition: Position = DEFAULT_POSITION
 let mockPositionError: GeolocationError | null = null
 const mockTriggerPositionUpdate = jest.fn()
 const mockShowGeolocPermissionModal = jest.fn()

--- a/src/features/favorites/pages/FavoritesSorts.web.test.tsx
+++ b/src/features/favorites/pages/FavoritesSorts.web.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { FavoritesWrapper } from 'features/favorites/context/FavoritesWrapper'
 import { FavoritesSorts } from 'features/favorites/pages/FavoritesSorts'
-import { GeolocPermissionState, GeolocationError, GeoCoordinates } from 'libs/geolocation'
+import { GeolocPermissionState, GeolocationError, GeoCoordinates, Position } from 'libs/geolocation'
 import { render, checkAccessibilityFor } from 'tests/utils/web'
 
 jest.mock('features/favorites/context/FavoritesWrapper', () =>
@@ -11,7 +11,7 @@ jest.mock('features/favorites/context/FavoritesWrapper', () =>
 
 const DEFAULT_POSITION = { latitude: 66, longitude: 66 } as GeoCoordinates
 const mockPermissionState = GeolocPermissionState.GRANTED
-const mockPosition: GeoCoordinates | null = DEFAULT_POSITION
+const mockPosition: Position = DEFAULT_POSITION
 const mockPositionError: GeolocationError | null = null
 
 jest.mock('libs/geolocation/GeolocationWrapper', () => ({

--- a/src/features/home/api/helpers/getRecommendationEndpoint.native.test.ts
+++ b/src/features/home/api/helpers/getRecommendationEndpoint.native.test.ts
@@ -16,6 +16,27 @@ describe('getRecommendationEndpoint', () => {
     })
     expect(endpoint).toBeUndefined()
   })
+
+  it('should return undefined when position is not yet retrived', () => {
+    const endpoint = getRecommendationEndpoint({
+      userId: mockUserId,
+      position: undefined,
+      modelEndpoint: undefined,
+    })
+    expect(endpoint).toBeUndefined()
+  })
+
+  it('should return endpoint with position is denied', () => {
+    const endpoint = getRecommendationEndpoint({
+      userId: mockUserId,
+      position: null,
+      modelEndpoint: undefined,
+    })
+    expect(endpoint).toEqual(
+      `${env.RECOMMENDATION_ENDPOINT}/playlist_recommendation/${mockUserId}?token=${env.RECOMMENDATION_TOKEN}`
+    )
+  })
+
   it('should return endpoint with latitude and longitude query params when position is provided', () => {
     const modelEndpoint = undefined
     const endpoint = getRecommendationEndpoint({ userId: mockUserId, position, modelEndpoint })
@@ -23,6 +44,7 @@ describe('getRecommendationEndpoint', () => {
       `${env.RECOMMENDATION_ENDPOINT}/playlist_recommendation/${mockUserId}?token=${env.RECOMMENDATION_TOKEN}&longitude=${position.longitude}&latitude=${position.latitude}`
     )
   })
+
   it('should return endpoint with endpoint query params when a endpoint is provided', () => {
     const modelEndpoint = 'endpoint'
     const endpoint = getRecommendationEndpoint({ userId: mockUserId, position, modelEndpoint })

--- a/src/features/home/api/helpers/getRecommendationEndpoint.ts
+++ b/src/features/home/api/helpers/getRecommendationEndpoint.ts
@@ -1,5 +1,5 @@
 import { env } from 'libs/environment'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 
 export const getRecommendationEndpoint = ({
   userId,
@@ -7,7 +7,7 @@ export const getRecommendationEndpoint = ({
   modelEndpoint,
 }: {
   userId: number | undefined
-  position: GeoCoordinates | null
+  position: Position
   modelEndpoint: string | undefined
 }): string | undefined => {
   let queryParams = ''

--- a/src/features/home/api/helpers/getRecommendationEndpoint.ts
+++ b/src/features/home/api/helpers/getRecommendationEndpoint.ts
@@ -12,6 +12,7 @@ export const getRecommendationEndpoint = ({
 }): string | undefined => {
   let queryParams = ''
   if (!userId) return undefined
+  if (position === undefined) return undefined
   const endpoint = `${env.RECOMMENDATION_ENDPOINT}/playlist_recommendation/${userId}?token=${env.RECOMMENDATION_TOKEN}`
   if (modelEndpoint) {
     queryParams = queryParams + `&modelEndpoint=${modelEndpoint}`

--- a/src/features/home/api/useHomeRecommendedHits.ts
+++ b/src/features/home/api/useHomeRecommendedHits.ts
@@ -6,7 +6,7 @@ import { getRecommendationEndpoint } from 'features/home/api/helpers/getRecommen
 import { RecommendedOffersModule } from 'features/home/types'
 import { SearchHit } from 'libs/algolia'
 import { getCategoriesFacetFilters } from 'libs/algolia/fetchAlgolia/buildAlgoliaParameters/getCategoriesFacetFilters'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 import { RecommendedIdsRequest } from 'libs/recommendation/types'
 import { useHomeRecommendedIdsMutation } from 'libs/recommendation/useHomeRecommendedIdsMutation'
 import { useSubcategoryLabelMapping } from 'libs/subcategories/mappings'
@@ -51,7 +51,7 @@ export function getRecommendationParameters(
 
 export const useHomeRecommendedHits = (
   userId: number | undefined,
-  position: GeoCoordinates | null,
+  position: Position,
   moduleId: string,
   recommendationParameters?: RecommendedOffersModule['recommendationParameters']
 ): SearchHit[] | undefined => {

--- a/src/features/home/components/modules/exclusivity/helpers/useShouldDisplayExcluOffer.native.test.ts
+++ b/src/features/home/components/modules/exclusivity/helpers/useShouldDisplayExcluOffer.native.test.ts
@@ -6,7 +6,7 @@ import { useShouldDisplayExcluOffer } from 'features/home/components/modules/exc
 import { ExclusivityModule } from 'features/home/types'
 import { offerResponseSnap as mockOffer } from 'features/offer/fixtures/offerResponse'
 import { useMaxPrice } from 'features/search/helpers/useMaxPrice/useMaxPrice'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 import { renderHook } from 'tests/utils'
 
 let display: ExclusivityModule['displayParameters'] = {
@@ -14,7 +14,7 @@ let display: ExclusivityModule['displayParameters'] = {
   isGeolocated: true,
 }
 
-let mockPosition: GeoCoordinates | null = null
+let mockPosition: Position = null
 jest.mock('libs/geolocation/GeolocationWrapper', () => ({
   useGeolocation: () => ({
     position: mockPosition,

--- a/src/features/home/components/modules/venues/VenueTile.tsx
+++ b/src/features/home/components/modules/venues/VenueTile.tsx
@@ -9,7 +9,7 @@ import { VenueDetails } from 'features/home/components/modules/venues/VenueDetai
 import { VenueTypeLocationIcon } from 'features/home/components/VenueTypeLocationIcon'
 import { VenueHit } from 'libs/algolia'
 import { analytics } from 'libs/firebase/analytics'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 import { useHandleFocus } from 'libs/hooks/useHandleFocus'
 import { formatDistance, mapVenueTypeToIcon } from 'libs/parsers'
 import { QueryKeys } from 'libs/queryKeys'
@@ -27,7 +27,7 @@ export interface VenueTileProps {
   homeEntryId?: string
   width: number
   height: number
-  userPosition: GeoCoordinates | null
+  userPosition: Position
 }
 
 const mergeVenueData =

--- a/src/features/profile/pages/Profile.native.test.tsx
+++ b/src/features/profile/pages/Profile.native.test.tsx
@@ -16,6 +16,7 @@ import {
   GeolocationError,
   GeoCoordinates,
   GEOLOCATION_USER_ERROR_MESSAGE,
+  Position,
 } from 'libs/geolocation'
 import { useNetInfoContext as useNetInfoContextDefault } from 'libs/network/NetInfoWrapper'
 import {
@@ -56,7 +57,7 @@ jest.mock('features/auth/helpers/useLogoutRoutine', () => ({
 
 const DEFAULT_POSITION = { latitude: 66, longitude: 66 } as GeoCoordinates
 let mockPermissionState = GeolocPermissionState.GRANTED
-let mockPosition: GeoCoordinates | null = DEFAULT_POSITION
+let mockPosition: Position = DEFAULT_POSITION
 let mockPositionError: GeolocationError | null = null
 const mockTriggerPositionUpdate = jest.fn()
 const mockShowGeolocPermissionModal = jest.fn()

--- a/src/features/search/components/NumberOfResults/NumberOfResults.native.test.tsx
+++ b/src/features/search/components/NumberOfResults/NumberOfResults.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { LocationType } from 'features/search/enums'
 import { LocationFilter } from 'features/search/types'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 import { mockedSuggestedVenues } from 'libs/venue/fixtures/mockedSuggestedVenues'
 import { render } from 'tests/utils'
 
@@ -10,7 +10,7 @@ import { NumberOfResults } from './NumberOfResults'
 
 jest.mock('react-query')
 
-const mockPosition: GeoCoordinates | null = null
+const mockPosition: Position = null
 jest.mock('libs/geolocation', () => ({
   useGeolocation: jest.fn(() => ({ position: mockPosition })),
 }))

--- a/src/features/search/components/SearchBox/SearchBox.native.test.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.native.test.tsx
@@ -11,7 +11,7 @@ import * as useFilterCountAPI from 'features/search/helpers/useFilterCount/useFi
 import { LocationFilter, SearchState, SearchView } from 'features/search/types'
 import { Venue } from 'features/venue/types'
 import { analytics } from 'libs/firebase/analytics'
-import { GeoCoordinates } from 'libs/geolocation'
+import { GeoCoordinates, Position } from 'libs/geolocation'
 import { SuggestedPlace } from 'libs/place'
 import { mockedSuggestedVenues } from 'libs/venue/fixtures/mockedSuggestedVenues'
 import { fireEvent, render, act, waitFor } from 'tests/utils'
@@ -64,7 +64,7 @@ jest.mock('features/auth/context/SettingsContext', () => ({
 }))
 
 const DEFAULT_POSITION: GeoCoordinates = { latitude: 2, longitude: 40 }
-let mockPosition: GeoCoordinates | null = DEFAULT_POSITION
+let mockPosition: Position = DEFAULT_POSITION
 
 jest.mock('libs/geolocation/GeolocationWrapper', () => ({
   useGeolocation: () => ({
@@ -407,7 +407,7 @@ describe('SearchBox component', () => {
       locationButtonLabel,
     }: {
       locationFilter: LocationFilter
-      position: GeoCoordinates | null
+      position: Position
       locationButtonLabel: string
     }) => {
       mockSearchState = { ...initialSearchState, locationFilter }

--- a/src/features/search/components/SearchResults/SearchResults.native.test.tsx
+++ b/src/features/search/components/SearchResults/SearchResults.native.test.tsx
@@ -14,7 +14,7 @@ import { beneficiaryUser, nonBeneficiaryUser } from 'fixtures/user'
 import { SearchHit } from 'libs/algolia'
 import { mockedAlgoliaResponse } from 'libs/algolia/__mocks__/mockedAlgoliaResponse'
 import { analytics } from 'libs/firebase/analytics'
-import { GeoCoordinates } from 'libs/geolocation'
+import { GeoCoordinates, Position } from 'libs/geolocation'
 import { SuggestedPlace } from 'libs/place'
 import { placeholderData as mockSubcategoriesData } from 'libs/subcategories/placeholderData'
 import { mockedSuggestedVenues } from 'libs/venue/fixtures/mockedSuggestedVenues'
@@ -79,7 +79,7 @@ jest.mock('features/auth/context/SettingsContext', () => ({
 }))
 
 const DEFAULT_POSITION = { latitude: 2, longitude: 40 } as GeoCoordinates
-let mockPosition: GeoCoordinates | null = DEFAULT_POSITION
+let mockPosition: Position = DEFAULT_POSITION
 const mockShowGeolocPermissionModal = jest.fn()
 
 jest.mock('libs/geolocation/GeolocationWrapper', () => ({
@@ -392,7 +392,7 @@ describe('SearchResults component', () => {
         locationButtonLabel,
       }: {
         locationFilter: LocationFilter
-        position: GeoCoordinates | null
+        position: Position
         locationButtonLabel: string
       }) => {
         mockPosition = position

--- a/src/features/search/components/SearchResults/SearchResults.web.test.tsx
+++ b/src/features/search/components/SearchResults/SearchResults.web.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { GeoCoordinates } from 'libs/geolocation'
+import { GeoCoordinates, Position } from 'libs/geolocation'
 import { render, screen } from 'tests/utils/web'
 
 import { SearchResults } from './SearchResults'
@@ -29,7 +29,7 @@ jest.mock('features/auth/context/SettingsContext', () => ({
 }))
 
 const DEFAULT_POSITION = { latitude: 2, longitude: 40 } as GeoCoordinates
-const mockPosition: GeoCoordinates | null = DEFAULT_POSITION
+const mockPosition: Position = DEFAULT_POSITION
 const mockShowGeolocPermissionModal = jest.fn()
 
 jest.mock('libs/geolocation/GeolocationWrapper', () => ({

--- a/src/features/search/components/sections/Location/Location.native.test.tsx
+++ b/src/features/search/components/sections/Location/Location.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Location } from 'features/search/components/sections/Location/Location'
 import { initialSearchState } from 'features/search/context/reducer'
 import { LocationType, RadioButtonLocation } from 'features/search/enums'
-import { GeoCoordinates } from 'libs/geolocation'
+import { GeoCoordinates, Position } from 'libs/geolocation'
 import { render, fireEvent, waitFor } from 'tests/utils'
 import * as useModalAPI from 'ui/components/modals/useModal'
 
@@ -17,7 +17,7 @@ jest.mock('features/search/context/SearchWrapper', () => ({
 }))
 
 const DEFAULT_POSITION: GeoCoordinates = { latitude: 2, longitude: 40 }
-let mockPosition: GeoCoordinates | null = DEFAULT_POSITION
+let mockPosition: Position = DEFAULT_POSITION
 
 jest.mock('libs/geolocation/GeolocationWrapper', () => ({
   useGeolocation: () => ({

--- a/src/features/search/helpers/useFilterCount/useFilterCount.test.ts
+++ b/src/features/search/helpers/useFilterCount/useFilterCount.test.ts
@@ -4,7 +4,7 @@ import { DATE_FILTER_OPTIONS } from 'features/search/enums'
 import { DEFAULT_TIME_RANGE, MAX_PRICE } from 'features/search/helpers/reducer.helpers'
 import { useMaxPrice } from 'features/search/helpers/useMaxPrice/useMaxPrice'
 import { SearchState } from 'features/search/types'
-import { GeoCoordinates } from 'libs/geolocation'
+import { GeoCoordinates, Position } from 'libs/geolocation'
 import { renderHook } from 'tests/utils'
 
 import { useFilterCount } from './useFilterCount'
@@ -26,7 +26,7 @@ jest.mock('features/search/helpers/useMaxPrice/useMaxPrice')
 const mockedUseMaxPrice = jest.mocked(useMaxPrice)
 
 const DEFAULT_POSITION: GeoCoordinates = { latitude: 2, longitude: 40 }
-let mockPosition: GeoCoordinates | null = DEFAULT_POSITION
+let mockPosition: Position = DEFAULT_POSITION
 jest.mock('libs/geolocation/GeolocationWrapper', () => ({
   useGeolocation: () => ({
     position: mockPosition,

--- a/src/features/search/helpers/useHasPosition/useHasPosition.test.ts
+++ b/src/features/search/helpers/useHasPosition/useHasPosition.test.ts
@@ -4,12 +4,12 @@ import { MAX_RADIUS } from 'features/search/helpers/reducer.helpers'
 import { useHasPosition } from 'features/search/helpers/useHasPosition/useHasPosition'
 import { LocationFilter } from 'features/search/types'
 import { Venue } from 'features/venue/types'
-import { GeoCoordinates } from 'libs/geolocation'
+import { GeoCoordinates, Position } from 'libs/geolocation'
 import { SuggestedPlace } from 'libs/place'
 import { mockedSuggestedVenues } from 'libs/venue/fixtures/mockedSuggestedVenues'
 
 const DEFAULT_POSITION: GeoCoordinates = { latitude: 2, longitude: 40 }
-let mockPosition: GeoCoordinates | null = DEFAULT_POSITION
+let mockPosition: Position = DEFAULT_POSITION
 
 jest.mock('libs/geolocation/GeolocationWrapper', () => ({
   useGeolocation: () => ({
@@ -49,7 +49,7 @@ describe('useLocationChoice', () => {
       hasPositionValue,
     }: {
       locationFilter: LocationFilter
-      position: GeoCoordinates | null
+      position: Position
       hasPositionValue: boolean
     }) => {
       mockSearchState = { ...initialSearchState, locationFilter }

--- a/src/features/search/helpers/useHasPosition/useHasPosition.ts
+++ b/src/features/search/helpers/useHasPosition/useHasPosition.ts
@@ -7,7 +7,7 @@ export const useHasPosition = () => {
   const { position } = useGeolocation()
 
   const isEverywhereSearch = searchState.locationFilter?.locationType === LocationType.EVERYWHERE
-  const isGeolocatedUser = position !== null
+  const isGeolocatedUser = !!position
 
   return !isEverywhereSearch || (isGeolocatedUser && isEverywhereSearch)
 }

--- a/src/features/search/helpers/useLocationChoice/useLocationChoice.test.ts
+++ b/src/features/search/helpers/useLocationChoice/useLocationChoice.test.ts
@@ -3,7 +3,7 @@ import { LocationType } from 'features/search/enums'
 import { MAX_RADIUS } from 'features/search/helpers/reducer.helpers'
 import { useLocationChoice } from 'features/search/helpers/useLocationChoice/useLocationChoice'
 import { Venue } from 'features/venue/types'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 import { SuggestedPlace } from 'libs/place'
 import { mockedSuggestedVenues } from 'libs/venue/fixtures/mockedSuggestedVenues'
 import { BicolorAroundMe as AroundMe } from 'ui/svg/icons/BicolorAroundMe'
@@ -18,7 +18,7 @@ jest.mock('features/search/context/SearchWrapper', () => ({
   }),
 }))
 
-let mockPosition: GeoCoordinates | null = { latitude: 2, longitude: 40 }
+let mockPosition: Position = { latitude: 2, longitude: 40 }
 
 jest.mock('libs/geolocation/GeolocationWrapper', () => ({
   useGeolocation: () => ({

--- a/src/features/search/pages/SearchFilter/SearchFilter.native.test.tsx
+++ b/src/features/search/pages/SearchFilter/SearchFilter.native.test.tsx
@@ -7,7 +7,7 @@ import { LocationType } from 'features/search/enums'
 import { MAX_RADIUS } from 'features/search/helpers/reducer.helpers'
 import { SearchView } from 'features/search/types'
 import { analytics } from 'libs/firebase/analytics'
-import { GeoCoordinates } from 'libs/geolocation'
+import { GeoCoordinates, Position } from 'libs/geolocation'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { fireEvent, render, screen, waitFor } from 'tests/utils'
 
@@ -23,7 +23,7 @@ jest.mock('features/search/context/SearchWrapper', () => ({
 }))
 
 const DEFAULT_POSITION: GeoCoordinates = { latitude: 2, longitude: 40 }
-let mockPosition: GeoCoordinates | null = DEFAULT_POSITION
+let mockPosition: Position = DEFAULT_POSITION
 jest.mock('libs/geolocation/GeolocationWrapper', () => ({
   useGeolocation: () => ({
     position: mockPosition,

--- a/src/features/search/pages/SearchFilter/SearchFilter.tsx
+++ b/src/features/search/pages/SearchFilter/SearchFilter.tsx
@@ -60,10 +60,9 @@ export const SearchFilter: React.FC = () => {
       type: 'SET_STATE',
       payload: {
         ...initialSearchState,
-        locationFilter:
-          position !== null
-            ? { locationType: LocationType.AROUND_ME, aroundRadius: MAX_RADIUS }
-            : { locationType: LocationType.EVERYWHERE },
+        locationFilter: position
+          ? { locationType: LocationType.AROUND_ME, aroundRadius: MAX_RADIUS }
+          : { locationType: LocationType.EVERYWHERE },
         minPrice: undefined,
         maxPrice: undefined,
         offerGenreTypes: undefined,

--- a/src/features/search/pages/modals/LocationModal/LocationModal.native.test.tsx
+++ b/src/features/search/pages/modals/LocationModal/LocationModal.native.test.tsx
@@ -16,6 +16,7 @@ import {
   GeolocationError,
   GeolocPermissionState,
   GeolocPositionError,
+  Position,
 } from 'libs/geolocation'
 import { SuggestedPlace } from 'libs/place'
 import { mockedSuggestedVenues } from 'libs/venue/fixtures/mockedSuggestedVenues'
@@ -35,7 +36,7 @@ jest.mock('features/search/context/SearchWrapper', () => ({
 }))
 
 const DEFAULT_POSITION: GeoCoordinates = { latitude: 2, longitude: 40 }
-let mockPosition: GeoCoordinates | null = DEFAULT_POSITION
+let mockPosition: Position = DEFAULT_POSITION
 let mockPermissionState = GeolocPermissionState.GRANTED
 let mockPositionError: GeolocationError | null = null
 const mockTriggerPositionUpdate = jest.fn()

--- a/src/features/search/pages/modals/LocationModal/LocationModal.tsx
+++ b/src/features/search/pages/modals/LocationModal/LocationModal.tsx
@@ -258,8 +258,7 @@ export const LocationModal: FunctionComponent<LocationModalProps> = ({
 
   const onResetPress = useCallback(() => {
     reset({
-      locationChoice:
-        position !== null ? RadioButtonLocation.AROUND_ME : RadioButtonLocation.EVERYWHERE,
+      locationChoice: position ? RadioButtonLocation.AROUND_ME : RadioButtonLocation.EVERYWHERE,
       aroundRadius: MAX_RADIUS,
       searchPlaceOrVenue: '',
       selectedPlaceOrVenue: undefined,

--- a/src/features/search/pages/modals/LocationModal/LocationModal.web.test.tsx
+++ b/src/features/search/pages/modals/LocationModal/LocationModal.web.test.tsx
@@ -5,10 +5,10 @@ import {
   LocationModal,
   LocationModalProps,
 } from 'features/search/pages/modals/LocationModal/LocationModal'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 import { act, checkAccessibilityFor, fireEvent, render, screen, waitFor } from 'tests/utils/web'
 
-const mockPosition: GeoCoordinates | null = { latitude: 2, longitude: 40 }
+const mockPosition: Position = { latitude: 2, longitude: 40 }
 jest.mock('libs/geolocation/GeolocationWrapper', () => ({
   useGeolocation: () => ({
     position: mockPosition,

--- a/src/features/venue/helpers/useVenueSearchParameters/useVenueSearchParameters.native.test.ts
+++ b/src/features/venue/helpers/useVenueSearchParameters/useVenueSearchParameters.native.test.ts
@@ -3,10 +3,10 @@ import { LocationType } from 'features/search/enums'
 import { SearchView } from 'features/search/types'
 import { venueResponseSnap as venue } from 'features/venue/fixtures/venueResponseSnap'
 import { useVenueSearchParameters } from 'features/venue/helpers/useVenueSearchParameters/useVenueSearchParameters'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 import { renderHook } from 'tests/utils'
 
-let mockPosition: GeoCoordinates | null = null
+let mockPosition: Position = null
 jest.mock('libs/geolocation', () => ({
   useGeolocation: jest.fn(() => ({ position: mockPosition })),
 }))

--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildGeolocationParameter.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildGeolocationParameter.ts
@@ -1,12 +1,12 @@
 import { LocationType } from 'features/search/enums'
 import { SearchState } from 'features/search/types'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 
 import { RADIUS_FILTERS } from '../../enums'
 
 export const buildGeolocationParameter = (
   locationFilter: SearchState['locationFilter'],
-  userLocation: GeoCoordinates | null,
+  userLocation: Position,
   isOnline?: SearchState['isOnline']
 ): { aroundLatLng: string; aroundRadius: 'all' | number } | undefined => {
   if (locationFilter.locationType === LocationType.VENUE) return

--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildOfferSearchParameters.ts.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildOfferSearchParameters.ts.ts
@@ -1,7 +1,7 @@
 import { SearchState } from 'features/search/types'
 import { buildFilters } from 'libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildFilters'
 import { buildGeolocationParameter } from 'libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildGeolocationParameter'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 
 import { buildFacetFilters } from './buildFacetFilters'
 import { buildNumericFilters } from './buildNumericFilters'
@@ -35,7 +35,7 @@ export const buildOfferSearchParameters = (
     isOnline = undefined,
     minBookingsThreshold = 0,
   }: SearchState & { objectIds?: string[]; excludedObjectIds?: string[] },
-  userLocation: GeoCoordinates | null,
+  userLocation: Position,
   isUserUnderage: boolean
 ) => ({
   ...buildFacetFilters({

--- a/src/libs/algolia/fetchAlgolia/fetchMultipleOffers/fetchMultipleOffers.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchMultipleOffers/fetchMultipleOffers.ts
@@ -8,11 +8,11 @@ import { offerAttributesToRetrieve } from 'libs/algolia/fetchAlgolia/buildAlgoli
 import { client } from 'libs/algolia/fetchAlgolia/clients'
 import { buildHitsPerPage } from 'libs/algolia/fetchAlgolia/utils'
 import { env } from 'libs/environment'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 
 type FetchMultipleOffersArgs = {
   paramsList: SearchState[]
-  userLocation: GeoCoordinates | null
+  userLocation: Position
   isUserUnderage: boolean
 }
 

--- a/src/libs/algolia/fetchAlgolia/fetchMultipleOffers/helpers/adaptOffersPlaylistParameters.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchMultipleOffers/helpers/adaptOffersPlaylistParameters.ts
@@ -5,12 +5,12 @@ import { SearchState, SearchView } from 'features/search/types'
 import { getCategoriesFacetFilters } from 'libs/algolia/fetchAlgolia/buildAlgoliaParameters/getCategoriesFacetFilters'
 import { buildOfferGenreTypesValues } from 'libs/algolia/fetchAlgolia/fetchMultipleOffers/helpers/buildOfferGenreTypesValues'
 import { adaptGeolocationParameters } from 'libs/algolia/fetchAlgolia/helpers/adaptGeolocationParameters'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 import { GenreTypeMapping, SubcategoryLabelMapping } from 'libs/subcategories/types'
 
 export const adaptOffersPlaylistParameters = (
   parameters: OffersModuleParameters,
-  geolocation: GeoCoordinates | null,
+  geolocation: Position,
   subcategoryLabelMapping: SubcategoryLabelMapping,
   genreTypeMapping: GenreTypeMapping
 ): SearchState | undefined => {

--- a/src/libs/algolia/fetchAlgolia/fetchMultipleVenues.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchMultipleVenues.ts
@@ -11,7 +11,7 @@ import { adaptGeolocationParameters } from 'libs/algolia/fetchAlgolia/helpers/ad
 import { buildHitsPerPage } from 'libs/algolia/fetchAlgolia/utils'
 import { VenuesParametersFields } from 'libs/contentful'
 import { env } from 'libs/environment'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 import { VenueTypeCode } from 'libs/parsers'
 
 const attributesToHighlight: string[] = [] // We disable highlighting because we don't need it
@@ -19,7 +19,7 @@ const attributesToHighlight: string[] = [] // We disable highlighting because we
 // Used for the venue playlists on the homepage
 export const fetchMultipleVenues = async (
   paramsList: VenuesParametersFields[],
-  userLocation: GeoCoordinates | null
+  userLocation: Position
 ): Promise<VenueHit[]> => {
   const queries = paramsList.map((params) => ({
     indexName: env.ALGOLIA_VENUES_INDEX_NAME,
@@ -41,10 +41,7 @@ export const fetchMultipleVenues = async (
   }
 }
 
-export const buildVenuesQueryOptions = (
-  params: VenuesParametersFields,
-  userLocation: GeoCoordinates | null
-) => {
+export const buildVenuesQueryOptions = (params: VenuesParametersFields, userLocation: Position) => {
   const { aroundRadius, isGeolocated, tags = [], venueTypes = [] } = params
 
   const locationFilter = adaptGeolocationParameters(userLocation, isGeolocated, aroundRadius) || {

--- a/src/libs/algolia/fetchAlgolia/fetchOffer.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchOffer.ts
@@ -9,11 +9,11 @@ import { client } from 'libs/algolia/fetchAlgolia/clients'
 import { buildHitsPerPage } from 'libs/algolia/fetchAlgolia/utils'
 import { SearchParametersQuery } from 'libs/algolia/types'
 import { env } from 'libs/environment'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 
 type FetchOfferArgs = {
   parameters: SearchParametersQuery
-  userLocation: GeoCoordinates | null
+  userLocation: Position
   isUserUnderage: boolean
   storeQueryID?: (queryID?: string) => void
   excludedObjectIds?: string[]

--- a/src/libs/algolia/fetchAlgolia/helpers/adaptGeolocationParameters.ts
+++ b/src/libs/algolia/fetchAlgolia/helpers/adaptGeolocationParameters.ts
@@ -1,9 +1,9 @@
 import { LocationType } from 'features/search/enums'
 import { SearchState } from 'features/search/types'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 
 export const adaptGeolocationParameters = (
-  geolocation: GeoCoordinates | null,
+  geolocation: Position,
   isGeolocated?: boolean,
   aroundRadius?: number
 ): SearchState['locationFilter'] | undefined => {

--- a/src/libs/geolocation/GeolocationWrapper.tsx
+++ b/src/libs/geolocation/GeolocationWrapper.tsx
@@ -18,7 +18,7 @@ import {
 } from './types'
 
 const GeolocationContext = React.createContext<IGeolocationContext>({
-  position: null,
+  position: undefined,
   positionError: null,
   permissionState: undefined,
   requestGeolocPermission: async () => {
@@ -34,7 +34,7 @@ export const GeolocationWrapper = memo(function GeolocationWrapper({
 }: {
   children: JSX.Element
 }) {
-  const [position, setPosition] = useSafeState<Position>(null)
+  const [position, setPosition] = useSafeState<Position>(undefined)
   const [positionError, setPositionError] = useSafeState<GeolocationError | null>(null)
   const [permissionState, setPermissionState] = useSafeState<GeolocPermissionState | undefined>(
     undefined

--- a/src/libs/geolocation/GeolocationWrapper.tsx
+++ b/src/libs/geolocation/GeolocationWrapper.tsx
@@ -20,7 +20,7 @@ import {
 const GeolocationContext = React.createContext<IGeolocationContext>({
   position: null,
   positionError: null,
-  permissionState: GeolocPermissionState.DENIED,
+  permissionState: undefined,
   requestGeolocPermission: async () => {
     // nothing
   },
@@ -36,8 +36,8 @@ export const GeolocationWrapper = memo(function GeolocationWrapper({
 }) {
   const [position, setPosition] = useSafeState<Position>(null)
   const [positionError, setPositionError] = useSafeState<GeolocationError | null>(null)
-  const [permissionState, setPermissionState] = useSafeState<GeolocPermissionState>(
-    GeolocPermissionState.DENIED
+  const [permissionState, setPermissionState] = useSafeState<GeolocPermissionState | undefined>(
+    undefined
   )
 
   const {
@@ -162,7 +162,7 @@ export function useGeolocation(): IGeolocationContext {
 function isGranted(permission: GeolocPermissionState) {
   return permission === GeolocPermissionState.GRANTED
 }
-function isRejected(permission: GeolocPermissionState) {
+function isRejected(permission: GeolocPermissionState | undefined) {
   return (
     permission === GeolocPermissionState.DENIED ||
     permission === GeolocPermissionState.NEVER_ASK_AGAIN

--- a/src/libs/geolocation/GeolocationWrapper.tsx
+++ b/src/libs/geolocation/GeolocationWrapper.tsx
@@ -12,9 +12,9 @@ import { getPosition } from './getPosition'
 import { requestGeolocPermission } from './requestGeolocPermission'
 import {
   GeolocationError,
-  GeoCoordinates,
   IGeolocationContext,
   RequestGeolocPermissionParams,
+  Position,
 } from './types'
 
 const GeolocationContext = React.createContext<IGeolocationContext>({
@@ -34,7 +34,7 @@ export const GeolocationWrapper = memo(function GeolocationWrapper({
 }: {
   children: JSX.Element
 }) {
-  const [position, setPosition] = useSafeState<GeoCoordinates | null>(null)
+  const [position, setPosition] = useSafeState<Position>(null)
   const [positionError, setPositionError] = useSafeState<GeolocationError | null>(null)
   const [permissionState, setPermissionState] = useSafeState<GeolocPermissionState>(
     GeolocPermissionState.DENIED

--- a/src/libs/geolocation/index.ts
+++ b/src/libs/geolocation/index.ts
@@ -2,7 +2,7 @@ import { checkGeolocPermission } from './checkGeolocPermission'
 import { GEOLOCATION_USER_ERROR_MESSAGE, GeolocPermissionState, GeolocPositionError } from './enums'
 import { useGeolocation, GeolocationWrapper } from './GeolocationWrapper'
 import { requestGeolocPermission } from './requestGeolocPermission'
-import { GeoCoordinates, GeolocationError, IGeolocationContext } from './types'
+import { GeoCoordinates, GeolocationError, IGeolocationContext, Position } from './types'
 
 export {
   useGeolocation,
@@ -13,4 +13,4 @@ export {
   GeolocPermissionState,
   GeolocPositionError,
 }
-export type { GeoCoordinates, GeolocationError, IGeolocationContext }
+export type { GeoCoordinates, GeolocationError, IGeolocationContext, Position }

--- a/src/libs/geolocation/types.ts
+++ b/src/libs/geolocation/types.ts
@@ -10,7 +10,8 @@ export type GeoCoordinates = {
   longitude: number
 }
 
-export type Position = GeoCoordinates | null
+// A position is either not yet asked (undefined), refused (null) or accepted and retrieved (coordinates)
+export type Position = GeoCoordinates | null | undefined
 
 export type RequestGeolocPermissionParams = {
   onAcceptance?: () => void

--- a/src/libs/geolocation/types.ts
+++ b/src/libs/geolocation/types.ts
@@ -10,6 +10,8 @@ export type GeoCoordinates = {
   longitude: number
 }
 
+export type Position = GeoCoordinates | null
+
 export type RequestGeolocPermissionParams = {
   onAcceptance?: () => void
   onRefusal?: () => void
@@ -19,7 +21,7 @@ export type AskGeolocPermission = () => Promise<GeolocPermissionState>
 export type ReadGeolocPermission = () => Promise<GeolocPermissionState>
 
 export type IGeolocationContext = {
-  position: GeoCoordinates | null
+  position: Position
   positionError: GeolocationError | null
   permissionState: GeolocPermissionState
   requestGeolocPermission: (params?: RequestGeolocPermissionParams) => Promise<void>

--- a/src/libs/geolocation/types.ts
+++ b/src/libs/geolocation/types.ts
@@ -23,7 +23,7 @@ export type ReadGeolocPermission = () => Promise<GeolocPermissionState>
 export type IGeolocationContext = {
   position: Position
   positionError: GeolocationError | null
-  permissionState: GeolocPermissionState
+  permissionState: GeolocPermissionState | undefined
   requestGeolocPermission: (params?: RequestGeolocPermissionParams) => Promise<void>
   triggerPositionUpdate: () => void
   showGeolocPermissionModal: () => void

--- a/src/libs/parsers/formatDistance.ts
+++ b/src/libs/parsers/formatDistance.ts
@@ -1,5 +1,5 @@
 import { Geoloc } from 'libs/algolia'
-import { GeoCoordinates } from 'libs/geolocation'
+import { Position } from 'libs/geolocation'
 
 const EARTH_RADIUS_KM = 6378.137
 
@@ -39,10 +39,7 @@ export const humanizeDistance = (distance: number) => {
   return `${distanceKm > 900 ? '900+' : distanceKm} km`
 }
 
-export const formatDistance = (
-  coords: Geoloc,
-  position: GeoCoordinates | null
-): string | undefined => {
+export const formatDistance = (coords: Geoloc, position: Position): string | undefined => {
   if (!position) return
 
   return getHumanizeRelativeDistance(coords.lat, coords.lng, position.latitude, position.longitude)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19699

## Contexte : 
En web, on faisait systématiquement un appel à l'api de recommandation avant même que la position ne soit récupérée. Cette PR améliore le typage de la géolocalisation pour faire la différence entre une localisation pas encore définie (qu'elle soit réfusée ou acceptée) et définie (null si refusée, latitude/longitude si acceptée). Ainsi, on peut économiser un appel à l'api de recommandation dans le cas où on n'a pas encore récupéré la position de l'utilisateur.

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

<img width="333" alt="Capture d’écran 2023-03-27 à 18 25 38" src="https://user-images.githubusercontent.com/22886846/228005961-1c3df821-7f3b-49c8-b326-34d88602d37f.png">

### Avant: premier appel sans géoloc
<img width="421" alt="Capture d’écran 2023-03-27 à 18 26 56" src="https://user-images.githubusercontent.com/22886846/228006156-f6f7204c-3bc6-4a18-a805-e656db895a9a.png">


### Après: premier appel avec géoloc
<img width="424" alt="Capture d’écran 2023-03-27 à 18 25 49" src="https://user-images.githubusercontent.com/22886846/228006098-dc8ed788-cc67-4f6a-ad15-b4e972b24c36.png">


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
