### PR TITLE
(PC-23831) feat(home): add highlight block duo offer info

### DIFF
--- a/src/features/home/components/modules/HighlightOfferModule.native.test.tsx
+++ b/src/features/home/components/modules/HighlightOfferModule.native.test.tsx
@@ -12,6 +12,7 @@ import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, fireEvent, render, screen } from 'tests/utils'
 
 const offerFixture = offersFixture[0]
+const duoOfferFixture = offersFixture[2]
 
 jest.mock('features/home/api/useHighlightOffer')
 const mockUseHighlightOffer = useHighlightOffer as jest.Mock
@@ -98,6 +99,28 @@ describe('HighlightOfferModule', () => {
       from: 'highlightOffer',
       moduleId: 'fH2FmoYeTzZPjhbz4ZHUW',
       moduleName: 'L’offre du moment 💥',
+    })
+  })
+
+  it('should show "- Duo" after price if offer isDuo', async () => {
+    mockUseHighlightOffer.mockReturnValueOnce(duoOfferFixture)
+
+    renderHighlightModule()
+
+    await act(async () => {
+      expect(screen.getByText('34 € - Duo')).toBeTruthy()
+      expect(screen.queryByText('34 €')).toBeNull()
+    })
+  })
+
+  it('should not show "- Duo" after price if offer is not isDuo', async () => {
+    mockUseHighlightOffer.mockReturnValueOnce(offerFixture)
+
+    renderHighlightModule()
+
+    await act(async () => {
+      expect(screen.getByText('28 €')).toBeTruthy()
+      expect(screen.queryByText('28 € - Duo')).toBeNull()
     })
   })
 })

--- a/src/features/home/components/modules/HighlightOfferModule.tsx
+++ b/src/features/home/components/modules/HighlightOfferModule.tsx
@@ -67,6 +67,7 @@ const UnmemoizedHighlightOfferModule = (props: HighlightOfferModuleProps) => {
   const venueName = venue.name
   const categoryLabel = categoryLabelMapping[offer.subcategoryId]
   const categoryId = categoryIdMapping[offer.subcategoryId]
+  const priceText = offer.isDuo ? `${formattedPrice} - Duo` : formattedPrice
 
   return (
     <Container>
@@ -116,7 +117,7 @@ const UnmemoizedHighlightOfferModule = (props: HighlightOfferModuleProps) => {
               <StyledOfferTitle>{props.offerTitle}</StyledOfferTitle>
               {!!formattedDate && <AdditionalDetail>{formattedDate}</AdditionalDetail>}
               {!!venueName && <AdditionalDetail>{venueName}</AdditionalDetail>}
-              {!!formattedPrice && <AdditionalDetail>{formattedPrice}</AdditionalDetail>}
+              {!!formattedPrice && <AdditionalDetail>{priceText}</AdditionalDetail>}
             </OfferDetails>
             <ArrowOffer>
               <PlainArrowNext size={theme.icons.sizes.small} />


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-23831

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

| Platform         | Not duo offer | Duo offer |
| :--------------- | :----: | :---: |
| iOS              |![Simulator Screen Shot - iPhone 14 - 2023-09-01 at 11 10 39](https://github.com/pass-culture/pass-culture-app-native/assets/47600889/50918ce2-5823-4ad4-98e4-87c450b3e878)|![Simulator Screen Shot - iPhone 14 - 2023-09-01 at 11 22 44](https://github.com/pass-culture/pass-culture-app-native/assets/47600889/b2214521-ab53-45ef-a55e-0435d846d0f1)|

