### PR TITLE
(PC-23704) fix(home): show tooltip once the splash screen is hidden

### DIFF
--- a/src/features/location/components/LocationWidget.native.test.tsx
+++ b/src/features/location/components/LocationWidget.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { LocationWidget } from 'features/location/components/LocationWidget'
 import { act, fireEvent, render, screen } from 'tests/utils'
 
+jest.mock('libs/splashscreen')
 const mockShowModal = jest.fn()
 jest.mock('ui/components/modals/useModal', () => ({
   useModal: () => ({

--- a/src/features/location/components/LocationWidget.tsx
+++ b/src/features/location/components/LocationWidget.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 
 import { LocationModal } from 'features/location/components/LocationModal'
 import { useGeolocation } from 'libs/geolocation'
+import { useSplashScreenContext } from 'libs/splashscreen'
 import { storage } from 'libs/storage'
 import { useModal } from 'ui/components/modals/useModal'
 import { Tooltip } from 'ui/components/Tooltip'
@@ -20,6 +21,7 @@ export const LocationWidget: React.FC = () => {
   const [isTooltipVisible, setIsTooltipVisible] = React.useState(false)
   const [widgetWidth, setWidgetWidth] = React.useState<number | undefined>()
   const { userPosition } = useGeolocation()
+  const { isSplashScreenHidden } = useSplashScreenContext()
 
   const hideTooltip = () => setIsTooltipVisible(false)
 
@@ -29,6 +31,8 @@ export const LocationWidget: React.FC = () => {
   }
 
   useEffect(() => {
+    if (!isSplashScreenHidden) return
+
     const displayTooltipIfNeeded = async () => {
       const timesLocationTooltipHasBeenDisplayed = Number(
         await storage.readString('times_location_tooltip_has_been_displayed')
@@ -46,8 +50,8 @@ export const LocationWidget: React.FC = () => {
       clearTimeout(timeoutOn)
       clearTimeout(timeoutOff)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- should only be called on mount
-  }, [])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- should only be called on startup
+  }, [isSplashScreenHidden])
 
   const locationTitle = 'Me localiser'
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-23704

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |        |       |
| Android          |        |       |
| Phone - Chrome   |        |       |
| Tablet - Chrome  |        |       |
| Desktop - Chrome |        |       |
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
