### PR TITLE
(PC-27901) fix(search): fix query reset on goback

### DIFF
--- a/src/features/search/components/SearchBox/SearchBox.native.test.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.native.test.tsx
@@ -382,6 +382,30 @@ describe('SearchBox component', () => {
     })
   })
 
+  it('should reset query when user go goBack to Landing', async () => {
+    mockSearchState = {
+      ...mockSearchState,
+      view: SearchView.Results,
+      query: 'Some text',
+    }
+    mockQuery = 'Some text'
+    renderSearchBox(true)
+
+    const goBackIcon = screen.getByTestId('icon-back')
+    await act(async () => {
+      fireEvent.press(goBackIcon)
+    })
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'SET_STATE',
+      payload: {
+        ...mockSearchState,
+        query: '',
+        view: SearchView.Landing,
+      },
+    })
+  })
+
   it('should execute a search if input is not empty', async () => {
     renderSearchBox()
 

--- a/src/features/search/components/SearchBox/SearchBox.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.tsx
@@ -174,7 +174,10 @@ export const SearchBox: React.FunctionComponent<Props> = ({
         break
       case searchState.view === SearchView.Results:
         setQuery('')
-        dispatch({ type: 'SET_STATE', payload: { ...searchState, view: SearchView.Landing } })
+        dispatch({
+          type: 'SET_STATE',
+          payload: { ...searchState, view: SearchView.Landing, query: '' },
+        })
         break
       default:
         break


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-27901

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]


Uploading Simulator Screen Recording - iPhone SE (3rd generation) - 2024-02-09 at 17.06.14.mp4…



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
