### PR TITLE
(PC-22963) feat(videoModule): use placeholder when no offer image provided 

### DIFF
--- a/__snapshots__/features/home/components/modals/VideoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modals/VideoModal.native.test.tsx.native-snap
@@ -454,43 +454,61 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
                   }
                 >
                   <View
+                    size="medium"
                     style={
                       Array [
                         Object {
-                          "overflow": "hidden",
+                          "borderRadius": 4,
+                          "height": 112,
+                          "shadowColor": "#696A6F",
+                          "shadowOffset": Object {
+                            "height": 4,
+                            "width": 0,
+                          },
+                          "shadowOpacity": 0.2,
+                          "shadowRadius": 4,
+                          "width": 80,
                         },
-                        Array [
-                          Object {
-                            "backgroundColor": "#F1F1F4",
-                          },
-                          Object {
-                            "borderRadius": 8,
-                            "height": 112,
-                            "width": 80,
-                          },
-                        ],
                       ]
                     }
                   >
-                    <FastImageView
-                      defaultSource={null}
-                      resizeMode="cover"
-                      source={
-                        Object {
-                          "uri": "https://storage.gra.cloud.ovh.net/v1/AUTH_688df1e25bd84a48a3804e7fa8938085/storage-pc-dev/thumbs/mediations/CDNQ",
-                        }
-                      }
+                    <View
                       style={
-                        Object {
-                          "bottom": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                        }
+                        Array [
+                          Object {
+                            "overflow": "hidden",
+                          },
+                          Array [
+                            Object {
+                              "backgroundColor": "#F1F1F4",
+                              "borderRadius": 4,
+                              "height": 112,
+                              "width": 80,
+                            },
+                          ],
+                        ]
                       }
-                      testID="tileImage"
-                    />
+                    >
+                      <FastImageView
+                        defaultSource={null}
+                        resizeMode="cover"
+                        size="medium"
+                        source={
+                          Object {
+                            "uri": "https://storage.gra.cloud.ovh.net/v1/AUTH_688df1e25bd84a48a3804e7fa8938085/storage-pc-dev/thumbs/mediations/CDNQ",
+                          }
+                        }
+                        style={
+                          Object {
+                            "bottom": 0,
+                            "left": 0,
+                            "position": "absolute",
+                            "right": 0,
+                            "top": 0,
+                          }
+                        }
+                      />
+                    </View>
                   </View>
                 </View>
                 <View

--- a/src/features/home/components/modules/OfferVideoModule.native.test.tsx
+++ b/src/features/home/components/modules/OfferVideoModule.native.test.tsx
@@ -1,3 +1,4 @@
+import { omit } from 'lodash'
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
@@ -21,5 +22,17 @@ describe('OfferVideoModule', () => {
     await act(async () => {})
 
     expect(navigate).toHaveBeenCalledWith('Offer', { id: 102_280 })
+  })
+
+  it('should display a placeholder if the offer has no image', async () => {
+    const offerWithoutImage = omit(mockOffer, 'offer.thumbUrl')
+    render(<OfferVideoModule offer={offerWithoutImage} color="" hideModal={hideModalMock} />, {
+      /* eslint-disable local-rules/no-react-query-provider-hoc */
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+
+    await act(async () => {})
+
+    expect(screen.getByTestId('imagePlaceholder')).toBeTruthy()
   })
 })

--- a/src/features/home/components/modules/OfferVideoModule.tsx
+++ b/src/features/home/components/modules/OfferVideoModule.tsx
@@ -7,14 +7,11 @@ import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcateg
 import { Offer } from 'shared/offer/types'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
 import { styledButton } from 'ui/components/buttons/styledButton'
-import { ImageTile } from 'ui/components/ImageTile'
+import { OfferImage } from 'ui/components/tiles/OfferImage'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
 import { Typo, getSpacing } from 'ui/theme'
-
-const OFFER_HEIGHT = getSpacing(28)
-const OFFER_WIDTH = getSpacing(20)
 
 type Props = {
   offer: Offer
@@ -46,9 +43,9 @@ export const OfferVideoModule: FunctionComponent<Props> = ({ offer, color, hideM
         })
       }}>
       <Row>
-        <OfferImage>
-          <ImageTile width={OFFER_WIDTH} height={OFFER_HEIGHT} uri={offer.offer.thumbUrl} />
-        </OfferImage>
+        <OfferImageContainer>
+          <OfferImage imageUrl={offer.offer.thumbUrl} categoryId={categoryId} size="medium" />
+        </OfferImageContainer>
         <OfferInformations>
           <CategoryText color={color}>{labelMapping[offer.offer.subcategoryId]}</CategoryText>
           <TitleText numberOfLines={2}>{offer.offer.name}</TitleText>
@@ -83,7 +80,7 @@ const OfferInformations = styled.View({
   flex: 1,
   marginRight: getSpacing(4),
 })
-const OfferImage = styled.View({
+const OfferImageContainer = styled.View({
   margin: getSpacing(4),
 })
 

--- a/src/features/home/components/modules/OfferVideoModule.tsx
+++ b/src/features/home/components/modules/OfferVideoModule.tsx
@@ -29,6 +29,8 @@ export const OfferVideoModule: FunctionComponent<Props> = ({ offer, color, hideM
 
   const prePopulateOffer = usePrePopulateOffer()
 
+  const categoryId = mapping[offer.offer.subcategoryId]
+
   return (
     <OfferInsert
       navigateTo={{
@@ -40,7 +42,7 @@ export const OfferVideoModule: FunctionComponent<Props> = ({ offer, color, hideM
         prePopulateOffer({
           ...offer.offer,
           offerId: +offer.objectID,
-          categoryId: mapping[offer.offer.subcategoryId],
+          categoryId,
         })
       }}>
       <Row>

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -93,6 +93,10 @@ export interface AppThemeType {
         width: number
         height: number
       }
+      medium: {
+        width: number
+        height: number
+      }
       tall: {
         width: number
         height: number
@@ -480,6 +484,10 @@ export const theme: AppThemeType = {
       small: {
         width: getSpacing(16),
         height: getSpacing(24),
+      },
+      medium: {
+        width: getSpacing(20),
+        height: getSpacing(28),
       },
       tall: {
         width: getSpacing(20),

--- a/src/ui/components/tiles/OfferImage.tsx
+++ b/src/ui/components/tiles/OfferImage.tsx
@@ -8,17 +8,18 @@ import styled from 'styled-components/native'
 import { CategoryIdEnum } from 'api/gen'
 import { mapCategoryToIcon } from 'libs/parsers'
 import { FastImage as ResizedFastImage } from 'libs/resizing-image-on-demand/FastImage'
+import { AppThemeType } from 'theme'
 import { ImagePlaceholder } from 'ui/components/ImagePlaceholder'
 import { getShadow, getSpacing } from 'ui/theme'
 
-type SizeProps = {
-  size?: 'small' | 'tall'
-}
+type SizeProp = keyof AppThemeType['tiles']['sizes']
+type StyleProps = { size: SizeProp }
 
 type Props = {
   imageUrl?: string
   categoryId?: CategoryIdEnum | null
-} & SizeProps
+  size?: SizeProp
+}
 
 export const OfferImage: React.FC<Props> = ({ categoryId, imageUrl, size = 'small' }) => {
   const Icon = mapCategoryToIcon(categoryId || null)
@@ -34,11 +35,11 @@ export const OfferImage: React.FC<Props> = ({ categoryId, imageUrl, size = 'smal
   )
 }
 
-const StyledFastImage = styled(ResizedFastImage).attrs<SizeProps>(({ theme, size }) => ({
-  ...(size === 'small' ? theme.tiles.sizes.small : theme.tiles.sizes.tall),
-}))<SizeProps>(({ theme, size }) => ({
+const StyledFastImage = styled(ResizedFastImage).attrs<StyleProps>(({ theme, size }) => ({
+  ...theme.tiles.sizes[size],
+}))<StyleProps>(({ theme, size }) => ({
   backgroundColor: theme.colors.greyLight,
-  ...(size === 'small' ? theme.tiles.sizes.small : theme.tiles.sizes.tall),
+  ...theme.tiles.sizes[size],
   borderRadius: theme.tiles.borderRadius,
 }))
 
@@ -48,9 +49,9 @@ const StyledImagePlaceholder = styled(ImagePlaceholder).attrs(({ theme }) => ({
   borderRadius: theme.tiles.borderRadius,
 }))``
 
-const Container = styled.View<SizeProps>(({ theme, size }) => ({
+const Container = styled.View<StyleProps>(({ theme, size }) => ({
   borderRadius: theme.tiles.borderRadius,
-  ...(size === 'small' ? theme.tiles.sizes.small : theme.tiles.sizes.tall),
+  ...theme.tiles.sizes[size],
   ...(Platform.OS !== 'web'
     ? getShadow({
         shadowOffset: { width: 0, height: getSpacing(1) },


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-22963

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

| Platform         | Before | After | After with placeholder |
| :--------------- | :----: | :---: | :-: |
| iOS              |        |       |   |
| Phone - Chrome   | <img width="375" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/33a53f45-21d4-48ea-af17-1a7c6685ae66"> | <img width="377" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/f6b9cf65-4106-459e-babe-a6df59c79b78"> | <img width="377" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/2c0360c8-74ed-4a72-b4ef-178c3c0773af"> |
| Desktop - Chrome |        |       |   |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
