### PR TITLE
(PC-23962) fix(safari): fix blur on offer header

### DIFF
--- a/src/ui/animations/helpers/getAnimationState.ts
+++ b/src/ui/animations/helpers/getAnimationState.ts
@@ -49,6 +49,10 @@ export const getAnimationState = (
         : headerTransition.interpolate(headerBackgroundInterpolation()),
     borderBottomWidth: headerTransition.interpolate(strokeBorderInterpolation()),
     backdropFilter: headerTransition.interpolate(blurHeaderWebInterpolation()),
+    // This is necessary to make the blur work on Safari (usually added by styled-components)
+    ...(Platform.OS === 'web'
+      ? { WebkitBackdropFilter: headerTransition.interpolate(blurHeaderWebInterpolation()) }
+      : {}),
   },
   blurContainerNative: {
     opacity: headerTransition,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-23962

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        | <img width="503" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/c489562d-7dfa-4838-a1c3-29697c231cf2"> |
| Phone - Safari   | <img width="503" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/e328f396-0f96-49b0-bc4f-d5db513cb8f2"> | <img width="503" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/7cb62617-1eef-47a6-9dde-b8d914f56c06"> |
| Desktop - Safari | <img width="1436" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/7bd8202a-7775-4fcc-ba0a-21ad3e10bc47"> | <img width="1436" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/7b21a33c-a83a-492c-8f3e-310a4a3639b4"> |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
