### PR TITLE
(PC-21980) fix(identification): add forward navigation to profile step screens

### DIFF
--- a/src/features/identityCheck/pages/profile/SetSchoolType.native.test.tsx
+++ b/src/features/identityCheck/pages/profile/SetSchoolType.native.test.tsx
@@ -1,7 +1,7 @@
 import { rest } from 'msw'
 import React from 'react'
 
-import { navigate } from '__mocks__/@react-navigation/native'
+import { CommonActions, dispatch } from '__mocks__/@react-navigation/native'
 import { ActivityIdEnum } from 'api/gen'
 import { initialSubscriptionState as mockState } from 'features/identityCheck/context/reducer'
 import { SchoolTypesSnap } from 'features/identityCheck/pages/profile/fixtures/mockedSchoolTypes'
@@ -93,7 +93,13 @@ describe('<SetSchoolType />', () => {
     fireEvent.press(screen.getByText(SchoolTypesSnap.school_types[0].label))
     fireEvent.press(screen.getByText('Continuer'))
 
-    await waitFor(() => expect(navigate).toHaveBeenCalledWith('Stepper'))
+    await waitFor(() => {
+      expect(dispatch).toHaveBeenCalledTimes(1)
+      expect(CommonActions.reset).toHaveBeenCalledWith({
+        index: 1,
+        routes: [{ name: 'TabNavigator' }, { name: 'Stepper' }],
+      })
+    })
   })
 })
 

--- a/src/features/identityCheck/pages/profile/SetSchoolType.tsx
+++ b/src/features/identityCheck/pages/profile/SetSchoolType.tsx
@@ -1,4 +1,3 @@
-import { useNavigation } from '@react-navigation/native'
 import React, { useEffect, useState } from 'react'
 import { View } from 'react-native'
 import { v4 as uuidv4 } from 'uuid'
@@ -9,13 +8,13 @@ import { useProfileOptions } from 'features/identityCheck/api/useProfileOptions'
 import { CenteredTitle } from 'features/identityCheck/components/CenteredTitle'
 import { PageWithHeader } from 'features/identityCheck/components/layout/PageWithHeader'
 import { useSubscriptionContext } from 'features/identityCheck/context/SubscriptionContextProvider'
+import { useNavigateForwardToStepper } from 'features/identityCheck/helpers/useNavigateForwardToStepper'
 import { useSaveStep } from 'features/identityCheck/pages/helpers/useSaveStep'
 import {
   getSchoolTypesIdsFromActivity,
   mapSchoolTypeIdToLabelAndDescription,
 } from 'features/identityCheck/pages/profile/helpers/schoolTypes'
 import { IdentityCheckStep } from 'features/identityCheck/types'
-import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { analytics } from 'libs/analytics'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
@@ -29,7 +28,7 @@ export const SetSchoolType = () => {
   const { schoolTypes, activities } = useProfileOptions()
   const saveStep = useSaveStep()
   const { mutateAsync: patchProfile, isLoading } = usePatchProfile()
-  const { navigate } = useNavigation<UseNavigationType>()
+  const { navigateForwardToStepper } = useNavigateForwardToStepper()
 
   const { dispatch, profile } = useSubscriptionContext()
   const [selectedSchoolTypeId, setSelectedSchoolTypeId] = useState<SchoolTypesIdEnum | null>(
@@ -47,7 +46,7 @@ export const SetSchoolType = () => {
 
     await patchProfile()
     await saveStep(IdentityCheckStep.PROFILE)
-    navigate('Stepper')
+    navigateForwardToStepper()
   }
 
   const activitySchoolTypes = activities

--- a/src/features/identityCheck/pages/profile/SetStatus.native.test.tsx
+++ b/src/features/identityCheck/pages/profile/SetStatus.native.test.tsx
@@ -1,7 +1,7 @@
 import { rest } from 'msw'
 import React from 'react'
 
-import { navigate } from '__mocks__/@react-navigation/native'
+import { CommonActions, dispatch, navigate } from '__mocks__/@react-navigation/native'
 import { ActivityIdEnum } from 'api/gen'
 import { initialSubscriptionState as mockState } from 'features/identityCheck/context/reducer'
 import { SchoolTypesSnap } from 'features/identityCheck/pages/profile/fixtures/mockedSchoolTypes'
@@ -87,7 +87,11 @@ describe('<SetStatus/>', () => {
     fireEvent.press(screen.getByText('Continuer'))
 
     await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('Stepper')
+      expect(dispatch).toHaveBeenCalledTimes(1)
+      expect(CommonActions.reset).toHaveBeenCalledWith({
+        index: 1,
+        routes: [{ name: 'TabNavigator' }, { name: 'Stepper' }],
+      })
     })
   })
 

--- a/src/features/identityCheck/pages/profile/SetStatus.tsx
+++ b/src/features/identityCheck/pages/profile/SetStatus.tsx
@@ -10,6 +10,7 @@ import { useProfileOptions } from 'features/identityCheck/api/useProfileOptions'
 import { CenteredTitle } from 'features/identityCheck/components/CenteredTitle'
 import { PageWithHeader } from 'features/identityCheck/components/layout/PageWithHeader'
 import { useSubscriptionContext } from 'features/identityCheck/context/SubscriptionContextProvider'
+import { useNavigateForwardToStepper } from 'features/identityCheck/helpers/useNavigateForwardToStepper'
 import { useSaveStep } from 'features/identityCheck/pages/helpers/useSaveStep'
 import { activityHasSchoolTypes } from 'features/identityCheck/pages/profile/helpers/schoolTypes'
 import { IdentityCheckStep } from 'features/identityCheck/types'
@@ -35,6 +36,7 @@ export const SetStatus = () => {
   const saveStep = useSaveStep()
   const { mutateAsync: patchProfile, isLoading } = usePatchProfile()
   const { navigate } = useNavigation<UseNavigationType>()
+  const { navigateForwardToStepper } = useNavigateForwardToStepper()
   const titleID = uuidv4()
   const { control, handleSubmit, watch } = useForm<StatusForm>({
     mode: 'onChange',
@@ -76,10 +78,10 @@ export const SetStatus = () => {
       } else {
         await patchProfile()
         await saveStep(IdentityCheckStep.PROFILE)
-        navigate('Stepper')
+        navigateForwardToStepper()
       }
     },
-    [dispatch, hasSchoolTypes, navigate, patchProfile, saveStep]
+    [dispatch, hasSchoolTypes, navigate, patchProfile, saveStep, navigateForwardToStepper]
   )
 
   return (


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |    

https://github.com/pass-culture/pass-culture-app-native/assets/47600889/a5baa0df-94e1-4ec7-b5a3-41c6f9a0f1dc

   |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
