### PR TITLE
(PC-24819) chore(deps): bump react-native-lottie-splash-screen from 1…

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -524,7 +524,7 @@ PODS:
     - React-Core
   - react-native-in-app-review (4.3.3):
     - React-Core
-  - react-native-lottie-splash-screen (1.0.1):
+  - react-native-lottie-splash-screen (1.1.2):
     - React
   - react-native-netinfo (9.0.0):
     - React-Core
@@ -1071,7 +1071,7 @@ SPEC CHECKSUMS:
   react-native-geolocation-service: 608e1da71a1ac31b4de64d9ef2815f697978c55b
   react-native-get-random-values: 2c4ff6b44cb71291dabe9a8ae87d3877dcf387da
   react-native-in-app-review: db8bb167a5f238e7ceca5c242d6b36ce8c4404a4
-  react-native-lottie-splash-screen: 068688c15dd478301fda00f8d87d7fb7d5b9a93e
+  react-native-lottie-splash-screen: 4e1b1fd9d6633f9cd2106d6877eb5ba0147f3e2b
   react-native-netinfo: 5b664b2945a8f02102b296f0f812bddd6827ed9c
   react-native-safe-area-context: 9e40fb181dac02619414ba1294d6c2a807056ab9
   react-native-tracking-transparency: b2029ff756f1128b1f2c7c7c7f3003bc3c950f9f

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "react-native-keychain": "^8.0.0",
     "react-native-launch-navigator": "^1.0.8",
     "react-native-linear-gradient": "^2.5.6",
-    "react-native-lottie-splash-screen": "^1.0.1",
+    "react-native-lottie-splash-screen": "^1.1.2",
     "react-native-modal": "^13.0.0",
     "react-native-permissions": "^3.8.0",
     "react-native-qrcode-svg": "^6.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23188,10 +23188,10 @@ react-native-linear-gradient@^2.5.6:
   resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.5.6.tgz#96215cbc5ec7a01247a20890888aa75b834d44a0"
   integrity sha512-HDwEaXcQIuXXCV70O+bK1rizFong3wj+5Q/jSyifKFLg0VWF95xh8XQgfzXwtq0NggL9vNjPKXa016KuFu+VFg==
 
-react-native-lottie-splash-screen@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-lottie-splash-screen/-/react-native-lottie-splash-screen-1.0.1.tgz#f195a04d3d36ef7f69361380f8c05267fb7b0a22"
-  integrity sha512-7V/ih/IvERkRXvwZ8pSZTYgRrKXYPhRXr8VWPpnGg0Bu1XQMP582bX9i2T7N30v/i3TEQjRowoExxODCG5yP7Q==
+react-native-lottie-splash-screen@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/react-native-lottie-splash-screen/-/react-native-lottie-splash-screen-1.1.2.tgz#7d044cb6aede33dc30611da7a7d9edcb14ee005f"
+  integrity sha512-5V4sk46UlU2MbRDlncT0O3qtBdqjxKfcW5/VXceU82CPcO0z0ItcaX34L74Zt5fqkR80OW1VCccrsIGly1y0lw==
   dependencies:
     lottie-ios "3.2.3"
     lottie-react-native "^5.1.3"


### PR DESCRIPTION
….0.1 to 1.1.2

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24819

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
