### PR TITLE
(PC-21060) chore(stepButton): fix step button label colors

### DIFF
--- a/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
@@ -197,7 +197,7 @@ Array [
                   style={
                     Array [
                       Object {
-                        "color": "#90949D",
+                        "color": "#696A6F",
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
@@ -452,7 +452,7 @@ Array [
                   style={
                     Array [
                       Object {
-                        "color": "#90949D",
+                        "color": "#696A6F",
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
@@ -561,7 +561,7 @@ Array [
                   style={
                     Array [
                       Object {
-                        "color": "#90949D",
+                        "color": "#696A6F",
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,

--- a/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
@@ -197,7 +197,7 @@ Array [
                   style={
                     Array [
                       Object {
-                        "color": "#161617",
+                        "color": "#90949D",
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
@@ -452,7 +452,7 @@ Array [
                   style={
                     Array [
                       Object {
-                        "color": "#161617",
+                        "color": "#90949D",
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
@@ -561,7 +561,7 @@ Array [
                   style={
                     Array [
                       Object {
-                        "color": "#161617",
+                        "color": "#90949D",
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,

--- a/src/features/identityCheck/components/StepButton.stories.tsx
+++ b/src/features/identityCheck/components/StepButton.stories.tsx
@@ -1,0 +1,104 @@
+import { NavigationContainer } from '@react-navigation/native'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import React from 'react'
+
+import { IconRetryStep } from 'features/identityCheck/components/IconRetryStep'
+import { IconStepDone } from 'features/identityCheck/components/IconStepDone'
+import { StepButton } from 'features/identityCheck/components/StepButton'
+import { IdentityCheckStep, StepButtonState } from 'features/identityCheck/types'
+import { theme } from 'theme'
+import { BicolorIdCard } from 'ui/svg/icons/BicolorIdCard'
+import { AccessibleIcon } from 'ui/svg/icons/types'
+
+const DisabledIdCardIcon: React.FC<AccessibleIcon> = () => (
+  <BicolorIdCard
+    size={24}
+    color={theme.colors.greyMedium}
+    color2={theme.colors.greyMedium}
+    testID="DisabledIdCardIcon"
+  />
+)
+
+export default {
+  title: 'ui/StepButton',
+  component: StepButton,
+  decorators: [
+    (Story) => (
+      <NavigationContainer>
+        <Story />
+      </NavigationContainer>
+    ),
+  ],
+} as ComponentMeta<typeof StepButton>
+
+const Template: ComponentStory<typeof StepButton> = (props) => <StepButton {...props} />
+
+export const Default = Template.bind({})
+Default.args = {
+  state: StepButtonState.CURRENT,
+  step: {
+    name: IdentityCheckStep.IDENTIFICATION,
+    screens: ['SelectIDOrigin'],
+    stepState: StepButtonState.CURRENT,
+    title: 'Identification',
+    icon: {
+      disabled: DisabledIdCardIcon,
+      current: BicolorIdCard,
+      completed: () => <IconStepDone Icon={BicolorIdCard} testID="identification-step-done" />,
+      retry: () => <IconRetryStep Icon={BicolorIdCard} testID="identification-retry-step" />,
+    },
+  },
+  navigateTo: { screen: 'SelectIDOrigin' },
+}
+
+export const DisabledStep = Template.bind({})
+DisabledStep.args = {
+  state: StepButtonState.DISABLED,
+  step: {
+    stepState: StepButtonState.DISABLED,
+    name: IdentityCheckStep.IDENTIFICATION,
+    screens: ['SelectIDOrigin'],
+    title: 'Identification',
+    icon: {
+      disabled: DisabledIdCardIcon,
+      current: BicolorIdCard,
+      completed: () => <IconStepDone Icon={BicolorIdCard} testID="identification-step-done" />,
+      retry: () => <IconRetryStep Icon={BicolorIdCard} testID="identification-retry-step" />,
+    },
+  },
+  navigateTo: { screen: 'SelectIDOrigin' },
+}
+export const RetryStep = Template.bind({})
+RetryStep.args = {
+  state: StepButtonState.RETRY,
+  step: {
+    stepState: StepButtonState.RETRY,
+    name: IdentityCheckStep.IDENTIFICATION,
+    screens: ['SelectIDOrigin'],
+    title: 'Identification',
+    icon: {
+      disabled: DisabledIdCardIcon,
+      current: BicolorIdCard,
+      completed: () => <IconStepDone Icon={BicolorIdCard} testID="identification-step-done" />,
+      retry: () => <IconRetryStep Icon={BicolorIdCard} testID="identification-retry-step" />,
+    },
+  },
+  navigateTo: { screen: 'SelectIDOrigin' },
+}
+export const CompletedStep = Template.bind({})
+CompletedStep.args = {
+  state: StepButtonState.COMPLETED,
+  step: {
+    stepState: StepButtonState.COMPLETED,
+    name: IdentityCheckStep.IDENTIFICATION,
+    screens: ['SelectIDOrigin'],
+    title: 'Identification',
+    icon: {
+      disabled: DisabledIdCardIcon,
+      current: BicolorIdCard,
+      completed: () => <IconStepDone Icon={BicolorIdCard} testID="identification-step-done" />,
+      retry: () => <IconRetryStep Icon={BicolorIdCard} testID="identification-retry-step" />,
+    },
+  },
+  navigateTo: { screen: 'SelectIDOrigin' },
+}

--- a/src/features/identityCheck/components/StepButton.tsx
+++ b/src/features/identityCheck/components/StepButton.tsx
@@ -140,7 +140,7 @@ const StyledButtonText = styled(Typo.ButtonText)<{ state: StepButtonState }>(
     color:
       state === (StepButtonState.CURRENT || StepButtonState.RETRY)
         ? theme.colors.black
-        : theme.colors.greySemiDark,
+        : theme.colors.greyDark,
   })
 )
 

--- a/src/features/identityCheck/components/StepButton.tsx
+++ b/src/features/identityCheck/components/StepButton.tsx
@@ -138,7 +138,7 @@ const StyledTouchableOpacity = styled(TouchableOpacity)({
 const StyledButtonText = styled(Typo.ButtonText)<{ state: StepButtonState }>(
   ({ state, theme }) => ({
     color:
-      state === StepButtonState.CURRENT || StepButtonState.RETRY
+      state === (StepButtonState.CURRENT || StepButtonState.RETRY)
         ? theme.colors.black
         : theme.colors.greySemiDark,
   })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-21060

On a [previous PR ](https://github.com/pass-culture/pass-culture-app-native/pull/4596) I accidentaly introduced a design bug by changing the label color condition.
This PR fixes the bug + add new snapshots tests to highligth any design changes on the stepButtons

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              | <img width="386" alt="image" src="https://user-images.githubusercontent.com/89008469/229460705-74180a3c-3c7a-4037-8b86-edec3f7f9a55.png"> | <img width="384" alt="image" src="https://user-images.githubusercontent.com/89008469/229477811-e2b41342-d26d-42e7-95ba-d1ec39d8ecf3.png"> |
| Android          |        |       |
| Desktop - Chrome | <img width="748" alt="image" src="https://user-images.githubusercontent.com/89008469/229461827-ea7c4241-37fd-4354-9e12-352742c90276.png"> | <img width="786" alt="image" src="https://user-images.githubusercontent.com/89008469/229478298-897e7b0a-b076-4066-8328-d1823d0f0cf2.png"> |


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
