### PR TITLE
(PC-25272) fix(sonar): readonly props

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,12 @@
   "editor.formatOnSave": true,
   "prettier.requireConfig": true,
   "eslint.enable": true,
-  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
   "files.associations": {
     "Fastfile*": "ruby",
     "Appfile": "ruby",
@@ -24,4 +29,8 @@
   "liveshare.allowGuestTaskControl": true,
   "liveshare.guestApprovalRequired": true,
   "emmet.showExpandedAbbreviation": "never",
+  "sonarlint.connectedMode.project": {
+    "connectionId": "pass-culture",
+    "projectKey": "pass-culture_pass-culture-app-native"
+  },
 }

--- a/src/features/auth/pages/forgottenPassword/ResetPasswordExpiredLink/ResetPasswordExpiredLink.tsx
+++ b/src/features/auth/pages/forgottenPassword/ResetPasswordExpiredLink/ResetPasswordExpiredLink.tsx
@@ -14,7 +14,7 @@ import { LayoutExpiredLink } from 'ui/components/LayoutExpiredLink'
 
 type Props = StackScreenProps<RootStackParamList, 'ResetPasswordExpiredLink'>
 
-export function ResetPasswordExpiredLink(props: Props) {
+export function ResetPasswordExpiredLink(props: Readonly<Props>) {
   const { navigate } = useNavigation<UseNavigationType>()
 
   const { email } = props.route.params

--- a/src/features/auth/pages/signup/SignupConfirmationExpiredLink/SignupConfirmationExpiredLink.tsx
+++ b/src/features/auth/pages/signup/SignupConfirmationExpiredLink/SignupConfirmationExpiredLink.tsx
@@ -14,7 +14,7 @@ import { LayoutExpiredLink } from 'ui/components/LayoutExpiredLink'
 
 type Props = StackScreenProps<RootStackParamList, 'SignupConfirmationExpiredLink'>
 
-export function SignupConfirmationExpiredLink(props: Props) {
+export function SignupConfirmationExpiredLink(props: Readonly<Props>) {
   const { navigate } = useNavigation<UseNavigationType>()
   const { email } = props.route.params
   const { refetch: signupConfirmationExpiredLinkQuery, isFetching } = useQuery(

--- a/src/features/bookOffer/components/AlreadyBooked.tsx
+++ b/src/features/bookOffer/components/AlreadyBooked.tsx
@@ -11,7 +11,7 @@ import { Spacer } from 'ui/components/spacer/Spacer'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { getSpacing, Typo } from 'ui/theme'
 
-export function AlreadyBooked({ offer }: { offer: OfferResponse }) {
+export function AlreadyBooked({ offer }: { offer: Readonly<OfferResponse> }) {
   const { bookingState, dismissModal, dispatch } = useBookingContext()
 
   // Change step to confirmation

--- a/src/features/bookOffer/components/BookingOfferLoader/BookingOfferLoader.tsx
+++ b/src/features/bookOffer/components/BookingOfferLoader/BookingOfferLoader.tsx
@@ -9,7 +9,7 @@ type BookingOfferLoaderProps = {
   message?: string
 }
 
-export function BookingOfferLoader({ message }: BookingOfferLoaderProps) {
+export function BookingOfferLoader({ message }: Readonly<BookingOfferLoaderProps>) {
   const theme = useTheme()
 
   return (

--- a/src/features/bookOffer/components/HourChoice.tsx
+++ b/src/features/bookOffer/components/HourChoice.tsx
@@ -29,7 +29,7 @@ export function HourChoice({
   hasSeveralPrices,
   features,
   index,
-}: Props) {
+}: Readonly<Props>) {
   const enoughCredit = price <= offerCredit
   const disabled = !isBookable || !enoughCredit
   const priceWording = getHourWording(price, isBookable, enoughCredit, hasSeveralPrices)

--- a/src/features/bookOffer/components/PriceLine.tsx
+++ b/src/features/bookOffer/components/PriceLine.tsx
@@ -44,7 +44,7 @@ export function PriceLine({
   label,
   shouldDisabledStyles = false,
   attributes,
-}: PriceLineProps) {
+}: Readonly<PriceLineProps>) {
   const totalPrice = formatToFrenchDecimal(quantity * unitPrice)
 
   const MainText = shouldDisabledStyles ? Typo.Body : Typo.Caption

--- a/src/features/bookings/components/BookingItemTitle.tsx
+++ b/src/features/bookings/components/BookingItemTitle.tsx
@@ -7,7 +7,7 @@ type Props = {
   title: string
 }
 
-export function BookingItemTitle(props: Props) {
+export function BookingItemTitle(props: Readonly<Props>) {
   return (
     <TitleContainer>
       <ButtonText>{props.title}</ButtonText>

--- a/src/features/bookings/components/Ticket/TicketSwiper.tsx
+++ b/src/features/bookings/components/Ticket/TicketSwiper.tsx
@@ -20,7 +20,7 @@ const INTERVAL = getSpacing(SEPARATOR_VALUE)
 const keyExtractor = (item: ReactElement<TicketsProps>, index: number) =>
   `${item.props.booking.stock.offer.name}-${index}`
 
-export function TicketSwiper({ booking }: TicketsProps) {
+export function TicketSwiper({ booking }: Readonly<TicketsProps>) {
   const { isTouch, appContentWidth, ticket } = useTheme()
   const flatListRef = useRef<FlatList>(null)
   const { tickets } = getTickets({ booking })

--- a/src/features/bookings/components/Ticket/TicketSwiperControls.tsx
+++ b/src/features/bookings/components/Ticket/TicketSwiperControls.tsx
@@ -21,7 +21,7 @@ export function TicketSwiperControls({
   nextTitle,
   onPressPrev,
   onPressNext,
-}: Props) {
+}: Readonly<Props>) {
   const showPrevButton = currentStep > 1
   const showNextButton = currentStep !== numberOfSteps
 

--- a/src/features/bookings/components/Ticket/TicketWithContent.tsx
+++ b/src/features/bookings/components/Ticket/TicketWithContent.tsx
@@ -10,7 +10,7 @@ export function TicketWithContent({
   booking,
   externalBookings,
   testID,
-}: BookingDetailsTicketContentProps) {
+}: Readonly<BookingDetailsTicketContentProps>) {
   return (
     <ThreeShapesTicket testID={testID}>
       <BookingDetailsTicketContent booking={booking} externalBookings={externalBookings} />

--- a/src/features/bookings/components/TicketCode.tsx
+++ b/src/features/bookings/components/TicketCode.tsx
@@ -8,7 +8,7 @@ type TicketCodeProps = {
   withdrawalType?: WithdrawalTypeEnum
 }
 
-export function TicketCode({ code, withdrawalType }: TicketCodeProps) {
+export function TicketCode({ code, withdrawalType }: Readonly<TicketCodeProps>) {
   if (withdrawalType === undefined || withdrawalType === WithdrawalTypeEnum.on_site) {
     return <TicketCodeTitle>{code}</TicketCodeTitle>
   }

--- a/src/features/bookings/components/TicketCode.web.tsx
+++ b/src/features/bookings/components/TicketCode.web.tsx
@@ -9,7 +9,7 @@ type TicketCodeProps = {
   withdrawalType?: WithdrawalTypeEnum
 }
 
-export function TicketCode({ code, withdrawalType }: TicketCodeProps) {
+export function TicketCode({ code, withdrawalType }: Readonly<TicketCodeProps>) {
   const { showSuccessSnackBar } = useSnackBarContext()
 
   const copyToClipboard = useCallback(() => {

--- a/src/features/gtlPlaylist/components/GtlPlaylist.tsx
+++ b/src/features/gtlPlaylist/components/GtlPlaylist.tsx
@@ -21,7 +21,7 @@ interface GtlPlaylistProps {
   playlist: GTLPlaylistResponse[number]
 }
 
-export function GtlPlaylist({ venue, playlist }: GtlPlaylistProps) {
+export function GtlPlaylist({ venue, playlist }: Readonly<GtlPlaylistProps>) {
   const transformOfferHits = useTransformOfferHits()
   const mapping = useCategoryIdMapping()
   const labelMapping = useCategoryHomeLabelMapping()

--- a/src/features/internal/marketingAndCommunication/atoms/DateChoice.tsx
+++ b/src/features/internal/marketingAndCommunication/atoms/DateChoice.tsx
@@ -6,7 +6,7 @@ interface Props {
   onChange: (date: Date | undefined) => void
 }
 
-export function DateChoice(props: Props) {
+export function DateChoice(props: Readonly<Props>) {
   const now = new Date()
   return <DateInput defaultSelectedDate={now} minimumDate={now} onChange={props.onChange} />
 }

--- a/src/features/offer/components/CTAButton/CTAButton.tsx
+++ b/src/features/offer/components/CTAButton/CTAButton.tsx
@@ -23,7 +23,7 @@ export function CTAButton({
   externalNav,
   navigateTo,
   isFreeDigitalOffer,
-}: CTAButtonProps) {
+}: Readonly<CTAButtonProps>) {
   const { isLoggedIn } = useAuthContext()
   const commonLinkProps = {
     as: ButtonWithLinearGradient,

--- a/src/features/offer/components/SelectableListItem/SelectableListItem.tsx
+++ b/src/features/offer/components/SelectableListItem/SelectableListItem.tsx
@@ -25,7 +25,7 @@ export function SelectableListItem({
   onSelect,
   render,
   ...props
-}: SelectableListItemProps) {
+}: Readonly<SelectableListItemProps>) {
   const { onFocus, onBlur, isFocus } = useHandleFocus()
   const { onMouseEnter, onMouseLeave, isHover } = useHandleHover()
 

--- a/src/features/offer/components/VenueSection/VenueSection.tsx
+++ b/src/features/offer/components/VenueSection/VenueSection.tsx
@@ -43,7 +43,12 @@ const mergeVenueData =
     ...(prevData ?? {}),
   })
 
-export function VenueSection({ beforeNavigateToItinerary, venue, showVenueBanner, title }: Props) {
+export function VenueSection({
+  beforeNavigateToItinerary,
+  venue,
+  showVenueBanner,
+  title,
+}: Readonly<Props>) {
   const { navigate } = useNavigation<UseNavigationType>()
   const queryClient = useQueryClient()
   const { latitude: lat, longitude: lng } = venue.coordinates

--- a/src/features/profile/components/Badges/YoungerBadge.tsx
+++ b/src/features/profile/components/Badges/YoungerBadge.tsx
@@ -4,7 +4,7 @@ import { formatToSlashedFrenchDate } from 'libs/dates'
 import { InfoBanner } from 'ui/components/banners/InfoBanner'
 import { BicolorClock } from 'ui/svg/icons/BicolorClock'
 
-export function YoungerBadge(props: { eligibilityStartDatetime: Date }) {
+export function YoungerBadge(props: { eligibilityStartDatetime: Readonly<Date> }) {
   const date = formatToSlashedFrenchDate(props.eligibilityStartDatetime.toISOString())
   const information = `Patience\u00a0! Reviens à partir du ${date} pour continuer ton inscription et bénéficier du crédit pass Culture.`
   return <InfoBanner icon={BicolorClock} message={information} testID="younger-badge" />

--- a/src/features/profile/components/BeneficiaryCeilings/BeneficiaryCeilings.tsx
+++ b/src/features/profile/components/BeneficiaryCeilings/BeneficiaryCeilings.tsx
@@ -11,7 +11,7 @@ type BeneficiaryCeilingsProps = {
   domainsCredit: DomainsCredit
 }
 
-export function BeneficiaryCeilings({ domainsCredit }: BeneficiaryCeilingsProps) {
+export function BeneficiaryCeilings({ domainsCredit }: Readonly<BeneficiaryCeilingsProps>) {
   const isUserUnderageBeneficiary = useIsUserUnderageBeneficiary()
 
   if (isUserUnderageBeneficiary || domainsCredit.all.remaining === 0) return null

--- a/src/features/profile/components/Header/CreditHeader/CreditHeader.tsx
+++ b/src/features/profile/components/Header/CreditHeader/CreditHeader.tsx
@@ -33,7 +33,7 @@ export function CreditHeader({
   age,
   domainsCredit,
   depositExpirationDate,
-}: CreditHeaderProps) {
+}: Readonly<CreditHeaderProps>) {
   const { homeEntryIdFreeOffers } = useRemoteConfigContext()
   const depositAmount = useDepositAmountsByAge()
   const incomingCreditLabelsMap: Record<number, { label: string; highlightedLabel: string }> = {

--- a/src/features/profile/components/Header/ProfileHeader/ProfileHeader.tsx
+++ b/src/features/profile/components/Header/ProfileHeader/ProfileHeader.tsx
@@ -12,7 +12,7 @@ type ProfileHeaderProps = {
   user?: UserProfileResponse
 }
 
-export function ProfileHeader(props: ProfileHeaderProps) {
+export function ProfileHeader(props: Readonly<ProfileHeaderProps>) {
   const { user } = props
   const { isLoggedIn } = useAuthContext()
 

--- a/src/features/profile/components/Modals/CreditCeilingsModal.tsx
+++ b/src/features/profile/components/Modals/CreditCeilingsModal.tsx
@@ -44,7 +44,7 @@ const CreditText = ({ domainsCredit }: Pick<Props, 'domainsCredit'>) => {
   )
 }
 
-export function CreditCeilingsModal({ domainsCredit, visible, hideModal }: Props) {
+export function CreditCeilingsModal({ domainsCredit, visible, hideModal }: Readonly<Props>) {
   return (
     <AppInformationModal
       title="Pourquoi cette limite&nbsp;?"

--- a/src/features/profile/components/Modals/ExpiredCreditModal.tsx
+++ b/src/features/profile/components/Modals/ExpiredCreditModal.tsx
@@ -8,7 +8,7 @@ type Props = {
   hideModal: () => void
 }
 
-export function ExpiredCreditModal({ visible, hideModal }: Props) {
+export function ExpiredCreditModal({ visible, hideModal }: Readonly<Props>) {
   return (
     <AppInformationModal
       title="Mon crédit est expiré, que faire&nbsp;?"

--- a/src/features/profile/components/StepCard/StepCard.tsx
+++ b/src/features/profile/components/StepCard/StepCard.tsx
@@ -23,7 +23,7 @@ export function StepCard({
   icon,
   type = StepCardType.ACTIVE,
   ...props
-}: StepCardProps) {
+}: Readonly<StepCardProps>) {
   const hasSubtitle = !!subtitle
   const theme = useTheme()
 

--- a/src/features/profile/components/StepList/StepList.tsx
+++ b/src/features/profile/components/StepList/StepList.tsx
@@ -35,7 +35,7 @@ function getVariantFromIndex(activeStepIndex: number, stepIndex: number) {
  *   </Step>
  * </StepList>
  */
-export function StepList({ activeStepIndex, children, ...props }: StepListProps) {
+export function StepList({ activeStepIndex, children, ...props }: Readonly<StepListProps>) {
   if (activeStepIndex > children.length - 1) {
     console.warn(
       `[StepList] - Given (\`activeStepIndex\`: ${activeStepIndex}) but children length is ${

--- a/src/features/profile/components/VerticalDots/AutomaticVerticalDots.tsx
+++ b/src/features/profile/components/VerticalDots/AutomaticVerticalDots.tsx
@@ -11,7 +11,7 @@ type Dimensions = Omit<LayoutRectangle, 'x' | 'y'>
 /**
  * This component is just a full flex wrapper that gives props to `VerticalDotProps`
  */
-export function AutomaticVerticalDots(props: AutomaticVerticalDotsProps) {
+export function AutomaticVerticalDots(props: Readonly<AutomaticVerticalDotsProps>) {
   const [{ width, height }, setDimensions] = useState<Dimensions>({
     width: 0,
     height: 0,

--- a/src/features/profile/components/VerticalDots/VerticalDots.tsx
+++ b/src/features/profile/components/VerticalDots/VerticalDots.tsx
@@ -121,7 +121,7 @@ export function VerticalDots({
   testID,
   firstDotSize = dotSize,
   lastDotSize = dotSize,
-}: VerticalDotsProps) {
+}: Readonly<VerticalDotsProps>) {
   const dotCount = getDotCount({
     dotHeight: getDotHeight(dotSize),
     minimumDotSpacing,

--- a/src/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.tsx
+++ b/src/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.tsx
@@ -17,7 +17,10 @@ import { Spacer, Typo } from 'ui/theme'
 
 type ConfirmChangeEmailProps = NativeStackScreenProps<RootStackParamList, 'ConfirmChangeEmail'>
 
-export function ConfirmChangeEmail({ route: { params }, navigation }: ConfirmChangeEmailProps) {
+export function ConfirmChangeEmail({
+  route: { params },
+  navigation,
+}: Readonly<ConfirmChangeEmailProps>) {
   const { data: emailUpdateStatus, isLoading: isLoadingEmailUpdateStatus } = useEmailUpdateStatus()
   const { showErrorSnackBar } = useSnackBarContext()
 

--- a/src/features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation.tsx
+++ b/src/features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation.tsx
@@ -25,7 +25,7 @@ type SuspendAccountConfirmationProps = NativeStackScreenProps<
 export function SuspendAccountConfirmation({
   route: { params },
   navigation,
-}: SuspendAccountConfirmationProps) {
+}: Readonly<SuspendAccountConfirmationProps>) {
   const { data: emailUpdateStatus, isLoading: isLoadingEmailUpdateStatus } = useEmailUpdateStatus()
   const { showErrorSnackBar } = useSnackBarContext()
 

--- a/src/features/profile/pages/ValidateEmailChange/ValidateEmailChange.tsx
+++ b/src/features/profile/pages/ValidateEmailChange/ValidateEmailChange.tsx
@@ -20,7 +20,10 @@ import { Spacer, Typo } from 'ui/theme'
 
 type ValidateEmailChangeProps = NativeStackScreenProps<RootStackParamList, 'ValidateEmailChange'>
 
-export function ValidateEmailChange({ route: { params }, navigation }: ValidateEmailChangeProps) {
+export function ValidateEmailChange({
+  route: { params },
+  navigation,
+}: Readonly<ValidateEmailChangeProps>) {
   const { data: emailUpdateStatus, isLoading: isLoadingEmailUpdateStatus } = useEmailUpdateStatus()
   const { showSuccessSnackBar, showErrorSnackBar } = useSnackBarContext()
 

--- a/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
+++ b/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
@@ -35,7 +35,7 @@ export function AutocompleteOfferItem({
   sendEvent,
   addSearchHistory,
   shouldShowCategory,
-}: AutocompleteOfferItemProps) {
+}: Readonly<AutocompleteOfferItemProps>) {
   const { query, [env.ALGOLIA_OFFERS_INDEX_NAME]: indexInfos } = hit
   // https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/query-suggestions/how-to/adding-category-suggestions/js/#suggestions-with-categories-index-schema
   const { ['offer.searchGroupNamev2']: categories, ['offer.nativeCategoryId']: nativeCategories } =

--- a/src/features/search/components/AutocompleteVenueItem/AutocompleteVenueItem.tsx
+++ b/src/features/search/components/AutocompleteVenueItem/AutocompleteVenueItem.tsx
@@ -14,7 +14,7 @@ type AutocompleteVenueItemProps = {
   onPress: () => Promise<void>
 }
 
-export function AutocompleteVenueItem({ hit, onPress }: AutocompleteVenueItemProps) {
+export function AutocompleteVenueItem({ hit, onPress }: Readonly<AutocompleteVenueItemProps>) {
   const { navigate } = useNavigation<UseNavigationType>()
 
   async function handlePress() {

--- a/src/features/search/components/SearchHistoryItem/SearchHistoryItem.tsx
+++ b/src/features/search/components/SearchHistoryItem/SearchHistoryItem.tsx
@@ -14,7 +14,7 @@ interface Props {
   onPress: (item: Highlighted<HistoryItem>) => void
 }
 
-export function SearchHistoryItem({ item, queryHistory, onPress }: Props) {
+export function SearchHistoryItem({ item, queryHistory, onPress }: Readonly<Props>) {
   const shouldDisplaySearchGroupOrNativeCategory = Boolean(
     item.nativeCategoryLabel || item.categoryLabel
   )

--- a/src/features/search/pages/modals/CategoriesModal/CategoriesSection.tsx
+++ b/src/features/search/pages/modals/CategoriesModal/CategoriesSection.tsx
@@ -52,7 +52,7 @@ export function CategoriesSection<
   onSelect,
   onSubmit,
   value,
-}: CategoriesSectionProps<T, N>) {
+}: Readonly<CategoriesSectionProps<T, N>>) {
   const { data: subcategoriesData } = useSubcategories()
   const displaySearchNbFacetResults = useFeatureFlag(
     RemoteStoreFeatureFlags.WIP_DISPLAY_SEARCH_NB_FACET_RESULTS

--- a/src/features/venue/components/VenueBody/VenueBody.tsx
+++ b/src/features/venue/components/VenueBody/VenueBody.tsx
@@ -30,7 +30,7 @@ interface Props {
   playlists?: GTLPlaylistResponse
 }
 
-export function VenueBody({ venueId, onScroll, playlists }: Props) {
+export function VenueBody({ venueId, onScroll, playlists }: Readonly<Props>) {
   const { data: venue } = useVenue(venueId)
   const { data: offers } = useVenueOffers(venueId)
   const scrollViewRef = useRef<ScrollView | null>(null)

--- a/src/libs/e2e/E2eContextProvider.tsx
+++ b/src/libs/e2e/E2eContextProvider.tsx
@@ -8,7 +8,7 @@ const E2eContext = React.createContext<boolean>(false)
 export function E2eContextProvider({
   children,
 }: {
-  children: React.JSX.Element | React.JSX.Element[]
+  children: Readonly<React.JSX.Element | React.JSX.Element[]>
 }) {
   const [isE2e, setIsE2e] = useState<boolean>(false)
   useEffect(() => {

--- a/src/libs/itinerary/components/SeeItineraryButton.tsx
+++ b/src/libs/itinerary/components/SeeItineraryButton.tsx
@@ -11,7 +11,7 @@ interface Props {
   onPress?: () => void
 }
 
-export function SeeItineraryButton(props: Props) {
+export function SeeItineraryButton(props: Readonly<Props>) {
   return (
     <Container>
       <ExternalTouchableLink

--- a/src/libs/network/OfflineModeContainer.tsx
+++ b/src/libs/network/OfflineModeContainer.tsx
@@ -6,7 +6,7 @@ import { getSpacing, Typo, Spacer } from 'ui/theme'
 
 const THIRTY_SECONDS = 15000
 
-export function OfflineModeContainer({ children }: { children: ReactNode }) {
+export function OfflineModeContainer({ children }: { children: Readonly<ReactNode> }) {
   const netInfo = useNetInfoContext()
   const [show, setShow] = useState(!netInfo.isConnected)
   const isInternetReachable = useRef(netInfo.isInternetReachable)

--- a/src/libs/recaptcha/ReCaptcha.web.tsx
+++ b/src/libs/recaptcha/ReCaptcha.web.tsx
@@ -22,7 +22,7 @@ const css = `
    }
 `
 
-export function ReCaptcha(props: Props) {
+export function ReCaptcha(props: Readonly<Props>) {
   useCaptcha()
 
   const reCaptchaContainerRef = useRef<HTMLDivElement>(null)

--- a/src/libs/styled/index.web.tsx
+++ b/src/libs/styled/index.web.tsx
@@ -11,7 +11,7 @@ type Props = {
   theme: ComputedTheme
 }
 
-export function ThemeProvider({ children, theme }: Props) {
+export function ThemeProvider({ children, theme }: Readonly<Props>) {
   const computedTheme = useComputedTheme(theme)
   return (
     <ThemeProviderWeb theme={computedTheme}>

--- a/src/ui/components/LayoutExpiredLink.tsx
+++ b/src/ui/components/LayoutExpiredLink.tsx
@@ -24,7 +24,7 @@ export function LayoutExpiredLink({
   urlFAQ,
   contactSupport,
   customBodyText,
-}: Props) {
+}: Readonly<Props>) {
   return (
     <GenericInfoPage
       title="Oups&nbsp;!"

--- a/src/ui/components/SocialNetworkCard.tsx
+++ b/src/ui/components/SocialNetworkCard.tsx
@@ -11,7 +11,7 @@ interface SocialNetworkCardProps {
   network: SocialNetwork
 }
 
-function SocialNetworkCardComponent(props: SocialNetworkCardProps) {
+function SocialNetworkCardComponent(props: Readonly<SocialNetworkCardProps>) {
   const { network } = props
   const { icon: Icon, link, fallbackLink } = SocialNetworkIconsMap[network]
   const name = network[0].toUpperCase() + network.slice(1)

--- a/src/ui/components/Spinner.tsx
+++ b/src/ui/components/Spinner.tsx
@@ -7,7 +7,7 @@ import { IconInterface } from 'ui/svg/icons/types'
 
 const USE_NATIVE_DRIVER = Platform.select({ default: false, ios: true, android: true })
 
-function NotMemoizedSpinner({ size, color, testID }: IconInterface) {
+function NotMemoizedSpinner({ size, color, testID }: Readonly<IconInterface>) {
   const animatedValue = useRef(new Animated.Value(0)).current
   const spin = animatedValue.interpolate({
     inputRange: [0, 1],

--- a/src/ui/components/inputs/DateInput/atoms/DateInputDisplay.tsx
+++ b/src/ui/components/inputs/DateInput/atoms/DateInputDisplay.tsx
@@ -13,7 +13,7 @@ interface Props {
   isError?: boolean
 }
 
-export function DateInputDisplay({ date, isError }: Props) {
+export function DateInputDisplay({ date, isError }: Readonly<Props>) {
   const dateInputID = uuidv4()
   const label = 'Date de naissance'
   return (

--- a/src/ui/components/inputs/DropDown/DropDown.web.tsx
+++ b/src/ui/components/inputs/DropDown/DropDown.web.tsx
@@ -30,7 +30,7 @@ export function DropDown({
   accessibilityLabel,
   isError = false,
   value,
-}: Props) {
+}: Readonly<Props>) {
   const [isEmpty, setIsEmpty] = useState(!value)
 
   const onChangeDate: React.ChangeEventHandler<HTMLSelectElement> = (event) => {

--- a/src/ui/components/inputs/Slider.tsx
+++ b/src/ui/components/inputs/Slider.tsx
@@ -30,7 +30,7 @@ const DEFAULT_VALUES = [DEFAULT_MIN, DEFAULT_MAX]
 const LEFT_CURSOR = 'LEFT_CURSOR'
 const RIGHT_CURSOR = 'RIGHT_CURSOR'
 
-export function Slider(props: Props) {
+export function Slider(props: Readonly<Props>) {
   const sliderContainerRef = useRef<View | null>(null)
 
   const min = props.min || DEFAULT_MIN

--- a/src/ui/components/placeholders/Placeholders.tsx
+++ b/src/ui/components/placeholders/Placeholders.tsx
@@ -14,12 +14,14 @@ const imageHeight = getSpacing(24) // ratio 2/3
 const bookingImageWidth = getSpacing(18)
 const bookingImageHeight = getSpacing(28)
 
-function BasePlaceholder(props: {
-  height: number
-  width: number
-  radius?: number
-  fullWidth?: boolean
-}) {
+function BasePlaceholder(
+  props: Readonly<{
+    height: number
+    width: number
+    radius?: number
+    fullWidth?: boolean
+  }>
+) {
   return (
     <SkeletonTile
       borderRadius={props.radius ?? borderRadius}
@@ -30,7 +32,7 @@ function BasePlaceholder(props: {
   )
 }
 
-function TextPlaceholder({ width, height }: { width: number; height?: number }) {
+function TextPlaceholder({ width, height }: Readonly<{ width: number; height?: number }>) {
   return <SkeletonTile borderRadius={2} height={height ?? getSpacing(3)} width={width} />
 }
 

--- a/src/ui/components/placeholders/SkeletonTile.tsx
+++ b/src/ui/components/placeholders/SkeletonTile.tsx
@@ -41,7 +41,12 @@ const useWaveAnimation = (width: number) => {
 const start = { x: 0, y: 0 }
 const end = { x: 1, y: 0 }
 
-function UnmemoizedSkeletonTile({ width, height, borderRadius, fullWidth }: DimensionProps) {
+function UnmemoizedSkeletonTile({
+  width,
+  height,
+  borderRadius,
+  fullWidth,
+}: Readonly<DimensionProps>) {
   const translateX = useWaveAnimation(width)
   const { uniqueColors } = useTheme()
   const colors = [

--- a/src/ui/components/radioButtons/RadioButton.tsx
+++ b/src/ui/components/radioButtons/RadioButton.tsx
@@ -29,7 +29,7 @@ type RadioButtonIconProps = {
   isLoading?: boolean
 }
 
-function RadioButtonIcon({ isSelected, isLoading }: RadioButtonIconProps) {
+function RadioButtonIcon({ isSelected, isLoading }: Readonly<RadioButtonIconProps>) {
   const { isMobileViewport, icons } = useTheme()
   const ValidateOff = isMobileViewport ? ValidateOffIcon : Fragment
 
@@ -44,7 +44,7 @@ function RadioButtonIcon({ isSelected, isLoading }: RadioButtonIconProps) {
   return <ValidateOff />
 }
 
-export function RadioButton(props: RadioButtonProps) {
+export function RadioButton(props: Readonly<RadioButtonProps>) {
   const containerRef = useRef(null)
   const { isMobileViewport } = useTheme()
   const { onFocus, onBlur, isFocus } = useHandleFocus()

--- a/src/web/useServiceWorker.tsx
+++ b/src/web/useServiceWorker.tsx
@@ -139,9 +139,9 @@ export function ServiceWorkerProvider({
   fileName,
   registrationOptions,
 }: {
-  children: React.ReactNode
-  fileName: string
-  registrationOptions?: RegistrationOptions
+  children: Readonly<React.ReactNode>
+  fileName: Readonly<string>
+  registrationOptions?: Readonly<RegistrationOptions>
 }) {
   const serviceWorker = useProvideServiceWorker(fileName, registrationOptions)
   return (


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25272

"React props should be read-only because it helps to enforce the principle of immutability in React functional components. By making props read-only, you ensure that the data passed from a parent component to a child component cannot be modified directly by the child component. This helps maintain a clear data flow and prevents unexpected side effects.

If props were mutable, child components could modify the props directly, leading to unpredictable behavior and making it harder to track down bugs. By enforcing read-only props, React promotes a more predictable and maintainable codebase. Additionally, read-only props enable performance optimizations in React’s rendering process by avoiding unnecessary re-renders of components.

Overall, enforcing read-only props in React helps improve code reliability, maintainability, and performance."

