### PR TITLE
(PC-25272) chore(sonar): Ignore 'Mark the props of the component as read-…

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,11 +12,15 @@ sonar.test.inclusions=src/**/*.test.*
 sonar.coverage.exclusions=src/**/*.web.*
 
 # Patterns to ignore issues on certain components and for certain coding rules
-sonar.issue.ignore.multicriteria=typescriptS6606,typescriptS6544
+sonar.issue.ignore.multicriteria=typescriptS6606,typescriptS6759,typescriptS6544
 
 # Disable this issue "Prefer using nullish coalescing operator (`??`) instead of a logical or (`||`)" because it is not equivalent (source of bugs)
 sonar.issue.ignore.multicriteria.typescriptS6606.ruleKey=typescript:S6606
 sonar.issue.ignore.multicriteria.typescriptS6606.resourceKey=**/*
+
+# Disable this issue "Mark the props of the component as read-only" because adding Readonly doesn't make the error detectable by typescript
+sonar.issue.ignore.multicriteria.typescriptS6759.ruleKey=typescript:S6759
+sonar.issue.ignore.multicriteria.typescriptS6759.resourceKey=**/*
 
 # Disable this bug "Promise returned in function argument where a void return was expected" because we'd rather trust typescript than Sonar
 sonar.issue.ignore.multicriteria.typescriptS6544.ruleKey=typescript:S6544


### PR DESCRIPTION
…only' issue

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25272

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]