### PR TITLE
(PC-22621) feat(BookingDetailsCancelButton): fix the display of the button depending on whether they are free physical offers

### DIFF
--- a/src/features/bookings/components/BookingDetailsCancelButton.native.test.tsx
+++ b/src/features/bookings/components/BookingDetailsCancelButton.native.test.tsx
@@ -1,6 +1,7 @@
 import mockdate from 'mockdate'
 import React from 'react'
 
+import { SubcategoryIdEnum } from 'api/gen'
 import {
   BookingDetailsCancelButton,
   BookingDetailsCancelButtonProps,
@@ -8,7 +9,7 @@ import {
 import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import { Booking } from 'features/bookings/types'
 import { isUserExBeneficiary } from 'features/profile/helpers/isUserExBeneficiary'
-import { fireEvent, render } from 'tests/utils'
+import { fireEvent, render, screen } from 'tests/utils'
 
 mockdate.set(new Date('2020-12-01T00:00:00Z'))
 
@@ -138,6 +139,17 @@ describe('<BookingDetailsCancelButton />', () => {
 
     const { queryByTestId } = renderBookingDetailsCancelButton(booking)
     expect(queryByTestId('cancel-annulation-message')).toBeNull()
+  })
+
+  it("should display expiration date message and not display cancel button when it's a free physical offer", () => {
+    const booking = { ...bookingsSnap.ongoing_bookings[0] }
+    booking.confirmationDate = null
+    booking.stock.offer.isDigital = false
+    booking.stock.offer.subcategoryId = SubcategoryIdEnum.ABO_MUSEE
+
+    renderBookingDetailsCancelButton(booking)
+    expect(screen.queryByTestId('Annuler ma réservation')).toBeFalsy()
+    expect(screen.queryByText('Ta réservation sera archivée le 17/03/2021')).toBeTruthy()
   })
 })
 

--- a/src/features/bookings/components/BookingDetailsCancelButton.tsx
+++ b/src/features/bookings/components/BookingDetailsCancelButton.tsx
@@ -5,6 +5,7 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { ActivationCodeButton } from 'features/bookings/components/ActivationCodeButton'
 import { BookingExpiration } from 'features/bookings/components/BookingExpiration'
 import { CancelBookingButton } from 'features/bookings/components/CancelBookingButton'
+import { FREE_OFFER_CATEGORIES_TO_ARCHIVE } from 'features/bookings/constants'
 import { getBookingProperties } from 'features/bookings/helpers'
 import { formattedExpirationDate } from 'features/bookings/helpers/expirationDateUtils'
 import { Booking } from 'features/bookings/types'
@@ -29,15 +30,21 @@ export const BookingDetailsCancelButton = (props: BookingDetailsCancelButtonProp
   const isExBeneficiary = user && isUserExBeneficiary(user)
   const remainingDays = formattedExpirationDate(booking.dateCreated)
   const isDigitalBooking = booking.stock.offer.isDigital === true && !booking.expirationDate
+  const isFreeOfferToArchive = FREE_OFFER_CATEGORIES_TO_ARCHIVE.includes(
+    booking.stock.offer.subcategoryId
+  )
 
   const renderButton = () => {
     if (properties.hasActivationCode) {
       return <ActivationCodeButton onTerminate={props.onTerminate} fullWidth={props.fullWidth} />
     }
-    return <CancelBookingButton onCancel={props.onCancel} fullWidth={props.fullWidth} />
+    if (!isFreeOfferToArchive) {
+      return <CancelBookingButton onCancel={props.onCancel} fullWidth={props.fullWidth} />
+    }
+    return null
   }
 
-  if (!booking.confirmationDate && isDigitalBooking) {
+  if ((!booking.confirmationDate && isDigitalBooking) || isFreeOfferToArchive) {
     return <BookingExpiration expirationDate={remainingDays}>{renderButton()}</BookingExpiration>
   }
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-22621

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |![Capture d’écran 2023-06-07 à 17 22 00](https://github.com/pass-culture/pass-culture-app-native/assets/62058919/1490d4a4-9f4e-4a93-a744-4666f036c6d6)|![Capture d’écran 2023-06-07 à 17 22 12](https://github.com/pass-culture/pass-culture-app-native/assets/62058919/908329ea-3ba3-4abf-912f-46cded088cb3)|
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
