### PR TITLE
(PC-26250) feat(Venue): add tags in new venue body

### DIFF
--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -5318,6 +5318,20 @@ exports[`<Venue /> with new venue body should match snapshot 1`] = `
             ]
           }
         >
+          <View
+            maxHeight={56}
+            style={
+              [
+                {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "maxHeight": 56,
+                  "overflow": "hidden",
+                },
+              ]
+            }
+            testID="tagsContainer"
+          />
           <Text
             accessibilityLabel="Nom du lieu : Le Petit Rintintin 1"
             adjustsFontSizeToFit={true}

--- a/__snapshots__/features/venue/pages/Venue/Venue.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.web.test.tsx.web-snap
@@ -302,6 +302,10 @@ exports[`<Venue /> Accessibility should render correctly in web for new version 
           <div
             class="css-view-175oi2r r-flexShrink-1wbh5a2 r-marginHorizontal-1hy1u7s"
           >
+            <div
+              class="css-view-175oi2r r-flexDirection-18u37iz r-flexWrap-1w6e6rj r-maxHeight-ormnx7 r-overflow-1udh08x"
+              data-testid="tagsContainer"
+            />
             <h1
               aria-label="Nom du lieu : Le Petit Rintintin 1"
               aria-level="1"

--- a/src/features/venue/components/VenueBodyNew/VenueBodyNew.tsx
+++ b/src/features/venue/components/VenueBodyNew/VenueBodyNew.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import styled, { useTheme } from 'styled-components/native'
 
-import { VenueResponse } from 'api/gen'
+import { VenueResponse, VenueTypeCodeKey } from 'api/gen'
 import { GTLPlaylistResponse } from 'features/gtlPlaylist/api/gtlPlaylistApi'
 import { PracticalInformation } from 'features/venue/components/PracticalInformation'
 import { TabLayout } from 'features/venue/components/TabLayout/TabLayout'
@@ -10,13 +10,16 @@ import { VenueMessagingApps } from 'features/venue/components/VenueMessagingApps
 import { VenueOffersNew } from 'features/venue/components/VenueOffers/VenueOffersNew'
 import { formatFullAddress } from 'libs/address/useFormatFullAddress'
 import { analytics } from 'libs/analytics'
+import { useDistance } from 'libs/geolocation/hooks/useDistance'
 import { SeeItineraryButton } from 'libs/itinerary/components/SeeItineraryButton'
 import { getGoogleMapsItineraryUrl } from 'libs/itinerary/openGoogleMapsItinerary'
+import { MAP_VENUE_TYPE_TO_LABEL } from 'libs/parsers'
 import { CopyToClipboardButton } from 'shared/CopyToClipboardButton/CopyToClipboardButton'
 import { Offer } from 'shared/offer/types'
 import { useGetHeaderHeight } from 'ui/components/headers/PageHeaderWithoutPlaceholder'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
 import { Separator } from 'ui/components/Separator'
+import { InformationTags } from 'ui/InformationTags/InformationTags'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
@@ -41,6 +44,16 @@ export const VenueBodyNew: FunctionComponent<Props> = ({
   const venueFullAddress = formatFullAddress(address, postalCode, city)
   const venueName = publicName || name
 
+  const distanceToVenue = useDistance({ lat: venue.latitude, lng: venue.longitude })
+  const venueTypeLabel =
+    venue.venueTypeCode && venue.venueTypeCode !== VenueTypeCodeKey.ADMINISTRATIVE
+      ? MAP_VENUE_TYPE_TO_LABEL[venue.venueTypeCode]
+      : undefined
+
+  const venueTags = []
+  venueTypeLabel && venueTags.push(venueTypeLabel)
+  distanceToVenue && venueTags.push(`À ${distanceToVenue}`)
+
   const FirstSectionContainer = isLargeScreen ? MarginContainer : SectionWithDivider
 
   return (
@@ -50,6 +63,7 @@ export const VenueBodyNew: FunctionComponent<Props> = ({
         <VenueBanner bannerUrl={bannerUrl} />
         <Spacer.Column numberOfSpaces={6} />
         <MarginContainer>
+          <InformationTags tags={venueTags} />
           <VenueTitle
             accessibilityLabel={`Nom du lieu\u00a0: ${venueName}`}
             adjustsFontSizeToFit

--- a/src/ui/InformationTags/InformationTags.native.test.tsx
+++ b/src/ui/InformationTags/InformationTags.native.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 
-import { OfferTags } from 'features/offerv2/components/OfferTags/OfferTags'
 import { render, screen } from 'tests/utils'
+import { InformationTags } from 'ui/InformationTags/InformationTags'
 
 const tags = ['Tag1', 'Tag2', 'Tag3']
 
 describe('OfferTags component', () => {
   it('should display tags correctly', () => {
-    render(<OfferTags tags={tags} />)
+    render(<InformationTags tags={tags} />)
 
     expect(screen.getByText('Tag1')).toBeOnTheScreen()
     expect(screen.getByText('Tag2')).toBeOnTheScreen()
@@ -16,7 +16,7 @@ describe('OfferTags component', () => {
 
   it('should display tags within the specified number of lines', () => {
     const tagsLines = 2
-    render(<OfferTags tags={tags} tagsLines={tagsLines} />)
+    render(<InformationTags tags={tags} tagsLines={tagsLines} />)
 
     expect(screen.getByTestId('tagsContainer')).toHaveStyle({
       maxHeight: 56,

--- a/src/ui/InformationTags/InformationTags.stories.tsx
+++ b/src/ui/InformationTags/InformationTags.stories.tsx
@@ -2,16 +2,16 @@ import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
 
 import { OfferExtraData } from 'api/gen'
-import { OfferTags } from 'features/offerv2/components/OfferTags/OfferTags'
 import { getOfferTags } from 'features/offerv2/helpers/getOfferTags/getOfferTags'
+import { InformationTags } from 'ui/InformationTags/InformationTags'
 
-const meta: ComponentMeta<typeof OfferTags> = {
-  title: 'features/offer/OfferTags',
-  component: OfferTags,
+const meta: ComponentMeta<typeof InformationTags> = {
+  title: 'ui/InformationTags',
+  component: InformationTags,
 }
 export default meta
 
-const Template: ComponentStory<typeof OfferTags> = (props) => <OfferTags {...props} />
+const Template: ComponentStory<typeof InformationTags> = (props) => <InformationTags {...props} />
 
 const tagsList = [
   'vinyle',

--- a/src/ui/InformationTags/InformationTags.tsx
+++ b/src/ui/InformationTags/InformationTags.tsx
@@ -13,7 +13,7 @@ const MARGIN_BOTTOM_TAGS = getSpacing(2)
 
 // This component is used to display tags on a number of lines defined as a parameter.
 // If the number of tags to display exceeds this limit, it will not be visible
-export function OfferTags({ tags, tagsLines = 2 }: Readonly<Props>) {
+export function InformationTags({ tags, tagsLines = 2 }: Readonly<Props>) {
   const maxContainerHeight = TAG_HEIGHT * tagsLines + MARGIN_BOTTOM_TAGS * (tagsLines - 1)
 
   return (


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-26250

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="517" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/7964574c-5139-40aa-932b-af06dcfa5591">|<img width="315" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/a3627b15-c624-43cd-98fa-13c457bc3a08">|
| Android          |<img width="517" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/fc934228-30a2-45a8-9acd-16d70f609f75">|<img width="406" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/93eaf398-e16b-4584-a631-6d9ea1d55ff9">|
| Phone - Chrome   |<img width="517" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/22f5088c-8fb1-4707-93f0-6b6a6ef32b21">|<img width="360" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/d111ea9d-7f6e-4a3c-844f-78823e332284">|
| Desktop - Chrome |<img width="626" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/65a22a9c-0a33-4bc5-a72b-b1a873824d13">|<img width="1026" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/13255235-3db2-492c-ac95-3584a1569910">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
