### PR TITLE
(PC-24162) fix(AccountSuspension): Direct user to fraud instead of support

### DIFF
--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
@@ -531,7 +531,7 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
         }
       />
       <View
-        accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support"
+        accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le service fraude"
         accessible={true}
         collapsable={false}
         focusable={true}
@@ -560,7 +560,7 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
             "width": "100%",
           }
         }
-        testID="Ouvrir le gestionnaire mail pour contacter le support"
+        testID="Ouvrir le gestionnaire mail pour contacter le service fraude"
       >
         <View
           style={
@@ -597,7 +597,7 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
             ]
           }
         >
-          Contacter le support
+          Contacter le service fraude
         </Text>
       </View>
     </View>

--- a/src/features/trustedDevice/pages/SuspensionChoice.native.test.tsx
+++ b/src/features/trustedDevice/pages/SuspensionChoice.native.test.tsx
@@ -2,7 +2,6 @@ import { rest } from 'msw'
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import { contactSupport } from 'features/auth/helpers/contactSupport'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { env } from 'libs/environment'
 import { eventMonitoring, MonitoringError } from 'libs/monitoring'
@@ -73,14 +72,10 @@ describe('<SuspensionChoice/>', () => {
   it('should open mail app when clicking on "Contacter le support" button', () => {
     renderSuspensionChoice()
 
-    const contactSupportButton = screen.getByText('Contacter le support')
+    const contactSupportButton = screen.getByText('Contacter le service fraude')
     fireEvent.press(contactSupportButton)
 
-    expect(openUrl).toBeCalledWith(
-      contactSupport.forGenericQuestion.url,
-      contactSupport.forGenericQuestion.params,
-      true
-    )
+    expect(openUrl).toBeCalledWith(`mailto:service.fraude@test.passculture.app`, undefined, true)
   })
 
   it('should open CGU url when clicking on "conditions générales d’utilisation" button', () => {

--- a/src/features/trustedDevice/pages/SuspensionChoice.tsx
+++ b/src/features/trustedDevice/pages/SuspensionChoice.tsx
@@ -2,7 +2,6 @@ import { useNavigation, useRoute } from '@react-navigation/native'
 import React, { useCallback } from 'react'
 import styled from 'styled-components/native'
 
-import { contactSupport } from 'features/auth/helpers/contactSupport'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { useSuspendForSuspiciousLoginMutation } from 'features/trustedDevice/helpers/useSuspendForSuspiciousLoginMutation'
 import { env } from 'libs/environment'
@@ -89,10 +88,10 @@ export const SuspensionChoice = () => {
         <Spacer.Column numberOfSpaces={2} />
         <ExternalTouchableLink
           as={ButtonTertiaryBlack}
-          wording="Contacter le support"
-          accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le support"
+          wording="Contacter le service fraude"
+          accessibilityLabel="Ouvrir le gestionnaire mail pour contacter le service fraude"
           icon={EmailFilled}
-          externalNav={contactSupport.forGenericQuestion}
+          externalNav={{ url: `mailto:${env.FRAUD_EMAIL_ADDRESS}` }}
         />
       </ButtonContainer>
     </GenericInfoPageWhite>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24162

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
