### PR TITLE
(PC-23726) fix(locationSearch): remove search input clear cross and adjust spaces

### DIFF
--- a/src/features/location/components/LocationSearchWidget.tsx
+++ b/src/features/location/components/LocationSearchWidget.tsx
@@ -34,8 +34,9 @@ export const LocationSearchWidget = () => {
 
   return (
     <Container>
+      <Spacer.Row numberOfSpaces={1} />
       <Separator.Vertical />
-      <Spacer.Row numberOfSpaces={2} />
+      <Spacer.Row numberOfSpaces={1} />
       <LocationButton
         onPress={showLocationModal}
         testID="Ouvrir la modale de localisation depuis la recherche">

--- a/src/features/location/components/LocationSearchWidget.tsx
+++ b/src/features/location/components/LocationSearchWidget.tsx
@@ -64,11 +64,11 @@ const Container = styled.View({
 
 const LocationPointerFilled = styled(LocationPointer).attrs(({ theme }) => ({
   color: theme.colors.primary,
-  size: theme.icons.sizes.small,
+  size: theme.icons.sizes.extraSmall,
 }))({})
 
 const SmallLocationPointerNotFilled = styled(LocationPointerNotFilled).attrs(({ theme }) => ({
-  size: theme.icons.sizes.small,
+  size: theme.icons.sizes.extraSmall,
 }))``
 
 const LocationTitle = styled(Typo.Caption).attrs({

--- a/src/features/search/components/SearchBox/SearchBox.native.test.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.native.test.tsx
@@ -118,29 +118,16 @@ describe('SearchBox component', () => {
     })
   })
 
-  const searchInputID = uuidv4()
-
   it('should render SearchBox', async () => {
-    render(
-      <SearchBox
-        searchInputID={searchInputID}
-        addSearchHistory={jest.fn()}
-        searchInHistory={jest.fn()}
-      />
-    )
+    renderSearchBox()
     await act(async () => {})
 
     expect(screen).toMatchSnapshot()
   })
 
   it('should call navigate on submit', async () => {
-    render(
-      <SearchBox
-        searchInputID={searchInputID}
-        addSearchHistory={jest.fn()}
-        searchInHistory={jest.fn()}
-      />
-    )
+    renderSearchBox()
+
     const searchInput = screen.getByPlaceholderText('Offre, artiste, point de vente...')
 
     await act(async () => {
@@ -161,13 +148,8 @@ describe('SearchBox component', () => {
 
   it('should not show back button when being on the search landing view', async () => {
     useRoute.mockReturnValueOnce({ params: { view: SearchView.Landing } })
-    render(
-      <SearchBox
-        searchInputID={searchInputID}
-        addSearchHistory={jest.fn()}
-        searchInHistory={jest.fn()}
-      />
-    )
+    renderSearchBox()
+
     const previousButton = screen.queryByTestId('Revenir en arrière')
 
     await act(async () => {
@@ -177,13 +159,8 @@ describe('SearchBox component', () => {
 
   it('should show back button when being on the search results view', async () => {
     useRoute.mockReturnValueOnce({ params: { view: SearchView.Results } })
-    render(
-      <SearchBox
-        searchInputID={searchInputID}
-        addSearchHistory={jest.fn()}
-        searchInHistory={jest.fn()}
-      />
-    )
+    renderSearchBox()
+
     const previousButton = screen.getByTestId('Revenir en arrière')
 
     await act(async () => {
@@ -193,13 +170,8 @@ describe('SearchBox component', () => {
 
   it('should show back button when being on the suggestions view', async () => {
     useRoute.mockReturnValueOnce({ params: { view: SearchView.Suggestions } })
-    render(
-      <SearchBox
-        searchInputID={searchInputID}
-        addSearchHistory={jest.fn()}
-        searchInHistory={jest.fn()}
-      />
-    )
+    renderSearchBox()
+
     const previousButton = screen.getByTestId('Revenir en arrière')
 
     await act(async () => {
@@ -208,13 +180,7 @@ describe('SearchBox component', () => {
   })
 
   it('should show the text typed by the user', async () => {
-    render(
-      <SearchBox
-        searchInputID={searchInputID}
-        addSearchHistory={jest.fn()}
-        searchInHistory={jest.fn()}
-      />
-    )
+    renderSearchBox()
 
     const searchInput = screen.getByPlaceholderText('Offre, artiste, point de vente...')
     await act(async () => {
@@ -225,13 +191,8 @@ describe('SearchBox component', () => {
   })
 
   it('should not execute a search if input is empty', async () => {
-    render(
-      <SearchBox
-        searchInputID={searchInputID}
-        addSearchHistory={jest.fn()}
-        searchInHistory={jest.fn()}
-      />
-    )
+    renderSearchBox()
+
     const searchInput = screen.getByPlaceholderText('Offre, artiste, point de vente...')
 
     await act(async () => {
@@ -251,13 +212,7 @@ describe('SearchBox component', () => {
         params: { view: SearchView.Suggestions, previousView: SearchView.Results },
       })
 
-      render(
-        <SearchBox
-          searchInputID={searchInputID}
-          addSearchHistory={jest.fn()}
-          searchInHistory={jest.fn()}
-        />
-      )
+      renderSearchBox()
 
       const previousButton = screen.getByTestId('Revenir en arrière')
 
@@ -280,13 +235,8 @@ describe('SearchBox component', () => {
       'should redirect on landing view when being on the suggestions view and press back button and previous view is %s view',
       async (previousView) => {
         useRoute.mockReturnValueOnce({ params: { view: SearchView.Suggestions, previousView } })
-        render(
-          <SearchBox
-            searchInputID={searchInputID}
-            addSearchHistory={jest.fn()}
-            searchInHistory={jest.fn()}
-          />
-        )
+        renderSearchBox()
+
         const previousButton = screen.getByTestId('Revenir en arrière')
 
         await act(async () => {
@@ -305,13 +255,8 @@ describe('SearchBox component', () => {
       useRoute.mockReturnValueOnce({
         params: { view: SearchView.Results, previousView: SearchView.Results },
       })
-      render(
-        <SearchBox
-          searchInputID={searchInputID}
-          addSearchHistory={jest.fn()}
-          searchInHistory={jest.fn()}
-        />
-      )
+      renderSearchBox()
+
       const previousButton = screen.getByTestId('Revenir en arrière')
 
       await act(async () => {
@@ -325,13 +270,8 @@ describe('SearchBox component', () => {
       useRoute.mockReturnValueOnce({
         params: { view: SearchView.Results, previousView: SearchView.Results },
       })
-      render(
-        <SearchBox
-          searchInputID={searchInputID}
-          addSearchHistory={jest.fn()}
-          searchInHistory={jest.fn()}
-        />
-      )
+      renderSearchBox()
+
       const previousButton = screen.getByTestId('Revenir en arrière')
 
       await act(async () => {
@@ -343,13 +283,8 @@ describe('SearchBox component', () => {
 
     it('should stay on the current view when focusing search input and being on the suggestions', async () => {
       useRoute.mockReturnValueOnce({ params: { view: SearchView.Suggestions } })
-      render(
-        <SearchBox
-          searchInputID={searchInputID}
-          addSearchHistory={jest.fn()}
-          searchInHistory={jest.fn()}
-        />
-      )
+      renderSearchBox()
+
       const searchInput = screen.getByPlaceholderText('Offre, artiste, point de vente...')
 
       await act(async () => {
@@ -363,13 +298,7 @@ describe('SearchBox component', () => {
       useRoute.mockReturnValueOnce({
         params: { view: SearchView.Suggestions, query: 'Some text' },
       })
-      render(
-        <SearchBox
-          searchInputID={searchInputID}
-          addSearchHistory={jest.fn()}
-          searchInHistory={jest.fn()}
-        />
-      )
+      renderSearchBox()
 
       const resetIcon = screen.getByTestId('Réinitialiser la recherche')
       await act(async () => {
@@ -396,13 +325,8 @@ describe('SearchBox component', () => {
       'should stay on the current view when focusing search input and being on the %s view',
       async (view) => {
         useRoute.mockReturnValueOnce({ params: { view } })
-        render(
-          <SearchBox
-            searchInputID={searchInputID}
-            addSearchHistory={jest.fn()}
-            searchInHistory={jest.fn()}
-          />
-        )
+        renderSearchBox()
+
         const searchInput = screen.getByPlaceholderText('Offre, artiste, point de vente...')
 
         await act(async () => {
@@ -415,13 +339,7 @@ describe('SearchBox component', () => {
 
     it('should reset input when user click on reset icon when being on the search suggestions view', async () => {
       useRoute.mockReturnValueOnce({ params: { view: SearchView.Suggestions, query: 'Some text' } })
-      render(
-        <SearchBox
-          searchInputID={searchInputID}
-          addSearchHistory={jest.fn()}
-          searchInHistory={jest.fn()}
-        />
-      )
+      renderSearchBox()
 
       const resetIcon = screen.getByTestId('Réinitialiser la recherche')
       await act(async () => {
@@ -440,13 +358,8 @@ describe('SearchBox component', () => {
   })
 
   it('should execute a search if input is not empty', async () => {
-    render(
-      <SearchBox
-        searchInputID={searchInputID}
-        addSearchHistory={jest.fn()}
-        searchInHistory={jest.fn()}
-      />
-    )
+    renderSearchBox()
+
     const searchInput = screen.getByPlaceholderText('Offre, artiste, point de vente...')
 
     await act(async () => {
@@ -475,13 +388,7 @@ describe('SearchBox component', () => {
       toggleModal: jest.fn(),
     })
     useRoute.mockReturnValueOnce({ params: { view: SearchView.Landing } })
-    render(
-      <SearchBox
-        searchInputID={searchInputID}
-        addSearchHistory={jest.fn()}
-        searchInHistory={jest.fn()}
-      />
-    )
+    renderSearchBox()
 
     const locationButton = screen.getByTestId('Partout')
 
@@ -493,13 +400,8 @@ describe('SearchBox component', () => {
   })
 
   it('should display suggestions view when focusing search input and no search executed', async () => {
-    render(
-      <SearchBox
-        searchInputID={searchInputID}
-        addSearchHistory={jest.fn()}
-        searchInHistory={jest.fn()}
-      />
-    )
+    renderSearchBox()
+
     const searchInput = screen.getByPlaceholderText('Offre, artiste, point de vente...')
 
     await act(async () => {
@@ -520,13 +422,7 @@ describe('SearchBox component', () => {
     'should hide the search filter button when being on the %s view',
     async (view) => {
       useRoute.mockReturnValueOnce({ params: { view, query: 'la fnac' } })
-      render(
-        <SearchBox
-          searchInputID={searchInputID}
-          addSearchHistory={jest.fn()}
-          searchInHistory={jest.fn()}
-        />
-      )
+      renderSearchBox()
 
       await act(async () => {
         expect(screen.queryByTestId(/Voir tous les filtres/)).not.toBeOnTheScreen()
@@ -559,13 +455,8 @@ describe('SearchBox component', () => {
       mockSearchState = { ...initialSearchState, locationFilter }
       mockPosition = position
       useRoute.mockReturnValueOnce({ params: { view: SearchView.Landing, locationFilter } })
-      render(
-        <SearchBox
-          searchInputID={searchInputID}
-          addSearchHistory={jest.fn()}
-          searchInHistory={jest.fn()}
-        />
-      )
+      renderSearchBox()
+
       await act(async () => {})
 
       expect(screen.queryByText(locationButtonLabel)).toBeOnTheScreen()
@@ -597,13 +488,8 @@ describe('SearchBox component', () => {
       mockSearchState = { ...initialSearchState, locationFilter }
       mockPosition = position
       useRoute.mockReturnValueOnce({ params: { view: SearchView.Results, locationFilter } })
-      render(
-        <SearchBox
-          searchInputID={searchInputID}
-          addSearchHistory={jest.fn()}
-          searchInHistory={jest.fn()}
-        />
-      )
+      renderSearchBox()
+
       await act(async () => {})
 
       expect(screen.getByText(locationSearchWidgetLabel)).toBeOnTheScreen()
@@ -624,14 +510,8 @@ describe('SearchBox component', () => {
         locationFilter: { locationType: LocationType.EVERYWHERE },
       },
     })
-    render(
-      <SearchBox
-        searchInputID={searchInputID}
-        addSearchHistory={jest.fn()}
-        searchInHistory={jest.fn()}
-      />,
-      { theme: { isDesktopViewport: true } }
-    )
+    renderSearchBox()
+
     await act(async () => {})
 
     expect(screen.getByText('Partout')).toBeOnTheScreen()
@@ -650,19 +530,12 @@ describe('SearchBox component with venue previous route', () => {
     })
   })
 
-  const searchInputID = uuidv4()
-
   it('should reset location to eveywhere when current and previous views are identical and previous route is Venue', async () => {
     useRoute.mockReturnValueOnce({
       params: { view: SearchView.Results, previousView: SearchView.Results },
     })
-    render(
-      <SearchBox
-        searchInputID={searchInputID}
-        addSearchHistory={jest.fn()}
-        searchInHistory={jest.fn()}
-      />
-    )
+    renderSearchBox()
+
     const previousButton = screen.getByTestId('Revenir en arrière')
 
     await act(async () => {
@@ -676,13 +549,8 @@ describe('SearchBox component with venue previous route', () => {
     useRoute.mockReturnValueOnce({
       params: { view: SearchView.Results, previousView: SearchView.Results },
     })
-    render(
-      <SearchBox
-        searchInputID={searchInputID}
-        addSearchHistory={jest.fn()}
-        searchInHistory={jest.fn()}
-      />
-    )
+    renderSearchBox()
+
     const previousButton = screen.getByTestId('Revenir en arrière')
 
     await act(async () => {
@@ -692,3 +560,16 @@ describe('SearchBox component with venue previous route', () => {
     expect(mockGoBack).toHaveBeenCalledTimes(1)
   })
 })
+
+function renderSearchBox(isDesktopViewport?: boolean) {
+  const searchInputID = uuidv4()
+
+  return render(
+    <SearchBox
+      searchInputID={searchInputID}
+      addSearchHistory={jest.fn()}
+      searchInHistory={jest.fn()}
+    />,
+    { theme: { isDesktopViewport: isDesktopViewport ?? false } }
+  )
+}

--- a/src/features/search/components/SearchBox/SearchBox.native.test.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.native.test.tsx
@@ -355,6 +355,25 @@ describe('SearchBox component', () => {
       )
       expect(mockClear).toHaveBeenCalledTimes(1)
     })
+
+    it('should reset input when user click on reset icon when being on the search results view when isDesktopViewport', async () => {
+      useRoute.mockReturnValueOnce({ params: { view: SearchView.Results, query: 'Some text' } })
+      renderSearchBox(true)
+
+      const resetIcon = screen.getByTestId('Réinitialiser la recherche')
+      await act(async () => {
+        fireEvent.press(resetIcon)
+      })
+
+      expect(navigate).toHaveBeenCalledWith(
+        ...getTabNavConfig('Search', {
+          ...mockSearchState,
+          query: '',
+          view: SearchView.Results,
+        })
+      )
+      expect(mockClear).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('should execute a search if input is not empty', async () => {

--- a/src/features/search/components/SearchBox/SearchBox.native.test.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.native.test.tsx
@@ -359,33 +359,32 @@ describe('SearchBox component', () => {
       expect(navigate).not.toHaveBeenCalled()
     })
 
-    it.each([[SearchView.Suggestions], [SearchView.Results]])(
-      'should reset input when user click on reset icon when being on the search %s view',
-      async (view) => {
-        useRoute.mockReturnValueOnce({ params: { view, query: 'Some text' } })
-        render(
-          <SearchBox
-            searchInputID={searchInputID}
-            addSearchHistory={jest.fn()}
-            searchInHistory={jest.fn()}
-          />
-        )
+    it('should reset input when user click on reset icon when being on the search suggestions view', async () => {
+      useRoute.mockReturnValueOnce({
+        params: { view: SearchView.Suggestions, query: 'Some text' },
+      })
+      render(
+        <SearchBox
+          searchInputID={searchInputID}
+          addSearchHistory={jest.fn()}
+          searchInHistory={jest.fn()}
+        />
+      )
 
-        const resetIcon = screen.getByTestId('Réinitialiser la recherche')
-        await act(async () => {
-          fireEvent.press(resetIcon)
+      const resetIcon = screen.getByTestId('Réinitialiser la recherche')
+      await act(async () => {
+        fireEvent.press(resetIcon)
+      })
+
+      expect(navigate).toHaveBeenCalledWith(
+        ...getTabNavConfig('Search', {
+          ...mockSearchState,
+          query: '',
+          view: SearchView.Suggestions,
         })
-
-        expect(navigate).toHaveBeenCalledWith(
-          ...getTabNavConfig('Search', {
-            ...mockSearchState,
-            query: '',
-            view: SearchView.Suggestions,
-          })
-        )
-        expect(mockClear).toHaveBeenCalledTimes(1)
-      }
-    )
+      )
+      expect(mockClear).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('Without autocomplete', () => {
@@ -414,33 +413,30 @@ describe('SearchBox component', () => {
       }
     )
 
-    it.each([[SearchView.Suggestions], [SearchView.Results]])(
-      'should reset input when user click on reset icon when being on the search %s view',
-      async (view) => {
-        useRoute.mockReturnValueOnce({ params: { view, query: 'Some text' } })
-        render(
-          <SearchBox
-            searchInputID={searchInputID}
-            addSearchHistory={jest.fn()}
-            searchInHistory={jest.fn()}
-          />
-        )
+    it('should reset input when user click on reset icon when being on the search suggestions view', async () => {
+      useRoute.mockReturnValueOnce({ params: { view: SearchView.Suggestions, query: 'Some text' } })
+      render(
+        <SearchBox
+          searchInputID={searchInputID}
+          addSearchHistory={jest.fn()}
+          searchInHistory={jest.fn()}
+        />
+      )
 
-        const resetIcon = screen.getByTestId('Réinitialiser la recherche')
-        await act(async () => {
-          fireEvent.press(resetIcon)
+      const resetIcon = screen.getByTestId('Réinitialiser la recherche')
+      await act(async () => {
+        fireEvent.press(resetIcon)
+      })
+
+      expect(navigate).toHaveBeenCalledWith(
+        ...getTabNavConfig('Search', {
+          ...mockSearchState,
+          query: '',
+          view: SearchView.Results,
         })
-
-        expect(navigate).toHaveBeenCalledWith(
-          ...getTabNavConfig('Search', {
-            ...mockSearchState,
-            query: '',
-            view: SearchView.Results,
-          })
-        )
-        expect(mockClear).toHaveBeenCalledTimes(1)
-      }
-    )
+      )
+      expect(mockClear).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('should execute a search if input is not empty', async () => {

--- a/src/features/search/components/SearchBox/SearchBox.native.test.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.native.test.tsx
@@ -34,6 +34,8 @@ jest.mock('features/search/context/SearchWrapper', () => ({
 
 jest.mock('libs/firebase/analytics')
 
+const useFeatureFlagSpy = jest.spyOn(useFeatureFlag, 'useFeatureFlag').mockReturnValue(false)
+
 const mockData = { pages: [{ nbHits: 0, hits: [], page: 0 }] }
 const mockHasNextPage = true
 const mockFetchNextPage = jest.fn()
@@ -339,6 +341,26 @@ describe('SearchBox component', () => {
 
     it('should reset input when user click on reset icon when being on the search suggestions view', async () => {
       useRoute.mockReturnValueOnce({ params: { view: SearchView.Suggestions, query: 'Some text' } })
+      renderSearchBox()
+
+      const resetIcon = screen.getByTestId('Réinitialiser la recherche')
+      await act(async () => {
+        fireEvent.press(resetIcon)
+      })
+
+      expect(navigate).toHaveBeenCalledWith(
+        ...getTabNavConfig('Search', {
+          ...mockSearchState,
+          query: '',
+          view: SearchView.Results,
+        })
+      )
+      expect(mockClear).toHaveBeenCalledTimes(1)
+    })
+
+    it('should reset input when user click on reset icon when being on the search results view with feature flag appLocation not enabled', async () => {
+      useFeatureFlagSpy.mockReturnValueOnce(false)
+      useRoute.mockReturnValueOnce({ params: { view: SearchView.Results, query: 'Some text' } })
       renderSearchBox()
 
       const resetIcon = screen.getByTestId('Réinitialiser la recherche')

--- a/src/features/search/components/SearchBox/SearchBox.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.tsx
@@ -313,7 +313,6 @@ const StyledView = styled.View({
   justifyContent: 'center',
   width: getSpacing(10),
   height: getSpacing(10),
-  marginRight: getSpacing(2),
 })
 
 const FlexView = styled.View({

--- a/src/features/search/components/SearchBox/SearchBox.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.tsx
@@ -10,7 +10,7 @@ import {
   TextInput as RNTextInput,
   TextInputSubmitEditingEventData,
 } from 'react-native'
-import styled from 'styled-components/native'
+import styled, { useTheme } from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
 
 import { useSettingsContext } from 'features/auth/context/SettingsContext'
@@ -56,7 +56,7 @@ export const SearchBox: React.FunctionComponent<Props> = ({
   ...props
 }) => {
   const enableAppLocation = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ENABLE_APP_LOCATION)
-
+  const { isDesktopViewport } = useTheme()
   const { params } = useRoute<UseRouteType<'Search'>>()
   const { searchState, dispatch } = useSearch()
   const { navigate } = useNavigation<UseNavigationType>()
@@ -239,6 +239,8 @@ export const SearchBox: React.FunctionComponent<Props> = ({
     ? params?.view === SearchView.Results
     : params === undefined || params.view === SearchView.Landing
 
+  const disableInputClearButton = params?.view === SearchView.Results && !isDesktopViewport
+
   return (
     <RowContainer>
       {!!accessibleHiddenTitle && (
@@ -267,6 +269,7 @@ export const SearchBox: React.FunctionComponent<Props> = ({
               onPressLocationButton={showLocationModal}
               accessibilityDescribedBy={accessibilityDescribedBy}
               numberOfLinesForLocation={locationType === LocationType.PLACE ? 1 : 2}
+              disableInputClearButton={disableInputClearButton}
             />
           </FlexView>
         </SearchInputA11yContainer>

--- a/src/features/search/components/SearchBox/SearchBox.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.tsx
@@ -239,7 +239,8 @@ export const SearchBox: React.FunctionComponent<Props> = ({
     ? params?.view === SearchView.Results
     : params === undefined || params.view === SearchView.Landing
 
-  const disableInputClearButton = params?.view === SearchView.Results && !isDesktopViewport
+  const disableInputClearButton =
+    params?.view === SearchView.Results && !isDesktopViewport && !!enableAppLocation
 
   return (
     <RowContainer>

--- a/src/features/search/components/SearchMainInput/SearchMainInput.tsx
+++ b/src/features/search/components/SearchMainInput/SearchMainInput.tsx
@@ -28,6 +28,7 @@ type FocusProps = {
   isFocusable?: boolean
   isFocus?: boolean
   onFocus?: () => void
+  disableInputClearButton: boolean
 }
 
 type LocationProps = {
@@ -57,6 +58,7 @@ export const SearchMainInput = forwardRef<RNTextInput, Props>(function SearchMai
     locationLabel,
     onPressLocationButton,
     numberOfLinesForLocation,
+    disableInputClearButton,
     ...props
   }: Props,
   ref
@@ -94,6 +96,7 @@ export const SearchMainInput = forwardRef<RNTextInput, Props>(function SearchMai
       LeftIcon={MagnifyingGlassIcon}
       inputHeight="regular"
       testID="searchInput"
+      disableClearButton={disableInputClearButton}
       {...props}>
       {renderSearchChildren()}
     </StyledSearchInput>

--- a/src/ui/components/inputs/SearchInput.tsx
+++ b/src/ui/components/inputs/SearchInput.tsx
@@ -35,11 +35,13 @@ const WithRefSearchInput: React.ForwardRefRenderFunction<RNTextInput, SearchInpu
     onFocus: onFocusProp,
     children,
     isRequiredField,
+    disableClearButton,
   } = customProps
   const { value = '' } = nativeProps
   const searchInputID = props.searchInputID ?? uuidv4()
   const searchInput = useRef<RNTextInput>(null)
   const defaultKeyboardType = Platform.OS === 'web' ? 'web-search' : undefined
+  const showClearButton = value.length > 0 && !disableClearButton
 
   function onFocus() {
     onFocusDefault()
@@ -92,7 +94,7 @@ const WithRefSearchInput: React.ForwardRefRenderFunction<RNTextInput, SearchInpu
           textStyle={props.textStyle}
         />
         {children}
-        {value.length > 0 && (
+        {!!showClearButton && (
           <Touchable
             hitSlop={hitSlop}
             onPress={onPressRightIcon}

--- a/src/ui/components/inputs/types.ts
+++ b/src/ui/components/inputs/types.ts
@@ -39,6 +39,7 @@ type CustomSearchInputProps = InputProps & {
   children?: React.ReactNode
   isRequiredField?: boolean
   textStyle?: ValueOf<AppThemeType['typography']>
+  disableClearButton?: boolean
 }
 
 export type RNTextInputProps = Pick<
@@ -118,6 +119,7 @@ export function getCustomSearchInputProps(props: SearchInputProps): CustomSearch
     isFocusable: props.isFocusable,
     onFocus: props.onFocus,
     isRequiredField: props.isRequiredField,
+    disableClearButton: props.disableClearButton,
   }
 }
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-23726

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |![search_befors](https://github.com/pass-culture/pass-culture-app-native/assets/47600889/1d027357-eb58-4ccb-8f0b-912e00b9e67d)|![search_after](https://github.com/pass-culture/pass-culture-app-native/assets/47600889/5642ec12-c33d-4404-846f-4a959be9caa7)|
| iOS - Video screenshot    |https://github.com/pass-culture/pass-culture-app-native/assets/47600889/bd203d5d-73d9-45a5-a580-6edc3f4c0e9c|https://github.com/pass-culture/pass-culture-app-native/assets/47600889/515471f3-7175-4ca3-8054-db5e35fbc3a2|
| Phone - Chrome   |<img width="1512" alt="Capture d’écran 2023-10-26 à 16 39 34" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/05acaffd-07cf-4976-acdd-efcbafbf6581">|<img width="1512" alt="Capture d’écran 2023-10-26 à 16 39 34" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/05acaffd-07cf-4976-acdd-efcbafbf6581">|
| Desktop - Chrome |<img width="1512" alt="Capture d’écran 2023-10-26 à 16 39 57" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/c87f06bf-cb4b-425c-b7a3-9ac8cc2ba78e">|<img width="1512" alt="Capture d’écran 2023-10-26 à 16 39 57" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/c87f06bf-cb4b-425c-b7a3-9ac8cc2ba78e">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
