### PR TITLE
(PC-24999) feat(SEO): add homeId in canonical link of thematic homes

### DIFF
--- a/server/src/middlewares/tests/webAppProxyMiddleware.test.ts
+++ b/server/src/middlewares/tests/webAppProxyMiddleware.test.ts
@@ -112,6 +112,18 @@ describe('metasResponseInterceptor', () => {
         expect(response).toMatch(hasCanonicalWith(url))
       })
 
+      it('with home id when url is thematic home', async () => {
+        const url = `${env.APP_PUBLIC_URL}/accueil-thematique?homeId=1324434`
+        const canonicalUrl = new RegExp(
+          `<head>.*?<link rel="canonical" href="${env.APP_PUBLIC_URL}/accueil-thematique\\?homeId=1324434" />.*?</head>`,
+          's'
+        )
+
+        const response = await htmlResponseFor(url)
+
+        expect(response).toMatch(canonicalUrl)
+      })
+
       it("when using `yarn dev` we don't have the host", async () => {
         const response = await htmlResponseFor('/')
 

--- a/server/src/middlewares/webAppProxyMiddleware.ts
+++ b/server/src/middlewares/webAppProxyMiddleware.ts
@@ -21,11 +21,15 @@ const options = {
   onProxyRes: responseInterceptor(metasResponseInterceptor),
 }
 
-const addCanonicalLinkToHTML = (html: string, url: URL): string =>
-  html.replace(
+const addCanonicalLinkToHTML = (html: string, url: URL): string => {
+  const isThematicHome = url.pathname === '/accueil-thematique'
+  const homeIdParams = url.searchParams.get('homeId')
+  const additionalParams = isThematicHome && homeIdParams ? `?homeId=${homeIdParams}` : ''
+  return html.replace(
     '<head>',
-    `<head><link rel="canonical" href="${env.APP_PUBLIC_URL}${url.pathname}" />`
+    `<head><link rel="canonical" href="${env.APP_PUBLIC_URL}${url.pathname}${additionalParams}" />`
   )
+}
 
 const addNoIndexToHTML = (html: string): string =>
   html.replace('<head>', `<head><meta name="robots" content="noindex" />`)
@@ -69,7 +73,7 @@ export async function metasResponseInterceptor(
   }
 
   try {
-    return replaceHtmlMetas(html, endpoint, entityKey as EntityKeys, Number(id))
+    return await replaceHtmlMetas(html, endpoint, entityKey as EntityKeys, Number(id))
   } catch (error) {
     // FIXME(kopax): when replaceHtmlMetas can really throw error, restore coverage for following lines and add a throw error unit test
     /* istanbul ignore next */


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24999

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
