### PR TITLE
(PC-23167) feat(HomeModule): add a feature flag for future new exclusivity block 

### DIFF
--- a/src/features/home/components/modules/HomeModule.native.test.tsx
+++ b/src/features/home/components/modules/HomeModule.native.test.tsx
@@ -1,0 +1,52 @@
+import { rest } from 'msw'
+import React from 'react'
+
+import { OfferResponse } from 'api/gen'
+import { formattedExclusivityModule } from 'features/home/fixtures/homepage.fixture'
+import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
+import { env } from 'libs/environment'
+import * as useFeatureFlag from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { server } from 'tests/server'
+import { render, screen, waitFor } from 'tests/utils'
+
+import { HomeModule } from './HomeModule'
+
+const index = 1
+const homeEntryId = '7tfixfH64pd5TMZeEKfNQ'
+
+const useFeatureFlagSpy = jest.spyOn(useFeatureFlag, 'useFeatureFlag')
+
+describe('<HomeModule />', () => {
+  it('should display old exclusivity module when feature flag is false', async () => {
+    server.use(
+      rest.get<OfferResponse>(`${env.API_BASE_URL}/native/v1/offer/123456789`, (_req, res, ctx) =>
+        res.once(ctx.status(200), ctx.json(offerResponseSnap))
+      )
+    )
+    useFeatureFlagSpy.mockReturnValueOnce(false)
+    renderHomeModule()
+
+    // we need to use findAllByLabelText because 'Week-end FRAC' is assigned twice
+    // in alt property for image and touchable link
+    expect(await screen.findAllByLabelText('Week-end FRAC')).toBeTruthy()
+  })
+
+  it('should not display old exclusivity module when feature flag is true', async () => {
+    useFeatureFlagSpy.mockReturnValueOnce(true)
+    renderHomeModule()
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Week-end FRAC')).toBeNull()
+    })
+  })
+})
+
+function renderHomeModule() {
+  return render(
+    // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+    reactQueryProviderHOC(
+      <HomeModule item={formattedExclusivityModule} index={index} homeEntryId={homeEntryId} />
+    )
+  )
+}

--- a/src/features/home/components/modules/HomeModule.tsx
+++ b/src/features/home/components/modules/HomeModule.tsx
@@ -22,6 +22,8 @@ import {
   isVideoModule,
   ModuleData,
 } from 'features/home/types'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 
 const UnmemoizedModule = ({
   item,
@@ -36,6 +38,10 @@ const UnmemoizedModule = ({
   data?: ModuleData
   videoModuleId?: string
 }) => {
+  const enableNewExclusivityBlock = useFeatureFlag(
+    RemoteStoreFeatureFlags.WIP_ENABLE_NEW_EXCLUSIVITY_BLOCK
+  )
+
   if (isOffersModule(item)) {
     return (
       <OffersModule
@@ -72,7 +78,7 @@ const UnmemoizedModule = ({
       />
     )
   }
-  if (isExclusivityModule(item)) {
+  if (isExclusivityModule(item) && !enableNewExclusivityBlock) {
     return (
       <ExclusivityModule
         moduleId={item.id}

--- a/src/libs/firebase/firestore/featureFlags/getFeatureFlag.native.test.ts
+++ b/src/libs/firebase/firestore/featureFlags/getFeatureFlag.native.test.ts
@@ -14,6 +14,7 @@ describe('getFeatureFlag', () => {
     RemoteStoreFeatureFlags.WIP_DISABLE_STORE_REVIEW,
     RemoteStoreFeatureFlags.WIP_ENABLE_MULTIVENUE_OFFER,
     RemoteStoreFeatureFlags.WIP_ENABLE_TRUSTED_DEVICE,
+    RemoteStoreFeatureFlags.WIP_ENABLE_NEW_EXCLUSIVITY_BLOCK,
     RemoteStoreFeatureFlags.WIP_PRICES_BY_CATEGORIES,
     RemoteStoreFeatureFlags.WIP_STEPPER_RETRY_UBBLE,
   ])(

--- a/src/libs/firebase/firestore/featureFlags/useFeatureFlag.native.test.ts
+++ b/src/libs/firebase/firestore/featureFlags/useFeatureFlag.native.test.ts
@@ -17,6 +17,7 @@ describe.each([
   RemoteStoreFeatureFlags.WIP_DISABLE_STORE_REVIEW,
   RemoteStoreFeatureFlags.WIP_ENABLE_MULTIVENUE_OFFER,
   RemoteStoreFeatureFlags.WIP_ENABLE_TRUSTED_DEVICE,
+  RemoteStoreFeatureFlags.WIP_ENABLE_NEW_EXCLUSIVITY_BLOCK,
   RemoteStoreFeatureFlags.WIP_PRICES_BY_CATEGORIES,
   RemoteStoreFeatureFlags.WIP_STEPPER_RETRY_UBBLE,
 ])('useFeatureFlag %s', (featureFlag: RemoteStoreFeatureFlags) => {

--- a/src/libs/firebase/firestore/types.ts
+++ b/src/libs/firebase/firestore/types.ts
@@ -21,6 +21,7 @@ export enum RemoteStoreFeatureFlags {
   WIP_CHANGE_EMAIL = 'wipChangeEmail',
   WIP_ENABLE_MULTIVENUE_OFFER = 'wipEnableMultivenueOffer',
   WIP_ENABLE_TRUSTED_DEVICE = 'wipEnableTrustedDevice',
+  WIP_ENABLE_NEW_EXCLUSIVITY_BLOCK = 'wipEnableNewExclusivityBlock',
   WIP_PRICES_BY_CATEGORIES = 'wipPricesByCategories',
   WIP_STEPPER_RETRY_UBBLE = 'wipStepperRetryUbble',
   WIP_ATTRIBUTES_CINEMA_OFFERS = 'wipAttributesCinemaOffers',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-23167

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

feature flag (en v260) pour simuler le nouveau bloc exclu non sorti -> affichage de l'actuel bloc exclu :
https://github.com/pass-culture/pass-culture-app-native/assets/131354212/e8120aa4-ee77-4fda-a83c-f5b5c5bbf6af

feature flag (en v220) pour simuler l'arriver du nouveau bloc exclu -> non affichage de l'actuel bloc exclu :
https://github.com/pass-culture/pass-culture-app-native/assets/131354212/92caf8f1-beb2-4730-86d4-33d63c71ee9b

les features flags (v260) en testing, staging et prod :
https://github.com/pass-culture/pass-culture-app-native/assets/131354212/1cd9903a-9a69-4279-8b34-ffbf333fa6b6
