### PR TITLE
(PC-22611) fix(BookingDetails): fix spacing and cancelletion details display when offers are free

### DIFF
--- a/src/features/bookOffer/components/BookingDetails.tsx
+++ b/src/features/bookOffer/components/BookingDetails.tsx
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { OfferStockResponse, SubcategoryIdEnum } from 'api/gen'
 import { useSearchVenueOffers } from 'api/useSearchVenuesOffer/useSearchVenueOffers'
+import { FREE_OFFER_CATEGORIES_TO_ARCHIVE } from 'features/bookings/constants'
 import { BookingInformations } from 'features/bookOffer/components/BookingInformations'
 import { BookingOfferLoader } from 'features/bookOffer/components/BookingOfferLoader/BookingOfferLoader'
 import { CancellationDetails } from 'features/bookOffer/components/CancellationDetails'
@@ -163,6 +164,9 @@ export function BookingDetails({ stocks, onPressBookOffer, isLoading }: BookingD
 
   const isStockBookable = !(isUserUnderage && selectedStock.isForbiddenToUnderage)
 
+  const isFreeOfferToArchive =
+    !!offer && FREE_OFFER_CATEGORIES_TO_ARCHIVE.includes(offer.subcategoryId)
+
   return isLoading ? (
     <BookingOfferLoader message={loadingMessage} />
   ) : (
@@ -201,11 +205,13 @@ export function BookingDetails({ stocks, onPressBookOffer, isLoading }: BookingD
           <Spacer.Column numberOfSpaces={6} />
         </React.Fragment>
       )}
-
-      <Separator />
-      <Spacer.Column numberOfSpaces={6} />
-
-      <CancellationDetails />
+      {!isFreeOfferToArchive && (
+        <React.Fragment>
+          <Separator />
+          <Spacer.Column numberOfSpaces={6} />
+          <CancellationDetails />
+        </React.Fragment>
+      )}
 
       <Spacer.Column numberOfSpaces={6} />
 

--- a/src/features/bookings/components/BookingExpiration.tsx
+++ b/src/features/bookings/components/BookingExpiration.tsx
@@ -16,7 +16,7 @@ export const BookingExpiration = ({ children, expirationDate }: BookingExpiratio
   return (
     <React.Fragment>
       {children}
-      <Spacer.Column numberOfSpaces={4} />
+      {!!children && <Spacer.Column numberOfSpaces={4} />}
       <StyledCaption>{expirationDateMessage}</StyledCaption>
     </React.Fragment>
   )


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-22611

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |![Capture d’écran 2023-06-15 à 14 21 49](https://github.com/pass-culture/pass-culture-app-native/assets/62058919/0163ca87-2c1b-48b2-8ceb-12f01202e54c)![Capture d’écran 2023-06-15 à 14 22 22](https://github.com/pass-culture/pass-culture-app-native/assets/62058919/a2f0c3e7-1cb8-46ee-9304-d9bcd0e11bfa)|
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
