### PR TITLE
(BSR) chore(circleCI): update Xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ executors:
 
   ios:
     macos:
-      xcode: '13.2.1'
+      xcode: '14.2'
 
   gcp:
     docker:
@@ -36,7 +36,7 @@ executors:
 
 commands:
   gcp-oidc-authenticate:
-    description: "Authenticate with GCP using a CircleCI OIDC token."
+    description: 'Authenticate with GCP using a CircleCI OIDC token.'
     parameters:
       project_id:
         type: env_var_name


### PR DESCRIPTION
Suite au passage à iOS 16, il faut qu'on build iOS sur une version d'Xcode >14.1. Cette PR met à jour la version indiquée pour CircleCI.

Cf.: https://developer.apple.com/news/?id=jd9wcyov