### PR TITLE
(PC-26715) feat(venue): add placeholder when no practical information

### DIFF
--- a/src/features/venue/components/NoInformationPlaceholder.tsx
+++ b/src/features/venue/components/NoInformationPlaceholder.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { BicolorCircledClock } from 'ui/svg/icons/BicolorCircledClock'
+import { getSpacing, Spacer, Typo } from 'ui/theme'
+
+export const NoInformationPlaceholder = () => (
+  <Container>
+    <Spacer.Column numberOfSpaces={6} />
+    <NoInfoIllustration />
+    <Spacer.Column numberOfSpaces={2} />
+    <Text>Les infos pratiques ne sont pas encore renseignées pour ce lieu</Text>
+    <Spacer.Column numberOfSpaces={6} />
+  </Container>
+)
+
+const Container = styled.View({
+  alignItems: 'center',
+  marginHorizontal: getSpacing(8),
+})
+
+const NoInfoIllustration = styled(BicolorCircledClock).attrs(({ theme }) => ({
+  color: theme.colors.greyMedium,
+  color2: theme.colors.greyMedium,
+}))``
+
+const Text = styled(Typo.Title4)({
+  textAlign: 'center',
+})

--- a/src/features/venue/components/PracticalInformation.native.test.tsx
+++ b/src/features/venue/components/PracticalInformation.native.test.tsx
@@ -34,6 +34,26 @@ describe('PracticalInformation', () => {
     expect(await screen.findAllByTestId('accessibilityAtomContainer')).not.toHaveLength(0)
   })
 
+  it('should display placeholder when no practical information provided', async () => {
+    const venueWithoutPracticalInformation = {
+      ...venueResponseSnap,
+      withdrawalDetails: undefined,
+      description: undefined,
+      contact: undefined,
+      accessibility: {
+        audioDisability: null,
+        mentalDisability: null,
+        motorDisability: null,
+        visualDisability: null,
+      },
+    }
+    render(reactQueryProviderHOC(<PracticalInformation venue={venueWithoutPracticalInformation} />))
+
+    expect(
+      screen.getByText('Les infos pratiques ne sont pas encore renseignées pour ce lieu')
+    ).toBeOnTheScreen()
+  })
+
   it('should not display withdrawal section when no withdrawal info provided', async () => {
     render(
       reactQueryProviderHOC(

--- a/src/features/venue/components/PracticalInformation.tsx
+++ b/src/features/venue/components/PracticalInformation.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 
 import { VenueResponse } from 'api/gen'
 import { ContactBlock } from 'features/venue/components/ContactBlockNew/ContactBlockNew'
+import { NoInformationPlaceholder } from 'features/venue/components/NoInformationPlaceholder'
 import { AccessibilityBlock } from 'ui/components/accessibility/AccessibilityBlock'
 import { Separator } from 'ui/components/Separator'
 import { Spacer, Typo } from 'ui/theme'
@@ -37,6 +38,10 @@ export const PracticalInformation: FunctionComponent<Props> = ({ venue }) => {
     },
   ]
   const sectionsToDisplay = sections.filter((section) => section.isDisplayed)
+
+  if (sectionsToDisplay.length === 0) {
+    return <NoInformationPlaceholder />
+  }
 
   return (
     <Container>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-26715

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              | <img width="489" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/a18bbb8e-abe0-4bc3-8866-7135a17da570"> | <img width="534" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/58cb70fe-d156-41d5-97da-69fd5f384f41"> |
| Phone - Chrome   | <img width="489" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/ca7da4e7-6b0a-4ce3-8368-4b2ef9d9d50d"> | <img width="377" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/fd152352-5cf4-459a-88e1-e184ed667c27"> |
| Desktop - Chrome |               | <img width="1512" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/26742386/8056c65d-6d8d-4aad-9ad9-f71554f8a90b"> |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
