### PR TITLE
(PC-25774) fix(Auth): refresh access token when it is unknow but refresh token is still valid

### DIFF
--- a/src/api/apiHelpers.native.test.ts
+++ b/src/api/apiHelpers.native.test.ts
@@ -258,18 +258,6 @@ describe('[api] helpers', () => {
       expect(mockFetch).not.toHaveBeenCalled()
     })
 
-    it('log exception to sentry when there is no refresh token', async () => {
-      mockGetTokenStatus.mockReturnValueOnce('expired')
-      mockGetRefreshToken.mockResolvedValueOnce(null)
-
-      await safeFetch(apiUrl, optionsWithAccessToken, api)
-
-      expect(eventMonitoring.captureException).toHaveBeenCalledWith(
-        new Error('safeFetch Erreur lors de la récupération du refresh token'),
-        { extra: { url: '/native/v1/me' } }
-      )
-    })
-
     it('needs authentication response when cannot get refresh token', async () => {
       mockGetTokenStatus.mockReturnValueOnce('expired')
       mockGetRefreshToken.mockRejectedValueOnce(new Error())

--- a/src/api/apiHelpers.native.test.ts
+++ b/src/api/apiHelpers.native.test.ts
@@ -1,5 +1,4 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import { captureException } from '@sentry/react-native'
 import mockdate from 'mockdate'
 import { Platform } from 'react-native'
 import CodePush from 'react-native-code-push'
@@ -265,7 +264,7 @@ describe('[api] helpers', () => {
 
       await safeFetch(apiUrl, optionsWithAccessToken, api)
 
-      expect(captureException).toHaveBeenCalledWith(
+      expect(eventMonitoring.captureException).toHaveBeenCalledWith(
         new Error('safeFetch Erreur lors de la récupération du refresh token'),
         { extra: { url: '/native/v1/me' } }
       )
@@ -286,9 +285,12 @@ describe('[api] helpers', () => {
 
       await safeFetch(apiUrl, optionsWithAccessToken, api)
 
-      expect(captureException).toHaveBeenCalledWith(new Error('safeFetch Error: Error'), {
-        extra: { url: '/native/v1/me' },
-      })
+      expect(eventMonitoring.captureException).toHaveBeenCalledWith(
+        new Error('safeFetch Error: Error'),
+        {
+          extra: { url: '/native/v1/me' },
+        }
+      )
     })
 
     it('retries to regenerate the access token when the access token is expired and the first try to regenerate fails', async () => {

--- a/src/api/apiHelpers.native.test.ts
+++ b/src/api/apiHelpers.native.test.ts
@@ -231,13 +231,21 @@ describe('[api] helpers', () => {
       expect(mockFetch).toHaveBeenCalledTimes(refreshAccessTokenCalls + apiURLCalls)
     })
 
-    it('needs authentication response when there is no access token', async () => {
+    it('should refresh access token when it is unknown and refresh token is valid', async () => {
       mockGetTokenStatus.mockReturnValueOnce('unknown')
+      const expectedResponse = await respondWith('some api response')
+      mockFetch
+        .mockResolvedValueOnce(respondWith({ accessToken }))
+        .mockResolvedValueOnce(expectedResponse)
 
       const response = await safeFetch(apiUrl, {}, api)
 
-      expect(response).toEqual(createNeedsAuthenticationResponse(apiUrl))
-      expect(mockFetch).not.toHaveBeenCalled()
+      const refreshAccessTokenCalls = 1
+      const apiURLCalls = 1
+
+      expect(mockFetch).toHaveBeenCalledTimes(refreshAccessTokenCalls + apiURLCalls)
+
+      expect(response).toEqual(expectedResponse)
     })
 
     it('needs authentication response when there is no refresh token', async () => {

--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -86,17 +86,17 @@ export const safeFetch = async (
     try {
       const { result: newAccessToken, error } = await refreshAccessToken(api)
 
-      if (error === REFRESH_TOKEN_IS_EXPIRED_ERROR) {
-        return RefreshTokenExpiredResponse
+      switch (error) {
+        case REFRESH_TOKEN_IS_EXPIRED_ERROR:
+          return RefreshTokenExpiredResponse
+        case FAILED_TO_GET_REFRESH_TOKEN_ERROR:
+          return createNeedsAuthenticationResponse(url)
+        case UNKNOWN_ERROR_WHILE_REFRESHING_ACCESS_TOKEN:
+          eventMonitoring.captureException(new Error(`safeFetch ${error}`, { cause: error }), {
+            extra: { url },
+          })
+          return createNeedsAuthenticationResponse(url)
       }
-
-      if (error) {
-        eventMonitoring.captureException(new Error(`safeFetch ${error}`, { cause: error }), {
-          extra: { url },
-        })
-        return createNeedsAuthenticationResponse(url)
-      }
-
       runtimeOptions = {
         ...runtimeOptions,
         headers: {

--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -81,14 +81,11 @@ export const safeFetch = async (
   const token = authorizationHeader.replace('Bearer ', '')
   const accessTokenStatus = getTokenStatus(token)
 
-  if (accessTokenStatus === 'unknown') {
-    return createNeedsAuthenticationResponse(url)
-  }
-
-  // If the token is expired, we refresh it before calling the backend
-  if (accessTokenStatus === 'expired') {
+  // If the token is expired or unknown, we refresh it before calling the backend
+  if (accessTokenStatus === 'expired' || accessTokenStatus === 'unknown') {
     try {
       const { result: newAccessToken, error } = await refreshAccessToken(api)
+
       if (error === REFRESH_TOKEN_IS_EXPIRED_ERROR) {
         return RefreshTokenExpiredResponse
       }

--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -92,10 +92,7 @@ export const safeFetch = async (
         case FAILED_TO_GET_REFRESH_TOKEN_ERROR:
           return createNeedsAuthenticationResponse(url)
         case UNKNOWN_ERROR_WHILE_REFRESHING_ACCESS_TOKEN:
-          eventMonitoring.captureException(new Error(`safeFetch ${error}`, { cause: error }), {
-            extra: { url },
-          })
-          return createNeedsAuthenticationResponse(url)
+          throw new Error(UNKNOWN_ERROR_WHILE_REFRESHING_ACCESS_TOKEN)
       }
       runtimeOptions = {
         ...runtimeOptions,

--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -91,7 +91,9 @@ export const safeFetch = async (
       }
 
       if (error) {
-        eventMonitoring.captureException(new Error(`safeFetch ${error}`))
+        eventMonitoring.captureException(new Error(`safeFetch ${error}`), {
+          extra: { url },
+        })
         return createNeedsAuthenticationResponse(url)
       }
 
@@ -106,7 +108,9 @@ export const safeFetch = async (
       // Here we are supposed to be logged-in (calling an authenticated endpoint)
       // But the access token is expired and cannot be refreshed.
       // In this case, we cleared the access token and we need to login again
-      eventMonitoring.captureException(new Error(`safeFetch ${error}`))
+      eventMonitoring.captureException(new Error(`safeFetch ${error}`), {
+        extra: { url },
+      })
       return createNeedsAuthenticationResponse(url)
     }
   }
@@ -241,14 +245,6 @@ export async function handleGeneratedApiResponse(response: Response): Promise<an
     response.status === NeedsAuthenticationStatus.status &&
     response.statusText === NeedsAuthenticationStatus.statusText
   ) {
-    eventMonitoring.captureMessage(NeedsAuthenticationStatus.statusText, {
-      extra: {
-        url: await response.text(),
-        status: response.status,
-        statusText: response.statusText,
-      },
-    })
-
     navigateToLogin()
     return {}
   }

--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -91,7 +91,7 @@ export const safeFetch = async (
       }
 
       if (error) {
-        eventMonitoring.captureException(new Error(`safeFetch ${error}`), {
+        eventMonitoring.captureException(new Error(`safeFetch ${error}`, { cause: error }), {
           extra: { url },
         })
         return createNeedsAuthenticationResponse(url)
@@ -108,7 +108,7 @@ export const safeFetch = async (
       // Here we are supposed to be logged-in (calling an authenticated endpoint)
       // But the access token is expired and cannot be refreshed.
       // In this case, we cleared the access token and we need to login again
-      eventMonitoring.captureException(new Error(`safeFetch ${error}`), {
+      eventMonitoring.captureException(new Error(`safeFetch ${error}`, { cause: error }), {
         extra: { url },
       })
       return createNeedsAuthenticationResponse(url)


### PR DESCRIPTION
This fixes untimely redirections on iOS.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25774

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_


| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              | https://github.com/pass-culture/pass-culture-app-native/assets/68000368/a3d29ffc-98e9-4412-868e-ba58fff558c0 | https://github.com/pass-culture/pass-culture-app-native/assets/68000368/428eaa1e-3a35-4ab3-9087-ba0d3319f417 |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
