### PR TITLE
(PC-24237) feat(booking): no displaying cancel button when category to archieve offer is free at booking time and becomes paid

### DIFF
--- a/src/features/bookings/components/BookingDetailsCancelButton.native.test.tsx
+++ b/src/features/bookings/components/BookingDetailsCancelButton.native.test.tsx
@@ -164,23 +164,49 @@ describe('<BookingDetailsCancelButton />', () => {
   })
 
   describe("When it's a free offer category to archieve", () => {
-    it('should display expiration date message', () => {
+    it('should display expiration date message when current price and price at booking time is 0', () => {
       const booking = { ...bookingsSnap.ongoing_bookings[0] }
       booking.confirmationDate = null
       booking.stock.offer.isDigital = false
       booking.stock.offer.subcategoryId = SubcategoryIdEnum.ABO_MUSEE
       booking.stock.price = 0
+      booking.totalAmount = 0
 
       renderBookingDetailsCancelButton(booking)
       expect(screen.getByText('Ta réservation sera archivée le 17/03/2021')).toBeOnTheScreen()
     })
 
-    it('should not display cancel button', () => {
+    it('should not display cancel button when current price and price at booking time is 0', () => {
       const booking = { ...bookingsSnap.ongoing_bookings[0] }
       booking.confirmationDate = null
       booking.stock.offer.isDigital = false
       booking.stock.offer.subcategoryId = SubcategoryIdEnum.ABO_MUSEE
       booking.stock.price = 0
+      booking.totalAmount = 0
+
+      renderBookingDetailsCancelButton(booking)
+      expect(screen.queryByTestId('Annuler ma réservation')).not.toBeOnTheScreen()
+    })
+
+    it('should display expiration date message when current price > 0 and price at booking is 0', () => {
+      const booking = { ...bookingsSnap.ongoing_bookings[0] }
+      booking.confirmationDate = null
+      booking.stock.offer.isDigital = false
+      booking.stock.offer.subcategoryId = SubcategoryIdEnum.ABO_MUSEE
+      booking.stock.price = 1000
+      booking.totalAmount = 0
+
+      renderBookingDetailsCancelButton(booking)
+      expect(screen.getByText('Ta réservation sera archivée le 17/03/2021')).toBeOnTheScreen()
+    })
+
+    it('should not display cancel button when current price > 0 and price at booking is 0', () => {
+      const booking = { ...bookingsSnap.ongoing_bookings[0] }
+      booking.confirmationDate = null
+      booking.stock.offer.isDigital = false
+      booking.stock.offer.subcategoryId = SubcategoryIdEnum.ABO_MUSEE
+      booking.stock.price = 1000
+      booking.totalAmount = 0
 
       renderBookingDetailsCancelButton(booking)
       expect(screen.queryByTestId('Annuler ma réservation')).not.toBeOnTheScreen()

--- a/src/features/bookings/components/BookingDetailsCancelButton.tsx
+++ b/src/features/bookings/components/BookingDetailsCancelButton.tsx
@@ -32,7 +32,7 @@ export const BookingDetailsCancelButton = (props: BookingDetailsCancelButtonProp
   const isDigitalBooking = booking.stock.offer.isDigital === true && !booking.expirationDate
   const isFreeOfferToArchive =
     FREE_OFFER_CATEGORIES_TO_ARCHIVE.includes(booking.stock.offer.subcategoryId) &&
-    booking.stock.price === 0
+    booking.totalAmount === 0
 
   const renderButton = () => {
     if (properties.hasActivationCode) {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** *if no UI change*

| Platform         | Before | After |
| :--------------- | :----: | :---: |
| iOS              |<img width="457" alt="Capture d’écran 2023-09-14 à 10 08 34" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/80988743-b400-4f09-ae78-65a756d44684">|<img width="438" alt="Capture d’écran 2023-09-14 à 10 10 26" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/9d37c986-7b6c-4f11-9e71-6cac33fa59f2">|
| Android          |<img width="432" alt="Capture d’écran 2023-09-14 à 10 09 32" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/8bec5047-4c47-4931-a1a7-c9cfddc156a0">|<img width="420" alt="Capture d’écran 2023-09-14 à 10 10 15" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/4369c0fb-fcc5-42d3-92ff-f4f31a6764c6">|
| Phone - Chrome   |<img width="402" alt="Capture d’écran 2023-09-14 à 10 06 12" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/cb854828-13c8-4047-9eae-117cb4030742">|<img width="399" alt="Capture d’écran 2023-09-14 à 10 10 46" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/820b53a1-ba7c-4d0d-9f97-639c975cc809">|
| Tablet - Chrome  |        |       |
| Desktop - Chrome |<img width="865" alt="Capture d’écran 2023-09-14 à 10 10 07" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/db92a739-94f8-4659-873e-fa8f2404c011">|<img width="1726" alt="Capture d’écran 2023-09-14 à 10 10 36" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/b24d7811-5fad-49a8-8afe-72f6e27b924e">|
| Desktop - Safari |        |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
