### PR TITLE
(PC-19058) test(a11y): add a11y tests for home

### DIFF
--- a/src/features/home/components/modules/HomeModule.web.test.tsx
+++ b/src/features/home/components/modules/HomeModule.web.test.tsx
@@ -1,0 +1,187 @@
+import mockdate from 'mockdate'
+import { rest } from 'msw'
+import React from 'react'
+
+import { OfferResponse } from 'api/gen'
+import { useHighlightOffer } from 'features/home/api/useHighlightOffer'
+import { highlightOfferModuleFixture } from 'features/home/fixtures/highlightOfferModule.fixture'
+import {
+  formattedExclusivityModule,
+  formattedBusinessModule,
+  formattedCategoryListModule,
+  formattedRecommendedOffersModule,
+  formattedThematicHighlightModule,
+  formattedOffersModule,
+} from 'features/home/fixtures/homepage.fixture'
+import { HomepageModule, ModuleData } from 'features/home/types'
+import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
+import { SimilarOffersResponse } from 'features/offer/types'
+import { mockedAlgoliaResponse } from 'libs/algolia/__mocks__/mockedAlgoliaResponse'
+import { env } from 'libs/environment'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { GeoCoordinates, Position } from 'libs/geolocation'
+import { offersFixture } from 'shared/offer/offer.fixture'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { server } from 'tests/server'
+import { act, checkAccessibilityFor, render, screen } from 'tests/utils/web'
+
+import { HomeModule } from './HomeModule'
+
+const index = 1
+const homeEntryId = '7tfixfH64pd5TMZeEKfNQ'
+
+const highlightOfferFixture = offersFixture[0]
+
+jest.mock('libs/firebase/firestore/featureFlags/useFeatureFlag')
+const mockedUseFeatureFlag = useFeatureFlag as jest.Mock
+
+jest.mock('features/home/api/useHighlightOffer')
+const mockUseHighlightOffer = useHighlightOffer as jest.Mock
+const mockUseAuthContext = jest.fn().mockReturnValue({
+  user: undefined,
+  isLoggedIn: false,
+})
+
+jest.mock('features/auth/context/AuthContext', () => ({
+  useAuthContext: () => mockUseAuthContext(),
+}))
+
+const DEFAULT_POSITION: GeoCoordinates = { latitude: 2, longitude: 40 }
+const mockPosition: Position = DEFAULT_POSITION
+
+jest.mock('libs/geolocation/GeolocationWrapper', () => ({
+  useGeolocation: () => ({
+    userPosition: mockPosition,
+  }),
+}))
+
+jest.mock('features/home/api/useAlgoliaRecommendedHits', () => ({
+  useAlgoliaRecommendedHits: jest.fn(() => mockedAlgoliaResponse.hits),
+}))
+
+const defaultData: ModuleData = {
+  playlistItems: offersFixture,
+  nbPlaylistResults: 4,
+  moduleId: 'blablabla',
+}
+
+describe('<HomeModule />', () => {
+  // Test a11y rules on each module instead of testing them on the whole page
+  // because it's easier to test them one by one
+  describe('Accessibility', () => {
+    it('Exclusivity module should not have basic accessibility issues', async () => {
+      server.use(
+        rest.get<OfferResponse>(`${env.API_BASE_URL}/native/v1/offer/123456789`, (_req, res, ctx) =>
+          res.once(ctx.status(200), ctx.json(offerResponseSnap))
+        )
+      )
+      mockedUseFeatureFlag.mockReturnValueOnce(false)
+      const { container } = renderHomeModule(formattedExclusivityModule)
+
+      // we need to use findAllByLabelText because 'Week-end FRAC' is assigned twice
+      // in alt property for image and touchable link
+      expect(await screen.findAllByLabelText('Week-end FRAC')).toBeTruthy()
+
+      const results = await checkAccessibilityFor(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('Highlight module should not have basic accessibility issues', async () => {
+      mockedUseFeatureFlag.mockReturnValueOnce(true)
+      mockUseHighlightOffer.mockReturnValueOnce(highlightOfferFixture)
+
+      const { container } = renderHomeModule(highlightOfferModuleFixture)
+
+      await act(async () => {
+        expect(screen.getByText(highlightOfferModuleFixture.highlightTitle)).toBeTruthy()
+      })
+
+      const results = await checkAccessibilityFor(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('Business module should not have basic accessibility issues', async () => {
+      const { container } = renderHomeModule(formattedBusinessModule)
+
+      expect(screen.getByText('Débloque ton crédit !')).toBeTruthy()
+
+      const results = await checkAccessibilityFor(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('CategoryList module should not have basic accessibility issues', async () => {
+      const { container } = renderHomeModule(formattedCategoryListModule)
+
+      expect(await screen.findByText('Cette semaine sur le pass')).toBeTruthy()
+
+      const results = await checkAccessibilityFor(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('Recommendation module should not have basic accessibility issues', async () => {
+      const recommendedOffers: SimilarOffersResponse = {
+        params: {
+          call_id: 'c2b19286-a4e9-4aef-9bab-3dcbbd631f0c',
+          filtered: true,
+          geo_located: true,
+          model_endpoint: 'default',
+          model_name: 'similar_offers_default_prod',
+          model_version: 'similar_offers_clicks_v2_1_prod_v_20230428T220000',
+          reco_origin: 'default',
+        },
+        results: ['102280', '102272'],
+      }
+
+      server.use(
+        rest.post(
+          env.RECOMMENDATION_ENDPOINT + '/playlist_recommendation/1234',
+          async (_, res, ctx) => res.once(ctx.status(200), ctx.json(recommendedOffers))
+        )
+      )
+
+      const { container } = renderHomeModule(formattedRecommendedOffersModule)
+      await act(async () => {})
+      expect(screen.getByText('Tes évènements en ligne')).toBeTruthy()
+
+      let results
+      await act(async () => {
+        results = await checkAccessibilityFor(container)
+      })
+      expect(results).toHaveNoViolations()
+    })
+
+    it('ThematicHighlight module should not have basic accessibility issues', async () => {
+      mockdate.set(new Date(2024))
+
+      const { container } = renderHomeModule(formattedThematicHighlightModule)
+
+      await act(async () => {})
+      expect(screen.getByText('Temps très fort')).toBeTruthy()
+
+      const results = await checkAccessibilityFor(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('OffersModule should not have basic accessibility issues', async () => {
+      const { container } = renderHomeModule(formattedOffersModule, defaultData)
+
+      await act(async () => {})
+      expect(screen.getByText('La nuit des temps')).toBeTruthy()
+
+      let results
+      await act(async () => {
+        results = await checkAccessibilityFor(container)
+      })
+      expect(results).toHaveNoViolations()
+    })
+  })
+})
+
+function renderHomeModule(item: HomepageModule, data?: ModuleData) {
+  return render(
+    // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+    reactQueryProviderHOC(
+      <HomeModule item={item} index={index} homeEntryId={homeEntryId} data={data} />
+    )
+  )
+}

--- a/src/features/home/components/modules/exclusivity/ExclusivityOffer.tsx
+++ b/src/features/home/components/modules/exclusivity/ExclusivityOffer.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 import { ExclusivityImage } from 'features/home/components/modules/exclusivity/ExclusivityImage'
 import { ExclusivityBannerProps } from 'features/home/components/modules/exclusivity/ExclusivityModule'
 import { useShouldDisplayExcluOffer } from 'features/home/components/modules/exclusivity/helpers/useShouldDisplayExcluOffer'
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { analytics } from 'libs/analytics'
 import { ContentTypes } from 'libs/contentful/types'
 import { useHandleFocus } from 'libs/hooks/useHandleFocus'
@@ -58,7 +59,8 @@ const UnmemoizedExclusivityOffer = ({
       isFocus={isFocus}
       disabled={offerId === undefined}
       style={style}
-      accessibilityLabel={alt}>
+      accessibilityLabel={alt}
+      accessibilityRole={AccessibilityRole.LINK}>
       <ExclusivityImage imageURL={imageURL} alt={alt} />
     </StyledTouchableLink>
   )

--- a/src/features/home/pages/Home.web.test.tsx
+++ b/src/features/home/pages/Home.web.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+
+import { useHomepageData } from 'features/home/api/useHomepageData'
+import { formattedBusinessModule } from 'features/home/fixtures/homepage.fixture'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { render, checkAccessibilityFor, act } from 'tests/utils/web'
+
+import { Home } from './Home'
+
+const mockShouldShowSkeleton = false
+jest.mock('features/home/api/useShowSkeleton', () => ({
+  useShowSkeleton: jest.fn(() => mockShouldShowSkeleton),
+}))
+
+jest.mock('features/home/api/useHomepageData')
+const mockUseHomepageData = useHomepageData as jest.Mock
+
+jest.mock('libs/geolocation')
+
+jest.mock('libs/firebase/firestore/featureFlags/useFeatureFlag')
+
+describe('<Home/>', () => {
+  describe('Accessibility', () => {
+    it('should not have basic accessibility issues', async () => {
+      mockUseHomepageData.mockReturnValueOnce({
+        modules: [formattedBusinessModule],
+        homeEntryId: 'fakeEntryId',
+      })
+
+      const { container } = render(<Home />, {
+        // eslint-disable-next-line local-rules/no-react-query-provider-hoc
+        wrapper: ({ children }) => reactQueryProviderHOC(children),
+      })
+
+      let results
+      await act(async () => {
+        results = await checkAccessibilityFor(container)
+      })
+      expect(results).toHaveNoViolations()
+    })
+  })
+})


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-19058

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
