### PR TITLE
(PC-23729) fix(UI): spacing between sections

### DIFF
--- a/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
@@ -230,11 +230,11 @@ exports[`<SearchFilter/> should render correctly 1`] = `
           }
         >
           <View
-            numberOfSpaces={4}
+            numberOfSpaces={6}
             style={
               [
                 {
-                  "height": 16,
+                  "height": 24,
                 },
               ]
             }
@@ -383,11 +383,11 @@ exports[`<SearchFilter/> should render correctly 1`] = `
             visible={false}
           />
           <View
-            numberOfSpaces={4}
+            numberOfSpaces={6}
             style={
               [
                 {
-                  "height": 16,
+                  "height": 24,
                 },
               ]
             }
@@ -417,11 +417,11 @@ exports[`<SearchFilter/> should render correctly 1`] = `
             }
           />
           <View
-            numberOfSpaces={4}
+            numberOfSpaces={6}
             style={
               [
                 {
-                  "height": 16,
+                  "height": 24,
                 },
               ]
             }
@@ -570,11 +570,11 @@ exports[`<SearchFilter/> should render correctly 1`] = `
             visible={false}
           />
           <View
-            numberOfSpaces={4}
+            numberOfSpaces={6}
             style={
               [
                 {
-                  "height": 16,
+                  "height": 24,
                 },
               ]
             }
@@ -604,11 +604,11 @@ exports[`<SearchFilter/> should render correctly 1`] = `
             }
           />
           <View
-            numberOfSpaces={4}
+            numberOfSpaces={6}
             style={
               [
                 {
-                  "height": 16,
+                  "height": 24,
                 },
               ]
             }
@@ -757,11 +757,11 @@ exports[`<SearchFilter/> should render correctly 1`] = `
             visible={false}
           />
           <View
-            numberOfSpaces={4}
+            numberOfSpaces={6}
             style={
               [
                 {
-                  "height": 16,
+                  "height": 24,
                 },
               ]
             }
@@ -791,11 +791,11 @@ exports[`<SearchFilter/> should render correctly 1`] = `
             }
           />
           <View
-            numberOfSpaces={4}
+            numberOfSpaces={6}
             style={
               [
                 {
-                  "height": 16,
+                  "height": 24,
                 },
               ]
             }
@@ -944,26 +944,16 @@ exports[`<SearchFilter/> should render correctly 1`] = `
             visible={false}
           />
           <View
-            numberOfSpaces={4}
+            numberOfSpaces={6}
             style={
               [
                 {
-                  "height": 16,
+                  "height": 24,
                 },
               ]
             }
           />
         </View>
-        <View
-          numberOfSpaces={2}
-          style={
-            [
-              {
-                "height": 8,
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </RCTScrollView>

--- a/src/features/search/pages/SearchFilter/SearchFilter.tsx
+++ b/src/features/search/pages/SearchFilter/SearchFilter.tsx
@@ -106,7 +106,6 @@ export const SearchFilter: React.FC = () => {
               </SectionWrapper>
             )
           })}
-          <Spacer.Column numberOfSpaces={2} />
         </VerticalUl>
       </ScrollView>
       <BlurHeader height={headerHeight} />
@@ -128,9 +127,9 @@ const SectionWrapper: React.FunctionComponent<{
   return (
     <StyledLi>
       {isFirstSectionItem ? null : <Separator />}
-      <Spacer.Column numberOfSpaces={4} />
+      <Spacer.Column numberOfSpaces={6} />
       {children}
-      <Spacer.Column numberOfSpaces={4} />
+      <Spacer.Column numberOfSpaces={6} />
     </StyledLi>
   )
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-23729
-> fix de la taille des espaces entre les section suite à un raté de lecture de la maquette

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change

## Screenshots
Desktop
<img width="1026" alt="Capture d’écran 2023-10-23 à 14 26 24" src="https://github.com/pass-culture/pass-culture-app-native/assets/144016890/551136bc-6bcd-4e65-bdf6-bed768561907">

iPhone11
![Simulator Screenshot - iPhone 11 - 2023-10-23 at 17 16 08](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/0d4d7405-8c8b-4e04-bdf4-9ffc4a170228)


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
