### PR TITLE
(PC-21416) fix(statusBar): flex the container of Profile page

### DIFF
--- a/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
@@ -69,7 +69,17 @@ exports[`Profile component should render correctly 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+          >
             <RCTScrollView
               bounces={false}
               onScroll={[Function]}

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -1,7 +1,7 @@
 import { useFocusEffect } from '@react-navigation/native'
 import debounce from 'lodash/debounce'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { NativeScrollEvent, Platform, ScrollView, View } from 'react-native'
+import { NativeScrollEvent, Platform, ScrollView } from 'react-native'
 import styled from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -114,7 +114,7 @@ const OnlineProfile: React.FC = () => {
   }, [])
 
   return (
-    <View>
+    <Container>
       <ScrollView
         bounces={false}
         ref={scrollViewRef}
@@ -261,7 +261,7 @@ const OnlineProfile: React.FC = () => {
         </ProfileContainer>
       </ScrollView>
       <StatusBarBlurredBackground />
-    </View>
+    </Container>
   )
 }
 
@@ -272,6 +272,8 @@ export const Profile: React.FC = () => {
   }
   return <OfflinePage />
 }
+
+const Container = styled.View({ flex: 1 })
 
 const paddingVertical = getSpacing(4)
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-21416

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              | <img width="353" alt="Capture d’écran 2023-08-01 à 12 06 38" src="https://github.com/pass-culture/pass-culture-app-native/assets/131354212/81514448-d660-4b05-a234-019df65defc3"> | <img width="350" alt="Capture d’écran 2023-08-01 à 12 05 32" src="https://github.com/pass-culture/pass-culture-app-native/assets/131354212/6f06a046-d011-40de-8138-bcbcfd9602ac"> |
| Android          | <img width="334" alt="Capture d’écran 2023-08-01 à 12 07 58" src="https://github.com/pass-culture/pass-culture-app-native/assets/131354212/1d78fbf3-35ba-449d-807d-110a200c3f20"> | <img width="333" alt="Capture d’écran 2023-08-01 à 12 05 40" src="https://github.com/pass-culture/pass-culture-app-native/assets/131354212/c3770c8b-c4ad-4f62-bcc5-80bdb1ca737a"> |
| Desktop - Firefox | <img width="1024" alt="Capture d’écran 2023-08-01 à 12 06 17" src="https://github.com/pass-culture/pass-culture-app-native/assets/131354212/1f7ef342-36b6-41b8-aacb-0d88554c34a0"> | <img width="1024" alt="Capture d’écran 2023-08-01 à 12 05 56" src="https://github.com/pass-culture/pass-culture-app-native/assets/131354212/36364a1d-ae5b-456e-95d2-b11b89133ea9"> |
