### PR TITLE
fix(android): cast elevation to string to avoid warning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,6 @@ import { SnackBarProvider } from 'ui/components/snackBar/SnackBarContext'
 
 LogBox.ignoreLogs([
   'Setting a timer',
-  'Expected style "elevation:',
   'OfferNotFoundError', // custom error
   // The following warning is caused by TabNavigationContext which is updated by the `tabbar` prop
   // of TabNavigator. As of today, no bug has been observed which seems related to the warning.

--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -184,8 +184,6 @@ describe('<OfferBody />', () => {
       afterAll(() => (Platform.OS = 'ios'))
 
       it('should open social medium on share button press using correct message', async () => {
-        // FIXME(PC-21174): This warning comes from android 'Expected style "elevation: 16px" to be unitless' due to shadow style
-        jest.spyOn(global.console, 'warn').mockImplementationOnce(() => null)
         canOpenURLSpy.mockResolvedValueOnce(true)
         renderOfferBody({})
 

--- a/src/features/profile/pages/NotificationSettings/NotificationSettings.native.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationSettings.native.test.tsx
@@ -31,9 +31,6 @@ describe('NotificationSettings', () => {
     })
 
     it('should only display the email switch on android', async () => {
-      // FIXME(PC-211174): This warning comes from android 'Expected style "elevation: 4px" to be unitless' due to shadow style (https://passculture.atlassian.net/browse/PC-21174)
-      jest.spyOn(global.console, 'warn').mockImplementationOnce(() => null)
-
       Platform.OS = 'android'
       renderNotificationSettings('granted', {} as UserProfileResponse)
 

--- a/src/features/venue/components/VenueBody/VenueBody.native.test.tsx
+++ b/src/features/venue/components/VenueBody/VenueBody.native.test.tsx
@@ -102,9 +102,6 @@ describe('<VenueBody />', () => {
     afterAll(() => (Platform.OS = 'ios'))
 
     it('should open social medium on share button press', async () => {
-      // FIXME(PC-21174): This warning comes from android 'Expected style "elevation: 16px" to be unitless' due to shadow style
-      jest.spyOn(global.console, 'warn').mockImplementationOnce(() => null)
-      jest.spyOn(global.console, 'warn').mockImplementationOnce(() => null)
       canOpenURLSpy.mockResolvedValueOnce(true)
       await renderVenueBody(venueId)
 

--- a/src/ui/theme/shadow.ts
+++ b/src/ui/theme/shadow.ts
@@ -1,5 +1,5 @@
 import colorAlpha from 'color-alpha'
-import { Platform, ViewStyle } from 'react-native'
+import { Platform } from 'react-native'
 
 // eslint-disable-next-line no-restricted-imports
 import { ColorsEnum } from 'ui/theme/colors'
@@ -13,7 +13,12 @@ type InputShadow = {
   shadowColor: ColorsEnum | string
   shadowOpacity: number
 }
-type AndroidShadow = Pick<ViewStyle, 'elevation'>
+type AndroidShadow = {
+  // To avoid the following error:
+  // WARN  Expected style "elevation: 2.2857142857142856px" to be unitless
+  // https://github.com/styled-components/styled-components/issues/3254
+  elevation: string
+}
 type IOSShadow = {
   shadowOffset: string
   shadowRadius: number
@@ -31,7 +36,7 @@ export function getShadow(
     if (Platform.Version < 5) {
       return {}
     }
-    return { elevation: Number(shadowInput.shadowOffset.height) * 2 }
+    return { elevation: `${Number(shadowInput.shadowOffset.height) * 2}` }
   }
   if (Platform.OS === 'ios') {
     return {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-21174

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
