### PR TITLE
(PC-22517) fix(openUrl): Fix to open url in browser for android 13

### DIFF
--- a/android/app/src/main/java/com/passculture/DefaultBrowserModule.java
+++ b/android/app/src/main/java/com/passculture/DefaultBrowserModule.java
@@ -30,10 +30,21 @@ public class DefaultBrowserModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void openUrl(String url, Promise promise) {
         try {
-            Intent defaultBrowser = Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_BROWSER);
-            defaultBrowser.setData(Uri.parse(url));
+            Intent emptyBrowserIntent = new Intent();
+            emptyBrowserIntent
+                .setAction(Intent.ACTION_VIEW)
+                .addCategory(Intent.CATEGORY_BROWSABLE)
+                .setData(Uri.fromParts("http", "", null));
+
+            Intent targetIntent = new Intent();
+            targetIntent
+                .setAction(Intent.ACTION_VIEW)
+                .addCategory(Intent.CATEGORY_BROWSABLE)
+                .setData(Uri.parse(url))
+                .setSelector(emptyBrowserIntent);
+            
             // Through ReactApplicationContext's current activty, start a new activity
-            this._context.getCurrentActivity().startActivity(defaultBrowser);
+            this._context.getCurrentActivity().startActivity(targetIntent);
             promise.resolve(true);
         } catch (Exception e) {
             // We land here if the user doesn't have any browsers installed on their phone


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-22517

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| Android          |        |    [fix-android-13.webm](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/32c21080-2df4-4dbb-9866-15425cf22df6) | 

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
