### PR TITLE
(PC-23707) fix(booking): display cancel button when it's an offer to archieve and it's not free

### DIFF
--- a/src/features/bookings/components/BookingDetailsCancelButton.native.test.tsx
+++ b/src/features/bookings/components/BookingDetailsCancelButton.native.test.tsx
@@ -25,16 +25,16 @@ describe('<BookingDetailsCancelButton />', () => {
     booking.activationCode = {
       code: 'someCode',
     }
-    const { queryByTestId } = renderBookingDetailsCancelButton(booking)
-    expect(queryByTestId('Terminer')).toBeTruthy()
+    renderBookingDetailsCancelButton(booking)
+    expect(screen.getByTestId('Terminer')).toBeTruthy()
   })
 
   it('should display button if confirmationDate is null', () => {
     const booking = { ...bookingsSnap.ongoing_bookings[0] }
     booking.confirmationDate = null
     booking.stock.offer.isDigital = false
-    const { queryByTestId } = renderBookingDetailsCancelButton(booking)
-    expect(queryByTestId('Annuler ma réservation')).toBeTruthy()
+    renderBookingDetailsCancelButton(booking)
+    expect(screen.getByTestId('Annuler ma réservation')).toBeTruthy()
   })
 
   it('should display button if confirmation date is not expired', () => {
@@ -43,8 +43,8 @@ describe('<BookingDetailsCancelButton />', () => {
     date.setDate(date.getDate() + 1)
     booking.confirmationDate = date.toISOString()
     booking.stock.offer.isDigital = false
-    const { queryByTestId } = renderBookingDetailsCancelButton(booking)
-    expect(queryByTestId('Annuler ma réservation')).toBeTruthy()
+    renderBookingDetailsCancelButton(booking)
+    expect(screen.getByTestId('Annuler ma réservation')).toBeTruthy()
   })
 
   it('should not display button if confirmation date is expired', async () => {
@@ -52,8 +52,8 @@ describe('<BookingDetailsCancelButton />', () => {
     booking.stock.offer.isPermanent = false
     booking.confirmationDate = '2020-03-15T23:01:37.925926'
     booking.stock.offer.isDigital = false
-    const { queryByTestId } = renderBookingDetailsCancelButton(booking)
-    expect(queryByTestId('Annuler ma réservation')).toBeNull()
+    renderBookingDetailsCancelButton(booking)
+    expect(screen.queryByTestId('Annuler ma réservation')).toBeNull()
   })
 
   it('should call onCancel', () => {
@@ -63,10 +63,10 @@ describe('<BookingDetailsCancelButton />', () => {
     booking.confirmationDate = date.toISOString()
     booking.stock.offer.isDigital = false
     const onCancel = jest.fn()
-    const { getByTestId } = renderBookingDetailsCancelButton(booking, {
+    renderBookingDetailsCancelButton(booking, {
       onCancel,
     })
-    const button = getByTestId('Annuler ma réservation')
+    const button = screen.getByTestId('Annuler ma réservation')
     fireEvent.press(button)
 
     expect(onCancel).toHaveBeenCalledTimes(1)
@@ -76,10 +76,10 @@ describe('<BookingDetailsCancelButton />', () => {
     const booking = { ...bookingsSnap.ongoing_bookings[0], activationCode: { code: 'someCode' } }
     booking.stock.offer.isDigital = false
     const onTerminate = jest.fn()
-    const { getByTestId } = renderBookingDetailsCancelButton(booking, {
+    renderBookingDetailsCancelButton(booking, {
       onTerminate,
     })
-    const button = getByTestId('Terminer')
+    const button = screen.getByTestId('Terminer')
     fireEvent.press(button)
 
     expect(onTerminate).toHaveBeenCalledTimes(1)
@@ -89,9 +89,9 @@ describe('<BookingDetailsCancelButton />', () => {
     const booking = { ...bookingsSnap.ongoing_bookings[0] }
     booking.confirmationDate = '2020-11-01T00:00:00Z'
     booking.stock.offer.isDigital = false
-    const { queryByText } = renderBookingDetailsCancelButton(booking)
+    renderBookingDetailsCancelButton(booking)
     expect(
-      queryByText(
+      screen.getByText(
         'Tu ne peux plus annuler ta réservation\u00a0: elle devait être annulée avant le\u00a01 novembre 2020'
       )
     ).toBeTruthy()
@@ -102,9 +102,9 @@ describe('<BookingDetailsCancelButton />', () => {
     booking.confirmationDate = '2020-11-01T00:00:00Z'
     booking.stock.offer.isDigital = false
     mockedisUserExBeneficiary.mockReturnValueOnce(true)
-    const { queryByText } = renderBookingDetailsCancelButton(booking)
+    renderBookingDetailsCancelButton(booking)
     expect(
-      queryByText(
+      screen.getByText(
         'Ton crédit est expiré.\nTu ne peux plus annuler ta réservation\u00a0: elle devait être annulée avant le 1 novembre 2020'
       )
     ).toBeTruthy()
@@ -115,41 +115,76 @@ describe('<BookingDetailsCancelButton />', () => {
     booking.confirmationDate = null
     booking.stock.offer.isDigital = true
 
-    const { queryByTestId, queryByText } = renderBookingDetailsCancelButton(booking)
+    renderBookingDetailsCancelButton(booking)
     const expirationDateMessage = 'Ta réservation sera archivée le 17/03/2021'
 
-    expect(queryByTestId('Annuler ma réservation')).toBeTruthy()
-    expect(queryByText(expirationDateMessage)).toBeTruthy()
+    expect(screen.getByTestId('Annuler ma réservation')).toBeTruthy()
+    expect(screen.getByText(expirationDateMessage)).toBeTruthy()
   })
 
   it('should display only an expiration date message when the booking is digital and is not still cancellable', () => {
     const booking = { ...bookingsSnap.ongoing_bookings[0] }
     booking.confirmationDate = '2020-11-01T00:00:00Z'
 
-    const { queryByText } = renderBookingDetailsCancelButton(booking)
+    renderBookingDetailsCancelButton(booking)
     const expirationDateMessage =
       'Tu ne peux plus annuler ta réservation. Elle expirera automatiquement le 17/03/2021'
 
-    expect(queryByText(expirationDateMessage)).toBeTruthy()
+    expect(screen.getByText(expirationDateMessage)).toBeTruthy()
   })
 
   it('should not display any message if there is no confirmation date', () => {
     const booking = { ...bookingsSnap.ongoing_bookings[0] }
     booking.confirmationDate = null
 
-    const { queryByTestId } = renderBookingDetailsCancelButton(booking)
-    expect(queryByTestId('cancel-annulation-message')).toBeNull()
+    renderBookingDetailsCancelButton(booking)
+    expect(screen.queryByTestId('cancel-annulation-message')).toBeNull()
   })
 
-  it("should display expiration date message and not display cancel button when it's a free physical offer", () => {
-    const booking = { ...bookingsSnap.ongoing_bookings[0] }
-    booking.confirmationDate = null
-    booking.stock.offer.isDigital = false
-    booking.stock.offer.subcategoryId = SubcategoryIdEnum.ABO_MUSEE
+  describe("When it's an offer category to archieve and it's not free", () => {
+    it('should not display expiration date message', () => {
+      const booking = { ...bookingsSnap.ongoing_bookings[0] }
+      booking.confirmationDate = null
+      booking.stock.offer.isDigital = false
+      booking.stock.offer.subcategoryId = SubcategoryIdEnum.ABO_MUSEE
 
-    renderBookingDetailsCancelButton(booking)
-    expect(screen.queryByTestId('Annuler ma réservation')).toBeFalsy()
-    expect(screen.queryByText('Ta réservation sera archivée le 17/03/2021')).toBeTruthy()
+      renderBookingDetailsCancelButton(booking)
+      expect(screen.queryByText('Ta réservation sera archivée le 17/03/2021')).toBeNull()
+    })
+
+    it('should display cancel button', () => {
+      const booking = { ...bookingsSnap.ongoing_bookings[0] }
+      booking.confirmationDate = null
+      booking.stock.offer.isDigital = false
+      booking.stock.offer.subcategoryId = SubcategoryIdEnum.ABO_MUSEE
+
+      renderBookingDetailsCancelButton(booking)
+      expect(screen.getByTestId('Annuler ma réservation')).toBeTruthy()
+    })
+  })
+
+  describe("When it's a free offer category to archieve", () => {
+    it('should display expiration date message', () => {
+      const booking = { ...bookingsSnap.ongoing_bookings[0] }
+      booking.confirmationDate = null
+      booking.stock.offer.isDigital = false
+      booking.stock.offer.subcategoryId = SubcategoryIdEnum.ABO_MUSEE
+      booking.stock.price = 0
+
+      renderBookingDetailsCancelButton(booking)
+      expect(screen.getByText('Ta réservation sera archivée le 17/03/2021')).toBeTruthy()
+    })
+
+    it('should not display cancel button', () => {
+      const booking = { ...bookingsSnap.ongoing_bookings[0] }
+      booking.confirmationDate = null
+      booking.stock.offer.isDigital = false
+      booking.stock.offer.subcategoryId = SubcategoryIdEnum.ABO_MUSEE
+      booking.stock.price = 0
+
+      renderBookingDetailsCancelButton(booking)
+      expect(screen.queryByTestId('Annuler ma réservation')).toBeNull()
+    })
   })
 })
 

--- a/src/features/bookings/components/BookingDetailsCancelButton.tsx
+++ b/src/features/bookings/components/BookingDetailsCancelButton.tsx
@@ -30,9 +30,9 @@ export const BookingDetailsCancelButton = (props: BookingDetailsCancelButtonProp
   const isExBeneficiary = user && isUserExBeneficiary(user)
   const remainingDays = formattedExpirationDate(booking.dateCreated)
   const isDigitalBooking = booking.stock.offer.isDigital === true && !booking.expirationDate
-  const isFreeOfferToArchive = FREE_OFFER_CATEGORIES_TO_ARCHIVE.includes(
-    booking.stock.offer.subcategoryId
-  )
+  const isFreeOfferToArchive =
+    FREE_OFFER_CATEGORIES_TO_ARCHIVE.includes(booking.stock.offer.subcategoryId) &&
+    booking.stock.price === 0
 
   const renderButton = () => {
     if (properties.hasActivationCode) {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-23707

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |![Capture d’écran 2023-08-04 à 12 46 32](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/951c9abd-a092-444a-bf0d-c5acfc4983c7)|![Capture d’écran 2023-08-04 à 12 43 51](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/fef5286d-9b46-4c5f-814b-177b26a1ee5f)|
| Android          |![Capture d’écran 2023-08-04 à 12 46 24](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/064b6a85-1946-41dc-a4ec-8d8b494900ae)|![Capture d’écran 2023-08-04 à 12 43 56](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/5d75b65b-343e-46ac-b7a2-4e8450212b3a)|
| Phone - Chrome   |<img width="412" alt="Capture d’écran 2023-08-04 à 12 46 17" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/9a81904e-d339-489b-9994-ff1402a8f1cd">|<img width="408" alt="Capture d’écran 2023-08-04 à 12 44 00" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/1b431aa4-16e0-4f4b-ac0f-8a661244bbe9">|
| Tablet - Chrome  |        |       |
| Desktop - Chrome |<img width="1727" alt="Capture d’écran 2023-08-04 à 12 44 28" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/f0d9a442-5cb6-43d7-88dc-37fb56f2e973">|<img width="1727" alt="Capture d’écran 2023-08-04 à 12 44 10" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/a25792a3-4a3d-49d2-b1eb-3c5b51aa8686">|
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
