### PR TITLE
(PC-26571) fix(cookies): Display full text in accordion

### DIFF
--- a/__snapshots__/features/cookies/components/CookiesSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/components/CookiesSettings.native.test.tsx.native-snap
@@ -401,8 +401,6 @@ exports[`<CookiesSettings/> should render correctly 1`] = `
             [
               {
                 "color": "#161617",
-                "flexBasis": 0,
-                "flexGrow": 0.9,
                 "flexShrink": 1,
                 "fontFamily": "Montserrat-Medium",
                 "fontSize": 18,
@@ -430,6 +428,7 @@ exports[`<CookiesSettings/> should render correctly 1`] = `
           collapsable={false}
           style={
             {
+              "marginLeft": 8,
               "transform": [
                 {
                   "rotateZ": "1.5707963267948966rad",
@@ -767,8 +766,6 @@ exports[`<CookiesSettings/> should render correctly 1`] = `
             [
               {
                 "color": "#161617",
-                "flexBasis": 0,
-                "flexGrow": 0.9,
                 "flexShrink": 1,
                 "fontFamily": "Montserrat-Medium",
                 "fontSize": 18,
@@ -796,6 +793,7 @@ exports[`<CookiesSettings/> should render correctly 1`] = `
           collapsable={false}
           style={
             {
+              "marginLeft": 8,
               "transform": [
                 {
                   "rotateZ": "1.5707963267948966rad",
@@ -1133,8 +1131,6 @@ exports[`<CookiesSettings/> should render correctly 1`] = `
             [
               {
                 "color": "#161617",
-                "flexBasis": 0,
-                "flexGrow": 0.9,
                 "flexShrink": 1,
                 "fontFamily": "Montserrat-Medium",
                 "fontSize": 18,
@@ -1162,6 +1158,7 @@ exports[`<CookiesSettings/> should render correctly 1`] = `
           collapsable={false}
           style={
             {
+              "marginLeft": 8,
               "transform": [
                 {
                   "rotateZ": "1.5707963267948966rad",
@@ -1502,8 +1499,6 @@ exports[`<CookiesSettings/> should render correctly 1`] = `
             [
               {
                 "color": "#161617",
-                "flexBasis": 0,
-                "flexGrow": 0.9,
                 "flexShrink": 1,
                 "fontFamily": "Montserrat-Medium",
                 "fontSize": 18,
@@ -1531,6 +1526,7 @@ exports[`<CookiesSettings/> should render correctly 1`] = `
           collapsable={false}
           style={
             {
+              "marginLeft": 8,
               "transform": [
                 {
                   "rotateZ": "1.5707963267948966rad",

--- a/__snapshots__/features/cookies/pages/CookiesDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesDetails.native.test.tsx.native-snap
@@ -85,8 +85,6 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
               [
                 {
                   "color": "#161617",
-                  "flexBasis": 0,
-                  "flexGrow": 0.9,
                   "flexShrink": 1,
                   "fontFamily": "Montserrat-Medium",
                   "fontSize": 18,
@@ -114,6 +112,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
             collapsable={false}
             style={
               {
+                "marginLeft": 8,
                 "transform": [
                   {
                     "rotateZ": "1.5707963267948966rad",
@@ -595,8 +594,6 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
             [
               {
                 "color": "#161617",
-                "flexBasis": 0,
-                "flexGrow": 0.9,
                 "flexShrink": 1,
                 "fontFamily": "Montserrat-Medium",
                 "fontSize": 18,
@@ -624,6 +621,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           collapsable={false}
           style={
             {
+              "marginLeft": 8,
               "transform": [
                 {
                   "rotateZ": "1.5707963267948966rad",
@@ -961,8 +959,6 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
             [
               {
                 "color": "#161617",
-                "flexBasis": 0,
-                "flexGrow": 0.9,
                 "flexShrink": 1,
                 "fontFamily": "Montserrat-Medium",
                 "fontSize": 18,
@@ -990,6 +986,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           collapsable={false}
           style={
             {
+              "marginLeft": 8,
               "transform": [
                 {
                   "rotateZ": "1.5707963267948966rad",
@@ -1327,8 +1324,6 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
             [
               {
                 "color": "#161617",
-                "flexBasis": 0,
-                "flexGrow": 0.9,
                 "flexShrink": 1,
                 "fontFamily": "Montserrat-Medium",
                 "fontSize": 18,
@@ -1356,6 +1351,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           collapsable={false}
           style={
             {
+              "marginLeft": 8,
               "transform": [
                 {
                   "rotateZ": "1.5707963267948966rad",
@@ -1696,8 +1692,6 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
             [
               {
                 "color": "#161617",
-                "flexBasis": 0,
-                "flexGrow": 0.9,
                 "flexShrink": 1,
                 "fontFamily": "Montserrat-Medium",
                 "fontSize": 18,
@@ -1725,6 +1719,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           collapsable={false}
           style={
             {
+              "marginLeft": 8,
               "transform": [
                 {
                   "rotateZ": "1.5707963267948966rad",

--- a/__snapshots__/features/internal/marketingAndCommunication/pages/DeeplinksGenerator.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/marketingAndCommunication/pages/DeeplinksGenerator.native.test.tsx.native-snap
@@ -329,8 +329,6 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "flexBasis": 0,
-                        "flexGrow": 0.9,
                         "flexShrink": 1,
                         "fontFamily": "Montserrat-Medium",
                         "fontSize": 18,
@@ -345,6 +343,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                   collapsable={false}
                   style={
                     {
+                      "marginLeft": 8,
                       "transform": [
                         {
                           "rotateZ": "4.71238898038469rad",
@@ -1628,8 +1627,6 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "flexBasis": 0,
-                        "flexGrow": 0.9,
                         "flexShrink": 1,
                         "fontFamily": "Montserrat-Medium",
                         "fontSize": 18,
@@ -1644,6 +1641,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                   collapsable={false}
                   style={
                     {
+                      "marginLeft": 8,
                       "transform": [
                         {
                           "rotateZ": "4.71238898038469rad",
@@ -1885,8 +1883,6 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "flexBasis": 0,
-                        "flexGrow": 0.9,
                         "flexShrink": 1,
                         "fontFamily": "Montserrat-Medium",
                         "fontSize": 18,
@@ -1901,6 +1897,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                   collapsable={false}
                   style={
                     {
+                      "marginLeft": 8,
                       "transform": [
                         {
                           "rotateZ": "4.71238898038469rad",
@@ -2615,8 +2612,6 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "flexBasis": 0,
-                        "flexGrow": 0.9,
                         "flexShrink": 1,
                         "fontFamily": "Montserrat-Medium",
                         "fontSize": 18,
@@ -2631,6 +2626,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                   collapsable={false}
                   style={
                     {
+                      "marginLeft": 8,
                       "transform": [
                         {
                           "rotateZ": "1.5707963267948966rad",

--- a/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
@@ -655,8 +655,6 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                 [
                   {
                     "color": "#161617",
-                    "flexBasis": 0,
-                    "flexGrow": 0.9,
                     "flexShrink": 1,
                     "fontFamily": "Montserrat-Medium",
                     "fontSize": 18,
@@ -684,6 +682,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
               collapsable={false}
               style={
                 {
+                  "marginLeft": 8,
                   "transform": [
                     {
                       "rotateZ": "1.5707963267948966rad",
@@ -1021,8 +1020,6 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                 [
                   {
                     "color": "#161617",
-                    "flexBasis": 0,
-                    "flexGrow": 0.9,
                     "flexShrink": 1,
                     "fontFamily": "Montserrat-Medium",
                     "fontSize": 18,
@@ -1050,6 +1047,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
               collapsable={false}
               style={
                 {
+                  "marginLeft": 8,
                   "transform": [
                     {
                       "rotateZ": "1.5707963267948966rad",
@@ -1387,8 +1385,6 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                 [
                   {
                     "color": "#161617",
-                    "flexBasis": 0,
-                    "flexGrow": 0.9,
                     "flexShrink": 1,
                     "fontFamily": "Montserrat-Medium",
                     "fontSize": 18,
@@ -1416,6 +1412,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
               collapsable={false}
               style={
                 {
+                  "marginLeft": 8,
                   "transform": [
                     {
                       "rotateZ": "1.5707963267948966rad",
@@ -1756,8 +1753,6 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                 [
                   {
                     "color": "#161617",
-                    "flexBasis": 0,
-                    "flexGrow": 0.9,
                     "flexShrink": 1,
                     "fontFamily": "Montserrat-Medium",
                     "fontSize": 18,
@@ -1785,6 +1780,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
               collapsable={false}
               style={
                 {
+                  "marginLeft": 8,
                   "transform": [
                     {
                       "rotateZ": "1.5707963267948966rad",

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -3581,8 +3581,6 @@ d’options
                   [
                     {
                       "color": "#161617",
-                      "flexBasis": 0,
-                      "flexGrow": 0.9,
                       "flexShrink": 1,
                       "fontFamily": "Montserrat-Medium",
                       "fontSize": 18,
@@ -3597,6 +3595,7 @@ d’options
                 collapsable={false}
                 style={
                   {
+                    "marginLeft": 8,
                     "transform": [
                       {
                         "rotateZ": "1.5707963267948966rad",
@@ -3788,8 +3787,6 @@ d’options
                   [
                     {
                       "color": "#161617",
-                      "flexBasis": 0,
-                      "flexGrow": 0.9,
                       "flexShrink": 1,
                       "fontFamily": "Montserrat-Medium",
                       "fontSize": 18,
@@ -3804,6 +3801,7 @@ d’options
                 collapsable={false}
                 style={
                   {
+                    "marginLeft": 8,
                     "transform": [
                       {
                         "rotateZ": "1.5707963267948966rad",
@@ -4439,8 +4437,6 @@ d’options
                   [
                     {
                       "color": "#161617",
-                      "flexBasis": 0,
-                      "flexGrow": 0.9,
                       "flexShrink": 1,
                       "fontFamily": "Montserrat-Medium",
                       "fontSize": 18,
@@ -4455,6 +4451,7 @@ d’options
                 collapsable={false}
                 style={
                   {
+                    "marginLeft": 8,
                     "transform": [
                       {
                         "rotateZ": "1.5707963267948966rad",

--- a/src/ui/components/AccordionItem.tsx
+++ b/src/ui/components/AccordionItem.tsx
@@ -108,9 +108,11 @@ export const AccordionItem = ({
           {...accessibilityProps}>
           <View nativeID={accordionLabelId} style={[styles.titleContainer, titleStyle]}>
             <Title>{title}</Title>
-            <Animated.View style={{ transform: [{ rotateZ: arrowAngle }] }} testID="accordionArrow">
+            <StyledArrowAnimatedView
+              style={{ transform: [{ rotateZ: arrowAngle }] }}
+              testID="accordionArrow">
               <ArrowNext />
-            </Animated.View>
+            </StyledArrowAnimatedView>
           </View>
         </StyledTouchableOpacity>
       </SwitchContainer>
@@ -161,8 +163,10 @@ const StyledTouchableOpacity = styled(TouchableOpacity).attrs({ activeOpacity: 1
   isFocus?: boolean
 }>(({ theme, isFocus }) => ({ flex: 1, ...touchableFocusOutline(theme, isFocus) }))
 
-const Title = styled(Typo.Title4).attrs(() => getHeadingAttrs(2))({
-  flex: '0.9',
+const Title = styled(Typo.Title4).attrs(() => getHeadingAttrs(2))({ flexShrink: 1 })
+
+const StyledArrowAnimatedView = styled(Animated.View)({
+  marginLeft: getSpacing(2),
 })
 
 const StyledAnimatedView = styled(Animated.View)({ overflow: 'hidden' })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-26571

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots
| Platform         | Before | After |
| :--------------- | :-----------: | :---: |
| Android          |     ![5d2ddc34-5928-40d7-bf0c-09c6a3a09302](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/385b6b4f-92f9-4f86-b0cf-92dc9dfff427)          | <img alt="Capture d’écran 2023-12-26 à 11 57 03" src="https://github.com/pass-culture/pass-culture-app-native/assets/46637324/4dd6aa9f-69b8-4566-9cd7-d23b20d6ae2f">      |
| iOS              |               |     ![Simulator Screenshot - iPhone 5 - 2023-12-26 at 11 57 15](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/24f6558f-dcd4-4ade-bb87-61284a122d14)  |
| Phone - Chrome   |               |  ![localhost_3000_profil_confidentialite](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/de0bcad6-905d-4643-bf83-912f1cffd93c)     |
| Desktop - Chrome |               |  <img width="1440" alt="Capture d’écran 2023-12-26 à 11 57 24" src="https://github.com/pass-culture/pass-culture-app-native/assets/46637324/c34ad95e-26bd-4515-a534-a403c24a509f">     |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
