### PR TITLE
(BSR) feat(eslintrc): use react-navigation/native instead of react-navigation/core

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,6 +72,7 @@ module.exports = {
       'error',
       {
         paths: [
+          { name: '@react-navigation/core', message: 'use @react-navigation/native' },
           { name: 'lottie-react-native', message: 'use libs/lottie instead' },
           { name: 'react-content-loader', message: 'use react-content-loader/native instead' },
           { name: 'react-device-detect', message: 'use libs/react-device-detect instead' },
@@ -323,14 +324,7 @@ module.exports = {
     jest: true,
     serviceworker: true,
   },
-  ignorePatterns: [
-    '/build',
-    '.*.js',
-    '*.config.js',
-    'node_modules',
-    '/coverage',
-    '/server',
-  ],
+  ignorePatterns: ['/build', '.*.js', '*.config.js', 'node_modules', '/coverage', '/server'],
   // TypeScript files overrides
   overrides: [
     {

--- a/src/features/navigation/RootNavigator/useScreenshotListener.ts
+++ b/src/features/navigation/RootNavigator/useScreenshotListener.ts
@@ -1,4 +1,4 @@
-import { useIsFocused, useRoute } from '@react-navigation/core'
+import { useIsFocused, useRoute } from '@react-navigation/native'
 import { useEffect } from 'react'
 import { Platform } from 'react-native'
 import { addScreenshotListener } from 'react-native-detector'

--- a/src/features/search/helpers/getIsVenuePreviousRoute/getIsVenuePreviousRoute.ts
+++ b/src/features/search/helpers/getIsVenuePreviousRoute/getIsVenuePreviousRoute.ts
@@ -1,4 +1,4 @@
-import { NavigatorScreenParams, ParamListBase, RouteProp } from '@react-navigation/core'
+import { NavigatorScreenParams, ParamListBase, RouteProp } from '@react-navigation/native'
 
 import { TabParamList } from 'features/navigation/TabBar/types'
 import { getRouteFromIndex } from 'shared/getRouteFromIndex/getRouteFromIndex'

--- a/src/shared/getRouteFromIndex/getRouteFromIndex.test.ts
+++ b/src/shared/getRouteFromIndex/getRouteFromIndex.test.ts
@@ -1,4 +1,4 @@
-import { ParamListBase, RouteProp } from '@react-navigation/core'
+import { ParamListBase, RouteProp } from '@react-navigation/native'
 
 import { getRouteFromIndex } from 'shared/getRouteFromIndex/getRouteFromIndex'
 

--- a/src/shared/getRouteFromIndex/getRouteFromIndex.ts
+++ b/src/shared/getRouteFromIndex/getRouteFromIndex.ts
@@ -1,4 +1,4 @@
-import { ParamListBase, RouteProp } from '@react-navigation/core'
+import { ParamListBase, RouteProp } from '@react-navigation/native'
 
 export function getRouteFromIndex(routes: RouteProp<ParamListBase>[], indexPreviousRoute: number) {
   if (!routes.length) {

--- a/src/ui/components/Tooltip.tsx
+++ b/src/ui/components/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { useFocusEffect } from '@react-navigation/core'
+import { useFocusEffect } from '@react-navigation/native'
 import React, { ComponentProps, FunctionComponent, useCallback, useEffect, useRef } from 'react'
 import { Path, Svg } from 'react-native-svg'
 import styled, { useTheme } from 'styled-components/native'


### PR DESCRIPTION
I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).

Pourquoi on veut cela:
 @react-navigation/native est conçu pour envelopper @react-navigation/core et fournir une intégration plus profonde avec l'environnement spécifique de React Native. Il utilise des composants natifs et des API spécifiques à la plateforme pour offrir une expérience utilisateur plus fluide et naturelle sur les appareils mobiles. (il peut s'en déduire des avantages de perf, de facilité d'utilisation et d'intégration et une sensation de comportement plus "natif")