### PR TITLE
(PC-22468) fix(category): limit text height

### DIFF
--- a/src/features/home/components/modules/categories/CategoryBlock.tsx
+++ b/src/features/home/components/modules/categories/CategoryBlock.tsx
@@ -48,8 +48,7 @@ const StyledShape = styled(Shape)({ position: 'absolute', right: 0 })
 
 const StyledTitle = styled(Typo.ButtonText)({
   color: theme.colors.white,
-  paddingVertical: getSpacing(3),
-  paddingHorizontal: getSpacing(3),
+  margin: getSpacing(3),
 })
 
 const StyledInternalTouchableLink = styled(InternalTouchableLink).attrs(({ theme }) => ({


### PR DESCRIPTION
by using margin instead of padding for a text

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-22468

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| Desktop - Chrome | <img width="1025" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/b79adfc9-6513-429a-b400-1aebdc94d1fc"> | <img width="1026" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/8be3d577-8f06-4d13-a793-f08f536b3bb8"> |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
