### PR TITLE
(PC-26723) fix(offer): possibility of using the position configured by the user and not necessarily his geolocation

### DIFF
--- a/src/api/useSearchVenuesOffer/useSearchVenueOffers.ts
+++ b/src/api/useSearchVenuesOffer/useSearchVenueOffers.ts
@@ -42,6 +42,8 @@ type FilterVenueOfferType = {
   venueId: number | undefined
 }
 
+const AROUND_RADIUS = 50 * 1000
+
 export function getVenueList(hits: Offer[], geolocation: Position) {
   const offerVenues: OfferVenueType[] = []
 
@@ -105,8 +107,14 @@ export const useSearchVenueOffers = ({
     [QueryKeys.SEARCH_RESULTS, { ...initialSearchState, view: undefined, query }],
     async ({ pageParam: page = 0 }) => {
       const response = await fetchOffers({
-        parameters: { ...initialSearchState, query, page, hitsPerPage: 10 },
+        parameters: {
+          ...initialSearchState,
+          query,
+          page,
+          hitsPerPage: 10,
+        },
         userLocation: geolocation,
+        aroundRadius: AROUND_RADIUS,
         isUserUnderage,
         storeQueryID: setCurrentQueryID,
         excludedObjectIds: previousPageObjectIds.current,

--- a/src/features/bookOffer/components/BookingDetails.tsx
+++ b/src/features/bookOffer/components/BookingDetails.tsx
@@ -78,7 +78,7 @@ export function BookingDetails({ stocks, onPressBookOffer, isLoading }: BookingD
   )
 
   const { onScroll: onScrollModal } = useOpacityTransition()
-  const { geolocPosition: position } = useLocation()
+  const { userLocation: position } = useLocation()
   const defaultSearchVenueOffers = {
     offerId: 0,
     venueId: undefined,

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -52,7 +52,7 @@ export const OfferBody: FunctionComponent<Props> = ({
 }) => {
   const { user } = useAuthContext()
   const scrollViewRef = useRef<ScrollView | null>(null)
-  const { geolocPosition } = useLocation()
+  const { userLocation } = useLocation()
   const mapping = useSubcategoriesMapping()
   const { categoryId, isEvent, appLabel: categoryLabel } = mapping[offer.subcategoryId]
 
@@ -113,7 +113,7 @@ export const OfferBody: FunctionComponent<Props> = ({
         <SectionBody>{capitalizedFormattedDateEvent}</SectionBody>
       </SectionWithDivider>
 
-      <OfferPlace offer={offer} geolocPosition={geolocPosition} isEvent={isEvent} />
+      <OfferPlace offer={offer} userLocation={userLocation} isEvent={isEvent} />
 
       <SectionWithDivider visible margin>
         <OfferMessagingApps offer={offer} />
@@ -145,7 +145,7 @@ export const OfferBody: FunctionComponent<Props> = ({
 
       <OfferPlaylistList
         offer={offer}
-        position={geolocPosition}
+        position={userLocation}
         sameCategorySimilarOffers={sameCategorySimilarOffers}
         apiRecoParamsSameCategory={apiRecoParamsSameCategory}
         otherCategoriesSimilarOffers={otherCategoriesSimilarOffers}

--- a/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
@@ -67,7 +67,7 @@ const useFeatureFlagSpy = jest
 
 const offerPlaceProps: OfferPlaceProps = {
   offer: mockOffer,
-  geolocPosition: null,
+  userLocation: null,
   isEvent: false,
 }
 
@@ -372,9 +372,9 @@ describe('<OfferPlace />', () => {
   })
 })
 
-const renderOfferPlace = ({ offer, geolocPosition, isEvent }: OfferPlaceProps) =>
+const renderOfferPlace = ({ offer, userLocation, isEvent }: OfferPlaceProps) =>
   render(
     reactQueryProviderHOC(
-      <OfferPlace offer={offer} geolocPosition={geolocPosition} isEvent={isEvent} />
+      <OfferPlace offer={offer} userLocation={userLocation} isEvent={isEvent} />
     )
   )

--- a/src/features/offer/components/OfferPlace/OfferPlace.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.tsx
@@ -22,11 +22,11 @@ import { Spacer } from 'ui/theme'
 
 export type OfferPlaceProps = {
   offer: OfferResponse
-  geolocPosition: Position
+  userLocation: Position
   isEvent: boolean
 }
 
-export function OfferPlace({ offer, geolocPosition, isEvent }: Readonly<OfferPlaceProps>) {
+export function OfferPlace({ offer, userLocation, isEvent }: Readonly<OfferPlaceProps>) {
   const { navigate } = useNavigation<UseNavigationType>()
   const showVenueBanner = offer.venue.isPermanent === true
   const fullAddress = getFormattedAddress(offer.venue, showVenueBanner)
@@ -59,7 +59,7 @@ export function OfferPlace({ offer, geolocPosition, isEvent }: Readonly<OfferPla
   } = useSearchVenueOffers({
     offerId: offer.id,
     venueId: offer.venue.id,
-    geolocation: geolocPosition ?? {
+    geolocation: userLocation ?? {
       latitude: offer.venue.coordinates.latitude ?? 0,
       longitude: offer.venue.coordinates.longitude ?? 0,
     },
@@ -147,7 +147,7 @@ export function OfferPlace({ offer, geolocPosition, isEvent }: Readonly<OfferPla
           nbLoadedHits={nbLoadedHits}
           nbHits={nbHits}
           isFetchingNextPage={isFetchingNextPage}
-          isSharingLocation={geolocPosition !== null}
+          isSharingLocation={userLocation !== null}
           venueName={offer.venue.publicName || offer.venue.name}
         />
       ) : null}

--- a/src/features/offer/helpers/useOfferPlaylist/useOfferPlaylist.test.ts
+++ b/src/features/offer/helpers/useOfferPlaylist/useOfferPlaylist.test.ts
@@ -7,6 +7,7 @@ import {
   mockedAlgoliaOffersWithSameArtistResponse,
   moreHitsForSimilarOffersPlaylist,
 } from 'libs/algolia/__mocks__/mockedAlgoliaResponse'
+import { Position } from 'libs/location'
 import { placeholderData } from 'libs/subcategories/placeholderData'
 import { RecommendationApiParams } from 'shared/offer/types'
 import { renderHook } from 'tests/utils'
@@ -43,7 +44,12 @@ const useSameArtistPlaylistSpy = jest
     refetchSameArtistPlaylist: jest.fn(),
   })
 
-jest.mock('libs/location')
+const mockPosition: Position = { latitude: 90.4773245, longitude: 90.4773245 }
+jest.mock('libs/location/LocationWrapper', () => ({
+  useLocation: () => ({
+    userLocation: mockPosition,
+  }),
+}))
 
 describe('useOfferPlaylist', () => {
   describe('When offer is defined', () => {

--- a/src/features/offer/helpers/useOfferPlaylist/useOfferPlaylist.ts
+++ b/src/features/offer/helpers/useOfferPlaylist/useOfferPlaylist.ts
@@ -30,7 +30,7 @@ export const useOfferPlaylist = ({
   offerSearchGroup,
   searchGroupList,
 }: Props): UseOfferPlaylistType => {
-  const { geolocPosition } = useLocation()
+  const { userLocation } = useLocation()
 
   const artists = offer.extraData?.author
   const ean = offer.extraData?.ean
@@ -42,7 +42,7 @@ export const useOfferPlaylist = ({
     venueLocation,
   })
 
-  const { latitude, longitude } = geolocPosition ?? {}
+  const { latitude, longitude } = userLocation ?? {}
   const roundedPosition: Position = useMemo(
     () => ({
       latitude: Number(latitude?.toFixed(3)),
@@ -51,7 +51,7 @@ export const useOfferPlaylist = ({
     [latitude, longitude]
   )
 
-  const position = geolocPosition ? roundedPosition : undefined
+  const position = userLocation ? roundedPosition : undefined
 
   const { similarOffers: sameCategorySimilarOffers, apiRecoParams: apiRecoParamsSameCategory } =
     useSimilarOffers({

--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildGeolocationParameter.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildGeolocationParameter.ts
@@ -11,6 +11,7 @@ type Params = {
   userLocation: Position
   isFullyDigitalOffersCategory?: SearchQueryParameters['isFullyDigitalOffersCategory']
   enableAppLocation?: boolean
+  aroundRadius?: number
 }
 
 export const buildGeolocationParameter = ({
@@ -19,6 +20,7 @@ export const buildGeolocationParameter = ({
   userLocation,
   isFullyDigitalOffersCategory,
   enableAppLocation,
+  aroundRadius,
 }: Params): { aroundLatLng: string; aroundRadius: 'all' | number } | undefined => {
   let locationFilter = providedLocationFilter
   if (isFullyDigitalOffersCategory && enableAppLocation) return
@@ -50,7 +52,7 @@ export const buildGeolocationParameter = ({
   if (locationFilter.locationType === LocationMode.EVERYWHERE) {
     return {
       aroundLatLng: `${userLocation.latitude}, ${userLocation.longitude}`,
-      aroundRadius: 'all',
+      aroundRadius: aroundRadius ?? 'all',
     }
   }
 

--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildOfferSearchParameters.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/buildOfferSearchParameters.ts
@@ -11,6 +11,7 @@ type Parameters = SearchQueryParameters & {
   excludedObjectIds?: string[]
   eanList?: string[]
   enableAppLocation?: boolean
+  aroundRadius?: number
 }
 
 export const buildOfferSearchParameters = (
@@ -44,7 +45,8 @@ export const buildOfferSearchParameters = (
   }: Parameters,
   userLocation: Position,
   isUserUnderage: boolean,
-  enableAppLocation?: boolean
+  enableAppLocation?: boolean,
+  aroundRadius?: number
 ) => ({
   ...buildFacetFilters({
     eanList,
@@ -82,6 +84,7 @@ export const buildOfferSearchParameters = (
     userLocation,
     isFullyDigitalOffersCategory,
     enableAppLocation,
+    aroundRadius,
   }),
   ...buildFilters({ excludedObjectIds }),
 })

--- a/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/tests/buildGeolocationParameter.test.ts
+++ b/src/libs/algolia/fetchAlgolia/buildAlgoliaParameters/tests/buildGeolocationParameter.test.ts
@@ -104,7 +104,7 @@ describe('buildGeolocationParameter', () => {
     expect(result).toEqual(expectOutput)
   })
 
-  it('should return geolocation parameter for "all" location type', () => {
+  it('should return geolocation parameter for everywhere location type with "all" around radius', () => {
     const result = buildGeolocationParameter({
       locationFilter: locationFilterEverywhere,
       userLocation,
@@ -113,6 +113,19 @@ describe('buildGeolocationParameter', () => {
     expect(result).toEqual({
       aroundLatLng: `${userLocation.latitude}, ${userLocation.longitude}`,
       aroundRadius: 'all',
+    })
+  })
+
+  it('should return geolocation parameter for everywhere location type with an around radius', () => {
+    const result = buildGeolocationParameter({
+      locationFilter: locationFilterEverywhere,
+      userLocation,
+      aroundRadius: 50000,
+    })
+
+    expect(result).toEqual({
+      aroundLatLng: `${userLocation.latitude}, ${userLocation.longitude}`,
+      aroundRadius: 50000,
     })
   })
 })

--- a/src/libs/algolia/fetchAlgolia/fetchOffers.native.test.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchOffers.native.test.ts
@@ -245,6 +245,55 @@ describe('fetchOffer', () => {
       })
     })
 
+    it('should fetch offers with geolocation coordinates, when latitude, longitude are provided and search is everywhere without radius', () => {
+      const query = 'searched query'
+
+      fetchOffers({
+        parameters: {
+          locationFilter: { locationType: LocationMode.EVERYWHERE },
+          query,
+        } as SearchQueryParameters,
+        userLocation,
+        isUserUnderage: false,
+      })
+
+      expect(search).toHaveBeenCalledWith(query, {
+        aroundLatLng: '42, 43',
+        aroundRadius: 'all',
+        page: 0,
+        attributesToHighlight: [],
+        facetFilters: [['offer.isEducational:false']],
+        numericFilters: [['offer.prices: 0 TO 300']],
+        attributesToRetrieve: offerAttributesToRetrieve,
+        clickAnalytics: true,
+      })
+    })
+
+    it('should fetch offers with geolocation coordinates, when latitude, longitude are provided and search is everywhere with radius', () => {
+      const query = 'searched query'
+
+      fetchOffers({
+        parameters: {
+          locationFilter: { locationType: LocationMode.EVERYWHERE },
+          query,
+        } as SearchQueryParameters,
+        userLocation,
+        isUserUnderage: false,
+        aroundRadius: 50000,
+      })
+
+      expect(search).toHaveBeenCalledWith(query, {
+        aroundLatLng: '42, 43',
+        aroundRadius: 50000,
+        page: 0,
+        attributesToHighlight: [],
+        facetFilters: [['offer.isEducational:false']],
+        numericFilters: [['offer.prices: 0 TO 300']],
+        attributesToRetrieve: offerAttributesToRetrieve,
+        clickAnalytics: true,
+      })
+    })
+
     it('should fetch offers with geolocation coordinates, when latitude, longitude, search is around me, and radius equals zero', () => {
       const query = 'searched query'
 

--- a/src/libs/algolia/fetchAlgolia/fetchOffers.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchOffers.ts
@@ -18,6 +18,7 @@ type FetchOfferArgs = {
   excludedObjectIds?: string[]
   indexSearch?: string
   isFromOffer?: boolean
+  aroundRadius?: number
 }
 
 export type FetchOffersResponse = Pick<
@@ -32,8 +33,15 @@ export const fetchOffers = async ({
   storeQueryID,
   indexSearch = env.ALGOLIA_OFFERS_INDEX_NAME,
   isFromOffer,
+  aroundRadius,
 }: FetchOfferArgs): Promise<FetchOffersResponse> => {
-  const searchParameters = buildOfferSearchParameters(parameters, userLocation, isUserUnderage)
+  const searchParameters = buildOfferSearchParameters(
+    parameters,
+    userLocation,
+    isUserUnderage,
+    undefined,
+    aroundRadius
+  )
   const index = client.initIndex(indexSearch)
 
   try {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-26723

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |![Capture d’écran 2024-01-04 à 17 19 41](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/58965b91-1be4-4789-8bad-e539dae91325) ![Capture d’écran 2024-01-04 à 17 19 48](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/09c441f4-c63c-4c9a-8b04-b94c47ff6208) ![Capture d’écran 2024-01-04 à 17 20 22](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/27ce6a08-88b3-4b03-a00c-cfe85c9b0f1f) ![Capture d’écran 2024-01-04 à 17 20 31](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/00c96b45-10be-4e24-9747-f3d3013e2ae2)|![Capture d’écran 2024-01-04 à 17 14 57](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/8836bfa1-c71b-466d-b37e-150e5c7d51e7) ![Capture d’écran 2024-01-04 à 17 15 09](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/f60bee5f-a37a-43d4-9e64-8024bd897638) ![Capture d’écran 2024-01-04 à 17 15 39](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/1e8e5060-5b4e-41fc-81c8-f9e113d30175) ![Capture d’écran 2024-01-04 à 17 15 19](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/2f6633b9-0be1-4d1b-a9b5-5017daa8f43f) ![Capture d’écran 2024-01-04 à 17 15 28](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/fb87978a-c93a-4e02-b1f9-1126800a0155)|
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
