### PR TITLE
(PC-20703) fix(Header): set header in white for android

### DIFF
--- a/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
@@ -990,7 +990,7 @@ exports[`BookingDetails should render correctly 1`] = `
     />
     <View
       collapsable={false}
-      safeAreaTop={16}
+      height={80}
       style={
         Object {
           "height": 80,

--- a/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
@@ -353,7 +353,7 @@ exports[`ThematicHome should render correctly 1`] = `
   </View>
   <View
     collapsable={false}
-    safeAreaTop={16}
+    height={80}
     style={
       Object {
         "backdropFilter": "blur(0px)",
@@ -382,7 +382,7 @@ exports[`ThematicHome should render correctly 1`] = `
     />
     <View
       collapsable={false}
-      safeAreaTop={16}
+      height={80}
       style={
         Object {
           "height": 80,

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -4095,7 +4095,7 @@ exports[`<Venue /> should match snapshot 1`] = `
   </RCTScrollView>
   <View
     collapsable={false}
-    safeAreaTop={16}
+    height={80}
     style={
       Object {
         "backdropFilter": "blur(0px)",
@@ -4124,7 +4124,7 @@ exports[`<Venue /> should match snapshot 1`] = `
     />
     <View
       collapsable={false}
-      safeAreaTop={16}
+      height={80}
       style={
         Object {
           "height": 80,

--- a/src/features/auth/pages/signup/SignupFormV2.tsx
+++ b/src/features/auth/pages/signup/SignupFormV2.tsx
@@ -21,7 +21,7 @@ import { analytics } from 'libs/analytics'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { AsyncError, eventMonitoring } from 'libs/monitoring'
-import { BlurHeader } from 'ui/components/headers/BlurHeader'
+import { BlurView } from 'ui/components/BlurView'
 import {
   PageHeaderWithoutPlaceholder,
   useGetHeaderHeight,
@@ -154,7 +154,7 @@ export const SignupForm: FunctionComponent = () => {
         signupStep={stepConfig.name}
       />
       <BlurHeaderContainer height={headerHeight}>
-        <BlurHeader />
+        <BlurView />
       </BlurHeaderContainer>
     </React.Fragment>
   )

--- a/src/features/auth/pages/signup/SignupFormV2.tsx
+++ b/src/features/auth/pages/signup/SignupFormV2.tsx
@@ -21,7 +21,7 @@ import { analytics } from 'libs/analytics'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { AsyncError, eventMonitoring } from 'libs/monitoring'
-import { BlurView } from 'ui/components/BlurView'
+import { BlurHeader } from 'ui/components/headers/BlurHeader'
 import {
   PageHeaderWithoutPlaceholder,
   useGetHeaderHeight,
@@ -153,9 +153,7 @@ export const SignupForm: FunctionComponent = () => {
         resume={hideFullPageModal}
         signupStep={stepConfig.name}
       />
-      <BlurHeaderContainer height={headerHeight}>
-        <BlurView />
-      </BlurHeaderContainer>
+      <BlurHeader height={headerHeight} />
     </React.Fragment>
   )
 }
@@ -169,16 +167,6 @@ const StyledScrollView = styled.ScrollView.attrs(({ theme }) => ({
     flex: 1,
   },
 }))``
-
-const BlurHeaderContainer = styled.View<{ height: number }>(({ height }) => ({
-  position: 'absolute',
-  top: 0,
-  left: 0,
-  right: 0,
-  height,
-  overflow: 'hidden',
-  backdropFilter: 'blur(20px)',
-}))
 
 const Placeholder = styled.View<{ height: number }>(({ height }) => ({
   height,

--- a/src/features/bookings/components/BookingDetailsHeader.tsx
+++ b/src/features/bookings/components/BookingDetailsHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Animated } from 'react-native'
+import { Animated, Platform } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled, { useTheme } from 'styled-components/native'
 
@@ -36,9 +36,11 @@ export const BookingDetailsHeader: React.FC<Props> = (props) => {
     <React.Fragment>
       <HeaderContainer style={containerStyle}>
         <Spacer.TopScreen />
-        <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
-          <BlurHeader />
-        </BlurNativeContainer>
+        {Platform.OS !== 'android' && (
+          <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
+            <BlurHeader />
+          </BlurNativeContainer>
+        )}
         <Spacer.Column numberOfSpaces={2} />
         <Row>
           <IconContainer>

--- a/src/features/bookings/components/BookingDetailsHeader.tsx
+++ b/src/features/bookings/components/BookingDetailsHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Animated, Platform } from 'react-native'
+import { Animated } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled, { useTheme } from 'styled-components/native'
 
@@ -38,12 +38,7 @@ export const BookingDetailsHeader: React.FC<Props> = (props) => {
     <React.Fragment>
       <HeaderContainer style={containerStyle}>
         <Spacer.TopScreen />
-        {
-          // There is an issue with the blur on Android: we chose not to render it and use a white background
-          Platform.OS !== 'android' && (
-            <AnimatedBlurHeader height={headerHeight} style={blurContainerNative} />
-          )
-        }
+        <AnimatedBlurHeader height={headerHeight} style={blurContainerNative} />
         <Spacer.Column numberOfSpaces={2} />
         <Row>
           <IconContainer>

--- a/src/features/bookings/components/BookingDetailsHeader.tsx
+++ b/src/features/bookings/components/BookingDetailsHeader.tsx
@@ -36,11 +36,14 @@ export const BookingDetailsHeader: React.FC<Props> = (props) => {
     <React.Fragment>
       <HeaderContainer style={containerStyle}>
         <Spacer.TopScreen />
-        {Platform.OS !== 'android' && (
-          <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
-            <BlurHeader />
-          </BlurNativeContainer>
-        )}
+        {
+          // There is an issue with the blur on Android: we chose not to render it and use a white background
+          Platform.OS !== 'android' && (
+            <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
+              <BlurHeader />
+            </BlurNativeContainer>
+          )
+        }
         <Spacer.Column numberOfSpaces={2} />
         <Row>
           <IconContainer>

--- a/src/features/bookings/components/BookingDetailsHeader.tsx
+++ b/src/features/bookings/components/BookingDetailsHeader.tsx
@@ -6,8 +6,8 @@ import styled, { useTheme } from 'styled-components/native'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { getAnimationState } from 'ui/animations/helpers/getAnimationState'
-import { BlurView } from 'ui/components/BlurView'
 import { RoundedButton } from 'ui/components/buttons/RoundedButton'
+import { AnimatedBlurHeader } from 'ui/components/headers/AnimatedBlurHeader'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
 interface Props {
@@ -22,6 +22,8 @@ export const BookingDetailsHeader: React.FC<Props> = (props) => {
   const theme = useTheme()
   const { headerTransition, title } = props
   const { top } = useSafeAreaInsets()
+  const headerHeight = theme.appBarHeight + top
+
   const { goBack } = useGoBack(...getTabNavConfig('Bookings'))
 
   const [accessibilityHiddenTitle, setAccessibilityHiddenTitle] = useState(true)
@@ -39,9 +41,7 @@ export const BookingDetailsHeader: React.FC<Props> = (props) => {
         {
           // There is an issue with the blur on Android: we chose not to render it and use a white background
           Platform.OS !== 'android' && (
-            <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
-              <BlurView />
-            </BlurNativeContainer>
+            <AnimatedBlurHeader height={headerHeight} style={blurContainerNative} />
           )
         }
         <Spacer.Column numberOfSpaces={2} />
@@ -77,17 +77,6 @@ const HeaderContainer = styled(Animated.View)(({ theme }) => ({
   borderBottomColor: theme.colors.greyLight,
   borderBottomWidth: 1,
 }))
-
-const BlurNativeContainer = styled(Animated.View)<{ safeAreaTop: number }>(
-  ({ theme, safeAreaTop }) => ({
-    position: 'absolute',
-    height: theme.appBarHeight + safeAreaTop,
-    top: 0,
-    left: 0,
-    right: 0,
-    overflow: 'hidden',
-  })
-)
 
 const Row = styled.View({
   flexDirection: 'row',

--- a/src/features/bookings/components/BookingDetailsHeader.tsx
+++ b/src/features/bookings/components/BookingDetailsHeader.tsx
@@ -6,8 +6,8 @@ import styled, { useTheme } from 'styled-components/native'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { getAnimationState } from 'ui/animations/helpers/getAnimationState'
+import { BlurView } from 'ui/components/BlurView'
 import { RoundedButton } from 'ui/components/buttons/RoundedButton'
-import { BlurHeader } from 'ui/components/headers/BlurHeader'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
 interface Props {
@@ -40,7 +40,7 @@ export const BookingDetailsHeader: React.FC<Props> = (props) => {
           // There is an issue with the blur on Android: we chose not to render it and use a white background
           Platform.OS !== 'android' && (
             <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
-              <BlurHeader />
+              <BlurView />
             </BlurNativeContainer>
           )
         }

--- a/src/features/home/components/headers/ThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/ThematicHomeHeader.tsx
@@ -41,11 +41,14 @@ export const ThematicHomeHeader: FunctionComponent<Props> = ({ title, headerTran
     <React.Fragment>
       <HeaderContainer style={containerStyle} safeAreaTop={top}>
         <Spacer.TopScreen />
-        {Platform.OS !== 'android' && (
-          <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
-            <BlurHeader />
-          </BlurNativeContainer>
-        )}
+        {
+          // There is an issue with the blur on Android: we chose not to render it and use a white background
+          Platform.OS !== 'android' && (
+            <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
+              <BlurHeader />
+            </BlurNativeContainer>
+          )
+        }
         <Spacer.Column numberOfSpaces={2} />
         <Row>
           <Spacer.Row numberOfSpaces={6} />

--- a/src/features/home/components/headers/ThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/ThematicHomeHeader.tsx
@@ -41,12 +41,7 @@ export const ThematicHomeHeader: FunctionComponent<Props> = ({ title, headerTran
     <React.Fragment>
       <HeaderContainer style={containerStyle} height={headerHeight}>
         <Spacer.TopScreen />
-        {
-          // There is an issue with the blur on Android: we chose not to render it and use a white background
-          Platform.OS !== 'android' && (
-            <AnimatedBlurHeader height={headerHeight} style={blurContainerNative} />
-          )
-        }
+        <AnimatedBlurHeader height={headerHeight} style={blurContainerNative} />
         <Spacer.Column numberOfSpaces={2} />
         <Row>
           <Spacer.Row numberOfSpaces={6} />

--- a/src/features/home/components/headers/ThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/ThematicHomeHeader.tsx
@@ -6,8 +6,8 @@ import styled, { useTheme } from 'styled-components/native'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { homeNavConfig } from 'features/navigation/TabBar/helpers'
 import { getAnimationState } from 'ui/animations/helpers/getAnimationState'
-import { BlurView } from 'ui/components/BlurView'
 import { RoundedButton } from 'ui/components/buttons/RoundedButton'
+import { AnimatedBlurHeader } from 'ui/components/headers/AnimatedBlurHeader'
 import { Spacer, Typo } from 'ui/theme'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
@@ -26,7 +26,7 @@ export const useGetThematicHeaderHeight = () => {
 export const ThematicHomeHeader: FunctionComponent<Props> = ({ title, headerTransition }) => {
   const { navigate } = useNavigation<UseNavigationType>()
   const onGoBack = useCallback(() => navigate(...homeNavConfig), [navigate])
-  const { top } = useCustomSafeInsets()
+  const headerHeight = useGetThematicHeaderHeight()
 
   const [ariaHiddenTitle, setAriaHiddenTitle] = useState(true)
   headerTransition.addListener((opacity) => setAriaHiddenTitle(opacity.value !== 1))
@@ -39,14 +39,12 @@ export const ThematicHomeHeader: FunctionComponent<Props> = ({ title, headerTran
 
   return (
     <React.Fragment>
-      <HeaderContainer style={containerStyle} safeAreaTop={top}>
+      <HeaderContainer style={containerStyle} height={headerHeight}>
         <Spacer.TopScreen />
         {
           // There is an issue with the blur on Android: we chose not to render it and use a white background
           Platform.OS !== 'android' && (
-            <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
-              <BlurView />
-            </BlurNativeContainer>
+            <AnimatedBlurHeader height={headerHeight} style={blurContainerNative} />
           )
         }
         <Spacer.Column numberOfSpaces={2} />
@@ -76,29 +74,16 @@ export const ThematicHomeHeader: FunctionComponent<Props> = ({ title, headerTran
   )
 }
 
-const HeaderContainer = styled(Animated.View)<{ safeAreaTop: number }>(
-  ({ theme, safeAreaTop }) => ({
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    height: theme.appBarHeight + safeAreaTop,
-    zIndex: theme.zIndex.header,
-    borderBottomColor: theme.colors.greyLight,
-    borderBottomWidth: 1,
-  })
-)
-
-const BlurNativeContainer = styled(Animated.View)<{ safeAreaTop: number }>(
-  ({ theme, safeAreaTop }) => ({
-    position: 'absolute',
-    height: theme.appBarHeight + safeAreaTop,
-    top: 0,
-    left: 0,
-    right: 0,
-    overflow: 'hidden',
-  })
-)
+const HeaderContainer = styled(Animated.View)<{ height: number }>(({ theme, height }) => ({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  height,
+  zIndex: theme.zIndex.header,
+  borderBottomColor: theme.colors.greyLight,
+  borderBottomWidth: 1,
+}))
 
 const Row = styled.View({
   flex: 1,

--- a/src/features/home/components/headers/ThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/ThematicHomeHeader.tsx
@@ -41,9 +41,11 @@ export const ThematicHomeHeader: FunctionComponent<Props> = ({ title, headerTran
     <React.Fragment>
       <HeaderContainer style={containerStyle} safeAreaTop={top}>
         <Spacer.TopScreen />
-        <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
-          <BlurHeader />
-        </BlurNativeContainer>
+        {Platform.OS !== 'android' && (
+          <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
+            <BlurHeader />
+          </BlurNativeContainer>
+        )}
         <Spacer.Column numberOfSpaces={2} />
         <Row>
           <Spacer.Row numberOfSpaces={6} />

--- a/src/features/home/components/headers/ThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/ThematicHomeHeader.tsx
@@ -6,8 +6,8 @@ import styled, { useTheme } from 'styled-components/native'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { homeNavConfig } from 'features/navigation/TabBar/helpers'
 import { getAnimationState } from 'ui/animations/helpers/getAnimationState'
+import { BlurView } from 'ui/components/BlurView'
 import { RoundedButton } from 'ui/components/buttons/RoundedButton'
-import { BlurHeader } from 'ui/components/headers/BlurHeader'
 import { Spacer, Typo } from 'ui/theme'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
@@ -45,7 +45,7 @@ export const ThematicHomeHeader: FunctionComponent<Props> = ({ title, headerTran
           // There is an issue with the blur on Android: we chose not to render it and use a white background
           Platform.OS !== 'android' && (
             <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
-              <BlurHeader />
+              <BlurView />
             </BlurNativeContainer>
           )
         }

--- a/src/features/identityCheck/components/layout/PageWithHeader.tsx
+++ b/src/features/identityCheck/components/layout/PageWithHeader.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 
 import { CustomKeyboardAvoidingView } from 'features/identityCheck/components/CustomKeyboardAvoidingView'
 import { useShouldEnableScrollOnView } from 'features/identityCheck/components/layout/helpers/useShouldEnableScrollView'
-import { BlurHeader } from 'ui/components/headers/BlurHeader'
+import { BlurView } from 'ui/components/BlurView'
 import {
   PageHeaderWithoutPlaceholder,
   useGetHeaderHeight,
@@ -54,7 +54,7 @@ export const PageWithHeader: FunctionComponent<Props> = (props) => {
         // There is an issue with the blur on Android: we chose not to render it and use a white background
         Platform.OS !== 'android' && (
           <BlurHeaderContainer height={headerHeight}>
-            <BlurHeader />
+            <BlurView />
           </BlurHeaderContainer>
         )
       }

--- a/src/features/identityCheck/components/layout/PageWithHeader.tsx
+++ b/src/features/identityCheck/components/layout/PageWithHeader.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 
 import { CustomKeyboardAvoidingView } from 'features/identityCheck/components/CustomKeyboardAvoidingView'
 import { useShouldEnableScrollOnView } from 'features/identityCheck/components/layout/helpers/useShouldEnableScrollView'
-import { BlurView } from 'ui/components/BlurView'
+import { BlurHeader } from 'ui/components/headers/BlurHeader'
 import {
   PageHeaderWithoutPlaceholder,
   useGetHeaderHeight,
@@ -52,11 +52,7 @@ export const PageWithHeader: FunctionComponent<Props> = (props) => {
       </CustomKeyboardAvoidingView>
       {
         // There is an issue with the blur on Android: we chose not to render it and use a white background
-        Platform.OS !== 'android' && (
-          <BlurHeaderContainer height={headerHeight}>
-            <BlurView />
-          </BlurHeaderContainer>
-        )
+        Platform.OS !== 'android' && <BlurHeader height={headerHeight} />
       }
     </React.Fragment>
   )
@@ -82,14 +78,4 @@ const FixedBottomChildrenView = styled.View(({ theme }) => ({
   paddingTop: getSpacing(3),
   backgroundColor: theme.colors.white,
   paddingHorizontal: getSpacing(5),
-}))
-
-const BlurHeaderContainer = styled.View<{ height: number }>(({ height }) => ({
-  position: 'absolute',
-  top: 0,
-  left: 0,
-  right: 0,
-  height,
-  overflow: 'hidden',
-  backdropFilter: 'blur(20px)',
 }))

--- a/src/features/identityCheck/components/layout/PageWithHeader.tsx
+++ b/src/features/identityCheck/components/layout/PageWithHeader.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, ReactNode, useState } from 'react'
-import { LayoutChangeEvent, Platform, View } from 'react-native'
+import { LayoutChangeEvent, View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { CustomKeyboardAvoidingView } from 'features/identityCheck/components/CustomKeyboardAvoidingView'
@@ -50,10 +50,7 @@ export const PageWithHeader: FunctionComponent<Props> = (props) => {
           </FixedBottomChildrenView>
         ) : null}
       </CustomKeyboardAvoidingView>
-      {
-        // There is an issue with the blur on Android: we chose not to render it and use a white background
-        Platform.OS !== 'android' && <BlurHeader height={headerHeight} />
-      }
+      <BlurHeader height={headerHeight} />
     </React.Fragment>
   )
 }

--- a/src/features/offer/components/OfferHeader/OfferHeader.tsx
+++ b/src/features/offer/components/OfferHeader/OfferHeader.tsx
@@ -133,9 +133,11 @@ export const OfferHeader: React.FC<Props> = (props) => {
     <React.Fragment>
       <HeaderContainer style={containerStyle} safeAreaTop={top}>
         <Spacer.TopScreen />
-        <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
-          <BlurHeader />
-        </BlurNativeContainer>
+        {Platform.OS !== 'android' && (
+          <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
+            <BlurHeader />
+          </BlurNativeContainer>
+        )}
         <Spacer.Column numberOfSpaces={2} />
         <Row>
           <Spacer.Row numberOfSpaces={6} />

--- a/src/features/offer/components/OfferHeader/OfferHeader.tsx
+++ b/src/features/offer/components/OfferHeader/OfferHeader.tsx
@@ -20,8 +20,8 @@ import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { storage } from 'libs/storage'
 import { accessibleCheckboxProps } from 'shared/accessibilityProps/accessibleCheckboxProps'
 import { getAnimationState } from 'ui/animations/helpers/getAnimationState'
+import { BlurView } from 'ui/components/BlurView'
 import { RoundedButton } from 'ui/components/buttons/RoundedButton'
-import { BlurHeader } from 'ui/components/headers/BlurHeader'
 import { useModal } from 'ui/components/modals/useModal'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { Spacer, Typo } from 'ui/theme'
@@ -137,7 +137,7 @@ export const OfferHeader: React.FC<Props> = (props) => {
           // There is an issue with the blur on Android: we chose not to render it and use a white background
           Platform.OS !== 'android' && (
             <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
-              <BlurHeader />
+              <BlurView />
             </BlurNativeContainer>
           )
         }

--- a/src/features/offer/components/OfferHeader/OfferHeader.tsx
+++ b/src/features/offer/components/OfferHeader/OfferHeader.tsx
@@ -134,12 +134,7 @@ export const OfferHeader: React.FC<Props> = (props) => {
     <React.Fragment>
       <HeaderContainer style={containerStyle} height={headerHeight}>
         <Spacer.TopScreen />
-        {
-          // There is an issue with the blur on Android: we chose not to render it and use a white background
-          Platform.OS !== 'android' && (
-            <AnimatedBlurHeader height={headerHeight} style={blurContainerNative} />
-          )
-        }
+        <AnimatedBlurHeader height={headerHeight} style={blurContainerNative} />
         <Spacer.Column numberOfSpaces={2} />
         <Row>
           <Spacer.Row numberOfSpaces={6} />

--- a/src/features/offer/components/OfferHeader/OfferHeader.tsx
+++ b/src/features/offer/components/OfferHeader/OfferHeader.tsx
@@ -133,11 +133,14 @@ export const OfferHeader: React.FC<Props> = (props) => {
     <React.Fragment>
       <HeaderContainer style={containerStyle} safeAreaTop={top}>
         <Spacer.TopScreen />
-        {Platform.OS !== 'android' && (
-          <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
-            <BlurHeader />
-          </BlurNativeContainer>
-        )}
+        {
+          // There is an issue with the blur on Android: we chose not to render it and use a white background
+          Platform.OS !== 'android' && (
+            <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
+              <BlurHeader />
+            </BlurNativeContainer>
+          )
+        }
         <Spacer.Column numberOfSpaces={2} />
         <Row>
           <Spacer.Row numberOfSpaces={6} />

--- a/src/features/offer/components/OfferHeader/OfferHeader.tsx
+++ b/src/features/offer/components/OfferHeader/OfferHeader.tsx
@@ -20,8 +20,8 @@ import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { storage } from 'libs/storage'
 import { accessibleCheckboxProps } from 'shared/accessibilityProps/accessibleCheckboxProps'
 import { getAnimationState } from 'ui/animations/helpers/getAnimationState'
-import { BlurView } from 'ui/components/BlurView'
 import { RoundedButton } from 'ui/components/buttons/RoundedButton'
+import { AnimatedBlurHeader } from 'ui/components/headers/AnimatedBlurHeader'
 import { useModal } from 'ui/components/modals/useModal'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { Spacer, Typo } from 'ui/theme'
@@ -67,6 +67,7 @@ export const OfferHeader: React.FC<Props> = (props) => {
   const favorite = useFavorite({ offerId })
   const { showErrorSnackBar } = useSnackBarContext()
   const { top } = useSafeAreaInsets()
+  const headerHeight = theme.appBarHeight + top
   const isFavListFakeDoorEnabled = useFeatureFlag(RemoteStoreFeatureFlags.FAV_LIST_FAKE_DOOR)
 
   const [ariaHiddenTitle, setAriaHiddenTitle] = useState(true)
@@ -131,14 +132,12 @@ export const OfferHeader: React.FC<Props> = (props) => {
 
   return (
     <React.Fragment>
-      <HeaderContainer style={containerStyle} safeAreaTop={top}>
+      <HeaderContainer style={containerStyle} height={headerHeight}>
         <Spacer.TopScreen />
         {
           // There is an issue with the blur on Android: we chose not to render it and use a white background
           Platform.OS !== 'android' && (
-            <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
-              <BlurView />
-            </BlurNativeContainer>
+            <AnimatedBlurHeader height={headerHeight} style={blurContainerNative} />
           )
         }
         <Spacer.Column numberOfSpaces={2} />
@@ -226,29 +225,16 @@ function animateIcon(animatedValue: Animated.Value): void {
   ]).start()
 }
 
-const HeaderContainer = styled(Animated.View)<{ safeAreaTop: number }>(
-  ({ theme, safeAreaTop }) => ({
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    height: theme.appBarHeight + safeAreaTop,
-    zIndex: theme.zIndex.header,
-    borderBottomColor: theme.colors.greyLight,
-    borderBottomWidth: 1,
-  })
-)
-
-const BlurNativeContainer = styled(Animated.View)<{ safeAreaTop: number }>(
-  ({ theme, safeAreaTop }) => ({
-    position: 'absolute',
-    height: theme.appBarHeight + safeAreaTop,
-    top: 0,
-    left: 0,
-    right: 0,
-    overflow: 'hidden',
-  })
-)
+const HeaderContainer = styled(Animated.View)<{ height: number }>(({ theme, height }) => ({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  height,
+  zIndex: theme.zIndex.header,
+  borderBottomColor: theme.colors.greyLight,
+  borderBottomWidth: 1,
+}))
 
 const Row = styled.View({
   flex: 1,

--- a/src/features/venue/components/VenueHeader/VenueHeader.tsx
+++ b/src/features/venue/components/VenueHeader/VenueHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Animated } from 'react-native'
+import { Animated, Platform } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled, { useTheme } from 'styled-components/native'
 
@@ -54,9 +54,11 @@ export const VenueHeader: React.FC<Props> = (props) => {
     <React.Fragment>
       <HeaderContainer style={containerStyle} safeAreaTop={top}>
         <Spacer.TopScreen />
-        <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
-          <BlurHeader />
-        </BlurNativeContainer>
+        {Platform.OS !== 'android' && (
+          <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
+            <BlurHeader />
+          </BlurNativeContainer>
+        )}
         <Spacer.Column numberOfSpaces={2} />
         <Row>
           <Spacer.Row numberOfSpaces={6} />

--- a/src/features/venue/components/VenueHeader/VenueHeader.tsx
+++ b/src/features/venue/components/VenueHeader/VenueHeader.tsx
@@ -54,11 +54,14 @@ export const VenueHeader: React.FC<Props> = (props) => {
     <React.Fragment>
       <HeaderContainer style={containerStyle} safeAreaTop={top}>
         <Spacer.TopScreen />
-        {Platform.OS !== 'android' && (
-          <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
-            <BlurHeader />
-          </BlurNativeContainer>
-        )}
+        {
+          // There is an issue with the blur on Android: we chose not to render it and use a white background
+          Platform.OS !== 'android' && (
+            <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
+              <BlurHeader />
+            </BlurNativeContainer>
+          )
+        }
         <Spacer.Column numberOfSpaces={2} />
         <Row>
           <Spacer.Row numberOfSpaces={6} />

--- a/src/features/venue/components/VenueHeader/VenueHeader.tsx
+++ b/src/features/venue/components/VenueHeader/VenueHeader.tsx
@@ -9,8 +9,8 @@ import { useShareVenue } from 'features/share/helpers/useShareVenue'
 import { WebShareModal } from 'features/share/pages/WebShareModal'
 import { analytics } from 'libs/analytics'
 import { getAnimationState } from 'ui/animations/helpers/getAnimationState'
-import { BlurView } from 'ui/components/BlurView'
 import { RoundedButton } from 'ui/components/buttons/RoundedButton'
+import { AnimatedBlurHeader } from 'ui/components/headers/AnimatedBlurHeader'
 import { useModal } from 'ui/components/modals/useModal'
 import { Spacer, Typo } from 'ui/theme'
 
@@ -49,17 +49,16 @@ export const VenueHeader: React.FC<Props> = (props) => {
     headerTransition
   )
   const { top } = useSafeAreaInsets()
+  const headerHeight = theme.appBarHeight + top
 
   return (
     <React.Fragment>
-      <HeaderContainer style={containerStyle} safeAreaTop={top}>
+      <HeaderContainer style={containerStyle} height={headerHeight}>
         <Spacer.TopScreen />
         {
           // There is an issue with the blur on Android: we chose not to render it and use a white background
           Platform.OS !== 'android' && (
-            <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
-              <BlurView />
-            </BlurNativeContainer>
+            <AnimatedBlurHeader height={headerHeight} style={blurContainerNative} />
           )
         }
         <Spacer.Column numberOfSpaces={2} />
@@ -107,29 +106,16 @@ const Body = styled(Typo.Body)(({ theme }) => ({
   color: theme.colors.black,
 }))
 
-const HeaderContainer = styled(Animated.View)<{ safeAreaTop: number }>(
-  ({ theme, safeAreaTop }) => ({
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    height: theme.appBarHeight + safeAreaTop,
-    zIndex: theme.zIndex.header,
-    borderBottomColor: theme.colors.greyLight,
-    borderBottomWidth: 1,
-  })
-)
-
-const BlurNativeContainer = styled(Animated.View)<{ safeAreaTop: number }>(
-  ({ theme, safeAreaTop }) => ({
-    position: 'absolute',
-    height: theme.appBarHeight + safeAreaTop,
-    top: 0,
-    left: 0,
-    right: 0,
-    overflow: 'hidden',
-  })
-)
+const HeaderContainer = styled(Animated.View)<{ height: number }>(({ theme, height }) => ({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  height,
+  zIndex: theme.zIndex.header,
+  borderBottomColor: theme.colors.greyLight,
+  borderBottomWidth: 1,
+}))
 
 const Row = styled.View({
   flex: 1,

--- a/src/features/venue/components/VenueHeader/VenueHeader.tsx
+++ b/src/features/venue/components/VenueHeader/VenueHeader.tsx
@@ -9,8 +9,8 @@ import { useShareVenue } from 'features/share/helpers/useShareVenue'
 import { WebShareModal } from 'features/share/pages/WebShareModal'
 import { analytics } from 'libs/analytics'
 import { getAnimationState } from 'ui/animations/helpers/getAnimationState'
+import { BlurView } from 'ui/components/BlurView'
 import { RoundedButton } from 'ui/components/buttons/RoundedButton'
-import { BlurHeader } from 'ui/components/headers/BlurHeader'
 import { useModal } from 'ui/components/modals/useModal'
 import { Spacer, Typo } from 'ui/theme'
 
@@ -58,7 +58,7 @@ export const VenueHeader: React.FC<Props> = (props) => {
           // There is an issue with the blur on Android: we chose not to render it and use a white background
           Platform.OS !== 'android' && (
             <BlurNativeContainer style={blurContainerNative} safeAreaTop={top}>
-              <BlurHeader />
+              <BlurView />
             </BlurNativeContainer>
           )
         }

--- a/src/features/venue/components/VenueHeader/VenueHeader.tsx
+++ b/src/features/venue/components/VenueHeader/VenueHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Animated, Platform } from 'react-native'
+import { Animated } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled, { useTheme } from 'styled-components/native'
 
@@ -55,12 +55,7 @@ export const VenueHeader: React.FC<Props> = (props) => {
     <React.Fragment>
       <HeaderContainer style={containerStyle} height={headerHeight}>
         <Spacer.TopScreen />
-        {
-          // There is an issue with the blur on Android: we chose not to render it and use a white background
-          Platform.OS !== 'android' && (
-            <AnimatedBlurHeader height={headerHeight} style={blurContainerNative} />
-          )
-        }
+        <AnimatedBlurHeader height={headerHeight} style={blurContainerNative} />
         <Spacer.Column numberOfSpaces={2} />
         <Row>
           <Spacer.Row numberOfSpaces={6} />

--- a/src/ui/animations/helpers/getAnimationState.ts
+++ b/src/ui/animations/helpers/getAnimationState.ts
@@ -1,4 +1,4 @@
-import { Animated, Easing } from 'react-native'
+import { Animated, Easing, Platform } from 'react-native'
 import { DefaultTheme } from 'styled-components/native'
 
 const blurHeaderWebInterpolation = () => ({
@@ -27,6 +27,11 @@ const headerBackgroundInterpolation = () => ({
   outputRange: ['rgba(255, 255, 255, 0)', 'rgba(255, 255, 255, 0.8)'],
 })
 
+const headerBackgroundAndroidInterpolation = () => ({
+  inputRange: [0, 1],
+  outputRange: ['rgba(255, 255, 255, 0)', 'rgba(255, 255, 255, 1)'],
+})
+
 export const getAnimationState = (
   theme: DefaultTheme,
   headerTransition: Animated.AnimatedInterpolation
@@ -37,7 +42,10 @@ export const getAnimationState = (
     transition: headerTransition,
   },
   containerStyle: {
-    backgroundColor: headerTransition.interpolate(headerBackgroundInterpolation()),
+    backgroundColor:
+      Platform.OS === 'android'
+        ? headerTransition.interpolate(headerBackgroundAndroidInterpolation())
+        : headerTransition.interpolate(headerBackgroundInterpolation()),
     borderBottomWidth: headerTransition.interpolate(strokeBorderInterpolation()),
     backdropFilter: headerTransition.interpolate(blurHeaderWebInterpolation()),
   },

--- a/src/ui/animations/helpers/getAnimationState.ts
+++ b/src/ui/animations/helpers/getAnimationState.ts
@@ -42,6 +42,7 @@ export const getAnimationState = (
     transition: headerTransition,
   },
   containerStyle: {
+    // There is an issue with the blur on Android: we chose to render a white background for the header
     backgroundColor:
       Platform.OS === 'android'
         ? headerTransition.interpolate(headerBackgroundAndroidInterpolation())

--- a/src/ui/components/BlurView.tsx
+++ b/src/ui/components/BlurView.tsx
@@ -1,0 +1,16 @@
+import { BlurView as RNCBlurView } from '@react-native-community/blur'
+import React from 'react'
+import styled from 'styled-components/native'
+
+type Props = {
+  blurAmount?: number
+  blurType?: 'dark' | 'light' | 'xlight'
+}
+
+export const BlurView = ({ blurAmount = 8, blurType = 'light' }: Props) => {
+  return <Blurred blurType={blurType} blurAmount={blurAmount} />
+}
+
+const Blurred = styled(RNCBlurView)({
+  flex: 1,
+})

--- a/src/ui/components/BlurView.web.tsx
+++ b/src/ui/components/BlurView.web.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+// We need to define this unused empty component in order to compile web app correctly. Without it,
+// the native component BlurView.tsx makes web compilation fail.
+export const BlurView: React.FC = () => {
+  return <React.Fragment />
+}

--- a/src/ui/components/headers/AnimatedBlurHeader.tsx
+++ b/src/ui/components/headers/AnimatedBlurHeader.tsx
@@ -1,0 +1,37 @@
+import { BlurView } from '@react-native-community/blur'
+import React from 'react'
+import { Animated, ViewStyle } from 'react-native'
+import styled from 'styled-components/native'
+
+type Props = {
+  height: number
+  blurAmount?: number
+  blurType?: 'dark' | 'light' | 'xlight'
+  style?: Animated.WithAnimatedObject<ViewStyle>
+}
+
+export const AnimatedBlurHeader = ({
+  height,
+  blurAmount = 8,
+  blurType = 'light',
+  style,
+}: Props) => {
+  return (
+    <BlurNativeContainer height={height} style={style}>
+      <Blurred blurType={blurType} blurAmount={blurAmount} />
+    </BlurNativeContainer>
+  )
+}
+
+const Blurred = styled(BlurView)({
+  flex: 1,
+})
+
+const BlurNativeContainer = styled(Animated.View)<{ height: number }>(({ height }) => ({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  height,
+  overflow: 'hidden',
+}))

--- a/src/ui/components/headers/AnimatedBlurHeader.tsx
+++ b/src/ui/components/headers/AnimatedBlurHeader.tsx
@@ -1,7 +1,8 @@
-import { BlurView } from '@react-native-community/blur'
 import React from 'react'
-import { Animated, ViewStyle } from 'react-native'
+import { Animated, Platform, ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
+
+import { BlurView } from 'ui/components/BlurView'
 
 type Props = {
   height: number
@@ -16,6 +17,9 @@ export const AnimatedBlurHeader = ({
   blurType = 'light',
   style,
 }: Props) => {
+  // There is an issue with the blur on Android: we chose not to render it and use a white background
+  if (Platform.OS === 'android') return null
+
   return (
     <BlurNativeContainer height={height} style={style}>
       <Blurred blurType={blurType} blurAmount={blurAmount} />

--- a/src/ui/components/headers/BlurHeader.tsx
+++ b/src/ui/components/headers/BlurHeader.tsx
@@ -1,6 +1,8 @@
-import { BlurView } from '@react-native-community/blur'
 import React from 'react'
+import { Platform } from 'react-native'
 import styled from 'styled-components/native'
+
+import { BlurView } from 'ui/components/BlurView'
 
 type Props = {
   height: number
@@ -9,6 +11,9 @@ type Props = {
 }
 
 export const BlurHeader = ({ height, blurAmount = 8, blurType = 'light' }: Props) => {
+  // There is an issue with the blur on Android: we chose not to render it and use a white background
+  if (Platform.OS === 'android') return null
+
   return (
     <BlurNativeContainer height={height}>
       <Blurred blurType={blurType} blurAmount={blurAmount} />

--- a/src/ui/components/headers/BlurHeader.tsx
+++ b/src/ui/components/headers/BlurHeader.tsx
@@ -3,14 +3,29 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 type Props = {
+  height: number
   blurAmount?: number
   blurType?: 'dark' | 'light' | 'xlight'
 }
 
-export const BlurHeader = ({ blurAmount = 8, blurType = 'light' }: Props) => {
-  return <Blurred blurType={blurType} blurAmount={blurAmount} />
+export const BlurHeader = ({ height, blurAmount = 8, blurType = 'light' }: Props) => {
+  return (
+    <BlurNativeContainer height={height}>
+      <Blurred blurType={blurType} blurAmount={blurAmount} />
+    </BlurNativeContainer>
+  )
 }
 
 const Blurred = styled(BlurView)({
   flex: 1,
 })
+
+const BlurNativeContainer = styled.View<{ height: number }>(({ height }) => ({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  height,
+  overflow: 'hidden',
+  backdropFilter: 'blur(20px)',
+}))

--- a/src/ui/components/headers/BlurHeader.web.tsx
+++ b/src/ui/components/headers/BlurHeader.web.tsx
@@ -1,7 +1,0 @@
-import React from 'react'
-
-// We need to define this unused empty component in order to compile web app correctly. Without it,
-// the native component BlurHeader.tsx makes web compilation fail.
-export const BlurHeader: React.FC = () => {
-  return <React.Fragment />
-}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-20703

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

Changes only for Android


| Before | After |
| :-: | :-: |
| <img width="292" alt="Capture d’écran 2023-06-13 à 23 47 21" src="https://github.com/pass-culture/pass-culture-app-native/assets/131354212/4db5c131-0d25-4779-b9ef-5606b1447154"> | <img width="284" alt="Capture d’écran 2023-06-13 à 23 46 29" src="https://github.com/pass-culture/pass-culture-app-native/assets/131354212/64484b24-276c-4a0c-91c2-a415d8c3709d"> |
|<img width="1512" alt="Capture d’écran 2023-06-15 à 13 47 29" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/753777c7-47a1-409a-9df2-4c486cbd1876">|<img width="1512" alt="Capture d’écran 2023-06-15 à 13 53 02" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/a6768268-a00c-4ced-a0e3-2950d51f743d">|
|![simulator_screenshot_5CF40152-63FB-4976-9843-1C41B9547FA6](https://github.com/pass-culture/pass-culture-app-native/assets/47600889/002d6a7a-5b27-4f1e-8c79-2a2f68c14990)|![simulator_screenshot_18E51B50-27E5-4001-AA1F-67ACAB8744A8](https://github.com/pass-culture/pass-culture-app-native/assets/47600889/4301c0aa-69ca-4e05-aeb3-cd8385872d75)|

