### PR TITLE
(BSR) chore(vscode): fix eslint plugin config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,7 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "eslint.lintTask.options": ". --ext .js,.ts,.tsx --cache",
   "eslint.options": {
-    "configFile": ".eslintrc.js"
+    "overrideConfigFile": ".eslintrc.js"
   },
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true


### PR DESCRIPTION
by replacing deprecated options by the new one

-> to avoid ESLint VSCode plugin to be broken : 
<img width="849" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/41ffd4b9-f73d-44f5-821d-f69c39f3fbcb">

