### PR TITLE
(PC-23231) feat(Module): add grey background on Video Thumbnail and Highlight Image for accessibility

### DIFF
--- a/src/features/home/components/modules/HighlightOfferModule.tsx
+++ b/src/features/home/components/modules/HighlightOfferModule.tsx
@@ -151,6 +151,7 @@ const OfferImage = styled.ImageBackground(({ theme }) => ({
   height: OFFER_IMAGE_HEIGHT,
   border: 1,
   borderColor: theme.colors.greyMedium,
+  backgroundColor: theme.colors.greyLight,
   ...(theme.isDesktopViewport ? getOfferImageDesktopStyle(theme) : getOfferImageMobileStyle(theme)),
 }))
 

--- a/src/features/home/components/modules/video/VideoModuleDesktop.tsx
+++ b/src/features/home/components/modules/video/VideoModuleDesktop.tsx
@@ -126,6 +126,7 @@ const Thumbnail = styled(ImageBackground)(({ theme }) => ({
   flex: 1,
   border: 1,
   borderColor: theme.colors.greyMedium,
+  backgroundColor: theme.colors.greyLight,
 }))
 
 const DurationCaption = styled(BlackCaption)({

--- a/src/features/home/components/modules/video/VideoModuleDesktop.tsx
+++ b/src/features/home/components/modules/video/VideoModuleDesktop.tsx
@@ -59,8 +59,9 @@ export const VideoModuleDesktop: FunctionComponent<VideoModuleProps> = (props) =
           <StyledTouchableHighlight
             onPress={props.showVideoModal}
             testID="video-thumbnail"
-            accessibilityRole="button">
-            <Thumbnail source={{ uri: props.videoThumbnail }} isMultiOffer={props.isMultiOffer}>
+            accessibilityRole="button"
+            isMultiOffer={props.isMultiOffer}>
+            <Thumbnail source={{ uri: props.videoThumbnail }}>
               <DurationCaption label={videoDuration} />
               <TextContainer>
                 <BlackGradient />
@@ -117,15 +118,12 @@ const VideoOfferContainer = styled.View(({ theme }) => ({
   height: '100%',
 }))
 
-const Thumbnail = styled(ImageBackground)<{
-  isMultiOffer: boolean
-}>(({ theme, isMultiOffer }) => ({
+const Thumbnail = styled(ImageBackground)(({ theme }) => ({
   // the overflow: hidden allow to add border radius to the image
   // https://stackoverflow.com/questions/49442165/how-do-you-add-borderradius-to-imagebackground/57616397
   overflow: 'hidden',
   borderRadius: theme.borderRadius.radius,
-  height: isMultiOffer ? THUMBNAIL_HEIGHT_MULTI_OFFER : THUMBNAIL_HEIGHT_MONO_OFFER,
-  width: isMultiOffer ? THUMBNAIL_WIDTH_MULTI_OFFER : THUMBNAIL_WIDTH_MONO_OFFER,
+  flex: 1,
   border: 1,
   borderColor: theme.colors.greyMedium,
 }))
@@ -182,8 +180,10 @@ const VideoTitle = styled(Typo.Title4)(({ theme }) => ({
 
 const StyledTouchableHighlight = styled.TouchableHighlight.attrs(({ theme }) => ({
   underlayColor: theme.colors.white,
-}))(({ theme }) => ({
+}))<{ isMultiOffer: boolean }>(({ theme, isMultiOffer }) => ({
   borderRadius: theme.borderRadius.radius,
+  height: isMultiOffer ? THUMBNAIL_HEIGHT_MULTI_OFFER : THUMBNAIL_HEIGHT_MONO_OFFER,
+  width: isMultiOffer ? THUMBNAIL_WIDTH_MULTI_OFFER : THUMBNAIL_WIDTH_MONO_OFFER,
 }))
 
 const StyledTitleContainer = styled.View(({ theme }) => ({

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -107,6 +107,7 @@ const Thumbnail = styled.ImageBackground(({ theme }) => ({
   width: '100%',
   border: 1,
   borderColor: theme.colors.greyMedium,
+  backgroundColor: theme.colors.greyLight,
 }))
 
 const DurationCaption = styled(BlackCaption)({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-23231

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

VideoModule et HighlightModule, image enlever manuellement :
https://github.com/pass-culture/pass-culture-app-native/assets/131354212/929b3eae-2afa-4e86-976f-21256855b950

HighlightModule, tester avec simulateur de connexion:
https://github.com/pass-culture/pass-culture-app-native/assets/131354212/273a0921-4420-42a3-bea3-2115033a4bb5

VideoModule, au clic:
https://github.com/pass-culture/pass-culture-app-native/assets/131354212/eb0232bd-9023-4f0d-ac6c-15ec9d45a508

Version Web Vidéo Module:
<img width="1035" alt="Capture d’écran 2023-08-04 à 11 01 42" src="https://github.com/pass-culture/pass-culture-app-native/assets/131354212/d232a213-b210-49a9-94d5-05d4457a315b">
