### PR TITLE
(PC-22096) fix(OfferHeader): fix double Tap / click causes blocking of favorites / removal from the offer consultation

### DIFF
--- a/src/features/offer/components/OfferHeader/OfferHeader.tsx
+++ b/src/features/offer/components/OfferHeader/OfferHeader.tsx
@@ -73,7 +73,7 @@ export const OfferHeader: React.FC<Props> = (props) => {
   const [ariaHiddenTitle, setAriaHiddenTitle] = useState(true)
   headerTransition.addListener((opacity) => setAriaHiddenTitle(opacity.value !== 1))
 
-  const { mutate: addFavorite } = useAddFavorite({
+  const { mutate: addFavorite, isLoading: addFavoriteIsLoading } = useAddFavorite({
     onSuccess: () => {
       if (typeof offerId === 'number') {
         const { from, moduleName, moduleId, searchId } = params
@@ -82,7 +82,7 @@ export const OfferHeader: React.FC<Props> = (props) => {
     },
   })
 
-  const { mutate: removeFavorite } = useRemoveFavorite({
+  const { mutate: removeFavorite, isLoading: removeFavoriteIsLoading } = useRemoveFavorite({
     onError: () => {
       showErrorSnackBar({
         message: 'L’offre n’a pas été retirée de tes favoris',
@@ -165,6 +165,7 @@ export const OfferHeader: React.FC<Props> = (props) => {
             initialColor={favorite ? theme.colors.primary : undefined}
             iconName={favorite ? 'favorite-filled' : 'favorite'}
             onPress={pressFavorite}
+            disabled={removeFavoriteIsLoading || addFavoriteIsLoading}
             {...accessibleCheckboxProps({ checked: !!favorite, label: 'Mettre en favoris' })}
           />
           <Spacer.Row numberOfSpaces={6} />

--- a/src/ui/components/buttons/RoundedButton.tsx
+++ b/src/ui/components/buttons/RoundedButton.tsx
@@ -28,6 +28,7 @@ interface Props {
   accessibilityRole?: AccessibilityRole
   accessibilityChecked?: boolean
   accessibilityLabel?: string
+  disabled?: boolean
 }
 
 const getIcon = (iconName: Props['iconName']): React.FC<IconInterface> => {
@@ -51,7 +52,11 @@ export const RoundedButton = (props: Props) => {
   }, [props.accessibilityRole, props.accessibilityChecked, props.accessibilityLabel])
 
   return (
-    <StyledTouchable activeOpacity={0.5} onPress={props.onPress} {...accessibilityProps}>
+    <StyledTouchable
+      activeOpacity={0.5}
+      onPress={props.onPress}
+      disabled={props.disabled}
+      {...accessibilityProps}>
       {props.animationState ? (
         <IconContainer
           testID="AnimatedHeaderIconRoundContainer"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-22096

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots


https://user-images.githubusercontent.com/62058919/236169606-4c601c64-e99a-4484-b9cf-d4e772eef712.mov



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
