### PR TITLE
(BSR) test(proxy): fix flakiness by using staging backend

### DIFF
--- a/server/src/middlewares/tests/__snapshots__/webAppProxyMiddleware.test.ts.snap
+++ b/server/src/middlewares/tests/__snapshots__/webAppProxyMiddleware.test.ts.snap
@@ -3,44 +3,44 @@
 exports[`metasResponseInterceptor with real backend should request the real testing backend and get the offer data 1`] = `
 "<!doctype html>
 <html lang=\\"fr\\">
-  <head><link rel=\\"canonical\\" href=\\"http://localhost:8080/offre/offerId\\" />
+  <head><link rel=\\"canonical\\" href=\\"http://localhost:8080/offre/1\\" />
     <meta charset=\\"utf-8\\">
     <title>pass Culture</title>
-    <meta name=\\"title\\" content=\\"pass Culture | C&apos;est notre prooooojecteur\\" />
-    <meta name=\\"description\\" content=\\"Ainsi, jusque dans notre propre individu, l&apos;individualité nous échappe. Nous nous mouvons parmi des généralités et des symboles, comme en un champ clos où notre force se mesure utilement avec d&apos;autres forces ; et, fascinés par l&apos;action, attirés par elle, pour notre plus grand bien, sur le terrain qu&apos;elle s&apos;est choisie, nous vivons dans une zone mitoyenne entre les choses et nous, extérieurement aux choses, extérieurement aussi à nous-mêmes.\\" />
+    <meta name=\\"title\\" content=\\"pass Culture | Atelier danses urbaines\\" />
+    <meta name=\\"description\\" content=\\"Les danseurs de tout style et de tout niveau, mais aussi tous les curieux, sont invités à participer à cet atelier conçu comme un moment de partage et animé par un danseur professionnel et un dj.\\" />
     <meta name=\\"author\\" content=\\"pass Culture\\"/>
     <meta property=\\"og:type\\" content=\\"website\\"/>
-    <meta property=\\"og:url\\" content=\\"http://localhost:8080/offre/offerId\\" />
-    <meta property=\\"og:title\\" content=\\"pass Culture | C&apos;est notre prooooojecteur\\" />
-    <meta property=\\"og:description\\" content=\\"Ainsi, jusque dans notre propre individu, l&apos;individualité nous échappe. Nous nous mouvons parmi des généralités et des symboles, comme en un champ clos où notre force se mesure utilement avec d&apos;autres forces ; et, fascinés par l&apos;action, attirés par elle, pour notre plus grand bien, sur le terrain qu&apos;elle s&apos;est choisie, nous vivons dans une zone mitoyenne entre les choses et nous, extérieurement aux choses, extérieurement aussi à nous-mêmes.\\" />
-    <meta property=\\"og:image\\" content=\\"https://app.testing.passculture.team/images/app-icon-512px.png\\"/>
-    <meta property=\\"og:image:alt\\" content=\\"C&apos;est notre prooooojecteur\\" />
+    <meta property=\\"og:url\\" content=\\"http://localhost:8080/offre/1\\" />
+    <meta property=\\"og:title\\" content=\\"pass Culture | Atelier danses urbaines\\" />
+    <meta property=\\"og:description\\" content=\\"Les danseurs de tout style et de tout niveau, mais aussi tous les curieux, sont invités à participer à cet atelier conçu comme un moment de partage et animé par un danseur professionnel et un dj.\\" />
+    <meta property=\\"og:image\\" content=\\"https://storage.googleapis.com/passculture-metier-ehp-staging-assets-fine-grained/thumbs/mediations/HE\\" />
+    <meta property=\\"og:image:alt\\" content=\\"Atelier danses urbaines\\" />
     <meta property=\\"og:locale\\" content=\\"fr_FR\\"/>
     <meta property=\\"og:site_name\\" content=\\"pass Culture\\"/>
     <meta name=\\"twitter:card\\" content=\\"summary\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:8080/offre/offerId\\" />
-    <meta name=\\"twitter:title\\" content=\\"pass Culture | C&apos;est notre prooooojecteur\\" />
-    <meta name=\\"twitter:description\\" content=\\"Ainsi, jusque dans notre propre individu, l&apos;individualité nous échappe. Nous nous mouvons parmi des généralités et des symboles, comme en un champ clos où notre force se mesure utilement avec d&apos;autres forces ; et, fascinés par l&apos;action, attirés par elle, pour notre plus grand bien, sur le terrain qu&apos;elle s&apos;est choisie, nous vivons dans une zone mitoyenne entre les choses et nous, extérieurement aux choses, extérieurement aussi à nous-mêmes.\\" />
-    <meta name=\\"twitter:image\\" content=\\"https://app.testing.passculture.team/images/app-icon-512px.png\\"/>
-    <meta name=\\"twitter:image:alt\\" content=\\"C&apos;est notre prooooojecteur\\" />
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:8080/offre/1\\" />
+    <meta name=\\"twitter:title\\" content=\\"pass Culture | Atelier danses urbaines\\" />
+    <meta name=\\"twitter:description\\" content=\\"Les danseurs de tout style et de tout niveau, mais aussi tous les curieux, sont invités à participer à cet atelier conçu comme un moment de partage et animé par un danseur professionnel et un dj.\\" />
+    <meta name=\\"twitter:image\\" content=\\"https://storage.googleapis.com/passculture-metier-ehp-staging-assets-fine-grained/thumbs/mediations/HE\\" />
+    <meta name=\\"twitter:image:alt\\" content=\\"Atelier danses urbaines\\" />
     <meta name=\\"twitter:site\\" content=\\"@pass_Culture\\"/>
     <meta name=\\"twitter:app:country\\" content=\\"FR\\"/>
     <meta name=\\"twitter:app:name:iphone\\" content=\\"pass Culture\\"/>
     <meta name=\\"twitter:app:id:iphone\\" content=\\"1557887412\\"/>
-    <meta name=\\"twitter:app:url:iphone\\" content=\\"passculture://http://localhost:8080/offre/offerId\\" />
+    <meta name=\\"twitter:app:url:iphone\\" content=\\"passculture://http://localhost:8080/offre/1\\" />
     <meta name=\\"twitter:app:name:ipad\\" content=\\"pass Culture\\"/>
     <meta name=\\"twitter:app:id:ipad\\" content=\\"1557887412\\"/>
-    <meta name=\\"twitter:app:url:ipad\\" content=\\"passculture://http://localhost:8080/offre/offerId\\" />
+    <meta name=\\"twitter:app:url:ipad\\" content=\\"passculture://http://localhost:8080/offre/1\\" />
     <meta name=\\"twitter:app:name:googleplay\\" content=\\"pass Culture\\"/>
     <meta name=\\"twitter:app:id:googleplay\\" content=\\"app.passculture.testing\\"/>
-    <meta name=\\"twitter:app:url:googleplay\\" content=\\"passculture://http://localhost:8080/offre/offerId\\" />
+    <meta name=\\"twitter:app:url:googleplay\\" content=\\"passculture://http://localhost:8080/offre/1\\" />
     <meta property=\\"al:ios:app_name\\" content=\\"pass Culture\\"/>
     <meta property=\\"al:ios:app_store_id\\" content=\\"1557887412\\"/>
     <meta property=\\"al:ios:url\\" content=\\"passculture://https://app.testing.passculture.team\\"/>
     <meta property=\\"al:android:url\\" content=\\"passculture://https://app.testing.passculture.team\\">
     <meta property=\\"al:android:app_name\\" content=\\"pass Culture\\"/>
     <meta property=\\"al:android:package\\" content=\\"app.passculture.testing\\"/>
-    <script type=\\"application/ld+json\\">{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Event\\",\\"name\\":\\"C'est notre prooooojecteur\\",\\"location\\":{\\"@type\\":\\"Place\\",\\"name\\":\\"Théâtre en feu\\",\\"address\\":{\\"@type\\":\\"PostalAddress\\",\\"streetAddress\\":\\"1 boulevard Poissonnière\\",\\"postalCode\\":\\"75000\\",\\"addressLocality\\":\\"Paris\\"},\\"geo\\":{\\"@type\\":\\"GeoCoordinates\\",\\"latitude\\":\\"5.15839\\",\\"longitude\\":\\"-52.63741\\"}},\\"startDate\\":\\"2023-07-12T20:00\\"}</script>
+    <script type=\\"application/ld+json\\">{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Event\\",\\"name\\":\\"Atelier danses urbaines\\",\\"image\\":\\"https://storage.googleapis.com/passculture-metier-ehp-staging-assets-fine-grained/thumbs/mediations/HE\\",\\"location\\":{\\"@type\\":\\"Place\\",\\"name\\":\\"Le Centquatre-Paris\\",\\"address\\":{\\"@type\\":\\"PostalAddress\\",\\"streetAddress\\":\\"5 rue Curial\\",\\"postalCode\\":\\"75019\\",\\"addressLocality\\":\\"Paris\\"},\\"geo\\":{\\"@type\\":\\"GeoCoordinates\\",\\"latitude\\":\\"48.89005\\",\\"longitude\\":\\"2.37068\\"}},\\"startDate\\":\\"2018-05-19T14:00\\"}</script>
   </head>
   <body>
     <p>Hello world</p>
@@ -51,37 +51,40 @@ exports[`metasResponseInterceptor with real backend should request the real test
 exports[`metasResponseInterceptor with real backend should request the real testing backend and get the venue data 1`] = `
 "<!doctype html>
 <html lang=\\"fr\\">
-  <head><link rel=\\"canonical\\" href=\\"http://localhost:8080/lieu/venueId\\" />
+  <head><link rel=\\"canonical\\" href=\\"http://localhost:8080/lieu/9\\" />
     <meta charset=\\"utf-8\\">
     <title>pass Culture</title>
-    <meta name=\\"title\\" content=\\"pass Culture | Terrain vague DATA\\" />
-    <meta name=\\"description\\" content=\\"Of of among place budget. People four car drop.\\" />
+    <meta name=\\"title\\" content=\\"pass Culture | Relais culturel La Nef\\" />
+    <meta name=\\"description\\"
+          content=\\"Dispositif porté par le ministère de la Culture, a pour but de faciliter l’accès des jeunes de 18 ans à la culture en leur offrant un crédit de 300€ à dépenser sur l’application pass Culture.\\"/>
     <meta name=\\"author\\" content=\\"pass Culture\\"/>
     <meta property=\\"og:type\\" content=\\"website\\"/>
-    <meta property=\\"og:url\\" content=\\"http://localhost:8080/lieu/venueId\\" />
-    <meta property=\\"og:title\\" content=\\"pass Culture | Terrain vague DATA\\" />
-    <meta property=\\"og:description\\" content=\\"Of of among place budget. People four car drop.\\" />
-    <meta property=\\"og:image\\" content=\\"https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/assets/venue_default_images/aleksandr-popov-hTv8aaPziOQ-unsplash.png\\" />
-    <meta property=\\"og:image:alt\\" content=\\"Of of among place budget. People four car drop.\\" />
+    <meta property=\\"og:url\\" content=\\"http://localhost:8080/lieu/9\\" />
+    <meta property=\\"og:title\\" content=\\"pass Culture | Relais culturel La Nef\\" />
+    <meta property=\\"og:description\\"
+          content=\\"Dispositif porté par le ministère de la Culture, a pour but de faciliter l’accès des jeunes de 18 ans à la culture en leur offrant un crédit de 300€ à dépenser sur l’application pass Culture.\\"/>
+    <meta property=\\"og:image\\" content=\\"https://storage.googleapis.com/passculture-metier-ehp-staging-assets-fine-grained/assets/venue_default_images/mark-williams-9bNmhMKQM1Q-unsplash_1.png\\" />
+    <meta property=\\"og:image:alt\\" content=\\"pass Culture\\"/>
     <meta property=\\"og:locale\\" content=\\"fr_FR\\"/>
     <meta property=\\"og:site_name\\" content=\\"pass Culture\\"/>
     <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:8080/lieu/venueId\\" />
-    <meta name=\\"twitter:title\\" content=\\"pass Culture | Terrain vague DATA\\" />
-    <meta name=\\"twitter:description\\" content=\\"Of of among place budget. People four car drop.\\" />
-    <meta name=\\"twitter:image\\" content=\\"https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/assets/venue_default_images/aleksandr-popov-hTv8aaPziOQ-unsplash.png\\" />
-    <meta name=\\"twitter:image:alt\\" content=\\"Of of among place budget. People four car drop.\\" />
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:8080/lieu/9\\" />
+    <meta name=\\"twitter:title\\" content=\\"pass Culture | Relais culturel La Nef\\" />
+    <meta name=\\"twitter:description\\"
+          content=\\"Dispositif porté par le ministère de la Culture, a pour but de faciliter l’accès des jeunes de 18 ans à la culture en leur offrant un crédit de 300€ à dépenser sur l’application pass Culture.\\"/>
+    <meta name=\\"twitter:image\\" content=\\"https://storage.googleapis.com/passculture-metier-ehp-staging-assets-fine-grained/assets/venue_default_images/mark-williams-9bNmhMKQM1Q-unsplash_1.png\\" />
+    <meta name=\\"twitter:image:alt\\" content=\\"pass Culture\\"/>
     <meta name=\\"twitter:site\\" content=\\"@pass_Culture\\"/>
     <meta name=\\"twitter:app:country\\" content=\\"FR\\"/>
     <meta name=\\"twitter:app:name:iphone\\" content=\\"pass Culture\\"/>
     <meta name=\\"twitter:app:id:iphone\\" content=\\"1557887412\\"/>
-    <meta name=\\"twitter:app:url:iphone\\" content=\\"passculture://http://localhost:8080/lieu/venueId\\" />
+    <meta name=\\"twitter:app:url:iphone\\" content=\\"passculture://http://localhost:8080/lieu/9\\" />
     <meta name=\\"twitter:app:name:ipad\\" content=\\"pass Culture\\"/>
     <meta name=\\"twitter:app:id:ipad\\" content=\\"1557887412\\"/>
-    <meta name=\\"twitter:app:url:ipad\\" content=\\"passculture://http://localhost:8080/lieu/venueId\\" />
+    <meta name=\\"twitter:app:url:ipad\\" content=\\"passculture://http://localhost:8080/lieu/9\\" />
     <meta name=\\"twitter:app:name:googleplay\\" content=\\"pass Culture\\"/>
     <meta name=\\"twitter:app:id:googleplay\\" content=\\"app.passculture.testing\\"/>
-    <meta name=\\"twitter:app:url:googleplay\\" content=\\"passculture://http://localhost:8080/lieu/venueId\\" />
+    <meta name=\\"twitter:app:url:googleplay\\" content=\\"passculture://http://localhost:8080/lieu/9\\" />
     <meta property=\\"al:ios:app_name\\" content=\\"pass Culture\\"/>
     <meta property=\\"al:ios:app_store_id\\" content=\\"1557887412\\"/>
     <meta property=\\"al:ios:url\\" content=\\"passculture://https://app.testing.passculture.team\\"/>

--- a/server/src/middlewares/tests/webAppProxyMiddleware.test.ts
+++ b/server/src/middlewares/tests/webAppProxyMiddleware.test.ts
@@ -72,7 +72,7 @@ describe('metasResponseInterceptor', () => {
       ['venue', 'lieu', `${VENUE_WITHOUT_BANNER_RESPONSE_SNAPSHOT.id}`],
     ])(
       `should edit html when req.url on %s use valid id: /%s/%s`,
-      async (entity: string, endpoint: string, id: string) => {
+      async (_entity: string, endpoint: string, id: string) => {
         const url = `${env.APP_PUBLIC_URL}/${endpoint}${id ? `/${id}` : ''}`
         const finalResponseBuffer = await htmlResponseFor(url)
 
@@ -121,6 +121,14 @@ describe('metasResponseInterceptor', () => {
   })
 
   describe('with real backend', () => {
+    const originalApiBaseUrl = env.API_BASE_URL
+    beforeAll(() => {
+      env.API_BASE_URL = 'https://backend.staging.passculture.team'
+    })
+    afterAll(() => {
+      env.API_BASE_URL = originalApiBaseUrl
+    })
+
     const responseBuffer = Buffer.from(TEST_HTML)
     const proxyRes = {
       headers: {
@@ -131,8 +139,7 @@ describe('metasResponseInterceptor', () => {
     const res = {} as ServerResponse
 
     it('should request the real testing backend and get the offer data', async () => {
-      const offerId = await getOfferId("C'est notre prooooojecteur")
-      const url = `${env.APP_PUBLIC_URL}/offre/${offerId}`
+      const url = `${env.APP_PUBLIC_URL}/offre/1`
       const html = await metasResponseInterceptor(
         responseBuffer,
         proxyRes,
@@ -143,18 +150,15 @@ describe('metasResponseInterceptor', () => {
         res
       )
 
-      const htmlWithoutOfferId = html
-        .toString()
-        .replaceAll(offerId, 'offerId')
-        .replace(/(?<=mediations\/)[A-Z0-9_]+/, 'humanizedOfferId')
+      const htmlWithoutOfferId = html.toString()
 
       expect(htmlWithoutOfferId).toMatchSnapshot()
     })
 
     it('should request the real testing backend and get the venue data', async () => {
-      const venueId = await getVenueId('Terrain vague')
-      const url = `${env.APP_PUBLIC_URL}/lieu/${venueId}`
-      const html = await metasResponseInterceptor(
+      const url = `${env.APP_PUBLIC_URL}/lieu/9`
+
+      const finalResponseBuffer = await metasResponseInterceptor(
         responseBuffer,
         proxyRes,
         {
@@ -164,59 +168,7 @@ describe('metasResponseInterceptor', () => {
         res
       )
 
-      const htmlWithoutOfferId = html
-      .toString()
-      .replaceAll(venueId, 'venueId')
-      .replace(/(?<=mediations\/)[A-Z0-9_]+/, 'humanizedVenueId')
-
-      expect(htmlWithoutOfferId).toMatchSnapshot()
+      expect(finalResponseBuffer).toMatchSnapshot()
     })
   })
 })
-
-const ALGOLIA_APPLICATION_ID = 'testingHXXTDUE7H0' // This is your unique application identifier. It's used to identify you when using Algolia's API.
-const ALGOLIA_OFFERS_INDEX_NAME = 'TESTING'
-const ALGOLIA_VENUES_INDEX_NAME = 'testing-venues'
-const ALGOLIA_SEARCH_API_KEY = '468f53ae703ee7ff219106f3d9a39e7f' //This is the public API key which can be safely used in your frontend code.This key is usable for search queries and it's also able to list the indices you've got access to.
-
-type Hit = {
-  objectID: string
-  offer: {
-    name?: string
-  }
-}
-
-const getAlgoliaObjectId = async (index: string, query: string): Promise<Hit[]> => {
-  const response = await fetch(
-    `https://${ALGOLIA_APPLICATION_ID}-dsn.algolia.net/1/indexes/${index}/query`,
-    {
-      method: 'POST',
-      headers: new Headers({
-        'X-Algolia-API-Key': ALGOLIA_SEARCH_API_KEY,
-        'X-Algolia-Application-Id': ALGOLIA_APPLICATION_ID,
-      }),
-      body: `{ "params": "query=${query}&hitsPerPage=10" }`,
-    }
-  )
-
-  const hits = await response.json()
-
-  return hits.hits
-}
-
-const firstObjectID = (hits: Hit[]): string => {
-  const hit = hits.at(0)
-  if (!hit) throw new Error("can't find Algolia result")
-  return hit.objectID
-}
-
-const getOfferId = async (query: string): Promise<string> => {
-  const hits = await getAlgoliaObjectId(ALGOLIA_OFFERS_INDEX_NAME, query)
-  const hitsWithoutDataInName = hits.filter((hit) => hit.offer.name?.includes('DATA') === false)
-  return firstObjectID(hitsWithoutDataInName)
-}
-
-const getVenueId = async (query: string): Promise<string> => {
-  const hits = await getAlgoliaObjectId(ALGOLIA_VENUES_INDEX_NAME, query)
-  return firstObjectID(hits)
-}

--- a/server/src/middlewares/tests/webAppProxyMiddleware.test.ts
+++ b/server/src/middlewares/tests/webAppProxyMiddleware.test.ts
@@ -121,6 +121,7 @@ describe('metasResponseInterceptor', () => {
   })
 
   describe('with real backend', () => {
+    // we use the staging backend to ensure that the offer/venue data is not changing at every sandbox reset
     const originalApiBaseUrl = env.API_BASE_URL
     beforeAll(() => {
       env.API_BASE_URL = 'https://backend.staging.passculture.team'
@@ -156,8 +157,7 @@ describe('metasResponseInterceptor', () => {
     })
 
     it('should request the real testing backend and get the venue data', async () => {
-      const url = `${env.APP_PUBLIC_URL}/lieu/9`
-
+      const url = `${env.APP_PUBLIC_URL}/lieu/9` // 9 is the id of the first permanent venue in the staging database
       const finalResponseBuffer = await metasResponseInterceptor(
         responseBuffer,
         proxyRes,

--- a/server/src/services/apiClient.ts
+++ b/server/src/services/apiClient.ts
@@ -4,11 +4,10 @@ import { env } from '../libs/environment/env'
 
 import { ENTITY_MAP, EntityKeys } from './entities/types'
 
-const { API_BASE_URL, API_BASE_PATH_NATIVE_V1, PROXY_CACHE_CONTROL } = env
-
-const { href } = new URL(API_BASE_URL)
-
 export async function apiClient(type: EntityKeys, id: number) {
+  const { API_BASE_URL, API_BASE_PATH_NATIVE_V1, PROXY_CACHE_CONTROL } = env
+
+  const { href } = new URL(API_BASE_URL)
   const entityValue = ENTITY_MAP[type]
   if (!entityValue) {
     throw new Error(`Unknown entity: ${type}`)


### PR DESCRIPTION
We chose to use the staging proxy, because the offer/venue data doesn't change every week: when using testing proxy, the snapshots were broken every Thursday.
The inconvenient is that, if the backend changes and breaks the offer/venue data model, we only see the issue after deploying to staging, but we think that the risk is low enough, so it is negligible.