### PR TITLE
(BSR) feat(StepButton): fix stepButton wrongly disabled

### DIFF
--- a/src/features/identityCheck/components/StepButton.native.test.tsx
+++ b/src/features/identityCheck/components/StepButton.native.test.tsx
@@ -61,6 +61,12 @@ describe('StepButton with DeprecatedStepConfig', () => {
       const { getByTestId } = render(<StepButton step={step} state={StepButtonState.CURRENT} />)
       expect(getByTestId(`${label} non complété`).props.accessibilityState.disabled).toBe(false)
     })
+    it('should be active if step is "retry"', () => {
+      const { getByTestId } = render(<StepButton step={step} state={StepButtonState.RETRY} />)
+      expect(getByTestId(`${label} à essayer de nouveau`).props.accessibilityState.disabled).toBe(
+        false
+      )
+    })
   })
 
   describe('icons', () => {

--- a/src/features/identityCheck/components/StepButton.tsx
+++ b/src/features/identityCheck/components/StepButton.tsx
@@ -44,11 +44,13 @@ export const StepButton = ({ step, state, navigateTo, onPress }: Props) => {
 
   const StyleContainer = styleContainer[state]
 
+  const isDisabled = state === StepButtonState.DISABLED || state === StepButtonState.COMPLETED
+
   return navigateTo ? (
     <StyledInternalTouchableLink
       navigateTo={navigateTo}
       onBeforeNavigate={onPress}
-      disabled={state !== 'current'}
+      disabled={isDisabled}
       accessibilityLabel={accessibilityLabel}>
       <StyleContainer LeftIcon={Icon}>
         <StyledButtonText state={state}>{label}</StyledButtonText>
@@ -57,7 +59,7 @@ export const StepButton = ({ step, state, navigateTo, onPress }: Props) => {
   ) : (
     <StyledTouchableOpacity
       onPress={onPress}
-      disabled={state !== 'current'}
+      disabled={isDisabled}
       accessibilityLabel={accessibilityLabel}>
       <StyleContainer LeftIcon={Icon}>
         <StyledButtonText state={state}>{label}</StyledButtonText>


### PR DESCRIPTION
StepButton should be enable if stepState is CURRENT or RETRY. In previous version, RETRY state was disabled


## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots




**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              | [ retry button disabled](https://user-images.githubusercontent.com/89008469/230593527-944d9eea-e105-49ad-a836-b497b914ddc5.mp4) | [retry button enabled](https://user-images.githubusercontent.com/89008469/230593373-3159412c-4c80-4bee-b884-3b5f8706b4c0.mp4) |

