### PR TITLE
(PC-24749) fix(ios): fix zoom in highlight thematic home

### DIFF
--- a/src/features/home/components/headers/AnimatedHighlightThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/AnimatedHighlightThematicHomeHeader.tsx
@@ -5,17 +5,13 @@ import styled from 'styled-components/native'
 import { BlackGradient } from 'features/home/components/BlackGradient'
 import { HEADER_BLACK_BACKGROUND_HEIGHT } from 'features/home/components/constants'
 import { BlackBackground } from 'features/home/components/headers/BlackBackground'
+import { Introduction } from 'features/home/components/headers/highlightThematic/Introduction'
 import { computeDateRangeDisplay } from 'features/home/components/helpers/computeDateRangeDisplay'
 import { HighlightThematicHeader } from 'features/home/types'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 type HighligthThematicHeaderProps = Omit<HighlightThematicHeader, 'type'>
-
-type IntroductionProps = {
-  title: string
-  paragraph: string
-}
 
 const MOBILE_HEADER_HEIGHT = getSpacing(70)
 
@@ -70,19 +66,6 @@ export const AnimatedHighlightThematicHomeHeader: FunctionComponent<
   )
 }
 
-const Introduction = ({ title, paragraph }: IntroductionProps) => (
-  <React.Fragment>
-    <IntroductionContainer>
-      <Typo.Title4 numberOfLines={3}>{title}</Typo.Title4>
-      <Spacer.Column numberOfSpaces={4} />
-      <Typo.Body>{paragraph}</Typo.Body>
-    </IntroductionContainer>
-    <Spacer.Column numberOfSpaces={6} />
-    <Divider />
-    <Spacer.Column numberOfSpaces={6} />
-  </React.Fragment>
-)
-
 const Container = styled.View({
   position: 'absolute',
   top: 0,
@@ -125,13 +108,4 @@ const Subtitle = styled(Typo.Title4)(({ theme }) => ({
 
 const Title = styled(Typo.Title1)(({ theme }) => ({
   color: theme.colors.white,
-}))
-
-const IntroductionContainer = styled.View({
-  paddingHorizontal: getSpacing(6),
-})
-
-const Divider = styled.View(({ theme }) => ({
-  height: getSpacing(1),
-  backgroundColor: theme.colors.greyLight,
 }))

--- a/src/features/home/components/headers/AnimatedHighlightThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/AnimatedHighlightThematicHomeHeader.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components/native'
 import { BlackGradient } from 'features/home/components/BlackGradient'
 import { HEADER_BLACK_BACKGROUND_HEIGHT } from 'features/home/components/constants'
 import { BlackBackground } from 'features/home/components/headers/BlackBackground'
-import { Introduction } from 'features/home/components/headers/highlightThematic/Introduction'
 import { computeDateRangeDisplay } from 'features/home/components/helpers/computeDateRangeDisplay'
 import { HighlightThematicHeader } from 'features/home/types'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
@@ -23,16 +22,12 @@ export const AnimatedHighlightThematicHomeHeader: FunctionComponent<
   imageUrl,
   beginningDate,
   endingDate,
-  introductionTitle,
-  introductionParagraph,
   gradientTranslation,
   imageAnimatedHeight,
 }) => {
   const { top } = useCustomSafeInsets()
 
   const dateRange = computeDateRangeDisplay(beginningDate, endingDate)
-
-  const shouldShowIntroduction = !!introductionTitle && !!introductionParagraph
 
   const AnimatedImage = Animated.createAnimatedComponent(StyledImage)
   const AnimatedBlackBackground = Animated.createAnimatedComponent(BlackBackground)
@@ -59,9 +54,6 @@ export const AnimatedHighlightThematicHomeHeader: FunctionComponent<
           <Title numberOfLines={2}>{title}</Title>
         </AnimatedBlackBackground>
       </TextContainer>
-      {shouldShowIntroduction ? (
-        <Introduction title={introductionTitle} paragraph={introductionParagraph} />
-      ) : null}
     </Container>
   )
 }

--- a/src/features/home/components/headers/AnimatedHighlightThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/AnimatedHighlightThematicHomeHeader.tsx
@@ -10,12 +10,12 @@ import { HighlightThematicHeader } from 'features/home/types'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
-type HighligthThematicHeaderProps = Omit<HighlightThematicHeader, 'type'>
+type HighlightThematicHeaderProps = Omit<HighlightThematicHeader, 'type'>
 
 const MOBILE_HEADER_HEIGHT = getSpacing(70)
 
 export const AnimatedHighlightThematicHomeHeader: FunctionComponent<
-  HighligthThematicHeaderProps
+  HighlightThematicHeaderProps
 > = ({
   title,
   subtitle,

--- a/src/features/home/components/headers/HighlightThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/HighlightThematicHomeHeader.tsx
@@ -4,17 +4,13 @@ import styled from 'styled-components/native'
 import { BlackGradient } from 'features/home/components/BlackGradient'
 import { HEADER_BLACK_BACKGROUND_HEIGHT } from 'features/home/components/constants'
 import { BlackBackground } from 'features/home/components/headers/BlackBackground'
+import { Introduction } from 'features/home/components/headers/highlightThematic/Introduction'
 import { computeDateRangeDisplay } from 'features/home/components/helpers/computeDateRangeDisplay'
 import { HighlightThematicHeader } from 'features/home/types'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 type HighligthThematicHeaderProps = Omit<HighlightThematicHeader, 'type'>
-
-type IntroductionProps = {
-  title: string
-  paragraph: string
-}
 
 const DESKTOP_HEADER_HEIGHT = getSpacing(100)
 const MOBILE_HEADER_HEIGHT = getSpacing(70)
@@ -60,19 +56,6 @@ export const HighlightThematicHomeHeader: FunctionComponent<HighligthThematicHea
   )
 }
 
-const Introduction = ({ title, paragraph }: IntroductionProps) => (
-  <React.Fragment>
-    <IntroductionContainer>
-      <Typo.Title4 numberOfLines={3}>{title}</Typo.Title4>
-      <Spacer.Column numberOfSpaces={4} />
-      <Typo.Body>{paragraph}</Typo.Body>
-    </IntroductionContainer>
-    <Spacer.Column numberOfSpaces={6} />
-    <Divider />
-    <Spacer.Column numberOfSpaces={6} />
-  </React.Fragment>
-)
-
 const ImageBackground = styled.ImageBackground(({ theme }) => ({
   height: theme.isDesktopViewport ? DESKTOP_HEADER_HEIGHT : MOBILE_HEADER_HEIGHT,
   marginBottom: getSpacing(6),
@@ -102,13 +85,4 @@ const Subtitle = styled(Typo.Title4)(({ theme }) => ({
 
 const Title = styled(Typo.Title1)(({ theme }) => ({
   color: theme.colors.white,
-}))
-
-const IntroductionContainer = styled.View({
-  paddingHorizontal: getSpacing(6),
-})
-
-const Divider = styled.View(({ theme }) => ({
-  height: getSpacing(1),
-  backgroundColor: theme.colors.greyLight,
 }))

--- a/src/features/home/components/headers/highlightThematic/Introduction.tsx
+++ b/src/features/home/components/headers/highlightThematic/Introduction.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { getSpacing, Spacer, Typo } from 'ui/theme'
+
+type IntroductionProps = {
+  title: string
+  paragraph: string
+}
+
+export const Introduction = ({ title, paragraph }: IntroductionProps) => (
+  <React.Fragment>
+    <IntroductionContainer>
+      <Typo.Title4 numberOfLines={3}>{title}</Typo.Title4>
+      <Spacer.Column numberOfSpaces={4} />
+      <Typo.Body>{paragraph}</Typo.Body>
+    </IntroductionContainer>
+    <Spacer.Column numberOfSpaces={6} />
+    <Divider />
+    <Spacer.Column numberOfSpaces={6} />
+  </React.Fragment>
+)
+
+const IntroductionContainer = styled.View({
+  paddingHorizontal: getSpacing(6),
+})
+
+const Divider = styled.View(({ theme }) => ({
+  height: getSpacing(1),
+  backgroundColor: theme.colors.greyLight,
+}))

--- a/src/features/home/pages/ThematicHome.native.test.tsx
+++ b/src/features/home/pages/ThematicHome.native.test.tsx
@@ -81,6 +81,26 @@ describe('ThematicHome', () => {
     expect(screen.getByTestId('animated-thematic-header')).toBeOnTheScreen()
   })
 
+  it('should show highlight thematic introduction when provided and platform is iOS', async () => {
+    Platform.OS = 'ios'
+
+    const mockedHighlightHeaderDataWithIntroduction = {
+      ...mockedHighlightHeaderData,
+      thematicHeader: {
+        ...mockedHighlightHeaderData.thematicHeader,
+        introductionTitle: 'IntroductionTitle',
+        introductionParagraph: 'IntroductionParagraph',
+      },
+    }
+    mockUseHomepageData.mockReturnValueOnce(mockedHighlightHeaderDataWithIntroduction)
+
+    renderThematicHome()
+    await act(async () => {})
+
+    expect(screen.getByText('IntroductionTitle')).toBeOnTheScreen()
+    expect(screen.getByText('IntroductionParagraph')).toBeOnTheScreen()
+  })
+
   it('should not show highlight animated header when provided and platform is Android', async () => {
     Platform.OS = 'android'
 

--- a/src/features/home/pages/ThematicHome.tsx
+++ b/src/features/home/pages/ThematicHome.tsx
@@ -8,6 +8,7 @@ import { GeolocationBanner } from 'features/home/components/banners/GeolocationB
 import { AnimatedHighlightThematicHomeHeader } from 'features/home/components/headers/AnimatedHighlightThematicHomeHeader'
 import { CategoryThematicHomeHeader } from 'features/home/components/headers/CategoryThematicHomeHeader'
 import { DefaultThematicHomeHeader } from 'features/home/components/headers/DefaultThematicHomeHeader'
+import { Introduction } from 'features/home/components/headers/highlightThematic/Introduction'
 import { HighlightThematicHomeHeader } from 'features/home/components/headers/HighlightThematicHomeHeader'
 import { ThematicHomeHeader } from 'features/home/components/headers/ThematicHomeHeader'
 import { useHomePosition } from 'features/home/helpers/useHomePosition'
@@ -23,7 +24,17 @@ const ANIMATED_HEADER_PLACEHOLDER_HEIGHT = 76
 const SubHeader: FunctionComponent<{ thematicHeader?: ThematicHeader }> = ({ thematicHeader }) => {
   if (thematicHeader?.type === ThematicHeaderType.Highlight) {
     if (Platform.OS === 'ios') {
-      return <Spacer.Column numberOfSpaces={ANIMATED_HEADER_PLACEHOLDER_HEIGHT} />
+      return (
+        <React.Fragment>
+          <Spacer.Column numberOfSpaces={ANIMATED_HEADER_PLACEHOLDER_HEIGHT} />
+          {!!(thematicHeader.introductionTitle && thematicHeader.introductionParagraph) && (
+            <Introduction
+              title={thematicHeader.introductionTitle}
+              paragraph={thematicHeader.introductionParagraph}
+            />
+          )}
+        </React.Fragment>
+      )
     }
     return <HighlightThematicHomeHeader {...thematicHeader} />
   }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24749

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

https://github.com/pass-culture/pass-culture-app-native/assets/26742386/59bd7479-2bd8-414e-a6da-b1fe3d4fed68

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              | <img width="546" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/d600cc8e-3a26-4af0-83c6-52c91d41ac62"> | <img width="546" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/4b10ec39-56b9-47c1-9fb9-af2b96cfcf6f"> |
| iOS          |               | <img width="546" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/fe34e730-ac62-4f6d-9193-c63e9db9c825"> |
| Phone - Chrome   | <img width="376" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/d504a68a-ab25-48a0-b582-2393a15ea622"> | <img width="376" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/47720aa0-121f-4a23-a45b-f7a37fd3c935"> |
| Desktop - Chrome | <img width="1512" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/a6cb20e0-6e6c-4781-88f3-9fc1e801173d"> | <img width="1512" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/b83edfe9-7a86-49a1-acb5-0aadbbb710e4"> |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
