### PR TITLE
(PC-25063) fix(web): Support multiple recaptcha widgets in dom

### DIFF
--- a/src/libs/recaptcha/ReCaptcha.web.tsx
+++ b/src/libs/recaptcha/ReCaptcha.web.tsx
@@ -25,11 +25,12 @@ export function ReCaptcha(props: Props) {
   useCaptcha()
 
   const reCaptchaContainerRef = useRef<HTMLDivElement>(null)
+  const reCaptchaWidgetRef = useRef<number>()
 
   function onSuccess(token: string) {
     const { grecaptcha } = window
     if (grecaptcha?.reset) {
-      grecaptcha.reset()
+      grecaptcha.reset(reCaptchaWidgetRef.current)
     }
     props.onSuccess(token)
   }
@@ -64,7 +65,7 @@ export function ReCaptcha(props: Props) {
         if (!isReCaptchaRendered) {
           grecaptcha.ready(() => {
             if (grecaptcha.render) {
-              grecaptcha.render(reCaptchaContainer, {
+              reCaptchaWidgetRef.current = grecaptcha.render(reCaptchaContainer, {
                 sitekey: env.SITE_KEY,
                 callback: onSuccess,
                 'expired-callback': props.onExpire,
@@ -77,7 +78,7 @@ export function ReCaptcha(props: Props) {
         }
         if (isReCaptchaRendered) {
           try {
-            grecaptcha.execute()
+            grecaptcha.execute(reCaptchaWidgetRef.current)
             clearInterval(intervalId)
           } catch (error) {
             if (error instanceof Error) props.onError('reCAPTCHA error: ' + error.message)

--- a/src/libs/recaptcha/ReCaptcha.web.tsx
+++ b/src/libs/recaptcha/ReCaptcha.web.tsx
@@ -64,7 +64,7 @@ export function ReCaptcha(props: Props) {
         if (!isReCaptchaRendered) {
           grecaptcha.ready(() => {
             if (grecaptcha.render) {
-              grecaptcha.render(reCaptchaContainer.id, {
+              grecaptcha.render(reCaptchaContainer, {
                 sitekey: env.SITE_KEY,
                 callback: onSuccess,
                 'expired-callback': props.onExpire,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,10 +5,10 @@ declare global {
   interface Window {
     // See usage of `window.grecaptcha` in ReCaptcha.web.tsx
     grecaptcha?: {
-      execute?: () => void
+      execute?: (widgetId?: number) => void
       ready?: (callback: () => void) => void
       render?: (
-        containerId: string,
+        container: HTMLElement | string,
         options: {
           sitekey: string
           callback: (token: string) => void
@@ -17,8 +17,8 @@ declare global {
           size: string
           theme: string
         }
-      ) => void
-      reset?: () => void
+      ) => number
+      reset?: (widgetId?: number) => void
     }
     onUbbleReady?: () => void
     pcupdate?: boolean


### PR DESCRIPTION
Link to JIRA ticket: [PC-25603](https://passculture.atlassian.net/browse/PC-25603
)
## Explication du bug
On doit initialiser un widget Recaptcha pour chaque formulaire pour lequel on veut activer Recaptcha. Vu qu'on l'a ajouté à la connexion et au formulaire "Mot de passe oublié", on avait un conflit : le deuxième formulaire initialiser le widget dans le premier formulaire, ce qui générait des erreurs. Pour fixer ça, on utilise la référence du container et la référence du widget pour cibler les bons éléments à utiliser. 


## Checklist
- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature. -> Recaptcha.web n'est pas testé, je ne sais pas pour où commencer, j'ai essayé de tester ce que j'ai implémenté mais je n'ai pas réussi (et je veux finir cette PR avant de partir en congés :))
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots
| Platform         | Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome |   [bug.mov](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/d11d71ae-b26f-44a4-be99-75c9e249febd)     |    [fix.mov](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/a91c5298-5c27-49cb-9f64-c0038026eb8f)    |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
