### PR TITLE
(PC-27722) feat(proxy): add offer canonical url to its description page

### DIFF
--- a/server/src/middlewares/tests/webAppProxyMiddleware.test.ts
+++ b/server/src/middlewares/tests/webAppProxyMiddleware.test.ts
@@ -193,6 +193,14 @@ describe('metasResponseInterceptor', () => {
           expect(response).not.toContain('<meta name="robots" content="noindex" />')
         }
       )
+
+      it('links offer description page to its offer page', async () => {
+        const url = `${env.APP_PUBLIC_URL}/offre/${OFFER_RESPONSE_SNAPSHOT.id}`
+
+        const response = await htmlResponseFor(`${url}/description`)
+
+        expect(response).toMatch(hasCanonicalWith(url))
+      })
     })
   })
 

--- a/server/src/middlewares/tests/webAppProxyMiddleware.test.ts
+++ b/server/src/middlewares/tests/webAppProxyMiddleware.test.ts
@@ -149,7 +149,7 @@ describe('metasResponseInterceptor', () => {
       it('with encoded home id when url is thematic home', async () => {
         const url = `${env.APP_PUBLIC_URL}/accueil-thematique?homeId=1324434"><script>alert('hack')</script>`
         const canonicalUrl = new RegExp(
-          `<head>.*?<link rel="canonical" href="${env.APP_PUBLIC_URL}/accueil-thematique\\?homeId=1324434%22%3E%3Cscript%3Ealert\\('hack'\\)%3C%2Fscript%3E\" />.*?</head>`,
+          `<head>.*?<link rel="canonical" href="${env.APP_PUBLIC_URL}/accueil-thematique\\?homeId=1324434%22%3E%3Cscript%3Ealert\\(%27hack%27\\)%3C%2Fscript%3E\" />.*?</head>`,
           's'
         )
 

--- a/server/src/middlewares/tests/webAppProxyMiddleware.test.ts
+++ b/server/src/middlewares/tests/webAppProxyMiddleware.test.ts
@@ -78,7 +78,7 @@ describe('metasResponseInterceptor', () => {
         jsResponseBuffer,
         proxyRes,
         {
-          path: 'static/js/main.abcdef.chunk.js'
+          path: 'static/js/main.abcdef.chunk.js',
         } as Request,
         {
           setHeader,

--- a/server/src/middlewares/webAppProxyMiddleware.ts
+++ b/server/src/middlewares/webAppProxyMiddleware.ts
@@ -22,15 +22,16 @@ const options = {
   onProxyRes: responseInterceptor(metasResponseInterceptor),
 }
 
-const addCanonicalLinkToHTML = (html: string, url: URL): string => {
+const computeCanonicalUrl = (url: URL): URL => {
   const isThematicHome = url.pathname === '/accueil-thematique'
   const homeIdParams = url.searchParams.get('homeId')
   const additionalParams =
     isThematicHome && homeIdParams ? `?homeId=${encodeURIComponent(homeIdParams)}` : ''
-  return html.replace(
-    '<head>',
-    `<head><link rel="canonical" href="${env.APP_PUBLIC_URL}${url.pathname}${additionalParams}" />`
-  )
+  return new URL(`${env.APP_PUBLIC_URL}${url.pathname}${additionalParams}`)
+}
+
+const addCanonicalLinkToHTML = (html: string, url: URL): string => {
+  return html.replace('<head>', `<head><link rel="canonical" href="${url}" />`)
 }
 
 const addNoIndexToHTML = (html: string): string =>
@@ -66,7 +67,7 @@ export async function metasResponseInterceptor(
     match = ENTITY_PATH_REGEXP.exec(req.url)
 
     const url = new URL(req.url.startsWith('/') ? env.APP_PUBLIC_URL + req.url : req.url)
-    html = addCanonicalLinkToHTML(html, url)
+    html = addCanonicalLinkToHTML(html, computeCanonicalUrl(url))
 
     const isSearchPageWithParams =
       url.pathname === '/recherche' && [...url.searchParams.keys()].length

--- a/server/src/middlewares/webAppProxyMiddleware.ts
+++ b/server/src/middlewares/webAppProxyMiddleware.ts
@@ -13,6 +13,7 @@ const { APP_BUCKET_URL } = env
 const { href } = new URL(APP_BUCKET_URL)
 
 const ENTITY_PATH_REGEXP = new RegExp(`/(${Object.keys(ENTITY_MAP).join('|')})/(\\d+)`)
+const OFFER_DESCRIPTION_PATH_REGEXP = /(\/offre\/\d+)\/description/
 
 const options = {
   target: href,
@@ -23,6 +24,12 @@ const options = {
 }
 
 const computeCanonicalUrl = (url: URL): URL => {
+  const match = url.pathname.match(OFFER_DESCRIPTION_PATH_REGEXP)
+  if (match) {
+    const offerUrl = match[1]
+    return new URL(`${env.APP_PUBLIC_URL}${offerUrl}`)
+  }
+
   const isThematicHome = url.pathname === '/accueil-thematique'
   const homeIdParams = url.searchParams.get('homeId')
   const additionalParams =

--- a/server/src/middlewares/webAppProxyMiddleware.ts
+++ b/server/src/middlewares/webAppProxyMiddleware.ts
@@ -24,7 +24,7 @@ const options = {
 }
 
 const computeCanonicalUrl = (url: URL): URL => {
-  const match = url.pathname.match(OFFER_DESCRIPTION_PATH_REGEXP)
+  const match = OFFER_DESCRIPTION_PATH_REGEXP.exec(url.pathname)
   if (match) {
     const offerUrl = match[1]
     return new URL(`${env.APP_PUBLIC_URL}${offerUrl}`)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-27722

Need to be tested in testing, once merged!

I prefer to keep using encodeURIComponent in webAppProxyMiddleware.ts, because new URL() encode characters, but not "/"