### PR TITLE
Revert "(PC-25575) chore(deps): Bump react-native-gesture-handler fro…

### DIFF
--- a/__snapshots__/features/home/components/HomeBodyPlaceholder.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/HomeBodyPlaceholder.native.test.tsx.native-snap
@@ -121,8 +121,6 @@ exports[`HomeBodyPlaceholder matches snapshot 1`] = `
         }
         getItem={[Function]}
         getItemCount={[Function]}
-        handlerTag={1}
-        handlerType="NativeViewGestureHandler"
         horizontal={true}
         keyExtractor={[Function]}
         onContentSizeChange={[Function]}
@@ -141,16 +139,6 @@ exports[`HomeBodyPlaceholder matches snapshot 1`] = `
         showsHorizontalScrollIndicator={false}
         stickyHeaderIndices={[]}
         viewabilityConfigCallbackPairs={[]}
-        waitFor={
-          [
-            {
-              "current": null,
-            },
-            {
-              "current": null,
-            },
-          ]
-        }
       >
         <View>
           <View
@@ -1171,8 +1159,6 @@ exports[`HomeBodyPlaceholder matches snapshot 1`] = `
         }
         getItem={[Function]}
         getItemCount={[Function]}
-        handlerTag={2}
-        handlerType="NativeViewGestureHandler"
         horizontal={true}
         keyExtractor={[Function]}
         onContentSizeChange={[Function]}
@@ -1191,16 +1177,6 @@ exports[`HomeBodyPlaceholder matches snapshot 1`] = `
         showsHorizontalScrollIndicator={false}
         stickyHeaderIndices={[]}
         viewabilityConfigCallbackPairs={[]}
-        waitFor={
-          [
-            {
-              "current": null,
-            },
-            {
-              "current": null,
-            },
-          ]
-        }
       >
         <View>
           <View
@@ -2532,8 +2508,6 @@ exports[`HomeBodyPlaceholder matches snapshot 1`] = `
         }
         getItem={[Function]}
         getItemCount={[Function]}
-        handlerTag={3}
-        handlerType="NativeViewGestureHandler"
         horizontal={true}
         keyExtractor={[Function]}
         onContentSizeChange={[Function]}
@@ -2552,16 +2526,6 @@ exports[`HomeBodyPlaceholder matches snapshot 1`] = `
         showsHorizontalScrollIndicator={false}
         stickyHeaderIndices={[]}
         viewabilityConfigCallbackPairs={[]}
-        waitFor={
-          [
-            {
-              "current": null,
-            },
-            {
-              "current": null,
-            },
-          ]
-        }
       >
         <View>
           <View
@@ -3802,8 +3766,6 @@ exports[`HomeBodyPlaceholder matches snapshot 1`] = `
         }
         getItem={[Function]}
         getItemCount={[Function]}
-        handlerTag={4}
-        handlerType="NativeViewGestureHandler"
         horizontal={true}
         keyExtractor={[Function]}
         onContentSizeChange={[Function]}
@@ -3822,16 +3784,6 @@ exports[`HomeBodyPlaceholder matches snapshot 1`] = `
         showsHorizontalScrollIndicator={false}
         stickyHeaderIndices={[]}
         viewabilityConfigCallbackPairs={[]}
-        waitFor={
-          [
-            {
-              "current": null,
-            },
-            {
-              "current": null,
-            },
-          ]
-        }
       >
         <View>
           <View

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -671,7 +671,7 @@ PODS:
     - RNFBApp
   - RNFlashList (1.4.1):
     - React-Core
-  - RNGestureHandler (2.13.1):
+  - RNGestureHandler (1.10.3):
     - React-Core
   - RNGoogleSignin (10.1.0):
     - GoogleSignIn (~> 7.0)
@@ -1134,7 +1134,7 @@ SPEC CHECKSUMS:
   RNFBPerf: c4b51d204881e99f1fccd491f8756c6be1bb8f3d
   RNFBRemoteConfig: ec7bfe6cff76296f0e5ec8ad0c0149f00d6d92ca
   RNFlashList: 8ec7f7454721145fe84566bb9e88bcf58981c9fe
-  RNGestureHandler: 38aa38413896620338948fbb5c90579a7b1c3fde
+  RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNGoogleSignin: a6a612cce56a45ab701c5c5c6e36f5390522d100
   RNKeychain: 4f63aada75ebafd26f4bc2c670199461eab85d94
   RNLaunchNavigator: 058ccdb86a80a9424d5e37f6ec54379e3018c52b

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "react-native-email-link": "^1.10.0",
     "react-native-fast-image": "^8.6.3",
     "react-native-geolocation-service": "5.3.1",
-    "react-native-gesture-handler": "^2.13.1",
+    "react-native-gesture-handler": "^1.10.3",
     "react-native-get-random-values": "^1.5.1",
     "react-native-in-app-review": "^4.3.1",
     "react-native-intersection-observer": "^0.2.0",

--- a/src/features/identityCheck/pages/identification/educonnect/EduConnectForm.tsx
+++ b/src/features/identityCheck/pages/identification/educonnect/EduConnectForm.tsx
@@ -1,7 +1,7 @@
 import { useFocusEffect, useNavigation } from '@react-navigation/native'
 import React, { useCallback, useRef, useState } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-import 'react-native-url-polyfill/auto'
+import { URL } from 'react-native-url-polyfill'
 import WebView, { WebViewNavigation } from 'react-native-webview'
 import { WebViewSource } from 'react-native-webview/lib/WebViewTypes'
 import styled from 'styled-components/native'

--- a/yarn.lock
+++ b/yarn.lock
@@ -11732,7 +11732,7 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@3.1.5, cross-fetch@^3.1.5:
+cross-fetch@3.1.5, cross-fetch@^3.0.4, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -13984,6 +13984,19 @@ fbjs-css-vars@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
   integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
+
+fbjs@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-3.0.1.tgz#70a053d34a96c2b513b559eaea124daed49ace64"
+  integrity sha512-8+vkGyT4lNDRKHQNPp0yh/6E7FfkLg89XqQbOYnvntRh+8RiSD43yrh9E5ejp1muCizTL4nDVG+y8W4e+LROHg==
+  dependencies:
+    cross-fetch "^3.0.4"
+    fbjs-css-vars "^1.0.0"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.30"
 
 fbjs@^3.0.4:
   version "3.0.4"
@@ -22090,15 +22103,15 @@ react-native-geolocation-service@5.3.1:
   resolved "https://registry.yarnpkg.com/react-native-geolocation-service/-/react-native-geolocation-service-5.3.1.tgz#4ce1017789da6fdfcf7576eb6f59435622af4289"
   integrity sha512-LTXPtPNmrdhx+yeWG47sAaCgQc3nG1z+HLLHlhK/5YfOgfLcAb9HAkhREPjQKPZOUx8pKZMIpdGFUGfJYtimXQ==
 
-react-native-gesture-handler@^2.13.1:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.13.1.tgz#bad89caacd62c4560b9953b02f85f37ee42d5d4c"
-  integrity sha512-hW454X7sjuiBN+lobqw63pmT3boAmTl5OP6zQLq83iEe4T6PcHZ9lxzgCrebtgmutY8cJfq9rM2dOUVh9WBcww==
+react-native-gesture-handler@^1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.10.3.tgz#942bbf2963bbf49fa79593600ee9d7b5dab3cfc0"
+  integrity sha512-cBGMi1IEsIVMgoox4RvMx7V2r6bNKw0uR1Mu1o7NbuHS6BRSVLq0dP34l2ecnPlC+jpWd3le6Yg1nrdCjby2Mw==
   dependencies:
     "@egjs/hammerjs" "^2.0.17"
+    fbjs "^3.0.0"
     hoist-non-react-statics "^3.3.0"
     invariant "^2.2.4"
-    lodash "^4.17.21"
     prop-types "^15.7.2"
 
 react-native-get-random-values@^1.5.1:


### PR DESCRIPTION
…m 1.10.3 to 2.13.1 (#5409)"

This reverts commit db983f1cd8ea4e45668e8b0f0a2269af25a03d8e.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
