### PR TITLE
(BSR) build(storybook): upgrade @chanzuckerberg/axe-storybook-testing from 7.1.1 to 7.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "@babel/preset-typescript": "^7.13.0",
     "@babel/runtime": "^7.22.10",
     "@bam.tech/eslint-plugin": "^1.0.1",
-    "@chanzuckerberg/axe-storybook-testing": "^7.1.1",
+    "@chanzuckerberg/axe-storybook-testing": "^7.1.2",
     "@google-cloud/local-auth": "^2.1.1",
     "@lhci/cli": "0.11.x",
     "@react-native-community/eslint-config": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4313,17 +4313,17 @@
     "@callstack/reassure-logger" "0.2.0"
     mathjs "^11.5.0"
 
-"@chanzuckerberg/axe-storybook-testing@^7.1.1":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@chanzuckerberg/axe-storybook-testing/-/axe-storybook-testing-7.1.1.tgz#2860fce2d90b18f513b8e7c9643d26e2979723f4"
-  integrity sha512-MZau1Dw7uu7YfmM0xc4e5QAqDqRoq4om0peb1l7VeSoy0V/RbzTgKDKwSRe4iiB24poyc+1A+X2O6lG3zvzRrw==
+"@chanzuckerberg/axe-storybook-testing@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@chanzuckerberg/axe-storybook-testing/-/axe-storybook-testing-7.1.2.tgz#2c5bd8cc9c9ef15c770348bdd001403f44f195bb"
+  integrity sha512-eHJyyBv4xnDd5CmURRBXpNpM1DrxVPlVArM1U5VJDvUsRAlcGZmJnW3yKYY3wDsLB4y2jQ+6gigKDl4WMyffDw==
   dependencies:
     http-server "^14.1.1"
     indent-string "^4.0.0"
     lodash "^4.17.21"
     mocha "^10.2.0"
     p-timeout "^4.1.0"
-    playwright "^1.33.0"
+    playwright "^1.36.2"
     portfinder "^1.0.32"
     ts-dedent "^2.2.0"
     yargs "^17.7.2"
@@ -15154,6 +15154,11 @@ fs@^0.0.1-security:
   resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
   integrity sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==
 
+fsevents@2.3.2, fsevents@^2.1.2, fsevents@^2.3.2, fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@^1.2.7:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.13.tgz#f325cb0455592428bcf11b383370ef70e3bfcc38"
@@ -15161,11 +15166,6 @@ fsevents@^1.2.7:
   dependencies:
     bindings "^1.5.0"
     nan "^2.12.1"
-
-fsevents@^2.1.2, fsevents@^2.3.2, fsevents@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 fstream@^1.0.12:
   version "1.0.12"
@@ -21324,10 +21324,10 @@ playwright-core@1.28.1:
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.28.1.tgz#8400be9f4a8d1c0489abdb9e75a4cc0ffc3c00cb"
   integrity sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==
 
-playwright-core@1.36.2:
-  version "1.36.2"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.36.2.tgz#32382f2d96764c24c65a86ea336cf79721c2e50e"
-  integrity sha512-sQYZt31dwkqxOrP7xy2ggDfEzUxM1lodjhsQ3NMMv5uGTRDsLxU0e4xf4wwMkF2gplIxf17QMBCodSFgm6bFVQ==
+playwright-core@1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.39.0.tgz#efeaea754af4fb170d11845b8da30b2323287c63"
+  integrity sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==
 
 playwright@^1.28.1:
   version "1.28.1"
@@ -21336,12 +21336,14 @@ playwright@^1.28.1:
   dependencies:
     playwright-core "1.28.1"
 
-playwright@^1.33.0:
-  version "1.36.2"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.36.2.tgz#4f25272209a31ad1138d7b9868e0325159f003e3"
-  integrity sha512-4Fmlq3KWsl85Bl4InJw1NC21aeQV0iSZuFvTDcy1F8zVmXmgQRe89GxF8zMSRt/KIS+2tUolak7EXVl9aC+JdA==
+playwright@^1.36.2:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.39.0.tgz#184c81cd6478f8da28bcd9e60e94fcebf566e077"
+  integrity sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==
   dependencies:
-    playwright-core "1.36.2"
+    playwright-core "1.39.0"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 please-upgrade-node@^3.1.1:
   version "3.2.0"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

Issue: https://github.com/microsoft/playwright/issues/24028

Autrement `yarn install` fail sur Debian 12 : 

```bash
Output:
/home/dka/workspace/github.com/pass-culture/pass-culture-app-native/node_modules/@chanzuckerberg/axe-storybook-testing/node_modules/playwright-core/lib/server/registry/index.js:684
    if (!downloadURLs.length) throw new Error(`ERROR: Playwright does not support ${descriptor.name} on ${_hostPlatform.hostPlatform}`);
                                    ^

Error: ERROR: Playwright does not support firefox on debian12
    at Registry._downloadExecutable (/home/dka/workspace/github.com/pass-culture/pass-culture-app-native/node_modules/@chanzuckerberg/axe-storybook-testing/node_modules/playwright-core/lib/server/registry/index.js:684:37)
    at Object._install (/home/dka/workspace/github.com/pass-culture/pass-culture-app-native/node_modules/@chanzuckerberg/axe-storybook-testing/node_modules/playwright-core/lib/server/registry/index.js:463:28)
    at Registry.install (/home/dka/workspace/github.com/pass-culture/pass-culture-app-native/node_modules/@chanzuckerberg/axe-storybook-testing/node_modules/playwright-core/lib/server/registry/index.js:642:26)
``` 

Ceci à cause de la cmd `npx playwright install-deps` qui n'a pas les deps nécessaire sur debian `bookwrom` :  

```bash
❯ npx playwright install-deps
BEWARE: your OS is not officially supported by Playwright; installing dependencies for Ubuntu as a fallback.
Installing dependencies...
Switching to root user to install dependencies...
Hit:1 http://security.debian.org/debian-security bookworm-security InRelease
Get:2 http://deb.debian.org/debian bookworm InRelease [151 kB]                                             
Hit:3 http://deb.debian.org/debian bookworm-updates InRelease                                                         
Hit:4 https://dl.google.com/linux/chrome/deb stable InRelease                                             
Hit:5 https://download.docker.com/linux/debian bookworm InRelease                   
Fetched 151 kB in 1s (135 kB/s)       
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'libfontconfig1' instead of 'libfontconfig'
Package ttf-ubuntu-font-family is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Package ttf-unifont is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  fonts-unifont

Package xfonts-cyrillic is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'ttf-unifont' has no installation candidate
E: Package 'xfonts-cyrillic' has no installation candidate
E: Package 'ttf-ubuntu-font-family' has no installation candidate
E: Unable to locate package libenchant1c2a
E: Unable to locate package libvpx6
E: Unable to locate package libwebp6
Failed to install browser dependencies
Error: Installation process exited with code: 100
```


## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
