### PR TITLE
(PC-27840) feat(OfferCinemaSeance): fix UI

### DIFF
--- a/src/ui/components/eventCard/EventCard.tsx
+++ b/src/ui/components/eventCard/EventCard.tsx
@@ -4,10 +4,10 @@ import styled from 'styled-components/native'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { getShadow, getSpacing, Spacer, Typo } from 'ui/theme'
-import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 
+const BORDER_WIDTH = getSpacing(0.25)
 const CARD_HEIGHT = getSpacing(17)
-const CARD_WIDTH = getSpacing(28)
+const CARD_WIDTH = getSpacing(30)
 
 interface Props {
   onPress: () => void
@@ -23,15 +23,20 @@ export const EventCard: React.FC<Props> = ({
   subtitleLeft,
   subtitleRight,
 }) => {
+  const hasSubtitleRight = !subtitleRight
   return (
-    <StyledPressable onPress={onPress} disabled={isDisabled}>
+    <StyledTouchableOpacity onPress={isDisabled ? undefined : onPress} isDisabled={isDisabled}>
       <Container isDisabled={isDisabled}>
         <Title accessibilityLabel={title} numberOfLines={1} isDisabled={isDisabled}>
           {title}
         </Title>
         <Spacer.Column numberOfSpaces={1} />
         <SubtitleContainer>
-          <SubtitleLeft accessibilityLabel={subtitleLeft} numberOfLines={1} isDisabled={isDisabled}>
+          <SubtitleLeft
+            accessibilityLabel={subtitleLeft}
+            numberOfLines={1}
+            isDisabled={isDisabled}
+            hasSubtitleRight={hasSubtitleRight}>
             {subtitleLeft}
           </SubtitleLeft>
           <SubtitleRight
@@ -42,29 +47,28 @@ export const EventCard: React.FC<Props> = ({
           </SubtitleRight>
         </SubtitleContainer>
       </Container>
-    </StyledPressable>
+    </StyledTouchableOpacity>
   )
 }
-const StyledPressable = styledButton(Touchable)<{ isFocus?: boolean }>(({ theme, isFocus }) => ({
-  width: CARD_WIDTH,
-  ...customFocusOutline({ isFocus, color: theme.colors.black }),
-  '&:focus': {
-    outlineOffset: getSpacing(0.75),
-    outlineWidth: getSpacing(0.25),
+const StyledTouchableOpacity = styledButton(Touchable)<{ isDisabled: boolean }>(
+  ({ theme, isDisabled }) => ({
+    width: 'fit-content',
     borderRadius: theme.borderRadius.radius,
-  },
-}))
+    '&:hover': { textDecoration: isDisabled ? 'none' : 'underline' },
+    '&:focus': { outline: 'none' },
+    '&:focus-visible': { outline: 'auto' },
+  })
+)
 
 const Container = styled.View<{ isDisabled: boolean }>(({ theme, isDisabled }) => ({
-  display: 'inline-flex',
-  backgroundColor: isDisabled ? theme.colors.greyLight : theme.colors.white,
-  alignItems: 'flex-start',
-  heigth: CARD_HEIGHT,
-  width: '100%',
-  padding: getSpacing(3),
+  width: CARD_WIDTH,
+  height: CARD_HEIGHT,
+  borderColor: isDisabled ? theme.colors.greyLight : theme.colors.black,
+  borderWidth: BORDER_WIDTH,
   borderRadius: theme.borderRadius.radius,
-  borderWidth: isDisabled ? 0 : getSpacing(0.25),
-  borderColor: theme.colors.black,
+  boxSizing: 'border-box',
+  padding: getSpacing(3),
+  backgroundColor: isDisabled ? theme.colors.greyLight : theme.colors.white,
   ...(!isDisabled
     ? getShadow({
         shadowOffset: { width: 0, height: getSpacing(1) },
@@ -86,13 +90,18 @@ const SubtitleContainer = styled.View({
   alignItems: 'center',
 })
 
-const SubtitleLeft = styled(Typo.Caption)<{ isDisabled: boolean }>(({ theme, isDisabled }) => ({
-  color: isDisabled ? theme.colors.greySemiDark : theme.colors.greyDark,
-  lineHeight: getSpacing(5),
-}))
+const SubtitleLeft = styled(Typo.Caption)<{ isDisabled: boolean; hasSubtitleRight: boolean }>(
+  ({ theme, isDisabled, hasSubtitleRight }) => ({
+    color: isDisabled ? theme.colors.greySemiDark : theme.colors.greyDark,
+    lineHeight: getSpacing(5),
+    textAlign: 'left',
+    flex: hasSubtitleRight ? 'auto' : 1,
+  })
+)
 
 const SubtitleRight = styled(Typo.Body)<{ isDisabled: boolean }>(({ theme, isDisabled }) => ({
   color: isDisabled ? theme.colors.greySemiDark : theme.colors.black,
+  textAlign: 'right',
   flexShrink: 0,
   paddingLeft: getSpacing(1),
 }))

--- a/src/ui/components/eventCard/EventCard.tsx
+++ b/src/ui/components/eventCard/EventCard.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Touchable } from 'ui/components/touchable/Touchable'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getShadow, getSpacing, Spacer, Typo } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 
 const CARD_HEIGHT = getSpacing(17)
@@ -65,6 +65,14 @@ const Container = styled.View<{ isDisabled: boolean }>(({ theme, isDisabled }) =
   borderRadius: theme.borderRadius.radius,
   borderWidth: isDisabled ? 0 : getSpacing(0.25),
   borderColor: theme.colors.black,
+  ...(!isDisabled
+    ? getShadow({
+        shadowOffset: { width: 0, height: getSpacing(1) },
+        shadowRadius: getSpacing(1),
+        shadowColor: theme.colors.greyDark,
+        shadowOpacity: 0.2,
+      })
+    : {}),
 }))
 
 const Title = styled(Typo.ButtonText)<{ isDisabled: boolean }>(({ theme, isDisabled }) => ({

--- a/src/ui/components/eventCard/EventCard.tsx
+++ b/src/ui/components/eventCard/EventCard.tsx
@@ -68,6 +68,7 @@ const Container = styled.View<{ isDisabled: boolean }>(({ theme, isDisabled }) =
   borderRadius: theme.borderRadius.radius,
   boxSizing: 'border-box',
   padding: getSpacing(3),
+  justifyContent: 'flex-start',
   backgroundColor: isDisabled ? theme.colors.greyLight : theme.colors.white,
   ...(!isDisabled
     ? getShadow({
@@ -81,6 +82,7 @@ const Container = styled.View<{ isDisabled: boolean }>(({ theme, isDisabled }) =
 
 const Title = styled(Typo.ButtonText)<{ isDisabled: boolean }>(({ theme, isDisabled }) => ({
   color: isDisabled ? theme.colors.greyDark : theme.colors.black,
+  textAlign: 'left',
 }))
 
 const SubtitleContainer = styled.View({
@@ -88,6 +90,8 @@ const SubtitleContainer = styled.View({
   flexDirection: 'row',
   width: '100%',
   alignItems: 'center',
+  justifyContent: 'space-between',
+  textOverflow: 'ellipsis',
 })
 
 const SubtitleLeft = styled(Typo.Caption)<{ isDisabled: boolean; hasSubtitleRight: boolean }>(
@@ -104,4 +108,5 @@ const SubtitleRight = styled(Typo.Body)<{ isDisabled: boolean }>(({ theme, isDis
   textAlign: 'right',
   flexShrink: 0,
   paddingLeft: getSpacing(1),
+  flex: 1,
 }))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-27840

[Maquette ](https://www.figma.com/file/5QmI5xtsSGThRQrwhQ1yGP/%5BCin%C3%A9ma%5D-Parcours-de-r%C3%A9servation?node-id=3514%3A20263&mode=dev)
[Story](https://61fd537ecf081f003a135235-asickdjwqf.chromatic.com/?path=/story/ui-eventcard--event-card-default)

## Screenshots

| Platform         | Design | Code |
| :--------------- | :-----------: | :---: |
| Default             | ![Capture d’écran 2024-02-13 à 11 54 33](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/4afa4775-d940-428b-a289-1b099743955c)| <img width="418" alt="Capture d’écran 2024-02-19 à 11 56 28" src="https://github.com/pass-culture/pass-culture-app-native/assets/144016890/2a2686d3-afee-4053-b586-a3445d080b21">|
| Disabled          |![Capture d’écran 2024-02-13 à 11 58 36](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/6199627a-42d5-4c7c-917b-7d6e629d2277) |<img width="382" alt="Capture d’écran 2024-02-19 à 11 57 21" src="https://github.com/pass-culture/pass-culture-app-native/assets/144016890/6a41279a-011f-470c-9140-e4c5a255917c">|
| Unbookable   | ![Capture d’écran 2024-02-13 à 11 58 44](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/838451b4-001d-43ef-beb6-fbac9820a8da)|<img width="414" alt="Capture d’écran 2024-02-19 à 11 57 48" src="https://github.com/pass-culture/pass-culture-app-native/assets/144016890/59222708-c085-4cdd-8a8f-3dbef7ac38ae">|
| Focus |![Capture d’écran 2024-02-13 à 11 58 49](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/6fe2329e-113d-4c04-ba1c-459a95229348) |<img width="420" alt="Capture d’écran 2024-02-19 à 11 57 10" src="https://github.com/pass-culture/pass-culture-app-native/assets/144016890/57f59dde-1509-49e7-9017-97c864e875be">|
| Hover |  ![Capture d’écran 2024-02-13 à 11 58 52](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/11140507-562a-45fe-9883-7971fb123cc5) |<img width="384" alt="Capture d’écran 2024-02-19 à 11 56 32" src="https://github.com/pass-culture/pass-culture-app-native/assets/144016890/31941aa0-2735-43e1-a155-010a25aa9910">| 
| Pressed |  ![Capture d’écran 2024-02-13 à 11 58 55](https://github.com/pass-culture/pass-culture-app-native/assets/144016890/d2d18be5-a4ef-429d-bb66-97449c7f671e)|<img width="374" alt="Capture d’écran 2024-02-19 à 11 56 47" src="https://github.com/pass-culture/pass-culture-app-native/assets/144016890/91e45e39-0bd0-4fdf-8517-5ab6132c203d">|




L'écart entre maquette et code pour l'état pressed est normal( en gros le design montre l'état pressed du mobile donc pas de hover alors qu'en web il y a un hover donc le surlignement reste)
