### PR TITLE
(PC-25284) fix(Accessibility): make profile tutorial step block not focusable

### DIFF
--- a/src/features/tutorial/components/CreditBlock.tsx
+++ b/src/features/tutorial/components/CreditBlock.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { TouchableWithoutFeedback, View } from 'react-native'
+import { View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { CreditStatusTag } from 'features/tutorial/components/CreditStatusTag'
@@ -7,6 +7,7 @@ import { CreditStatus } from 'features/tutorial/enums'
 import { customEaseInOut, DURATION_IN_MS } from 'features/tutorial/helpers/animationProps'
 import { getBackgroundColor } from 'features/tutorial/helpers/getBackgroundColor'
 import { AnimatedView, NAV_DELAY_IN_MS } from 'libs/react-native-animatable'
+import { TouchableWithoutFeedback } from 'ui/components/touchable/TouchableWithoutFeedback'
 import { getSpacing } from 'ui/theme'
 
 type Props = {

--- a/src/ui/components/touchable/TouchableWithoutFeedback.tsx
+++ b/src/ui/components/touchable/TouchableWithoutFeedback.tsx
@@ -1,0 +1,3 @@
+import { TouchableWithoutFeedback as RNTouchableWithoutFeedback } from 'react-native'
+
+export const TouchableWithoutFeedback = RNTouchableWithoutFeedback

--- a/src/ui/components/touchable/TouchableWithoutFeedback.web.test.tsx
+++ b/src/ui/components/touchable/TouchableWithoutFeedback.web.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+import { fireEvent, render, screen } from 'tests/utils/web'
+
+import { TouchableWithoutFeedback } from './TouchableWithoutFeedback.web'
+
+describe('TouchableWithoutFeedback', () => {
+  it('calls onPress when clicked', () => {
+    const onPress = jest.fn()
+    render(<TouchableWithoutFeedback onPress={onPress} />)
+    const button = screen.getByRole('button')
+    fireEvent.click(button)
+
+    expect(onPress).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/ui/components/touchable/TouchableWithoutFeedback.web.tsx
+++ b/src/ui/components/touchable/TouchableWithoutFeedback.web.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { TouchableWithoutFeedbackProps } from 'react-native'
+import styled from 'styled-components'
+
+const StyledTouchableWithoutFeedback = styled.button.attrs<TouchableWithoutFeedbackProps>(
+  ({ onClick, testID, accessibilityLabel, ...rest }) => ({
+    tabIndex: '-1',
+    onClick,
+    'data-testid': accessibilityLabel || testID,
+    'aria-label': accessibilityLabel,
+    title: accessibilityLabel,
+    ...rest,
+  })
+)({
+  borderWidth: 0,
+  backgroundColor: 'transparent',
+  padding: 0,
+  textAlign: 'left',
+})
+
+export const TouchableWithoutFeedback: React.ForwardRefRenderFunction<
+  HTMLButtonElement,
+  TouchableWithoutFeedbackProps
+> = ({ onPress, ...rest }) => (
+  /*
+    We can't export styled.button.attrs directly,
+    despite the Props type given to attrs,
+    Styled would log the following warning in the tests :
+    Warning: Unknown event handler property `onPress`. It will be ignored.
+    */
+  // @ts-ignore bug with typescript
+  <StyledTouchableWithoutFeedback onClick={onPress} {...rest} />
+)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25284

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome |[Video accessibility bug](https://github.com/pass-culture/pass-culture-app-native/assets/68000368/e9a189e4-df70-462b-bbf2-2d920279004e)|[Video bug fixed](https://github.com/pass-culture/pass-culture-app-native/assets/68000368/409cf2e9-7b31-40bc-bf7a-b739cfd12a09)|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
