### PR TITLE
(PC-25102) feat(location): adapt displayed distance to custom location when set

### DIFF
--- a/src/libs/geolocation/hooks/useDistance.test.ts
+++ b/src/libs/geolocation/hooks/useDistance.test.ts
@@ -20,29 +20,38 @@ describe('useDistance()', () => {
     mockUseGeolocation.mockReturnValue({ userPosition: position } as ILocationContext)
     useDistance(offerPosition)
 
-    expect(useLocation).toHaveBeenCalledWith()
+    expect(formatDistance).toHaveBeenCalledWith(offerPosition, position)
+  })
+
+  it('should call useLocation and formatDistance when geolocation is off but user set a custom position', () => {
+    // eslint-disable-next-line local-rules/independent-mocks
+    mockUseGeolocation.mockReturnValue({
+      userPosition: null,
+      customPosition: position,
+      isCustomPosition: true,
+    } as ILocationContext)
+    useDistance(offerPosition)
+
     expect(formatDistance).toHaveBeenCalledWith(offerPosition, position)
   })
 
   it('should return undefined when no offerPosition given', () => {
-    // @ts-expect-error offer position should not be undefined or null
-    useDistance(undefined)
+    // eslint-disable-next-line local-rules/independent-mocks
+    mockUseGeolocation.mockReturnValue({
+      userPosition: position,
+      customPosition: position,
+    } as ILocationContext)
 
-    expect(useLocation).toHaveBeenCalledWith()
-    expect(formatDistance).not.toHaveBeenCalled()
-
-    useDistance(undefinedOfferPosition)
-
-    expect(useLocation).toHaveBeenCalledWith()
-    expect(formatDistance(undefinedOfferPosition, position)).toEqual(undefined)
+    expect(useDistance(undefinedOfferPosition)).toEqual(undefined)
   })
 
-  it('should return undefined when position is null', () => {
+  it('should return undefined when user position and custom position are null', () => {
     // eslint-disable-next-line local-rules/independent-mocks
-    mockUseGeolocation.mockReturnValue({ userPosition: null } as ILocationContext)
-    useDistance(offerPosition)
+    mockUseGeolocation.mockReturnValue({
+      userPosition: null,
+      customPosition: null,
+    } as ILocationContext)
 
-    expect(useLocation).toHaveBeenCalledWith()
-    expect(formatDistance).not.toHaveBeenCalled()
+    expect(useDistance(offerPosition)).toEqual(undefined)
   })
 })

--- a/src/libs/geolocation/hooks/useDistance.test.ts
+++ b/src/libs/geolocation/hooks/useDistance.test.ts
@@ -9,6 +9,10 @@ const mockUseGeolocation = jest.mocked(useLocation)
 
 const position = { latitude: 90, longitude: 90 }
 const offerPosition = { lat: 31, long: 56 }
+const undefinedOfferPosition = {
+  lat: undefined,
+  lng: undefined,
+}
 
 describe('useDistance()', () => {
   it('should call useLocation and formatDistance when geolocation is on', () => {
@@ -26,6 +30,11 @@ describe('useDistance()', () => {
 
     expect(useLocation).toHaveBeenCalledWith()
     expect(formatDistance).not.toHaveBeenCalled()
+
+    useDistance(undefinedOfferPosition)
+
+    expect(useLocation).toHaveBeenCalledWith()
+    expect(formatDistance(undefinedOfferPosition, position)).toEqual(undefined)
   })
 
   it('should return undefined when position is null', () => {

--- a/src/libs/geolocation/hooks/useDistance.ts
+++ b/src/libs/geolocation/hooks/useDistance.ts
@@ -6,7 +6,6 @@ export const useDistance = (offerPosition: {
   lng?: number | null
 }): string | undefined => {
   const { userPosition } = useLocation()
-  // TODO(voisinhugo): check if !offerPosition check is useful - add data validation from API if needed
-  if (!userPosition || !offerPosition) return undefined
+  if (!userPosition) return undefined
   return formatDistance(offerPosition, userPosition)
 }

--- a/src/libs/geolocation/hooks/useDistance.ts
+++ b/src/libs/geolocation/hooks/useDistance.ts
@@ -5,7 +5,7 @@ export const useDistance = (offerPosition: {
   lat?: number | null
   lng?: number | null
 }): string | undefined => {
-  const { userPosition } = useLocation()
-  if (!userPosition) return undefined
-  return formatDistance(offerPosition, userPosition)
+  const { userPosition, customPosition, isCustomPosition } = useLocation()
+  if (!userPosition && !customPosition) return undefined
+  return formatDistance(offerPosition, isCustomPosition ? customPosition : userPosition)
 }

--- a/src/libs/parsers/formatDistance.ts
+++ b/src/libs/parsers/formatDistance.ts
@@ -4,11 +4,12 @@ import { Position } from 'libs/geolocation'
 const EARTH_RADIUS_KM = 6378.137
 
 export const getHumanizeRelativeDistance = (
-  userLat?: number | null,
-  userLng?: number | null,
-  venueLat?: number | null,
-  venueLng?: number | null
+  userLocation: Geoloc,
+  venueLocation: Geoloc
 ): string | undefined => {
+  const { lat: userLat, lng: userLng } = userLocation
+  const { lat: venueLat, lng: venueLng } = venueLocation
+
   if (!userLat || !userLng || !venueLat || !venueLng) return
 
   const distanceInMeters = computeDistanceInMeters(venueLat, venueLng, userLat, userLng)
@@ -40,7 +41,17 @@ export const humanizeDistance = (distance: number) => {
 }
 
 export const formatDistance = (coords: Geoloc, position: Position): string | undefined => {
-  if (!position) return
+  if (!position || !coords) return
 
-  return getHumanizeRelativeDistance(position.latitude, position.longitude, coords.lat, coords.lng)
+  const userLocation: Geoloc = {
+    lat: position.latitude,
+    lng: position.longitude,
+  }
+
+  const venueLocation: Geoloc = {
+    lat: coords.lat,
+    lng: coords.lng,
+  }
+
+  return getHumanizeRelativeDistance(userLocation, venueLocation)
 }

--- a/src/libs/parsers/formatDistance.ts
+++ b/src/libs/parsers/formatDistance.ts
@@ -6,8 +6,8 @@ const EARTH_RADIUS_KM = 6378.137
 export const getHumanizeRelativeDistance = (
   userLat?: number | null,
   userLng?: number | null,
-  venueLat?: number,
-  venueLng?: number
+  venueLat?: number | null,
+  venueLng?: number | null
 ): string | undefined => {
   if (!userLat || !userLng || !venueLat || !venueLng) return
 
@@ -42,5 +42,5 @@ export const humanizeDistance = (distance: number) => {
 export const formatDistance = (coords: Geoloc, position: Position): string | undefined => {
   if (!position) return
 
-  return getHumanizeRelativeDistance(coords.lat, coords.lng, position.latitude, position.longitude)
+  return getHumanizeRelativeDistance(position.latitude, position.longitude, coords.lat, coords.lng)
 }

--- a/src/libs/parsers/tests/formatDistance.test.ts
+++ b/src/libs/parsers/tests/formatDistance.test.ts
@@ -18,10 +18,14 @@ describe('formatDistance', () => {
   `('getHumanizeRelativeDistance($actualDistance) \t= $expected', ({ lat, lng, expected }) => {
     expect(
       getHumanizeRelativeDistance(
-        lat,
-        lng,
-        EiffelTourCoordinates.latitude,
-        EiffelTourCoordinates.longitude
+        {
+          lat: lat,
+          lng: lng,
+        },
+        {
+          lat: EiffelTourCoordinates.latitude,
+          lng: EiffelTourCoordinates.longitude,
+        }
       )
     ).toBe(expected)
   })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25102

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| No localisation              |<img width="831" alt="nothing" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/1acd9921-013c-41dc-9368-985600217ef8">|<img width="831" alt="nothing" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/1acd9921-013c-41dc-9368-985600217ef8">|
| Only custom loc          |![image](https://github.com/pass-culture/pass-culture-app-native/assets/47600889/fb2c4c99-e5a5-4cfa-a79b-85ebb3087448)|<img width="830" alt="only_custom" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/47666d37-dcde-44f8-af20-042773089908">|
| Only geoloc   |<img width="831" alt="Capture d’écran 2023-10-25 à 10 41 11" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/149954fb-8a61-4173-aa04-766736aef62b">|<img width="829" alt="only_geoloc" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/20bc0c8b-4fee-434d-847a-ef71e4a3f773">|
| Custom loc over geoloc |<img width="829" alt="Capture d’écran 2023-10-25 à 10 42 19" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/33436d65-ef65-4e90-9c1f-fcb8d0c2c641">|<img width="830" alt="custom_over_geoloc" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/fef27f8d-4fd8-4c21-b6cf-cf93f5ac9a86">|
