### PR TITLE
(BSR) fix(CI): Use allowed bundler ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,16 +8,8 @@ updates:
       - 'Lucasbeneston'
       - 'bruno-ebstein-pass-culture'
       - 'pierrecanthelou'
-  - package-ecosystem: 'RubyGems'
+  - package-ecosystem: 'bundler'
     directory: '/'
-    schedule:
-      interval: 'weekly'
-    reviewers:
-      - 'Lucasbeneston'
-      - 'bruno-ebstein-pass-culture'
-      - 'pierrecanthelou'
-  - package-ecosystem: 'bundle'
-    directory: '/ios'
     schedule:
       interval: 'weekly'
     reviewers:


### PR DESCRIPTION
En regardant sur d'autres projets,  il faut utiliser l'ecosystem `bundler` pour RubyGems et bundle

https://github.blog/changelog/2020-09-23-dependabot-supports-vendoring-for-ruby-bundler/


## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
