### PR TITLE
(PC-26803) fix(offer): reload query cache when ean change

### DIFF
--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -30,10 +30,8 @@ const useSimilarOffersSpy = jest
   .mockImplementation()
   .mockReturnValue({ similarOffers: undefined, apiRecoParams: undefined })
 
-const mockRefetchSameArtistPlaylist = jest.fn()
 jest.spyOn(useSameArtistPlaylist, 'useSameArtistPlaylist').mockReturnValue({
   sameArtistPlaylist: mockedAlgoliaOffersWithSameArtistResponse,
-  refetchSameArtistPlaylist: mockRefetchSameArtistPlaylist,
 })
 
 jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true)
@@ -43,7 +41,7 @@ jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true)
  * it is an alternative solution which allows you to replace the scroll simulation
  * it's not optimal, if you have better idea don't hesitate to update
  */
-const mockInView = mockRefetchSameArtistPlaylist
+const mockInView = jest.fn()
 jest.mock('react-native-intersection-observer', () => {
   const InView = (props: InViewProps) => {
     mockInView.mockImplementation(props.onChange)
@@ -105,8 +103,8 @@ describe('<OfferContent />', () => {
   beforeEach(() => {
     mockUseAuthContext.mockReturnValue({
       isLoggedIn: false,
-      setIsLoggedIn: mockRefetchSameArtistPlaylist,
-      refetchUser: mockRefetchSameArtistPlaylist,
+      setIsLoggedIn: jest.fn(),
+      refetchUser: jest.fn(),
       isUserLoading: false,
     })
   })
@@ -127,8 +125,8 @@ describe('<OfferContent />', () => {
   it('should log analytics when display authentication modal', async () => {
     mockUseAuthContext.mockImplementationOnce(() => ({
       isLoggedIn: false,
-      setIsLoggedIn: mockRefetchSameArtistPlaylist,
-      refetchUser: mockRefetchSameArtistPlaylist,
+      setIsLoggedIn: jest.fn(),
+      refetchUser: jest.fn(),
       isUserLoading: false,
     }))
 
@@ -368,27 +366,6 @@ describe('<OfferContent />', () => {
   })
 
   describe('With same artist playlist', () => {
-    const extraData = {
-      author: 'Eiichiro Oda',
-      ean: '9782723492607',
-    }
-
-    it('should call refetch when artist and EAN are provided because playlist not refresh correctly when navigate to an other offer', async () => {
-      renderOfferContent({ offer: { ...offerResponseSnap, extraData } })
-
-      await act(async () => {})
-
-      expect(mockRefetchSameArtistPlaylist).toHaveBeenCalledTimes(1)
-    })
-
-    it('should not call refetch when artist and EAN are not provided', async () => {
-      renderOfferContent({})
-
-      await act(async () => {})
-
-      expect(mockRefetchSameArtistPlaylist).not.toHaveBeenCalled()
-    })
-
     it('should trigger logSameArtistPlaylistVerticalScroll when scrolling to the playlist', async () => {
       renderOfferContent({})
 

--- a/src/features/offer/components/OfferContent/OfferContent.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.tsx
@@ -52,7 +52,6 @@ export function OfferContent({
 
   const {
     sameArtistPlaylist,
-    refetchSameArtistPlaylist,
     sameCategorySimilarOffers,
     apiRecoParamsSameCategory,
     otherCategoriesSimilarOffers,
@@ -75,14 +74,6 @@ export function OfferContent({
     nbOtherCategoriesSimilarOffers: otherCategoriesSimilarOffers?.length ?? 0,
     fromOfferId,
   })
-
-  const artists = offer.extraData?.author
-  const ean = offer.extraData?.ean
-  useEffect(() => {
-    if (artists && ean) {
-      refetchSameArtistPlaylist()
-    }
-  }, [artists, ean, refetchSameArtistPlaylist])
 
   useEffect(() => {
     let timeoutId: NodeJS.Timeout

--- a/src/features/offer/components/OfferPlaylist/hook/useSameArtistPlaylist.tsx
+++ b/src/features/offer/components/OfferPlaylist/hook/useSameArtistPlaylist.tsx
@@ -19,7 +19,7 @@ export const useSameArtistPlaylist = ({
   const transformHits = useTransformOfferHits()
 
   const { data, refetch } = useQuery(
-    [QueryKeys.SAME_ARTIST_PLAYLIST],
+    [QueryKeys.SAME_ARTIST_PLAYLIST, ean],
     () => {
       return fetchOffersByArtist({ artists, ean, searchGroupName, venueLocation })
     },

--- a/src/features/offer/components/OfferPlaylist/hook/useSameArtistPlaylist.tsx
+++ b/src/features/offer/components/OfferPlaylist/hook/useSameArtistPlaylist.tsx
@@ -18,7 +18,7 @@ export const useSameArtistPlaylist = ({
   const netInfo = useNetInfoContext()
   const transformHits = useTransformOfferHits()
 
-  const { data, refetch } = useQuery(
+  const { data } = useQuery(
     [QueryKeys.SAME_ARTIST_PLAYLIST, ean],
     () => {
       return fetchOffersByArtist({ artists, ean, searchGroupName, venueLocation })
@@ -28,5 +28,5 @@ export const useSameArtistPlaylist = ({
 
   const sameArtistPlaylist = data?.map(transformHits) as HitOfferWithArtistAndEan[]
 
-  return { sameArtistPlaylist, refetchSameArtistPlaylist: refetch }
+  return { sameArtistPlaylist }
 }

--- a/src/features/offer/helpers/useOfferPlaylist/useOfferPlaylist.test.ts
+++ b/src/features/offer/helpers/useOfferPlaylist/useOfferPlaylist.test.ts
@@ -41,7 +41,6 @@ const useSameArtistPlaylistSpy = jest
   .mockImplementation()
   .mockReturnValue({
     sameArtistPlaylist: mockedAlgoliaOffersWithSameArtistResponse,
-    refetchSameArtistPlaylist: jest.fn(),
   })
 
 const mockPosition: Position = { latitude: 90.4773245, longitude: 90.4773245 }
@@ -63,18 +62,6 @@ describe('useOfferPlaylist', () => {
       )
 
       expect(result.current?.sameArtistPlaylist).toEqual(mockedAlgoliaOffersWithSameArtistResponse)
-    })
-
-    it('should return refetch same artist playlist function', () => {
-      const { result } = renderHook(() =>
-        useOfferPlaylist({
-          offer,
-          offerSearchGroup,
-          searchGroupList,
-        })
-      )
-
-      expect(result.current?.refetchSameArtistPlaylist).toEqual(expect.any(Function))
     })
 
     it('should return same category similar offers playlist', () => {

--- a/src/features/offer/helpers/useOfferPlaylist/useOfferPlaylist.ts
+++ b/src/features/offer/helpers/useOfferPlaylist/useOfferPlaylist.ts
@@ -1,5 +1,4 @@
 import { useMemo } from 'react'
-import { QueryObserverResult, RefetchOptions, RefetchQueryFilters } from 'react-query'
 
 import { OfferResponse, SearchGroupNameEnumv2, SearchGroupResponseModelv2 } from 'api/gen'
 import { useSimilarOffers } from 'features/offer/api/useSimilarOffers'
@@ -16,9 +15,6 @@ type Props = {
 
 type UseOfferPlaylistType = {
   sameArtistPlaylist: HitOfferWithArtistAndEan[]
-  refetchSameArtistPlaylist: <TPageData>(
-    options?: (RefetchOptions & RefetchQueryFilters<TPageData>) | undefined
-  ) => Promise<QueryObserverResult<HitOfferWithArtistAndEan[], unknown>>
   sameCategorySimilarOffers?: Offer[]
   apiRecoParamsSameCategory?: RecommendationApiParams
   otherCategoriesSimilarOffers?: Offer[]
@@ -35,7 +31,7 @@ export const useOfferPlaylist = ({
   const artists = offer.extraData?.author
   const ean = offer.extraData?.ean
   const venueLocation = offer.venue.coordinates
-  const { sameArtistPlaylist, refetchSameArtistPlaylist } = useSameArtistPlaylist({
+  const { sameArtistPlaylist } = useSameArtistPlaylist({
     artists,
     ean,
     searchGroupName: offerSearchGroup,
@@ -72,7 +68,6 @@ export const useOfferPlaylist = ({
 
   return {
     sameArtistPlaylist,
-    refetchSameArtistPlaylist,
     sameCategorySimilarOffers,
     apiRecoParamsSameCategory,
     otherCategoriesSimilarOffers,

--- a/src/features/offer/pages/Offer/Offer.native.test.tsx
+++ b/src/features/offer/pages/Offer/Offer.native.test.tsx
@@ -18,7 +18,6 @@ jest
 
 jest.spyOn(useSameArtistPlaylist, 'useSameArtistPlaylist').mockImplementation().mockReturnValue({
   sameArtistPlaylist: mockedAlgoliaOffersWithSameArtistResponse,
-  refetchSameArtistPlaylist: jest.fn(),
 })
 
 let mockData: SubcategoriesResponseModelv2 | undefined = placeholderData


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-26803

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

Première vidéo avant puis deuxième après

## Screenshots


https://github.com/pass-culture/pass-culture-app-native/assets/78556024/4f614271-7382-455c-aaa2-7572fae81b69


https://github.com/pass-culture/pass-culture-app-native/assets/78556024/eee8abfa-0eb5-477c-99ef-8ca48d60c21d




[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
