### PR TITLE
(PC-26567) ci(native): fix deploy testing on MES

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -92,7 +92,7 @@ jobs:
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
   soft-deploy-testing:
     needs: yarn-tester
-    if: github.ref == 'refs/heads/master'
+    if: ${{ github.ref == 'refs/heads/master' && !startsWith(github.event.head_commit.message, 'v') }}
     uses: ./.github/workflows/dev_on_workflow_environment_soft_deploy.yml
     with:
       ENV: testing
@@ -119,7 +119,7 @@ jobs:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
   hard-deploy-android-testing:
     needs: yarn-tester
-    if: startsWith(github.ref, 'refs/tags/testing')
+    if: ${{ startsWith(github.ref, 'refs/tags/testing') || startsWith(github.event.head_commit.message, 'v') }}
     uses: ./.github/workflows/dev_on_workflow_environment_android_deploy.yml
     with:
       ENV: testing
@@ -128,7 +128,7 @@ jobs:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
   hard-deploy-ios-testing:
     needs: yarn-tester
-    if: startsWith(github.ref, 'refs/tags/testing')
+    if: ${{ startsWith(github.ref, 'refs/tags/testing') || startsWith(github.event.head_commit.message, 'v') }}
     uses: ./.github/workflows/dev_on_workflow_environment_ios_deploy.yml
     with:
       ENV: testing
@@ -172,7 +172,9 @@ jobs:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
   deploy-web-testing:
-    needs: soft-deploy-testing
+    needs: [soft-deploy-testing, hard-deploy-android-testing, hard-deploy-ios-testing]
+    # see https://stackoverflow.com/a/66358138 for details
+    if: ${{ always() && contains(needs.*.result, 'success') && !contains(needs.*.result, 'failure') }}
     uses: ./.github/workflows/dev_on_workflow_web_deploy.yml
     with:
       ENV: testing


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-26567

**Problème :**

Ce [workflow](https://github.com/pass-culture/pass-culture-app-native/actions/runs/7275320663) n'a pas créé la version testing iOS/Android appcenter alors qu’il aurait du. 

Il a été trigger via Jira puis [ce workflow](https://github.com/pass-culture/pass-culture-app-native/actions/runs/7275319749)

**Solution :** 

- L95 : on ne veut pas de code push sur la première version de testing après une MES, pour annuler le code push, on vérifie que le commit message ne commence pas par un `v`
- L122 et L131 : on veut une nouvelle release hard iOS et Android si le commit message sur master commence par `v` (en plus de quand on trigger un tag manuelle qui commence par testing)
- L175 à 177 : on a 3 needs, mais on run toujours le job, les explications de cette technique sont disponible [ici](https://stackoverflow.com/a/66358138)  ← noté que cela est possible si et seulement si `deploy-web-testing` n'est pas needed dans un autre job.


## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
