### PR TITLE
(PC-23326) fix(video): fix swipe and scroll inside modale + design

### DIFF
--- a/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
@@ -621,6 +621,16 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
                 </View>
               </View>
             </View>
+            <View
+              numberOfSpaces={8}
+              style={
+                Array [
+                  Object {
+                    "height": 32,
+                  },
+                ]
+              }
+            />
           </View>
         </RCTScrollView>
         <View

--- a/src/features/home/components/modules/video/VideoModal.tsx
+++ b/src/features/home/components/modules/video/VideoModal.tsx
@@ -104,12 +104,15 @@ export const VideoModal: React.FC<VideoModalProps> = (props) => {
             analyticsParams={analyticsParams}
           />
         ) : (
-          <VideoMonoOfferTile
-            offer={props.offers[0]}
-            color={props.color}
-            hideModal={props.hideModal}
-            analyticsParams={analyticsParams}
-          />
+          <React.Fragment>
+            <VideoMonoOfferTile
+              offer={props.offers[0]}
+              color={props.color}
+              hideModal={props.hideModal}
+              analyticsParams={analyticsParams}
+            />
+            <Spacer.Column numberOfSpaces={8} />
+          </React.Fragment>
         )}
       </StyledScrollView>
       <StyledTouchable onPress={onPressCloseModal} accessibilityLabel="Fermer la modale vidéo">

--- a/src/features/home/components/modules/video/VideoMultiOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMultiOfferTile.tsx
@@ -59,7 +59,7 @@ export const VideoMultiOfferTile: FunctionComponent<Props> = ({
           withStroke
         />
         <Spacer.Column numberOfSpaces={2} />
-        <TitleText numberOfLines={1}>{offer.offer.name}</TitleText>
+        <Typo.Caption numberOfLines={1}>{offer.offer.name}</Typo.Caption>
         <AdditionalInfoText>{labelMapping[offer.offer.subcategoryId]}</AdditionalInfoText>
         {!!displayPrice && <AdditionalInfoText>{displayPrice}</AdditionalInfoText>}
       </StyledTouchableLink>
@@ -76,11 +76,6 @@ const StyledTouchableLink = styled(InternalTouchableLink)(({ theme }) => ({
   width: theme.tiles.sizes['large'].width,
 }))
 
-const TitleText = styled(Typo.Caption)({
-  marginBottom: getSpacing(1),
-})
-
 const AdditionalInfoText = styled(Typo.Caption)(({ theme }) => ({
   color: theme.colors.greyDark,
-  marginBottom: getSpacing(1),
 }))

--- a/src/ui/components/modals/AppModal.tsx
+++ b/src/ui/components/modals/AppModal.tsx
@@ -48,6 +48,7 @@ type Props = {
   children: React.ReactNode
   onSwipe?: () => void
   swipeDirection?: ModalSwipeDirection
+  propagateSwipe?: boolean
 } & ModalIconProps
 
 // Without this, the margin is recomputed with arbitrary values
@@ -85,6 +86,7 @@ export const AppModal: FunctionComponent<Props> = ({
   isUpToStatusBar,
   onSwipe,
   swipeDirection,
+  propagateSwipe,
 }) => {
   const iconProps = {
     rightIconAccessibilityLabel,
@@ -208,7 +210,8 @@ export const AppModal: FunctionComponent<Props> = ({
       accessibilityModal
       onModalHide={onModalHide}
       onSwipeComplete={onSwipe}
-      swipeDirection={swipeDirection}>
+      swipeDirection={swipeDirection}
+      propagateSwipe={propagateSwipe}>
       <ModalContainer
         height={maxHeight ? undefined : modalContainerHeight}
         testID="modalContainer"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-23326

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS - fix scroll  |https://github.com/pass-culture/pass-culture-app-native/assets/47600889/d1deae7a-54c3-4a10-a42b-d5ad5e0c3051|https://github.com/pass-culture/pass-culture-app-native/assets/47600889/230548df-1760-49c3-bb9b-4f1cfd7bfb5f|
| Android - fix scroll  |    --    |[after_android.webm](https://github.com/pass-culture/pass-culture-app-native/assets/47600889/68409a43-d8a2-4f4b-bf8e-e8393571acf6)|
| iOS - fix tile  |![before_tile](https://github.com/pass-culture/pass-culture-app-native/assets/47600889/35b71021-1d86-4ac6-913f-444974b18c02)|![after_tile](https://github.com/pass-culture/pass-culture-app-native/assets/47600889/64042862-43a5-4737-a843-87287a3b3735)|
| web - add spacer   |<img width="1512" alt="spacer_before" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/46b88f4d-ce22-4f58-8c6b-e41092c184cd">|<img width="1512" alt="spacer_after" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/6ae1f6fc-ea0e-4fe2-b393-f0b00f9e0861">|


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
