### PR TITLE
(PC-24769) fix(nbResultsFacet): fix ui of nbResultFacets complement & ValidateIcon

### DIFF
--- a/src/features/search/components/FilterRow/FilterRow.tsx
+++ b/src/features/search/components/FilterRow/FilterRow.tsx
@@ -94,10 +94,10 @@ const TitleAndDescriptionContainer = styled.View(({ theme }) => ({
 const ComplementContainer = styled.View({
   flexShrink: 0,
   justifyContent: 'center',
-  marginRight: getSpacing(3),
+  marginRight: getSpacing(3.5),
 })
 
 const ComplementLabel = styled(Typo.Caption)(({ theme }) => ({
   color: theme.colors.greyDark,
-  marginLeft: getSpacing(1),
+  marginLeft: getSpacing(2),
 }))

--- a/src/ui/components/radioButtons/RadioButton.tsx
+++ b/src/ui/components/radioButtons/RadioButton.tsx
@@ -143,16 +143,19 @@ const Label = styled(Typo.ButtonText)<{ isSelected: boolean }>(({ isSelected, th
 
 const ComplementLabel = styled(Typo.Caption)<{ isSelected: boolean }>(({ isSelected, theme }) => ({
   color: isSelected ? theme.colors.primary : theme.colors.greyDark,
-  marginLeft: getSpacing(1),
+  marginLeft: getSpacing(2),
   flexShrink: 0,
 }))
 
 const IconContainer = styled.View(({ theme }) => ({
-  flex: 0.1,
+  flexShrink: 1,
+  flexBasis: 0,
+  flexGrow: theme.isMobileViewport ? 0.1 : undefined,
   justifyContent: 'center',
   alignItems: 'flex-end',
   width: theme.icons.sizes.smaller,
   height: theme.icons.sizes.smaller,
+  marginLeft: theme.isDesktopViewport ? getSpacing(2) : undefined,
 }))
 
 const ValidateIconPrimary = styled(Validate).attrs(({ theme }) => ({


### PR DESCRIPTION
…

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24769

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |![Capture d’écran 2023-11-08 à 11 03 11](https://github.com/pass-culture/pass-culture-app-native/assets/62058919/cc0f92e0-0f44-4f04-b870-b52fe612d6a3)|
| Android          |               |![Capture d’écran 2023-11-08 à 11 18 19](https://github.com/pass-culture/pass-culture-app-native/assets/62058919/58b61845-7cf2-4e3e-addc-95dd81ed0e72)|
| Phone - Chrome   |               |![Capture d’écran 2023-11-08 à 10 55 44](https://github.com/pass-culture/pass-culture-app-native/assets/62058919/8e4c2eca-ac8b-455c-b444-da6bec622d6a)|
| Desktop - Chrome |               |![Capture d’écran 2023-11-08 à 10 55 35](https://github.com/pass-culture/pass-culture-app-native/assets/62058919/b50f206a-bfcd-49a2-9f40-de1bc135a899)|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
