### PR TITLE
(PC-22421) home(VideoModule): show VideoModal from home VideoModule

### DIFF
--- a/src/features/home/components/modals/VideoModal.native.test.tsx
+++ b/src/features/home/components/modals/VideoModal.native.test.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 
 import { VideoModal } from 'features/home/components/modals/VideoModal'
+import { videoModuleFixture } from 'features/home/fixtures/videoModule.fixture'
 import { render, screen } from 'tests/utils'
 
 const hideModalMock = jest.fn()
 
 describe('VideoModal', () => {
   it('should render correctly if modal visible', () => {
-    render(<VideoModal visible hideModal={hideModalMock} />)
+    render(<VideoModal visible hideModal={hideModalMock} {...videoModuleFixture} />)
 
     expect(screen).toMatchSnapshot()
   })

--- a/src/features/home/components/modals/VideoModal.tsx
+++ b/src/features/home/components/modals/VideoModal.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 
 import { getTagColor } from 'features/home/components/helpers/getTagColor'
 import { VideoPlayer } from 'features/home/components/VideoPlayer'
-import { videoModuleFixture } from 'features/home/fixtures/videoModule.fixture'
+import { VideoModule } from 'features/home/types'
 import { theme } from 'theme'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { AppModal } from 'ui/components/modals/AppModal'
@@ -12,12 +12,12 @@ import { Touchable } from 'ui/components/touchable/Touchable'
 import { Close } from 'ui/svg/icons/Close'
 import { Spacer, Typo, getSpacing } from 'ui/theme'
 
-interface VideoModalProps {
+interface VideoModalProps extends VideoModule {
   visible: boolean
   hideModal: () => void
 }
 
-export const VideoModal: React.FC<VideoModalProps> = ({ visible, hideModal }) => {
+export const VideoModal: React.FC<VideoModalProps> = (props) => {
   // TODO(PC-21762) provide description and publication date with content from contentful
   const descriptionText =
     'Laissons ici la place pour mettre du contexte sur la vidéo si besoin cela permet à l’utilisateur de savoir sans voir de quoi le vidéo parle. Pas plus de 130 caractères.'
@@ -30,29 +30,29 @@ export const VideoModal: React.FC<VideoModalProps> = ({ visible, hideModal }) =>
   return (
     <AppModal
       title={''}
-      visible={visible}
+      visible={props.visible}
       isUpToStatusBar
       noPadding
       scrollEnabled={false}
       customModalHeader={<React.Fragment />}>
-      <VideoPlayer youtubeVideoId={videoModuleFixture.youtubeVideoId} />
+      <VideoPlayer youtubeVideoId={props.youtubeVideoId} />
       <StyledScrollView>
         <Spacer.Column numberOfSpaces={4} />
         <StyledTagContainer>
-          <StyledTagBackground color={videoModuleFixture.color}>
-            <StyledCaptionTag>{videoModuleFixture.videoTag}</StyledCaptionTag>
+          <StyledTagBackground color={props.color}>
+            <StyledCaptionTag>{props.videoTag}</StyledCaptionTag>
           </StyledTagBackground>
         </StyledTagContainer>
         <Spacer.Column numberOfSpaces={2} />
-        <Typo.Title3>{videoModuleFixture.title}</Typo.Title3>
+        <Typo.Title3>{props.title}</Typo.Title3>
         <Spacer.Column numberOfSpaces={2} />
         <StyledCaptionDate>{`Publiée le ${publicationDate}`}</StyledCaptionDate>
         <Spacer.Column numberOfSpaces={2} />
         <StyledBody>{descriptionText}</StyledBody>
         <Spacer.Column numberOfSpaces={6} />
-        <Typo.Title4>{videoModuleFixture.offerTitle}</Typo.Title4>
+        <Typo.Title4>{props.offerTitle}</Typo.Title4>
       </StyledScrollView>
-      <StyledTouchable onPress={hideModal} accessibilityLabel="Fermer la modale vidéo">
+      <StyledTouchable onPress={props.hideModal} accessibilityLabel="Fermer la modale vidéo">
         <StyledCloseIcon />
       </StyledTouchable>
     </AppModal>

--- a/src/features/home/components/modules/VideoModule.native.test.tsx
+++ b/src/features/home/components/modules/VideoModule.native.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+import { VideoModule } from 'features/home/components/modules/VideoModule'
+import { videoModuleFixture } from 'features/home/fixtures/videoModule.fixture'
+import { fireEvent, render, screen } from 'tests/utils'
+
+const mockShowModal = jest.fn()
+jest.mock('ui/components/modals/useModal', () => ({
+  useModal: () => ({
+    visible: false,
+    showModal: mockShowModal,
+    hideModal: jest.fn(),
+  }),
+}))
+
+describe('VideoModule', () => {
+  it('should show modal when pressing video thumbnail', () => {
+    render(<VideoModule {...videoModuleFixture} />)
+    const button = screen.getByTestId('video-thumbnail')
+
+    fireEvent.press(button)
+    expect(mockShowModal).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/home/components/modules/VideoModule.tsx
+++ b/src/features/home/components/modules/VideoModule.tsx
@@ -31,7 +31,7 @@ export const VideoModule: FunctionComponent<VideoModuleProps> = (props) => {
     <Container>
       <Typo.Title3>{props.title}</Typo.Title3>
       <Spacer.Column numberOfSpaces={5} />
-      <StyledTouchable onPress={showVideoModal}>
+      <StyledTouchable onPress={showVideoModal} testID={'video-thumbnail'}>
         <Thumbnail source={{ uri: props.videoThumbnail }}>
           <DurationCaptionContainer>
             <DurationCaption>{videoDuration}</DurationCaption>

--- a/src/features/home/components/modules/VideoModule.tsx
+++ b/src/features/home/components/modules/VideoModule.tsx
@@ -4,6 +4,11 @@ import styled from 'styled-components/native'
 
 import { BlackGradient } from 'features/home/components/BlackGradient'
 import { TEXT_BACKGROUND_OPACITY } from 'features/home/components/constants'
+import { VideoModal } from 'features/home/components/modals/VideoModal'
+import { VideoModule as VideoModuleProps } from 'features/home/types'
+import { styledButton } from 'ui/components/buttons/styledButton'
+import { useModal } from 'ui/components/modals/useModal'
+import { Touchable } from 'ui/components/touchable/Touchable'
 import { Play } from 'ui/svg/icons/Play'
 import { Spacer, Typo, getSpacing } from 'ui/theme'
 
@@ -14,39 +19,35 @@ const PLAYER_TOP_MARGIN = getSpacing(12.5)
 
 const PLAYER_SIZE = getSpacing(14.5)
 
-type Props = {
-  title: string
-  videoTitle: string
-  videoThumbnail: string
-  durationInMinutes: number
-}
-
-export const VideoModule: FunctionComponent<Props> = ({
-  title,
-  videoThumbnail,
-  videoTitle,
-  durationInMinutes,
-}) => {
-  const videoDuration = `${durationInMinutes} min`
+export const VideoModule: FunctionComponent<VideoModuleProps> = (props) => {
+  const {
+    visible: videoModalVisible,
+    showModal: showVideoModal,
+    hideModal: hideVideoModal,
+  } = useModal(false)
+  const videoDuration = `${props.durationInMinutes} min`
 
   return (
     <Container>
-      <Typo.Title3>{title}</Typo.Title3>
+      <Typo.Title3>{props.title}</Typo.Title3>
       <Spacer.Column numberOfSpaces={5} />
-      <Thumbnail source={{ uri: videoThumbnail }}>
-        <DurationCaptionContainer>
-          <DurationCaption>{videoDuration}</DurationCaption>
-        </DurationCaptionContainer>
-        <TextContainer>
-          <BlackGradient />
-          <BlackBackground>
-            <VideoTitle numberOfLines={2}>{videoTitle}</VideoTitle>
-          </BlackBackground>
-        </TextContainer>
-        <PlayerContainer>
-          <Player />
-        </PlayerContainer>
-      </Thumbnail>
+      <StyledTouchable onPress={showVideoModal}>
+        <Thumbnail source={{ uri: props.videoThumbnail }}>
+          <DurationCaptionContainer>
+            <DurationCaption>{videoDuration}</DurationCaption>
+          </DurationCaptionContainer>
+          <TextContainer>
+            <BlackGradient />
+            <BlackBackground>
+              <VideoTitle numberOfLines={2}>{props.videoTitle}</VideoTitle>
+            </BlackBackground>
+          </TextContainer>
+          <PlayerContainer>
+            <Player />
+          </PlayerContainer>
+        </Thumbnail>
+      </StyledTouchable>
+      <VideoModal visible={videoModalVisible} hideModal={hideVideoModal} {...props} />
     </Container>
   )
 }
@@ -97,3 +98,5 @@ const BlackBackground = styled.View(({ theme }) => ({
 const VideoTitle = styled(Typo.Title4)(({ theme }) => ({
   color: theme.colors.white,
 }))
+
+const StyledTouchable = styledButton(Touchable)``

--- a/src/features/internal/cheatcodes/pages/Navigation/Navigation.tsx
+++ b/src/features/internal/cheatcodes/pages/Navigation/Navigation.tsx
@@ -7,7 +7,6 @@ import { v4 as uuidv4 } from 'uuid'
 import { CookiesConsent } from 'features/cookies/pages/CookiesConsent'
 import { FavoriteListSurveyModal } from 'features/favorites/favoriteList/FakeDoor/FavoriteListSurveyModal'
 import { ForceUpdate } from 'features/forceUpdate/pages/ForceUpdate'
-import { VideoModal } from 'features/home/components/modals/VideoModal'
 import { CheatCodesButton } from 'features/internal/cheatcodes/components/CheatCodesButton/CheatCodesButton'
 import { Row } from 'features/internal/cheatcodes/components/Row'
 import { useSomeVenueId } from 'features/internal/cheatcodes/hooks/useSomeVenueId'
@@ -28,7 +27,6 @@ const EIFFEL_TOWER_COORDINATES = { lat: 48.8584, lng: 2.2945 }
 export function Navigation(): JSX.Element {
   const { navigate } = useNavigation<UseNavigationType>()
   const [screenError, setScreenError] = useState<ScreenError | undefined>(undefined)
-  const [videoModalVisible, setVideoModalVisible] = useState(false)
   const distanceToEiffelTower = useDistance(EIFFEL_TOWER_COORDINATES)
   const venueId = useSomeVenueId()
   const { showInfoSnackBar } = useSnackBarContext()
@@ -216,13 +214,9 @@ export function Navigation(): JSX.Element {
               onPress={() => navigate('DynamicSocials')}
             />
           </Row>
-          <Row half>
-            <ButtonPrimary wording="Modale vidéo 🎥" onPress={() => setVideoModalVisible(true)} />
-          </Row>
         </StyledContainer>
         <Spacer.BottomScreen />
       </ScrollView>
-      <VideoModal visible={videoModalVisible} hideModal={() => setVideoModalVisible(false)} />
     </React.Fragment>
   )
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-22421

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots


| Platform         | After |
| :--------------- | :---: |
| iOS              |[Uploading Simulator Screen Recording - iPhone 13 - 2023-06-08 at 18.18.52.mp4…](https://github.com/pass-culture/pass-culture-app-native/assets/22886846/e693a9de-f52c-4a89-ae07-3026601e7004)|
| Android          |https://github.com/pass-culture/pass-culture-app-native/assets/22886846/65e51cbb-1f69-4568-b617-8dcbdc6667f5|




[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
