### PR TITLE
(PC-24058) feat(search): force min height for venue playlist item

### DIFF
--- a/__snapshots__/features/search/components/SearchResults/SearchResults.web.test.tsx.web-snap
+++ b/__snapshots__/features/search/components/SearchResults/SearchResults.web.test.tsx.web-snap
@@ -479,7 +479,7 @@ exports[`SearchResults component should render correctly 1`] = `
                           >
                             <div
                               aria-label="Lieu ESPACE CULTUREL LECLERC CHATEAU GONTIER du type Autre type de lieu, à 900+ km"
-                              class="css-view-175oi2r r-transitionProperty-1i6wzkk r-cursor-1loqt21 r-touchAction-1otgn73 r-userSelect-bj6uhd r-borderRadius-1xfd6ze r-marginVertical-1p6iasa r-maxHeight-9stuvb r-width-1sqjfdd"
+                              class="css-view-175oi2r r-transitionProperty-1i6wzkk r-cursor-1loqt21 r-touchAction-1otgn73 r-userSelect-bj6uhd r-borderRadius-1xfd6ze r-marginVertical-1p6iasa r-maxHeight-1ykvnaz r-width-1sqjfdd"
                               data-testid="Lieu ESPACE CULTUREL LECLERC CHATEAU GONTIER du type Autre type de lieu, à 900+ km"
                               style="transition-duration: 0s;"
                               tabindex="0"
@@ -499,7 +499,7 @@ exports[`SearchResults component should render correctly 1`] = `
                                   </div>
                                 </div>
                                 <div
-                                  class="css-view-175oi2r r-marginTop-knv0ih r-maxWidth-1a0sep6"
+                                  class="css-view-175oi2r r-marginTop-knv0ih r-maxWidth-1a0sep6 r-minHeight-1d5ogoq"
                                 >
                                   <div
                                     class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
@@ -531,7 +531,7 @@ exports[`SearchResults component should render correctly 1`] = `
                           >
                             <div
                               aria-label="Lieu CAC - Concarneau Scènes du type Autre type de lieu, à 900+ km"
-                              class="css-view-175oi2r r-transitionProperty-1i6wzkk r-cursor-1loqt21 r-touchAction-1otgn73 r-userSelect-bj6uhd r-borderRadius-1xfd6ze r-marginVertical-1p6iasa r-maxHeight-9stuvb r-width-1sqjfdd"
+                              class="css-view-175oi2r r-transitionProperty-1i6wzkk r-cursor-1loqt21 r-touchAction-1otgn73 r-userSelect-bj6uhd r-borderRadius-1xfd6ze r-marginVertical-1p6iasa r-maxHeight-1ykvnaz r-width-1sqjfdd"
                               data-testid="Lieu CAC - Concarneau Scènes du type Autre type de lieu, à 900+ km"
                               style="transition-duration: 0s;"
                               tabindex="0"
@@ -551,7 +551,7 @@ exports[`SearchResults component should render correctly 1`] = `
                                   </div>
                                 </div>
                                 <div
-                                  class="css-view-175oi2r r-marginTop-knv0ih r-maxWidth-1a0sep6"
+                                  class="css-view-175oi2r r-marginTop-knv0ih r-maxWidth-1a0sep6 r-minHeight-1d5ogoq"
                                 >
                                   <div
                                     class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
@@ -1155,7 +1155,7 @@ exports[`SearchResults component should render correctly 1`] = `
                         >
                           <div
                             aria-label="Lieu ESPACE CULTUREL LECLERC CHATEAU GONTIER du type Autre type de lieu, à 900+ km"
-                            class="css-view-175oi2r r-transitionProperty-1i6wzkk r-cursor-1loqt21 r-touchAction-1otgn73 r-userSelect-bj6uhd r-borderRadius-1xfd6ze r-marginVertical-1p6iasa r-maxHeight-9stuvb r-width-1sqjfdd"
+                            class="css-view-175oi2r r-transitionProperty-1i6wzkk r-cursor-1loqt21 r-touchAction-1otgn73 r-userSelect-bj6uhd r-borderRadius-1xfd6ze r-marginVertical-1p6iasa r-maxHeight-1ykvnaz r-width-1sqjfdd"
                             data-testid="Lieu ESPACE CULTUREL LECLERC CHATEAU GONTIER du type Autre type de lieu, à 900+ km"
                             style="transition-duration: 0s;"
                             tabindex="0"
@@ -1175,7 +1175,7 @@ exports[`SearchResults component should render correctly 1`] = `
                                 </div>
                               </div>
                               <div
-                                class="css-view-175oi2r r-marginTop-knv0ih r-maxWidth-1a0sep6"
+                                class="css-view-175oi2r r-marginTop-knv0ih r-maxWidth-1a0sep6 r-minHeight-1d5ogoq"
                               >
                                 <div
                                   class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
@@ -1207,7 +1207,7 @@ exports[`SearchResults component should render correctly 1`] = `
                         >
                           <div
                             aria-label="Lieu CAC - Concarneau Scènes du type Autre type de lieu, à 900+ km"
-                            class="css-view-175oi2r r-transitionProperty-1i6wzkk r-cursor-1loqt21 r-touchAction-1otgn73 r-userSelect-bj6uhd r-borderRadius-1xfd6ze r-marginVertical-1p6iasa r-maxHeight-9stuvb r-width-1sqjfdd"
+                            class="css-view-175oi2r r-transitionProperty-1i6wzkk r-cursor-1loqt21 r-touchAction-1otgn73 r-userSelect-bj6uhd r-borderRadius-1xfd6ze r-marginVertical-1p6iasa r-maxHeight-1ykvnaz r-width-1sqjfdd"
                             data-testid="Lieu CAC - Concarneau Scènes du type Autre type de lieu, à 900+ km"
                             style="transition-duration: 0s;"
                             tabindex="0"
@@ -1227,7 +1227,7 @@ exports[`SearchResults component should render correctly 1`] = `
                                 </div>
                               </div>
                               <div
-                                class="css-view-175oi2r r-marginTop-knv0ih r-maxWidth-1a0sep6"
+                                class="css-view-175oi2r r-marginTop-knv0ih r-maxWidth-1a0sep6 r-minHeight-1d5ogoq"
                               >
                                 <div
                                   class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"

--- a/src/features/search/components/SearchVenueItems/SearchVenueItem.tsx
+++ b/src/features/search/components/SearchVenueItems/SearchVenueItem.tsx
@@ -27,7 +27,7 @@ export interface SearchVenueItemProps {
   searchId?: string
 }
 
-const MAX_VENUE_CAPTION_HEIGHT = getSpacing(18)
+const MAX_VENUE_CAPTION_HEIGHT = getSpacing(19)
 
 const mergeVenueData = (venue: AlgoliaVenue) => (prevData: AlgoliaVenue | undefined) => ({
   ...venue,
@@ -83,7 +83,12 @@ const UnmemoizedSearchVenueItem = ({ venue, height, width, searchId }: SearchVen
               />
             </SearchVenueTypeTile>
           )}
-          <SearchVenueItemDetails width={width} name={venue.name} city={venue.city} />
+          <SearchVenueItemDetails
+            width={width}
+            height={height + MAX_VENUE_CAPTION_HEIGHT}
+            name={venue.name}
+            city={venue.city}
+          />
         </View>
       </SearchVenueTouchableLink>
     </View>

--- a/src/features/search/components/SearchVenueItemsDetails/SearchVenueItemDetails.native.test.tsx
+++ b/src/features/search/components/SearchVenueItemsDetails/SearchVenueItemDetails.native.test.tsx
@@ -7,6 +7,7 @@ const props = {
   width: 300,
   name: 'Test Venue',
   city: 'Test City',
+  height: 172,
 }
 
 describe('SearchVenueItemDetails', () => {

--- a/src/features/search/components/SearchVenueItemsDetails/SearchVenueItemDetails.tsx
+++ b/src/features/search/components/SearchVenueItemsDetails/SearchVenueItemDetails.tsx
@@ -6,23 +6,32 @@ import { Typo, GUTTER_DP } from 'ui/theme'
 
 interface SearchVenueItemDetailsProps {
   width: number
+  height: number
   name: string
   city: string
 }
 
-export const SearchVenueItemDetails = ({ width, name, city }: SearchVenueItemDetailsProps) => {
+export const SearchVenueItemDetails = ({
+  width,
+  height,
+  name,
+  city,
+}: SearchVenueItemDetailsProps) => {
   return (
-    <Container maxWidth={width}>
+    <Container maxWidth={width} minHeight={height}>
       <VenueName>{name}</VenueName>
       <CityLabel>{city}</CityLabel>
     </Container>
   )
 }
 
-const Container = styled.View<{ maxWidth: number }>(({ maxWidth }) => ({
-  maxWidth,
-  marginTop: PixelRatio.roundToNearestPixel(GUTTER_DP / 2),
-}))
+const Container = styled.View<{ maxWidth: number; minHeight: number }>(
+  ({ maxWidth, minHeight }) => ({
+    maxWidth,
+    marginTop: PixelRatio.roundToNearestPixel(GUTTER_DP / 2),
+    minHeight,
+  })
+)
 
 const VenueName = styled(Typo.ButtonText).attrs({
   numberOfLines: 2,

--- a/src/features/search/helpers/useShowResultsForCategory/useShowResultsForCategory.native.test.ts
+++ b/src/features/search/helpers/useShowResultsForCategory/useShowResultsForCategory.native.test.ts
@@ -11,10 +11,11 @@ import { renderHook } from 'tests/utils'
 import { useShowResultsForCategory } from './useShowResultsForCategory'
 
 let mockSearchState = initialSearchState
+const mockDispatch = jest.fn()
 jest.mock('features/search/context/SearchWrapper', () => ({
   useSearch: () => ({
     searchState: mockSearchState,
-    dispatch: jest.fn(),
+    dispatch: mockDispatch,
   }),
 }))
 
@@ -93,6 +94,36 @@ describe('useShowResultsForCategory', () => {
         searchId,
       },
       screen: 'Search',
+    })
+  })
+
+  it('should dispatch state to avoid useless fetch the time that the url parameters are loaded', () => {
+    const { result: resultCallback } = renderHook(useShowResultsForCategory)
+
+    resultCallback.current(SearchGroupNameEnumv2.EVENEMENTS_EN_LIGNE)
+
+    expect(mockDispatch).toHaveBeenNthCalledWith(1, {
+      type: 'SET_STATE',
+      payload: {
+        beginningDatetime: undefined,
+        date: null,
+        endingDatetime: undefined,
+        hitsPerPage: 20,
+        isOnline: true,
+        locationFilter: { locationType: 'EVERYWHERE' },
+        offerCategories: [SearchGroupNameEnumv2.EVENEMENTS_EN_LIGNE],
+        offerIsDuo: false,
+        offerIsFree: false,
+        offerIsNew: false,
+        offerSubcategories: [],
+        offerTypes: { isDigital: false, isEvent: false, isThing: false },
+        priceRange: [0, 300],
+        query: 'Big flo et Oli',
+        view: SearchView.Results,
+        tags: [],
+        timeRange: null,
+        searchId,
+      },
     })
   })
 })

--- a/src/features/search/helpers/useShowResultsForCategory/useShowResultsForCategory.ts
+++ b/src/features/search/helpers/useShowResultsForCategory/useShowResultsForCategory.ts
@@ -11,7 +11,7 @@ import { SearchView } from 'features/search/types'
 import { useSubcategories } from 'libs/subcategories/useSubcategories'
 
 export const useShowResultsForCategory = (): OnPressCategory => {
-  const { searchState } = useSearch()
+  const { searchState, dispatch } = useSearch()
   const { navigate } = useNavigation<UseNavigationType>()
   const { data } = useSubcategories()
 
@@ -29,8 +29,9 @@ export const useShowResultsForCategory = (): OnPressCategory => {
         searchId,
         isOnline: isOnlyOnline(data, pressedCategory) || undefined,
       }
+      dispatch({ type: 'SET_STATE', payload: newSearchState })
       navigate(...getTabNavConfig('Search', newSearchState))
     },
-    [data, navigate, searchState]
+    [data, dispatch, navigate, searchState]
   )
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24058

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |<img width="467" alt="Capture d’écran 2023-08-28 à 18 36 09" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/738f68cc-80a4-47cd-a6f5-418b6783b96e">|<img width="443" alt="Capture d’écran 2023-08-28 à 18 29 32" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/edaad123-c92d-49fd-8c95-d942a8037adc"> <img width="470" alt="Capture d’écran 2023-08-28 à 18 42 35" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/90595a91-559b-4498-9d6f-e0233ece2b12">|
| Android          |<img width="432" alt="Capture d’écran 2023-08-28 à 18 36 15" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/e7da1ad4-38c3-4432-ae3d-62dc48d1f173">|<img width="410" alt="Capture d’écran 2023-08-28 à 18 42 44" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/3050ea53-2715-43b2-959c-b191afe14008"> <img width="423" alt="Capture d’écran 2023-08-28 à 18 29 39" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/14f386a8-7ab8-49b8-ad92-2429fce359fd">|
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
