### PR TITLE
(BSR) test(perf): Use different node env for performance tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "test": "yarn test:lint && yarn test:types && yarn test:unit && yarn test:unit:web",
     "test:lighthouse": "lhci autorun",
     "test:lint": "eslint . --ext .js,.ts,.tsx,.mjs --cache",
-    "test:perf": "TEST_RUNNER_ARGS='--runInBand --testMatch \"<rootDir>/**/*.perf.test.tsx\"' yarn reassure",
+    "test:perf": "NODE_ENV=performance TEST_RUNNER_ARGS='--runInBand --testMatch \"<rootDir>/**/*.perf.test.tsx\"' yarn reassure",
     "test:storybook:accessibility": "axe-storybook --storybook-address http://localhost:6006",
     "test:types": "tsc",
     "test:unit": "TZ=UTC JEST=true node --no-compilation-cache --expose-gc ./node_modules/.bin/jest --forceExit --logHeapUsage",

--- a/src/features/search/pages/Search/Search.perf.test.tsx
+++ b/src/features/search/pages/Search/Search.perf.test.tsx
@@ -22,6 +22,10 @@ jest.mock('react-instantsearch-hooks', () => ({
   useInfiniteHits: () => ({ hits: mockSuggestionHits }),
 }))
 
+// Performance measuring is run multiple times so we need to increase the timeout
+const TEST_TIMEOUT_IN_MS = 30_000
+jest.setTimeout(TEST_TIMEOUT_IN_MS)
+
 describe('<Search />', () => {
   describe('Search Landing Page -', () => {
     beforeAll(() => {
@@ -31,7 +35,7 @@ describe('<Search />', () => {
     it('Performance test for Search Landing page', async () => {
       await measurePerformance(<SearchPage />, {
         scenario: async () => {
-          await screen.findByText('Spectacles') // Last category that is rendered
+          await screen.findByText('Spectacles', {}, { timeout: TEST_TIMEOUT_IN_MS }) // Last category that is rendered
         },
       })
     })
@@ -46,7 +50,7 @@ describe('<Search />', () => {
     it('Performance test for Search Results page', async () => {
       await measurePerformance(<SearchPage />, {
         scenario: async () => {
-          await screen.findByText('4 résultats')
+          await screen.findByText('4 résultats', {}, { timeout: TEST_TIMEOUT_IN_MS })
         },
       })
     })
@@ -60,7 +64,7 @@ describe('<Search />', () => {
     it('Performance test for Search Suggestions page', async () => {
       await measurePerformance(<SearchPage />, {
         scenario: async () => {
-          await screen.findAllByText('Séances de cinéma')
+          await screen.findAllByText('Séances de cinéma', {}, { timeout: TEST_TIMEOUT_IN_MS })
         },
       })
     })

--- a/src/features/venue/pages/Venue/Venue.perf.test.tsx
+++ b/src/features/venue/pages/Venue/Venue.perf.test.tsx
@@ -8,6 +8,10 @@ import { measurePerformance, screen } from 'tests/utils'
 
 useRoute.mockImplementation(() => ({ params: { id: venueResponseSnap.id } }))
 
+// Performance measuring is run multiple times so we need to increase the timeout
+const TEST_TIMEOUT_IN_MS = 30_000
+jest.setTimeout(TEST_TIMEOUT_IN_MS)
+
 describe('<Venue />', () => {
   it('Performance test for Venue page', async () => {
     await measurePerformance(
@@ -15,7 +19,9 @@ describe('<Venue />', () => {
       reactQueryProviderHOC(<Venue />),
       {
         scenario: async () => {
-          await screen.findByLabelText('Nom du lieu : Le Petit Rintintin 1')
+          await screen.findByLabelText('Nom du lieu : Le Petit Rintintin 1', {
+            timeout: TEST_TIMEOUT_IN_MS,
+          })
         },
       }
     )


### PR DESCRIPTION
## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
