### PR TITLE
(PC-25021) fix(search): not use native category and category in autocomplete item when there are unknown in the app

### DIFF
--- a/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.native.test.tsx
+++ b/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.native.test.tsx
@@ -13,6 +13,7 @@ import {
   mockHitSeveralCategoriesWithAssociationToNativeCategory,
   mockHitWithOnlyCategory,
   mockHitWithoutCategoryAndNativeCategory,
+  mockHitUnknownNativeCategory,
 } from 'features/search/fixtures/autocompleteHits'
 import { SearchState, SearchView } from 'features/search/types'
 import { Venue } from 'features/venue/types'
@@ -247,6 +248,32 @@ describe('AutocompleteOfferItem component', () => {
           })
         )
       })
+
+      it('without the most popular native category but the most popular category when native category is unknown in the app', async () => {
+        render(
+          <AutocompleteOfferItem
+            hit={mockHitUnknownNativeCategory}
+            sendEvent={mockSendEvent}
+            shouldShowCategory
+            addSearchHistory={jest.fn()}
+          />
+        )
+        await fireEvent.press(screen.getByTestId('autocompleteOfferItem_1'))
+
+        expect(navigate).toBeCalledWith(
+          ...getTabNavConfig('Search', {
+            ...initialSearchState,
+            query: mockHitWithOnlyCategory.query,
+            offerCategories: [SearchGroupNameEnumv2.CD_VINYLE_MUSIQUE_EN_LIGNE],
+            offerNativeCategories: undefined,
+            locationFilter: mockSearchState.locationFilter,
+            priceRange: mockSearchState.priceRange,
+            view: SearchView.Results,
+            searchId,
+            isAutocomplete: true,
+          })
+        )
+      })
     })
 
     describe('should display the most popular native category of the query suggestion', () => {
@@ -305,6 +332,19 @@ describe('AutocompleteOfferItem component', () => {
 
         expect(screen.queryByText('Arts visuels')).not.toBeOnTheScreen()
       })
+
+      it('when it is unknown in the app', () => {
+        render(
+          <AutocompleteOfferItem
+            hit={mockHitUnknownNativeCategory}
+            sendEvent={mockSendEvent}
+            shouldShowCategory
+            addSearchHistory={jest.fn()}
+          />
+        )
+
+        expect(screen.queryByText('dans CD_VINYLES')).not.toBeOnTheScreen()
+      })
     })
 
     describe('should not display the most popular category of the query suggestion ', () => {
@@ -360,6 +400,19 @@ describe('AutocompleteOfferItem component', () => {
         )
 
         expect(screen.getByText('Films, séries, cinéma')).toBeOnTheScreen()
+      })
+
+      it('native category is unknown in the app', async () => {
+        render(
+          <AutocompleteOfferItem
+            hit={mockHitUnknownNativeCategory}
+            sendEvent={mockSendEvent}
+            shouldShowCategory
+            addSearchHistory={jest.fn()}
+          />
+        )
+
+        expect(screen.getByText('CD, vinyles, musique en ligne')).toBeOnTheScreen()
       })
     })
   })

--- a/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.native.test.tsx
+++ b/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.native.test.tsx
@@ -14,6 +14,8 @@ import {
   mockHitWithOnlyCategory,
   mockHitWithoutCategoryAndNativeCategory,
   mockHitUnknownNativeCategory,
+  mockHitUnknownNativeCategoryAndCategory,
+  mockHitUnknownCategory,
 } from 'features/search/fixtures/autocompleteHits'
 import { SearchState, SearchView } from 'features/search/types'
 import { Venue } from 'features/venue/types'
@@ -249,6 +251,57 @@ describe('AutocompleteOfferItem component', () => {
         )
       })
 
+      it('without the most popular category and native category when there are unknown in the app', async () => {
+        render(
+          <AutocompleteOfferItem
+            hit={mockHitUnknownNativeCategoryAndCategory}
+            sendEvent={mockSendEvent}
+            shouldShowCategory
+            addSearchHistory={jest.fn()}
+          />
+        )
+        await fireEvent.press(screen.getByTestId('autocompleteOfferItem_1'))
+
+        expect(navigate).toBeCalledWith(
+          ...getTabNavConfig('Search', {
+            ...initialSearchState,
+            query: mockHitWithOnlyCategory.query,
+            offerCategories: [],
+            offerNativeCategories: undefined,
+            locationFilter: mockSearchState.locationFilter,
+            priceRange: mockSearchState.priceRange,
+            view: SearchView.Results,
+            searchId,
+            isAutocomplete: true,
+          })
+        )
+      })
+
+      it('without the most popular category when it is unknown in the app', async () => {
+        render(
+          <AutocompleteOfferItem
+            hit={mockHitUnknownCategory}
+            sendEvent={mockSendEvent}
+            shouldShowCategory
+            addSearchHistory={jest.fn()}
+          />
+        )
+        await fireEvent.press(screen.getByTestId('autocompleteOfferItem_1'))
+
+        expect(navigate).toBeCalledWith(
+          ...getTabNavConfig('Search', {
+            ...initialSearchState,
+            query: mockHitWithOnlyCategory.query,
+            offerCategories: [],
+            locationFilter: mockSearchState.locationFilter,
+            priceRange: mockSearchState.priceRange,
+            view: SearchView.Results,
+            searchId,
+            isAutocomplete: true,
+          })
+        )
+      })
+
       it('without the most popular native category but the most popular category when native category is unknown in the app', async () => {
         render(
           <AutocompleteOfferItem
@@ -317,6 +370,19 @@ describe('AutocompleteOfferItem component', () => {
 
         expect(screen.queryByText('dans')).not.toBeOnTheScreen()
       })
+
+      it('when there are unknown in the app', async () => {
+        render(
+          <AutocompleteOfferItem
+            hit={mockHitUnknownNativeCategoryAndCategory}
+            sendEvent={mockSendEvent}
+            shouldShowCategory
+            addSearchHistory={jest.fn()}
+          />
+        )
+
+        expect(screen.queryByText('dans')).not.toBeOnTheScreen()
+      })
     })
 
     describe('should not display the most popular native category of the query suggestion ', () => {
@@ -372,6 +438,19 @@ describe('AutocompleteOfferItem component', () => {
         )
 
         expect(screen.queryByText('Films, séries, cinéma')).not.toBeOnTheScreen()
+      })
+
+      it('when category is unknown in the app', async () => {
+        render(
+          <AutocompleteOfferItem
+            hit={mockHitUnknownCategory}
+            sendEvent={mockSendEvent}
+            shouldShowCategory
+            addSearchHistory={jest.fn()}
+          />
+        )
+
+        expect(screen.queryByText('dans')).not.toBeOnTheScreen()
       })
     })
 

--- a/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.native.test.tsx
+++ b/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.native.test.tsx
@@ -7,10 +7,15 @@ import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { AutocompleteOfferItem } from 'features/search/components/AutocompleteOfferItem/AutocompleteOfferItem'
 import { initialSearchState } from 'features/search/context/reducer'
 import { LocationType } from 'features/search/enums'
+import {
+  mockHit,
+  mockHitSeveralCategoriesWithoutAssociationToNativeCategory,
+  mockHitSeveralCategoriesWithAssociationToNativeCategory,
+  mockHitWithOnlyCategory,
+  mockHitWithoutCategoryAndNativeCategory,
+} from 'features/search/fixtures/autocompleteHits'
 import { SearchState, SearchView } from 'features/search/types'
 import { Venue } from 'features/venue/types'
-import { AlgoliaSuggestionHit } from 'libs/algolia'
-import { env } from 'libs/environment'
 import { placeholderData as mockData } from 'libs/subcategories/placeholderData'
 import { mockedSuggestedVenues } from 'libs/venue/fixtures/mockedSuggestedVenues'
 import { render, fireEvent, screen } from 'tests/utils'
@@ -37,129 +42,6 @@ jest.mock('libs/subcategories/useSubcategories', () => ({
 const mockSendEvent = jest.fn()
 
 const searchId = uuidv4()
-
-const mockHit = {
-  objectID: '1',
-  query: 'cinéma',
-  _highlightResult: {
-    query: {
-      value: '<mark>cinéma</mark>',
-      matchLevel: 'full',
-      fullyHighlighted: true,
-      matchedWords: ['cinéma'],
-    },
-  },
-  __position: 123,
-  [env.ALGOLIA_OFFERS_INDEX_NAME]: {
-    exact_nb_hits: 2,
-    facets: {
-      analytics: {
-        ['offer.searchGroupNamev2']: [
-          {
-            attribute: '',
-            operator: '',
-            value: SearchGroupNameEnumv2.FILMS_SERIES_CINEMA,
-            count: 10,
-          },
-        ],
-        ['offer.nativeCategoryId']: [
-          {
-            attribute: '',
-            operator: '',
-            value: NativeCategoryIdEnumv2.SEANCES_DE_CINEMA,
-            count: 10,
-          },
-        ],
-      },
-    },
-  },
-} as AlgoliaSuggestionHit
-
-const mockHitSeveralCategoriesWithAssociationToNativeCategory = {
-  ...mockHit,
-  [env.ALGOLIA_OFFERS_INDEX_NAME]: {
-    exact_nb_hits: 2,
-    facets: {
-      analytics: {
-        ['offer.searchGroupNamev2']: [
-          {
-            attribute: '',
-            operator: '',
-            value: SearchGroupNameEnumv2.MUSEES_VISITES_CULTURELLES,
-            count: 10,
-          },
-        ],
-        ['offer.nativeCategoryId']: [
-          {
-            attribute: '',
-            operator: '',
-            value: NativeCategoryIdEnumv2.ARTS_VISUELS,
-            count: 10,
-          },
-        ],
-      },
-    },
-  },
-}
-const mockHitSeveraCategoriesWithoutAssociationToNativeCategory = {
-  ...mockHit,
-  [env.ALGOLIA_OFFERS_INDEX_NAME]: {
-    exact_nb_hits: 2,
-    facets: {
-      analytics: {
-        ['offer.searchGroupNamev2']: [
-          {
-            attribute: '',
-            operator: '',
-            value: SearchGroupNameEnumv2.FILMS_SERIES_CINEMA,
-            count: 10,
-          },
-        ],
-        ['offer.nativeCategoryId']: [
-          {
-            attribute: '',
-            operator: '',
-            value: NativeCategoryIdEnumv2.ARTS_VISUELS,
-            count: 10,
-          },
-        ],
-      },
-    },
-  },
-}
-
-const mockHitWithoutCategoryAndNativeCategory = {
-  ...mockHit,
-  [env.ALGOLIA_OFFERS_INDEX_NAME]: {
-    exact_nb_hits: 2,
-    facets: {
-      analytics: {
-        ['offer.searchGroupNamev2']: [],
-        ['offer.nativeCategoryId']: [],
-      },
-    },
-  },
-}
-
-const mockHitWithOnlyCategory = {
-  ...mockHit,
-  [env.ALGOLIA_OFFERS_INDEX_NAME]: {
-    exact_nb_hits: 2,
-    facets: {
-      analytics: {
-        ['offer.searchGroupNamev2']: [
-          {
-            attribute: '',
-            operator: '',
-            value: SearchGroupNameEnumv2.FILMS_SERIES_CINEMA,
-            count: 10,
-          },
-        ],
-        ['offer.nativeCategoryId']: [],
-      },
-    },
-  },
-}
 
 describe('AutocompleteOfferItem component', () => {
   beforeEach(() => {
@@ -319,7 +201,7 @@ describe('AutocompleteOfferItem component', () => {
       it('its most popular category when native category associated to several categories and not associated to the most popular category', async () => {
         render(
           <AutocompleteOfferItem
-            hit={mockHitSeveraCategoriesWithoutAssociationToNativeCategory}
+            hit={mockHitSeveralCategoriesWithoutAssociationToNativeCategory}
             sendEvent={mockSendEvent}
             shouldShowCategory
             addSearchHistory={jest.fn()}
@@ -330,7 +212,7 @@ describe('AutocompleteOfferItem component', () => {
         expect(navigate).toBeCalledWith(
           ...getTabNavConfig('Search', {
             ...initialSearchState,
-            query: mockHitSeveraCategoriesWithoutAssociationToNativeCategory.query,
+            query: mockHitSeveralCategoriesWithoutAssociationToNativeCategory.query,
             offerCategories: [SearchGroupNameEnumv2.FILMS_SERIES_CINEMA],
             locationFilter: mockSearchState.locationFilter,
             priceRange: mockSearchState.priceRange,
@@ -395,34 +277,38 @@ describe('AutocompleteOfferItem component', () => {
       })
     })
 
-    it('should not display the most popular category or native category  of the query suggestion when it does not return by Algolia', async () => {
-      render(
-        <AutocompleteOfferItem
-          hit={mockHitWithoutCategoryAndNativeCategory}
-          sendEvent={mockSendEvent}
-          shouldShowCategory
-          addSearchHistory={jest.fn()}
-        />
-      )
+    describe('should not display the most popular category or native category of the query suggestion ', () => {
+      it('when it does not return by Algolia', async () => {
+        render(
+          <AutocompleteOfferItem
+            hit={mockHitWithoutCategoryAndNativeCategory}
+            sendEvent={mockSendEvent}
+            shouldShowCategory
+            addSearchHistory={jest.fn()}
+          />
+        )
 
-      expect(screen.queryByText('dans')).not.toBeOnTheScreen()
+        expect(screen.queryByText('dans')).not.toBeOnTheScreen()
+      })
     })
 
-    it('should not display the most popular native category of the query suggestion when it is not associated to the most popular category', async () => {
-      render(
-        <AutocompleteOfferItem
-          hit={mockHitSeveraCategoriesWithoutAssociationToNativeCategory}
-          sendEvent={mockSendEvent}
-          shouldShowCategory
-          addSearchHistory={jest.fn()}
-        />
-      )
+    describe('should not display the most popular native category of the query suggestion ', () => {
+      it('when it is not associated to the most popular category', async () => {
+        render(
+          <AutocompleteOfferItem
+            hit={mockHitSeveralCategoriesWithoutAssociationToNativeCategory}
+            sendEvent={mockSendEvent}
+            shouldShowCategory
+            addSearchHistory={jest.fn()}
+          />
+        )
 
-      expect(screen.queryByText('Arts visuels')).not.toBeOnTheScreen()
+        expect(screen.queryByText('Arts visuels')).not.toBeOnTheScreen()
+      })
     })
 
-    describe('should not display the most popular category of the query suggestion when native category', () => {
-      it('associated to only one category', async () => {
+    describe('should not display the most popular category of the query suggestion ', () => {
+      it('when native category associated to only one category', async () => {
         render(
           <AutocompleteOfferItem
             hit={mockHit}
@@ -435,7 +321,7 @@ describe('AutocompleteOfferItem component', () => {
         expect(screen.queryByText('Films, séries, cinéma')).not.toBeOnTheScreen()
       })
 
-      it('associated to the most popular category', async () => {
+      it('when native category associated to the most popular category', async () => {
         render(
           <AutocompleteOfferItem
             hit={mockHitSeveralCategoriesWithAssociationToNativeCategory}
@@ -453,7 +339,7 @@ describe('AutocompleteOfferItem component', () => {
       it('it is not associated to the most popular category', async () => {
         render(
           <AutocompleteOfferItem
-            hit={mockHitSeveraCategoriesWithoutAssociationToNativeCategory}
+            hit={mockHitSeveralCategoriesWithoutAssociationToNativeCategory}
             sendEvent={mockSendEvent}
             shouldShowCategory
             addSearchHistory={jest.fn()}

--- a/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
+++ b/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
@@ -54,6 +54,8 @@ export function AutocompleteOfferItem({
   )?.value
   const hasMostPopularHitNativeCategory =
     nativeCategories.length > 0 && !!mostPopularNativeCategoryId
+  const hasMostPopularHitCategory =
+    categories.length > 0 && categories[0].value in SearchGroupNameEnumv2
   const categoriesFromNativeCategory = useMemo(
     () => getSearchGroupsEnumArrayFromNativeCategoryEnum(data, mostPopularNativeCategoryId),
     [data, mostPopularNativeCategoryId]
@@ -66,9 +68,13 @@ export function AutocompleteOfferItem({
 
   const mostPopularCategory = useMemo(() => {
     if (hasSeveralCategoriesFromNativeCategory || !hasMostPopularHitNativeCategory) {
-      return categories.length > 0 ? [categories[0].value] : []
+      return categories.length > 0 && categories[0].value in SearchGroupNameEnumv2
+        ? [categories[0].value]
+        : []
     } else {
-      return [categoriesFromNativeCategory[0]]
+      return categoriesFromNativeCategory[0] in SearchGroupNameEnumv2
+        ? [categoriesFromNativeCategory[0]]
+        : []
     }
   }, [
     categories,

--- a/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
+++ b/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
@@ -5,7 +5,7 @@ import { Keyboard, Text } from 'react-native'
 import styled from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
 
-import { SearchGroupNameEnumv2 } from 'api/gen'
+import { NativeCategoryIdEnumv2, SearchGroupNameEnumv2 } from 'api/gen'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { Highlight } from 'features/search/components/Highlight/Highlight'
@@ -46,13 +46,14 @@ export function AutocompleteOfferItem({
   const searchGroupLabel = useSearchGroupLabel(
     categories.length > 0 ? categories[0].value : SearchGroupNameEnumv2.NONE
   )
-  const mostPopularNativeCategoryId = nativeCategories[0]?.value
+  const mostPopularNativeCategoryId =
+    nativeCategories[0]?.value in NativeCategoryIdEnumv2 ? nativeCategories[0]?.value : undefined
   const mostPopularNativeCategoryValue = getNativeCategoryFromEnum(
     data,
     mostPopularNativeCategoryId
   )?.value
-  const hasMostPopularHitNativeCategory = nativeCategories.length > 0
-  const hasMostPopularHitCategory = categories.length > 0
+  const hasMostPopularHitNativeCategory =
+    nativeCategories.length > 0 && !!mostPopularNativeCategoryId
   const categoriesFromNativeCategory = useMemo(
     () => getSearchGroupsEnumArrayFromNativeCategoryEnum(data, mostPopularNativeCategoryId),
     [data, mostPopularNativeCategoryId]

--- a/src/features/search/fixtures/autocompleteHits.ts
+++ b/src/features/search/fixtures/autocompleteHits.ts
@@ -1,0 +1,201 @@
+import { NativeCategoryIdEnumv2, SearchGroupNameEnumv2 } from 'api/gen'
+import { AlgoliaSuggestionHit } from 'libs/algolia'
+import { env } from 'libs/environment'
+
+export const mockHit = {
+  objectID: '1',
+  query: 'cinéma',
+  _highlightResult: {
+    query: {
+      value: '<mark>cinéma</mark>',
+      matchLevel: 'full',
+      fullyHighlighted: true,
+      matchedWords: ['cinéma'],
+    },
+  },
+  __position: 123,
+  [env.ALGOLIA_OFFERS_INDEX_NAME]: {
+    exact_nb_hits: 2,
+    facets: {
+      analytics: {
+        ['offer.searchGroupNamev2']: [
+          {
+            attribute: '',
+            operator: '',
+            value: SearchGroupNameEnumv2.FILMS_SERIES_CINEMA,
+            count: 10,
+          },
+        ],
+        ['offer.nativeCategoryId']: [
+          {
+            attribute: '',
+            operator: '',
+            value: NativeCategoryIdEnumv2.SEANCES_DE_CINEMA,
+            count: 10,
+          },
+        ],
+      },
+    },
+  },
+} as AlgoliaSuggestionHit
+
+export const mockHitSeveralCategoriesWithAssociationToNativeCategory = {
+  ...mockHit,
+  [env.ALGOLIA_OFFERS_INDEX_NAME]: {
+    exact_nb_hits: 2,
+    facets: {
+      analytics: {
+        ['offer.searchGroupNamev2']: [
+          {
+            attribute: '',
+            operator: '',
+            value: SearchGroupNameEnumv2.MUSEES_VISITES_CULTURELLES,
+            count: 10,
+          },
+        ],
+        ['offer.nativeCategoryId']: [
+          {
+            attribute: '',
+            operator: '',
+            value: NativeCategoryIdEnumv2.ARTS_VISUELS,
+            count: 10,
+          },
+        ],
+      },
+    },
+  },
+}
+
+export const mockHitSeveralCategoriesWithoutAssociationToNativeCategory = {
+  ...mockHit,
+  [env.ALGOLIA_OFFERS_INDEX_NAME]: {
+    exact_nb_hits: 2,
+    facets: {
+      analytics: {
+        ['offer.searchGroupNamev2']: [
+          {
+            attribute: '',
+            operator: '',
+            value: SearchGroupNameEnumv2.FILMS_SERIES_CINEMA,
+            count: 10,
+          },
+        ],
+        ['offer.nativeCategoryId']: [
+          {
+            attribute: '',
+            operator: '',
+            value: NativeCategoryIdEnumv2.ARTS_VISUELS,
+            count: 10,
+          },
+        ],
+      },
+    },
+  },
+}
+
+export const mockHitWithoutCategoryAndNativeCategory = {
+  ...mockHit,
+  [env.ALGOLIA_OFFERS_INDEX_NAME]: {
+    exact_nb_hits: 2,
+    facets: {
+      analytics: {
+        ['offer.searchGroupNamev2']: [],
+        ['offer.nativeCategoryId']: [],
+      },
+    },
+  },
+}
+
+export const mockHitWithOnlyCategory = {
+  ...mockHit,
+  [env.ALGOLIA_OFFERS_INDEX_NAME]: {
+    exact_nb_hits: 2,
+    facets: {
+      analytics: {
+        ['offer.searchGroupNamev2']: [
+          {
+            attribute: '',
+            operator: '',
+            value: SearchGroupNameEnumv2.FILMS_SERIES_CINEMA,
+            count: 10,
+          },
+        ],
+        ['offer.nativeCategoryId']: [],
+      },
+    },
+  },
+}
+
+export const mockHitUnknownNativeCategory = {
+  ...mockHit,
+  [env.ALGOLIA_OFFERS_INDEX_NAME]: {
+    exact_nb_hits: 2,
+    facets: {
+      analytics: {
+        ['offer.searchGroupNamev2']: [
+          {
+            attribute: '',
+            operator: '',
+            value: SearchGroupNameEnumv2.CD_VINYLE_MUSIQUE_EN_LIGNE,
+            count: 10,
+          },
+        ],
+        ['offer.nativeCategoryId']: [
+          {
+            attribute: '',
+            operator: '',
+            value: 'CD_VINYLES' as NativeCategoryIdEnumv2,
+            count: 10,
+          },
+        ],
+      },
+    },
+  },
+}
+
+export const mockHitUnknownCategory = {
+  ...mockHit,
+  [env.ALGOLIA_OFFERS_INDEX_NAME]: {
+    exact_nb_hits: 2,
+    facets: {
+      analytics: {
+        ['offer.searchGroupNamev2']: [
+          {
+            attribute: '',
+            operator: '',
+            value: 'undefined' as SearchGroupNameEnumv2,
+            count: 10,
+          },
+        ],
+        ['offer.nativeCategoryId']: [],
+      },
+    },
+  },
+}
+
+export const mockHitUnknownNativeCategoryAndCategory = {
+  ...mockHit,
+  [env.ALGOLIA_OFFERS_INDEX_NAME]: {
+    exact_nb_hits: 2,
+    facets: {
+      analytics: {
+        ['offer.searchGroupNamev2']: [
+          {
+            attribute: '',
+            operator: '',
+            value: 'undefined' as SearchGroupNameEnumv2,
+            count: 10,
+          },
+        ],
+        ['offer.nativeCategoryId']: [
+          {
+            attribute: '',
+            operator: '',
+            value: 'CD_VINYLES' as NativeCategoryIdEnumv2,
+            count: 10,
+          },
+        ],
+      },
+    },
+  },
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25021

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |![Capture d’écran 2023-10-12 à 18 30 38](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/f06451bd-2ca0-43bd-b414-331eab225cdb)|![Capture d’écran 2023-10-12 à 18 30 11](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/0a16c817-712a-4ccd-bda4-78d56ada1d69)|
| Desktop - Chrome |![Capture d’écran 2023-10-12 à 18 31 00](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/57471c7d-9f47-4270-90a6-2f110a189085)|![Capture d’écran 2023-10-12 à 18 30 02](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/cddd962f-dc2f-4dfe-8d28-13094cb30605)|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
