### PR TITLE
(PC-23688) fix(home): fix video mono offer and hightlight blocks design

### DIFF
--- a/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
@@ -601,8 +601,8 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
                 }
               >
                 <View
-                  height={20}
-                  width={20}
+                  height={24}
+                  width={24}
                 >
                   <Text>
                     undefined-SVG-Mock

--- a/src/features/home/components/modules/HighlightOfferModule.tsx
+++ b/src/features/home/components/modules/HighlightOfferModule.tsx
@@ -10,6 +10,7 @@ import { HighlightOfferModule as HighlightOfferModuleProps } from 'features/home
 import { formatDates, getDisplayPrice } from 'libs/parsers'
 import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
+import { theme } from 'theme'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
 import { Spacer, Typo, getSpacing } from 'ui/theme'
@@ -85,7 +86,7 @@ const UnmemoizedHighlightOfferModule = (props: HighlightOfferModuleProps) => {
               {!!formattedPrice && <AdditionalDetail>{formattedPrice}</AdditionalDetail>}
             </OfferDetails>
             <ArrowOffer>
-              <PlainArrowNext />
+              <PlainArrowNext size={theme.icons.sizes.small} />
             </ArrowOffer>
           </TouchableContent>
         </StyledTouchableLink>

--- a/src/features/home/components/modules/video/VideoModuleDesktop.tsx
+++ b/src/features/home/components/modules/video/VideoModuleDesktop.tsx
@@ -197,6 +197,7 @@ const StyledTitleComponent = styled(Typo.Title3).attrs({
 })({})
 
 const StyledVideoMonoOfferTile = styled(VideoMonoOfferTile)({
+  flex: 1,
   flexGrow: 1,
 })
 

--- a/src/features/home/components/modules/video/VideoModuleDesktop.tsx
+++ b/src/features/home/components/modules/video/VideoModuleDesktop.tsx
@@ -20,7 +20,8 @@ import { Spacer, Typo, getSpacing } from 'ui/theme'
 
 const THUMBNAIL_HEIGHT_MULTI_OFFER = getSpacing(90)
 const THUMBNAIL_HEIGHT_MONO_OFFER = getSpacing(45)
-const THUMBNAIL_WIDTH = getSpacing(132)
+const THUMBNAIL_WIDTH_MULTI_OFFER = getSpacing(132)
+const THUMBNAIL_WIDTH_MONO_OFFER = getSpacing(82)
 // We do not center the player icon for mono offer, because when the title is 2-line long,
 // the title is to close to the player. So the player is closer to the top.
 const PLAYER_TOP_MARGIN = getSpacing(12.5)
@@ -124,7 +125,7 @@ const Thumbnail = styled(ImageBackground)<{
   overflow: 'hidden',
   borderRadius: theme.borderRadius.radius,
   height: isMultiOffer ? THUMBNAIL_HEIGHT_MULTI_OFFER : THUMBNAIL_HEIGHT_MONO_OFFER,
-  width: THUMBNAIL_WIDTH,
+  width: isMultiOffer ? THUMBNAIL_WIDTH_MULTI_OFFER : THUMBNAIL_WIDTH_MONO_OFFER,
   border: 1,
   borderColor: theme.colors.greyMedium,
 }))

--- a/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
@@ -80,7 +80,7 @@ export const VideoMonoOfferTile: FunctionComponent<Props> = ({
         </OfferInformations>
       </Row>
       <ArrowOffer>
-        <PlainArrowNext />
+        <PlainArrowNext size={theme.icons.sizes.small} />
       </ArrowOffer>
     </OfferInsert>
   )


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-23688

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Bloc exlu - web          |<img width="1076" alt="before_exclu" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/31c42dbe-59db-4dd7-9745-15bc81449a7d">|<img width="1069" alt="after_exclu" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/ecee5c42-a115-45f9-8bde-4d362e6cf1d1">|
| Video mono - web   |<img width="1080" alt="before_video_mono" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/9037f872-519a-44c4-ad81-22e15a2cbefd">|<img width="1069" alt="after_video_mono" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/3adbf13a-c3f4-4c9d-9dc5-4e078ad51625">|
| Title video 2 lines - web  |<img width="1062" alt="before_title" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/e1c5cf10-007e-4890-988d-dbb0f580b101">|<img width="1086" alt="Capture d’écran 2023-08-03 à 17 25 04" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/2a920de0-3606-4da8-92cd-a3277ce574f0">|
| Title video 3 lines - web |<img width="1062" alt="before_title" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/e1c5cf10-007e-4890-988d-dbb0f580b101">|<img width="1064" alt="Capture d’écran 2023-08-03 à 17 24 29" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/2e8e7bb1-39fe-4871-8b14-48031281e246">|
