### PR TITLE
(BSR) feat(ExternalTouchableLink): remove openInNewWindow prop

### DIFF
--- a/__snapshots__/features/identityCheck/pages/identification/identificationStart/SelectPhoneStatus.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/identificationStart/SelectPhoneStatus.web.test.tsx.web-snap
@@ -89,7 +89,7 @@ Object {
                 >
                   <button
                     aria-label="Revenir en arrière"
-                    class="c0 c1 sc-gsDKAQ c1"
+                    class="c0 c1 sc-fotOHu c1"
                     data-testid="Revenir en arrière"
                     tabindex="0"
                     title="Revenir en arrière"
@@ -400,7 +400,7 @@ Object {
               >
                 <button
                   aria-label="Revenir en arrière"
-                  class="c0 c1 sc-gsDKAQ c1"
+                  class="c0 c1 sc-fotOHu c1"
                   data-testid="Revenir en arrière"
                   tabindex="0"
                   title="Revenir en arrière"

--- a/src/features/auth/components/AuthenticationButton/AuthenticationButton.tsx
+++ b/src/features/auth/components/AuthenticationButton/AuthenticationButton.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import React from 'react'
 import styled from 'styled-components/native'
 
 import { RootNavigateParams, RootStackParamList } from 'features/navigation/RootNavigator/types'
@@ -27,12 +27,12 @@ type Props = {
   preventCancellation?: boolean
 } & (LoginProps | SignupProps)
 
-export const AuthenticationButton: FunctionComponent<Props> = ({
+export function AuthenticationButton({
   type,
   linkColor,
   params = {},
   onAdditionalPress: onPress,
-}) => {
+}: Props) {
   const isLogin = type === 'login'
   const nextNavigation: {
     screen: RootNavigateParams[0]

--- a/src/features/auth/helpers/useBeneficiaryValidationNavigation.ts
+++ b/src/features/auth/helpers/useBeneficiaryValidationNavigation.ts
@@ -57,7 +57,8 @@ const useNavigateToNextSubscriptionStep = () => {
   const { navigate } = useNavigation<UseNavigationType>()
 
   return (navConfig: NextStepNavConfig) => {
-    if (!navConfig) {
+    // We check if internalUrl is in navConfig for typescript only, but it should not happen here
+    if (!navConfig || 'internalUrl' in navConfig) {
       navigateToHome()
     } else {
       const { screen, params } = navConfig

--- a/src/features/deeplinks/helpers/getScreenFromDeeplink.ts
+++ b/src/features/deeplinks/helpers/getScreenFromDeeplink.ts
@@ -1,13 +1,11 @@
+import { removePrefixFromUrl } from 'features/deeplinks/helpers/removePrefixFromUrl'
 import { linking } from 'features/navigation/RootNavigator/linking'
 import { NavigationResultState } from 'features/navigation/RootNavigator/types'
 
 import { DeeplinkParts } from '../types'
 
 export function getScreenFromDeeplink(url: string): DeeplinkParts {
-  let pathWithQueryString = url
-  for (const prefix of linking.prefixes) {
-    pathWithQueryString = pathWithQueryString.replace(prefix, '')
-  }
+  const pathWithQueryString = removePrefixFromUrl(url)
   const navigationState = linking.getStateFromPath(pathWithQueryString, linking.config)
   const route = getLastRouteFromState(navigationState)
   const screen = route.name

--- a/src/features/deeplinks/helpers/removePrefixFromUrl.test.ts
+++ b/src/features/deeplinks/helpers/removePrefixFromUrl.test.ts
@@ -1,0 +1,16 @@
+import { removePrefixFromUrl } from 'features/deeplinks/helpers/removePrefixFromUrl'
+import { linking } from 'features/navigation/RootNavigator/linking/__mocks__'
+
+jest.mock('features/navigation/RootNavigator/linking')
+
+describe('removePrefixFromUrl', () => {
+  it.each`
+    url                               | expectedUrl
+    ${`${linking.prefixes[0]}my-url`} | ${'my-url'}
+    ${`${linking.prefixes[1]}my-url`} | ${'my-url'}
+    ${'my-url-whitout-prefix'}        | ${'my-url-whitout-prefix'}
+  `('should remove prefix from url', ({ url, expectedUrl }) => {
+    const urlWithoutPrefix = removePrefixFromUrl(url)
+    expect(urlWithoutPrefix).toEqual(expectedUrl)
+  })
+})

--- a/src/features/deeplinks/helpers/removePrefixFromUrl.ts
+++ b/src/features/deeplinks/helpers/removePrefixFromUrl.ts
@@ -1,0 +1,9 @@
+import { linking } from 'features/navigation/RootNavigator/linking'
+
+export const removePrefixFromUrl = (urlWithPrefix: string) => {
+  let pathWithQueryString = urlWithPrefix
+  for (const prefix of linking.prefixes) {
+    pathWithQueryString = pathWithQueryString.replace(prefix, '')
+  }
+  return pathWithQueryString
+}

--- a/src/features/favorites/components/Favorite.tsx
+++ b/src/features/favorites/components/Favorite.tsx
@@ -129,11 +129,7 @@ export const Favorite: React.FC<Props> = (props) => {
       <Animated.View onLayout={onLayout} style={animatedViewStyle}>
         <Container>
           <StyledTouchableLink
-            navigateTo={
-              offer.id
-                ? { screen: 'Offer', params: { id: offer.id, from: 'favorites' } }
-                : undefined
-            }
+            navigateTo={{ screen: 'Offer', params: { id: offer.id, from: 'favorites' } }}
             onBeforeNavigate={handlePressOffer}
             accessibilityLabel={accessibilityLabel}>
             <Row>

--- a/src/features/home/components/modules/exclusivity/ExclusivityExternalLink.native.test.tsx
+++ b/src/features/home/components/modules/exclusivity/ExclusivityExternalLink.native.test.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
+import { Linking } from 'react-native'
 
 import { ExclusivityExternalLink } from 'features/home/components/modules/exclusivity/ExclusivityExternalLink'
-import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
+import { navigateFromRef } from 'features/navigation/navigationRef'
+import { linking } from 'features/navigation/RootNavigator/linking'
 import { ContentTypes } from 'libs/contentful'
 import { analytics } from 'libs/firebase/analytics'
-import { fireEvent, render } from 'tests/utils'
+import { fireEvent, render, screen } from 'tests/utils'
 
-const openUrl = jest.spyOn(NavigationHelpers, 'openUrl')
+jest.mock('features/navigation/navigationRef')
 
 const props = {
   title: 'Image d’Adèle',
@@ -32,11 +34,25 @@ describe('ExclusivityExternalLink component', () => {
     )
   })
 
-  it('should open url when clicking on the component', () => {
-    const { getByTestId } = render(<ExclusivityExternalLink {...props} />)
+  it('should open external url when clicking on the component and url is not in-app url', async () => {
+    render(<ExclusivityExternalLink {...props} />)
 
-    fireEvent.press(getByTestId('Image d’Adèle'))
+    fireEvent.press(screen.getByTestId('Image d’Adèle'))
 
-    expect(openUrl).toHaveBeenCalledWith(props.url, undefined, false)
+    expect(Linking.openURL).toHaveBeenCalledWith(props.url)
   })
+
+  it.each(linking.prefixes)(
+    'should open internal url when clicking on the component and url is prefixed with %s',
+    (urlPrefix) => {
+      const internalUrl = `${urlPrefix}profil`
+      render(<ExclusivityExternalLink {...props} url={internalUrl} />)
+
+      fireEvent.press(screen.getByTestId('Image d’Adèle'))
+
+      expect(navigateFromRef).toHaveBeenCalledWith('TabNavigator', {
+        screen: 'Profile',
+      })
+    }
+  )
 })

--- a/src/features/home/components/modules/exclusivity/ExclusivityExternalLink.tsx
+++ b/src/features/home/components/modules/exclusivity/ExclusivityExternalLink.tsx
@@ -1,12 +1,14 @@
-import React, { memo, useEffect } from 'react'
+import React, { ElementType, memo, useEffect } from 'react'
 import styled from 'styled-components/native'
 
 import { ExclusivityImage } from 'features/home/components/modules/exclusivity/ExclusivityImage'
 import { ExclusivityBannerProps } from 'features/home/components/modules/exclusivity/ExclusivityModule'
+import { isAppUrl } from 'features/navigation/helpers'
 import { ContentTypes } from 'libs/contentful'
 import { analytics } from 'libs/firebase/analytics'
 import { useHandleFocus } from 'libs/hooks/useHandleFocus'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
+import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 
 interface ExclusivityExternalLinkProps extends ExclusivityBannerProps {
@@ -28,24 +30,43 @@ const UnmemoizedExclusivityExternalLink = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [moduleId, homeEntryId])
 
+  const isUrlAnInternalUrl = isAppUrl(url)
+
+  const TouchableLinkComponent: ElementType = isUrlAnInternalUrl
+    ? StyledInternalTouchableLink
+    : StyledExternalTouchableLink
+
+  const touchableLinkProps = isUrlAnInternalUrl
+    ? { navigateTo: { internalUrl: url } }
+    : { externalNav: { url } }
+
+  const sharedLinkProps = {
+    highlight: true,
+    accessibilityLabel: alt,
+    isFocus,
+    style,
+    onFocus,
+    onBlur,
+  }
+
   return (
-    <StyledTouchableLink
-      highlight
-      onFocus={onFocus}
-      onBlur={onBlur}
-      isFocus={isFocus}
-      externalNav={{ url }}
-      style={style}
-      accessibilityLabel={alt}
-      openInNewWindow={false}>
+    <TouchableLinkComponent {...sharedLinkProps} {...touchableLinkProps}>
       <ExclusivityImage imageURL={imageURL} alt={alt} />
-    </StyledTouchableLink>
+    </TouchableLinkComponent>
   )
 }
 
 export const ExclusivityExternalLink = memo(UnmemoizedExclusivityExternalLink)
 
-const StyledTouchableLink = styled(ExternalTouchableLink)<{
+const StyledExternalTouchableLink = styled(ExternalTouchableLink)<{
+  isFocus?: boolean
+}>(({ theme, isFocus }) => ({
+  flex: 1,
+  borderRadius: theme.borderRadius.radius,
+  ...customFocusOutline({ isFocus, color: theme.colors.black }),
+}))
+
+const StyledInternalTouchableLink = styled(InternalTouchableLink)<{
   isFocus?: boolean
 }>(({ theme, isFocus }) => ({
   flex: 1,

--- a/src/features/internal/cheatcodes/pages/AppComponents/AppComponents.tsx
+++ b/src/features/internal/cheatcodes/pages/AppComponents/AppComponents.tsx
@@ -17,7 +17,10 @@ import { Icons } from 'features/internal/cheatcodes/pages/AppComponents/Icons'
 import { Illustrations } from 'features/internal/cheatcodes/pages/AppComponents/Illustrations'
 import { navigateToHomeConfig } from 'features/navigation/helpers'
 import { BottomBanner } from 'features/offer/components/BottomBanner/BottomBanner'
-import { SubscriptionMessageBadge } from 'features/profile/components/Badges/SubscriptionMessageBadge'
+import {
+  CallToAction,
+  SubscriptionMessageBadge,
+} from 'features/profile/components/Badges/SubscriptionMessageBadge'
 import { CreditHeader } from 'features/profile/components/Header/CreditHeader/CreditHeader'
 import { NonBeneficiaryHeader } from 'features/profile/components/Header/NonBeneficiaryHeader/NonBeneficiaryHeader'
 import { domains_credit_v1 } from 'features/profile/fixtures/domainsCredit'
@@ -62,7 +65,6 @@ import { SlantTag } from 'ui/components/SlantTag'
 import { useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { StepDots } from 'ui/components/StepDots'
 import { OfferImage } from 'ui/components/tiles/OfferImage'
-import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { BackgroundPlaceholder } from 'ui/svg/BackgroundPlaceholder'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
@@ -472,16 +474,28 @@ export const AppComponents: FunctionComponent = () => {
 
           <Spacer.Column numberOfSpaces={2} />
 
-          <Banner message="Banner with ExternalTouchableLink" withLightColorMessage>
+          <Banner message="Banner with external" withLightColorMessage>
             <Spacer.Column numberOfSpaces={2} />
-            <ExternalTouchableLink
-              wording="Call to action title"
-              numberOfLines={2}
-              justifyContent="flex-start"
-              as={ButtonQuaternarySecondary}
-              externalNav={{ url: 'callToActionLink' }}
-              icon={ExternalSiteFilled}
-              inline
+            <CallToAction
+              subscriptionMessage={{
+                userMessage: 'Should be external',
+                callToAction: {
+                  callToActionTitle: 'toto',
+                  callToActionLink: 'https://google.com',
+                },
+              }}
+            />
+          </Banner>
+          <Banner message="Banner with internal" withLightColorMessage>
+            <Spacer.Column numberOfSpaces={2} />
+            <CallToAction
+              subscriptionMessage={{
+                userMessage: 'Should be internal',
+                callToAction: {
+                  callToActionTitle: 'toto',
+                  callToActionLink: 'toto',
+                },
+              }}
             />
           </Banner>
         </AccordionItem>

--- a/src/features/profile/components/Badges/SubscriptionMessageBadge.native.test.tsx
+++ b/src/features/profile/components/Badges/SubscriptionMessageBadge.native.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { Linking } from 'react-native'
+
+import { navigateFromRef } from 'features/navigation/navigationRef'
+import { linking } from 'features/navigation/RootNavigator/linking'
+import { SubscriptionMessageBadge } from 'features/profile/components/Badges/SubscriptionMessageBadge'
+import { fireEvent, render, screen } from 'tests/utils'
+
+jest.mock('features/navigation/navigationRef')
+
+describe('SubscriptionMessageBadge', () => {
+  it('should open external url when clicking on the component and url is not in-app url', async () => {
+    const externalUrl = 'http://toto.com'
+
+    render(
+      <SubscriptionMessageBadge
+        subscriptionMessage={{
+          userMessage: 'coucou',
+          callToAction: { callToActionLink: externalUrl, callToActionTitle: 'callToAction' },
+        }}
+      />
+    )
+
+    fireEvent.press(screen.getByText('callToAction'))
+
+    expect(Linking.openURL).toHaveBeenCalledWith(externalUrl)
+  })
+
+  it.each(linking.prefixes)(
+    'should open internal url when clicking on the component and url is prefixed with %s',
+    (urlPrefix) => {
+      const internalUrl = `${urlPrefix}profil`
+      render(
+        <SubscriptionMessageBadge
+          subscriptionMessage={{
+            userMessage: 'coucou',
+            callToAction: { callToActionLink: internalUrl, callToActionTitle: 'callToAction' },
+          }}
+        />
+      )
+
+      fireEvent.press(screen.getByText('callToAction'))
+
+      expect(navigateFromRef).toHaveBeenCalledWith('TabNavigator', {
+        screen: 'Profile',
+      })
+    }
+  )
+})

--- a/src/features/profile/components/Badges/SubscriptionMessageBadge.tsx
+++ b/src/features/profile/components/Badges/SubscriptionMessageBadge.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { openInbox } from 'react-native-email-link'
 
 import { SubscriptionMessage } from 'api/gen'
+import { isAppUrl } from 'features/navigation/helpers'
 import { Subtitle } from 'features/profile/components/Subtitle/Subtitle'
 import { formatDateToLastUpdatedAtMessage } from 'features/profile/helpers/formatDateToLastUpdatedAtMessage'
 import { matchSubscriptionMessageIconToSvg } from 'features/profile/helpers/matchSubscriptionMessageIconToSvg'
@@ -10,6 +11,7 @@ import { Banner } from 'ui/components/Banner'
 import { BaseButtonProps } from 'ui/components/buttons/AppButton/types'
 import { ButtonQuaternarySecondary } from 'ui/components/buttons/ButtonQuarternarySecondary'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
+import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { Clock } from 'ui/svg/icons/BicolorClock'
 import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
@@ -18,7 +20,8 @@ import { Spacer } from 'ui/theme'
 type Props = {
   subscriptionMessage: SubscriptionMessage
 }
-const CallToAction = ({ subscriptionMessage }: Props) => {
+
+export const CallToAction = ({ subscriptionMessage }: Props) => {
   const { callToActionTitle, callToActionLink, callToActionIcon } =
     subscriptionMessage.callToAction || {}
 
@@ -33,6 +36,24 @@ const CallToAction = ({ subscriptionMessage }: Props) => {
     inline: true as BaseButtonProps['inline'],
   }
 
+  const isCallToActionAnAppUrl = isAppUrl(callToActionLink)
+  const TouchableLink = isCallToActionAnAppUrl ? (
+    <InternalTouchableLink
+      as={ButtonQuaternarySecondary}
+      navigateTo={{ internalUrl: callToActionLink }}
+      icon={ExternalSiteFilled}
+      {...sharedButtonProps}
+    />
+  ) : (
+    <ExternalTouchableLink
+      as={ButtonQuaternarySecondary}
+      externalNav={{ url: callToActionLink }}
+      icon={ExternalSiteFilled}
+      {...sharedButtonProps}
+    />
+  )
+
+  //TODO(EveJulliard) A CHANGER le openInNewWindow={false}
   return (
     <React.Fragment>
       <Spacer.Column numberOfSpaces={2} />
@@ -43,13 +64,7 @@ const CallToAction = ({ subscriptionMessage }: Props) => {
           {...sharedButtonProps}
         />
       ) : (
-        <ExternalTouchableLink
-          as={ButtonQuaternarySecondary}
-          externalNav={{ url: callToActionLink }}
-          openInNewWindow={false}
-          icon={ExternalSiteFilled}
-          {...sharedButtonProps}
-        />
+        TouchableLink
       )}
     </React.Fragment>
   )

--- a/src/features/profile/components/Badges/SubscriptionMessageBadge.tsx
+++ b/src/features/profile/components/Badges/SubscriptionMessageBadge.tsx
@@ -53,7 +53,6 @@ export const CallToAction = ({ subscriptionMessage }: Props) => {
     />
   )
 
-  //TODO(EveJulliard) A CHANGER le openInNewWindow={false}
   return (
     <React.Fragment>
       <Spacer.Column numberOfSpaces={2} />

--- a/src/ui/components/touchableLink/ExternalTouchableLink.test.tsx
+++ b/src/ui/components/touchableLink/ExternalTouchableLink.test.tsx
@@ -2,8 +2,6 @@ import React from 'react'
 import { Text } from 'react-native'
 
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
-import { navigateFromRef } from 'features/navigation/navigationRef'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
 import { mockedFullAddress } from 'libs/address/fixtures/mockedFormatFullAddress'
 import { WEBAPP_V2_URL } from 'libs/environment'
 import { getGoogleMapsItineraryUrl } from 'libs/itinerary/openGoogleMapsItinerary'
@@ -80,24 +78,6 @@ describe('<ExternalTouchableLink />', () => {
 
       await waitFor(() => {
         expect(openUrl).toHaveBeenCalledWith(WEBAPP_V2_URL, undefined, true)
-      })
-    })
-
-    it('should open in-app urls in current window or app when openInNewWindow=false', async () => {
-      render(
-        <ExternalTouchableLink
-          externalNav={{
-            url: WEBAPP_V2_URL,
-          }}
-          openInNewWindow={false}>
-          <ExternalTouchableLinkContent />
-        </ExternalTouchableLink>
-      )
-
-      fireEvent.press(screen.getByText(linkText))
-
-      await waitFor(() => {
-        expect(navigateFromRef).toHaveBeenCalledWith(...homeNavConfig)
       })
     })
   })

--- a/src/ui/components/touchableLink/ExternalTouchableLink.tsx
+++ b/src/ui/components/touchableLink/ExternalTouchableLink.tsx
@@ -5,20 +5,16 @@ import { useItinerary } from 'libs/itinerary/useItinerary'
 import { TouchableLink } from 'ui/components/touchableLink/TouchableLink'
 import { ExternalTouchableLinkProps } from 'ui/components/touchableLink/types'
 
-export function ExternalTouchableLink({
-  externalNav,
-  openInNewWindow = true,
-  ...rest
-}: ExternalTouchableLinkProps) {
+export function ExternalTouchableLink({ externalNav, ...rest }: ExternalTouchableLinkProps) {
   const { navigateTo: navigateToItinerary } = useItinerary()
   const handleNavigation = useCallback(() => {
     const { url, params, address, onSuccess, onError } = externalNav
     if (address) {
       navigateToItinerary(address)
     } else {
-      openUrl(url, params, openInNewWindow).then(onSuccess).catch(onError)
+      openUrl(url, params, true).then(onSuccess).catch(onError)
     }
-  }, [externalNav, openInNewWindow, navigateToItinerary])
+  }, [externalNav, navigateToItinerary])
   return (
     <TouchableLink
       handleNavigation={handleNavigation}

--- a/src/ui/components/touchableLink/InternalTouchableLink.test.tsx
+++ b/src/ui/components/touchableLink/InternalTouchableLink.test.tsx
@@ -2,11 +2,15 @@ import React from 'react'
 import { Text } from 'react-native'
 
 import { navigate, push } from '__mocks__/@react-navigation/native'
+import { openUrl } from 'features/navigation/helpers/__mocks__'
 import { navigateFromRef, pushFromRef } from 'features/navigation/navigationRef'
+import { linking } from 'features/navigation/RootNavigator/linking/__mocks__'
 import { render, fireEvent, screen, waitFor } from 'tests/utils'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 
 jest.mock('features/navigation/navigationRef')
+jest.mock('features/navigation/helpers')
+jest.mock('features/navigation/RootNavigator/linking')
 
 const navigateToItineraryMock = jest.fn()
 const useItinerary = () => ({
@@ -114,6 +118,58 @@ describe('<InternalTouchableLink />', () => {
         screen: 'Home',
         params: undefined,
       })
+    })
+  })
+
+  describe('internalUrl', () => {
+    it.each(linking.prefixes)(
+      'should navigate using openUrl when internalUrl is prefixed with %s',
+      async (appUrlPrefix) => {
+        const internalUrl = `${appUrlPrefix}my-url`
+        render(
+          <InternalTouchableLink
+            enableNavigate
+            navigateTo={{
+              internalUrl,
+            }}>
+            <InternalTouchableLinkContent />
+          </InternalTouchableLink>
+        )
+
+        fireEvent.press(screen.getByText(linkText))
+
+        expect(openUrl).toHaveBeenNthCalledWith(1, internalUrl)
+      }
+    )
+
+    it('should not navigate when internalUrl is not in-app url', async () => {
+      render(
+        <InternalTouchableLink
+          enableNavigate={false}
+          navigateTo={{
+            internalUrl: 'http://my-url',
+          }}>
+          <InternalTouchableLinkContent />
+        </InternalTouchableLink>
+      )
+
+      fireEvent.press(screen.getByText(linkText))
+
+      expect(openUrl).not.toHaveBeenCalled()
+    })
+
+    it('should not navigate when internalUrl is defined and enableNavigate is false', async () => {
+      render(
+        <InternalTouchableLink
+          enableNavigate={false}
+          navigateTo={{ internalUrl: `${linking.prefixes[0]}my-url` }}>
+          <InternalTouchableLinkContent />
+        </InternalTouchableLink>
+      )
+
+      fireEvent.press(screen.getByText(linkText))
+
+      expect(openUrl).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/ui/components/touchableLink/InternalTouchableLink.tsx
+++ b/src/ui/components/touchableLink/InternalTouchableLink.tsx
@@ -1,29 +1,46 @@
 import { useLinkProps, useNavigation } from '@react-navigation/native'
-import React, { FunctionComponent, useCallback } from 'react'
+import React, { useCallback } from 'react'
 
+import { isAppUrl, openUrl } from 'features/navigation/helpers'
 import { pushFromRef, navigateFromRef } from 'features/navigation/navigationRef'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { eventMonitoring } from 'libs/monitoring'
 import { TouchableLink } from 'ui/components/touchableLink/TouchableLink'
 import { InternalTouchableLinkProps } from 'ui/components/touchableLink/types'
 
-export const InternalTouchableLink: FunctionComponent<InternalTouchableLinkProps> = ({
+export function InternalTouchableLink({
   navigateTo,
   enableNavigate = true,
   ...rest
-}) => {
+}: InternalTouchableLinkProps) {
+  // When navigating using in-app urls instead of screen names, we use internalUrl prop (e.g: links from backend).
+  const hasInternalUrl = 'internalUrl' in navigateTo
+  const linkTo = hasInternalUrl ? '' : navigateTo
   // We use nullish operator here because TabBar uses InteralTouchableLink but navigateTo is undefined during launch
-  const internalLinkProps = useLinkProps({ to: navigateTo ?? '' })
+  const internalLinkProps = useLinkProps({ to: linkTo ?? '' })
+  // const linkProps = hasInternalUrl ? navigateTo.internalUrl : internalLinkProps
   const { navigate, push } = useNavigation<UseNavigationType>()
   const handleNavigation = useCallback(() => {
     if (enableNavigate) {
-      const { screen, params, fromRef, withPush } = navigateTo
-      if (withPush) {
-        fromRef ? pushFromRef(screen, params) : push(screen, params)
+      if (!hasInternalUrl) {
+        const { screen, params, fromRef, withPush } = navigateTo
+        if (withPush) {
+          fromRef ? pushFromRef(screen, params) : push(screen, params)
+        } else {
+          fromRef ? navigateFromRef(screen, params) : navigate(screen, params)
+        }
       } else {
-        fromRef ? navigateFromRef(screen, params) : navigate(screen, params)
+        if (navigateTo.internalUrl && isAppUrl(navigateTo.internalUrl)) {
+          openUrl(navigateTo.internalUrl)
+        } else {
+          eventMonitoring.captureException(
+            `InternalUrl was not an in-app url: ${navigateTo.internalUrl}`
+          )
+        }
       }
     }
-  }, [enableNavigate, navigateTo, push, navigate])
+  }, [enableNavigate, navigateTo, push, navigate, hasInternalUrl])
+  //TODO(EveJulliard): virer le navigateTo des deps
   return (
     <TouchableLink handleNavigation={handleNavigation} linkProps={internalLinkProps} {...rest} />
   )

--- a/src/ui/components/touchableLink/types.ts
+++ b/src/ui/components/touchableLink/types.ts
@@ -3,17 +3,21 @@ import { GestureResponderEvent, TouchableOpacityProps } from 'react-native'
 
 import { UrlParamsProps } from 'features/navigation/helpers'
 import { RootNavigateParams } from 'features/navigation/RootNavigator/types'
+
 // eslint-disable-next-line no-restricted-imports
 import { ColorsEnum } from 'ui/theme/colors'
 
 export type InternalNavigationProps = {
   enableNavigate?: boolean // It is used by offline mode to prevent navigation
-  navigateTo: {
-    screen: RootNavigateParams[0]
-    params?: RootNavigateParams[1]
-    withPush?: boolean // If true, uses push instead of navigate
-    fromRef?: boolean // If true, uses navigateFromRef/pushFromRef instead of navigate/push
-  }
+  navigateTo:
+    | {
+        screen: RootNavigateParams[0]
+        params?: RootNavigateParams[1]
+        withPush?: boolean // If true, uses push instead of navigate
+        fromRef?: boolean // If true, uses navigateFromRef/pushFromRef instead of navigate/push
+        internalUrl?: never
+      }
+    | { screen?: never; params?: never; withPush?: never; fromRef?: never; internalUrl: string } // When navigating using in-app urls instead of screen names, we use internalUrl prop (e.g: links from backend).
   externalNav?: never
 }
 

--- a/src/ui/components/touchableLink/types.ts
+++ b/src/ui/components/touchableLink/types.ts
@@ -3,7 +3,6 @@ import { GestureResponderEvent, TouchableOpacityProps } from 'react-native'
 
 import { UrlParamsProps } from 'features/navigation/helpers'
 import { RootNavigateParams } from 'features/navigation/RootNavigator/types'
-
 // eslint-disable-next-line no-restricted-imports
 import { ColorsEnum } from 'ui/theme/colors'
 

--- a/src/ui/components/touchableLink/types.ts
+++ b/src/ui/components/touchableLink/types.ts
@@ -29,7 +29,6 @@ export type ExternalNavigationProps = {
     onSuccess?: () => void | Promise<void>
     onError?: () => void
   }
-  openInNewWindow?: boolean
   enableNavigate?: never
   navigateTo?: never
 }


### PR DESCRIPTION
This props has been added in [this PR](https://github.com/pass-culture/pass-culture-app-native/commit/d0e27f1905467171d6205bcdaf15a2918b4ff361) to let the possibility of opening an internalUrl via an ExternalTouchableLink in ExclusivityExternalLink. But this logic goes against the InternalTouchableLink and ExternalTouchableLink separation. It also caused [a bug ](https://github.com/pass-culture/pass-culture-app-native/pull/4519) because of it's usage in SubscriptionMessageBadge. Therefore we decided to remove it in this PR