### PR TITLE
(PC-22949) fix(ui): add left margin to LocationWidget

### DIFF
--- a/src/features/location/components/LocationWidget.tsx
+++ b/src/features/location/components/LocationWidget.tsx
@@ -35,6 +35,7 @@ export const LocationWidget: React.FC = () => {
 
 const StyledTouchable = styledButton(Touchable)({
   alignItems: 'center',
+  marginLeft: getSpacing(2),
 })
 
 const StyledCaption = styled(Typo.Caption)({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-22949

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

<img width="248" alt="Capture d’écran 2023-08-31 à 09 57 55" src="https://github.com/pass-culture/pass-culture-app-native/assets/22886846/d6a0275f-0457-4ea4-9c25-9ef1d355d1ab">

<img width="426" alt="Capture d’écran 2023-08-31 à 10 09 57" src="https://github.com/pass-culture/pass-culture-app-native/assets/22886846/ae1b14da-d679-4dde-8224-0d1b886b3aa5">

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
