### PR TITLE
(PC-22543) feat(TrustedDevice): fix typo size for AccountSecurity screen

### DIFF
--- a/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
@@ -182,8 +182,8 @@ exports[`<AccountSecurity/> should match snapshot when no token 1`] = `
               Object {
                 "color": "#161617",
                 "fontFamily": "Montserrat-Regular",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 12,
+                "lineHeight": 16,
               },
             ]
           }
@@ -193,9 +193,9 @@ exports[`<AccountSecurity/> should match snapshot when no token 1`] = `
               Array [
                 Object {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-SemiBold",
+                  "fontSize": 12,
+                  "lineHeight": 16,
                 },
               ]
             }
@@ -211,9 +211,9 @@ exports[`<AccountSecurity/> should match snapshot when no token 1`] = `
               Array [
                 Object {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-SemiBold",
+                  "fontSize": 12,
+                  "lineHeight": 16,
                 },
               ]
             }
@@ -229,9 +229,9 @@ exports[`<AccountSecurity/> should match snapshot when no token 1`] = `
               Array [
                 Object {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-SemiBold",
+                  "fontSize": 12,
+                  "lineHeight": 16,
                 },
               ]
             }
@@ -686,8 +686,8 @@ exports[`<AccountSecurity/> should match snapshot with valid token 1`] = `
               Object {
                 "color": "#161617",
                 "fontFamily": "Montserrat-Regular",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 12,
+                "lineHeight": 16,
               },
             ]
           }
@@ -697,9 +697,9 @@ exports[`<AccountSecurity/> should match snapshot with valid token 1`] = `
               Array [
                 Object {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-SemiBold",
+                  "fontSize": 12,
+                  "lineHeight": 16,
                 },
               ]
             }
@@ -715,9 +715,9 @@ exports[`<AccountSecurity/> should match snapshot with valid token 1`] = `
               Array [
                 Object {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-SemiBold",
+                  "fontSize": 12,
+                  "lineHeight": 16,
                 },
               ]
             }
@@ -733,9 +733,9 @@ exports[`<AccountSecurity/> should match snapshot with valid token 1`] = `
               Array [
                 Object {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-SemiBold",
+                  "fontSize": 12,
+                  "lineHeight": 16,
                 },
               ]
             }

--- a/src/features/trustedDevice/pages/AccountSecurity.tsx
+++ b/src/features/trustedDevice/pages/AccountSecurity.tsx
@@ -1,5 +1,6 @@
 import { useRoute } from '@react-navigation/native'
 import React from 'react'
+import styled from 'styled-components/native'
 
 import { navigateToHome } from 'features/navigation/helpers'
 import { UseRouteType } from 'features/navigation/RootNavigator/types'
@@ -62,12 +63,16 @@ const DeviceInformations = () => {
   const { location, osAndSource, loginDate } = formatTokenInfo(getTokenInfo(params.token))
 
   return (
-    <Typo.Body>
-      <Typo.ButtonText>Appareil utilisé&nbsp;: </Typo.ButtonText> {osAndSource}
+    <CaptionRegular>
+      <Typo.Caption>Appareil utilisé&nbsp;: </Typo.Caption> {osAndSource}
       {LINE_BREAK}
-      <Typo.ButtonText>Lieu&nbsp;: </Typo.ButtonText> {location}
+      <Typo.Caption>Lieu&nbsp;: </Typo.Caption> {location}
       {LINE_BREAK}
-      <Typo.ButtonText>Date et heure&nbsp;: </Typo.ButtonText> {loginDate}
-    </Typo.Body>
+      <Typo.Caption>Date et heure&nbsp;: </Typo.Caption> {loginDate}
+    </CaptionRegular>
   )
 }
+
+const CaptionRegular = styled(Typo.Caption)(({ theme }) => ({
+  fontFamily: theme.fontFamily.regular,
+}))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-22543

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
