### PR TITLE
(PC-21434) fix(web): Fix webapp on Brave

### DIFF
--- a/__snapshots__/web/SupportedBrowsersGate.native.test.tsx.native-snap
+++ b/__snapshots__/web/SupportedBrowsersGate.native.test.tsx.native-snap
@@ -388,7 +388,36 @@ exports[`SupportedBrowsersGate render correctly 1`] = `
               ]
             }
           >
-            - Les navigateurs basés sur Chromium (autre que Chrome)
+            - Brave (version &gt; 98)
+          </Text>
+        </View>
+        <View
+          accessibilityRole="none"
+          style={
+            [
+              {
+                "display": "flex",
+              },
+            ]
+          }
+        >
+          <Text
+            style={
+              [
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 20,
+                  "paddingBottom": 20,
+                  "paddingLeft": 20,
+                  "paddingRight": 20,
+                  "paddingTop": 20,
+                },
+              ]
+            }
+          >
+            - Les navigateurs basés sur Chromium (autre que Chrome et Brave)
           </Text>
         </View>
       </View>

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -49,8 +49,8 @@ export function App() {
   return (
     <RemoteConfigProvider>
       <ServiceWorkerProvider fileName={`${env.PUBLIC_URL}/service-worker.js`}>
-        <SupportedBrowsersGate>
-          <ThemeProvider theme={theme}>
+        <ThemeProvider theme={theme}>
+          <SupportedBrowsersGate>
             <SafeAreaProvider>
               <ReactQueryClientProvider>
                 <SettingsWrapper>
@@ -85,8 +85,8 @@ export function App() {
                 </SettingsWrapper>
               </ReactQueryClientProvider>
             </SafeAreaProvider>
-          </ThemeProvider>
-        </SupportedBrowsersGate>
+          </SupportedBrowsersGate>
+        </ThemeProvider>
       </ServiceWorkerProvider>
     </RemoteConfigProvider>
   )

--- a/src/features/internal/cheatcodes/pages/NavigationNotScreensPages.tsx
+++ b/src/features/internal/cheatcodes/pages/NavigationNotScreensPages.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react'
+// eslint-disable-next-line no-restricted-imports
+import * as DeviceDetect from 'react-device-detect'
 import { ScrollView } from 'react-native'
 import styled from 'styled-components/native'
 
@@ -16,8 +18,34 @@ const doNothing = () => {
   /* do nothing */
 }
 
+const messengerBrowserRegex = new RegExp(/FBA[VN]/i)
+const isFacebookMessenger = !!messengerBrowserRegex.exec(navigator?.userAgent)
+const browserVersion = Number(DeviceDetect.browserVersion)
+const supportedBrowsers = [
+  { browser: 'Facebook Messenger', active: isFacebookMessenger, version: 1 },
+  { browser: 'Chrome', active: DeviceDetect.isChrome, version: 50 },
+  { browser: 'Safari sur iOS', active: DeviceDetect.isMobileSafari, version: 12 },
+  { browser: 'Safari sur macOS', active: DeviceDetect.isSafari, version: 10 },
+  { browser: 'Firefox', active: DeviceDetect.isFirefox, version: 55 },
+  { browser: 'Edge sur Windows', active: DeviceDetect.isEdge, version: 79 },
+  { browser: 'Opera', active: DeviceDetect.isOpera && DeviceDetect.isDesktop, version: 80 },
+  { browser: 'Samsung', active: DeviceDetect.isSamsungBrowser, version: 5 },
+  { browser: 'Instagram', active: DeviceDetect.browserName === 'Instagram', version: 200 },
+  { browser: 'Brave', active: DeviceDetect.browserName === 'Brave', version: 98 },
+  {
+    browser: 'Les navigateurs basés sur Chromium (autre que Chrome et Brave)',
+    active: DeviceDetect.isChromium,
+    version: 0,
+  },
+]
 const mapPageToComponent: Record<Page, React.JSX.Element> = {
-  [Page.BrowserNotSupportedPage]: <BrowserNotSupportedPage onPress={doNothing} />,
+  [Page.BrowserNotSupportedPage]: (
+    <BrowserNotSupportedPage
+      onPress={doNothing}
+      browserVersion={browserVersion}
+      supportedBrowsers={supportedBrowsers}
+    />
+  ),
 }
 
 export function NavigationNotScreensPages(): React.JSX.Element {

--- a/src/web/SupportedBrowsersGate.native.test.tsx
+++ b/src/web/SupportedBrowsersGate.native.test.tsx
@@ -1,11 +1,72 @@
 import React from 'react'
 
-import { render } from 'tests/utils'
+import { render, screen } from 'tests/utils'
 import { SupportedBrowsersGate } from 'web/SupportedBrowsersGate'
+
+const defaultDeviceMock: Record<string, unknown> = {
+  __esModule: true,
+  isChrome: false,
+  isMobileSafari: false,
+  isSafari: false,
+  isFirefox: false,
+  isEdge: false,
+  isSamsungBrowser: false,
+  browserName: 'none',
+}
+jest.mock('react-device-detect', () => defaultDeviceMock)
 
 describe('SupportedBrowsersGate', () => {
   it('render correctly', () => {
     const renderAPI = render(<SupportedBrowsersGate />)
     expect(renderAPI).toMatchSnapshot()
+  })
+
+  describe.each`
+    browserProperty       | browserName        | minimalSupportedVersion
+    ${'isChrome'}         | ${'Chrome'}        | ${50}
+    ${'isMobileSafari'}   | ${'Mobile Safari'} | ${12}
+    ${'isSafari'}         | ${'Safari'}        | ${10}
+    ${'isFirefox'}        | ${'Firefox'}       | ${55}
+    ${'isEdge'}           | ${'Edge'}          | ${79}
+    ${'isSamsungBrowser'} | ${'Samsung'}       | ${5}
+    ${'isInstagram'}      | ${'Instagram'}     | ${200}
+    ${'isBrave'}          | ${'Brave'}         | ${98}
+    ${'isChromium'}       | ${'Chromium'}      | ${0}
+  `('', ({ browserProperty, browserName, minimalSupportedVersion }) => {
+    beforeAll(() => {
+      defaultDeviceMock[browserProperty] = true
+      defaultDeviceMock.browserName = browserName
+    })
+
+    afterAll(() => {
+      defaultDeviceMock[browserProperty] = false
+      defaultDeviceMock.browserName = 'none'
+      defaultDeviceMock.browserVersion = undefined
+    })
+
+    it(`should support ${browserName} for versions ${minimalSupportedVersion} and above`, () => {
+      defaultDeviceMock.browserVersion = minimalSupportedVersion
+
+      render(<SupportedBrowsersGate />)
+
+      expect(
+        screen.queryByText(
+          `Oups ! Nous ne pouvons afficher correctement l’application car ton navigateur (${browserName} v${minimalSupportedVersion}) n’est pas à jour`
+        )
+      ).not.toBeOnTheScreen()
+    })
+
+    it(`should not support ${browserName} for versions below ${minimalSupportedVersion}`, () => {
+      const unsupportedVersion = minimalSupportedVersion - 1
+      defaultDeviceMock.browserVersion = unsupportedVersion
+
+      render(<SupportedBrowsersGate />)
+
+      expect(
+        screen.getByText(
+          `Oups ! Nous ne pouvons afficher correctement l’application car ton navigateur (${browserName} v${unsupportedVersion}) n’est pas à jour`
+        )
+      ).toBeOnTheScreen()
+    })
   })
 })

--- a/src/web/SupportedBrowsersGate.tsx
+++ b/src/web/SupportedBrowsersGate.tsx
@@ -9,7 +9,11 @@ import { Li } from 'ui/components/Li'
 import { VerticalUl } from 'ui/components/Ul'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
-const browserVersion = Number(DeviceDetect.browserVersion)
+type SupportedBrowsers = Array<{
+  browser: string
+  active: boolean
+  version: number
+}>
 
 // To check if browser is in-app Facebook Messenger browser, we check if FBAV or FBAN is in user agent
 // https://stackoverflow.com/a/32348687
@@ -17,37 +21,42 @@ const messengerBrowserRegex = new RegExp(/FBA[VN]/i)
 const isFacebookMessenger = !!messengerBrowserRegex.exec(navigator?.userAgent)
 
 export const SupportedBrowsersGate: React.FC<PropsWithChildren> = ({ children }) => {
-  const [shouldDisplayApp, setShouldDisplayApp] = React.useState(() => isBrowserSupported())
+  const browserVersion = Number(DeviceDetect.browserVersion)
+  const supportedBrowsers: SupportedBrowsers = [
+    { browser: 'Facebook Messenger', active: isFacebookMessenger, version: 1 },
+    { browser: 'Chrome', active: DeviceDetect.isChrome, version: 50 },
+    { browser: 'Safari sur iOS', active: DeviceDetect.isMobileSafari, version: 12 },
+    { browser: 'Safari sur macOS', active: DeviceDetect.isSafari, version: 10 },
+    { browser: 'Firefox', active: DeviceDetect.isFirefox, version: 55 },
+    { browser: 'Edge sur Windows', active: DeviceDetect.isEdge, version: 79 },
+    { browser: 'Opera', active: DeviceDetect.isOpera && DeviceDetect.isDesktop, version: 80 },
+    { browser: 'Samsung', active: DeviceDetect.isSamsungBrowser, version: 5 },
+    { browser: 'Instagram', active: DeviceDetect.browserName === 'Instagram', version: 200 },
+    { browser: 'Brave', active: DeviceDetect.browserName === 'Brave', version: 98 },
+    {
+      browser: 'Les navigateurs basés sur Chromium (autre que Chrome et Brave)',
+      active: DeviceDetect.isChromium,
+      version: 0,
+    },
+  ]
+
+  const [shouldDisplayApp, setShouldDisplayApp] = React.useState(() =>
+    isBrowserSupported(browserVersion, supportedBrowsers)
+  )
 
   if (!shouldDisplayApp) {
-    return <BrowserNotSupportedPage onPress={() => setShouldDisplayApp(true)} />
+    return (
+      <BrowserNotSupportedPage
+        browserVersion={browserVersion}
+        supportedBrowsers={supportedBrowsers}
+        onPress={() => setShouldDisplayApp(true)}
+      />
+    )
   }
   return <React.Fragment>{children}</React.Fragment>
 }
 
-const supportedBrowsers: Array<{
-  browser: string
-  active: boolean
-  version: number
-}> = [
-  { browser: 'Facebook Messenger', active: isFacebookMessenger, version: 1 },
-  { browser: 'Chrome', active: DeviceDetect.isChrome, version: 50 },
-  { browser: 'Safari sur iOS', active: DeviceDetect.isMobileSafari, version: 12 },
-  { browser: 'Safari sur macOS', active: DeviceDetect.isSafari, version: 10 },
-  { browser: 'Firefox', active: DeviceDetect.isFirefox, version: 55 },
-  { browser: 'Edge sur Windows', active: DeviceDetect.isEdge, version: 79 },
-  { browser: 'Opera', active: DeviceDetect.isOpera && DeviceDetect.isDesktop, version: 80 },
-  { browser: 'Samsung', active: DeviceDetect.isSamsungBrowser, version: 5 },
-  { browser: 'Instagram', active: DeviceDetect.browserName === 'Instagram', version: 200 },
-  { browser: 'Brave', active: DeviceDetect.browserName === 'Brave', version: 98 },
-  {
-    browser: 'Les navigateurs basés sur Chromium (autre que Chrome et Brave)',
-    active: DeviceDetect.isChromium,
-    version: 0,
-  },
-]
-
-function isBrowserSupported() {
+function isBrowserSupported(browserVersion: number, supportedBrowsers: SupportedBrowsers) {
   for (const supportedBrowser of supportedBrowsers) {
     if (supportedBrowser.active && browserVersion >= supportedBrowser.version) {
       return true
@@ -56,7 +65,11 @@ function isBrowserSupported() {
   return false
 }
 
-export const BrowserNotSupportedPage: React.FC<{ onPress: () => void }> = ({ onPress }) => {
+export const BrowserNotSupportedPage: React.FC<{
+  browserVersion: number
+  supportedBrowsers: SupportedBrowsers
+  onPress: () => void
+}> = ({ browserVersion, supportedBrowsers, onPress }) => {
   const title = `Oups\u00a0! Nous ne pouvons afficher correctement l’application car ton navigateur (${DeviceDetect.browserName} v${browserVersion}) n’est pas à jour`
   return (
     <ScrollView contentContainerStyle={contentContainerStyle}>

--- a/src/web/SupportedBrowsersGate.tsx
+++ b/src/web/SupportedBrowsersGate.tsx
@@ -39,8 +39,9 @@ const supportedBrowsers: Array<{
   { browser: 'Opera', active: DeviceDetect.isOpera && DeviceDetect.isDesktop, version: 80 },
   { browser: 'Samsung', active: DeviceDetect.isSamsungBrowser, version: 5 },
   { browser: 'Instagram', active: DeviceDetect.browserName === 'Instagram', version: 200 },
+  { browser: 'Brave', active: DeviceDetect.browserName === 'Brave', version: 98 },
   {
-    browser: 'Les navigateurs basés sur Chromium (autre que Chrome)',
+    browser: 'Les navigateurs basés sur Chromium (autre que Chrome et Brave)',
     active: DeviceDetect.isChromium,
     version: 0,
   },


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-21434

## Explication de la source du bug
Une sous-dépendance (`ua-parser-js`) a été mise à jour, de la `0.7.30` à la `1.0.34` ([dans cette PR](https://github.com/pass-culture/pass-culture-app-native/pull/4583)).
À partir de la version `1.0.34`, Brave est détecté comme un navigateur "à part entière" (cf [changelog](https://github.com/faisalman/ua-parser-js/blob/master/CHANGELOG.md#version-0734--1034), il était détecté juste comme Chrome avant). La webapp essayait donc d'afficher la page "Ce navigateur n'est pas supporté", mais avait des erreurs `reading property ... of undefined`, parce qu'il n'arrivait pas accéder au thème de l'app (`SupportedBrowsersGate` était défini avant le `ThemeProvider`).

1er commit : Déplacement du détecteur de navigateur dans le ThemeProvider
2ème commit : Ajout de Brave en tant que navigateur supporté
3ème commit : Refacto pour pouvoir mocker la lib `react-device-detect`
4ème commit : Écriture de test pour les navigateurs supportés et non supportés

## Checklist
I have:
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots
| Platform         |  Version < 98 (structuredClone not supported) | Version >= 98 |
| :--------------- |  :---: | :---: |
| Desktop - Brave |     <img width="1285" alt="Capture d’écran 2023-10-04 à 07 50 44" src="https://github.com/pass-culture/pass-culture-app-native/assets/46637324/cbe61a16-7fbe-4649-9068-cfd0954de58a">        |   <img width="1188" alt="Capture d’écran 2023-10-04 à 07 45 05" src="https://github.com/pass-culture/pass-culture-app-native/assets/46637324/471332d1-f5b0-4693-99b2-384fac15f775">    |

