### PR TITLE
(PC-22172) fix(video): add a white underlay on VideoModule player press

### DIFF
--- a/src/features/home/components/modules/VideoModule.tsx
+++ b/src/features/home/components/modules/VideoModule.tsx
@@ -9,9 +9,7 @@ import { TEXT_BACKGROUND_OPACITY } from 'features/home/components/constants'
 import { VideoModal } from 'features/home/components/modals/VideoModal'
 import { OfferVideoModule } from 'features/home/components/modules/OfferVideoModule'
 import { VideoModule as VideoModuleProps } from 'features/home/types'
-import { styledButton } from 'ui/components/buttons/styledButton'
 import { useModal } from 'ui/components/modals/useModal'
-import { Touchable } from 'ui/components/touchable/Touchable'
 import { Play } from 'ui/svg/icons/Play'
 import { Spacer, Typo, getSpacing } from 'ui/theme'
 
@@ -46,7 +44,10 @@ export const VideoModule: FunctionComponent<VideoModuleProps> = (props) => {
       <VideoOfferContainer>
         <Typo.Title3>{props.title}</Typo.Title3>
         <Spacer.Column numberOfSpaces={5} />
-        <StyledTouchable onPress={showVideoModal} testID={'video-thumbnail'}>
+        <StyledTouchableHighlight
+          onPress={showVideoModal}
+          testID="video-thumbnail"
+          accessibilityRole="button">
           <Thumbnail source={{ uri: props.videoThumbnail }}>
             <DurationCaptionContainer>
               <DurationCaption>{videoDuration}</DurationCaption>
@@ -61,7 +62,7 @@ export const VideoModule: FunctionComponent<VideoModuleProps> = (props) => {
               <Player />
             </PlayerContainer>
           </Thumbnail>
-        </StyledTouchable>
+        </StyledTouchableHighlight>
         <VideoModal visible={videoModalVisible} hideModal={hideVideoModal} {...props} />
       </VideoOfferContainer>
       <Spacer.Column numberOfSpaces={2} />
@@ -135,4 +136,8 @@ const VideoTitle = styled(Typo.Title4)(({ theme }) => ({
   textAlign: 'left',
 }))
 
-const StyledTouchable = styledButton(Touchable)``
+const StyledTouchableHighlight = styled.TouchableHighlight.attrs(({ theme }) => ({
+  underlayColor: theme.colors.white,
+}))(({ theme }) => ({
+  borderRadius: theme.borderRadius.radius,
+}))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-22172

## Checklist
Tested on Android and iOS

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |https://github.com/pass-culture/pass-culture-app-native/assets/47600889/aab30e06-66ac-4c64-a9d0-03a268c809a7|https://github.com/pass-culture/pass-culture-app-native/assets/47600889/35f8601d-4b81-4123-a02c-577babbd4a5b|


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
