### PR TITLE
(PC-24404) fix(MessagingApps): Send single url in share message

### DIFF
--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -275,7 +275,7 @@ describe('<OfferBody />', () => {
 
       expect(mockShareSingle).toHaveBeenCalledWith({
         social: Social.Instagram,
-        message: encodeURI(
+        message: encodeURIComponent(
           `Retrouve "${mockOffer.name}" chez "${mockOffer.venue.name}" sur le pass Culture\n${expectedUrl}`
         ),
         type: 'text',
@@ -304,7 +304,7 @@ describe('<OfferBody />', () => {
 
         expect(mockShareSingle).toHaveBeenCalledWith({
           social: Social.Instagram,
-          message: encodeURI(
+          message: encodeURIComponent(
             `Retrouve "${mockOffer.name}" chez "${mockOffer.venue.name}" sur le pass Culture\n${expectedUrl}`
           ),
           type: 'text',

--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -1,6 +1,6 @@
 import mockdate from 'mockdate'
 import React from 'react'
-import { Linking, Share as NativeShare } from 'react-native'
+import { Linking, Platform, Share as NativeShare } from 'react-native'
 import Share, { Social } from 'react-native-share'
 import { UseQueryResult } from 'react-query'
 
@@ -280,6 +280,36 @@ describe('<OfferBody />', () => {
         ),
         type: 'text',
         url: undefined,
+      })
+    })
+
+    describe('on Android', () => {
+      beforeAll(() => (Platform.OS = 'android'))
+      afterAll(() => (Platform.OS = 'ios'))
+
+      it('should open social medium on share button press using correct message', async () => {
+        // FIXME(PC-21174): This warning comes from android 'Expected style "elevation: 16px" to be unitless' due to shadow style
+        jest.spyOn(global.console, 'warn').mockImplementationOnce(() => null)
+        canOpenURLSpy.mockResolvedValueOnce(true)
+        renderOfferBody()
+
+        await act(async () => {
+          const socialMediumButton = await screen.findByText(`Envoyer sur ${[Network.instagram]}`)
+          fireEvent.press(socialMediumButton)
+        })
+
+        const expectedUrl = `${getOfferUrl(offerId, 'social_media')}&utm_source=${
+          Network.instagram
+        }`
+
+        expect(mockShareSingle).toHaveBeenCalledWith({
+          social: Social.Instagram,
+          message: encodeURI(
+            `Retrouve "${mockOffer.name}" chez "${mockOffer.venue.name}" sur le pass Culture\n${expectedUrl}`
+          ),
+          type: 'text',
+          url: undefined,
+        })
       })
     })
 

--- a/src/features/share/components/MessagingApps/InstalledMessagingApps.native.test.tsx
+++ b/src/features/share/components/MessagingApps/InstalledMessagingApps.native.test.tsx
@@ -56,7 +56,7 @@ describe('<InstalledMessagingApps />', () => {
 
     expect(mockShareSingle).toHaveBeenCalledWith({
       social: Social.Instagram,
-      message: encodeURI(
+      message: encodeURIComponent(
         'Retrouve cette offre sur le passCulture\nhttps://passculture.app/accueil?utm_campaign=share_offer&utm_source=Instagram'
       ),
       type: 'text',

--- a/src/features/share/components/MessagingApps/MessagingAppButton.tsx
+++ b/src/features/share/components/MessagingApps/MessagingAppButton.tsx
@@ -31,16 +31,18 @@ export const MessagingAppButton = ({
 
   // Message has to be concatenated with url if url option is not supported, and in web
   const message = supportsURL && !isWeb ? shareMessage : shareMessage + '\n' + shareUrl
+  const encodedMessage = encodeURIComponent(message)
 
   const onPress = async () => {
     try {
       onPressAnalytics(options.social)
-      if (isWeb && webUrl) await Linking.openURL(webUrl + encodeURIComponent(message))
-      else if (isNative && options.url) await Linking.openURL(options.url + message)
+      if (isWeb && webUrl) await Linking.openURL(webUrl + encodedMessage)
+      else if (isNative && options.url) await Linking.openURL(options.url + encodedMessage)
       else {
+        const url = shouldEncodeURI ? encodeURIComponent(shareUrl) : shareUrl
         await Share.shareSingle({
-          message: shouldEncodeURI ? encodeURI(message) : message,
-          url: supportsURL ? shareUrl : undefined,
+          message: shouldEncodeURI ? encodedMessage : message,
+          url: supportsURL ? url : undefined,
           ...options,
         })
       }
@@ -71,7 +73,7 @@ const mapNetworkToSocial: Record<
     shouldEncodeURI: Platform.OS === 'ios',
     type: 'text',
   },
-  [Network.messenger]: { social: Social.Messenger },
+  [Network.messenger]: { social: Social.Messenger, shouldEncodeURI: Platform.OS === 'ios' },
   [Network.snapchat]: { social: Social.Snapchat },
   [Network.googleMessages]: {
     social: Social.Sms,
@@ -84,6 +86,7 @@ const mapNetworkToSocial: Record<
   [Network.telegram]: {
     social: Social.Telegram,
     webUrl: 'https://telegram.me/share/msg?url=',
+    supportsURL: false,
   },
   [Network.viber]: {
     social: Social.Viber,

--- a/src/features/share/components/MessagingApps/MessagingApps.tsx
+++ b/src/features/share/components/MessagingApps/MessagingApps.tsx
@@ -40,7 +40,7 @@ export const MessagingApps = ({ title, shareContent, share, messagingAppAnalytic
       <IconsWrapper>
         <StyledUl>
           <InstalledMessagingApps
-            shareMessage={shareContent.message}
+            shareMessage={shareContent.messageWithoutLink}
             shareUrl={shareContent.url}
             messagingAppAnalytics={messagingAppAnalytics}
           />

--- a/src/features/share/helpers/shareApp.ts
+++ b/src/features/share/helpers/shareApp.ts
@@ -11,11 +11,13 @@ const shareOptions = {
 export const shareApp = (utmMedium: string) => {
   const url = `${WEBAPP_V2_URL}/accueil`
   const urlWithUtmParams = `${url}?utm_campaign=share_app&utm_medium=${utmMedium}`
-  const message = `Profite toi aussi de tous les bons plans du pass Culture\u00a0: \n${urlWithUtmParams}`
+  const messageWithoutLink = 'Profite toi aussi de tous les bons plans du pass Culture'
+  const message = `${messageWithoutLink}\u00a0: \n${urlWithUtmParams}`
 
   const shareAppContent = {
     title: shareAppTitle,
     message,
+    messageWithoutLink,
   }
   return share(shareAppContent, shareOptions, true)
 }

--- a/src/features/share/helpers/useShareOffer.native.test.ts
+++ b/src/features/share/helpers/useShareOffer.native.test.ts
@@ -25,6 +25,7 @@ const shareMessage =
 
 const shareContentIos = {
   message: shareMessage,
+  messageWithoutLink: shareMessage,
   url: `${WEBAPP_V2_URL}/offre/146112?utm_campaign=share_offer&utm_medium=utm_medium`,
   title: shareTitle,
 }
@@ -34,6 +35,7 @@ const shareContentAndroid = {
     shareMessage +
     DOUBLE_LINE_BREAK +
     `${WEBAPP_V2_URL}/offre/146112?utm_campaign=share_offer&utm_medium=utm_medium`,
+  messageWithoutLink: shareMessage,
   url: `${WEBAPP_V2_URL}/offre/146112?utm_campaign=share_offer&utm_medium=utm_medium`,
   title: shareTitle,
 }
@@ -122,6 +124,8 @@ describe('getShareOffer', () => {
         {
           message:
             'Retrouve "Donjons & Dragons : L’Honneur des voleurs - VO" chez "L’Orange Bleue*" sur le pass Culture',
+          messageWithoutLink:
+            'Retrouve "Donjons & Dragons : L’Honneur des voleurs - VO" chez "L’Orange Bleue*" sur le pass Culture',
           url: `${WEBAPP_V2_URL}/offre/146112?utm_campaign=share_offer&utm_medium=utm_medium`,
           title: shareTitle,
         },
@@ -147,6 +151,8 @@ describe('getShareOffer', () => {
         1,
         {
           message: `Retrouve "Donjons & Dragons : L’Honneur des voleurs - VO" chez "L’Orange Bleue*" sur le pass Culture\n\n${WEBAPP_V2_URL}/offre/146112?utm_campaign=share_offer&utm_medium=utm_medium`,
+          messageWithoutLink:
+            'Retrouve "Donjons & Dragons : L’Honneur des voleurs - VO" chez "L’Orange Bleue*" sur le pass Culture',
           url: `${WEBAPP_V2_URL}/offre/146112?utm_campaign=share_offer&utm_medium=utm_medium`,
           title: shareTitle,
         },

--- a/src/features/share/helpers/useShareOffer.ts
+++ b/src/features/share/helpers/useShareOffer.ts
@@ -50,18 +50,19 @@ export const getShareOffer = ({
     }
   }
 
-  const message = formatShareOfferMessage({
+  const messageWithoutLink = formatShareOfferMessage({
     offerName,
     venueName,
   })
 
   const shareUrl = getOfferUrl(offerId, utmMedium)
-  const shareAndroidMessage = message + DOUBLE_LINE_BREAK + shareUrl
+  const messageWithLink = messageWithoutLink + DOUBLE_LINE_BREAK + shareUrl
   // url share content param is only for iOS, so we add url in message for android
-  const shareMessage = Platform.OS === 'android' ? shareAndroidMessage : message
+  const shareMessage = Platform.OS === 'android' ? messageWithLink : messageWithoutLink
 
   const shareContent = {
     url: shareUrl,
+    messageWithoutLink,
     message: shareMessage,
     title: shareTitle,
   }

--- a/src/features/share/helpers/useShareVenue.native.test.ts
+++ b/src/features/share/helpers/useShareVenue.native.test.ts
@@ -22,6 +22,7 @@ const shareOptions = {
 
 const shareContentIos = {
   message: shareTitle,
+  messageWithoutLink: shareTitle,
   url: `${WEBAPP_V2_URL}/lieu/5543?utm_campaign=share_venue&utm_medium=utm_medium`,
   title: shareTitle,
 }
@@ -31,6 +32,7 @@ const shareContentAndroid = {
     shareTitle +
     DOUBLE_LINE_BREAK +
     `${WEBAPP_V2_URL}/lieu/5543?utm_campaign=share_venue&utm_medium=utm_medium`,
+  messageWithoutLink: shareTitle,
   url: `${WEBAPP_V2_URL}/lieu/5543?utm_campaign=share_venue&utm_medium=utm_medium`,
   title: shareTitle,
 }

--- a/src/features/share/helpers/useShareVenue.ts
+++ b/src/features/share/helpers/useShareVenue.ts
@@ -35,6 +35,7 @@ export const useShareVenue = (venueId: number, utmMedium: string): ShareOutput =
   const shareContent = {
     url: shareUrl,
     message: shareMessage,
+    messageWithoutLink: shareTitle,
     title: shareTitle,
   }
 

--- a/src/features/share/pages/WebShareModal.native.test.tsx
+++ b/src/features/share/pages/WebShareModal.native.test.tsx
@@ -7,7 +7,11 @@ import { WebShareModal } from './WebShareModal'
 const defaultProps = {
   visible: true,
   headerTitle: 'Partager l’offre',
-  shareContent: { message: 'Voici une super offre !', url: 'https://url.com/offer' },
+  shareContent: {
+    message: 'Voici une super offre !',
+    messageWithoutLink: 'Message',
+    url: 'https://url.com/offer',
+  },
   dismissModal: jest.fn(),
 }
 

--- a/src/features/share/pages/WebShareModal.web.test.tsx
+++ b/src/features/share/pages/WebShareModal.web.test.tsx
@@ -13,7 +13,11 @@ const mockDismissModal = jest.fn()
 const defaultProps = {
   visible: true,
   headerTitle: 'Partager l’offre',
-  shareContent: { message: 'Voici une super offre !', url: 'https://url.com/offer' },
+  shareContent: {
+    message: 'Voici une super offre !',
+    messageWithoutLink: 'Message',
+    url: 'https://url.com/offer',
+  },
   dismissModal: mockDismissModal,
 }
 

--- a/src/features/venue/components/VenueBody/VenueBody.native.test.tsx
+++ b/src/features/venue/components/VenueBody/VenueBody.native.test.tsx
@@ -84,7 +84,7 @@ describe('<VenueBody />', () => {
 
     expect(mockShareSingle).toHaveBeenCalledWith({
       social: Social.Instagram,
-      message: encodeURI(
+      message: encodeURIComponent(
         `Retrouve "${venueResponseSnap.name}" sur le pass Culture\nhttps://webapp-v2.example.com/lieu/5543?utm_campaign=share_venue&utm_medium=social_media&utm_source=Instagram`
       ),
       type: 'text',
@@ -109,7 +109,7 @@ describe('<VenueBody />', () => {
 
       expect(mockShareSingle).toHaveBeenCalledWith({
         social: Social.Instagram,
-        message: encodeURI(
+        message: encodeURIComponent(
           `Retrouve "${venueResponseSnap.name}" sur le pass Culture\nhttps://webapp-v2.example.com/lieu/5543?utm_campaign=share_venue&utm_medium=social_media&utm_source=Instagram`
         ),
         type: 'text',

--- a/src/features/venue/components/VenueBody/VenueBody.native.test.tsx
+++ b/src/features/venue/components/VenueBody/VenueBody.native.test.tsx
@@ -1,6 +1,6 @@
 import mockdate from 'mockdate'
 import React from 'react'
-import { Linking, Share as NativeShare } from 'react-native'
+import { Linking, Platform, Share as NativeShare } from 'react-native'
 import Share, { Social } from 'react-native-share'
 import { UseQueryResult } from 'react-query'
 
@@ -89,6 +89,32 @@ describe('<VenueBody />', () => {
       ),
       type: 'text',
       url: undefined,
+    })
+  })
+
+  describe('on Android', () => {
+    beforeAll(() => (Platform.OS = 'android'))
+    afterAll(() => (Platform.OS = 'ios'))
+
+    it('should open social medium on share button press', async () => {
+      // FIXME(PC-21174): This warning comes from android 'Expected style "elevation: 16px" to be unitless' due to shadow style
+      jest.spyOn(global.console, 'warn').mockImplementationOnce(() => null)
+      jest.spyOn(global.console, 'warn').mockImplementationOnce(() => null)
+      canOpenURLSpy.mockResolvedValueOnce(true)
+      await renderVenueBody(venueId)
+
+      await act(async () => {
+        fireEvent.press(await screen.findByText(`Envoyer sur ${[Network.instagram]}`))
+      })
+
+      expect(mockShareSingle).toHaveBeenCalledWith({
+        social: Social.Instagram,
+        message: encodeURI(
+          `Retrouve "${venueResponseSnap.name}" sur le pass Culture\nhttps://webapp-v2.example.com/lieu/5543?utm_campaign=share_venue&utm_medium=social_media&utm_source=Instagram`
+        ),
+        type: 'text',
+        url: undefined,
+      })
     })
   })
 

--- a/src/libs/share/share.native.test.ts
+++ b/src/libs/share/share.native.test.ts
@@ -4,7 +4,7 @@ import { analytics } from 'libs/analytics'
 import { share } from 'libs/share'
 import { waitFor } from 'tests/utils'
 
-const defaultContent = { message: 'Message' }
+const defaultContent = { message: 'Message', messageWithoutLink: 'Message' }
 const defaultOptions = {}
 const shareMockReturnValue = { action: Share.sharedAction, activityType: 'copy' }
 const shareMock = jest.spyOn(Share, 'share').mockResolvedValue(shareMockReturnValue)

--- a/src/libs/share/share.ts
+++ b/src/libs/share/share.ts
@@ -5,6 +5,7 @@ import { analytics } from 'libs/analytics'
 export type ShareContent = {
   title?: string
   message: string
+  messageWithoutLink: string
   url?: string // Works with IOS only
 }
 

--- a/src/libs/share/share.web.test.ts
+++ b/src/libs/share/share.web.test.ts
@@ -2,7 +2,7 @@ import { Share } from 'react-native'
 
 import { share } from 'libs/share'
 
-const defaultContent = { message: 'Message' }
+const defaultContent = { message: 'Message', messageWithoutLink: 'Message' }
 const defaultOptions = {}
 const shareMock = jest.spyOn(Share, 'share')
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24404

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots
| Platform         | Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |     [bug.mp4](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/006a37c2-b3a1-4e21-9b7e-17a9846d0e97)       |     [fix.mp4](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/9f820438-f2d1-4d72-8a1a-6a8dfedf0b9f)  |
| Android          |      [bug.mp4](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/69aba3ca-ad7f-4154-9005-4311099f31b9)        |   [fix.mp4](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/19f19bd4-a69d-44bd-8115-041b611d398e)    |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
