### PR TITLE
(PC-24066) fix(search): remove separator when no search venues playlist

### DIFF
--- a/src/features/search/components/SearchListHeader/SearchListHeader.tsx
+++ b/src/features/search/components/SearchListHeader/SearchListHeader.tsx
@@ -155,9 +155,9 @@ export const SearchListHeader: React.FC<SearchListHeaderProps> = ({ nbHits, user
             />
           </View>
           <Spacer.Column numberOfSpaces={3} />
+          <StyledSeparator />
         </React.Fragment>
       )}
-      <StyledSeparator />
       <Spacer.Column numberOfSpaces={5} />
       <Title>{offerTitle}</Title>
       <NumberOfResults nbHits={nbHits} />


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24066

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |<img width="470" alt="Capture d’écran 2023-08-29 à 15 04 55" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/84a4e950-3a51-4258-bde4-9987830666cb">|<img width="465" alt="Capture d’écran 2023-08-29 à 14 56 03" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/da959a08-313a-4f68-9e41-718e34cabd99">|
| Android          |<img width="455" alt="Capture d’écran 2023-08-29 à 15 04 48" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/8bfe6d61-22bd-4888-a641-2cb7a68338f1">|<img width="455" alt="Capture d’écran 2023-08-29 à 14 55 55" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/a2900130-1b7e-4ecf-86bf-1347b76c597a">|
| Phone - Chrome   |<img width="408" alt="Capture d’écran 2023-08-29 à 15 04 30" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/a9911f10-467c-469e-ac18-f596fab5c975">|<img width="446" alt="Capture d’écran 2023-08-29 à 14 56 23" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/305ba69b-a1ef-4001-ba6e-b90701df07e2">|
| Tablet - Chrome  |        |       |
| Desktop - Chrome |<img width="865" alt="Capture d’écran 2023-08-29 à 15 04 40" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/9e1f29a0-0050-4716-a83c-70cc4c7ad47f">|<img width="865" alt="Capture d’écran 2023-08-29 à 14 56 16" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/629b5270-24d8-4120-a383-05c6e25cce06">|
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
