### PR TITLE
(PC-26512) fix(Tooltip): clickable only on cross

### DIFF
--- a/src/ui/components/Tooltip.tsx
+++ b/src/ui/components/Tooltip.tsx
@@ -76,6 +76,7 @@ const StyledPointer = styled(Pointer)({
 
 const Background = styled.View(({ theme }) => ({
   flexDirection: 'row',
+  alignItems: 'flex-start',
   width: '100%',
   padding: getSpacing(2),
   paddingLeft: getSpacing(4),
@@ -90,6 +91,7 @@ const StyledText = styled(Typo.Caption)(({ theme }) => ({
 
 const StyledClearContainer = styledButton(Touchable)({
   marginLeft: getSpacing(2),
+  flexShrink: 1,
 })
 
 const StyledClearIcon = styled(Clear).attrs(({ theme }) => ({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-26512

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change

## Screenshots

https://github.com/pass-culture/pass-culture-app-native/assets/144016890/8f348ad6-7836-4ddb-90c5-64ad77068fa5


