### PR TITLE
(PC-26714) fix(Venue): hide practical information titles when sections are empty

### DIFF
--- a/src/features/venue/components/PracticalInformation.native.test.tsx
+++ b/src/features/venue/components/PracticalInformation.native.test.tsx
@@ -62,6 +62,18 @@ describe('PracticalInformation', () => {
     expect(screen.queryByText('Contact')).not.toBeOnTheScreen()
   })
 
+  it('should not display contact section when empty contacts fields provided', async () => {
+    render(
+      reactQueryProviderHOC(
+        <PracticalInformation
+          venue={{ ...venueResponseSnap, contact: { email: '', phoneNumber: '' } }}
+        />
+      )
+    )
+
+    expect(screen.queryByText('Contact')).not.toBeOnTheScreen()
+  })
+
   it('should not display accessibility section when no accessibility info provided', async () => {
     render(
       reactQueryProviderHOC(

--- a/src/features/venue/components/PracticalInformation.native.test.tsx
+++ b/src/features/venue/components/PracticalInformation.native.test.tsx
@@ -65,7 +65,17 @@ describe('PracticalInformation', () => {
   it('should not display accessibility section when no accessibility info provided', async () => {
     render(
       reactQueryProviderHOC(
-        <PracticalInformation venue={{ ...venueResponseSnap, accessibility: {} }} />
+        <PracticalInformation
+          venue={{
+            ...venueResponseSnap,
+            accessibility: {
+              audioDisability: null,
+              mentalDisability: null,
+              motorDisability: null,
+              visualDisability: null,
+            },
+          }}
+        />
       )
     )
 

--- a/src/features/venue/components/PracticalInformation.tsx
+++ b/src/features/venue/components/PracticalInformation.tsx
@@ -2,7 +2,7 @@ import React, { Fragment, FunctionComponent } from 'react'
 import { FlatList, ListRenderItemInfo } from 'react-native'
 import styled from 'styled-components/native'
 
-import { VenueAccessibilityModel, VenueContactModel, VenueResponse } from 'api/gen'
+import { VenueResponse } from 'api/gen'
 import { ContactBlock } from 'features/venue/components/ContactBlockNew/ContactBlockNew'
 import { AccessibilityBlock } from 'ui/components/accessibility/AccessibilityBlock'
 import { Separator } from 'ui/components/Separator'
@@ -10,13 +10,6 @@ import { Spacer, Typo } from 'ui/theme'
 
 type Props = { venue: VenueResponse }
 type Section = { title: string; body: JSX.Element; isDisplayed: boolean }
-
-function checkIfSectionIsEmpty<T>(section: T | null | undefined): boolean {
-  if (!section) return true
-  const sectionValues = Object.keys(section) as (keyof T)[]
-
-  return !sectionValues.some((key) => section[key] !== null || undefined)
-}
 
 export const PracticalInformation: FunctionComponent<Props> = ({ venue }) => {
   const sections: Section[] = [
@@ -33,14 +26,18 @@ export const PracticalInformation: FunctionComponent<Props> = ({ venue }) => {
     {
       title: 'Contact',
       body: <ContactBlock venue={venue} />,
-      isDisplayed: !!venue.contact && !checkIfSectionIsEmpty<VenueContactModel>(venue.contact),
+      isDisplayed:
+        !!venue.contact &&
+        Object.values(venue.contact).some(
+          (value) => value !== null && value !== undefined && value !== ''
+        ),
     },
     {
       title: 'Accessibilité',
       body: <AccessibilityBlock {...venue.accessibility} />,
       isDisplayed:
         !!venue.accessibility &&
-        !checkIfSectionIsEmpty<VenueAccessibilityModel>(venue.accessibility),
+        Object.values(venue.accessibility).some((value) => value !== null && value !== undefined),
     },
   ]
   const sectionsToDisplay = sections.filter((section) => section.isDisplayed)

--- a/src/features/venue/components/PracticalInformation.tsx
+++ b/src/features/venue/components/PracticalInformation.tsx
@@ -1,9 +1,8 @@
-import isEmpty from 'lodash/isEmpty'
 import React, { Fragment, FunctionComponent } from 'react'
 import { FlatList, ListRenderItemInfo } from 'react-native'
 import styled from 'styled-components/native'
 
-import { VenueResponse } from 'api/gen'
+import { VenueAccessibilityModel, VenueContactModel, VenueResponse } from 'api/gen'
 import { ContactBlock } from 'features/venue/components/ContactBlockNew/ContactBlockNew'
 import { AccessibilityBlock } from 'ui/components/accessibility/AccessibilityBlock'
 import { Separator } from 'ui/components/Separator'
@@ -11,6 +10,13 @@ import { Spacer, Typo } from 'ui/theme'
 
 type Props = { venue: VenueResponse }
 type Section = { title: string; body: JSX.Element; isDisplayed: boolean }
+
+function checkIfSectionIsEmpty<T>(section: T | null | undefined): boolean {
+  if (!section) return true
+  const sectionValues = Object.keys(section) as (keyof T)[]
+
+  return !sectionValues.some((key) => section[key] !== null || undefined)
+}
 
 export const PracticalInformation: FunctionComponent<Props> = ({ venue }) => {
   const sections: Section[] = [
@@ -27,12 +33,14 @@ export const PracticalInformation: FunctionComponent<Props> = ({ venue }) => {
     {
       title: 'Contact',
       body: <ContactBlock venue={venue} />,
-      isDisplayed: !!venue.contact && !isEmpty(venue.contact),
+      isDisplayed: !!venue.contact && !checkIfSectionIsEmpty<VenueContactModel>(venue.contact),
     },
     {
       title: 'Accessibilité',
       body: <AccessibilityBlock {...venue.accessibility} />,
-      isDisplayed: !!venue.accessibility && !isEmpty(venue.accessibility),
+      isDisplayed:
+        !!venue.accessibility &&
+        !checkIfSectionIsEmpty<VenueAccessibilityModel>(venue.accessibility),
     },
   ]
   const sectionsToDisplay = sections.filter((section) => section.isDisplayed)

--- a/src/features/venue/components/PracticalInformation.tsx
+++ b/src/features/venue/components/PracticalInformation.tsx
@@ -26,11 +26,7 @@ export const PracticalInformation: FunctionComponent<Props> = ({ venue }) => {
     {
       title: 'Contact',
       body: <ContactBlock venue={venue} />,
-      isDisplayed:
-        !!venue.contact &&
-        Object.values(venue.contact).some(
-          (value) => value !== null && value !== undefined && value !== ''
-        ),
+      isDisplayed: !!venue.contact && Object.values(venue.contact).some((value) => !!value),
     },
     {
       title: 'Accessibilité',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-26714

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |<img width="344" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/f5811fbc-51f0-4c04-a8d1-b7bce78be7a8">|<img width="346" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/71daa355-4254-4d9a-a884-90a9c9d3e652">|
| Desktop - Chrome |<img width="1020" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/709320bf-9753-4042-bf51-93e51da8b9b3">|<img width="1023" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/574b250a-2538-4388-b3d2-4cfee030a9e6">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
