### PR TITLE
(BSR) fix(global): use `React.JSX` instead of the global `JSX` namespace

### DIFF
--- a/src/features/auth/context/AuthContext.tsx
+++ b/src/features/auth/context/AuthContext.tsx
@@ -60,7 +60,11 @@ export function useAuthContext(): IAuthContext {
   return useContext(AuthContext)
 }
 
-export const AuthWrapper = memo(function AuthWrapper({ children }: { children: JSX.Element }) {
+export const AuthWrapper = memo(function AuthWrapper({
+  children,
+}: {
+  children: React.JSX.Element
+}) {
   const [loading, setLoading] = useState(true)
   const [isLoggedIn, setIsLoggedIn] = useState(false)
   const connectServicesRequiringUserId = useConnectServicesRequiringUserId()

--- a/src/features/auth/context/SettingsContext.tsx
+++ b/src/features/auth/context/SettingsContext.tsx
@@ -23,7 +23,7 @@ export function useSettingsContext(): ISettingsContext {
 export const SettingsWrapper = memo(function SettingsWrapper({
   children,
 }: {
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const { data, isLoading } = useAppSettings()
 

--- a/src/features/bookOffer/components/BookingInformations.tsx
+++ b/src/features/bookOffer/components/BookingInformations.tsx
@@ -101,7 +101,7 @@ export const BookingInformations = ({ shouldDisplayAddress = true }: Props) => {
 
 const Item: React.FC<{
   Icon: React.FC<IconInterface>
-  message: JSX.Element | string
+  message: React.JSX.Element | string
   subtext?: string
   testID?: string
 }> = ({ Icon, message, subtext = '', testID }) => {

--- a/src/features/bookOffer/components/ChoiceBloc.tsx
+++ b/src/features/bookOffer/components/ChoiceBloc.tsx
@@ -20,7 +20,7 @@ export const getTextColor = (theme: DefaultTheme, selected: boolean, disabled: b
 interface Props {
   selected: boolean
   onPress: () => void
-  children: JSX.Element
+  children: React.JSX.Element
   accessibilityLabel: string
   disabled?: boolean
 }

--- a/src/features/bookOffer/components/DuoChoiceSelector.tsx
+++ b/src/features/bookOffer/components/DuoChoiceSelector.tsx
@@ -42,7 +42,7 @@ export const DuoChoiceSelector: React.FC = () => {
 
 const SoloPerson = (props: IconInterface) => <ProfileIcon {...props} />
 
-const DuoPerson = (props: IconInterface): JSX.Element => (
+const DuoPerson = (props: IconInterface): React.JSX.Element => (
   <DuoPersonContainer>
     <ProfileIcon {...props} />
     <ProfileIcon {...props} />

--- a/src/features/bookOffer/helpers/useModalContent.tsx
+++ b/src/features/bookOffer/helpers/useModalContent.tsx
@@ -19,7 +19,7 @@ import { ModalLeftIconProps } from 'ui/components/modals/types'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 
 type ModalContent = {
-  children: JSX.Element
+  children: React.JSX.Element
   title: string
 } & ModalLeftIconProps
 

--- a/src/features/cookies/components/useCookiesModalContent.tsx
+++ b/src/features/cookies/components/useCookiesModalContent.tsx
@@ -20,9 +20,9 @@ interface Props {
 }
 
 type ReportOfferModalContent = {
-  children: JSX.Element
+  children: React.JSX.Element
   title: string
-  fixedModalBottom: JSX.Element
+  fixedModalBottom: React.JSX.Element
 } & ModalLeftIconProps
 
 export const useCookiesModalContent = ({

--- a/src/features/culturalSurvey/context/CulturalSurveyContextProvider.tsx
+++ b/src/features/culturalSurvey/context/CulturalSurveyContextProvider.tsx
@@ -18,7 +18,7 @@ const CulturalSurveyContext = React.createContext<ICulturalSurveyContext | null>
 export const CulturalSurveyContextProvider = ({
   children,
 }: {
-  children: JSX.Element | JSX.Element[]
+  children: React.JSX.Element | React.JSX.Element[]
 }) => {
   const { data: culturalSurveyQuestionsData } = useCulturalSurveyQuestions()
 

--- a/src/features/culturalSurvey/pages/CulturalSurveyIntro.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyIntro.tsx
@@ -25,7 +25,7 @@ const FAQTouchableLinkProps = {
   accessibilityLabel: 'En savoir plus sur ce qu’on fait de tes données',
 }
 
-export const CulturalSurveyIntro = (): JSX.Element => {
+export const CulturalSurveyIntro = (): React.JSX.Element => {
   const { navigate } = useNavigation<UseNavigationType>()
   const { questionsToDisplay: initialQuestions } = useCulturalSurveyContext()
 

--- a/src/features/culturalSurvey/pages/CulturalSurveyQuestions.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyQuestions.tsx
@@ -44,7 +44,9 @@ type CulturalSurveyQuestionsProps = StackScreenProps<
   'CulturalSurveyQuestions'
 >
 
-export const CulturalSurveyQuestions = ({ route }: CulturalSurveyQuestionsProps): JSX.Element => {
+export const CulturalSurveyQuestions = ({
+  route,
+}: CulturalSurveyQuestionsProps): React.JSX.Element => {
   const [bottomChildrenViewHeight, setBottomChildrenViewHeight] = useState(0)
   const { push, navigate } = useNavigation<UseNavigationType>()
   const { data: culturalSurveyQuestionsData } = useCulturalSurveyQuestions()

--- a/src/features/errors/pages/ScreenErrorProvider.tsx
+++ b/src/features/errors/pages/ScreenErrorProvider.tsx
@@ -7,7 +7,11 @@ import { MaintenanceErrorPage } from 'features/maintenance/pages/MaintenanceErro
 import { MAINTENANCE } from 'libs/firebase/firestore/maintenance'
 import { ScreenError } from 'libs/monitoring/errors'
 
-export const ScreenErrorProvider = ({ children }: { children?: JSX.Element | JSX.Element[] }) => {
+export const ScreenErrorProvider = ({
+  children,
+}: {
+  children?: React.JSX.Element | React.JSX.Element[]
+}) => {
   const { status } = useMaintenance()
   const mustUpdateApp = useMustUpdateApp()
 

--- a/src/features/favorites/context/FavoritesWrapper.tsx
+++ b/src/features/favorites/context/FavoritesWrapper.tsx
@@ -8,10 +8,10 @@ import {
 
 const FavoritesContext = React.createContext<FavoritesContextType | null>(null)
 
-export const FavoritesWrapper = memo<{ children: JSX.Element }>(function FavoritesWrapper({
+export const FavoritesWrapper = memo<{ children: React.JSX.Element }>(function FavoritesWrapper({
   children,
 }: {
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const [contextValueWithoutDispatch, dispatch] = useReducer(
     favoritesReducer,

--- a/src/features/identityCheck/context/SubscriptionContextProvider.tsx
+++ b/src/features/identityCheck/context/SubscriptionContextProvider.tsx
@@ -15,7 +15,7 @@ const SubscriptionContext = React.createContext<ISubscriptionContext | null>(nul
 export const SubscriptionContextProvider = ({
   children,
 }: {
-  children: JSX.Element | JSX.Element[]
+  children: React.JSX.Element | React.JSX.Element[]
 }) => {
   const [subscriptionState, dispatch] = useReducer(SubscriptionReducer, initialSubscriptionState)
 

--- a/src/features/identityCheck/pages/identification/dms/DMSIntroduction.tsx
+++ b/src/features/identityCheck/pages/identification/dms/DMSIntroduction.tsx
@@ -20,7 +20,7 @@ import { BicolorIconInterface } from 'ui/svg/icons/types'
 import { LogoDMS } from 'ui/svg/LogoDMS'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
-export const DMSIntroduction = (): JSX.Element => {
+export const DMSIntroduction = (): React.JSX.Element => {
   useEffect(() => {
     analytics.logScreenViewDMSIntroduction()
   }, [])

--- a/src/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.tsx
@@ -12,7 +12,7 @@ import { BicolorIdCardError } from 'ui/svg/icons/BicolorIdCardError'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
-export const ExpiredOrLostID = (): JSX.Element => {
+export const ExpiredOrLostID = (): React.JSX.Element => {
   useEffect(() => {
     BatchUser.trackEvent(BatchEvent.screenViewExpiredOrLostId)
     analytics.logScreenViewExpiredOrLostId()

--- a/src/features/internal/cheatcodes/pages/Navigation/Navigation.tsx
+++ b/src/features/internal/cheatcodes/pages/Navigation/Navigation.tsx
@@ -24,7 +24,7 @@ import { Spacer } from 'ui/theme'
 
 const EIFFEL_TOWER_COORDINATES = { lat: 48.8584, lng: 2.2945 }
 
-export function Navigation(): JSX.Element {
+export function Navigation(): React.JSX.Element {
   const { navigate } = useNavigation<UseNavigationType>()
   const [screenError, setScreenError] = useState<ScreenError | undefined>(undefined)
   const distanceToEiffelTower = useDistance(EIFFEL_TOWER_COORDINATES)

--- a/src/features/internal/cheatcodes/pages/NavigationAccountSuspension/NavigationAccountSuspension.tsx
+++ b/src/features/internal/cheatcodes/pages/NavigationAccountSuspension/NavigationAccountSuspension.tsx
@@ -6,7 +6,7 @@ import { LinkToComponent } from 'features/internal/cheatcodes/components/LinkToC
 import { PageHeaderSecondary } from 'ui/components/headers/PageHeaderSecondary'
 import { Spacer } from 'ui/theme'
 
-export function NavigationAccountSuspension(): JSX.Element {
+export function NavigationAccountSuspension(): React.JSX.Element {
   return (
     <ScrollView>
       <PageHeaderSecondary title="Account Management 🎨" />

--- a/src/features/internal/cheatcodes/pages/NavigationCulturalSurvey/NavigationCulturalSurvey.tsx
+++ b/src/features/internal/cheatcodes/pages/NavigationCulturalSurvey/NavigationCulturalSurvey.tsx
@@ -6,7 +6,7 @@ import { LinkToComponent } from 'features/internal/cheatcodes/components/LinkToC
 import { PageHeaderSecondary } from 'ui/components/headers/PageHeaderSecondary'
 import { Spacer } from 'ui/theme'
 
-export function NavigationCulturalSurvey(): JSX.Element {
+export function NavigationCulturalSurvey(): React.JSX.Element {
   return (
     <ScrollView>
       <PageHeaderSecondary title="CulturalSurvey 🎨" />

--- a/src/features/internal/cheatcodes/pages/NavigationNotScreensPages.tsx
+++ b/src/features/internal/cheatcodes/pages/NavigationNotScreensPages.tsx
@@ -16,11 +16,11 @@ const doNothing = () => {
   /* do nothing */
 }
 
-const mapPageToComponent: Record<Page, JSX.Element> = {
+const mapPageToComponent: Record<Page, React.JSX.Element> = {
   [Page.BrowserNotSupportedPage]: <BrowserNotSupportedPage onPress={doNothing} />,
 }
 
-export function NavigationNotScreensPages(): JSX.Element {
+export function NavigationNotScreensPages(): React.JSX.Element {
   const [page, setPage] = useState<Page | null>(null)
 
   if (page) {

--- a/src/features/internal/cheatcodes/pages/NavigationOnboarding/NavigationOnboarding.tsx
+++ b/src/features/internal/cheatcodes/pages/NavigationOnboarding/NavigationOnboarding.tsx
@@ -7,7 +7,7 @@ import { LinkToComponent } from 'features/internal/cheatcodes/components/LinkToC
 import { PageHeaderSecondary } from 'ui/components/headers/PageHeaderSecondary'
 import { Spacer } from 'ui/theme'
 
-export function NavigationOnboarding(): JSX.Element {
+export function NavigationOnboarding(): React.JSX.Element {
   useFocusEffect(
     React.useCallback(() => {
       StatusBar.setBarStyle('dark-content', true)

--- a/src/features/internal/cheatcodes/pages/NavigationProfile/NavigationProfile.tsx
+++ b/src/features/internal/cheatcodes/pages/NavigationProfile/NavigationProfile.tsx
@@ -13,7 +13,7 @@ import { PageHeaderSecondary } from 'ui/components/headers/PageHeaderSecondary'
 import { useModal } from 'ui/components/modals/useModal'
 import { Spacer } from 'ui/theme'
 
-export function NavigationProfile(): JSX.Element {
+export function NavigationProfile(): React.JSX.Element {
   const {
     visible: ceilingModalVisible,
     showModal: showCeilingModal,

--- a/src/features/internal/cheatcodes/pages/NavigationShareApp/NavigationShareApp.tsx
+++ b/src/features/internal/cheatcodes/pages/NavigationShareApp/NavigationShareApp.tsx
@@ -8,7 +8,7 @@ import { ShareAppModalType } from 'features/share/helpers/shareAppModalInformati
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { PageHeaderSecondary } from 'ui/components/headers/PageHeaderSecondary'
 
-export function NavigationShareApp(): JSX.Element {
+export function NavigationShareApp(): React.JSX.Element {
   const { showShareAppModal } = useShareAppContext()
 
   return (

--- a/src/features/internal/cheatcodes/pages/NavigationSignUp/NavigationIdentityCheck/NavigationIdentityCheck.tsx
+++ b/src/features/internal/cheatcodes/pages/NavigationSignUp/NavigationIdentityCheck/NavigationIdentityCheck.tsx
@@ -16,7 +16,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { PageHeaderSecondary } from 'ui/components/headers/PageHeaderSecondary'
 import { Spacer } from 'ui/theme'
 
-export function NavigationIdentityCheck(): JSX.Element {
+export function NavigationIdentityCheck(): React.JSX.Element {
   const { goBack } = useGoBack('Navigation', undefined)
   const [screenError, setScreenError] = useState<ScreenError | undefined>(undefined)
   const [

--- a/src/features/internal/cheatcodes/pages/NavigationSignUp/NavigationIdentityCheck/NewIdentificationFlow/NewIdentificationFlow.tsx
+++ b/src/features/internal/cheatcodes/pages/NavigationSignUp/NavigationIdentityCheck/NewIdentificationFlow/NewIdentificationFlow.tsx
@@ -8,7 +8,7 @@ import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { PageHeaderSecondary } from 'ui/components/headers/PageHeaderSecondary'
 import { Spacer } from 'ui/theme'
 
-export function NewIdentificationFlow(): JSX.Element {
+export function NewIdentificationFlow(): React.JSX.Element {
   const { navigate } = useNavigation<UseNavigationType>()
 
   return (

--- a/src/features/internal/cheatcodes/pages/NavigationSignUp/NavigationSignUp.tsx
+++ b/src/features/internal/cheatcodes/pages/NavigationSignUp/NavigationSignUp.tsx
@@ -17,7 +17,7 @@ import { PageHeaderSecondary } from 'ui/components/headers/PageHeaderSecondary'
 import { useModal } from 'ui/components/modals/useModal'
 import { Spacer } from 'ui/theme'
 
-export function NavigationSignUp(): JSX.Element {
+export function NavigationSignUp(): React.JSX.Element {
   const { navigate } = useNavigation<UseNavigationType>()
   const offerId = useSomeOfferId()
 

--- a/src/features/internal/cheatcodes/pages/NavigationTrustedDevice/NavigationTrustedDevice.tsx
+++ b/src/features/internal/cheatcodes/pages/NavigationTrustedDevice/NavigationTrustedDevice.tsx
@@ -9,7 +9,7 @@ import { Spacer } from 'ui/theme'
 const TOKEN =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIxIiwibG9jYXRpb24iOiJQYXJpcyIsImRhdGVDcmVhdGVkIjoiMjAyMy0wNi0wOVQxMDowMDowMFoiLCJvcyI6ImlPUyIsInNvdXJjZSI6ImlQaG9uZSAxMyJ9.0x9m4wEh0QKefPSsCOJDVrA-xVRGnUcoJR_vEbjNtaE'
 
-export function NavigationTrustedDevice(): JSX.Element {
+export function NavigationTrustedDevice(): React.JSX.Element {
   return (
     <ScrollView>
       <PageHeaderSecondary title="Trusted device 📱" />

--- a/src/features/internal/marketingAndCommunication/atoms/DeeplinkItem.tsx
+++ b/src/features/internal/marketingAndCommunication/atoms/DeeplinkItem.tsx
@@ -10,7 +10,7 @@ import { getSpacing, Spacer, Typo } from 'ui/theme'
 
 interface Props {
   deeplink: GeneratedDeeplink
-  before?: JSX.Element | JSX.Element[]
+  before?: React.JSX.Element | React.JSX.Element[]
 }
 
 export const DeeplinkItem = ({ deeplink, before }: Props) => {

--- a/src/features/navigation/RootNavigator/linking/getScreenComponent.tsx
+++ b/src/features/navigation/RootNavigator/linking/getScreenComponent.tsx
@@ -12,7 +12,7 @@ export function getScreenComponent(
   name: string,
   route: Route | TabRoute,
   ScreenComponent: ComponentType<any> // eslint-disable-line @typescript-eslint/no-explicit-any
-): JSX.Element {
+): React.JSX.Element {
   let component = route.component
   component = route.hoc ? route.hoc(component) : withAsyncErrorBoundary(component)
   if (route.secure) component = withAuthProtection(component)

--- a/src/features/navigation/RootNavigator/useInitialScreenConfig.native.test.tsx
+++ b/src/features/navigation/RootNavigator/useInitialScreenConfig.native.test.tsx
@@ -66,7 +66,7 @@ describe('useInitialScreen()', () => {
 
 async function renderUseInitialScreen() {
   const wrapper = (props: { children: unknown }) => (
-    <SplashScreenProvider>{props.children as JSX.Element}</SplashScreenProvider>
+    <SplashScreenProvider>{props.children as React.JSX.Element}</SplashScreenProvider>
   )
   const { result } = renderHook(useInitialScreen, { wrapper })
   await superFlushWithAct()

--- a/src/features/navigation/RootNavigator/useInitialScreenConfig.web.test.tsx
+++ b/src/features/navigation/RootNavigator/useInitialScreenConfig.web.test.tsx
@@ -8,7 +8,7 @@ import { renderHook, waitFor } from 'tests/utils/web'
 import { useInitialScreen } from './useInitialScreenConfig'
 
 const wrapper = (props: { children: unknown }) => (
-  <SplashScreenProvider>{props.children as JSX.Element}</SplashScreenProvider>
+  <SplashScreenProvider>{props.children as React.JSX.Element}</SplashScreenProvider>
 )
 
 describe('useInitialScreen()', () => {

--- a/src/features/notifications/context/PushNotificationsWrapper.tsx
+++ b/src/features/notifications/context/PushNotificationsWrapper.tsx
@@ -23,7 +23,7 @@ const PUSH_NOTIFICATIONS_STORAGE_KEY = 'has_seen_push_notifications_modal_once'
 export const PushNotificationsWrapper = memo(function PushNotificationsWrapper({
   children,
 }: {
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const {
     visible: isPushNotificationsModalVisible,

--- a/src/features/offer/helpers/useReportOfferModalContent/useReportOfferModalContent.tsx
+++ b/src/features/offer/helpers/useReportOfferModalContent/useReportOfferModalContent.tsx
@@ -16,7 +16,7 @@ interface Props {
 }
 
 type ReportOfferModalContent = {
-  children: JSX.Element
+  children: React.JSX.Element
   title: string
 } & ModalLeftIconProps
 

--- a/src/features/onboarding/context/OnboardingWrapper.tsx
+++ b/src/features/onboarding/context/OnboardingWrapper.tsx
@@ -15,7 +15,7 @@ const OnboardingContext = React.createContext<OnboardingContextValue>({
 export const OnboardingWrapper = memo(function OnboardingWrapper({
   children,
 }: {
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const { showModal, ...modalProps } = useModal(false)
   const [modalType, setModalType] = useState(NonEligible.UNDER_15)

--- a/src/features/onboarding/pages/AgeInformation.tsx
+++ b/src/features/onboarding/pages/AgeInformation.tsx
@@ -34,7 +34,7 @@ const onSignupPress = () => {
   analytics.logSignUpClicked({ from: 'onboarding' })
 }
 
-export const AgeInformation = ({ route }: AgeInformationProps): JSX.Element => {
+export const AgeInformation = ({ route }: AgeInformationProps): React.JSX.Element => {
   const { reset } = useNavigation<UseNavigationType>()
   const userAge = route.params.age
   const isEighteen = userAge === 18

--- a/src/features/profile/components/VerticalStepper/VerticalStepper.tsx
+++ b/src/features/profile/components/VerticalStepper/VerticalStepper.tsx
@@ -20,7 +20,7 @@ export type VerticalStepperProps = FirstOrLastProps &
     /**
      * Use this if you want to override middle icon.
      */
-    iconComponent?: JSX.Element
+    iconComponent?: React.JSX.Element
   }
 
 type CustomComponentProps = FirstOrLastProps & {

--- a/src/features/profile/pages/Profile.native.test.tsx
+++ b/src/features/profile/pages/Profile.native.test.tsx
@@ -340,7 +340,7 @@ describe('Profile component', () => {
 })
 
 interface Options {
-  wrapper?: NamedExoticComponent<{ children: JSX.Element }> | undefined
+  wrapper?: NamedExoticComponent<{ children: React.JSX.Element }> | undefined
 }
 
 const defaultOptions = {

--- a/src/features/search/components/CenteredSection.tsx
+++ b/src/features/search/components/CenteredSection.tsx
@@ -5,8 +5,8 @@ import { getSpacing, Typo, Spacer } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export const CenteredSection: React.FC<{
-  title: JSX.Element | string
-  children: JSX.Element | Array<JSX.Element | null>
+  title: React.JSX.Element | string
+  children: React.JSX.Element | Array<React.JSX.Element | null>
 }> = ({ title, children }) => (
   <MarginHorizontalContainer>
     <Title>{title}</Title>

--- a/src/features/search/components/SearchAutocomplete/SearchAutocomplete.tsx
+++ b/src/features/search/components/SearchAutocomplete/SearchAutocomplete.tsx
@@ -7,7 +7,7 @@ import { AlgoliaSuggestionHit } from 'libs/algolia'
 import { getSpacing } from 'ui/theme'
 
 type Props = UseInfiniteHitsProps & {
-  hitComponent: (props: HitProps) => JSX.Element
+  hitComponent: (props: HitProps) => React.JSX.Element
 }
 
 export const SearchAutocomplete: React.FC<Props> = ({ hitComponent: Item, ...props }) => {

--- a/src/features/search/context/SearchWrapper.tsx
+++ b/src/features/search/context/SearchWrapper.tsx
@@ -11,7 +11,11 @@ interface ISearchContext {
 
 const SearchContext = React.createContext<ISearchContext | null>(null)
 
-export const SearchWrapper = memo(function SearchWrapper({ children }: { children: JSX.Element }) {
+export const SearchWrapper = memo(function SearchWrapper({
+  children,
+}: {
+  children: React.JSX.Element
+}) {
   const maxPrice = useMaxPrice()
   const priceRange: [number, number] = [0, maxPrice]
 

--- a/src/features/share/context/ShareAppWrapper.tsx
+++ b/src/features/share/context/ShareAppWrapper.tsx
@@ -15,7 +15,7 @@ const ShareAppContext = React.createContext<ShareAppContextValue>({
 export const ShareAppWrapper = memo(function ShareAppWrapper({
   children,
 }: {
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const { showModal, ...shareAppModalProps } = useModal(false)
   const [modalType, setModalType] = useState(ShareAppModalType.NOT_ELIGIBLE)

--- a/src/libs/algolia/analytics/SearchAnalyticsWrapper.tsx
+++ b/src/libs/algolia/analytics/SearchAnalyticsWrapper.tsx
@@ -13,7 +13,7 @@ const defaultContext = {
 }
 const SearchAnalyticsContext = React.createContext<SearchAnalyticsContextType>(defaultContext)
 
-export const SearchAnalyticsWrapper = ({ children }: { children: JSX.Element }) => {
+export const SearchAnalyticsWrapper = ({ children }: { children: React.JSX.Element }) => {
   const [currentQueryID, setCurrentQueryID] = useState<string | undefined>()
 
   const value = useMemo(

--- a/src/libs/e2e/E2eContextProvider.tsx
+++ b/src/libs/e2e/E2eContextProvider.tsx
@@ -5,7 +5,11 @@ import { env } from 'libs/environment'
 
 const E2eContext = React.createContext<boolean>(false)
 
-export function E2eContextProvider({ children }: { children: JSX.Element | JSX.Element[] }) {
+export function E2eContextProvider({
+  children,
+}: {
+  children: React.JSX.Element | React.JSX.Element[]
+}) {
   const [isE2e, setIsE2e] = useState<boolean>(false)
   useEffect(() => {
     getIsE2e().then(setIsE2e)

--- a/src/libs/firebase/remoteConfig/RemoteConfigProvider.tsx
+++ b/src/libs/firebase/remoteConfig/RemoteConfigProvider.tsx
@@ -11,7 +11,7 @@ export function useRemoteConfigContext() {
 }
 
 export const RemoteConfigProvider = memo(function RemoteConfigProvider(props: {
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const [contextValue, setContextValue] = useState<CustomRemoteConfig>(DEFAULT_REMOTE_CONFIG)
 

--- a/src/libs/firebase/remoteConfig/RemoteConfigProvider.web.tsx
+++ b/src/libs/firebase/remoteConfig/RemoteConfigProvider.web.tsx
@@ -11,7 +11,7 @@ export function useRemoteConfigContext() {
 }
 
 export const RemoteConfigProvider = memo(function RemoteConfigProvider(props: {
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const [contextValue, setContextValue] = useState<CustomRemoteConfig>(DEFAULT_REMOTE_CONFIG)
   useEffect(() => {

--- a/src/libs/geolocation/GeolocationWrapper.tsx
+++ b/src/libs/geolocation/GeolocationWrapper.tsx
@@ -34,7 +34,7 @@ const GeolocationContext = React.createContext<IGeolocationContext>({
 export const GeolocationWrapper = memo(function GeolocationWrapper({
   children,
 }: {
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const [userPosition, setUserPosition] = useSafeState<Position>(undefined)
   const [customPosition, setCustomPosition] = useSafeState<Position>(undefined)

--- a/src/libs/network/NetInfoWrapper.tsx
+++ b/src/libs/network/NetInfoWrapper.tsx
@@ -9,7 +9,7 @@ import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/S
 export const NetInfoWrapper = memo(function NetInfoWrapper({
   children,
 }: {
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const networkInfo = useNetInfo()
   const { showInfoSnackBar } = useSnackBarContext()

--- a/src/libs/react-query/ReactQueryClientProvider.tsx
+++ b/src/libs/react-query/ReactQueryClientProvider.tsx
@@ -29,7 +29,7 @@ reactQueryFocusManager.setEventListener((handleFocus) => {
   }
 })
 
-export const ReactQueryClientProvider = ({ children }: { children: JSX.Element }) => {
+export const ReactQueryClientProvider = ({ children }: { children: React.JSX.Element }) => {
   usePrefetchQueries()
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 }

--- a/src/libs/react-query/ReactQueryClientProvider.web.tsx
+++ b/src/libs/react-query/ReactQueryClientProvider.web.tsx
@@ -4,7 +4,7 @@ import { QueryClientProvider } from 'react-query'
 import { queryClient } from 'libs/react-query/queryClient'
 import { usePrefetchQueries } from 'libs/react-query/usePrefetchQueries'
 
-export const ReactQueryClientProvider = ({ children }: { children: JSX.Element }) => {
+export const ReactQueryClientProvider = ({ children }: { children: React.JSX.Element }) => {
   usePrefetchQueries()
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 }

--- a/src/libs/splashscreen/splashscreen.tsx
+++ b/src/libs/splashscreen/splashscreen.tsx
@@ -14,7 +14,7 @@ export function useSplashScreenContext() {
 }
 
 export const SplashScreenProvider = memo(function SplashScreenProvider(props: {
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const splashScreenBeginningTime = new Date().getTime()
   const [isSplashScreenHidden, setIsSplashScreenHidden] = useState<boolean>(false)

--- a/src/ui/components/SectionRowContent.tsx
+++ b/src/ui/components/SectionRowContent.tsx
@@ -17,7 +17,7 @@ export type SectionRowContentProps = {
   style?: StyleProp<ViewStyle>
 } & (
   | {
-      renderTitle: (title: string) => JSX.Element
+      renderTitle: (title: string) => React.JSX.Element
       numberOfLines?: never
     }
   | {

--- a/src/ui/components/SectionWithDivider.stories.tsx
+++ b/src/ui/components/SectionWithDivider.stories.tsx
@@ -15,7 +15,7 @@ const Template: ComponentStory<typeof SectionWithDivider> = (props) => (
   <SectionWithDivider {...props} />
 )
 
-const SectionContent: JSX.Element = (
+const SectionContent: React.JSX.Element = (
   <View>
     <Typo.Title4>Section with divider</Typo.Title4>
     <Typo.Body>

--- a/src/ui/components/SectionWithDivider.tsx
+++ b/src/ui/components/SectionWithDivider.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/native'
 import { getSpacing } from 'ui/theme'
 interface SectionProps {
   visible: boolean
-  children: JSX.Element | JSX.Element[]
+  children: React.JSX.Element | React.JSX.Element[]
   margin?: boolean
   onLayout?: (event: LayoutChangeEvent) => void
   testID?: string

--- a/src/ui/components/achievements/components/GenericAchievementCard/GenericAchievementCard.tsx
+++ b/src/ui/components/achievements/components/GenericAchievementCard/GenericAchievementCard.tsx
@@ -36,7 +36,7 @@ export type AchievementCardProps = AchievementCardKeyProps & {
   buttonAccessibilityLabel?: string
   pauseAnimationOnRenderAtFrame: number
   subTitle?: string
-  centerChild?: (() => JSX.Element) | null
+  centerChild?: (() => React.JSX.Element) | null
   text: string
   title: string
   ignoreBottomPadding?: boolean

--- a/src/ui/svg/icons/BicolorConfirmation.tsx
+++ b/src/ui/svg/icons/BicolorConfirmation.tsx
@@ -13,7 +13,7 @@ function ConfirmationSvg({
   accessibilityLabel,
   testID,
   opacity,
-}: AccessibleIcon): JSX.Element {
+}: AccessibleIcon): React.JSX.Element {
   const { id, fill } = svgIdentifier()
 
   return (

--- a/src/ui/svg/icons/BicolorNoId.tsx
+++ b/src/ui/svg/icons/BicolorNoId.tsx
@@ -13,7 +13,7 @@ function BicolorNoIdSvg({
   accessibilityLabel,
   testID,
   opacity,
-}: AccessibleIcon): JSX.Element {
+}: AccessibleIcon): React.JSX.Element {
   const { id, fill } = svgIdentifier()
 
   return (

--- a/src/ui/svg/icons/Clear.tsx
+++ b/src/ui/svg/icons/Clear.tsx
@@ -6,7 +6,7 @@ import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
 
 import { AccessibleIcon } from './types'
 
-function ClearSvg({ size, color, accessibilityLabel, testID }: AccessibleIcon): JSX.Element {
+function ClearSvg({ size, color, accessibilityLabel, testID }: AccessibleIcon): React.JSX.Element {
   return (
     <AccessibleSvg
       width={size}

--- a/src/ui/svg/icons/Connect.tsx
+++ b/src/ui/svg/icons/Connect.tsx
@@ -6,7 +6,12 @@ import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
 
 import { AccessibleIcon } from './types'
 
-function ConnectSvg({ size, color, accessibilityLabel, testID }: AccessibleIcon): JSX.Element {
+function ConnectSvg({
+  size,
+  color,
+  accessibilityLabel,
+  testID,
+}: AccessibleIcon): React.JSX.Element {
   return (
     <AccessibleSvg
       width={size}

--- a/src/ui/svg/icons/EditPen.tsx
+++ b/src/ui/svg/icons/EditPen.tsx
@@ -6,7 +6,12 @@ import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
 
 import { AccessibleIcon } from './types'
 
-function EditPenSvg({ size, color, accessibilityLabel, testID }: AccessibleIcon): JSX.Element {
+function EditPenSvg({
+  size,
+  color,
+  accessibilityLabel,
+  testID,
+}: AccessibleIcon): React.JSX.Element {
   return (
     <AccessibleSvg
       width={size}

--- a/src/ui/svg/icons/Eye.tsx
+++ b/src/ui/svg/icons/Eye.tsx
@@ -6,7 +6,7 @@ import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
 
 import { AccessibleIcon } from './types'
 
-function EyeSvg({ size, color, accessibilityLabel, testID }: AccessibleIcon): JSX.Element {
+function EyeSvg({ size, color, accessibilityLabel, testID }: AccessibleIcon): React.JSX.Element {
   return (
     <AccessibleSvg
       width={size}

--- a/src/ui/svg/icons/EyeSlash.tsx
+++ b/src/ui/svg/icons/EyeSlash.tsx
@@ -6,7 +6,12 @@ import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
 
 import { AccessibleIcon } from './types'
 
-function EyeSlashSvg({ size, color, accessibilityLabel, testID }: AccessibleIcon): JSX.Element {
+function EyeSlashSvg({
+  size,
+  color,
+  accessibilityLabel,
+  testID,
+}: AccessibleIcon): React.JSX.Element {
   return (
     <AccessibleSvg
       width={size}

--- a/src/ui/svg/icons/Profile.tsx
+++ b/src/ui/svg/icons/Profile.tsx
@@ -6,7 +6,12 @@ import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
 
 import { AccessibleIcon } from './types'
 
-function ProfileSvg({ size, color, accessibilityLabel, testID }: AccessibleIcon): JSX.Element {
+function ProfileSvg({
+  size,
+  color,
+  accessibilityLabel,
+  testID,
+}: AccessibleIcon): React.JSX.Element {
   return (
     <AccessibleSvg
       width={size}

--- a/src/ui/svg/icons/ProfileDeletion.tsx
+++ b/src/ui/svg/icons/ProfileDeletion.tsx
@@ -10,7 +10,7 @@ function ProfileDeletionSvg({
   testID,
   accessibilityLabel,
   opacity,
-}: AccessibleIcon): JSX.Element {
+}: AccessibleIcon): React.JSX.Element {
   return (
     <AccessibleSvg
       width={size}

--- a/src/ui/svg/icons/bicolor/Bookstore.tsx
+++ b/src/ui/svg/icons/bicolor/Bookstore.tsx
@@ -13,7 +13,7 @@ function BookstoreSvg({
   color2,
   accessibilityLabel,
   testID,
-}: AccessibleIcon): JSX.Element {
+}: AccessibleIcon): React.JSX.Element {
   const { id: gradientId, fill: gradientFill } = svgIdentifier()
   return (
     <AccessibleSvg

--- a/src/ui/svg/icons/bicolor/Castle.tsx
+++ b/src/ui/svg/icons/bicolor/Castle.tsx
@@ -12,7 +12,7 @@ function CastleSvg({
   color2,
   accessibilityLabel,
   testID,
-}: AccessibleIcon): JSX.Element {
+}: AccessibleIcon): React.JSX.Element {
   const {
     colors: { primary, secondary },
   } = useTheme()

--- a/src/ui/svg/icons/bicolor/ChemistryTools.tsx
+++ b/src/ui/svg/icons/bicolor/ChemistryTools.tsx
@@ -12,7 +12,7 @@ function ChemistryToolsSvg({
   color2,
   accessibilityLabel,
   testID,
-}: AccessibleIcon): JSX.Element {
+}: AccessibleIcon): React.JSX.Element {
   const {
     colors: { primary, secondary },
   } = useTheme()

--- a/src/ui/svg/icons/bicolor/CulturalCentre.tsx
+++ b/src/ui/svg/icons/bicolor/CulturalCentre.tsx
@@ -12,7 +12,7 @@ function CulturalCentreSvg({
   color2,
   accessibilityLabel,
   testID,
-}: AccessibleIcon): JSX.Element {
+}: AccessibleIcon): React.JSX.Element {
   const {
     colors: { primary, secondary },
   } = useTheme()

--- a/src/ui/svg/icons/bicolor/Digital.tsx
+++ b/src/ui/svg/icons/bicolor/Digital.tsx
@@ -12,7 +12,7 @@ function DigitalSvg({
   color2,
   accessibilityLabel,
   testID,
-}: AccessibleIcon): JSX.Element {
+}: AccessibleIcon): React.JSX.Element {
   const {
     colors: { primary, secondary },
   } = useTheme()

--- a/src/ui/svg/icons/bicolor/Festival.tsx
+++ b/src/ui/svg/icons/bicolor/Festival.tsx
@@ -13,7 +13,7 @@ function FestivalSvg({
   color2,
   accessibilityLabel,
   testID,
-}: AccessibleIcon): JSX.Element {
+}: AccessibleIcon): React.JSX.Element {
   const {
     colors: { primary, secondary },
   } = useTheme()

--- a/src/ui/svg/icons/bicolor/Landscape.tsx
+++ b/src/ui/svg/icons/bicolor/Landscape.tsx
@@ -12,7 +12,7 @@ function LandscapeSvg({
   color2,
   accessibilityLabel,
   testID,
-}: AccessibleIcon): JSX.Element {
+}: AccessibleIcon): React.JSX.Element {
   const {
     colors: { primary, secondary },
   } = useTheme()

--- a/src/ui/svg/icons/bicolor/PerformingArts.tsx
+++ b/src/ui/svg/icons/bicolor/PerformingArts.tsx
@@ -13,7 +13,7 @@ function PerformingArtsSvg({
   color2,
   accessibilityLabel,
   testID,
-}: AccessibleIcon): JSX.Element {
+}: AccessibleIcon): React.JSX.Element {
   const {
     colors: { primary, secondary },
   } = useTheme()

--- a/src/ui/svg/icons/bicolor/Turntable.tsx
+++ b/src/ui/svg/icons/bicolor/Turntable.tsx
@@ -12,7 +12,7 @@ function TurntableSvg({
   color2,
   accessibilityLabel,
   testID,
-}: AccessibleIcon): JSX.Element {
+}: AccessibleIcon): React.JSX.Element {
   const {
     colors: { primary, secondary },
   } = useTheme()


### PR DESCRIPTION
`JSX` is deprecated

split de https://github.com/pass-culture/pass-culture-app-native/pull/4896