### PR TITLE
(PC-25347) fix(offer): CTA when offer is digital and free and user not eligible

### DIFF
--- a/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts
+++ b/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts
@@ -82,6 +82,32 @@ describe('getCtaWordingAndAction', () => {
         wording: 'Accéder au site partenaire',
       })
     })
+
+    it('should display "Accéder au site partenaire" wording when external url and offer is digital and free', () => {
+      const result = getCtaWordingAndAction({
+        isLoggedIn: true,
+        userStatus: { statusType: YoungStatusType.non_eligible },
+        isBeneficiary: false,
+        offer: buildOffer({
+          externalTicketOfficeUrl: 'https://url-externe',
+          isDigital: true,
+          stocks: [{ ...baseOffer.stocks[0], price: 0 }],
+        }),
+        subcategory: buildSubcategory({}),
+        hasEnoughCredit: false,
+        bookedOffers: {},
+        isUnderageBeneficiary: false,
+        bookOffer: () => {},
+        isBookingLoading: false,
+        booking: undefined,
+      })
+
+      expect(result).toEqual({
+        externalNav: { url: 'https://url-externe' },
+        isDisabled: false,
+        wording: 'Accéder au site partenaire',
+      })
+    })
   })
 
   describe('Eligible but non Beneficiary yet', () => {

--- a/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts
+++ b/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts
@@ -158,7 +158,7 @@ export const getCtaWordingAndAction = ({
     }
   }
 
-  if (isFreeDigitalOffer) {
+  if (isFreeDigitalOffer && userStatus?.statusType !== YoungStatusType.non_eligible) {
     return {
       wording: getDigitalOfferBookingWording(subcategoryId),
       isDisabled: isBookingLoading,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25347

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="462" alt="Capture d’écran 2023-10-27 à 12 40 52" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/6bf9ba83-db9f-4f51-9f1a-23b86da6d95d">|<img width="439" alt="Capture d’écran 2023-10-27 à 12 39 48" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/5631398f-3243-462d-8580-a8857f6540a5">|
| Android          |<img width="426" alt="Capture d’écran 2023-10-27 à 12 40 47" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/188d84cf-4187-4497-86f4-81d5a61f67ec">|<img width="424" alt="Capture d’écran 2023-10-27 à 12 39 55" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/95d1ad80-e340-429d-8f6d-b3421fbdb29e">|
| Phone - Chrome   |<img width="404" alt="Capture d’écran 2023-10-27 à 12 41 00" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/6079b4c7-dd95-472f-b234-4091c40962a3">|<img width="402" alt="Capture d’écran 2023-10-27 à 12 31 49" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/a1977b65-aef5-4ed2-8c2c-b63eb51d4947">|
| Desktop - Chrome |<img width="1726" alt="Capture d’écran 2023-10-27 à 12 41 10" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/a2ed0d2c-9fc8-4292-b5a1-b5354df5cf56">|<img width="1726" alt="Capture d’écran 2023-10-27 à 12 31 33" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/04f4ef01-d6ef-42b6-a031-3fc738d26bf7">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
