### PR TITLE
(BSR) ci(web): deploy web testing only on master

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -92,7 +92,7 @@ jobs:
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
   soft-deploy-testing:
     needs: yarn-tester
-    if: ${{ github.ref == 'refs/heads/master' && !startsWith(github.event.head_commit.message, 'v') }}
+    if: github.ref == 'refs/heads/master'
     uses: ./.github/workflows/dev_on_workflow_environment_soft_deploy.yml
     with:
       ENV: testing
@@ -174,7 +174,7 @@ jobs:
   deploy-web-testing:
     needs: [soft-deploy-testing, hard-deploy-android-testing, hard-deploy-ios-testing]
     # see https://stackoverflow.com/a/66358138 for details
-    if: ${{ always() && contains(needs.*.result, 'success') && !contains(needs.*.result, 'failure') }}
+    if: ${{ always() && contains(needs.*.result, 'success') && !contains(needs.*.result, 'failure') && github.ref == 'refs/heads/master'}}
     uses: ./.github/workflows/dev_on_workflow_web_deploy.yml
     with:
       ENV: testing


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
