### PR TITLE
(PC-21766) feat(video): add calque to video when it ends

### DIFF
--- a/__snapshots__/features/home/components/modals/VideoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modals/VideoModal.native.test.tsx.native-snap
@@ -174,7 +174,7 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
           <View
             style={
               Object {
-                "height": 422,
+                "height": 421.875,
                 "width": 750,
               }
             }

--- a/src/features/home/components/VideoPlayer.tsx
+++ b/src/features/home/components/VideoPlayer.tsx
@@ -86,8 +86,7 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
           onPressReplay={replayVideo}
           offerId={offerId}
           onPressSeeOffer={onPressSeeOffer}
-          height={playerHeight}
-          width={playerWidth}
+          style={{ height: playerHeight, width: playerWidth }}
           videoThumbnail={videoThumbnail}
         />
       )}

--- a/src/features/home/components/VideoPlayer.tsx
+++ b/src/features/home/components/VideoPlayer.tsx
@@ -12,12 +12,14 @@ interface VideoPlayerProps {
   youtubeVideoId: string
   offerId: string
   onPressSeeOffer: () => void
+  videoThumbnail: string
 }
 
 export const VideoPlayer: React.FC<VideoPlayerProps> = ({
   youtubeVideoId,
   offerId,
   onPressSeeOffer,
+  videoThumbnail,
 }) => {
   const [isPlaying, setIsPlaying] = useState(true)
   const [hasFinishPlaying, setHasFinishPlaying] = useState(false)

--- a/src/features/home/components/VideoPlayer.tsx
+++ b/src/features/home/components/VideoPlayer.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { useWindowDimensions, AppState } from 'react-native'
+import { useWindowDimensions, AppState, Alert } from 'react-native'
 import YoutubePlayer from 'react-native-youtube-iframe'
 import styled, { useTheme } from 'styled-components/native'
 
 import { getVideoPlayerDimensions } from 'features/home/components/helpers/getVideoPlayerDimensions'
+import { VideoEndView } from 'features/home/components/modules/video/VideoEndView'
 import { theme } from 'theme'
 import { getSpacing } from 'ui/theme'
 
@@ -13,6 +14,7 @@ interface VideoPlayerProps {
 
 export const VideoPlayer: React.FC<VideoPlayerProps> = ({ youtubeVideoId }) => {
   const [isPlaying, setIsPlaying] = useState(true)
+  const [hasFinishPlaying, setHasFinishPlaying] = useState(false)
   const { isDesktopViewport } = useTheme()
   const { width: windowWidth } = useWindowDimensions()
   const { playerHeight, playerWidth } = getVideoPlayerDimensions(isDesktopViewport, windowWidth)
@@ -37,6 +39,7 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({ youtubeVideoId }) => {
   const onChangeState = useCallback((state: string) => {
     if (state === 'ended') {
       setIsPlaying(false)
+      setHasFinishPlaying(true)
     }
   }, [])
 

--- a/src/features/home/components/VideoPlayer.tsx
+++ b/src/features/home/components/VideoPlayer.tsx
@@ -5,19 +5,20 @@ import styled, { useTheme } from 'styled-components/native'
 
 import { getVideoPlayerDimensions } from 'features/home/components/helpers/getVideoPlayerDimensions'
 import { VideoEndView } from 'features/home/components/modules/video/VideoEndView'
+import { Offer } from 'shared/offer/types'
 import { theme } from 'theme'
 import { getSpacing } from 'ui/theme'
 
 interface VideoPlayerProps {
   youtubeVideoId: string
-  offerId: string
+  offer: Offer
   onPressSeeOffer: () => void
   videoThumbnail: string
 }
 
 export const VideoPlayer: React.FC<VideoPlayerProps> = ({
   youtubeVideoId,
-  offerId,
+  offer,
   onPressSeeOffer,
   videoThumbnail,
 }) => {
@@ -86,7 +87,7 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
       {!!hasFinishPlaying && (
         <VideoEndView
           onPressReplay={replayVideo}
-          offerId={offerId}
+          offer={offer}
           onPressSeeOffer={onPressSeeOffer}
           style={{ height: playerHeight, width: playerWidth }}
           videoThumbnail={videoThumbnail}

--- a/src/features/home/components/VideoPlayer.tsx
+++ b/src/features/home/components/VideoPlayer.tsx
@@ -10,9 +10,15 @@ import { getSpacing } from 'ui/theme'
 
 interface VideoPlayerProps {
   youtubeVideoId: string
+  offerId: string
+  onPressSeeOffer: () => void
 }
 
-export const VideoPlayer: React.FC<VideoPlayerProps> = ({ youtubeVideoId }) => {
+export const VideoPlayer: React.FC<VideoPlayerProps> = ({
+  youtubeVideoId,
+  offerId,
+  onPressSeeOffer,
+}) => {
   const [isPlaying, setIsPlaying] = useState(true)
   const [hasFinishPlaying, setHasFinishPlaying] = useState(false)
   const { isDesktopViewport } = useTheme()

--- a/src/features/home/components/helpers/getVideoPlayerDimensions.native.test.ts
+++ b/src/features/home/components/helpers/getVideoPlayerDimensions.native.test.ts
@@ -10,7 +10,7 @@ describe('getVideoPlayerDimensions', () => {
 
     const dimensions = getVideoPlayerDimensions(isDesktopViewport, windowWidth)
 
-    expect(dimensions).toEqual({ playerHeight: 220, playerWidth: 390 })
+    expect(dimensions).toEqual({ playerHeight: 219.375, playerWidth: 390 })
   })
   it('should return a width and heigth for desktop view', () => {
     const isDesktopViewport = true
@@ -18,6 +18,6 @@ describe('getVideoPlayerDimensions', () => {
 
     const dimensions = getVideoPlayerDimensions(isDesktopViewport, windowWidth)
 
-    expect(dimensions).toEqual({ playerHeight: 293, playerWidth: 520 })
+    expect(dimensions).toEqual({ playerHeight: 292.5, playerWidth: 520 })
   })
 })

--- a/src/features/home/components/helpers/getVideoPlayerDimensions.ts
+++ b/src/features/home/components/helpers/getVideoPlayerDimensions.ts
@@ -6,13 +6,13 @@ export const getVideoPlayerDimensions = (
   isDesktopViewport: boolean | undefined,
   windowWidth: number
 ) => {
-  const playerHeight = Math.ceil(
+  const playerHeight =
     ((isDesktopViewport
       ? Math.min(windowWidth, theme.modal.desktopMaxWidth) * PixelRatio.get()
       : windowWidth * PixelRatio.get()) *
       (9 / 16)) /
-      PixelRatio.get()
-  )
+    PixelRatio.get()
+
   const playerWidth = isDesktopViewport
     ? Math.min(windowWidth, theme.modal.desktopMaxWidth)
     : windowWidth

--- a/src/features/home/components/modals/VideoModal.tsx
+++ b/src/features/home/components/modals/VideoModal.tsx
@@ -62,7 +62,7 @@ export const VideoModal: React.FC<VideoModalProps> = (props) => {
         <Spacer.Column numberOfSpaces={6} />
         <Typo.Title4>{props.offerTitle}</Typo.Title4>
         <Spacer.Column numberOfSpaces={4} />
-        <OfferVideoModule offer={props.offer} color={props.color} />
+        <OfferVideoModule offer={props.offer} color={props.color} hideModal={props.hideModal} />
       </StyledScrollView>
       <StyledTouchable onPress={props.hideModal} accessibilityLabel="Fermer la modale vidéo">
         <StyledCloseIcon />

--- a/src/features/home/components/modals/VideoModal.tsx
+++ b/src/features/home/components/modals/VideoModal.tsx
@@ -39,6 +39,7 @@ export const VideoModal: React.FC<VideoModalProps> = (props) => {
         youtubeVideoId={props.youtubeVideoId}
         offerId={props.offerId}
         onPressSeeOffer={props.hideModal}
+        videoThumbnail={props.videoThumbnail}
       />
       <StyledScrollView>
         <Spacer.Column numberOfSpaces={4} />

--- a/src/features/home/components/modals/VideoModal.tsx
+++ b/src/features/home/components/modals/VideoModal.tsx
@@ -36,7 +36,7 @@ export const VideoModal: React.FC<VideoModalProps> = (props) => {
       customModalHeader={<React.Fragment />}>
       <VideoPlayer
         youtubeVideoId={props.youtubeVideoId}
-        offerId={props.offer.objectID}
+        offer={props.offer}
         onPressSeeOffer={props.hideModal}
         videoThumbnail={props.videoThumbnail}
       />

--- a/src/features/home/components/modals/VideoModal.tsx
+++ b/src/features/home/components/modals/VideoModal.tsx
@@ -19,6 +19,7 @@ interface VideoModalProps extends VideoModule {
   offer: Offer
   visible: boolean
   hideModal: () => void
+  offerId: string
 }
 
 export const VideoModal: React.FC<VideoModalProps> = (props) => {
@@ -34,7 +35,11 @@ export const VideoModal: React.FC<VideoModalProps> = (props) => {
       noPadding
       scrollEnabled={false}
       customModalHeader={<React.Fragment />}>
-      <VideoPlayer youtubeVideoId={props.youtubeVideoId} />
+      <VideoPlayer
+        youtubeVideoId={props.youtubeVideoId}
+        offerId={props.offerId}
+        onPressSeeOffer={props.hideModal}
+      />
       <StyledScrollView>
         <Spacer.Column numberOfSpaces={4} />
         <StyledTagContainer>

--- a/src/features/home/components/modals/VideoModal.tsx
+++ b/src/features/home/components/modals/VideoModal.tsx
@@ -19,7 +19,6 @@ interface VideoModalProps extends VideoModule {
   offer: Offer
   visible: boolean
   hideModal: () => void
-  offerId: string
 }
 
 export const VideoModal: React.FC<VideoModalProps> = (props) => {
@@ -37,7 +36,7 @@ export const VideoModal: React.FC<VideoModalProps> = (props) => {
       customModalHeader={<React.Fragment />}>
       <VideoPlayer
         youtubeVideoId={props.youtubeVideoId}
-        offerId={props.offerId}
+        offerId={props.offer.objectID}
         onPressSeeOffer={props.hideModal}
         videoThumbnail={props.videoThumbnail}
       />

--- a/src/features/home/components/modules/OfferVideoModule.native.test.tsx
+++ b/src/features/home/components/modules/OfferVideoModule.native.test.tsx
@@ -8,9 +8,11 @@ import { act, fireEvent, render, screen } from 'tests/utils'
 
 const mockOffer = mockedAlgoliaResponse.hits[0]
 
+const hideModalMock = jest.fn()
+
 describe('OfferVideoModule', () => {
   it('should redirect to an offer when pressing it', async () => {
-    render(<OfferVideoModule offer={mockOffer} color="" />, {
+    render(<OfferVideoModule offer={mockOffer} color="" hideModal={hideModalMock} />, {
       /* eslint-disable local-rules/no-react-query-provider-hoc */
       wrapper: ({ children }) => reactQueryProviderHOC(children),
     })

--- a/src/features/home/components/modules/OfferVideoModule.tsx
+++ b/src/features/home/components/modules/OfferVideoModule.tsx
@@ -19,9 +19,10 @@ const OFFER_WIDTH = getSpacing(20)
 type Props = {
   offer: Offer
   color: string
+  hideModal: () => void
 }
 
-export const OfferVideoModule: FunctionComponent<Props> = ({ offer, color }) => {
+export const OfferVideoModule: FunctionComponent<Props> = ({ offer, color, hideModal }) => {
   const timestampsInMillis = offer.offer.dates?.map((timestampInSec) => timestampInSec * 1000)
   const labelMapping = useCategoryHomeLabelMapping()
   const mapping = useCategoryIdMapping()
@@ -34,13 +35,14 @@ export const OfferVideoModule: FunctionComponent<Props> = ({ offer, color }) => 
         screen: 'Offer',
         params: { id: +offer.objectID },
       }}
-      onBeforeNavigate={() =>
+      onBeforeNavigate={() => {
+        hideModal()
         prePopulateOffer({
           ...offer.offer,
           offerId: +offer.objectID,
           categoryId: mapping[offer.offer.subcategoryId],
         })
-      }>
+      }}>
       <Row>
         <OfferImage>
           <ImageTile width={OFFER_WIDTH} height={OFFER_HEIGHT} uri={offer.offer.thumbUrl} />

--- a/src/features/home/components/modules/VideoModule.tsx
+++ b/src/features/home/components/modules/VideoModule.tsx
@@ -72,7 +72,7 @@ export const VideoModule: FunctionComponent<VideoModuleProps> = (props) => {
       </VideoOfferContainer>
       <Spacer.Column numberOfSpaces={2} />
       <VideoOfferContainer>
-        <OfferVideoModule offer={offer} color={props.color} />
+        <OfferVideoModule offer={offer} color={props.color} hideModal={hideVideoModal} />
       </VideoOfferContainer>
       <Spacer.Column numberOfSpaces={5} />
     </Container>

--- a/src/features/home/components/modules/video/ButtonWithCaption.tsx
+++ b/src/features/home/components/modules/video/ButtonWithCaption.tsx
@@ -1,0 +1,59 @@
+import React, { FunctionComponent } from 'react'
+import styled from 'styled-components/native'
+
+import { styledButton } from 'ui/components/buttons/styledButton'
+import { Touchable } from 'ui/components/touchable/Touchable'
+import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
+import { InternalNavigationProps } from 'ui/components/touchableLink/types'
+import { IconInterface } from 'ui/svg/icons/types'
+import { Spacer, Typo, getSpacing } from 'ui/theme'
+
+type ButtonWithCaptionProps = {
+  onPress: () => void
+  icon: FunctionComponent<IconInterface>
+  wording: string
+  accessibilityLabel: string
+  navigateTo?: InternalNavigationProps['navigateTo']
+}
+
+export const ButtonWithCaption: React.FC<ButtonWithCaptionProps> = ({
+  onPress,
+  icon: Icon,
+  wording,
+  accessibilityLabel,
+  navigateTo,
+}) => {
+  return (
+    <ButtonWithCaptionContainer>
+      {navigateTo ? (
+        <StyledTouchableLink navigateTo={navigateTo} accessibilityLabel={accessibilityLabel}>
+          <Icon />
+        </StyledTouchableLink>
+      ) : (
+        <StyledTouchable onPress={onPress} accessibilityLabel={accessibilityLabel}>
+          <Icon />
+        </StyledTouchable>
+      )}
+      <Spacer.Column numberOfSpaces={1.5} />
+      <ButtonCaption>{wording}</ButtonCaption>
+    </ButtonWithCaptionContainer>
+  )
+}
+
+const ButtonWithCaptionContainer = styled.View({
+  alignItems: 'center',
+})
+
+const ButtonCaption = styled(Typo.Caption)(({ theme }) => ({ color: theme.colors.white }))
+
+const StyledTouchable = styledButton(Touchable)(({ theme }) => ({
+  borderRadius: theme.buttons.roundedButton.size,
+  padding: getSpacing(2.5),
+  backgroundColor: theme.colors.white,
+}))
+
+const StyledTouchableLink = styledButton(InternalTouchableLink)(({ theme }) => ({
+  borderRadius: theme.buttons.roundedButton.size,
+  padding: getSpacing(2.5),
+  backgroundColor: theme.colors.white,
+}))

--- a/src/features/home/components/modules/video/ButtonWithCaption.tsx
+++ b/src/features/home/components/modules/video/ButtonWithCaption.tsx
@@ -26,7 +26,10 @@ export const ButtonWithCaption: React.FC<ButtonWithCaptionProps> = ({
   return (
     <ButtonWithCaptionContainer>
       {navigateTo ? (
-        <StyledTouchableLink navigateTo={navigateTo} accessibilityLabel={accessibilityLabel}>
+        <StyledTouchableLink
+          navigateTo={navigateTo}
+          onBeforeNavigate={onPress}
+          accessibilityLabel={accessibilityLabel}>
           <Icon />
         </StyledTouchableLink>
       ) : (

--- a/src/features/home/components/modules/video/VideoEndView.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoEndView.native.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+
+import { VideoEndView } from 'features/home/components/modules/video/VideoEndView'
+import { mockedAlgoliaResponse } from 'libs/algolia/__mocks__/mockedAlgoliaResponse'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { act, fireEvent, render, screen } from 'tests/utils'
+
+const mockReplay = jest.fn()
+const mockHideModal = jest.fn()
+const mockOffer = mockedAlgoliaResponse.hits[0]
+
+describe('VideoEndView', () => {
+  it('should replay video when pressing replay button', () => {
+    renderVideoEndView()
+
+    const replayButton = screen.getByText('Revoir')
+    fireEvent.press(replayButton)
+
+    expect(mockReplay).toHaveBeenCalledTimes(1)
+  })
+
+  it('should hide modal page when pressing "Voir l’offre" button', () => {
+    renderVideoEndView()
+
+    const seeOfferButton = screen.getByText('Voir l’offre')
+
+    fireEvent.press(seeOfferButton)
+
+    expect(mockHideModal).toHaveBeenCalledTimes(1)
+  })
+})
+
+const renderVideoEndView = async () => {
+  const viewDimensions = { height: 100, width: 100 }
+  render(
+    <VideoEndView
+      onPressReplay={mockReplay}
+      offer={mockOffer}
+      onPressSeeOffer={mockHideModal}
+      style={viewDimensions}
+      videoThumbnail={'http://toto'}
+    />,
+    {
+      /* eslint-disable local-rules/no-react-query-provider-hoc */
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    }
+  )
+
+  await act(async () => {})
+}

--- a/src/features/home/components/modules/video/VideoEndView.tsx
+++ b/src/features/home/components/modules/video/VideoEndView.tsx
@@ -3,6 +3,9 @@ import { StyleProp, ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
 
 import { ButtonWithCaption } from 'features/home/components/modules/video/ButtonWithCaption'
+import { useCategoryIdMapping } from 'libs/subcategories'
+import { Offer } from 'shared/offer/types'
+import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
 import { ArrowAgain } from 'ui/svg/icons/ArrowAgain'
 import { Offers } from 'ui/svg/icons/Offers'
 import { Spacer, getSpacing } from 'ui/theme'
@@ -40,7 +43,7 @@ export const VideoEndView: React.FC<{
               }}
               navigateTo={{
                 screen: 'Offer',
-                params: { id: offer.objectID },
+                params: { id: +offer.objectID },
               }}
               accessibilityLabel="Voir l’offre"
               wording="Voir l’offre"

--- a/src/features/home/components/modules/video/VideoEndView.tsx
+++ b/src/features/home/components/modules/video/VideoEndView.tsx
@@ -6,10 +6,11 @@ import { ArrowAgain } from 'ui/svg/icons/ArrowAgain'
 import { Offers } from 'ui/svg/icons/Offers'
 import { Spacer, getSpacing } from 'ui/theme'
 
-export const VideoEndView: React.FC<{ onPressReplay: () => void; onPressSeeOffer: () => void }> = ({
-  onPressReplay,
-  onPressSeeOffer,
-}) => {
+export const VideoEndView: React.FC<{
+  onPressReplay: () => void
+  onPressSeeOffer: () => void
+  offerId: string
+}> = ({ onPressReplay, offerId, onPressSeeOffer }) => {
   return (
     <VideoEndViewContainer>
       <ButtonsContainer>
@@ -22,7 +23,11 @@ export const VideoEndView: React.FC<{ onPressReplay: () => void; onPressSeeOffer
         <Spacer.Row numberOfSpaces={9} />
         <ButtonWithCaption
           onPress={onPressSeeOffer}
-          accessibilityLabel="Revoir la vidéo"
+          navigateTo={{
+            screen: 'Offer',
+            params: { id: offerId },
+          }}
+          accessibilityLabel="Voir l’offre"
           wording="Voir l’offre"
           icon={StyledOffersIcon}
         />

--- a/src/features/home/components/modules/video/VideoEndView.tsx
+++ b/src/features/home/components/modules/video/VideoEndView.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { StyleProp, ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
 
 import { ButtonWithCaption } from 'features/home/components/modules/video/ButtonWithCaption'
@@ -9,41 +10,51 @@ import { Spacer, getSpacing } from 'ui/theme'
 export const VideoEndView: React.FC<{
   onPressReplay: () => void
   onPressSeeOffer: () => void
-  offerId: string
-}> = ({ onPressReplay, offerId, onPressSeeOffer }) => {
+  offer: Offer
+  style: StyleProp<ViewStyle>
+  videoThumbnail: string
+}> = ({ onPressReplay, offer, onPressSeeOffer, style, videoThumbnail }) => {
+  const prePopulateOffer = usePrePopulateOffer()
+  const mapping = useCategoryIdMapping()
+
   return (
-    <VideoEndViewContainer>
-      <ButtonsContainer>
-        <ButtonWithCaption
-          onPress={onPressReplay}
-          accessibilityLabel="Revoir la vidéo"
-          wording={'Revoir'}
-          icon={StyledReplayIcon}
-        />
-        <Spacer.Row numberOfSpaces={9} />
-        <ButtonWithCaption
-          onPress={onPressSeeOffer}
-          navigateTo={{
-            screen: 'Offer',
-            params: { id: offerId },
-          }}
-          accessibilityLabel="Voir l’offre"
-          wording="Voir l’offre"
-          icon={StyledOffersIcon}
-        />
-      </ButtonsContainer>
+    <VideoEndViewContainer style={style}>
+      <Thumbnail source={{ uri: videoThumbnail }} style={style}>
+        <BlackView>
+          <ButtonsContainer>
+            <ButtonWithCaption
+              onPress={onPressReplay}
+              accessibilityLabel="Revoir la vidéo"
+              wording={'Revoir'}
+              icon={StyledReplayIcon}
+            />
+            <Spacer.Row numberOfSpaces={9} />
+            <ButtonWithCaption
+              onPress={() => {
+                onPressSeeOffer()
+                prePopulateOffer({
+                  ...offer.offer,
+                  offerId: +offer.objectID,
+                  categoryId: mapping[offer.offer.subcategoryId],
+                })
+              }}
+              navigateTo={{
+                screen: 'Offer',
+                params: { id: offer.objectID },
+              }}
+              accessibilityLabel="Voir l’offre"
+              wording="Voir l’offre"
+              icon={StyledOffersIcon}
+            />
+          </ButtonsContainer>
+        </BlackView>
+      </Thumbnail>
     </VideoEndViewContainer>
   )
 }
 
 const VideoEndViewContainer = styled.View({
   position: 'absolute',
-  width: '100%',
-  height: 210,
-  backgroundColor: 'black',
-  justifyContent: 'center',
-  borderTopLeftRadius: getSpacing(4),
-  borderTopRightRadius: getSpacing(4),
 })
 
 const ButtonsContainer = styled.View({
@@ -58,3 +69,17 @@ const StyledReplayIcon = styled(ArrowAgain).attrs(({ theme }) => ({
 const StyledOffersIcon = styled(Offers).attrs(({ theme }) => ({
   size: theme.icons.sizes.smaller,
 }))``
+
+const Thumbnail = styled.ImageBackground({
+  // the overflow: hidden allow to add border radius to the image
+  // https://stackoverflow.com/questions/49442165/how-do-you-add-borderradius-to-imagebackground/57616397
+  overflow: 'hidden',
+  borderTopLeftRadius: getSpacing(4),
+  borderTopRightRadius: getSpacing(4),
+})
+
+const BlackView = styled.View({
+  backgroundColor: 'rgba(22, 22, 23, 0.48)',
+  height: '100%',
+  justifyContent: 'center',
+})

--- a/src/features/home/components/modules/video/VideoEndView.tsx
+++ b/src/features/home/components/modules/video/VideoEndView.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { ButtonWithCaption } from 'features/home/components/modules/video/ButtonWithCaption'
+import { ArrowAgain } from 'ui/svg/icons/ArrowAgain'
+import { Offers } from 'ui/svg/icons/Offers'
+import { Spacer, getSpacing } from 'ui/theme'
+
+export const VideoEndView: React.FC<{ onPressReplay: () => void; onPressSeeOffer: () => void }> = ({
+  onPressReplay,
+  onPressSeeOffer,
+}) => {
+  return (
+    <VideoEndViewContainer>
+      <ButtonsContainer>
+        <ButtonWithCaption
+          onPress={onPressReplay}
+          accessibilityLabel="Revoir la vidéo"
+          wording={'Revoir'}
+          icon={StyledReplayIcon}
+        />
+        <Spacer.Row numberOfSpaces={9} />
+        <ButtonWithCaption
+          onPress={onPressSeeOffer}
+          accessibilityLabel="Revoir la vidéo"
+          wording="Voir l’offre"
+          icon={StyledOffersIcon}
+        />
+      </ButtonsContainer>
+    </VideoEndViewContainer>
+  )
+}
+
+const VideoEndViewContainer = styled.View({
+  position: 'absolute',
+  width: '100%',
+  height: 210,
+  backgroundColor: 'black',
+  justifyContent: 'center',
+  borderTopLeftRadius: getSpacing(4),
+  borderTopRightRadius: getSpacing(4),
+})
+
+const ButtonsContainer = styled.View({
+  flexDirection: 'row',
+  justifyContent: 'center',
+})
+
+const StyledReplayIcon = styled(ArrowAgain).attrs(({ theme }) => ({
+  size: theme.icons.sizes.smaller,
+}))``
+
+const StyledOffersIcon = styled(Offers).attrs(({ theme }) => ({
+  size: theme.icons.sizes.smaller,
+}))``

--- a/src/features/internal/cheatcodes/pages/AppComponents/iconsExports.ts
+++ b/src/features/internal/cheatcodes/pages/AppComponents/iconsExports.ts
@@ -82,6 +82,7 @@ import { LogoPassCulture as PassCultureIcon } from 'ui/svg/icons/LogoPassCulture
 import { MagnifyingGlass } from 'ui/svg/icons/MagnifyingGlass'
 import { More } from 'ui/svg/icons/More'
 import { OfferEvent } from 'ui/svg/icons/OfferEvent'
+import { Offers } from 'ui/svg/icons/Offers'
 import { OrderPrice } from 'ui/svg/icons/OrderPrice'
 import { OtherOffer } from 'ui/svg/icons/OtherOffer'
 import { PhoneFilled } from 'ui/svg/icons/PhoneFilled'
@@ -205,6 +206,7 @@ export const SecondaryAndBiggerIcons = {
   OfferEvent,
   OrderPrice,
   OtherOffer,
+  Offers,
   ProfileDeletion,
   PhoneIcon,
   Quote,

--- a/src/ui/svg/icons/Offers.tsx
+++ b/src/ui/svg/icons/Offers.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Path } from 'react-native-svg'
+import styled from 'styled-components/native'
+
+import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
+import { AccessibleIcon } from 'ui/svg/icons/types'
+
+function OffersSvg({ size, testID, accessibilityLabel, color }: AccessibleIcon) {
+  return (
+    <AccessibleSvg
+      width={size}
+      height={size}
+      accessibilityLabel={accessibilityLabel}
+      testID={testID}
+      viewBox="0 0 20 20">
+      <Path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8.25954 3.33268C8.25954 2.87389 8.6326 2.49935 9.10191 2.49935H16.6568C17.1261 2.49935 17.4991 2.87389 17.4991 3.33268V4.41185C17.4991 4.64197 17.6857 4.82852 17.9159 4.82852C18.1461 4.82852 18.3327 4.64197 18.3327 4.41185V3.33268C18.3327 2.40814 17.5809 1.66602 16.6568 1.66602H9.10191C8.17777 1.66602 7.42599 2.40814 7.42599 3.33268V16.666C7.42599 17.5906 8.17777 18.3327 9.10191 18.3327H16.6568C17.5809 18.3327 18.3327 17.5906 18.3327 16.666V7.32852C18.3327 7.0984 18.1461 6.91185 17.9159 6.91185C17.6857 6.91185 17.4991 7.0984 17.4991 7.32852V16.666C17.4991 17.1248 17.1261 17.4993 16.6568 17.4993H9.10191C8.6326 17.4993 8.25954 17.1248 8.25954 16.666V3.33268ZM5.79523 3.52325C6.0179 3.46495 6.15114 3.23723 6.09282 3.01462C6.03451 2.79201 5.80672 2.65881 5.58405 2.71711L2.91069 3.41705C2.01569 3.65042 1.48299 4.56757 1.72397 5.4582L4.94731 17.3913C5.00732 17.6135 5.23611 17.7449 5.45833 17.6849C5.68055 17.6249 5.81205 17.3962 5.75204 17.174L2.52857 5.24049C2.40877 4.79794 2.67333 4.34008 3.12119 4.22337L5.79523 3.52325Z"
+        fill={color}
+      />
+    </AccessibleSvg>
+  )
+}
+
+export const Offers = styled(OffersSvg).attrs(({ color, size, theme }) => ({
+  color: color ?? theme.colors.black,
+  size: size ?? theme.icons.sizes.standard,
+}))``


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-21766

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots
| Platform         | Screenshot video | 
| :--------------- | :----: |
| Android          |https://github.com/pass-culture/pass-culture-app-native/assets/47600889/99ef244a-36c4-41ff-bf9f-a54d990ec15a|  
| iOS          |https://github.com/pass-culture/pass-culture-app-native/assets/47600889/7f84b7ab-ab1e-48c4-bd69-8e50e5535d29|  


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
