### PR TITLE
(BSR) fix(extensions): fix deprecated ruby extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,6 @@
     "christian-kohler.npm-intellisense",
     "christian-kohler.path-intellisense",
     "dsznajder.es7-react-js-snippets",
-    "esbenp.prettier-vscode",
     "timonwong.shellcheck",
     "streetsidesoftware.code-spell-checker",
     "streetsidesoftware.code-spell-checker-french",
@@ -16,8 +15,7 @@
     "yoavbls.pretty-ts-errors",
     "p42ai.refactor",
     "mikestead.dotenv",
-    "rebornix.ruby",
-    "wingrunr21.vscode-ruby",
     "firsttris.vscode-jest-runner",
+    "shopify.ruby-lsp"
   ]
 }


### PR DESCRIPTION
<img width="1440" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/70148476/2aa49709-6f59-4258-a55a-decd13780792">
<img width="1440" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/70148476/bb57302f-91a5-4a68-8dbb-a24fa9f7534e">
<img width="1440" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/70148476/aa108c5b-b329-47da-97ad-d8366d4e81ab">
