### PR TITLE
(PC-26799) fix(firestore): Fix Could not reach Cloud Firestore backend error

### DIFF
--- a/src/libs/firebase/firestore/client.web.ts
+++ b/src/libs/firebase/firestore/client.web.ts
@@ -1,0 +1,4 @@
+import firestore from 'libs/firebase/shims/firestore/index.web'
+
+export const firestoreRemoteStore = firestore()
+firestoreRemoteStore.settings({ experimentalAutoDetectLongPolling: true, merge: true })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-26799

cf [cette issue](https://github.com/firebase/firebase-js-sdk/issues/6951)

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome |               |   Mouna a validé que ça marchait    |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
