### PR TITLE
(PC-22517) fix(openUrl): Open external url in browser for Android

### DIFF
--- a/android/app/src/main/java/com/passculture/DefaultBrowserModule.java
+++ b/android/app/src/main/java/com/passculture/DefaultBrowserModule.java
@@ -1,0 +1,44 @@
+package com.passculture;
+
+import android.content.Intent;
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+// This module has been created to open app links in browser, even if user has chosen to open them inside the app (in Android settings).
+
+public class DefaultBrowserModule extends ReactContextBaseJavaModule {
+    private ReactApplicationContext _context;
+
+    DefaultBrowserModule(ReactApplicationContext context) {
+        super(context);
+        this._context = context;
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "DefaultBrowserModule";
+    }
+
+    @ReactMethod
+    public void openUrl(String url, Promise promise) {
+        try {
+            Intent defaultBrowser = Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_BROWSER);
+            defaultBrowser.setData(Uri.parse(url));
+            // Through ReactApplicationContext's current activty, start a new activity
+            this._context.getCurrentActivity().startActivity(defaultBrowser);
+            promise.resolve(true);
+        } catch (Exception e) {
+            // We land here if the user doesn't have any browsers installed on their phone
+            promise.reject(
+                new JSApplicationIllegalArgumentException("Could not open URL '" + url + "': " + e.getMessage()));
+        } 
+    }
+}

--- a/android/app/src/main/java/com/passculture/DefaultBrowserPackage.java
+++ b/android/app/src/main/java/com/passculture/DefaultBrowserPackage.java
@@ -1,0 +1,30 @@
+package com.passculture;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+// This package has been created to be able to open app links in browser, even if user has chosen to open them inside the app (in Android settings).
+
+public class DefaultBrowserPackage implements ReactPackage {
+    @NonNull
+    @Override
+    public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+        modules.add(new DefaultBrowserModule(reactContext));
+        return modules;
+    }
+
+    @NonNull
+    @Override
+    public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}

--- a/android/app/src/main/java/com/passculture/MainApplication.java
+++ b/android/app/src/main/java/com/passculture/MainApplication.java
@@ -18,6 +18,7 @@ import com.passculture.newarchitecture.MainApplicationReactNativeHost;
 import com.microsoft.codepush.react.CodePush; // @codepush
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import com.passculture.DefaultBrowserPackage;
 
 public class MainApplication extends Application implements ReactApplication {
 
@@ -43,6 +44,10 @@ public class MainApplication extends Application implements ReactApplication {
       List<ReactPackage> packages = new PackageList(this).getPackages();
       // Packages that cannot be autolinked yet can be added manually here, for example:
       // packages.add(new MyReactNativePackage());
+
+      // This module has been added to be able to open app links in browser, even if user has chosen to open them inside the app (in Android settings).
+      packages.add(new DefaultBrowserPackage());
+
       return packages;
     }
 

--- a/src/features/navigation/helpers/openUrl.native.test.ts
+++ b/src/features/navigation/helpers/openUrl.native.test.ts
@@ -66,116 +66,124 @@ describe('openUrl', () => {
     })
   })
 
-  it('should navigate to in-app screen and navigate to it (ex: Offer)', async () => {
-    const openURL = openURLSpy.mockResolvedValueOnce(undefined)
-    getScreenFromDeeplinkModuleSpy.mockImplementationOnce(
-      () => ({ screen: 'Offer', params: { id: 1, from: 'offer' } } as DeeplinkParts)
-    )
-    const path = getScreenPath('Offer', { id: 1, from: 'offer', moduleName: undefined })
+  describe('InApp screen', () => {
+    it('should navigate to in-app screen (ex: Offer)', async () => {
+      const openURL = openURLSpy.mockResolvedValueOnce(undefined)
+      getScreenFromDeeplinkModuleSpy.mockImplementationOnce(
+        () => ({ screen: 'Offer', params: { id: 1, from: 'offer' } } as DeeplinkParts)
+      )
+      const path = getScreenPath('Offer', { id: 1, from: 'offer', moduleName: undefined })
 
-    const link = 'https://mockValidPrefix1' + `/${path}`
-    await openUrl(link)
+      const link = 'https://mockValidPrefix1' + `/${path}`
+      await openUrl(link)
 
-    expect(openURL).not.toBeCalled()
-    expect(navigateFromRef).toBeCalledWith('Offer', { id: 1, from: 'offer' })
+      expect(openURL).not.toBeCalled()
+      expect(navigateFromRef).toBeCalledWith('Offer', { id: 1, from: 'offer' })
+    })
+
+    it('should navigate to external screen even when screen is in-app when isExternal is true (ex: Offer)', async () => {
+      const openURL = openURLSpy.mockResolvedValueOnce(undefined)
+      const path = getScreenPath('Offer', { id: 1, from: 'offer', moduleName: undefined })
+
+      const link = 'https://mockValidPrefix1' + `/${path}`
+      await openUrl(link, undefined, true)
+
+      expect(navigateFromRef).not.toHaveBeenCalled()
+      expect(openURL).toBeCalledWith(link)
+    })
+
+    it('should navigate to PageNotFound when in-app screen cannot be found (ex: Offer)', async () => {
+      const openURL = openURLSpy.mockResolvedValueOnce(undefined)
+      getScreenFromDeeplinkModuleSpy.mockImplementationOnce(
+        () => ({ screen: 'PageNotFound', params: undefined } as DeeplinkParts)
+      )
+
+      const link = 'https://mockValidPrefix2' + '/unknown'
+      await openUrl(link)
+
+      expect(openURL).not.toBeCalled()
+      expect(navigateFromRef).toBeCalledWith('PageNotFound', undefined)
+    })
   })
 
-  it('should navigate to external screen even when screen is in-app when isExternal is true (ex: Offer)', async () => {
-    const openURL = openURLSpy.mockResolvedValueOnce(undefined)
-    const path = getScreenPath('Offer', { id: 1, from: 'offer', moduleName: undefined })
+  describe('Analytics', () => {
+    it('should log analytics when shouldLogEvent is true (default behavior)', async () => {
+      openURLSpy.mockResolvedValueOnce(undefined)
 
-    const link = 'https://mockValidPrefix1' + `/${path}`
-    await openUrl(link, undefined, true)
+      const link = 'https://www.google.com'
+      await openUrl(link)
 
-    expect(navigateFromRef).not.toHaveBeenCalled()
-    expect(openURL).toBeCalledWith(link)
+      await act(async () => {})
+      expect(analytics.logOpenExternalUrl).toHaveBeenCalledWith(link, {})
+    })
+
+    it('should not log analytics event when shouldLogEvent is false', async () => {
+      openURLSpy.mockResolvedValueOnce(undefined)
+
+      const link = 'https://www.google.com'
+      await openUrl(link, { shouldLogEvent: false })
+
+      expect(analytics.logOpenExternalUrl).not.toBeCalled()
+    })
   })
 
-  it('should navigate to PageNotFound when in-app screen cannot be found (ex: Offer)', async () => {
-    const openURL = openURLSpy.mockResolvedValueOnce(undefined)
-    getScreenFromDeeplinkModuleSpy.mockImplementationOnce(
-      () => ({ screen: 'PageNotFound', params: undefined } as DeeplinkParts)
-    )
+  describe('Sentry', () => {
+    it('should log an info in Sentry when Linking.openURL throws', async () => {
+      openURLSpy.mockImplementationOnce(() => Promise.reject(new Error('Did not open correctly')))
 
-    const link = 'https://mockValidPrefix2' + '/unknown'
-    await openUrl(link)
+      const link = 'https://www.google.com'
+      await openUrl(link)
 
-    expect(openURL).not.toBeCalled()
-    expect(navigateFromRef).toBeCalledWith('PageNotFound', undefined)
+      expect(eventMonitoring.captureMessage).toHaveBeenNthCalledWith(
+        1,
+        'OpenExternalUrlError: Did not open correctly',
+        'info'
+      )
+    })
+
+    it('should log an info in Sentry when Linking.openURL throws and fallbackUrl throws', async () => {
+      openURLSpy.mockImplementationOnce(() => Promise.reject(new Error('Did not open correctly')))
+      openURLSpy.mockImplementationOnce(() => Promise.reject(new Error('Did not open correctly')))
+
+      const link = 'https://www.google.com'
+      const fallbackLink = 'https://www.googlefallback.com'
+      await openUrl(link, { fallbackUrl: fallbackLink })
+      await act(async () => {})
+      expect(eventMonitoring.captureMessage).toHaveBeenNthCalledWith(
+        1,
+        'OpenExternalUrlError: Did not open correctly',
+        'info'
+      )
+      expect(eventMonitoring.captureMessage).toHaveBeenNthCalledWith(
+        2,
+        'OpenExternalUrlError_FallbackUrl: Did not open correctly',
+        'info'
+      )
+    })
   })
 
-  it('should log analytics when shouldLogEvent is true (default behavior)', async () => {
-    openURLSpy.mockResolvedValueOnce(undefined)
+  describe('Alert prompt', () => {
+    it('should display alert when Linking.openURL throws', async () => {
+      openURLSpy.mockImplementationOnce(() => Promise.reject(new Error('Did not open correctly')))
+      const alertMock = jest.spyOn(Alert, 'alert')
 
-    const link = 'https://www.google.com'
-    await openUrl(link)
+      const link = 'https://www.google.com'
+      await openUrl(link)
 
-    await act(async () => {})
-    expect(analytics.logOpenExternalUrl).toHaveBeenCalledWith(link, {})
-  })
+      expect(alertMock).toHaveBeenCalledTimes(1)
+    })
 
-  it('should not log analytics event when shouldLogEvent is false', async () => {
-    openURLSpy.mockResolvedValueOnce(undefined)
+    it('should not display alert when Linking.openURL throws but fallbackUrl is valid', async () => {
+      // Last in first out, it will fail then succeed.
+      openURLSpy.mockResolvedValueOnce(undefined)
+      openURLSpy.mockImplementationOnce(() => Promise.reject(new Error('Did not open correctly')))
+      const alertMock = jest.spyOn(Alert, 'alert')
 
-    const link = 'https://www.google.com'
-    await openUrl(link, { shouldLogEvent: false })
+      const link = 'https://www.google.com'
+      const fallbackLink = 'https://www.googlefallback.com'
+      await openUrl(link, { fallbackUrl: fallbackLink })
 
-    expect(analytics.logOpenExternalUrl).not.toBeCalled()
-  })
-
-  it('should display alert when Linking.openURL throws', async () => {
-    openURLSpy.mockImplementationOnce(() => Promise.reject(new Error('Did not open correctly')))
-    const alertMock = jest.spyOn(Alert, 'alert')
-
-    const link = 'https://www.google.com'
-    await openUrl(link)
-
-    expect(alertMock).toHaveBeenCalledTimes(1)
-  })
-
-  it('should log an info in Sentry when Linking.openURL throws', async () => {
-    openURLSpy.mockImplementationOnce(() => Promise.reject(new Error('Did not open correctly')))
-
-    const link = 'https://www.google.com'
-    await openUrl(link)
-
-    expect(eventMonitoring.captureMessage).toHaveBeenNthCalledWith(
-      1,
-      'OpenExternalUrlError: Did not open correctly',
-      'info'
-    )
-  })
-
-  it('should not display alert when Linking.openURL throws but fallbackUrl is valid', async () => {
-    // Last in first out, it will fail then succeed.
-    openURLSpy.mockResolvedValueOnce(undefined)
-    openURLSpy.mockImplementationOnce(() => Promise.reject(new Error('Did not open correctly')))
-    const alertMock = jest.spyOn(Alert, 'alert')
-
-    const link = 'https://www.google.com'
-    const fallbackLink = 'https://www.googlefallback.com'
-    await openUrl(link, { fallbackUrl: fallbackLink })
-
-    expect(alertMock).not.toHaveBeenCalled()
-  })
-
-  it('should log an info in Sentry when Linking.openURL throws and fallbackUrl throws', async () => {
-    openURLSpy.mockImplementationOnce(() => Promise.reject(new Error('Did not open correctly')))
-    openURLSpy.mockImplementationOnce(() => Promise.reject(new Error('Did not open correctly')))
-
-    const link = 'https://www.google.com'
-    const fallbackLink = 'https://www.googlefallback.com'
-    await openUrl(link, { fallbackUrl: fallbackLink })
-    await act(async () => {})
-    expect(eventMonitoring.captureMessage).toHaveBeenNthCalledWith(
-      1,
-      'OpenExternalUrlError: Did not open correctly',
-      'info'
-    )
-    expect(eventMonitoring.captureMessage).toHaveBeenNthCalledWith(
-      2,
-      'OpenExternalUrlError_FallbackUrl: Did not open correctly',
-      'info'
-    )
+      expect(alertMock).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-22517

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Si un browser disponible | Si aucun browser disponible |
| :--------------- | :----: | :---: |
| Android          |   [available_browser.mp4](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/119bc93f-da0e-443b-9ada-06b4c5279c2f)    |   [no_available_browser.mp4](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/35061da5-6014-4f6b-84a2-1838269506c8)   |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
