### PR TITLE
(PC-24167) chore(tech): avoid error when start web server

### DIFF
--- a/.github/workflows/dev_on_schedule_e2e_android_browser.yml
+++ b/.github/workflows/dev_on_schedule_e2e_android_browser.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Start Local dev server
         env:
-          NODE_OPTIONS: '--openssl-legacy-provider --max-old-space-size=4096'
+          NODE_OPTIONS: '--max-old-space-size=4096'
         run: |
           cwd=$(pwd)
           pushd "$cwd"

--- a/.github/workflows/dev_on_schedule_e2e_browser.yml
+++ b/.github/workflows/dev_on_schedule_e2e_browser.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Start local dev server
         env:
-          NODE_OPTIONS: '--openssl-legacy-provider --max-old-space-size=4096'
+          NODE_OPTIONS: '--max-old-space-size=4096'
         run: |
           cwd=$(pwd)
           pushd "$cwd"

--- a/.github/workflows/dev_on_schedule_e2e_ios_browser.yml
+++ b/.github/workflows/dev_on_schedule_e2e_ios_browser.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Start Local dev server
         env:
-          NODE_OPTIONS: '--openssl-legacy-provider --max-old-space-size=4096'
+          NODE_OPTIONS: '--max-old-space-size=4096'
         run: |
           cwd=$(pwd)
           pushd "$cwd"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "prune:scan": "yarn --silent ts-prune",
     "prune:count": "yarn prune:scan | wc -l",
     "start": "react-native start",
-    "start:web": "node web/scripts/start.js",
+    "start:web": "node --openssl-legacy-provider web/scripts/start.js",
     "start:web:development": "ENV=development yarn start:web",
     "start:web:integration": "ENV=integration yarn start:web",
     "start:web:production": "ENV=production yarn start:web",


### PR DESCRIPTION
à chaque fois qu'on lance le serveur web (`yarn start:web:testing`), on a l'erreur suivante

```js
{
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```

Une solution est d'exporter une variable pour changer les options de node

```sh
export NODE_OPTIONS='--openssl-legacy-provider'
```

Il faut le faire à chaque fois, c'est pénible (ou le mettre dans sa config globale mais c'est une mauvaise solution)

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24167

En ajoutant l'argument à la commande le bug n'est plus là

Il faut avoir Node>=18 pour que ça fonctionne

Node<=16 fera une erreur

Notre `.nvmrc` impose d'avoir Node 18, donc ça ne devrait pas poser de problème

https://github.com/pass-culture/pass-culture-app-native/blob/a5046450560ee34165ec03f0d0f5d3cf8c094ee2/.nvmrc#L1

## Checklist

I have:

- [ ] ~~Made sure my feature is working on the relevant real / virtual devices (native and web).~~
- [ ] ~~Written **unit tests** native (and web when implementation is different) for my feature.~~
- [ ] ~~Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change~~
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
