### PR TITLE
(PC-24042) feat(eslint): add rule to avoid hardcoded id in svg

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
   rules: {
     'testing-library/await-async-utils': ['error'],
     'local-rules/independent-mocks': ['error'],
+    'local-rules/no-hardcoded-id-in-svg': ['error'],
     'local-rules/no-raw-text': ['error'],
     'local-rules/no-string-check-before-component': ['error'],
     'local-rules/no-react-query-provider-hoc': ['error'],

--- a/doc/development/how-to/eslint-custom-rule.md
+++ b/doc/development/how-to/eslint-custom-rule.md
@@ -18,7 +18,7 @@ Sinon, continuer ce mode opératoire.
 
 - Dans [.eslintrc.js](../.eslintrc.js), ajouter dans `rules` : `'local-rules/<ma-règle-ESLint>': ['error'],`
 
-- Créer un fichier de test dans `/eslint-custom-rules/__tests__` : `<ma-règle-ESLint>.test.js`, et utiliser le snippet `eslint-rule-test` pour générer des tests à remplir.
+- Créer un fichier de test dans `/eslint-custom-rules/__tests__` : `<ma-règle-ESLint>.test.js`, et utiliser le snippet `eslint-test` pour générer des tests à remplir.
 
 ### 3. Écrire une règle
 
@@ -31,8 +31,8 @@ Puis, pour améliorer la règle, il faut comprendre l'Abstract Syntax Tree (AST)
 Une fois une particularité de notre cas identifiée, l'ajouter à la règle. Il y a 2 façons de faire :
 
 - soit avec un sélecteur AST (préférable) : il s'agit de sélecteur semblable aux sélecteurs CSS.
-Par exemple, `MemberExpression[object.name=clef][property.name=champs]` va exécuter son code si on rencontre le code `clef.champs`.
-Plus d'informations [ici](https://eslint.org/docs/latest/extend/selectors#what-syntax-can-selectors-have).
+  Par exemple, `MemberExpression[object.name=clef][property.name=champs]` va exécuter son code si on rencontre le code `clef.champs`.
+  Plus d'informations [ici](https://eslint.org/docs/latest/extend/selectors#what-syntax-can-selectors-have).
 
 - soit en manipulant l'AST à la main, en faisant des conditions nous-même.
 
@@ -48,8 +48,8 @@ Si on veut que la règle ESLint corrige automatiquement un cas d'erreur, il faut
 context.report({
   node,
   message: "<message-d'erreur>",
-  fix: fixer => {
-    return fixer.replaceText(node, "<code-corrigé>");
+  fix: (fixer) => {
+    return fixer.replaceText(node, '<code-corrigé>')
   },
 })
 ```

--- a/eslint-custom-rules/__tests__/no-hardcoded-id-in-svg.test.js
+++ b/eslint-custom-rules/__tests__/no-hardcoded-id-in-svg.test.js
@@ -1,0 +1,26 @@
+import { RuleTester } from 'eslint'
+import { config } from './config'
+
+import rule from '../no-hardcoded-id-in-svg'
+
+const ruleTester = new RuleTester()
+
+const tests = {
+  valid: [
+    { code: '<View />' },
+    { code: '<View id="viewId" />' },
+    { code: '<ClipPath />' },
+    { code: '<ClipPath id={clipPath} />' },
+    { code: '<LinearGradient />' },
+    { code: '<LinearGradient id={linearGradient} />' },
+  ],
+  invalid: [
+    { code: '<ClipPath id="clip0_3962_10903" />', errors: 1 },
+    { code: '<LinearGradient id="clip0_3962_10903" />', errors: 1 },
+  ],
+}
+
+tests.valid.forEach((t) => Object.assign(t, config))
+tests.invalid.forEach((t) => Object.assign(t, config))
+
+ruleTester.run('no-hardcoded-id-in-svg', rule, tests)

--- a/eslint-custom-rules/no-hardcoded-id-in-svg.js
+++ b/eslint-custom-rules/no-hardcoded-id-in-svg.js
@@ -1,0 +1,26 @@
+const SVGElementsToAvoid = ['ClipPath', 'Filter', 'LinearGradient', 'Marker', 'Mask', 'Pattern', 'RadialGradient', 'Symbol']
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'With hardcoded id in svg we can have displaying issues when there is a duplicated id in the DOM',
+    },
+  },
+  create(context) {
+    return {
+      JSXOpeningElement: (node) => {
+        if (SVGElementsToAvoid.includes(node.name.name)) {
+          node.attributes.forEach((attribute) => {
+            if (attribute.name.name === 'id' && attribute.value.type === 'Literal') {
+              context.report({
+                node,
+                message: 'Please use svgIdentifier instead of hardcoded id',
+              })
+            }
+          })
+        }
+      },
+    }
+  },
+}

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -7,15 +7,17 @@ const todoFormat = require('./eslint-custom-rules/todo-format')
 const apostropheInText = require('./eslint-custom-rules/apostrophe-in-text')
 const useTheRightTestUtils = require('./eslint-custom-rules/use-the-right-test-utils')
 const noUseOfAlgoliaMultipleQueries = require('./eslint-custom-rules/no-use-of-algolia-multiple-queries')
+const noHardcodeIdInSvg = require('./eslint-custom-rules/no-hardcoded-id-in-svg')
 
 module.exports = {
   'independent-mocks': independentMocks,
   'nbsp-in-text': nbspInText,
+  'no-hardcoded-id-in-svg': noHardcodeIdInSvg,
   'no-raw-text': noRawText,
   'no-react-query-provider-hoc': noReactQueryProviderHOC,
   'no-string-check-before-component': noStringCheckBeforeComponent,
   'todo-format': todoFormat,
   'apostrophe-in-text': apostropheInText,
   'use-the-right-test-utils': useTheRightTestUtils,
-  'no-use-of-algolia-multiple-queries': noUseOfAlgoliaMultipleQueries
+  'no-use-of-algolia-multiple-queries': noUseOfAlgoliaMultipleQueries,
 }

--- a/src/ui/svg/icons/Ubble.tsx
+++ b/src/ui/svg/icons/Ubble.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Path, Defs, LinearGradient, Stop, ClipPath, Rect } from 'react-native-svg'
+import { Path, Defs, LinearGradient, Stop } from 'react-native-svg'
 import styled from 'styled-components/native'
 
 import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
@@ -122,9 +122,6 @@ const UbbleSvg: React.FunctionComponent<AccessibleIcon> = ({
           <Stop offset="0.4662" stopColor="#3B8BF3" />
           <Stop offset="1" stopColor="#7314F5" />
         </LinearGradient>
-        <ClipPath id="clip0_3962_10903">
-          <Rect width="38.4" height="38.4" fill="white" transform="translate(0.800781 0.800049)" />
-        </ClipPath>
       </Defs>
     </AccessibleSvg>
   )


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24042

https://www.notion.so/passcultureapp/SVG-utiliser-des-id-variables-au-lieu-d-id-en-dur-deac58a24a1241db89310b783fbb0feb?pvs=4 