### PR TITLE
(BSR) feat(getCodePushId): Fetch metadata once

### DIFF
--- a/src/api/getCodePushId.native.test.ts
+++ b/src/api/getCodePushId.native.test.ts
@@ -1,10 +1,14 @@
 import CodePush, { LocalPackage } from 'react-native-code-push'
 
-import { getCodePushId } from './getCodePushId'
+import { getCodePushId, metadataRef } from './getCodePushId'
 
 const codePushSpy = jest.spyOn(CodePush, 'getUpdateMetadata')
 
 describe('getCodePushId', () => {
+  beforeEach(() => {
+    metadataRef.hasFetchedMetadata = false
+  })
+
   it('should return empty string when there is no code push information', async () => {
     codePushSpy.mockResolvedValueOnce(null)
     const codePushId = await getCodePushId()
@@ -17,6 +21,14 @@ describe('getCodePushId', () => {
     const codePushId = await getCodePushId()
 
     expect(codePushId).toEqual('4')
+  })
+
+  it('should fetch metadata once', async () => {
+    codePushSpy.mockResolvedValueOnce({ label: 'V4' } as LocalPackage)
+    await getCodePushId()
+    await getCodePushId()
+
+    expect(codePushSpy).toHaveBeenCalledTimes(1)
   })
 
   it('should return empty string when there is an error', async () => {

--- a/src/api/getCodePushId.ts
+++ b/src/api/getCodePushId.ts
@@ -1,11 +1,19 @@
 import CodePush from 'react-native-code-push'
 
+// Exported for tests only
+export const metadataRef = { hasFetchedMetadata: false }
+let codePushLabel = ''
+
 export const getCodePushId = async () => {
   try {
-    const metadata = await CodePush.getUpdateMetadata()
+    if (!metadataRef.hasFetchedMetadata) {
+      const metadata = await CodePush.getUpdateMetadata()
+      metadataRef.hasFetchedMetadata = true
 
-    // We want to remove the letter 'v' from the  code push label : 'v4' => '4'
-    const codePushLabel = metadata ? metadata.label.slice(1) : ''
+      // We want to remove the letter 'v' from the  code push label : 'v4' => '4'
+      codePushLabel = metadata ? metadata.label.slice(1) : ''
+      return codePushLabel
+    }
 
     return codePushLabel
   } catch {


### PR DESCRIPTION

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
