### PR TITLE
(PC-22765) feat(VideoModule): update color to be dynamic

### DIFF
--- a/src/features/home/components/helpers/getGradientColors.native.test.ts
+++ b/src/features/home/components/helpers/getGradientColors.native.test.ts
@@ -1,0 +1,61 @@
+import { getGradientColors } from 'features/home/components/helpers/getGradientColors'
+import { theme } from 'theme'
+
+describe('getTagColor', () => {
+  it('should return gold color code', () => {
+    const input = 'Gold'
+
+    const color = getGradientColors(input)
+
+    expect(color[0]).toEqual('#FA9F16FF')
+    expect(color[1]).toEqual(theme.colors.gold)
+  })
+  it('should return aquamarine color code', () => {
+    const input = 'Aquamarine'
+
+    const color = getGradientColors(input)
+
+    expect(color[0]).toEqual('#27DCA8FF')
+    expect(color[1]).toEqual(theme.colors.aquamarine)
+  })
+  it('should return skyBlue color code', () => {
+    const input = 'SkyBlue'
+
+    const color = getGradientColors(input)
+
+    expect(color[0]).toEqual('#20C5E9FF')
+    expect(color[1]).toEqual(theme.colors.skyBlue)
+  })
+  it('should return deepPink color code', () => {
+    const input = 'DeepPink'
+
+    const color = getGradientColors(input)
+
+    expect(color[0]).toEqual('#EC3478FF')
+    expect(color[1]).toEqual(theme.colors.deepPink)
+  })
+  it('should return coral color code', () => {
+    const input = 'Coral'
+
+    const color = getGradientColors(input)
+
+    expect(color[0]).toEqual('#F8733DFF')
+    expect(color[1]).toEqual(theme.colors.coral)
+  })
+  it('should return lilac color code', () => {
+    const input = 'Lilac'
+
+    const color = getGradientColors(input)
+
+    expect(color[0]).toEqual('#AD87FFFF')
+    expect(color[1]).toEqual(theme.colors.lilac)
+  })
+  it('should return black color code by default', () => {
+    const input = ''
+
+    const color = getGradientColors(input)
+
+    expect(color[0]).toEqual(theme.colors.white)
+    expect(color[1]).toEqual(theme.colors.white)
+  })
+})

--- a/src/features/home/components/helpers/getGradientColors.ts
+++ b/src/features/home/components/helpers/getGradientColors.ts
@@ -1,0 +1,20 @@
+import { theme } from 'theme'
+
+export const getGradientColors = (color: string) => {
+  switch (color) {
+    case 'Gold':
+      return ['#FA9F16FF', theme.colors.gold]
+    case 'Aquamarine':
+      return ['#27DCA8FF', theme.colors.aquamarine]
+    case 'SkyBlue':
+      return ['#20C5E9FF', theme.colors.skyBlue]
+    case 'DeepPink':
+      return ['#EC3478FF', theme.colors.deepPink]
+    case 'Coral':
+      return ['#F8733DFF', theme.colors.coral]
+    case 'Lilac':
+      return ['#AD87FFFF', theme.colors.lilac]
+    default:
+      return [theme.colors.white, theme.colors.white]
+  }
+}

--- a/src/features/home/components/modules/OfferVideoModule.tsx
+++ b/src/features/home/components/modules/OfferVideoModule.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
+import { getTagColor } from 'features/home/components/helpers/getTagColor'
 import { formatDates, getDisplayPrice } from 'libs/parsers'
 import { useCategoryHomeLabelMapping } from 'libs/subcategories'
 import { Offer } from 'shared/offer/types'
@@ -15,9 +16,10 @@ const OFFER_WIDTH = getSpacing(20)
 
 type Props = {
   offer: Offer
+  color: string
 }
 
-export const OfferVideoModule: FunctionComponent<Props> = ({ offer }) => {
+export const OfferVideoModule: FunctionComponent<Props> = ({ offer, color }) => {
   const timestampsInMillis = offer.offer.dates?.map((timestampInSec) => timestampInSec * 1000)
   const labelMapping = useCategoryHomeLabelMapping()
 
@@ -28,7 +30,7 @@ export const OfferVideoModule: FunctionComponent<Props> = ({ offer }) => {
           <ImageTile width={OFFER_WIDTH} height={OFFER_HEIGHT} uri={offer.offer.thumbUrl} />
         </OfferImage>
         <OfferInformations>
-          <CategoryText>{labelMapping[offer.offer.subcategoryId]}</CategoryText>
+          <CategoryText color={color}>{labelMapping[offer.offer.subcategoryId]}</CategoryText>
           <TitleText numberOfLines={2}>{offer.offer.name}</TitleText>
           {/* // TODO(PC-22422): Update dates to display only 1 on modal*/}
           <AdditionalInfoText>{formatDates(timestampsInMillis)}</AdditionalInfoText>
@@ -72,11 +74,10 @@ const ArrowOffer = styledButton(Touchable)({
   right: getSpacing(4),
 })
 
-const CategoryText = styled(Typo.Caption)({
-  // TODO(PC-22765): update fixed color to dynamic color
-  color: '#B85901FF',
+const CategoryText = styled(Typo.Caption)<{ color: string }>(({ color }) => ({
+  color: getTagColor(color),
   marginBottom: getSpacing(1),
-})
+}))
 
 const TitleText = styled(Typo.ButtonText)({
   marginBottom: getSpacing(1),

--- a/src/features/home/components/modules/VideoModule.tsx
+++ b/src/features/home/components/modules/VideoModule.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components/native'
 import { useVideoOffer } from 'features/home/api/useVideoOffer'
 import { BlackGradient } from 'features/home/components/BlackGradient'
 import { TEXT_BACKGROUND_OPACITY } from 'features/home/components/constants'
+import { getGradientColors } from 'features/home/components/helpers/getGradientColors'
 import { VideoModal } from 'features/home/components/modals/VideoModal'
 import { OfferVideoModule } from 'features/home/components/modules/OfferVideoModule'
 import { VideoModule as VideoModuleProps } from 'features/home/types'
@@ -38,8 +39,7 @@ export const VideoModule: FunctionComponent<VideoModuleProps> = (props) => {
       <ColorCategoryBackground
         start={{ x: 0, y: 0 }}
         end={{ x: 0, y: 1 }}
-        // TODO(PC-22765): update fixed color to dynamic color
-        colors={['#27DCA8FF', '#0E8474FF']}
+        colors={getGradientColors(props.color)}
       />
       <VideoOfferContainer>
         <Typo.Title3>{props.title}</Typo.Title3>
@@ -67,7 +67,7 @@ export const VideoModule: FunctionComponent<VideoModuleProps> = (props) => {
       </VideoOfferContainer>
       <Spacer.Column numberOfSpaces={2} />
       <VideoOfferContainer>
-        <OfferVideoModule offer={offer} />
+        <OfferVideoModule offer={offer} color={props.color} />
       </VideoOfferContainer>
       <Spacer.Column numberOfSpaces={5} />
     </Container>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-22765

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change

## Screenshots
2 exemples de couleurs :

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              | <img width="325" alt="Capture d’écran 2023-06-19 à 16 04 21" src="https://github.com/pass-culture/pass-culture-app-native/assets/131354212/d274bf8f-233b-40c6-bfe4-c7d3b53fd396"> | <img width="330" alt="Capture d’écran 2023-06-19 à 16 04 30" src="https://github.com/pass-culture/pass-culture-app-native/assets/131354212/d10b4f63-e739-4fef-8b33-824b18990936"> |
| Android          | <img width="294" alt="Capture d’écran 2023-06-19 à 16 04 40" src="https://github.com/pass-culture/pass-culture-app-native/assets/131354212/decc878b-7b28-415d-84ff-3e55628c7e4a"> | <img width="275" alt="Capture d’écran 2023-06-19 à 16 07 59" src="https://github.com/pass-culture/pass-culture-app-native/assets/131354212/272ac47b-78c6-4265-aa0d-f96ea48d1e96"> |