### PR TITLE
(BSR) fix(home): Dont display spinner on web

### DIFF
--- a/src/features/home/pages/GenericHome.tsx
+++ b/src/features/home/pages/GenericHome.tsx
@@ -140,7 +140,9 @@ export const OnlineHome: FunctionComponent<GenericHomeProps> = ({
           data={modulesToDisplay}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
-          ListFooterComponent={<FooterComponent hasShownAll={maxIndex >= modules.length} />}
+          ListFooterComponent={
+            <FooterComponent hasShownAll={modulesToDisplay.length >= modules.length} />
+          }
           ListHeaderComponent={Header}
           initialNumToRender={initialNumToRender}
           removeClippedSubviews={false}


### PR DESCRIPTION
## Checklist
Le spinner reste toujours afficher en web, alors que le chargement progressif n'est pas implémenté.

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |   https://user-images.githubusercontent.com/46637324/235642693-dbe587a7-35f2-4e8a-9569-11c285b64579.mp4    |
| Desktop - Chrome |        |      <img width="717" alt="Capture d’écran 2023-05-02 à 12 14 41" src="https://user-images.githubusercontent.com/46637324/235642674-eaa71e0a-0eb6-485e-93e8-b0f9552eef23.png"> |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
