### PR TITLE
(BSR) test(e2e): Use new URL to toggle feature flags in e2e tests

### DIFF
--- a/e2e/tests/pc/helpers/FeatureClient.ts
+++ b/e2e/tests/pc/helpers/FeatureClient.ts
@@ -14,7 +14,7 @@ const bright = '\x1b[1m'
 
 class FeatureClient {
   private static API_BASE_URL = env.API_BASE_URL
-  private static ENDPOINT = 'native/v1/features'
+  private static ENDPOINT = 'testing/features'
 
   private async patchFeatures(features: Features) {
     try {

--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -1113,33 +1113,6 @@ export interface FavoritesCountResponse {
   count: number
 }
 /**
- * @export
- * @interface FeatureToggle
- */
-export interface FeatureToggle {
-  /**
-   * @type {boolean}
-   * @memberof FeatureToggle
-   */
-  isActive: boolean
-  /**
-   * @type {string}
-   * @memberof FeatureToggle
-   */
-  name: string
-}
-/**
- * @export
- * @interface FeaturesToggleRequest
- */
-export interface FeaturesToggleRequest {
-  /**
-   * @type {Array<FeatureToggle>}
-   * @memberof FeaturesToggleRequest
-   */
-  features: Array<FeatureToggle>
-}
-/**
  * An enumeration.
  * @export
  * @enum {string}
@@ -3619,26 +3592,6 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
       }
     },
     /**
-     * @summary set_feature <PATCH>
-     * @param {FeaturesToggleRequest} [body] 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async patchnativev1features(body?: FeaturesToggleRequest, options: any = {}): Promise<FetchArgs> {
-      const pathname = `/native/v1/features`
-      let secureOptions = Object.assign(options, { credentials: 'omit' })
-      const localVarRequestOptions = Object.assign({ method: 'PATCH' }, secureOptions)
-      const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
-      localVarHeaderParameter['Content-Type'] = 'application/json'
-      localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
-      const needsSerialization = (<any>"FeaturesToggleRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json'
-      localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (body || "")
-      return {
-        url: pathname,
-        options: localVarRequestOptions,
-      }
-    },
-    /**
      * @summary create_account <POST>
      * @param {AccountRequest} [body] 
      * @param {*} [options] Override http request option.
@@ -4515,18 +4468,6 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     },
     /**
      * 
-     * @summary set_feature <PATCH>
-     * @param {FeaturesToggleRequest} [body] 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async patchnativev1features(body?: FeaturesToggleRequest, options?: any): Promise<EmptyResponse> {
-      const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).patchnativev1features(body, options)
-      const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
-      return handleGeneratedApiResponse(response)
-    },
-    /**
-     * 
      * @summary create_account <POST>
      * @param {AccountRequest} [body] 
      * @param {*} [options] Override http request option.
@@ -5113,18 +5054,6 @@ export class DefaultApi extends BaseAPI {
   public async getnativev1venuevenueId(venue_id: number, options?: any) {
     const configuration = await this.getConfiguration()
     return DefaultApiFp(this, configuration).getnativev1venuevenueId(venue_id, options)
-  }
-  /**
-    * 
-    * @summary set_feature <PATCH>
-    * @param {FeaturesToggleRequest} [body] 
-    * @param {*} [options] Override http request option.
-    * @throws {RequiredError}
-    * @memberof DefaultApi
-    */
-  public async patchnativev1features(body?: FeaturesToggleRequest, options?: any) {
-    const configuration = await this.getConfiguration()
-    return DefaultApiFp(this, configuration).patchnativev1features(body, options)
   }
   /**
     * 


### PR DESCRIPTION
The endpoint will be used by tests of the pro portal as well, so it
has been moved from the app API schema.

See pass-culture/pass-culture-main@a61e144c012dc8df219b317f6784327288bc2d63.