### PR TITLE
(PC-24687) fix(search): fix cropped filter label on android

### DIFF
--- a/__snapshots__/features/search/components/SearchResults/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/components/SearchResults/SearchResults.native.test.tsx.native-snap
@@ -223,10 +223,8 @@ exports[`SearchResults component should render correctly 1`] = `
                   "height": 32,
                   "justifyContent": "center",
                   "opacity": 1,
-                  "paddingBottom": 6,
                   "paddingLeft": 16,
                   "paddingRight": 16,
-                  "paddingTop": 6,
                   "userSelect": "auto",
                 }
               }
@@ -324,10 +322,8 @@ exports[`SearchResults component should render correctly 1`] = `
                   "height": 32,
                   "justifyContent": "center",
                   "opacity": 1,
-                  "paddingBottom": 6,
                   "paddingLeft": 16,
                   "paddingRight": 16,
-                  "paddingTop": 6,
                   "userSelect": "auto",
                 }
               }
@@ -405,10 +401,8 @@ exports[`SearchResults component should render correctly 1`] = `
                   "height": 32,
                   "justifyContent": "center",
                   "opacity": 1,
-                  "paddingBottom": 6,
                   "paddingLeft": 16,
                   "paddingRight": 16,
-                  "paddingTop": 6,
                   "userSelect": "auto",
                 }
               }
@@ -486,10 +480,8 @@ exports[`SearchResults component should render correctly 1`] = `
                   "height": 32,
                   "justifyContent": "center",
                   "opacity": 1,
-                  "paddingBottom": 6,
                   "paddingLeft": 16,
                   "paddingRight": 16,
-                  "paddingTop": 6,
                   "userSelect": "auto",
                 }
               }
@@ -568,10 +560,8 @@ exports[`SearchResults component should render correctly 1`] = `
                   "height": 32,
                   "justifyContent": "center",
                   "opacity": 1,
-                  "paddingBottom": 6,
                   "paddingLeft": 16,
                   "paddingRight": 16,
-                  "paddingTop": 6,
                   "userSelect": "auto",
                 }
               }

--- a/__snapshots__/features/search/components/SearchResults/SearchResults.web.test.tsx.web-snap
+++ b/__snapshots__/features/search/components/SearchResults/SearchResults.web.test.tsx.web-snap
@@ -93,8 +93,6 @@ exports[`SearchResults component should render correctly 1`] = `
   align-items: center;
   padding-left: 16px;
   padding-right: 16px;
-  padding-top: 6px;
-  padding-bottom: 6px;
   height: 32px;
   background-color: #F1F1F4;
   border-color: #161617;
@@ -129,8 +127,6 @@ exports[`SearchResults component should render correctly 1`] = `
   align-items: center;
   padding-left: 16px;
   padding-right: 16px;
-  padding-top: 6px;
-  padding-bottom: 6px;
   height: 32px;
   background-color: #ffffff;
   border-color: #161617;
@@ -637,8 +633,6 @@ exports[`SearchResults component should render correctly 1`] = `
   align-items: center;
   padding-left: 16px;
   padding-right: 16px;
-  padding-top: 6px;
-  padding-bottom: 6px;
   height: 32px;
   background-color: #F1F1F4;
   border-color: #161617;
@@ -673,8 +667,6 @@ exports[`SearchResults component should render correctly 1`] = `
   align-items: center;
   padding-left: 16px;
   padding-right: 16px;
-  padding-top: 6px;
-  padding-bottom: 6px;
   height: 32px;
   background-color: #ffffff;
   border-color: #161617;

--- a/src/features/search/components/Buttons/SingleFilterButton/SingleFilterButton.tsx
+++ b/src/features/search/components/Buttons/SingleFilterButton/SingleFilterButton.tsx
@@ -52,8 +52,6 @@ const TouchableContainer = styledButton(Touchable)<IsSelectedProps>(({ theme, is
   alignItems: 'center',
   paddingLeft: getSpacing(4),
   paddingRight: getSpacing(4),
-  paddingTop: getSpacing(1.5),
-  paddingBottom: getSpacing(1.5),
   height: getSpacing(8),
   backgroundColor: isSelected ? theme.colors.greyLight : theme.colors.white,
   borderColor: theme.colors.black,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24687

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |![ios_before](https://github.com/pass-culture/pass-culture-app-native/assets/47600889/1f9886a1-4c9c-443e-ae0e-9ce0c76817f2)|![ios_after](https://github.com/pass-culture/pass-culture-app-native/assets/47600889/d9ff1666-e939-4ec8-bf0e-877c4f2400bb)|
| Android          |![androis_before](https://github.com/pass-culture/pass-culture-app-native/assets/47600889/f313a5d0-67c6-4070-bfda-f6ab005d8b69)|![Screenshot_20231012-135623_pass Culture T](https://github.com/pass-culture/pass-culture-app-native/assets/47600889/428e078d-e6c5-4c47-89fd-fc610fd24e8c)|
| Web - Arc |<img width="565" alt="web_before" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/d081628f-e4e3-42f9-9bda-7c932d41178d">|<img width="560" alt="web_after" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/f851f2ec-8b78-4832-a4ea-f6bfe45b4ce5">|
