### PR TITLE
(PC-25839) fix(location): fix header design issue on the location modal

### DIFF
--- a/__snapshots__/features/search/pages/modals/LocationModal/LocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/LocationModal/LocationModal.native.test.tsx.native-snap
@@ -115,7 +115,7 @@ exports[`<LocationModal/> should render modal correctly after animation and with
   >
     <View
       desktopMaxHeight={1000.5}
-      height={1334}
+      height={1318}
       maxHeight={1334}
       noPadding={true}
       style={
@@ -132,7 +132,7 @@ exports[`<LocationModal/> should render modal correctly after animation and with
             "borderTopRightRadius": 20,
             "borderTopStartRadius": 16,
             "flexDirection": "column",
-            "height": 1334,
+            "height": 1318,
             "justifyContent": "center",
             "maxHeight": 1334,
             "maxWidth": 960,

--- a/src/features/search/pages/modals/LocationModal/LocationModal.tsx
+++ b/src/features/search/pages/modals/LocationModal/LocationModal.tsx
@@ -372,7 +372,7 @@ export const LocationModal: FunctionComponent<LocationModalProps> = ({
         />
       }
       title={title}
-      isFullscreen
+      isUpToStatusBar
       noPadding
       modalSpacing={modal.spacing.MD}
       rightIconAccessibilityLabel={accessibilityLabel}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25839

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots


| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="329" alt="Capture d’écran 2023-11-16 à 11 04 20" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/6c3f4574-e2c1-49af-8d2a-051f0ae4004f">|<img width="334" alt="Capture d’écran 2023-11-16 à 12 01 36" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/677d7c0a-b117-4dad-9fe2-79e86fdcdc9c">|
| Android          |<img width="372" alt="Capture d’écran 2023-11-16 à 11 53 31" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/f1e7ddba-2046-44ae-b705-757fb97f1229">|<img width="375" alt="Capture d’écran 2023-11-16 à 11 53 54" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/6c95b0a4-707e-420f-a415-37aed631a24f">|
| Desktop - Chrome |<img width="508" alt="Capture d’écran 2023-11-16 à 11 27 29" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/dd6c28c1-719b-4bca-ad6a-0cf9e1811983">|<img width="508" alt="Capture d’écran 2023-11-16 à 11 27 29" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/dd6c28c1-719b-4bca-ad6a-0cf9e1811983">|
