### PR TITLE
(PC-27171) refactor(useOfferAnalytics): create useLogPlaylistVertical.

### DIFF
--- a/src/features/offer/helpers/useLogPlaylistVertical/useLogPlaylistVertical.test.ts
+++ b/src/features/offer/helpers/useLogPlaylistVertical/useLogPlaylistVertical.test.ts
@@ -1,0 +1,173 @@
+import { PlaylistType } from 'features/offer/enums'
+import { useLogPlaylist } from 'features/offer/helpers/useLogPlaylistVertical/useLogPlaylistVertical'
+import { analytics } from 'libs/analytics'
+import { RecommendationApiParams } from 'shared/offer/types'
+import { renderHook } from 'tests/utils'
+
+const apiRecoParams: RecommendationApiParams = {
+  call_id: '1',
+  filtered: true,
+  geo_located: false,
+  model_endpoint: 'default',
+  model_name: 'similar_offers_default_prod',
+  model_version: 'similar_offers_clicks_v2_1_prod_v_20230317T173445',
+  reco_origin: 'default',
+}
+
+describe('useLogPlaylist', () => {
+  it('should logSameCategoryPlaylistVerticalScroll correctly', () => {
+    const { result } = renderHook(() =>
+      useLogPlaylist({
+        offerId: 1,
+        nbSameArtistPlaylist: 3,
+        nbSameCategorySimilarOffers: 5,
+        nbOtherCategoriesSimilarOffers: 0,
+        apiRecoParamsSameCategory: apiRecoParams,
+        fromOfferId: 2,
+      })
+    )
+
+    result.current.logSameCategoryPlaylistVerticalScroll()
+
+    expect(analytics.logPlaylistVerticalScroll).toHaveBeenNthCalledWith(1, {
+      ...apiRecoParams,
+      fromOfferId: 2,
+      offerId: 1,
+      playlistType: PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS,
+      nbResults: 5,
+    })
+  })
+
+  it('should log only once logSameCategoryPlaylistVerticalScroll', () => {
+    const { result } = renderHook(() =>
+      useLogPlaylist({
+        offerId: 1,
+        nbSameArtistPlaylist: 3,
+        nbSameCategorySimilarOffers: 5,
+        nbOtherCategoriesSimilarOffers: 0,
+        apiRecoParamsSameCategory: apiRecoParams,
+        fromOfferId: 2,
+      })
+    )
+
+    result.current.logSameCategoryPlaylistVerticalScroll()
+
+    expect(analytics.logPlaylistVerticalScroll).toHaveBeenCalledTimes(1)
+
+    result.current.logSameCategoryPlaylistVerticalScroll()
+
+    expect(analytics.logPlaylistVerticalScroll).toHaveBeenCalledTimes(1)
+  })
+
+  it('should logOtherCategoriesPlaylistVerticalScroll correctly', () => {
+    const { result } = renderHook(() =>
+      useLogPlaylist({
+        offerId: 1,
+        nbSameArtistPlaylist: 3,
+        nbSameCategorySimilarOffers: 0,
+        nbOtherCategoriesSimilarOffers: 5,
+        apiRecoParamsOtherCategories: apiRecoParams,
+        fromOfferId: 2,
+      })
+    )
+
+    result.current.logOtherCategoriesPlaylistVerticalScroll()
+
+    expect(analytics.logPlaylistVerticalScroll).toHaveBeenNthCalledWith(1, {
+      ...apiRecoParams,
+      fromOfferId: 2,
+      offerId: 1,
+      playlistType: PlaylistType.OTHER_CATEGORIES_SIMILAR_OFFERS,
+      nbResults: 5,
+    })
+  })
+
+  it('should log only once logOtherCategoriesPlaylistVerticalScroll', () => {
+    const { result } = renderHook(() =>
+      useLogPlaylist({
+        offerId: 1,
+        nbSameArtistPlaylist: 3,
+        nbSameCategorySimilarOffers: 0,
+        nbOtherCategoriesSimilarOffers: 5,
+        apiRecoParamsOtherCategories: apiRecoParams,
+        fromOfferId: 2,
+      })
+    )
+
+    result.current.logOtherCategoriesPlaylistVerticalScroll()
+
+    expect(analytics.logPlaylistVerticalScroll).toHaveBeenCalledTimes(1)
+
+    result.current.logOtherCategoriesPlaylistVerticalScroll()
+
+    expect(analytics.logPlaylistVerticalScroll).toHaveBeenCalledTimes(1)
+  })
+
+  it('should logSameArtistPlaylistVerticalScroll correctly', () => {
+    const { result } = renderHook(() =>
+      useLogPlaylist({
+        offerId: 1,
+        nbSameArtistPlaylist: 3,
+        nbOtherCategoriesSimilarOffers: 0,
+        nbSameCategorySimilarOffers: 0,
+        fromOfferId: 2,
+      })
+    )
+
+    result.current.logSameArtistPlaylistVerticalScroll()
+
+    expect(analytics.logPlaylistVerticalScroll).toHaveBeenNthCalledWith(1, {
+      fromOfferId: 2,
+      offerId: 1,
+      playlistType: PlaylistType.SAME_ARTIST_PLAYLIST,
+      nbResults: 3,
+    })
+  })
+
+  it('should log only once logSameArtistPlaylistVerticalScroll', () => {
+    const { result } = renderHook(() =>
+      useLogPlaylist({
+        offerId: 1,
+        nbSameArtistPlaylist: 3,
+        nbOtherCategoriesSimilarOffers: 0,
+        nbSameCategorySimilarOffers: 0,
+        fromOfferId: 2,
+      })
+    )
+
+    result.current.logSameArtistPlaylistVerticalScroll()
+
+    expect(analytics.logPlaylistVerticalScroll).toHaveBeenCalledTimes(1)
+
+    result.current.logSameArtistPlaylistVerticalScroll()
+
+    expect(analytics.logPlaylistVerticalScroll).toHaveBeenCalledTimes(1)
+  })
+
+  it('should logPlaylistHorizontalScroll correctly', () => {
+    const { result, rerender } = renderHook(
+      ({ fromOfferId }) =>
+        useLogPlaylist({
+          offerId: 1,
+          nbSameArtistPlaylist: 3,
+          nbOtherCategoriesSimilarOffers: 0,
+          nbSameCategorySimilarOffers: 0,
+          fromOfferId,
+        }),
+      {
+        initialProps: { fromOfferId: 2 },
+      }
+    )
+
+    result.current.logPlaylistHorizontalScroll()
+
+    expect(analytics.logPlaylistHorizontalScroll).toHaveBeenCalledWith(2)
+
+    // Testing with a different fromOfferId
+    rerender({ fromOfferId: 3 })
+
+    result.current.logPlaylistHorizontalScroll()
+
+    expect(analytics.logPlaylistHorizontalScroll).toHaveBeenCalledWith(3)
+  })
+})

--- a/src/features/offer/helpers/useLogPlaylistVertical/useLogPlaylistVertical.tsx
+++ b/src/features/offer/helpers/useLogPlaylistVertical/useLogPlaylistVertical.tsx
@@ -1,0 +1,73 @@
+import { useCallback } from 'react'
+
+import { PlaylistType } from 'features/offer/enums'
+import { analytics } from 'libs/analytics'
+import { useFunctionOnce } from 'libs/hooks'
+import { RecommendationApiParams } from 'shared/offer/types'
+
+type Props = {
+  offerId: number
+  nbSameArtistPlaylist: number
+  nbSameCategorySimilarOffers: number
+  nbOtherCategoriesSimilarOffers: number
+  apiRecoParamsSameCategory?: RecommendationApiParams
+  apiRecoParamsOtherCategories?: RecommendationApiParams
+  fromOfferId?: number
+}
+
+type UseLogPlaylistType = {
+  logPlaylistHorizontalScroll: VoidFunction
+  logSameCategoryPlaylistVerticalScroll: VoidFunction
+  logOtherCategoriesPlaylistVerticalScroll: VoidFunction
+  logSameArtistPlaylistVerticalScroll: VoidFunction
+}
+
+export const useLogPlaylist = ({
+  nbSameArtistPlaylist,
+  apiRecoParamsSameCategory,
+  nbSameCategorySimilarOffers,
+  apiRecoParamsOtherCategories,
+  nbOtherCategoriesSimilarOffers,
+  offerId,
+  fromOfferId,
+}: Props): UseLogPlaylistType => {
+  const logPlaylistHorizontalScroll = useCallback(() => {
+    analytics.logPlaylistHorizontalScroll(fromOfferId)
+  }, [fromOfferId])
+
+  const logSameCategoryPlaylistVerticalScroll = useFunctionOnce(() => {
+    analytics.logPlaylistVerticalScroll({
+      ...apiRecoParamsSameCategory,
+      fromOfferId,
+      offerId,
+      playlistType: PlaylistType.SAME_CATEGORY_SIMILAR_OFFERS,
+      nbResults: nbSameCategorySimilarOffers,
+    })
+  })
+
+  const logOtherCategoriesPlaylistVerticalScroll = useFunctionOnce(() => {
+    analytics.logPlaylistVerticalScroll({
+      ...apiRecoParamsOtherCategories,
+      fromOfferId,
+      offerId,
+      playlistType: PlaylistType.OTHER_CATEGORIES_SIMILAR_OFFERS,
+      nbResults: nbOtherCategoriesSimilarOffers,
+    })
+  })
+
+  const logSameArtistPlaylistVerticalScroll = useFunctionOnce(() => {
+    analytics.logPlaylistVerticalScroll({
+      fromOfferId,
+      offerId,
+      playlistType: PlaylistType.SAME_ARTIST_PLAYLIST,
+      nbResults: nbSameArtistPlaylist,
+    })
+  })
+
+  return {
+    logPlaylistHorizontalScroll,
+    logSameCategoryPlaylistVerticalScroll,
+    logOtherCategoriesPlaylistVerticalScroll,
+    logSameArtistPlaylistVerticalScroll,
+  }
+}

--- a/src/features/offerv2/components/OfferPlaylistList/OfferPlaylistList.native.test.tsx
+++ b/src/features/offerv2/components/OfferPlaylistList/OfferPlaylistList.native.test.tsx
@@ -38,9 +38,6 @@ const mockSearchHits = [...mockedAlgoliaResponse.hits, ...moreHitsForSimilarOffe
 const offerPlaylistListProps: OfferPlaylistListProps = {
   offer: mockOffer,
   position: null,
-  handleChangeSameArtistPlaylistDisplay: jest.fn(),
-  handleChangeSameCategoryPlaylistDisplay: jest.fn(),
-  handleChangeOtherCategoriesPlaylistDisplay: jest.fn(),
 }
 
 describe('<OfferPlaylistList />', () => {
@@ -165,9 +162,6 @@ const renderOfferPlaylistList = ({
   sameCategorySimilarOffers,
   otherCategoriesSimilarOffers,
   sameArtistPlaylist,
-  handleChangeSameArtistPlaylistDisplay,
-  handleChangeSameCategoryPlaylistDisplay,
-  handleChangeOtherCategoriesPlaylistDisplay,
 }: OfferPlaylistListProps) =>
   render(
     reactQueryProviderHOC(
@@ -177,9 +171,6 @@ const renderOfferPlaylistList = ({
         sameCategorySimilarOffers={sameCategorySimilarOffers}
         otherCategoriesSimilarOffers={otherCategoriesSimilarOffers}
         sameArtistPlaylist={sameArtistPlaylist}
-        handleChangeSameArtistPlaylistDisplay={handleChangeSameArtistPlaylistDisplay}
-        handleChangeSameCategoryPlaylistDisplay={handleChangeSameCategoryPlaylistDisplay}
-        handleChangeOtherCategoriesPlaylistDisplay={handleChangeOtherCategoriesPlaylistDisplay}
       />
     )
   )

--- a/src/features/offerv2/components/OfferPlaylistList/OfferPlaylistList.tsx
+++ b/src/features/offerv2/components/OfferPlaylistList/OfferPlaylistList.tsx
@@ -6,7 +6,9 @@ import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { HitOfferWithArtistAndEan } from 'features/offer/components/OfferPlaylistOld/api/fetchOffersByArtist'
 import { OfferTile } from 'features/offer/components/OfferTile/OfferTile'
 import { PlaylistType } from 'features/offer/enums'
+import { useLogPlaylist } from 'features/offer/helpers/useLogPlaylistVertical/useLogPlaylistVertical'
 import { OfferPlaylist } from 'features/offerv2/components/OfferPlaylist/OfferPlaylist'
+import { useLogScrollHandler } from 'features/offerv2/helpers/useLogScrolHandler/useLogScrollHandler'
 import { analytics } from 'libs/analytics'
 import { getPlaylistItemDimensionsFromLayout } from 'libs/contentful/dimensions'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
@@ -22,9 +24,6 @@ import { Spacer } from 'ui/theme'
 
 export type OfferPlaylistListProps = {
   offer: OfferResponse
-  handleChangeSameArtistPlaylistDisplay: (inView: boolean) => void
-  handleChangeSameCategoryPlaylistDisplay: (inView: boolean) => void
-  handleChangeOtherCategoriesPlaylistDisplay: (inView: boolean) => void
   position: Position
   sameCategorySimilarOffers?: Offer[]
   apiRecoParamsSameCategory?: RecommendationApiParams
@@ -93,14 +92,37 @@ export function OfferPlaylistList({
   otherCategoriesSimilarOffers,
   apiRecoParamsOtherCategories,
   sameArtistPlaylist,
-  handleChangeSameArtistPlaylistDisplay,
-  handleChangeSameCategoryPlaylistDisplay,
-  handleChangeOtherCategoriesPlaylistDisplay,
 }: Readonly<OfferPlaylistListProps>) {
   const route = useRoute<UseRouteType<'Offer'>>()
   const fromOfferId = route.params?.fromOfferId
   const categoryMapping = useCategoryIdMapping()
   const labelMapping = useCategoryHomeLabelMapping()
+
+  const {
+    logSameCategoryPlaylistVerticalScroll,
+    logOtherCategoriesPlaylistVerticalScroll,
+    logSameArtistPlaylistVerticalScroll,
+  } = useLogPlaylist({
+    offerId: offer.id,
+    nbSameArtistPlaylist: sameArtistPlaylist?.length ?? 0,
+    apiRecoParamsSameCategory,
+    nbSameCategorySimilarOffers: sameCategorySimilarOffers?.length ?? 0,
+    apiRecoParamsOtherCategories,
+    nbOtherCategoriesSimilarOffers: otherCategoriesSimilarOffers?.length ?? 0,
+    fromOfferId,
+  })
+
+  const handleChangeSameArtistPlaylistDisplay = useLogScrollHandler(
+    logSameArtistPlaylistVerticalScroll
+  )
+
+  const handleChangeOtherCategoriesPlaylistDisplay = useLogScrollHandler(
+    logOtherCategoriesPlaylistVerticalScroll
+  )
+
+  const handleChangeSameCategoryPlaylistDisplay = useLogScrollHandler(
+    logSameCategoryPlaylistVerticalScroll
+  )
 
   const enableSameArtistPlaylist = useFeatureFlag(RemoteStoreFeatureFlags.WIP_SAME_ARTIST_PLAYLIST)
   const shouldDisplaySameArtistPlaylist =


### PR DESCRIPTION
When we going to clean offer v1 legacy we can remove useOfferAnalytics hook

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-27171

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
