### PR TITLE
(PC-25003) fix(search): visual harmonization

### DIFF
--- a/__snapshots__/features/search/components/SearchResults/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/components/SearchResults/SearchResults.native.test.tsx.native-snap
@@ -3,16 +3,6 @@
 exports[`SearchResults component should render correctly 1`] = `
 [
   <View>
-    <View
-      numberOfSpaces={2}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
     <RCTScrollView
       horizontal={true}
       showsHorizontalScrollIndicator={false}

--- a/__snapshots__/features/search/components/SearchResults/SearchResults.web.test.tsx.web-snap
+++ b/__snapshots__/features/search/components/SearchResults/SearchResults.web.test.tsx.web-snap
@@ -247,9 +247,6 @@ exports[`SearchResults component should render correctly 1`] = `
         class="css-view-175oi2r"
       >
         <div
-          class="css-view-175oi2r r-height-3da1kt"
-        />
-        <div
           class="css-view-175oi2r r-WebkitOverflowScrolling-150rngu r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-overflowX-lltvgl r-overflowY-buy8e9 r-transform-1sncvnh r-scrollbarWidth-2eszeu"
         >
           <div
@@ -721,9 +718,6 @@ exports[`SearchResults component should render correctly 1`] = `
     <div
       class="css-view-175oi2r"
     >
-      <div
-        class="css-view-175oi2r r-height-3da1kt"
-      />
       <div
         class="css-view-175oi2r r-WebkitOverflowScrolling-150rngu r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-overflowX-lltvgl r-overflowY-buy8e9 r-transform-1sncvnh r-scrollbarWidth-2eszeu"
       >

--- a/__snapshots__/features/search/pages/Search/Search.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/Search/Search.native.test.tsx.native-snap
@@ -416,11 +416,11 @@ exports[`<Search/> should render Search 1`] = `
     </View>
   </View>
   <View
-    numberOfSpaces={4}
+    numberOfSpaces={2}
     style={
       [
         {
-          "height": 16,
+          "height": 8,
         },
       ]
     }
@@ -893,7 +893,7 @@ exports[`<Search/> should render Search 1`] = `
                   "fontSize": 20,
                   "lineHeight": 24,
                   "marginBottom": 8,
-                  "marginTop": 24,
+                  "marginTop": 16,
                   "paddingHorizontal": 12,
                 },
               ]

--- a/src/features/search/components/CategoriesButtonsDisplay/CategoriesButtonsDisplay.tsx
+++ b/src/features/search/components/CategoriesButtonsDisplay/CategoriesButtonsDisplay.tsx
@@ -45,7 +45,7 @@ const CategoriesTitle = styled(Typo.Title3).attrs({
   children: 'Explore les catégories',
   ...getHeadingAttrs(2),
 })(({ theme }) => ({
-  marginTop: getSpacing(6),
+  marginTop: getSpacing(4),
   marginBottom: getSpacing(theme.isDesktopViewport ? 1 : 2),
   paddingHorizontal: getSpacing(3),
 }))

--- a/src/features/search/components/SearchListHeader/SearchListHeader.tsx
+++ b/src/features/search/components/SearchListHeader/SearchListHeader.tsx
@@ -104,7 +104,7 @@ export const SearchListHeader: React.FC<SearchListHeaderProps> = ({
     <View testID="searchListHeader">
       {!!shouldDisplayGeolocationButton && (
         <React.Fragment>
-          <Spacer.Column numberOfSpaces={3} />
+          <Spacer.Column numberOfSpaces={4} />
           <GeolocationButtonContainer
             onPress={onPress}
             accessibilityLabel="Active ta géolocalisation">
@@ -126,7 +126,7 @@ export const SearchListHeader: React.FC<SearchListHeaderProps> = ({
       )}
       {!!shouldDisplayVenuesPlaylist && (
         <React.Fragment>
-          <Spacer.Column numberOfSpaces={3} />
+          <Spacer.Column numberOfSpaces={4} />
           <View>
             <Title>{venueTitle}</Title>
             <NumberOfResults nbHits={venues?.length ?? 0} />
@@ -150,7 +150,7 @@ export const SearchListHeader: React.FC<SearchListHeaderProps> = ({
           <StyledSeparator />
         </React.Fragment>
       )}
-      <Spacer.Column numberOfSpaces={5} />
+      <Spacer.Column numberOfSpaces={4} />
       <Title>{offerTitle}</Title>
       <NumberOfResults nbHits={nbHits} />
     </View>

--- a/src/features/search/components/SearchResults/SearchResults.tsx
+++ b/src/features/search/components/SearchResults/SearchResults.tsx
@@ -218,7 +218,6 @@ export const SearchResults: React.FC = () => {
         toggle={() => setAutoScrollEnabled((autoScroll) => !autoScroll)}
       />
       <View>
-        <Spacer.Column numberOfSpaces={2} />
         <ScrollView horizontal showsHorizontalScrollIndicator={false}>
           <Spacer.Row numberOfSpaces={5} />
           <Ul>

--- a/src/features/search/components/SearchSuggestions/SearchSuggestions.tsx
+++ b/src/features/search/components/SearchSuggestions/SearchSuggestions.tsx
@@ -84,7 +84,7 @@ export const SearchSuggestions = ({
       keyboardShouldPersistTaps="handled"
       onScroll={Keyboard.dismiss}
       scrollEventThrottle={16}>
-      <Spacer.Column numberOfSpaces={2} />
+      <Spacer.Column numberOfSpaces={4} />
       <SearchHistory
         history={filteredHistory}
         queryHistory={queryHistory}

--- a/src/features/search/pages/Search/Search.tsx
+++ b/src/features/search/pages/Search/Search.tsx
@@ -74,7 +74,7 @@ export function Search() {
             addSearchHistory={addToHistory}
             searchInHistory={setQueryHistoryMemoized}
           />
-          <Spacer.Column numberOfSpaces={4} />
+          <Spacer.Column numberOfSpaces={2} />
           {isFocusOnSuggestions ? (
             <SearchSuggestions
               queryHistory={queryHistory}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25003

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |<img width="438" alt="Capture d’écran 2024-01-22 à 18 25 52" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/ced2ac9b-c5b9-4c66-b2cf-61a596bced77"> <img width="445" alt="Capture d’écran 2024-01-22 à 18 25 58" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/62d995d1-647d-45e1-94ec-58609c2c7b58"> <img width="448" alt="Capture d’écran 2024-01-22 à 18 26 17" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/79bed39d-be28-4cd7-921a-a0cc3c34ae17"> <img width="439" alt="Capture d’écran 2024-01-22 à 18 26 04" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/d269b183-52bc-41cf-a380-d116854ac02e"> <img width="436" alt="Capture d’écran 2024-01-22 à 18 26 24" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/e6e0a34e-e416-4a07-af82-08d792232e60">|
| Android          |               |<img width="432" alt="Capture d’écran 2024-01-22 à 18 24 26" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/e7a554ce-e1d2-4e78-a1eb-22989b7fc249"> <img width="437" alt="Capture d’écran 2024-01-22 à 18 24 33" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/a7f6ede5-9a27-4d22-a7b9-218f22ccffc3"> <img width="434" alt="Capture d’écran 2024-01-22 à 18 24 17" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/2b12b920-9227-4f50-a060-34fc9f0ff16d"> <img width="428" alt="Capture d’écran 2024-01-22 à 18 24 49" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/f153dce0-ea41-494f-b7ed-fa40aed3e382"> <img width="421" alt="Capture d’écran 2024-01-22 à 18 24 58" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/5c3deee2-8870-4085-b81c-fba7257c6002">|
| Phone - Chrome   |<img width="444" alt="Capture d’écran 2024-01-22 à 18 28 37" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/390f7bae-a017-4155-8ba9-8301d509a7aa"> <img width="405" alt="Capture d’écran 2024-01-22 à 18 28 13" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/9267891b-e714-48db-93e5-a797d186a532"> <img width="395" alt="Capture d’écran 2024-01-22 à 18 28 18" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/be623f01-61d1-49c7-89f6-05392c17927c"> <img width="430" alt="Capture d’écran 2024-01-22 à 18 28 24" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/ed924b85-cb35-4a27-a2a6-e6c16714d605"> <img width="440" alt="Capture d’écran 2024-01-22 à 18 28 32" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/ccab8e3d-b549-4505-9578-3af6208401b2">|![Capture d’écran 2024-01-22 à 18 11 48](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/68892e1b-8d65-4245-bbf7-43bdbf76d696) ![Capture d’écran 2024-01-22 à 18 11 56](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/3b83e42d-e35f-43b4-ba48-0bbb61f5d4b3) ![Capture d’écran 2024-01-22 à 18 12 03](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/d919fdef-96c5-40e2-9e12-c96d1a251d33) ![Capture d’écran 2024-01-22 à 18 12 16](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/11765b4c-8d1b-4465-a4c0-a575d3a32090) ![Capture d’écran 2024-01-22 à 18 12 21](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/64d8d44d-13e7-4671-b02f-79a040a43de1)|
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
