### PR TITLE
(PC-24945) fix(sourcemaps): use --sourcemap-output-dir instead

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -64,7 +64,7 @@ platform :ios do
           --target-binary-version \"#{ENV['VERSION']}\" \
           --description \"#{escaped_release_notes}\" \
           --disable-duplicate-release-error \
-          --sourcemap-output \
+          --sourcemap-output-dir build/CodePush \
           --output-dir ./build"
       upload_sentry_sourceMaps_soft
     else
@@ -154,7 +154,7 @@ platform :android do
             --target-binary-version \"#{ENV['VERSION']}\" \
             --description \"#{escaped_release_notes}\" \
             --disable-duplicate-release-error \
-            --sourcemap-output \
+            --sourcemap-output-dir build/CodePush \
             --output-dir ./build"
       upload_sentry_sourceMaps_soft
     else


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24945

Reason for this change as it seems that: 

- `--sourcemap-output` now expect the relative filepath where to generate the sourcemaps but it is not possible to pass this value (see https://github.com/microsoft/appcenter-cli/issues/2462#issue-1933337023)
- by reading appcenter-cli repo, there is a `--sourcemap-output-dir` available, and seems to works fine (https://github.com/microsoft/appcenter-cli/blob/v2.12.0/src/commands/codepush/release-react.ts#L188)

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
