### PR TITLE
(PC-26917) fix(SetPassword): Removed "Obligatoire" from screen to set password

### DIFF
--- a/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
@@ -75,20 +75,6 @@ exports[`SetPassword Page should render correctly 1`] = `
         >
           Mot de passe
         </Text>
-        <Text
-          style={
-            [
-              {
-                "color": "#696A6F",
-                "fontFamily": "Montserrat-SemiBold",
-                "fontSize": 12,
-                "lineHeight": 16,
-              },
-            ]
-          }
-        >
-          Obligatoire
-        </Text>
       </View>
     </View>
     <View
@@ -129,7 +115,7 @@ exports[`SetPassword Page should render correctly 1`] = `
     >
       <TextInput
         accessibilityDescribedBy="testUuidV4"
-        accessibilityRequired={true}
+        accessibilityRequired={false}
         autoCapitalize="none"
         autoFocus={true}
         editable={true}

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -2809,20 +2809,6 @@ exports[`Signup Form should render correctly for SetPassword 1`] = `
               >
                 Mot de passe
               </Text>
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#696A6F",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 12,
-                      "lineHeight": 16,
-                    },
-                  ]
-                }
-              >
-                Obligatoire
-              </Text>
             </View>
           </View>
           <View
@@ -2863,7 +2849,7 @@ exports[`Signup Form should render correctly for SetPassword 1`] = `
           >
             <TextInput
               accessibilityDescribedBy="testUuidV4"
-              accessibilityRequired={true}
+              accessibilityRequired={false}
               autoCapitalize="none"
               autoFocus={true}
               editable={true}

--- a/src/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx
+++ b/src/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx
@@ -29,6 +29,12 @@ describe('SetPassword Page', () => {
     expect(screen.getByText('12 caractères')).toBeOnTheScreen()
   })
 
+  it('should not display "Obligatoire"', () => {
+    render(<SetPassword {...props} />)
+
+    expect(screen.queryByText('Obligatoire')).toBeNull()
+  })
+
   it('should disable the submit button when password is incorrect', () => {
     render(<SetPassword {...props} />)
 

--- a/src/features/auth/pages/signup/SetPassword/SetPassword.tsx
+++ b/src/features/auth/pages/signup/SetPassword/SetPassword.tsx
@@ -48,6 +48,7 @@ export const SetPassword: FunctionComponent<PreValidationSignupNormalStepProps> 
         securityRulesAlwaysVisible
         autoFocus
         nativeAutoFocus
+        isRequiredField={false}
       />
       <Spacer.Column numberOfSpaces={10} />
       <ButtonPrimary


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-26917

## Checklist

I have:

- [x] Made sure my feature is working on the web.
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome | <img width="1440" alt="Screenshot 2024-01-22 at 10 31 08" src="https://github.com/pass-culture/pass-culture-app-native/assets/75068235/9e305984-6320-421d-9a53-d21a261497f5"> | <img width="1440" alt="Screenshot 2024-01-22 at 10 31 34" src="https://github.com/pass-culture/pass-culture-app-native/assets/75068235/33c7baf9-980e-49ce-a28c-3d4e62924bb2"> |