### PR TITLE
(PC-25084) fix(Profiletutorial): fix warning icon color

### DIFF
--- a/src/features/tutorial/components/profileTutorial/Timelines/CommonSteps.tsx
+++ b/src/features/tutorial/components/profileTutorial/Timelines/CommonSteps.tsx
@@ -13,6 +13,7 @@ const GreyOffers = styled(Offers).attrs(({ theme }) => ({
 
 const GreyWarning = styled(Warning).attrs(({ theme }) => ({
   color: theme.colors.greySemiDark,
+  color2: theme.colors.greySemiDark,
 }))``
 
 export const eighteenSeparatorStep: CreditComponentProps = {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25084

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome | <img width="265" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/ced8006c-5293-4765-877d-9b0cc453f3a4"> | <img width="278" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/70c97acd-401d-4d25-91e5-5117e8a1718b"> |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
