### PR TITLE
(PC-21674) feat(TrustedDevice): add SuspencionChoice screen and tests

### DIFF
--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
@@ -1,0 +1,618 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SuspensionChoice/> should match snapshot 1`] = `
+Array [
+  <View
+    accessibilityLabel="Revenir en arrière"
+    accessibilityRole="button"
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "left": 24,
+        "opacity": 1,
+        "position": "absolute",
+        "top": 30,
+        "userSelect": "auto",
+        "zIndex": 1,
+      }
+    }
+    testID="Revenir en arrière"
+  >
+    <View
+      accessibilityLabel="Revenir en arrière"
+      height={24}
+      width={24}
+    >
+      <Text>
+        undefined-SVG-Mock
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      Array [
+        Object {
+          "alignSelf": "center",
+          "flexBasis": 0,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "maxWidth": 500,
+          "overflow": "scroll",
+          "paddingHorizontal": 24,
+          "width": "100%",
+        },
+      ]
+    }
+  >
+    <View
+      flex={2}
+      style={
+        Array [
+          Object {
+            "flexBasis": 0,
+            "flexGrow": 2,
+            "flexShrink": 1,
+          },
+        ]
+      }
+    />
+    <View
+      hasHeight={false}
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexGrow": 1,
+            "justifyContent": "center",
+          },
+        ]
+      }
+    >
+      <View
+        height={156}
+        width={200}
+      >
+        <Text>
+          undefined-SVG-Mock
+        </Text>
+      </View>
+    </View>
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#161617",
+            "fontFamily": "Montserrat-Bold",
+            "fontSize": 20,
+            "lineHeight": 24,
+            "textAlign": "center",
+          },
+        ]
+      }
+    >
+      Souhaites-tu suspendre ton compte pass Culture ?
+    </Text>
+    <View
+      flex={0.5}
+      style={
+        Array [
+          Object {
+            "flexBasis": 0,
+            "flexGrow": 0.5,
+            "flexShrink": 1,
+          },
+        ]
+      }
+    />
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#161617",
+            "fontFamily": "Montserrat-Bold",
+            "fontSize": 15,
+            "lineHeight": 20,
+          },
+        ]
+      }
+    >
+      Les conséquences :
+    </Text>
+    <View
+      accessibilityRole="list"
+      style={
+        Array [
+          Object {
+            "flexDirection": "column",
+            "paddingLeft": 0,
+          },
+        ]
+      }
+    >
+      <View
+        accessibilityRole="none"
+        style={
+          Array [
+            Object {
+              "display": "flex",
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "flexDirection": "row",
+                "marginLeft": 12,
+                "marginTop": 0,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "height": 20,
+                  "justifyContent": "center",
+                },
+              ]
+            }
+          >
+            <View
+              borderColor="#161617"
+              fillColor="#161617"
+              height={3}
+              width={3}
+            >
+              <Text>
+                undefined-SVG-Mock
+              </Text>
+            </View>
+          </View>
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#161617",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontFamily": "Montserrat-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 20,
+                  "marginLeft": 12,
+                },
+              ]
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              tes réservations seront annulées sauf pour certains cas précisés dans les
+               
+              <View>
+                <View
+                  accessibilityLabel="conditions générales d’utilisation"
+                  accessibilityRole="link"
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "opacity": 1,
+                      "top": 3,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="conditions générales d’utilisation"
+                >
+                  <View
+                    paddingForIcon={0}
+                    style={
+                      Array [
+                        Object {
+                          "flexDirection": "row",
+                          "top": 0,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      accessibilityLabel="Nouvelle fenêtre"
+                      height={20}
+                      testID="button-icon"
+                      width={20}
+                    >
+                      <Text>
+                        button-icon-SVG-Mock
+                      </Text>
+                    </View>
+                    <View
+                      numberOfSpaces={1}
+                      style={
+                        Array [
+                          Object {
+                            "width": 4,
+                          },
+                        ]
+                      }
+                    />
+                    <Text
+                      color="#161617"
+                      style={
+                        Array [
+                          Object {
+                            "color": "#161617",
+                            "fontFamily": "Montserrat-Bold",
+                            "fontSize": 15,
+                            "lineHeight": 20,
+                          },
+                        ]
+                      }
+                      typography="ButtonText"
+                    >
+                      conditions générales d’utilisation
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </Text>
+          </Text>
+        </View>
+      </View>
+      <View
+        accessibilityRole="none"
+        style={
+          Array [
+            Object {
+              "display": "flex",
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "flexDirection": "row",
+                "marginLeft": 12,
+                "marginTop": 0,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "height": 20,
+                  "justifyContent": "center",
+                },
+              ]
+            }
+          >
+            <View
+              borderColor="#161617"
+              fillColor="#161617"
+              height={3}
+              width={3}
+            >
+              <Text>
+                undefined-SVG-Mock
+              </Text>
+            </View>
+          </View>
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#161617",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontFamily": "Montserrat-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 20,
+                  "marginLeft": 12,
+                },
+              ]
+            }
+          >
+            si tu as un dossier en cours, tu ne pourras pas en déposer un nouveau
+          </Text>
+        </View>
+      </View>
+      <View
+        accessibilityRole="none"
+        style={
+          Array [
+            Object {
+              "display": "flex",
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "flexDirection": "row",
+                "marginLeft": 12,
+                "marginTop": 0,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "height": 20,
+                  "justifyContent": "center",
+                },
+              ]
+            }
+          >
+            <View
+              borderColor="#161617"
+              fillColor="#161617"
+              height={3}
+              width={3}
+            >
+              <Text>
+                undefined-SVG-Mock
+              </Text>
+            </View>
+          </View>
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#161617",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontFamily": "Montserrat-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 20,
+                  "marginLeft": 12,
+                },
+              ]
+            }
+          >
+            tu n’auras plus accès au catalogue
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View
+      numberOfSpaces={4}
+      style={
+        Array [
+          Object {
+            "height": 16,
+          },
+        ]
+      }
+    />
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#161617",
+            "fontFamily": "Montserrat-Bold",
+            "fontSize": 15,
+            "lineHeight": 20,
+          },
+        ]
+      }
+    >
+      Les données qu’on conserve :
+    </Text>
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#161617",
+            "fontFamily": "Montserrat-Regular",
+            "fontSize": 15,
+            "lineHeight": 20,
+          },
+        ]
+      }
+    >
+      Nous gardons toutes les informations personnelles que tu nous as transmises lors de la vérification de ton identité.
+    </Text>
+    <View
+      numberOfSpaces={4}
+      style={
+        Array [
+          Object {
+            "height": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "paddingBottom": 40,
+          },
+        ]
+      }
+    >
+      <View
+        accessibilityLabel="Oui, suspendre mon compte"
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#eb0055",
+            "borderRadius": 24,
+            "flexDirection": "row",
+            "justifyContent": "center",
+            "maxWidth": 500,
+            "minHeight": 40,
+            "opacity": 1,
+            "paddingBottom": 2,
+            "paddingLeft": 20,
+            "paddingRight": 20,
+            "paddingTop": 2,
+            "userSelect": "auto",
+            "width": "100%",
+          }
+        }
+        testID="Oui, suspendre mon compte"
+      >
+        <Text
+          adjustsFontSizeToFit={false}
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "color": "#ffffff",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 15,
+                "lineHeight": 20,
+                "marginLeft": 0,
+                "maxWidth": "100%",
+              },
+            ]
+          }
+        >
+          Oui, suspendre mon compte
+        </Text>
+      </View>
+      <View
+        numberOfSpaces={2}
+        style={
+          Array [
+            Object {
+              "height": 8,
+            },
+          ]
+        }
+      />
+      <View
+        accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support"
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "transparent",
+            "borderRadius": 24,
+            "flexDirection": "row",
+            "justifyContent": "center",
+            "maxWidth": 500,
+            "minHeight": 40,
+            "opacity": 1,
+            "paddingBottom": 2,
+            "paddingLeft": 2,
+            "paddingRight": 2,
+            "paddingTop": 2,
+            "userSelect": "auto",
+            "width": "100%",
+          }
+        }
+        testID="Ouvrir le gestionnaire mail pour contacter le support"
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "flexShrink": 0,
+              },
+            ]
+          }
+        >
+          <View
+            height={20}
+            testID="button-icon"
+            width={20}
+          >
+            <Text>
+              button-icon-SVG-Mock
+            </Text>
+          </View>
+        </View>
+        <Text
+          adjustsFontSizeToFit={false}
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 15,
+                "lineHeight": 20,
+                "marginLeft": 8,
+                "maxWidth": "100%",
+              },
+            ]
+          }
+        >
+          Contacter le support
+        </Text>
+      </View>
+    </View>
+    <View
+      flex={1.5}
+      style={
+        Array [
+          Object {
+            "flexBasis": 0,
+            "flexGrow": 1.5,
+            "flexShrink": 1,
+          },
+        ]
+      }
+    />
+  </View>,
+]
+`;

--- a/src/features/internal/cheatcodes/pages/NavigationTrustedDevice/NavigationTrustedDevice.tsx
+++ b/src/features/internal/cheatcodes/pages/NavigationTrustedDevice/NavigationTrustedDevice.tsx
@@ -12,6 +12,7 @@ export function NavigationTrustedDevice(): JSX.Element {
       <PageHeaderSecondary title="Trusted device 📱" />
       <StyledContainer>
         <LinkToComponent name="TrustedDeviceInfos" />
+        <LinkToComponent name="SuspensionChoice" />
         <LinkToComponent name="SuspensionConfirmation" />
       </StyledContainer>
       <Spacer.BottomScreen />

--- a/src/features/navigation/RootNavigator/trustedDeviceRoutes.ts
+++ b/src/features/navigation/RootNavigator/trustedDeviceRoutes.ts
@@ -4,6 +4,7 @@ import {
   TrustedDeviceRootStackParamList,
   GenericRoute,
 } from 'features/navigation/RootNavigator/types'
+import { SuspensionChoice } from 'features/trustedDevice/pages/SuspensionChoice'
 import { SuspensionConfirmation } from 'features/trustedDevice/pages/SuspensionConfirmation'
 
 // Try to keep those routes in the same order as the user flow
@@ -17,6 +18,11 @@ export const trustedDeviceRoutes: GenericRoute<TrustedDeviceRootStackParamList>[
     name: 'TrustedDeviceInfos',
     component: TrustedDeviceInfos,
     path: 'appareil-de-confiance-cheatcode-informations',
+  },
+  {
+    name: 'SuspensionChoice',
+    component: SuspensionChoice,
+    path: 'securisation-compte/suspension',
   },
   {
     name: 'SuspensionConfirmation',

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -67,6 +67,7 @@ export type OnboardingRootStackParamList = {
 export type TrustedDeviceRootStackParamList = {
   NavigationTrustedDevice: undefined
   TrustedDeviceInfos: undefined
+  SuspensionChoice: undefined
   SuspensionConfirmation: undefined
 }
 

--- a/src/features/trustedDevice/pages/SuspensionChoice.native.test.tsx
+++ b/src/features/trustedDevice/pages/SuspensionChoice.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { navigate } from '__mocks__/@react-navigation/native'
 import { contactSupport } from 'features/auth/helpers/contactSupport'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
+import { env } from 'libs/environment/env'
 import { fireEvent, render, screen } from 'tests/utils'
 
 import { SuspensionChoice } from './SuspensionChoice'
@@ -36,5 +37,14 @@ describe('<SuspensionChoice/>', () => {
       contactSupport.forGenericQuestion.params,
       true
     )
+  })
+
+  it('should open CGU url when clicking on "conditions générales d’utilisation" button', () => {
+    render(<SuspensionChoice />)
+
+    const cguButton = screen.getByText('conditions générales d’utilisation')
+    fireEvent.press(cguButton)
+
+    expect(openUrl).toHaveBeenNthCalledWith(1, env.CGU_LINK, undefined, true)
   })
 })

--- a/src/features/trustedDevice/pages/SuspensionChoice.native.test.tsx
+++ b/src/features/trustedDevice/pages/SuspensionChoice.native.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+import { navigate } from '__mocks__/@react-navigation/native'
+import { contactSupport } from 'features/auth/helpers/contactSupport'
+import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
+import { fireEvent, render, screen } from 'tests/utils'
+
+import { SuspensionChoice } from './SuspensionChoice'
+
+const openUrl = jest.spyOn(NavigationHelpers, 'openUrl')
+
+describe('<SuspensionChoice/>', () => {
+  it('should match snapshot', () => {
+    render(<SuspensionChoice />)
+
+    expect(screen).toMatchSnapshot()
+  })
+
+  it('should navigate to suspension confirmation screen when clicking on "Oui, suspendre mon compte" button', () => {
+    render(<SuspensionChoice />)
+
+    const acceptSuspensionButton = screen.getByText('Oui, suspendre mon compte')
+    fireEvent.press(acceptSuspensionButton)
+
+    expect(navigate).toHaveBeenNthCalledWith(1, 'SuspensionConfirmation')
+  })
+
+  it('should open mail app when clicking on "Contacter le support" button', () => {
+    render(<SuspensionChoice />)
+
+    const contactSupportButton = screen.getByText('Contacter le support')
+    fireEvent.press(contactSupportButton)
+
+    expect(openUrl).toBeCalledWith(
+      contactSupport.forPhoneNumberConfirmation.url,
+      contactSupport.forPhoneNumberConfirmation.params,
+      true
+    )
+  })
+})

--- a/src/features/trustedDevice/pages/SuspensionChoice.native.test.tsx
+++ b/src/features/trustedDevice/pages/SuspensionChoice.native.test.tsx
@@ -32,8 +32,8 @@ describe('<SuspensionChoice/>', () => {
     fireEvent.press(contactSupportButton)
 
     expect(openUrl).toBeCalledWith(
-      contactSupport.forPhoneNumberConfirmation.url,
-      contactSupport.forPhoneNumberConfirmation.params,
+      contactSupport.forGenericQuestion.url,
+      contactSupport.forGenericQuestion.params,
       true
     )
   })

--- a/src/features/trustedDevice/pages/SuspensionChoice.tsx
+++ b/src/features/trustedDevice/pages/SuspensionChoice.tsx
@@ -60,7 +60,7 @@ export const SuspensionChoice = () => {
           wording="Contacter le support"
           accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support"
           icon={EmailFilled}
-          externalNav={contactSupport.forPhoneNumberConfirmation}
+          externalNav={contactSupport.forGenericQuestion}
         />
       </ButtonContainer>
     </GenericInfoPageWhite>

--- a/src/features/trustedDevice/pages/SuspensionChoice.tsx
+++ b/src/features/trustedDevice/pages/SuspensionChoice.tsx
@@ -1,0 +1,76 @@
+import { useNavigation } from '@react-navigation/native'
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { contactSupport } from 'features/auth/helpers/contactSupport'
+import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { env } from 'libs/environment'
+import { BulletListItem } from 'ui/components/BulletListItem'
+import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
+import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
+import { VerticalUl } from 'ui/components/Ul'
+import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
+import { BicolorUserError } from 'ui/svg/BicolorUserError'
+import { EmailFilled } from 'ui/svg/icons/EmailFilled'
+import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
+import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { SPACE } from 'ui/theme/constants'
+
+export const SuspensionChoice = () => {
+  const navigation = useNavigation<UseNavigationType>()
+  const onPressContinue = () => navigation.navigate('SuspensionConfirmation')
+
+  return (
+    <GenericInfoPageWhite
+      headerGoBack
+      titleComponent={Typo.Title3}
+      title="Souhaites-tu suspendre ton compte pass&nbsp;Culture&nbsp;?"
+      separateIconFromTitle={false}
+      icon={BicolorUserError}>
+      <Typo.ButtonText>Les conséquences&nbsp;:</Typo.ButtonText>
+      <VerticalUl>
+        <BulletListItem>
+          <Typo.Body>
+            tes réservations seront annulées sauf pour certains cas précisés dans les{SPACE}
+            <ExternalTouchableLink
+              as={StyledButtonInsideText}
+              wording="conditions générales d’utilisation"
+              icon={ExternalSiteFilled}
+              externalNav={{ url: env.CGU_LINK }}
+            />
+          </Typo.Body>
+        </BulletListItem>
+        <BulletListItem text="si tu as un dossier en cours, tu ne pourras pas en déposer un nouveau" />
+        <BulletListItem text="tu n’auras plus accès au catalogue" />
+      </VerticalUl>
+      <Spacer.Column numberOfSpaces={4} />
+      <Typo.ButtonText>Les données qu’on conserve&nbsp;:</Typo.ButtonText>
+      <Typo.Body>
+        Nous gardons toutes les informations personnelles que tu nous as transmises lors de la
+        vérification de ton identité.
+      </Typo.Body>
+      <Spacer.Column numberOfSpaces={4} />
+      <ButtonContainer>
+        <ButtonPrimary wording="Oui, suspendre mon compte" onPress={onPressContinue} />
+        <Spacer.Column numberOfSpaces={2} />
+        <ExternalTouchableLink
+          as={ButtonTertiaryBlack}
+          wording="Contacter le support"
+          accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support"
+          icon={EmailFilled}
+          externalNav={contactSupport.forPhoneNumberConfirmation}
+        />
+      </ButtonContainer>
+    </GenericInfoPageWhite>
+  )
+}
+
+const ButtonContainer = styled.View({
+  paddingBottom: getSpacing(10),
+})
+
+const StyledButtonInsideText = styled(ButtonInsideText).attrs(({ theme }) => ({
+  buttonColor: theme.colors.black,
+}))``

--- a/src/features/trustedDevice/pages/SuspensionChoice.web.test.tsx
+++ b/src/features/trustedDevice/pages/SuspensionChoice.web.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import { render, checkAccessibilityFor } from 'tests/utils/web'
+
+import { SuspensionChoice } from './SuspensionChoice'
+
+describe('<SuspensionChoice/>', () => {
+  describe('Accessibility', () => {
+    it('should not have basic accessibility issues', async () => {
+      const { container } = render(<SuspensionChoice />)
+
+      const results = await checkAccessibilityFor(container)
+
+      expect(results).toHaveNoViolations()
+    })
+  })
+})


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-21674

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        | <img width="396" alt="Capture d’écran 2023-06-01 à 14 05 05" src="https://github.com/pass-culture/pass-culture-app-native/assets/62059034/ba188e23-0250-416c-848b-b33f9be53da8"> |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
