### PR TITLE
(PC-25610) fix(security): Encode home id params to avoid xss attack

### DIFF
--- a/server/src/middlewares/tests/webAppProxyMiddleware.test.ts
+++ b/server/src/middlewares/tests/webAppProxyMiddleware.test.ts
@@ -124,6 +124,18 @@ describe('metasResponseInterceptor', () => {
         expect(response).toMatch(canonicalUrl)
       })
 
+      it('with encoded home id when url is thematic home', async () => {
+        const url = `${env.APP_PUBLIC_URL}/accueil-thematique?homeId=1324434"><script>alert('hack')</script>`
+        const canonicalUrl = new RegExp(
+          `<head>.*?<link rel="canonical" href="${env.APP_PUBLIC_URL}/accueil-thematique\\?homeId=1324434%22%3E%3Cscript%3Ealert\\('hack'\\)%3C%2Fscript%3E\" />.*?</head>`,
+          's'
+        )
+
+        const response = await htmlResponseFor(url)
+
+        expect(response).toMatch(canonicalUrl)
+      })
+
       it("when using `yarn dev` we don't have the host", async () => {
         const response = await htmlResponseFor('/')
 

--- a/server/src/middlewares/webAppProxyMiddleware.ts
+++ b/server/src/middlewares/webAppProxyMiddleware.ts
@@ -24,7 +24,8 @@ const options = {
 const addCanonicalLinkToHTML = (html: string, url: URL): string => {
   const isThematicHome = url.pathname === '/accueil-thematique'
   const homeIdParams = url.searchParams.get('homeId')
-  const additionalParams = isThematicHome && homeIdParams ? `?homeId=${homeIdParams}` : ''
+  const additionalParams =
+    isThematicHome && homeIdParams ? `?homeId=${encodeURIComponent(homeIdParams)}` : ''
   return html.replace(
     '<head>',
     `<head><link rel="canonical" href="${env.APP_PUBLIC_URL}${url.pathname}${additionalParams}" />`


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25610

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
