### PR TITLE
(BSR) ci(fastlane): add env LANG and LC_ALL set to en_US.UTF-8

### DIFF
--- a/.github/workflows/dev_on_workflow_environment_android_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_android_deploy.yml
@@ -77,6 +77,8 @@ jobs:
         run: |
           bundle exec fastlane android deploy --env ${{ inputs.ENV }} --verbose
         env:
+          LC_ALL: en_US.UTF-8
+          LANG: en_US.UTF-8
           ANDROID_APPCENTER_API_TOKEN: ${{ steps.secrets.outputs.ANDROID_APPCENTER_API_TOKEN }}
       - name: Create Sentry sourcemaps
         run: bash -c 'source scripts/upload_sourcemaps_to_sentry.sh;upload_sourcemaps "android" ${{ inputs.ENV }}'

--- a/.github/workflows/dev_on_workflow_environment_ios_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_ios_deploy.yml
@@ -67,6 +67,8 @@ jobs:
         run: |
           bundle exec fastlane ios deploy --env ${{ inputs.ENV }} --verbose
         env:
+          LC_ALL: en_US.UTF-8
+          LANG: en_US.UTF-8
           FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ steps.secrets.outputs.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
           IOS_APPCENTER_API_TOKEN: ${{ steps.secrets.outputs.IOS_APPCENTER_API_TOKEN }}
           MATCH_PASSWORD: ${{ steps.secrets.outputs.MATCH_PASSWORD }}

--- a/.github/workflows/dev_on_workflow_environment_soft_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_soft_deploy.yml
@@ -54,11 +54,15 @@ jobs:
         run: |
           bundle exec fastlane android deploy codepush: --env ${{ inputs.ENV }}
         env:
+          LC_ALL: en_US.UTF-8
+          LANG: en_US.UTF-8
           ANDROID_APPCENTER_API_TOKEN: ${{ steps.secrets.outputs.ANDROID_APPCENTER_API_TOKEN }}
       - name: Deploy soft ios App for ${{ inputs.ENV }}
         run: |
           bundle exec fastlane ios deploy codepush: --env ${{ inputs.ENV }}
         env:
+          LC_ALL: en_US.UTF-8
+          LANG: en_US.UTF-8
           IOS_APPCENTER_API_TOKEN: ${{ steps.secrets.outputs.IOS_APPCENTER_API_TOKEN }}
 
   slack_notify:


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

See doc here :  https://docs.fastlane.tools/getting-started/ios/setup/#set-up-environment-variables
See Warning here :  https://github.com/pass-culture/pass-culture-app-native/actions/runs/6394734967/job/17384663425#step:12:20

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
