### PR TITLE
(PC-24700) fix(AuthenticationModal): fix buttons alignment

### DIFF
--- a/src/shared/offer/components/AuthenticationModal/AuthenticationModal.tsx
+++ b/src/shared/offer/components/AuthenticationModal/AuthenticationModal.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useCallback } from 'react'
-import styled, { useTheme } from 'styled-components/native'
+import styled from 'styled-components/native'
 
 import { AuthenticationButton } from 'features/auth/components/AuthenticationButton/AuthenticationButton'
 import { analytics } from 'libs/analytics'
@@ -25,8 +25,6 @@ export const AuthenticationModal: FunctionComponent<Props> = ({
   offerId,
   from,
 }) => {
-  const theme = useTheme()
-
   const closeModal = useCallback(() => {
     analytics.logQuitAuthenticationModal(offerId)
     hideModal()
@@ -64,7 +62,6 @@ export const AuthenticationModal: FunctionComponent<Props> = ({
             params: { preventCancellation: true, offerId, from },
           }}
           onBeforeNavigate={signUp}
-          fitContentWidth={theme.isDesktopViewport}
         />
       </StyledButtonContainer>
       <Spacer.Column numberOfSpaces={4} />


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24700

Explications : 
Le thème était importé de /theme directement au lieu de passer par useTheme, la propriété fitContentWidth de la modale était donc toujours à false car on avait pas encore compute le thème. En fixant cela, un bug a été introduit en passant fitContentWidth à true. On fix le bug en supprimant cet prop.

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              | <img width="328" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/9ac432ac-ea16-4574-875b-1f905610090c"> |<img width="326" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/ec799827-e2fd-4bc6-b43d-4da55efb50bc">|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome | ![image](https://github.com/pass-culture/pass-culture-app-native/assets/68000368/7e051313-8b8e-4f43-8c87-2842c9e03388) |![image](https://github.com/pass-culture/pass-culture-app-native/assets/68000368/9383f5df-7cfc-4731-9a1c-4e82422cedb6)|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
