### PR TITLE
(PC-25901) fix(babelRuntime): move runtime in run dependencies and up…

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   "dependencies": {
     "@algolia/client-search": "^4.6.0",
     "@amplitude/analytics-react-native": "^1.0.1",
+    "@babel/runtime": "^7.23.7",
     "@bam.tech/react-native-config": "^1.4.5",
     "@batch.com/react-native-plugin": "^8.1.2",
     "@hookform/resolvers": "^2.9.11",
@@ -200,7 +201,6 @@
     "@babel/preset-env": "^7.20.0",
     "@babel/preset-react": "^7.12.5",
     "@babel/preset-typescript": "^7.13.0",
-    "@babel/runtime": "^7.22.10",
     "@bam.tech/eslint-plugin": "^1.0.1",
     "@chanzuckerberg/axe-storybook-testing": "^7.1.3",
     "@google-cloud/local-auth": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4073,6 +4073,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.23.7":
+  version "7.23.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.7.tgz#dd7c88deeb218a0f8bd34d5db1aa242e0f203193"
+  integrity sha512-w06OXVOFso7LcbzMiDGt+3X7Rh7Ho8MmgPoWU3rarH+8upf+wSU/grlGbWzQyr3DkdN6ZeuMFjpdwW0Q+HxobA==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.0.0", "@babel/template@^7.16.0", "@babel/template@^7.3.3":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.0.tgz#d16a35ebf4cd74e202083356fab21dd89363ddd6"


### PR DESCRIPTION
…date version

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25901

I suppose it's caused by the missing running [dependency](https://babeljs.io/docs/babel-runtime) therefore moving it from the dev dependencies would fix it.