### PR TITLE
(PC-22233) test(reactQuery): remove react query from birthday notifications

### DIFF
--- a/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.native.test.tsx
+++ b/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.native.test.tsx
@@ -3,11 +3,11 @@ import React from 'react'
 
 import { IAuthContext, useAuthContext } from 'features/auth/context/AuthContext'
 import { underageBeneficiaryUser } from 'fixtures/user'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen } from 'tests/utils'
 
 import { RecreditBirthdayNotification } from './RecreditBirthdayNotification'
 
-jest.mock('react-query')
 jest.mock('features/auth/context/AuthContext')
 jest.mock('features/profile/api/useUpdateProfileMutation', () => ({
   useResetRecreditAmountToShow: jest.fn().mockReturnValue({
@@ -37,7 +37,7 @@ describe('<RecreditBirthdayNotification />', () => {
   })
 
   it('should have correct text', async () => {
-    render(<RecreditBirthdayNotification />)
+    render(reactQueryProviderHOC(<RecreditBirthdayNotification />))
 
     const recreditText = screen.getByText(
       'Pour tes 16 ans, 50\u00a0€ ont été ajoutés à ton compte. Tu disposes maintenant de :'

--- a/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.web.test.tsx
+++ b/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.web.test.tsx
@@ -1,15 +1,14 @@
 import React from 'react'
 
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, checkAccessibilityFor, screen } from 'tests/utils/web'
 
 import { RecreditBirthdayNotification } from './RecreditBirthdayNotification'
 
-jest.mock('react-query')
-
 describe('<RecreditBirthdayNotification/>', () => {
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
-      const { container } = render(<RecreditBirthdayNotification />)
+      const { container } = render(reactQueryProviderHOC(<RecreditBirthdayNotification />))
 
       const results = await checkAccessibilityFor(container)
 

--- a/src/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx
@@ -17,7 +17,6 @@ import { analytics } from 'libs/analytics'
 import { render, screen, fireEvent, middleScrollEvent, bottomScrollEvent } from 'tests/utils'
 
 jest.mock('features/navigation/helpers')
-jest.mock('react-query')
 jest.mock('features/culturalSurvey/context/CulturalSurveyContextProvider')
 
 const mockedUseCulturalSurveyAnswersMutation = jest.mocked(useCulturalSurveyAnswersMutation)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-22233

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
