### PR TITLE
(BSR) fix(profileStep): make sure we put profile information in subscription contexte before calling API

### DIFF
--- a/src/features/identityCheck/pages/profile/SetStatus.tsx
+++ b/src/features/identityCheck/pages/profile/SetStatus.tsx
@@ -70,7 +70,9 @@ export const SetStatus = () => {
   const submitStatus = useCallback(
     async (formValues: StatusForm) => {
       if (!formValues.selectedStatus) return
-      dispatch({ type: 'SET_STATUS', payload: formValues.selectedStatus })
+      // do not remove await statement here as we need to wait for status to be dispatched
+      // in subscription context before posting profile to the api
+      await dispatch({ type: 'SET_STATUS', payload: formValues.selectedStatus })
       analytics.logSetStatusClicked()
 
       if (hasSchoolTypes) {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

Avant:

https://github.com/pass-culture/pass-culture-app-native/assets/22886846/e628fe58-cfee-4fd6-bcc4-6d8c3c425adf

Après:

https://github.com/pass-culture/pass-culture-app-native/assets/22886846/c643fe01-4474-4d94-98e1-8aaf8c238c41




[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
