### PR TITLE
(BSR) fix(CI): add default value for third argument in sentry sourcemap upload script

### DIFF
--- a/scripts/upload_sourcemaps_to_sentry.sh
+++ b/scripts/upload_sourcemaps_to_sentry.sh
@@ -62,7 +62,7 @@ create_sourcemaps() {
 upload_sourcemaps() {
   APP_OS="$1"
   APP_ENV="$2"
-  CODE_PUSH_LABEL="$3"
+  CODE_PUSH_LABEL="${3:-}"
   VERSION=$(jq -r .version package.json)
   BUILD=$(jq -r .build package.json)
 


### PR DESCRIPTION
This config option was added recently to the script and when we call the script without a third argument it is now failing:
`set -o nounset`

I added a default value for the third argument (empty string) to fix it.
