### PR TITLE
(PC-23426) feat(offer): added label for free offer

### DIFF
--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -181,13 +181,24 @@ export const Offer: FunctionComponent = () => {
       {!!wording && (
         <React.Fragment>
           <CallToActionContainer testID="CTA-button">
-            <CTAButton
-              wording={wording}
-              onPress={onPress}
-              navigateTo={navigateTo}
-              externalNav={externalNav}
-              isDisabled={isDisabled}
-            />
+            {offerResponse.stocks[0].price === 0 ? (
+              <ButtonWithLinearGradient
+                wording={wording + 'héhé'} // have to put an icon before the wording :(
+                onPress={onPress}
+                navigateTo={navigateTo}
+                externalNav={externalNav}
+                isDisabled={isDisabled}
+              />
+            ) : (
+              <CTAButton
+                wording={wording}
+                onPress={onPress}
+                navigateTo={navigateTo}
+                externalNav={externalNav}
+                isDisabled={isDisabled}
+              />
+            )}
+
             <Spacer.Column numberOfSpaces={bottomBannerText ? 4.5 : 6} />
           </CallToActionContainer>
           {bottomBannerText ? <BottomBanner text={bottomBannerText} /> : <Spacer.BottomScreen />}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-23426

J'ai ajouté les méthodes de fetch manquantes ainsi que le wording du bouton.
J'aurai aimé corriger la façon dont c'est fait. Aujourd'hui `useCtaWordingAndAction` fait juste quelques fetch et passe ensuite le résultat à `getCtaWordingAndAction`. Autant je peux parfois être d'accord sur cette méthode, autant là ça fait le bordel. J'aurai aimé nettoyer un peu tout ça.

Le gros point manquant à l'heure actuelle c'est qu'il manque l'icône <img width="102" alt="CleanShot 2023-07-28 at 17 15 33@2x" src="https://github.com/pass-culture/pass-culture-app-native/assets/114916654/4883ed91-ca70-4fc2-838f-97836eeb38ce"> et c'est pas simple à insérer vu qu'on a déjà des `if` de partout...

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
