### PR TITLE
(BSR) fix(sonar): fix some new Sonar issues

### DIFF
--- a/src/features/auth/components/PasswordSecurityRules.tsx
+++ b/src/features/auth/components/PasswordSecurityRules.tsx
@@ -34,19 +34,19 @@ function isLongEnough(password: string): boolean {
 }
 
 function containsCapital(password: string): boolean {
-  return password.match(CAPITAL_REGEX) ? true : false
+  return CAPITAL_REGEX.test(password)
 }
 
 function containsLowercase(password: string): boolean {
-  return password.match(LOWERCASE_REGEX) ? true : false
+  return LOWERCASE_REGEX.test(password)
 }
 
 function containsNumber(password: string): boolean {
-  return password.match(NUMBER_REGEX) ? true : false
+  return NUMBER_REGEX.test(password)
 }
 
 function containsSpecialCharacter(password: string): boolean {
-  return password.match(SPECIAL_CHARACTER_REGEX) ? true : false
+  return SPECIAL_CHARACTER_REGEX.test(password)
 }
 
 export const PasswordSecurityRules: FunctionComponent<Props> = ({

--- a/src/features/auth/pages/suspendedAccount/SuspendedAccount/SuspendedAccount.tsx
+++ b/src/features/auth/pages/suspendedAccount/SuspendedAccount/SuspendedAccount.tsx
@@ -52,7 +52,7 @@ export const SuspendedAccount = () => {
     unsuspendAccount()
   }
 
-  const unsuspensionDelay = settings?.accountUnsuspensionLimit || 60
+  const unsuspensionDelay = settings?.accountUnsuspensionLimit ?? 60
   let formattedDate = ''
 
   if (accountSuspensionDate?.date) {

--- a/src/features/favorites/components/FavoritesResults.tsx
+++ b/src/features/favorites/components/FavoritesResults.tsx
@@ -85,8 +85,7 @@ export const FavoritesResults: React.FC = React.memo(function FavoritesResults()
   const credit = useAvailableCredit()
 
   useEffect(() => {
-    if (flatListRef && flatListRef.current)
-      flatListRef.current.scrollToOffset({ animated: true, offset: 0 })
+    if (flatListRef?.current) flatListRef.current.scrollToOffset({ animated: true, offset: 0 })
   }, [favoritesState.sortBy])
 
   const renderItem = useCallback(

--- a/src/features/favorites/components/FavoritesResults.tsx
+++ b/src/features/favorites/components/FavoritesResults.tsx
@@ -85,7 +85,7 @@ export const FavoritesResults: React.FC = React.memo(function FavoritesResults()
   const credit = useAvailableCredit()
 
   useEffect(() => {
-    if (flatListRef?.current) flatListRef.current.scrollToOffset({ animated: true, offset: 0 })
+    flatListRef?.current?.scrollToOffset({ animated: true, offset: 0 })
   }, [favoritesState.sortBy])
 
   const renderItem = useCallback(

--- a/src/features/navigation/RootNavigator/linking/__mocks__/withAuthProtection.tsx
+++ b/src/features/navigation/RootNavigator/linking/__mocks__/withAuthProtection.tsx
@@ -1,9 +1,10 @@
 import React, { ComponentType } from 'react'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function withAuthProtection(WrappedComponent: ComponentType<any>) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function ComponentWithAuthProtection(props: any) {
+type Props = any
+
+export function withAuthProtection(WrappedComponent: ComponentType<Props>) {
+  return function ComponentWithAuthProtection(props: Props) {
     return <WrappedComponent {...props} />
   }
 }

--- a/src/features/navigation/RootNavigator/linking/withAuthProtection.tsx
+++ b/src/features/navigation/RootNavigator/linking/withAuthProtection.tsx
@@ -3,7 +3,8 @@ import React, { ComponentType } from 'react'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { Login } from 'features/auth/pages/login/Login'
 
-type Props = any // eslint-disable-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Props = any
 
 export function withAuthProtection(WrappedComponent: ComponentType<Props>) {
   return function ComponentWithAuthProtection(props: Props) {


### PR DESCRIPTION
## Nouvelles issues Sonar

N°1 : [Prefer using nullish coalescing operator (`??`) instead of a logical or (`||`), as it is a safer operator.](https://sonarcloud.io/project/issues?resolved=false&rules=typescript%3AS6606&types=CODE_SMELL&id=pass-culture_pass-culture-app-native&open=AYfcmBJq1_2M_ybCqkZo)
**Exemple de résolution** : https://github.com/pass-culture/pass-culture-app-native/pull/4761/commits/c4d33e8ef1a36ad7dc59506802b61b8f0edd3439

**Pourquoi cette règle ?**
_L'opérateur `??` retourne la première valeur qui n'est pas `null` ou `undefined`. Cela signifie qu'il ne remplacera pas les valeurs `falsy` par une valeur de secours, contrairement à l'opérateur `||`. Il est plus sûr que l'opérateur `||` car il n'interprète pas certaines valeurs `falsy` (comme la chaîne de caractères vide) comme n'étant pas définies._

---

N°2 : [Prefer using an optional chain expression instead, as it's more concise and easier to read.](https://sonarcloud.io/project/issues?resolved=false&rules=typescript%3AS6582&types=CODE_SMELL&id=pass-culture_pass-culture-app-native&open=AYfcmA_j1_2M_ybCqkYx&tab=code)
**Exemple de résolution** :  https://github.com/pass-culture/pass-culture-app-native/pull/4761/commits/3f2838ead89e3bc0799c0cbc427f6983a883d837

**Pourquoi cette règle ?**
_Utiliser `value?.current`est une alternative plus concise et plus sûre à l'utilisation de `value && value.current` qui évite les erreurs de type "Cannot read property 'current' of null"._

---

N°3 : [Use the "RegExp.exec()" method instead.](https://sonarcloud.io/project/issues?resolved=false&rules=typescript%3AS6594&types=CODE_SMELL&id=pass-culture_pass-culture-app-native&open=AYfcmBNb1_2M_ybCqkZ8&tab=code)
**Exemple de résolution** : https://github.com/pass-culture/pass-culture-app-native/pull/4761/commits/8940ca764e7901cd214f2db9e56783fa09f30e26

**Pourquoi cette règle ?**
`String.match(RegExp)` se comporte de la même manière que `RegExp.exec()` lorsque l'expression régulière n'inclut pas l'indicateur global g. Bien qu'ils fonctionnent de la même manière, `RegExp.exec()` peut être légèrement plus rapide que String.match(). Par conséquent, il devrait être préféré pour de meilleures performances. 

Dans notre cas (https://github.com/pass-culture/pass-culture-app-native/pull/4761/commits/8940ca764e7901cd214f2db9e56783fa09f30e26) l'utilisation de `RegExp.test()` est recommandé (gain de perfomance) car elle ne retourne qu'un booléen contrairement à `RegExp.exec()` qui crée en plus un tableau de correspondance détaillé. Ici nous voulons simplement qu'une chaîne de caractères correspond à une expression régulière. 
