### PR TITLE
(PC-26333) fix(ReCaptcha): Fix wording and logging to sentry on network failure when doing ReCaptcha

### DIFF
--- a/__snapshots__/libs/recaptcha/ReCaptcha.native.test.tsx.native-snap
+++ b/__snapshots__/libs/recaptcha/ReCaptcha.native.test.tsx.native-snap
@@ -78,7 +78,11 @@ exports[`<ReCaptcha /> should render correctly 1`] = `
                     } 
                     if (numberOfRetryRender > 15) {
                         clearInterval(readyInterval);
-                        onError("ReCaptchaNumberOfRenderRetriesExceeded");
+                        if (window.navigator.onLine) {
+                            onError("ReCaptchaNumberOfRenderRetriesExceeded");
+                        } else {
+                            onError("ReCaptchaNetworkError");
+                        }
                     }
                 }
 

--- a/src/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx
+++ b/src/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx
@@ -143,6 +143,22 @@ describe('<ForgottenPassword />', () => {
     expect(captureMonitoringError).not.toHaveBeenCalled()
   })
 
+  it('should notifies user on reCAPTCHA network error', async () => {
+    renderForgottenPassword()
+
+    const emailInput = screen.getByPlaceholderText('tonadresse@email.com')
+    fireEvent.changeText(emailInput, 'john.doe@gmail.com')
+    fireEvent.press(screen.getByText('Valider'))
+    const recaptchaWebview = screen.getByTestId('recaptcha-webview')
+    simulateWebviewMessage(recaptchaWebview, NetworkErrorFixture)
+
+    expect(
+      screen.getByText(
+        'Un problème est survenu pendant la réinitialisation, vérifie ta connexion internet et réessaie plus tard.'
+      )
+    ).toBeOnTheScreen()
+  })
+
   it('should NOT redirect to ResetPasswordEmailSent when reCAPTCHA challenge has failed', async () => {
     renderForgottenPassword()
 

--- a/src/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
+++ b/src/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
@@ -189,8 +189,12 @@ const useForgottenPasswordForm = (settings: UseQueryResult<SettingsResponse, unk
       },
       onReCaptchaError(errorCode: ReCaptchaError, error: string | undefined) {
         setValue('isDoingReCaptchaChallenge', false)
-        setCustomError('Un problème est survenu pendant la réinitialisation, réessaie plus tard.')
-        if (errorCode !== 'ReCaptchaNetworkError') {
+        if (errorCode === 'ReCaptchaNetworkError') {
+          setCustomError(
+            'Un problème est survenu pendant la réinitialisation, vérifie ta connexion internet et réessaie plus tard.'
+          )
+        } else {
+          setCustomError('Un problème est survenu pendant la réinitialisation, réessaie plus tard.')
           captureMonitoringError(`${errorCode} ${error}`, 'ForgottenPasswordOnRecaptchaError')
         }
       },

--- a/src/features/auth/pages/login/Login.native.test.tsx
+++ b/src/features/auth/pages/login/Login.native.test.tsx
@@ -602,6 +602,22 @@ describe('<Login/>', () => {
       expect(captureMonitoringError).not.toHaveBeenCalled()
     })
 
+    it('should precise when it is a network failure on reCAPTCHA failure', async () => {
+      renderLogin()
+
+      await fillInputs()
+      await act(() => fireEvent.press(screen.getByText('Se connecter')))
+
+      const recaptchaWebview = screen.getByTestId('recaptcha-webview')
+      await simulateWebviewMessage(recaptchaWebview, NetworkErrorFixture)
+
+      expect(
+        screen.queryByText(
+          'Un problème est survenu, vérifie ta connexion internet avant de rééssayer.'
+        )
+      ).toBeOnTheScreen()
+    })
+
     it('should display error message when reCAPTCHA token has expired', async () => {
       renderLogin()
 

--- a/src/features/auth/pages/login/Login.tsx
+++ b/src/features/auth/pages/login/Login.tsx
@@ -179,8 +179,12 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
   const onReCaptchaError = useCallback(
     (errorCode: ReCaptchaError, error?: string | undefined) => {
       setIsDoingReCaptchaChallenge(false)
-      setErrorMessage('Un problème est survenu, réessaie plus tard.')
-      if (errorCode !== ReCaptchaInternalError.NetworkError) {
+      if (errorCode === ReCaptchaInternalError.NetworkError) {
+        setErrorMessage(
+          'Un problème est survenu, vérifie ta connexion internet avant de rééssayer.'
+        )
+      } else {
+        setErrorMessage('Un problème est survenu, réessaie plus tard.')
         captureMonitoringError(`${errorCode} ${error}`, 'LoginOnRecaptchaError')
       }
     },

--- a/src/libs/recaptcha/webviewHTML.ts
+++ b/src/libs/recaptcha/webviewHTML.ts
@@ -39,7 +39,11 @@ export const reCaptchaWebviewHTML = `
                     } 
                     if (numberOfRetryRender > 15) {
                         clearInterval(readyInterval);
-                        onError("${ReCaptchaInternalError.NumberOfRenderRetriesExceeded}");
+                        if (window.navigator.onLine) {
+                            onError("${ReCaptchaInternalError.NumberOfRenderRetriesExceeded}");
+                        } else {
+                            onError("${ReCaptchaInternalError.NetworkError}");
+                        }
                     }
                 }
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-26333

Quelques précisions : 
- Le composant AcceptCgu gère déjà le cas hors ligne autrement dans l'affichage donc pas besoin de changer la notification à l'utilisateur
- Le test sur Android n'était pas vraiment concluant, mais je me demande si ce n'est pas du au test sur émulateur... Il faudrait recetter sur vrai device mais en tout cas le nombre d'erreurs devrait bien descendre

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |<img width="320" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/893f50aa-7a85-4864-9898-dc6b9fca07ec">|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
