### PR TITLE
(BSR) fix(typo): Spell it "évènement", not "événement"

### DIFF
--- a/.maestro/tests/ReservationsOffresDuo.yml
+++ b/.maestro/tests/ReservationsOffresDuo.yml
@@ -54,7 +54,7 @@ appId: app.passculture.staging
 - assertVisible: "Les biens acquis ou réservés sur le pass Culture sont destinés à\
     \ un usage strictement personnel et ne peuvent faire l’objet de revente."
 - assertVisible: "Informations"
-- assertVisible: "Lieu de l’événement"
+- assertVisible: "Lieu de l’évènement"
 - assertVisible: "Conditions d’annulation"
 - assertVisible: "Confirmer la réservation"
 - runFlow: reusableFlows/components/buttons/SimpleActionButtonConfirmReservation.yml

--- a/.maestro/tests/ReservationsOffresEvent.yml
+++ b/.maestro/tests/ReservationsOffresEvent.yml
@@ -43,7 +43,7 @@ appId: app.passculture.staging
 - assertVisible: "Les biens acquis ou réservés sur le pass Culture sont destinés à\
     \ un usage strictement personnel et ne peuvent faire l’objet de revente."
 - assertVisible: "Informations"
-- assertVisible: "Lieu de l’événement"
+- assertVisible: "Lieu de l’évènement"
 - assertVisible: "Conditions d’annulation"
 - runFlow: reusableFlows/components/buttons/SimpleActionButtonConfirmReservation.yml
 - assertVisible: "Réservation confirmée\_!"

--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -541,7 +541,7 @@ describe('<OfferBody />', () => {
         renderOfferBody()
 
         await screen.findByTestId('offer-container')
-        expect(screen.queryByText('Lieu de l’événement')).toBeOnTheScreen()
+        expect(screen.queryByText('Lieu de l’évènement')).toBeOnTheScreen()
       })
 
       it('With "Lieu de projection" in title when offer subcategory is "Séances de cinéma"', async () => {

--- a/src/features/offer/helpers/getVenueSectionTitle/getVenueSectionTitle.test.ts
+++ b/src/features/offer/helpers/getVenueSectionTitle/getVenueSectionTitle.test.ts
@@ -12,8 +12,8 @@ describe('getVenueSectionTitle', () => {
     expect(venueSectionTitle).toEqual('Lieu de projection')
   })
 
-  it('should return "Lieu de l’événement" when offer is an event', () => {
+  it('should return "Lieu de l’évènement" when offer is an event', () => {
     const venueSectionTitle = getVenueSectionTitle(SubcategoryIdEnum.CONCERT, true)
-    expect(venueSectionTitle).toEqual('Lieu de l’événement')
+    expect(venueSectionTitle).toEqual('Lieu de l’évènement')
   })
 })

--- a/src/features/offer/helpers/getVenueSectionTitle/getVenueSectionTitle.ts
+++ b/src/features/offer/helpers/getVenueSectionTitle/getVenueSectionTitle.ts
@@ -2,6 +2,6 @@ import { SubcategoryIdEnum } from 'api/gen'
 
 export function getVenueSectionTitle(subcategoryId: SubcategoryIdEnum, isEvent: boolean) {
   if (subcategoryId === SubcategoryIdEnum.SEANCE_CINE) return 'Lieu de projection'
-  if (isEvent) return 'Lieu de l’événement'
+  if (isEvent) return 'Lieu de l’évènement'
   return 'Lieu de retrait'
 }


### PR DESCRIPTION
Both forms are correct but we should use one consistently, not both.

See pass-culture/pass-culture-main@206bede290a1a3135119c6c6eeb05be21f6b3247 for a precedent.


---

Pas de ticket, pas de nouveau test, pas de capture d'écran.