### PR TITLE
(PC-24309) fix(ui): GenericInfoPageWhite with overflow auto on web platform

### DIFF
--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.web.test.tsx.web-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.web.test.tsx.web-snap
@@ -162,7 +162,7 @@ exports[`CulturalSurveyIntro page should render the page with correct layout 1`]
 <body>
     <div>
       <div
-        class="css-view-175oi2r r-alignSelf-1kihuf0 r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-maxWidth-1ik5qf4 r-overflow-1jwulwa r-paddingHorizontal-1guathk r-width-13qz1uu"
+        class="css-view-175oi2r r-alignSelf-1kihuf0 r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-maxWidth-1ik5qf4 r-overflow-1dqxon3 r-paddingHorizontal-1guathk r-width-13qz1uu"
       >
         <div
           class="css-view-175oi2r r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
@@ -460,7 +460,7 @@ exports[`CulturalSurveyIntro page should render the page with correct layout 1`]
 
 <div>
     <div
-      class="css-view-175oi2r r-alignSelf-1kihuf0 r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-maxWidth-1ik5qf4 r-overflow-1jwulwa r-paddingHorizontal-1guathk r-width-13qz1uu"
+      class="css-view-175oi2r r-alignSelf-1kihuf0 r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-maxWidth-1ik5qf4 r-overflow-1dqxon3 r-paddingHorizontal-1guathk r-width-13qz1uu"
     >
       <div
         class="css-view-175oi2r r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2"

--- a/src/ui/pages/GenericInfoPageWhite.tsx
+++ b/src/ui/pages/GenericInfoPageWhite.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
+import { Platform } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import { RootNavigateParams } from 'features/navigation/RootNavigator/types'
@@ -149,7 +150,7 @@ const ContentContainer = styled.View(({ theme }) => ({
   flex: 1,
   paddingHorizontal: getSpacing(6),
   maxWidth: theme.contentPage.maxWidth,
-  overflow: 'scroll',
+  overflow: Platform.OS === 'web' ? 'auto' : 'scroll',
   width: '100%',
 }))
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-24309

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |<img width="865" alt="Capture d’écran 2023-11-23 à 14 48 50" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/1c342e25-7bcf-4364-8545-6d10b9dd1351"> <img width="1727" alt="Capture d’écran 2023-11-23 à 14 48 13" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/55c54899-dc5c-4c81-a454-9b3e0256fd11">|<img width="1724" alt="Capture d’écran 2023-11-23 à 14 47 16" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/ef75b822-2de8-4e5c-99fe-0cd1c8c80865"> <img width="1720" alt="Capture d’écran 2023-11-23 à 14 48 25" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/266095a1-f963-496a-a3f5-cfa9ce3b76c7">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
