### PR TITLE
(PC-24407) feat(offer): Handle no session left when booking an offer

### DIFF
--- a/src/features/bookOffer/pages/BookingOfferModal.native.test.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.native.test.tsx
@@ -415,11 +415,12 @@ describe('<BookingOfferModalComponent />', () => {
       })
 
       it.each`
-        code                     | message
-        ${undefined}             | ${'En raison d’une erreur technique, l’offre n’a pas pu être réservée'}
-        ${'INSUFFICIENT_CREDIT'} | ${'Attention, ton crédit est insuffisant pour pouvoir réserver cette offre\u00a0!'}
-        ${'ALREADY_BOOKED'}      | ${'Attention, il est impossible de réserver plusieurs fois la même offre\u00a0!'}
-        ${'STOCK_NOT_BOOKABLE'}  | ${'Oups, cette offre n’est plus disponible\u00a0!'}
+        code                         | message
+        ${undefined}                 | ${'En raison d’une erreur technique, l’offre n’a pas pu être réservée'}
+        ${'INSUFFICIENT_CREDIT'}     | ${'Attention, ton crédit est insuffisant pour pouvoir réserver cette offre\u00a0!'}
+        ${'ALREADY_BOOKED'}          | ${'Attention, il est impossible de réserver plusieurs fois la même offre\u00a0!'}
+        ${'STOCK_NOT_BOOKABLE'}      | ${'Oups, cette offre n’est plus disponible\u00a0!'}
+        ${'PROVIDER_STOCK_SOLD_OUT'} | ${'Oups, cette offre n’est plus disponible\u00a0!'}
       `(
         'should show the error snackbar with message="$message" for errorCode="code" if booking an offer fails',
         ({ code, message }: { code: string | undefined; message: string }) => {

--- a/src/features/bookOffer/pages/BookingOfferModal.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.tsx
@@ -40,6 +40,7 @@ const errorCodeToMessage: Record<string, string> = {
     'Attention, ton crédit est insuffisant pour pouvoir réserver cette offre\u00a0!',
   ALREADY_BOOKED: 'Attention, il est impossible de réserver plusieurs fois la même offre\u00a0!',
   STOCK_NOT_BOOKABLE: 'Oups, cette offre n’est plus disponible\u00a0!',
+  PROVIDER_STOCK_SOLD_OUT: 'Oups, cette offre n’est plus disponible\u00a0!',
 }
 
 export const BookingOfferModalComponent: React.FC<BookingOfferModalComponentProps> = ({


### PR DESCRIPTION
A booking can run out of stock between the moment it was accessed and the attempt to book it. In such cases, the provider API won't let us book the offer, hence a new code to handle (PROVIDER_STOCK_SOLD_OUT)

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24407

[PR back](https://github.com/pass-culture/pass-culture-main/pull/8163)

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots
![Capture d’écran 2023-09-13 à 15 14 17](https://github.com/pass-culture/pass-culture-app-native/assets/139759736/31793624-643d-48a8-968c-1a4aff68f778)

->

![Capture d’écran 2023-09-13 à 15 15 34](https://github.com/pass-culture/pass-culture-app-native/assets/139759736/abe4659d-5554-4eb8-8868-44d5cd034232)

