### PR TITLE
(PC-24931) ci(notification): improve slack notifications and rename android workflow

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -60,9 +60,8 @@ jobs:
   soft-deploy-testing:
     needs: yarn-tester
     if: github.ref == 'refs/heads/master'
-    uses: ./.github/workflows/dev_on_workflow_environment_deploy.yml
+    uses: ./.github/workflows/dev_on_workflow_environment_soft_deploy.yml
     with:
-      TYPE: soft
       ENV: testing
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
@@ -70,9 +69,8 @@ jobs:
   soft-deploy-staging:
     needs: yarn-tester
     if: startsWith(github.ref, 'refs/tags/hotfix-staging')
-    uses: ./.github/workflows/dev_on_workflow_environment_deploy.yml
+    uses: ./.github/workflows/dev_on_workflow_environment_soft_deploy.yml
     with:
-      TYPE: soft
       ENV: staging
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
@@ -80,9 +78,8 @@ jobs:
   soft-deploy-production:
     needs: yarn-tester
     if: startsWith(github.ref, 'refs/tags/hotfix-production')
-    uses: ./.github/workflows/dev_on_workflow_environment_deploy.yml
+    uses: ./.github/workflows/dev_on_workflow_environment_soft_deploy.yml
     with:
-      TYPE: soft
       ENV: production
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
@@ -90,9 +87,8 @@ jobs:
   hard-deploy-android-testing:
     needs: yarn-tester
     if: startsWith(github.ref, 'refs/tags/testing') || startsWith(github.ref, 'refs/tags/v')
-    uses: ./.github/workflows/dev_on_workflow_environment_deploy.yml
+    uses: ./.github/workflows/dev_on_workflow_environment_android_deploy.yml
     with:
-      TYPE: hard
       ENV: testing
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
@@ -102,7 +98,6 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/testing') || startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/dev_on_workflow_environment_ios_deploy.yml
     with:
-      TYPE: hard
       ENV: testing
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
@@ -110,9 +105,8 @@ jobs:
   hard-deploy-android-staging:
     needs: yarn-tester
     if: startsWith(github.ref, 'refs/tags/patch') || startsWith(github.ref, 'refs/tags/v')
-    uses: ./.github/workflows/dev_on_workflow_environment_deploy.yml
+    uses: ./.github/workflows/dev_on_workflow_environment_android_deploy.yml
     with:
-      TYPE: hard
       ENV: staging
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
@@ -122,7 +116,6 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/patch') || startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/dev_on_workflow_environment_ios_deploy.yml
     with:
-      TYPE: hard
       ENV: staging
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
@@ -130,9 +123,8 @@ jobs:
   hard-deploy-android-production:
     needs: yarn-tester
     if: startsWith(github.ref, 'refs/tags/prod-hard-deploy')
-    uses: ./.github/workflows/dev_on_workflow_environment_deploy.yml
+    uses: ./.github/workflows/dev_on_workflow_environment_android_deploy.yml
     with:
-      TYPE: hard
       ENV: production
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
@@ -142,7 +134,6 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/prod-hard-deploy')
     uses: ./.github/workflows/dev_on_workflow_environment_ios_deploy.yml
     with:
-      TYPE: hard
       ENV: production
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}

--- a/.github/workflows/dev_on_workflow_environment_android_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_android_deploy.yml
@@ -1,12 +1,9 @@
-name: Install runtime environment and dependencies
+name: Install runtime environment and dependencies Android deploy
 
 on:
   workflow_call:
     inputs:
       ENV:
-        type: string
-        required: true
-      TYPE:
         type: string
         required: true
     secrets:
@@ -48,7 +45,6 @@ jobs:
             ANDROID_KEYSTORE_KEY_PASSWORD:passculture-metier-ehp/passculture-app-native-android-${{ inputs.ENV }}-keystore-key-password
             ANDROID_KEYSTORE:passculture-metier-ehp/passculture-app-native-${{ inputs.ENV }}-keystore
             ANDROID_PLAYSTORE_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-app-native-android-production-service-account
-            IOS_APPCENTER_API_TOKEN:passculture-metier-ehp/passculture-app-native-ios-${{ inputs.ENV }}-token
             SENTRY_AUTH_TOKEN:passculture-metier-ehp/passculture-app-native-sentry-token
       - name: 'Render Sentry Template'
         id: render_template
@@ -58,28 +54,13 @@ jobs:
           vars: |
             token: ${{ steps.secrets.outputs.SENTRY_AUTH_TOKEN }}
           result_path: .sentryclirc
-      - name: Deploy soft android for ${{ inputs.ENV }}
-        if:  ${{ inputs.TYPE == 'soft' }}
-        run: |
-          bundle exec fastlane android deploy codepush: --env ${{ inputs.ENV }}
-        env:
-          ANDROID_APPCENTER_API_TOKEN: ${{ steps.secrets.outputs.ANDROID_APPCENTER_API_TOKEN }}
-      - name: Deploy soft ios App for ${{ inputs.ENV }}
-        if:  ${{ inputs.TYPE == 'soft' }}
-        run: |
-          bundle exec fastlane ios deploy codepush: --env ${{ inputs.ENV }}
-        env:
-          IOS_APPCENTER_API_TOKEN: ${{ steps.secrets.outputs.IOS_APPCENTER_API_TOKEN }}
       - name: Create a directory for keystores
-        if: ${{ inputs.TYPE == 'hard'}}
         run: |
           mkdir --parents android/keystores/
       - name: Setup android keystore for ${{ inputs.ENV }} environment
-        if: ${{ inputs.TYPE == 'hard'}}
         run: |
           echo '${{ steps.secrets.outputs.ANDROID_KEYSTORE }}' |  base64 --decode > android/keystores/${{ inputs.ENV }}.keystore
       - name: Setup android keystore properties for ${{ inputs.ENV }} environment
-        if: ${{ inputs.TYPE == 'hard'}}
         uses: chuhlomin/render-template@v1.6
         with:
           template: templates_github_ci/${{ inputs.ENV }}.keystore.properties
@@ -89,19 +70,15 @@ jobs:
             ANDROID_KEYSTORE_KEY_PASSWORD: ${{ steps.secrets.outputs.ANDROID_KEYSTORE_KEY_PASSWORD }}
           result_path: android/keystores/${{ inputs.ENV }}.keystore.properties
       - name: Setup android Google services config
-        if: ${{ inputs.TYPE == 'hard'}}
         run: echo '${{ steps.secrets.outputs.ANDROID_GOOGLE_SERVICES_JSON }}' > android/app/google-services.json
       - name: Setup android Google services config
-        if: ${{ inputs.TYPE == 'hard'}}
         run: echo '${{ steps.secrets.outputs.ANDROID_PLAYSTORE_SERVICE_ACCOUNT }}' > fastlane/playStoreServiceAccount.json
       - name: Deploy hard android for ${{ inputs.ENV }}
-        if: ${{ inputs.TYPE == 'hard'}}
         run: |
           bundle exec fastlane android deploy --env ${{ inputs.ENV }} --verbose
         env:
           ANDROID_APPCENTER_API_TOKEN: ${{ steps.secrets.outputs.ANDROID_APPCENTER_API_TOKEN }}
       - name: Create Sentry sourcemaps
-        if: ${{ inputs.TYPE == 'hard'}}
         run: bash -c 'source scripts/upload_sourcemaps_to_sentry.sh;upload_sourcemaps "android" ${{ inputs.ENV }}'
 
   slack_notify:
@@ -120,11 +97,9 @@ jobs:
         with:
           secrets: |-
             SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-app-native-slack-token
-      - uses: technote-space/workflow-conclusion-action@v3
-        if: ${{ always() }}
       - name: Post to a Slack channel
         id: slack
-        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' }}
+        if: ${{ steps.sentry_and_deploy.outputs.status == 'failure' }}
         uses: slackapi/slack-github-action@v1.23.0
         with:
           # channel #alertes-deploiement-native
@@ -134,13 +109,13 @@ jobs:
               "attachments": [
                   {
                       "mrkdwn_in": ["text"],
-                      "color": "${{ fromJSON('["#36a64f", "#A30002"]')[ env.WORKFLOW_CONCLUSION == 'failure'] }}",
+                      "color": "${{ fromJSON('["#36a64f", "#A30002"]')[ steps.sentry_and_deploy.outputs.status == 'failure'] }}",
                       "author_name": "${{github.actor}}",
                       "author_link": "https://github.com/${{github.actor}}",
                       "author_icon": "https://github.com/${{github.actor}}.png",
                       "title": "PCAPPNATIVE Deployment",
                       "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                      "text": "Le déploiement sur `${{ inputs.ENV }}` a échoué :boom:"
+                      "text": "Le déploiement android sur `${{ inputs.ENV }}` a ${{ fromJSON('["échoué :boom:", "réussi :rocket:"]')[ steps.sentry_and_deploy.outputs.status == 'failure'] }} :boom:"
                   }
               ],
               "unfurl_links": false,

--- a/.github/workflows/dev_on_workflow_environment_soft_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_soft_deploy.yml
@@ -1,4 +1,4 @@
-name: Install runtime environment and dependencies iOS deploy
+name: Install runtime environment and dependencies soft deploy
 
 on:
   workflow_call:
@@ -14,66 +14,52 @@ on:
 
 jobs:
   sentry_and_deploy:
-    runs-on: macos-12
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - name: Setup yarn
-        run: npm install -g yarn
       - name: Setup java
         uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'temurin'
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
       - name: Yarn install
         run: yarn install
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - name: Install cocoapods
-        run: cd ios/ && bundle exec pod install
       - name: Authentification to Google
         uses: 'google-github-actions/auth@v1'
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      - name: Get Secret from Secret Manager
+      - name: Get Secret
         id: 'secrets'
         uses: 'google-github-actions/get-secretmanager-secrets@v1'
         with:
           secrets: |-
-            FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD:passculture-metier-ehp/passculture-app-native-ios-fastlane-password
+            ANDROID_APPCENTER_API_TOKEN:passculture-metier-ehp/passculture-app-native-android-${{ inputs.ENV }}-token
             IOS_APPCENTER_API_TOKEN:passculture-metier-ehp/passculture-app-native-ios-${{ inputs.ENV }}-token
-            IOS_GOOGLE_SERVICES_PLIST:passculture-metier-ehp/passculture-app-native-ios-google-services-plist-${{ inputs.ENV }}
-            MATCH_GIT_URL:passculture-metier-ehp/passculture-app-native-match-git-url
-            MATCH_PASSWORD:passculture-metier-ehp/passculture-app-native-match-password
-            MATCH_SSH_KEY:passculture-metier-ehp/passculture-app-native-match-ssh-key
-            MATCH_USERNAME:passculture-metier-ehp/passculture-app-native-match-username
             SENTRY_AUTH_TOKEN:passculture-metier-ehp/passculture-app-native-sentry-token
-      - name: 'Render Template'
-        run: |
-          cp templates_github_ci/.sentryclirc .sentryclirc
-          sed '$d' .sentryclirc
-          echo "token=${{ steps.secrets.outputs.SENTRY_AUTH_TOKEN }}" >> .sentryclirc
-      - name: Setup iOS Google services config
-        run: echo '${{ steps.secrets.outputs.IOS_GOOGLE_SERVICES_PLIST }}' > ios/GoogleService-Info.plist
-      - name: Add ssh key needed
-        uses: webfactory/ssh-agent@v0.7.0
+      - name: 'Render Sentry Template'
+        id: render_template
+        uses: chuhlomin/render-template@v1.6
         with:
-          ssh-private-key: ${{  steps.secrets.outputs.MATCH_SSH_KEY }}
-      - name: Deploy hard ios for ${{ inputs.ENV }}
+          template: templates_github_ci/.sentryclirc
+          vars: |
+            token: ${{ steps.secrets.outputs.SENTRY_AUTH_TOKEN }}
+          result_path: .sentryclirc
+      - name: Deploy soft android for ${{ inputs.ENV }}
         run: |
-          bundle exec fastlane ios deploy --env ${{ inputs.ENV }} --verbose
+          bundle exec fastlane android deploy codepush: --env ${{ inputs.ENV }}
         env:
-          FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ steps.secrets.outputs.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
+          ANDROID_APPCENTER_API_TOKEN: ${{ steps.secrets.outputs.ANDROID_APPCENTER_API_TOKEN }}
+      - name: Deploy soft ios App for ${{ inputs.ENV }}
+        run: |
+          bundle exec fastlane ios deploy codepush: --env ${{ inputs.ENV }}
+        env:
           IOS_APPCENTER_API_TOKEN: ${{ steps.secrets.outputs.IOS_APPCENTER_API_TOKEN }}
-          MATCH_PASSWORD: ${{ steps.secrets.outputs.MATCH_PASSWORD }}
-          MATCH_USERNAME: ${{ steps.secrets.outputs.MATCH_USERNAME }}
-          MATCH_GIT_URL: ${{ steps.secrets.outputs.MATCH_GIT_URL }}
-      - name: Create Sentry sourcemaps
-        run: bash -c 'source scripts/upload_sourcemaps_to_sentry.sh;upload_sourcemaps "ios" ${{ inputs.ENV }}'
 
   slack_notify:
     runs-on: [self-hosted, linux, x64]
@@ -109,7 +95,7 @@ jobs:
                       "author_icon": "https://github.com/${{github.actor}}.png",
                       "title": "PCAPPNATIVE Deployment",
                       "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                      "text": "Le déploiement ios sur `${{ inputs.ENV }}` a ${{ fromJSON('["échoué :boom:", "réussi :rocket:"]')[ steps.sentry_and_deploy.outputs.status == 'failure'] }} :boom:"
+                      "text": "Le déploiement android sur `${{ inputs.ENV }}` a ${{ fromJSON('["échoué :boom:", "réussi :rocket:"]')[ steps.sentry_and_deploy.outputs.status == 'failure'] }} :boom:"
                   }
               ],
               "unfurl_links": false,

--- a/.github/workflows/dev_on_workflow_update_jira_issues.yml
+++ b/.github/workflows/dev_on_workflow_update_jira_issues.yml
@@ -22,6 +22,7 @@ jobs:
       commit-hash: ${{ steps.get_commit_info.outputs.commit-hash }}
       commit-number: ${{ steps.get_commit_info.outputs.commit-number }}
     runs-on: [self-hosted, linux, x64]
+    continue-on-error: true
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
@@ -85,6 +86,7 @@ jobs:
     runs-on: [self-hosted, linux, x64]
     needs: issue-number
     if: needs.issue-number.outputs.status != null
+    continue-on-error: true
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3

--- a/.github/workflows/dev_on_workflow_web_deploy.yml
+++ b/.github/workflows/dev_on_workflow_web_deploy.yml
@@ -95,11 +95,9 @@ jobs:
         with:
           secrets: |-
             SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-app-native-slack-token
-      - uses: technote-space/workflow-conclusion-action@v3
-        if: ${{ always() }}
       - name: Post to a Slack channel
         id: slack
-        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' }}
+        if: ${{ steps.web_deploy.outputs.status == 'failure' }}
         uses: slackapi/slack-github-action@v1.23.0
         with:
           # channel #alertes-deploiement-native
@@ -109,13 +107,13 @@ jobs:
               "attachments": [
                   {
                       "mrkdwn_in": ["text"],
-                      "color": "${{ fromJSON('["#36a64f", "#A30002"]')[ env.WORKFLOW_CONCLUSION == 'failure'] }}",
+                      "color": "${{ fromJSON('["#36a64f", "#A30002"]')[ steps.web_deploy.outputs.status == 'failure'] }}",
                       "author_name": "${{github.actor}}",
                       "author_link": "https://github.com/${{github.actor}}",
                       "author_icon": "https://github.com/${{github.actor}}.png",
                       "title": "PCAPPNATIVE Deployment",
                       "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                      "text": "Le déploiement web sur `${{ inputs.ENV }}` a échoué :boom:"
+                      "text": "Le déploiement web sur `${{ inputs.ENV }}` a ${{ fromJSON('["échoué :boom:", "réussi :rocket:"]')[ steps.web_deploy.outputs.status == 'failure'] }}"
                   }
               ],
               "unfurl_links": false,

--- a/.github/workflows/dev_on_workflow_web_proxy_deploy.yml
+++ b/.github/workflows/dev_on_workflow_web_proxy_deploy.yml
@@ -85,11 +85,9 @@ jobs:
         with:
           secrets: |-
             SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-app-native-slack-token
-      - uses: technote-space/workflow-conclusion-action@v3
-        if: ${{ always() }}
       - name: Post to a Slack channel
         id: slack
-        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' }}
+        if: ${{ steps.web_proxy_deploy.outputs.status == 'failure' }}
         uses: slackapi/slack-github-action@v1.23.0
         with:
           # channel #alertes-deploiement-native
@@ -99,13 +97,13 @@ jobs:
               "attachments": [
                   {
                       "mrkdwn_in": ["text"],
-                      "color": "${{ fromJSON('["#36a64f", "#A30002"]')[ env.WORKFLOW_CONCLUSION == 'failure'] }}",
+                      "color": "${{ fromJSON('["#36a64f", "#A30002"]')[ steps.web_proxy_deploy.outputs.status == 'failure'] }}",
                       "author_name": "${{github.actor}}",
                       "author_link": "https://github.com/${{github.actor}}",
                       "author_icon": "https://github.com/${{github.actor}}.png",
                       "title": "PCAPPNATIVE Deployment",
                       "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                      "text": "Le déploiement web proxy sur `${{ inputs.ENV }}` a échoué :boom:"
+                      "text": "Le déploiement web proxy sur `${{ inputs.ENV }}` a ${{ fromJSON('["échoué :boom:", "réussi :rocket:"]')[ steps.web_proxy_deploy.outputs.status == 'failure'] }} :boom:"
                   }
               ],
               "unfurl_links": false,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24931

- Split du job android hard et soft ios/android en 2 workflow
- Notifications slacks sur #alertes-deploiement-native alerte si le déploiement a eu lieu, et tolère l'échec de d'autres étapes (comme déplacé le ticket jira)
- Le ticket jira ne termine plus la CI en échec si le job fail.


## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
