### PR TITLE
(PC-23134) feat(video): add the possibility to set video module offers by ID

### DIFF
--- a/src/features/home/components/modules/video/VideoModule.tsx
+++ b/src/features/home/components/modules/video/VideoModule.tsx
@@ -43,7 +43,7 @@ export const VideoModule: FunctionComponent<VideoModuleProps> = (props) => {
   } = useModal(false)
   const videoDuration = `${props.durationInMinutes} min`
 
-  const { offers } = useVideoOffers(props.offersModuleParameters, props.id)
+  const { offers } = useVideoOffers(props.offersModuleParameters, props.id, props.offerIds)
 
   const shouldModuleBeDisplayed = offers.length > 0
   const isMultiOffer = offers.length > 1

--- a/src/features/home/fixtures/videoModule.fixture.ts
+++ b/src/features/home/fixtures/videoModule.fixture.ts
@@ -20,4 +20,5 @@ export const videoModuleFixture: VideoModule = {
   videoPublicationDate: '2023-06-16',
   videoDescription:
     'Lujipeka répond à vos questions sur sa tournée, sa musique, ses inspirations et pleins d’autres questions&nbsp;!',
+  offerIds: ['12345', '67890'],
 }

--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -253,6 +253,7 @@ export type VideoModule = {
   offerTitle: string
   videoDescription: string
   videoPublicationDate: string
+  offerIds: string[]
 }
 
 export type OfferModuleParamsInfo = {

--- a/src/libs/contentful/adapters/modules/adaptVideoModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptVideoModule.ts
@@ -26,5 +26,6 @@ export const adaptVideoModule = (module: VideoContentModel): VideoModule | null 
     offerTitle: module.fields.offerTitle,
     videoDescription: module.fields.videoDescription,
     videoPublicationDate: module.fields.videoPublicationDate,
+    offerIds: module.fields.offerIds,
   }
 }

--- a/src/libs/contentful/fixtures/videoContentModel.fixture.ts
+++ b/src/libs/contentful/fixtures/videoContentModel.fixture.ts
@@ -119,5 +119,6 @@ export const videoContentModelFixture: VideoContentModel = {
     videoDescription:
       'Lujipeka répond à vos questions sur sa tournée, sa musique, ses inspirations et pleins d’autres questions&nbsp;!',
     videoPublicationDate: '2023-06-16',
+    offerIds: ['12345', '67890'],
   },
 }

--- a/src/libs/contentful/types.ts
+++ b/src/libs/contentful/types.ts
@@ -184,6 +184,7 @@ type VideoFields = {
   offerTitle: string
   videoDescription: string
   videoPublicationDate: string
+  offerIds: string[]
 }
 
 export type Cover = Entry<CoverFields, ContentTypes.INFORMATION>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-23134

On ré-utilise `fetchOfferHits` qui permet déjà de faire des requêtes d'offres par id.
Côté Contentful le champ ID d'offres accepte une liste d'IDs
Si le champ est complété la playlist sera ignorée.
L'affichage du composant vidéo mono ou multi-offre est conditionné au nombre d'offres que l'on récupère suite à la requête Algolia (fonctionnement idem que pour le cas d'une playlist) 

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

| Platform         | Mono-offer | Multi-offer |
| :--------------- | :----: | :---: |
| iOS |<img width="1512" alt="Capture d’écran 2023-07-17 à 14 00 48" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/1be5fd31-ad50-4f58-8c22-93b3670a9987">|<img width="1512" alt="Capture d’écran 2023-07-17 à 14 00 08" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/2c3a1b08-bd3b-4ca3-bdee-c2e26856f2dd">|