### PR TITLE
(PC-26572) feat(venue): reduce blurry background for CTA venue

### DIFF
--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -8797,7 +8797,7 @@ d’options
     }
   >
     <BlurView
-      blurAmount={10}
+      blurAmount={1}
       blurType="light"
       reducedTransparencyFallbackColor="white"
       style={
@@ -8821,7 +8821,7 @@ d’options
           [
             {
               "alignItems": "center",
-              "marginHorizontal": 24,
+              "paddingHorizontal": 24,
             },
           ]
         }

--- a/src/features/venue/components/VenueCTA/VenueCTA.tsx
+++ b/src/features/venue/components/VenueCTA/VenueCTA.tsx
@@ -8,7 +8,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { StickyBottomWrapper } from 'ui/components/StickyBottomWrapper/StickyBottomWrapper'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { MagnifyingGlassFilled } from 'ui/svg/icons/MagnifyingGlassFilled'
-import { getSpacing, Spacer } from 'ui/theme'
+import { Spacer } from 'ui/theme'
 
 export const VENUE_CTA_HEIGHT_IN_SPACES = 6 + 10 + 6
 
@@ -43,7 +43,11 @@ const SmallMagnifyingGlass = styled(MagnifyingGlassFilled).attrs(({ theme }) => 
   size: theme.icons.sizes.small,
 }))``
 
-const CallToActionContainer = styled.View({
-  marginHorizontal: getSpacing(6),
+const CallToActionContainer = styled.View(({ theme }) => ({
   alignItems: 'center',
-})
+  paddingHorizontal: theme.contentPage.marginHorizontal,
+  ...(!theme.isMobileViewport && {
+    width: '100%',
+    maxWidth: theme.contentPage.maxWidth,
+  }),
+}))

--- a/src/ui/components/BlurryWrapper/BlurryWrapper.tsx
+++ b/src/ui/components/BlurryWrapper/BlurryWrapper.tsx
@@ -13,7 +13,7 @@ export function BlurryWrapper({ children }: Props) {
   ) : (
     <StyledBlurry
       blurType="light"
-      blurAmount={10}
+      blurAmount={1}
       reducedTransparencyFallbackColor="white"
       testID="blurry-wrapper">
       {children}
@@ -30,5 +30,5 @@ const StyledBlurry = styled(BlurView)<{
 })
 
 const TransparentBackground = styled.View({
-  backgroundColor: 'rgba(255, 255, 255, 0.85)',
+  backgroundColor: 'rgba(255, 255, 255, 0.5)',
 })

--- a/src/ui/components/BlurryWrapper/BlurryWrapper.web.tsx
+++ b/src/ui/components/BlurryWrapper/BlurryWrapper.web.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components/native'
 
 export const BlurryWrapper = styled.View({
-  backdropFilter: 'blur(20px)',
+  backdropFilter: 'blur(2px)',
   alignItems: 'center',
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-26572

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              | ![Capture d’écran 2023-12-27 à 11 12 36](https://github.com/pass-culture/pass-culture-app-native/assets/62059034/aac66ff2-de29-4c26-a5d7-ca0713f114a6) |  ![Capture d’écran 2023-12-27 à 11 12 24](https://github.com/pass-culture/pass-culture-app-native/assets/62059034/0b36461c-5ce0-495d-b59e-34d32f37e17d)  |
| Android          | <img width="410" alt="Capture d’écran 2023-12-27 à 14 55 59" src="https://github.com/pass-culture/pass-culture-app-native/assets/62059034/4539c7b8-20bd-4345-baba-78a65fec8c37"> |  <img width="407" alt="Capture d’écran 2023-12-27 à 14 55 36" src="https://github.com/pass-culture/pass-culture-app-native/assets/62059034/b84e9c17-42a6-40c9-b8ee-e71458d5e588"> |
| Phone - Chrome   |   ![Capture d’écran 2023-12-27 à 10 45 10](https://github.com/pass-culture/pass-culture-app-native/assets/62059034/0f3fbf34-3d40-4aca-8117-beadfb3fd2b5) | ![Capture d’écran 2023-12-27 à 10 59 27](https://github.com/pass-culture/pass-culture-app-native/assets/62059034/19d28e2b-b03d-49cc-92bf-a6f294215fdd) |
| Desktop - Chrome |   ![Capture d’écran 2023-12-27 à 10 44 56](https://github.com/pass-culture/pass-culture-app-native/assets/62059034/dc912639-5095-43de-9fe8-99a397f1342e) |   ![Capture d’écran 2023-12-27 à 10 08 37](https://github.com/pass-culture/pass-culture-app-native/assets/62059034/7e00407c-c4e7-470b-9488-f81eb382e43f)  |


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
