### PR TITLE
(PC-27872) fix(CinemaCalendar): add padding instead of margin

### DIFF
--- a/__snapshots__/features/offerv2/components/MovieCalendar/MovieCalendar.native.test.tsx.native-snap
+++ b/__snapshots__/features/offerv2/components/MovieCalendar/MovieCalendar.native.test.tsx.native-snap
@@ -25,8 +25,7 @@ exports[`<MovieCalendar/> should render MovieCalendar 1`] = `
   <RCTScrollView
     contentContainerStyle={
       {
-        "marginLeft": 24,
-        "marginRight": 24,
+        "paddingHorizontal": 24,
       }
     }
     horizontal={true}

--- a/src/features/offerv2/components/MovieCalendar/MovieCalendar.tsx
+++ b/src/features/offerv2/components/MovieCalendar/MovieCalendar.tsx
@@ -73,7 +73,7 @@ export const MovieCalendar: React.FC<Props> = ({ dates, selectedDate, onTabChang
 
 const Container = styled.View({})
 
-const scrollViewContainer = { marginLeft: getSpacing(6), marginRight: getSpacing(6) }
+const scrollViewContainer = { paddingHorizontal: getSpacing(6) }
 
 const BottomBar = styled.View(({ theme }) => ({
   position: 'absolute',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-27872

## Screenshots
| Before | After |
| :-----------: | :---: |
| https://github.com/pass-culture/pass-culture-app-native/assets/144016890/87c6d126-39d1-4262-b320-8136774c17a5 |https://github.com/pass-culture/pass-culture-app-native/assets/144016890/14eafef1-eb43-4436-9939-dec1e0d442d1
