### PR TITLE
(PC-25137) fix(offer): align external link icon with text in offer description

### DIFF
--- a/src/ui/components/buttons/externalLink/ExternalLink.tsx
+++ b/src/ui/components/buttons/externalLink/ExternalLink.tsx
@@ -40,7 +40,7 @@ const ButtonText = styled(Typo.ButtonText)<{ primary?: boolean }>(({ primary, th
 
 const ExternalSite = styled(DefaultExternalSite).attrs<{ primary?: boolean }>(
   ({ primary, theme }) => ({
-    color: primary ? theme.colors.primary : undefined,
+    color: primary ? theme.colors.primary : theme.colors.black,
     size: theme.icons.sizes.extraSmall,
   })
 )<{ primary?: boolean }>``

--- a/src/ui/components/buttons/externalLink/ExternalLink.web.tsx
+++ b/src/ui/components/buttons/externalLink/ExternalLink.web.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import webStyled from 'styled-components'
 import styled from 'styled-components/native'
 
 import { extractExternalLinkParts } from 'ui/components/buttons/externalLink/ExternalLink.service'
@@ -35,9 +36,11 @@ export const ExternalLink: React.FC<Props> = ({ url, text, primary, testID }) =>
   )
 }
 
-const Text = styled.Text({
+const Text = webStyled.span(({ theme }) => ({
   whiteSpace: 'nowrap',
-})
+  verticalAlign: 'middle',
+  ...theme.typography.buttonText,
+}))
 
 const StyledTouchableLink = styled(ExternalTouchableLink).attrs<{
   primary?: boolean

--- a/src/ui/svg/icons/ExternalSiteFilled.tsx
+++ b/src/ui/svg/icons/ExternalSiteFilled.tsx
@@ -13,7 +13,7 @@ const ExternalSiteFilledSvg: React.FunctionComponent<AccessibleIcon> = ({
   <AccessibleSvg
     width={size}
     height={size}
-    viewBox="0 0 48 36"
+    viewBox="0 0 48 48"
     testID={testID}
     accessibilityLabel={accessibilityLabel ?? 'Nouvelle fenêtre'}>
     <Path

--- a/src/ui/svg/icons/ExternalSiteFilled.tsx
+++ b/src/ui/svg/icons/ExternalSiteFilled.tsx
@@ -13,7 +13,7 @@ const ExternalSiteFilledSvg: React.FunctionComponent<AccessibleIcon> = ({
   <AccessibleSvg
     width={size}
     height={size}
-    viewBox="0 0 48 48"
+    viewBox="0 0 48 36"
     testID={testID}
     accessibilityLabel={accessibilityLabel ?? 'Nouvelle fenêtre'}>
     <Path


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25137

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |![Screenshot_1707316012](https://github.com/pass-culture/pass-culture-app-native/assets/75068235/182d0bfc-88c5-4bd2-8252-efd97172788b)|![Screenshot_1707315932](https://github.com/pass-culture/pass-culture-app-native/assets/75068235/43e01d26-549c-486c-8003-a886e79fb5ee)|
| Phone - Chrome   |               |       |
| Desktop - Chrome |<img width="480" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/75068235/7675def3-0703-4c54-a96b-a9a979025449">|<img width="474" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/75068235/951ea362-16ea-45ca-b602-585a0a05debb">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
