### PR TITLE
(PC-24618) feat(search): use item history highlight

### DIFF
--- a/__snapshots__/features/search/components/Highlight/Highlight.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/components/Highlight/Highlight.native.test.tsx.native-snap
@@ -69,3 +69,21 @@ exports[`Highlight component for a venue suggestion should render Highlight 1`] 
   </Text>,
 ]
 `;
+
+exports[`Highlight component for an history item should render Highlight 1`] = `
+<Text
+  style={
+    [
+      {
+        "color": "#161617",
+        "fontFamily": "Montserrat-BoldItalic",
+        "fontSize": 15,
+        "lineHeight": 20,
+      },
+    ]
+  }
+  testID="nonHighlightedHistoryItemText"
+>
+  manga
+</Text>
+`;

--- a/src/features/search/components/Highlight/Highlight.native.test.tsx
+++ b/src/features/search/components/Highlight/Highlight.native.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react'
 
 import { NativeCategoryIdEnumv2, SearchGroupNameEnumv2 } from 'api/gen'
-import { Highlight, HighlightPart } from 'features/search/components/Highlight/Highlight'
+import {
+  Highlight,
+  HighlightHistoryItemPart,
+  HighlightPart,
+} from 'features/search/components/Highlight/Highlight'
 import { mockVenueHits } from 'features/search/fixtures/algolia'
+import { mockedSearchHistory } from 'features/search/fixtures/mockedSearchHistory'
 import { AlgoliaSuggestionHit } from 'libs/algolia'
 import { env } from 'libs/environment'
 import { render, screen } from 'tests/utils'
@@ -48,6 +53,18 @@ describe('Highlight component for a offer suggestion', () => {
   it('should render Highlight', () => {
     expect(render(<Highlight suggestionHit={hit} attribute="query" />)).toMatchSnapshot()
   })
+
+  it('should use highlight part for display', () => {
+    render(<Highlight suggestionHit={hit} attribute="query" />)
+
+    expect(screen.getByTestId('nonHighlightedText')).toBeOnTheScreen()
+  })
+
+  it('should not use highlight history item part for display', () => {
+    render(<Highlight suggestionHit={hit} attribute="query" />)
+
+    expect(screen.queryByTestId('nonHighlightedHistoryItemText')).not.toBeOnTheScreen()
+  })
 })
 
 describe('Highlight component for a venue suggestion', () => {
@@ -55,6 +72,38 @@ describe('Highlight component for a venue suggestion', () => {
 
   it('should render Highlight', () => {
     expect(render(<Highlight venueHit={hit} attribute="name" />)).toMatchSnapshot()
+  })
+
+  it('should use highlight part for display', () => {
+    render(<Highlight venueHit={hit} attribute="name" />)
+
+    expect(screen.getByTestId('nonHighlightedText')).toBeOnTheScreen()
+  })
+
+  it('should not use highlight history item part for display', () => {
+    render(<Highlight venueHit={hit} attribute="name" />)
+
+    expect(screen.queryByTestId('nonHighlightedHistoryItemText')).not.toBeOnTheScreen()
+  })
+})
+
+describe('Highlight component for an history item', () => {
+  const historyItem = { ...mockedSearchHistory[0], _highlightResult: { query: { value: 'manga' } } }
+
+  it('should render Highlight', () => {
+    expect(render(<Highlight historyItem={historyItem} />)).toMatchSnapshot()
+  })
+
+  it('should use highlight history item part for display', () => {
+    render(<Highlight historyItem={historyItem} />)
+
+    expect(screen.getByTestId('nonHighlightedHistoryItemText')).toBeOnTheScreen()
+  })
+
+  it('should not use highlight part for display', () => {
+    render(<Highlight historyItem={historyItem} />)
+
+    expect(screen.queryByTestId('nonHighlightedText')).not.toBeOnTheScreen()
   })
 })
 
@@ -64,12 +113,52 @@ describe('HighlightPart component', () => {
   it('should use body typo when the part of the hit is highlighted', () => {
     render(<HighlightPart isHighlighted>{children}</HighlightPart>)
 
-    expect(screen.queryByTestId('highlightedText')).toBeOnTheScreen()
+    expect(screen.getByTestId('highlightedText')).toBeOnTheScreen()
+  })
+
+  it('should not use body typo when the part of the hit is not highlighted', () => {
+    render(<HighlightPart isHighlighted={false}>{children}</HighlightPart>)
+
+    expect(screen.queryByTestId('highlightedText')).not.toBeOnTheScreen()
   })
 
   it('should use button text typo when the part of the hit is not highlighted', () => {
     render(<HighlightPart isHighlighted={false}>{children}</HighlightPart>)
 
-    expect(screen.queryByTestId('nonHighlightedText')).toBeOnTheScreen()
+    expect(screen.getByTestId('nonHighlightedText')).toBeOnTheScreen()
+  })
+
+  it('should not use button text typo when the part of the hit is  highlighted', () => {
+    render(<HighlightPart isHighlighted>{children}</HighlightPart>)
+
+    expect(screen.queryByTestId('nonHighlightedText')).not.toBeOnTheScreen()
+  })
+})
+
+describe('HighlightHistoryItemPart component', () => {
+  const children = 'guerre et'
+
+  it('should use placeholder typo when the part of the hit is highlighted', () => {
+    render(<HighlightHistoryItemPart isHighlighted>{children}</HighlightHistoryItemPart>)
+
+    expect(screen.getByTestId('highlightedHistoryItemText')).toBeOnTheScreen()
+  })
+
+  it('should not use placeholder typo when the part of the hit is not highlighted', () => {
+    render(<HighlightHistoryItemPart isHighlighted={false}>{children}</HighlightHistoryItemPart>)
+
+    expect(screen.queryByTestId('highlightedHistoryItemText')).not.toBeOnTheScreen()
+  })
+
+  it('should use body bold italic typo when the part of the hit is not highlighted', () => {
+    render(<HighlightHistoryItemPart isHighlighted={false}>{children}</HighlightHistoryItemPart>)
+
+    expect(screen.getByTestId('nonHighlightedHistoryItemText')).toBeOnTheScreen()
+  })
+
+  it('should not use body bold italic typo when the part of the hit is highlighted', () => {
+    render(<HighlightHistoryItemPart isHighlighted>{children}</HighlightHistoryItemPart>)
+
+    expect(screen.queryByTestId('nonHighlightedHistoryItemText')).not.toBeOnTheScreen()
   })
 })

--- a/src/features/search/components/SearchHistory/SearchHistory.native.test.tsx
+++ b/src/features/search/components/SearchHistory/SearchHistory.native.test.tsx
@@ -39,7 +39,7 @@ describe('SearchHistory', () => {
   })
 
   it('should not display delete button in history item when queryHistory is not an empty string', () => {
-    render(<SearchHistory history={mockHistory} queryHistory="a" removeItem={mockRemoveItem} />)
+    render(<SearchHistory history={mockHistory} queryHistory="man" removeItem={mockRemoveItem} />)
 
     expect(screen.queryByTestId('Supprimer manga de l’historique')).not.toBeOnTheScreen()
   })

--- a/src/features/search/components/SearchHistory/SearchHistory.tsx
+++ b/src/features/search/components/SearchHistory/SearchHistory.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { SearchHistoryItem } from 'features/search/components/SearchHistoryItem/SearchHistoryItem'
+import { addHighlightedAttribute } from 'features/search/helpers/addHighlightedAttribute/addHighlightedAttribute'
 import { HistoryItem } from 'features/search/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Touchable } from 'ui/components/touchable/Touchable'
@@ -24,7 +25,10 @@ export function SearchHistory({ history, queryHistory, removeItem }: Props) {
       <StyledVerticalUl>
         {history.map((item) => (
           <Container key={item.createdAt} testID="searchHistoryItem">
-            <SearchHistoryItem item={item} />
+            <SearchHistoryItem
+              item={addHighlightedAttribute({ item, query: queryHistory })}
+              queryHistory={queryHistory}
+            />
             {queryHistory === '' && (
               <RemoveButton
                 accessibilityLabel={`Supprimer ${item.label} de l’historique`}

--- a/src/features/search/components/SearchHistoryItem/SearchHistoryItem.tsx
+++ b/src/features/search/components/SearchHistoryItem/SearchHistoryItem.tsx
@@ -7,9 +7,10 @@ import { v4 as uuidv4 } from 'uuid'
 import { SearchGroupNameEnumv2 } from 'api/gen'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { Highlight } from 'features/search/components/Highlight/Highlight'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { getNativeCategoryFromEnum } from 'features/search/helpers/categoriesHelpers/categoriesHelpers'
-import { HistoryItem, SearchState, SearchView } from 'features/search/types'
+import { Highlighted, HistoryItem, SearchState, SearchView } from 'features/search/types'
 import { useSearchGroupLabel } from 'libs/subcategories'
 import { useSubcategories } from 'libs/subcategories/useSubcategories'
 import { Li } from 'ui/components/Li'
@@ -17,10 +18,11 @@ import { ClockFilled } from 'ui/svg/icons/ClockFilled'
 import { Typo, getSpacing } from 'ui/theme'
 
 type Props = {
-  item: HistoryItem
+  item: Highlighted<HistoryItem>
+  queryHistory: string
 }
 
-export function SearchHistoryItem({ item }: Props) {
+export function SearchHistoryItem({ item, queryHistory }: Props) {
   const { data } = useSubcategories()
   const { searchState } = useSearch()
   const { navigate } = useNavigation<UseNavigationType>()
@@ -58,7 +60,11 @@ export function SearchHistoryItem({ item }: Props) {
           <ClockFilledIcon />
         </ClockIconContainer>
         <StyledText numberOfLines={1}>
-          <ItalicText>{item.query}</ItalicText>
+          {queryHistory === '' ? (
+            <ItalicText testID="withoutUsingHighlight">{item.query}</ItalicText>
+          ) : (
+            <Highlight historyItem={item} />
+          )}
           {!!shouldDisplaySearchGroupOrNativeCategory && (
             <React.Fragment>
               <ItalicText> dans </ItalicText>

--- a/src/features/search/helpers/addHighlightedAttribute/addHighlightedAttribute.test.ts
+++ b/src/features/search/helpers/addHighlightedAttribute/addHighlightedAttribute.test.ts
@@ -1,0 +1,26 @@
+import { mockedSearchHistory } from 'features/search/fixtures/mockedSearchHistory'
+import { addHighlightedAttribute } from 'features/search/helpers/addHighlightedAttribute/addHighlightedAttribute'
+
+describe('addHighlightedAttribute', () => {
+  it('should return an item without highlighting when query is an empty string', () => {
+    const attribute = addHighlightedAttribute({ item: mockedSearchHistory[0], query: '' })
+
+    expect(attribute).toEqual({
+      _highlightResult: { query: { value: 'manga' } },
+      createdAt: 1695632460000,
+      query: 'manga',
+      label: 'manga',
+    })
+  })
+
+  it('should return an item with highlighting when query is not an empty string', () => {
+    const attribute = addHighlightedAttribute({ item: mockedSearchHistory[0], query: 'man' })
+
+    expect(attribute).toEqual({
+      _highlightResult: { query: { value: '<mark>man</mark>ga' } },
+      createdAt: 1695632460000,
+      query: 'manga',
+      label: 'manga',
+    })
+  })
+})

--- a/src/features/search/helpers/addHighlightedAttribute/addHighlightedAttribute.ts
+++ b/src/features/search/helpers/addHighlightedAttribute/addHighlightedAttribute.ts
@@ -1,0 +1,25 @@
+import { Highlighted, HistoryItem } from 'features/search/types'
+
+type HighlightParams<TItem> = {
+  item: TItem
+  query: string
+}
+
+export function addHighlightedAttribute<TItem extends HistoryItem>({
+  item,
+  query,
+}: HighlightParams<TItem>): Highlighted<TItem> {
+  const valueToHighlight = query
+    ? item.query.replace(
+        new RegExp(query.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&'), 'gi'),
+        '<mark>$&</mark>'
+      )
+    : item.query
+
+  return {
+    ...item,
+    _highlightResult: {
+      query: { value: valueToHighlight },
+    },
+  }
+}

--- a/src/features/search/helpers/addHighlightedAttribute/addHighlightedAttribute.ts
+++ b/src/features/search/helpers/addHighlightedAttribute/addHighlightedAttribute.ts
@@ -1,3 +1,4 @@
+import { getHighlightedQuery } from 'features/search/helpers/getHighlightedQuery/getHighlightedQuery'
 import { Highlighted, HistoryItem } from 'features/search/types'
 
 type HighlightParams<TItem> = {
@@ -9,12 +10,7 @@ export function addHighlightedAttribute<TItem extends HistoryItem>({
   item,
   query,
 }: HighlightParams<TItem>): Highlighted<TItem> {
-  const valueToHighlight = query
-    ? item.query.replace(
-        new RegExp(query.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&'), 'gi'),
-        '<mark>$&</mark>'
-      )
-    : item.query
+  const valueToHighlight = query ? getHighlightedQuery(item.query, query) : item.query
 
   return {
     ...item,

--- a/src/features/search/helpers/getHighlightedQuery/getHighlightedQuery.test.ts
+++ b/src/features/search/helpers/getHighlightedQuery/getHighlightedQuery.test.ts
@@ -1,0 +1,27 @@
+import { getHighlightedQuery } from 'features/search/helpers/getHighlightedQuery/getHighlightedQuery'
+
+describe('getHighlightedQuery', () => {
+  it('should return highlighted query', () => {
+    const highlightedQuery = getHighlightedQuery('one piece', 'one')
+
+    expect(highlightedQuery).toEqual('<mark>one</mark> piece')
+  })
+
+  it('should return highlighted query by handleling case insensitively', () => {
+    const highlightedQuery = getHighlightedQuery('one piece', 'oNe')
+
+    expect(highlightedQuery).toEqual('<mark>one</mark> piece')
+  })
+
+  it('should return highlighted query with special character', () => {
+    const highlightedQuery = getHighlightedQuery('$one piece', '$one')
+
+    expect(highlightedQuery).toEqual('<mark>$one</mark> piece')
+  })
+
+  it('should return query without highlightening when part to hightlight is an empty string', () => {
+    const highlightedQuery = getHighlightedQuery('one piece', '')
+
+    expect(highlightedQuery).toEqual('one piece')
+  })
+})

--- a/src/features/search/helpers/getHighlightedQuery/getHighlightedQuery.ts
+++ b/src/features/search/helpers/getHighlightedQuery/getHighlightedQuery.ts
@@ -1,0 +1,9 @@
+export function getHighlightedQuery(query: string, partToHighlight: string): string {
+  if (partToHighlight === '') return query
+
+  const escapedPartToHighlight = partToHighlight.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&')
+
+  const regex = new RegExp(escapedPartToHighlight, 'gi')
+
+  return query.replace(regex, '<mark>$&</mark>')
+}

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -140,6 +140,14 @@ export type CreateHistoryItem = {
   category?: SearchGroupNameEnumv2
 }
 
+export type Highlighted<TItem> = TItem & {
+  _highlightResult: {
+    query: {
+      value: string
+    }
+  }
+}
+
 export type HistoryItem = CreateHistoryItem & {
   createdAt: number
   label: string


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24618

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="386" alt="Capture d’écran 2023-10-02 à 14 00 13" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/5c77254a-4af7-45c8-94d4-ec478e8251ae">|<img width="456" alt="Capture d’écran 2023-10-02 à 13 58 26" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/ba20bbb0-d6a4-4ed2-a03e-3c5a6a8216ec">|
| Android          |               |<img width="435" alt="Capture d’écran 2023-10-02 à 13 57 53" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/0aaf2a0b-04d5-470f-ab57-4a61f7c0f104">|
| Phone - Chrome   |              |<img width="410" alt="Capture d’écran 2023-10-02 à 12 46 46" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/20453258-ffd0-4821-bb90-9d7ee44d4b20">|
| Desktop - Chrome |               |<img width="1724" alt="Capture d’écran 2023-10-02 à 12 46 38" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/94c18630-9c78-4c01-8440-013f426b594d">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
