### PR TITLE
(PC-25011) feat(maestro): Disable recaptcha before tests

### DIFF
--- a/scripts/enableNativeAppRecaptcha.ts
+++ b/scripts/enableNativeAppRecaptcha.ts
@@ -1,0 +1,55 @@
+/// <reference types="node" />
+
+type Feature = { name: string; isActive: boolean }
+type Features = Array<Feature>
+
+const CYAN = '\x1b[36m'
+const RED = '\x1b[31m'
+const RESET_COLOR = '\x1b[0m'
+const API_BASE_URL = `https://backend.${process.argv[2]}.passculture.team`
+
+async function patchFeatures(features: Features) {
+  try {
+    const response = await fetch(`${API_BASE_URL}/testing/features`, {
+      method: 'PATCH',
+      mode: 'cors',
+      headers: new Headers({
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      }),
+      body: JSON.stringify({
+        features,
+      }),
+    })
+
+    if (!response.ok) {
+      throw new Error(response.statusText)
+    }
+
+    // eslint-disable-next-line no-console
+    console.info(
+      `${CYAN}INFO`,
+      `${RESET_COLOR}${features
+        .map(({ name, isActive }) => `${name} set to ${isActive}`)
+        .join('\n')}`
+    )
+  } catch (error) {
+    console.error(
+      `${RED}ERROR`,
+      `${RESET_COLOR}Failed to patch ${features.length} feature(s): ${error}`
+    )
+  }
+}
+
+const enableNativeAppRecaptcha = async (isActive: boolean) => {
+  return patchFeatures([
+    {
+      name: 'ENABLE_NATIVE_APP_RECAPTCHA',
+      isActive,
+    },
+  ])
+}
+
+enableNativeAppRecaptcha(process.argv[3] as unknown as boolean)
+
+export {}

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -49,4 +49,6 @@ fi
 
 password=$(parse_env_variable PASSWORD .maestro/.env.secret)
 
+ts-node -O '{"module": "commonjs"}' ./scripts/enableNativeRecaptcha.ts "$env" false
 maestro test -e APP_ID="$app_id" -e USERNAME="dev-tests-e2e@passculture.team" -e USERNAME_UNKNOWN="dev-tests-e2e-unknown@passculture.team" -e NEW_USERNAME="dev-tests-e2e-new@passculture.team" -e NUMBER_PHONE="0607080910" -e PASSWORD="$password" "$tests_path"
+ts-node -O '{"module": "commonjs"}' ./scripts/enableNativeRecaptcha.ts "$env" true


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25011

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
