### PR TITLE
(PC-27006) fix(collapsible): do not collapse text when last line not filled

### DIFF
--- a/src/ui/components/CollapsibleText/CollapsibleText.tsx
+++ b/src/ui/components/CollapsibleText/CollapsibleText.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback, useState } from 'react'
-import { LayoutChangeEvent } from 'react-native'
-import styled, { useTheme } from 'styled-components/native'
+import React, { useState } from 'react'
+import styled from 'styled-components/native'
 
 import { highlightLinks } from 'libs/parsers/highlightLinks'
 import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
@@ -8,6 +7,8 @@ import { styledButton } from 'ui/components/buttons/styledButton'
 import { ArrowDown } from 'ui/svg/icons/ArrowDown'
 import { ArrowUp } from 'ui/svg/icons/ArrowUp'
 import { Typo } from 'ui/theme'
+
+import { useIsTextEllipsis } from './useIsTextEllipsis'
 
 type Props = {
   children: string
@@ -17,21 +18,13 @@ type Props = {
 
 export function CollapsibleText({ children, numberOfLines }: Readonly<Props>) {
   const [expanded, setExpanded] = useState(false)
-  const [shouldDisplayButton, setShouldDisplayButton] = useState(false)
-  const theme = useTheme()
-  const lineHeight = Number(theme.typography.body.lineHeight.slice(0, -2))
+  const {
+    isTextEllipsis: shouldDisplayButton,
+    onTextLayout,
+    onLayout,
+  } = useIsTextEllipsis(numberOfLines)
 
   const onPress = () => setExpanded((prevExpanded) => !prevExpanded)
-
-  const onLayout = useCallback(
-    (event: LayoutChangeEvent) => {
-      const textHeight = event.nativeEvent.layout.height
-      const maxTextHeight = lineHeight * numberOfLines
-
-      setShouldDisplayButton(textHeight >= maxTextHeight)
-    },
-    [lineHeight, numberOfLines]
-  )
 
   const buttonText = expanded ? 'Voir moins' : 'Voir plus'
   const accessibilityLabel = expanded ? 'Réduire le texte' : 'Étendre le texte'
@@ -39,7 +32,10 @@ export function CollapsibleText({ children, numberOfLines }: Readonly<Props>) {
 
   return (
     <React.Fragment>
-      <Typo.Body numberOfLines={expanded ? undefined : numberOfLines} onLayout={onLayout}>
+      <Typo.Body
+        numberOfLines={expanded ? undefined : numberOfLines}
+        onLayout={onLayout}
+        onTextLayout={onTextLayout}>
         {highlightLinks(children)}
       </Typo.Body>
       {shouldDisplayButton ? (

--- a/src/ui/components/CollapsibleText/types.ts
+++ b/src/ui/components/CollapsibleText/types.ts
@@ -1,0 +1,7 @@
+import { LayoutChangeEvent, NativeSyntheticEvent, TextLayoutEventData } from 'react-native'
+
+export type IsTextEllipsisOutput = {
+  isTextEllipsis: boolean
+  onTextLayout?: (event: NativeSyntheticEvent<TextLayoutEventData>) => void
+  onLayout?: (event: LayoutChangeEvent) => void
+}

--- a/src/ui/components/CollapsibleText/useIsTextEllipsis.android.test.tsx
+++ b/src/ui/components/CollapsibleText/useIsTextEllipsis.android.test.tsx
@@ -1,0 +1,34 @@
+import { NativeSyntheticEvent, TextLayoutEventData } from 'react-native'
+
+import { act, renderHook } from 'tests/utils'
+import { useIsTextEllipsis } from 'ui/components/CollapsibleText/useIsTextEllipsis.android'
+
+describe('useIsTextEllipsis', () => {
+  it('should return the text ends with ellipsis when the text takes more lines than the max', async () => {
+    const numberOfLines = 2
+    const { result } = renderHook(() => useIsTextEllipsis(numberOfLines))
+
+    const threeLinesEvent = {
+      nativeEvent: { lines: [{ width: 300 }, { width: 300 }, { width: 300 }] },
+    } as NativeSyntheticEvent<TextLayoutEventData>
+    await act(async () => {
+      result.current.onTextLayout?.(threeLinesEvent)
+    })
+
+    expect(result.current).toEqual({ isTextEllipsis: true, onTextLayout: expect.any(Function) })
+  })
+
+  it("should return the text doesn't end with ellipsis when the text fits in the max number of lines", async () => {
+    const numberOfLines = 2
+    const { result } = renderHook(() => useIsTextEllipsis(numberOfLines))
+
+    const twoLinesEvent = {
+      nativeEvent: { lines: [{ width: 300 }, { width: 300 }] },
+    } as NativeSyntheticEvent<TextLayoutEventData>
+    await act(async () => {
+      result.current.onTextLayout?.(twoLinesEvent)
+    })
+
+    expect(result.current).toEqual({ isTextEllipsis: false, onTextLayout: expect.any(Function) })
+  })
+})

--- a/src/ui/components/CollapsibleText/useIsTextEllipsis.android.ts
+++ b/src/ui/components/CollapsibleText/useIsTextEllipsis.android.ts
@@ -1,21 +1,21 @@
 import { useCallback, useState } from 'react'
-import { useTheme } from 'styled-components/native'
 
 import { IsTextEllipsisOutput } from './types'
 
+// On Android, onTextLayout returns the number of text lines without numberOfLines.
+// So we can check if the number of lines is greater than numberOfLines.
 export const useIsTextEllipsis = (numberOfLines: number): IsTextEllipsisOutput => {
   const [isTextEllipsis, setIsTextEllipsis] = useState(false)
-  const theme = useTheme()
-  const lineHeight = Number(theme.typography.body.lineHeight.slice(0, -2))
 
-  const onLayout: Required<IsTextEllipsisOutput>['onLayout'] = useCallback(
+  const onTextLayout: Required<IsTextEllipsisOutput>['onTextLayout'] = useCallback(
     (event) => {
-      const textHeight = event.nativeEvent.layout.height
-      const maxTextHeight = lineHeight * numberOfLines
+      const linesWidth = event.nativeEvent.lines.map((line) => line.width)
 
-      setIsTextEllipsis(textHeight >= maxTextHeight)
+      if (linesWidth.length > numberOfLines) {
+        setIsTextEllipsis(true)
+      }
     },
-    [lineHeight, numberOfLines]
+    [numberOfLines]
   )
-  return { isTextEllipsis, onLayout }
+  return { isTextEllipsis, onTextLayout }
 }

--- a/src/ui/components/CollapsibleText/useIsTextEllipsis.android.ts
+++ b/src/ui/components/CollapsibleText/useIsTextEllipsis.android.ts
@@ -1,0 +1,21 @@
+import { useCallback, useState } from 'react'
+import { useTheme } from 'styled-components/native'
+
+import { IsTextEllipsisOutput } from './types'
+
+export const useIsTextEllipsis = (numberOfLines: number): IsTextEllipsisOutput => {
+  const [isTextEllipsis, setIsTextEllipsis] = useState(false)
+  const theme = useTheme()
+  const lineHeight = Number(theme.typography.body.lineHeight.slice(0, -2))
+
+  const onLayout: Required<IsTextEllipsisOutput>['onLayout'] = useCallback(
+    (event) => {
+      const textHeight = event.nativeEvent.layout.height
+      const maxTextHeight = lineHeight * numberOfLines
+
+      setIsTextEllipsis(textHeight >= maxTextHeight)
+    },
+    [lineHeight, numberOfLines]
+  )
+  return { isTextEllipsis, onLayout }
+}

--- a/src/ui/components/CollapsibleText/useIsTextEllipsis.ios.ts
+++ b/src/ui/components/CollapsibleText/useIsTextEllipsis.ios.ts
@@ -1,21 +1,28 @@
-import { useCallback, useState } from 'react'
-import { useTheme } from 'styled-components/native'
+import { useCallback, useRef, useState } from 'react'
 
 import { IsTextEllipsisOutput } from './types'
 
+const ELLIPSIS_LENGTH = 10
+
+// On iOS, onTextLayout doesn't return more text lines than numberOfLines.
+// So we check if the last line is long enough, compared to the whole text width.
 export const useIsTextEllipsis = (numberOfLines: number): IsTextEllipsisOutput => {
+  const textWidth = useRef<number | undefined>(undefined)
   const [isTextEllipsis, setIsTextEllipsis] = useState(false)
-  const theme = useTheme()
-  const lineHeight = Number(theme.typography.body.lineHeight.slice(0, -2))
 
-  const onLayout: Required<IsTextEllipsisOutput>['onLayout'] = useCallback(
+  const onTextLayout: Required<IsTextEllipsisOutput>['onTextLayout'] = useCallback(
     (event) => {
-      const textHeight = event.nativeEvent.layout.height
-      const maxTextHeight = lineHeight * numberOfLines
-
-      setIsTextEllipsis(textHeight >= maxTextHeight)
+      const linesWidth = event.nativeEvent.lines.map((line) => line.width)
+      if (linesWidth.length === numberOfLines && textWidth.current !== undefined) {
+        setIsTextEllipsis(linesWidth[linesWidth.length - 1] >= textWidth.current - ELLIPSIS_LENGTH)
+      }
     },
-    [lineHeight, numberOfLines]
+    [numberOfLines]
   )
-  return { isTextEllipsis, onLayout }
+
+  const onLayout: Required<IsTextEllipsisOutput>['onLayout'] = useCallback((event) => {
+    textWidth.current = event.nativeEvent.layout.width
+  }, [])
+
+  return { isTextEllipsis, onTextLayout, onLayout }
 }

--- a/src/ui/components/CollapsibleText/useIsTextEllipsis.ios.ts
+++ b/src/ui/components/CollapsibleText/useIsTextEllipsis.ios.ts
@@ -1,0 +1,21 @@
+import { useCallback, useState } from 'react'
+import { useTheme } from 'styled-components/native'
+
+import { IsTextEllipsisOutput } from './types'
+
+export const useIsTextEllipsis = (numberOfLines: number): IsTextEllipsisOutput => {
+  const [isTextEllipsis, setIsTextEllipsis] = useState(false)
+  const theme = useTheme()
+  const lineHeight = Number(theme.typography.body.lineHeight.slice(0, -2))
+
+  const onLayout: Required<IsTextEllipsisOutput>['onLayout'] = useCallback(
+    (event) => {
+      const textHeight = event.nativeEvent.layout.height
+      const maxTextHeight = lineHeight * numberOfLines
+
+      setIsTextEllipsis(textHeight >= maxTextHeight)
+    },
+    [lineHeight, numberOfLines]
+  )
+  return { isTextEllipsis, onLayout }
+}

--- a/src/ui/components/CollapsibleText/useIsTextEllipsis.ts
+++ b/src/ui/components/CollapsibleText/useIsTextEllipsis.ts
@@ -3,6 +3,8 @@ import { useTheme } from 'styled-components/native'
 
 import { IsTextEllipsisOutput } from './types'
 
+// React Native Web doesn't support onTextLayout
+// https://github.com/necolas/react-native-web/issues/1685
 export const useIsTextEllipsis = (numberOfLines: number): IsTextEllipsisOutput => {
   const [isTextEllipsis, setIsTextEllipsis] = useState(false)
   const theme = useTheme()

--- a/src/ui/components/CollapsibleText/useIsTextEllipsis.ts
+++ b/src/ui/components/CollapsibleText/useIsTextEllipsis.ts
@@ -1,0 +1,21 @@
+import { useCallback, useState } from 'react'
+import { useTheme } from 'styled-components/native'
+
+import { IsTextEllipsisOutput } from './types'
+
+export const useIsTextEllipsis = (numberOfLines: number): IsTextEllipsisOutput => {
+  const [isTextEllipsis, setIsTextEllipsis] = useState(false)
+  const theme = useTheme()
+  const lineHeight = Number(theme.typography.body.lineHeight.slice(0, -2))
+
+  const onLayout: Required<IsTextEllipsisOutput>['onLayout'] = useCallback(
+    (event) => {
+      const textHeight = event.nativeEvent.layout.height
+      const maxTextHeight = lineHeight * numberOfLines
+
+      setIsTextEllipsis(textHeight >= maxTextHeight)
+    },
+    [lineHeight, numberOfLines]
+  )
+  return { isTextEllipsis, onLayout }
+}

--- a/src/ui/components/CollapsibleText/useIsTextEllipsis.web.test.tsx
+++ b/src/ui/components/CollapsibleText/useIsTextEllipsis.web.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { LayoutChangeEvent } from 'react-native'
+import { ThemeProvider } from 'styled-components/native'
+
+import { computedTheme } from 'tests/computedTheme'
+import { act, renderHook } from 'tests/utils/web'
+import { useIsTextEllipsis } from 'ui/components/CollapsibleText/useIsTextEllipsis'
+
+const LINE_HEIGHT = Number(computedTheme.typography.body.lineHeight.slice(0, -2))
+
+describe('useIsTextEllipsis', () => {
+  it('should return the text ends with ellipsis when the text takes more lines than the max', async () => {
+    const numberOfLines = 2
+    const { result } = renderHook(() => useIsTextEllipsis(numberOfLines), {
+      wrapper: ({ children }) => <ThemeProvider theme={computedTheme}>{children}</ThemeProvider>,
+    })
+
+    const threeLinesEvent = {
+      nativeEvent: { layout: { x: 0, y: 0, height: LINE_HEIGHT * 3, width: 300 } },
+    } as LayoutChangeEvent
+    await act(async () => {
+      result.current.onLayout?.(threeLinesEvent)
+    })
+
+    expect(result.current).toEqual({ isTextEllipsis: true, onLayout: expect.any(Function) })
+  })
+
+  it("should return the text doesn't end with ellipsis when the text is one line", async () => {
+    const numberOfLines = 2
+    const { result } = renderHook(() => useIsTextEllipsis(numberOfLines), {
+      wrapper: ({ children }) => <ThemeProvider theme={computedTheme}>{children}</ThemeProvider>,
+    })
+
+    const oneLineEvent = {
+      nativeEvent: { layout: { x: 0, y: 0, height: LINE_HEIGHT * 1, width: 300 } },
+    } as LayoutChangeEvent
+    await act(async () => {
+      result.current.onLayout?.(oneLineEvent)
+    })
+
+    expect(result.current).toEqual({ isTextEllipsis: false, onLayout: expect.any(Function) })
+  })
+})


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-27006

Not fixed in web ! :'( 

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

| Platform         | Mockup/Before | After | After |
| :--------------- | :-----------: | :---: | :---: |
| iOS              | ![image](https://github.com/pass-culture/pass-culture-app-native/assets/26742386/d20df413-d2d1-4eef-b8dc-ab7d09c33ee3) | ![image](https://github.com/pass-culture/pass-culture-app-native/assets/26742386/a85f60f0-faaf-4aaf-9722-369f1b756f44) | ![image](https://github.com/pass-culture/pass-culture-app-native/assets/26742386/f818d48e-e32d-43f4-a36c-db72d6c2194d) |
| Android          | ![image](https://github.com/pass-culture/pass-culture-app-native/assets/26742386/0b0dbd80-f3d5-47ff-9576-20c50e5cb075) | ![image](https://github.com/pass-culture/pass-culture-app-native/assets/26742386/61fdd60e-5a7c-4429-a2b8-17753e4fca5e) | ![image](https://github.com/pass-culture/pass-culture-app-native/assets/26742386/5e76cd2a-e02b-4293-a4d0-eb236ce41561) |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
