### PR TITLE
(PC-21532) feat(proxy): move metadata to the end of head

### DIFF
--- a/server/src/utils/metas.ts
+++ b/server/src/utils/metas.ts
@@ -127,10 +127,10 @@ export async function replaceHtmlMetas(
 
   if (entity['metadata']) {
     html = html.replace(
-      '</body>',
+      '</head>',
       `  <script type="application/ld+json">${JSON.stringify(
         entity['metadata']
-      )}</script>\n  </body>`
+      )}</script>\n  </head>`
     )
   }
 

--- a/server/src/utils/tests/__snapshots__/metas.test.ts.snap
+++ b/server/src/utils/tests/__snapshots__/metas.test.ts.snap
@@ -43,10 +43,10 @@ Tous les détails du film sur AlloCiné: https://www.allocine.fr/film/fichefilm_
     <meta property=\\"al:android:url\\" content=\\"passculture://https://app.testing.passculture.team\\">
     <meta property=\\"al:android:app_name\\" content=\\"pass Culture\\"/>
     <meta property=\\"al:android:package\\" content=\\"app.passculture.testing\\"/>
+    <script type=\\"application/ld+json\\">{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Event\\",\\"name\\":\\"Sous les étoiles de Paris - VF\\",\\"location\\":{\\"@type\\":\\"Place\\",\\"name\\":\\"PATHE BEAUGRENELLE\\",\\"address\\":{\\"@type\\":\\"PostalAddress\\",\\"streetAddress\\":\\"2 RUE LAMENNAIS\\",\\"postalCode\\":\\"75008\\",\\"addressLocality\\":\\"PARIS 8\\"},\\"geo\\":{\\"@type\\":\\"GeoCoordinates\\",\\"latitude\\":\\"20\\",\\"longitude\\":\\"2\\"}}}</script>
   </head>
   <body>
     <p>Hello world</p>
-    <script type=\\"application/ld+json\\">{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Event\\",\\"name\\":\\"Sous les étoiles de Paris - VF\\",\\"location\\":{\\"@type\\":\\"Place\\",\\"name\\":\\"PATHE BEAUGRENELLE\\",\\"address\\":{\\"@type\\":\\"PostalAddress\\",\\"streetAddress\\":\\"2 RUE LAMENNAIS\\",\\"postalCode\\":\\"75008\\",\\"addressLocality\\":\\"PARIS 8\\"},\\"geo\\":{\\"@type\\":\\"GeoCoordinates\\",\\"latitude\\":\\"20\\",\\"longitude\\":\\"2\\"}}}</script>
   </body>
 </html>"
 `;


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-21532

On soupçonne que React écrase le contenu du body pour afficher les pages qu'il veut, donc on déplace les métadonnées  à la fin de la balise `head`


## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
