### PR TITLE
(PC-23621) fix(proxy): clean unused proxy instances

### DIFF
--- a/.github/workflows/dev_on_workflow_web_proxy_deploy.yml
+++ b/.github/workflows/dev_on_workflow_web_proxy_deploy.yml
@@ -50,6 +50,11 @@ jobs:
       - name: 'Push proxy for input env'
         run: |
           yarn --cwd server deploy:${{ inputs.ENV }}
+      - name: 'Clear unused apps'
+        run: |
+          gcloud app versions list --service=web-proxy-${{ inputs.ENV }} --format="table[no-heading](id)" \
+            | grep -v $(gcloud app versions list --service=web-proxy-${{ inputs.ENV }} --hide-no-traffic --format="table[no-heading](id)") \
+            | xargs gcloud app versions delete --service=web-proxy-${{ inputs.ENV }}
   slack_notify:
     runs-on: [self-hosted, linux, x64]
     if: ${{ always() }}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-23621

Test CI: https://github.com/pass-culture/pass-culture-app-native/actions/runs/6001805852/job/16276796309#step:12:25

During deployment: 

```
$ gcloud app versions list --service=web-proxy-testing 
SERVICE            VERSION.ID       TRAFFIC_SPLIT  LAST_DEPLOYED              SERVING_STATUS
web-proxy-testing  20230720t163425  0.00           2023-07-20T18:35:59+02:00  SERVING
web-proxy-testing  20230828t152440  1.00           2023-08-28T17:26:10+02:00  SERVING
```

After deployment:

```
$ gcloud app versions list --service=web-proxy-testing 
SERVICE            VERSION.ID       TRAFFIC_SPLIT  LAST_DEPLOYED              SERVING_STATUS
web-proxy-testing  20230828t153356  1.00           2023-08-28T17:35:07+02:00  SERVING
```

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
