### PR TITLE
(PC-27872) fix(UI): add container to add margin to calendar only and not BottomBar

### DIFF
--- a/__snapshots__/features/offerv2/components/MovieCalendar/MovieCalendar.native.test.tsx.native-snap
+++ b/__snapshots__/features/offerv2/components/MovieCalendar/MovieCalendar.native.test.tsx.native-snap
@@ -23,6 +23,12 @@ exports[`<MovieCalendar/> should render MovieCalendar 1`] = `
     }
   />
   <RCTScrollView
+    contentContainerStyle={
+      {
+        "marginLeft": 24,
+        "marginRight": 24,
+      }
+    }
     horizontal={true}
     showsHorizontalScrollIndicator={false}
   >

--- a/src/features/offerv2/components/MovieCalendar/MovieCalendar.tsx
+++ b/src/features/offerv2/components/MovieCalendar/MovieCalendar.tsx
@@ -42,7 +42,10 @@ export const MovieCalendar: React.FC<Props> = ({ dates, selectedDate, onTabChang
   return (
     <Container>
       <BottomBar />
-      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={scrollViewContainer}>
         {dates.map((date) => {
           const { weekday, fullWeekDay, dayDate, month, fullMonth, timestamp } = extractDate(date)
           const isSelected = selectedDate.getTime() === timestamp
@@ -69,6 +72,8 @@ export const MovieCalendar: React.FC<Props> = ({ dates, selectedDate, onTabChang
 }
 
 const Container = styled.View({})
+
+const scrollViewContainer = { marginLeft: getSpacing(6), marginRight: getSpacing(6) }
 
 const BottomBar = styled.View(({ theme }) => ({
   position: 'absolute',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-27872

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change


## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              | ![Simulator Screenshot - iPhone Xs - 2024-02-08 at 12 02 09](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/b3b0e5e9-f9a0-4de5-95c4-ce035d93a7e1)| ![Simulator Screenshot - iPhone Xs - 2024-02-08 at 11 58 48](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/11daa540-4195-4caf-bd65-e7cfac795ecb)|
| Android          |![Screenshot_1707388425](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/08c8f258-dee2-4f76-b757-48a9e3ba1723)| ![Screenshot_1707390400](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/2e0c7736-69c4-4917-8e4b-e7949d35c158)|

