### PR TITLE
(BSR) fix(CI): add openssl-legacy-provider option to build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "android:staging": "react-native run-android --variant=stagingDebug --appId=app.passculture.staging",
     "android:testing": "react-native run-android --variant=apptestingDebug --appId=app.passculture.testing",
     "appcenter:install": "./scripts/appcenter-download-release.sh",
-    "build": "SHOW_DUPLICATES_PLUGIN=${SHOW_DUPLICATES_PLUGIN:-true} node web/scripts/build.js",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider SHOW_DUPLICATES_PLUGIN=${SHOW_DUPLICATES_PLUGIN:-true} node web/scripts/build.js",
     "build-storybook": "NODE_OPTIONS=--openssl-legacy-provider build-storybook --static-dir ./public",
     "build:development": "ENV=development yarn build",
     "build:integration": "ENV=integration yarn build",


### PR DESCRIPTION
Added `openssl-legacy-provider` to build command because of the upgrade to node 18