### PR TITLE
(PC-25557) fix(search): reset param from history when pressing category button

### DIFF
--- a/src/features/search/helpers/useShowResultsForCategory/useShowResultsForCategory.native.test.ts
+++ b/src/features/search/helpers/useShowResultsForCategory/useShowResultsForCategory.native.test.ts
@@ -126,4 +126,37 @@ describe('useShowResultsForCategory', () => {
       },
     })
   })
+
+  it('should navigate without isFromHistory param when category selected and previous search was from history', () => {
+    mockSearchState = {
+      ...mockSearchState,
+      isFromHistory: true,
+    }
+    const { result: resultCallback } = renderHook(useShowResultsForCategory)
+
+    resultCallback.current(SearchGroupNameEnumv2.SPECTACLES)
+
+    expect(mockNavigate).toHaveBeenCalledWith('TabNavigator', {
+      params: {
+        beginningDatetime: undefined,
+        date: null,
+        endingDatetime: undefined,
+        hitsPerPage: 20,
+        locationFilter: { locationType: 'EVERYWHERE' },
+        offerCategories: [SearchGroupNameEnumv2.SPECTACLES],
+        offerIsDuo: false,
+        offerIsFree: false,
+        offerIsNew: false,
+        offerSubcategories: [],
+        offerTypes: { isDigital: false, isEvent: false, isThing: false },
+        priceRange: [0, 300],
+        query: 'Big flo et Oli',
+        view: SearchView.Results,
+        tags: [],
+        timeRange: null,
+        searchId,
+      },
+      screen: 'Search',
+    })
+  })
 })

--- a/src/features/search/helpers/useShowResultsForCategory/useShowResultsForCategory.ts
+++ b/src/features/search/helpers/useShowResultsForCategory/useShowResultsForCategory.ts
@@ -28,6 +28,7 @@ export const useShowResultsForCategory = (): OnPressCategory => {
         view: SearchView.Results,
         searchId,
         isFullyDigitalOffersCategory: isOnlyOnline(data, pressedCategory) || undefined,
+        isFromHistory: undefined,
       }
       dispatch({ type: 'SET_STATE', payload: newSearchState })
       navigate(...getTabNavConfig('Search', newSearchState))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25557

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
