### PR TITLE
(PC-27840) feat(cinema): component EventCard

### DIFF
--- a/src/ui/components/eventCard/EventCard.stories.tsx
+++ b/src/ui/components/eventCard/EventCard.stories.tsx
@@ -1,0 +1,20 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import React from 'react'
+
+import { EventCard } from './EventCard'
+
+const meta: ComponentMeta<typeof EventCard> = {
+  title: 'ui/EventCard',
+  component: EventCard,
+}
+export default meta
+
+const Template: ComponentStory<typeof EventCard> = (props) => <EventCard {...props} />
+
+export const EventCardDefault = Template.bind({})
+EventCardDefault.args = {
+  title: '17h35',
+  subtitleLeft: 'VO,3D max',
+  subtitleRight: '7,99€',
+  isDisabled: false,
+}

--- a/src/ui/components/eventCard/EventCard.tsx
+++ b/src/ui/components/eventCard/EventCard.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { styledButton } from 'ui/components/buttons/styledButton'
+import { Touchable } from 'ui/components/touchable/Touchable'
+import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
+
+interface Props {
+  onPress: () => void
+  isDisabled: boolean
+  title: string
+  subtitleLeft: string
+  subtitleRight?: string
+}
+export const EventCard: React.FC<Props> = ({
+  onPress,
+  isDisabled,
+  title,
+  subtitleLeft,
+  subtitleRight,
+}) => {
+  return (
+    <StyledPressable onPress={onPress} disabled={isDisabled}>
+      <Container isDisabled={isDisabled}>
+        <Title accessibilityLabel={title} numberOfLines={1} isDisabled={isDisabled}>
+          {title}
+        </Title>
+        <Spacer.Column numberOfSpaces={1} />
+        <SubtitleContainer>
+          <SubtitleLeft accessibilityLabel={subtitleLeft} numberOfLines={1} isDisabled={isDisabled}>
+            {subtitleLeft}
+          </SubtitleLeft>
+          <SubtitleRight
+            accessibilityLabel={subtitleRight}
+            numberOfLines={1}
+            isDisabled={isDisabled}>
+            {subtitleRight}
+          </SubtitleRight>
+        </SubtitleContainer>
+      </Container>
+    </StyledPressable>
+  )
+}
+const StyledPressable = styledButton(Touchable)<{ isFocus?: boolean }>(({ theme, isFocus }) => ({
+  width: getSpacing(28),
+  ...customFocusOutline({ isFocus, color: theme.colors.black }),
+  '&:focus': {
+    outlineOffset: getSpacing(0.75),
+    outlineWidth: getSpacing(0.25),
+    borderRadius: theme.borderRadius.radius,
+  },
+}))
+
+const Container = styled.View<{ isDisabled: boolean }>(({ theme, isDisabled }) => ({
+  display: 'inline-flex',
+  backgroundColor: isDisabled ? theme.colors.greyLight : theme.colors.white,
+  alignItems: 'flex-start',
+  heigth: getSpacing(17),
+  width: '100%',
+  padding: getSpacing(3),
+  borderRadius: theme.borderRadius.radius,
+  borderWidth: isDisabled ? 0 : getSpacing(0.25),
+  borderColor: theme.colors.black,
+}))
+
+const Title = styled(Typo.ButtonText)<{ isDisabled: boolean }>(({ theme, isDisabled }) => ({
+  color: isDisabled ? theme.colors.greyDark : theme.colors.black,
+}))
+
+const SubtitleContainer = styled.View({
+  alignSelf: 'stretch',
+  flexDirection: 'row',
+  width: '100%',
+  alignItems: 'center',
+})
+
+const SubtitleLeft = styled(Typo.Caption)<{ isDisabled: boolean }>(({ theme, isDisabled }) => ({
+  color: isDisabled ? theme.colors.greySemiDark : theme.colors.greyDark,
+  lineHeight: getSpacing(5),
+}))
+
+const SubtitleRight = styled(Typo.Body)<{ isDisabled: boolean }>(({ theme, isDisabled }) => ({
+  color: isDisabled ? theme.colors.greySemiDark : theme.colors.black,
+  flexShrink: 0,
+  paddingLeft: getSpacing(1),
+}))

--- a/src/ui/components/eventCard/EventCard.tsx
+++ b/src/ui/components/eventCard/EventCard.tsx
@@ -6,6 +6,9 @@ import { Touchable } from 'ui/components/touchable/Touchable'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 
+const CARD_HEIGHT = getSpacing(17)
+const CARD_WIDTH = getSpacing(28)
+
 interface Props {
   onPress: () => void
   isDisabled: boolean
@@ -43,7 +46,7 @@ export const EventCard: React.FC<Props> = ({
   )
 }
 const StyledPressable = styledButton(Touchable)<{ isFocus?: boolean }>(({ theme, isFocus }) => ({
-  width: getSpacing(28),
+  width: CARD_WIDTH,
   ...customFocusOutline({ isFocus, color: theme.colors.black }),
   '&:focus': {
     outlineOffset: getSpacing(0.75),
@@ -56,7 +59,7 @@ const Container = styled.View<{ isDisabled: boolean }>(({ theme, isDisabled }) =
   display: 'inline-flex',
   backgroundColor: isDisabled ? theme.colors.greyLight : theme.colors.white,
   alignItems: 'flex-start',
-  heigth: getSpacing(17),
+  heigth: CARD_HEIGHT,
   width: '100%',
   padding: getSpacing(3),
   borderRadius: theme.borderRadius.radius,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-27840

## Checklist

I have made a Story.

## Screenshots

**delete** _if no UI change_

| Platform         | Design | Code |
| :--------------- | :-----------: | :---: |
| Default             | ![Capture d’écran 2024-02-13 à 11 54 33](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/4afa4775-d940-428b-a289-1b099743955c)| ![Capture d’écran 2024-02-13 à 10 07 50](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/b0490a6c-ed86-4ba4-b35e-c080cc037919) |
| Disabled          |![Capture d’écran 2024-02-13 à 11 58 36](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/6199627a-42d5-4c7c-917b-7d6e629d2277) |![Capture d’écran 2024-02-13 à 10 08 30](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/4113d329-4b80-4251-aed1-298adf04f983)|
| Unbookable   | ![Capture d’écran 2024-02-13 à 11 58 44](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/838451b4-001d-43ef-beb6-fbac9820a8da)|![Capture d’écran 2024-02-13 à 10 10 00](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/1f6a7f8a-5973-43fe-94ff-8b4ac5655869)|
| Focus |![Capture d’écran 2024-02-13 à 11 58 49](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/6fe2329e-113d-4c04-ba1c-459a95229348) |![Capture d’écran 2024-02-13 à 10 13 08](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/95860704-b164-4c1e-bea7-ff841faa937f)|
| Hover |  ![Capture d’écran 2024-02-13 à 11 58 52](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/11140507-562a-45fe-9883-7971fb123cc5) |![Capture d’écran 2024-02-13 à 10 13 20](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/adb7b96d-b9d6-4563-be52-1f1cd2907eea) | 
| Pressed |  ![Capture d’écran 2024-02-13 à 11 58 55](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/d2d18be5-a4ef-429d-bb66-97449c7f671e)| ![Capture d’écran 2024-02-13 à 11 29 43 (2)](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/60422fa1-47c8-4775-b5de-2ffbca964169)|


L'écart entre maquette et code pour l'état pressed est normal( en gros le design montre l'état pressed du mobile donc pas de hover alors qu'en web il y a un hover donc le surlignement reste)
