### PR TITLE
(PC-28041) test(ReactQuery): Remove last react query mocks in native

### DIFF
--- a/src/features/gtlPlaylist/components/GtlPlaylist.native.test.tsx
+++ b/src/features/gtlPlaylist/components/GtlPlaylist.native.test.tsx
@@ -10,9 +10,8 @@ import { venueResponseSnap } from 'features/venue/fixtures/venueResponseSnap'
 import { analytics } from 'libs/analytics'
 import { placeholderData } from 'libs/subcategories/placeholderData'
 import { Offer } from 'shared/offer/types'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, fireEvent, render, screen } from 'tests/utils'
-
-jest.mock('react-query')
 
 const mockSubcategories = placeholderData.subcategories
 jest.mock('libs/subcategories/useSubcategories', () => ({
@@ -142,7 +141,7 @@ jest.mock('react-native-intersection-observer', () => {
 
 describe('GtlPlaylist', () => {
   it('should log ConsultOffer when pressing an item', () => {
-    render(<GtlPlaylist playlist={playlists[0]} venue={venue} />)
+    render(reactQueryProviderHOC(<GtlPlaylist playlist={playlists[0]} venue={venue} />))
 
     fireEvent.press(screen.queryAllByText('Mon abonnement bibliothèque')[0])
 
@@ -156,7 +155,7 @@ describe('GtlPlaylist', () => {
   })
 
   it('should log AllTilesSeen only once when scrolling to the end of the playlist', async () => {
-    render(<GtlPlaylist playlist={playlists[0]} venue={venue} />)
+    render(reactQueryProviderHOC(<GtlPlaylist playlist={playlists[0]} venue={venue} />))
     const scrollView = screen.getByTestId('offersModuleList')
 
     await act(async () => {
@@ -177,7 +176,7 @@ describe('GtlPlaylist', () => {
   })
 
   it('should log ModuleDisplayed when scrolling to the playlist', () => {
-    render(<GtlPlaylist playlist={playlists[0]} venue={venue} />)
+    render(reactQueryProviderHOC(<GtlPlaylist playlist={playlists[0]} venue={venue} />))
 
     mockInView(true)
 
@@ -189,7 +188,7 @@ describe('GtlPlaylist', () => {
   })
 
   it('should not log ModuleDisplayed when not scrolling to the playlist', () => {
-    render(<GtlPlaylist playlist={playlists[0]} venue={venue} />)
+    render(reactQueryProviderHOC(<GtlPlaylist playlist={playlists[0]} venue={venue} />))
 
     mockInView(false)
 

--- a/src/features/search/components/SearchHistory/SearchHistory.native.test.tsx
+++ b/src/features/search/components/SearchHistory/SearchHistory.native.test.tsx
@@ -9,8 +9,6 @@ const TODAY_DATE = new Date('2023-09-26T00:00:00.000Z')
 
 const mockRemoveItem = jest.fn()
 
-jest.mock('react-query')
-
 const mockHistory = [mockedSearchHistory[0]]
 
 describe('SearchHistory', () => {

--- a/src/features/search/pages/SearchLanding/SearchLanding.native.test.tsx
+++ b/src/features/search/pages/SearchLanding/SearchLanding.native.test.tsx
@@ -40,8 +40,6 @@ jest.mock('features/search/context/SearchWrapper', () => ({
   }),
 }))
 
-jest.mock('react-query')
-
 const mockData = { pages: [{ nbHits: 0, hits: [], page: 0 }] }
 const mockHasNextPage = true
 const mockFetchNextPage = jest.fn()

--- a/src/features/search/pages/SearchResults/SearchResults.native.test.tsx
+++ b/src/features/search/pages/SearchResults/SearchResults.native.test.tsx
@@ -39,8 +39,6 @@ jest.mock('features/search/context/SearchWrapper', () => ({
   }),
 }))
 
-jest.mock('react-query')
-
 const mockData = { pages: [{ nbHits: 0, hits: [], page: 0 }] }
 const mockHasNextPage = true
 const mockFetchNextPage = jest.fn()

--- a/src/ui/components/tiles/HorizontalOfferTile.native.test.tsx
+++ b/src/ui/components/tiles/HorizontalOfferTile.native.test.tsx
@@ -5,6 +5,7 @@ import { mockedAlgoliaResponse } from 'libs/algolia/__mocks__/mockedAlgoliaRespo
 import * as logClickOnProductAPI from 'libs/algolia/analytics/logClickOnOffer'
 import { analytics } from 'libs/analytics'
 import { OfferAnalyticsParams } from 'libs/analytics/types'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { fireEvent, render, screen, waitFor } from 'tests/utils'
 
 import { HorizontalOfferTile } from './HorizontalOfferTile'
@@ -22,7 +23,6 @@ let mockDistance: string | null = null
 jest.mock('libs/location/hooks/useDistance', () => ({
   useDistance: () => mockDistance,
 }))
-jest.mock('react-query')
 
 const spyLogClickOnOffer = jest.fn()
 const mockUseLogClickOnOffer = jest.spyOn(logClickOnProductAPI, 'useLogClickOnOffer')
@@ -34,7 +34,11 @@ jest.mock('libs/algolia/analytics/SearchAnalyticsWrapper', () => ({
 
 describe('HorizontalOfferTile component', () => {
   it('should navigate to the offer when pressing an offer', async () => {
-    render(<HorizontalOfferTile offer={mockOffer} analyticsParams={mockAnalyticsParams} />)
+    render(
+      reactQueryProviderHOC(
+        <HorizontalOfferTile offer={mockOffer} analyticsParams={mockAnalyticsParams} />
+      )
+    )
 
     fireEvent.press(screen.getByRole('link'))
 
@@ -48,7 +52,11 @@ describe('HorizontalOfferTile component', () => {
   })
 
   it('should log analytics event when pressing an offer', async () => {
-    render(<HorizontalOfferTile offer={mockOffer} analyticsParams={mockAnalyticsParams} />)
+    render(
+      reactQueryProviderHOC(
+        <HorizontalOfferTile offer={mockOffer} analyticsParams={mockAnalyticsParams} />
+      )
+    )
     fireEvent.press(screen.getByRole('link'))
 
     expect(analytics.logConsultOffer).toHaveBeenCalledTimes(1)
@@ -62,7 +70,11 @@ describe('HorizontalOfferTile component', () => {
   })
 
   it('should notify Algolia when pressing an offer', async () => {
-    render(<HorizontalOfferTile offer={mockOffer} analyticsParams={mockAnalyticsParams} />)
+    render(
+      reactQueryProviderHOC(
+        <HorizontalOfferTile offer={mockOffer} analyticsParams={mockAnalyticsParams} />
+      )
+    )
 
     const hitComponent = screen.getByRole('link')
     fireEvent.press(hitComponent)
@@ -75,7 +87,11 @@ describe('HorizontalOfferTile component', () => {
 
   it('should show distance if geolocation enabled', () => {
     mockDistance = '10 km'
-    render(<HorizontalOfferTile offer={mockOffer} analyticsParams={mockAnalyticsParams} />)
+    render(
+      reactQueryProviderHOC(
+        <HorizontalOfferTile offer={mockOffer} analyticsParams={mockAnalyticsParams} />
+      )
+    )
 
     expect(screen.queryByText('10 km')).toBeOnTheScreen()
   })
@@ -84,14 +100,22 @@ describe('HorizontalOfferTile component', () => {
     const offer = { ...mockOffer, objectID: '' }
 
     it('should not navigate to the offer', async () => {
-      render(<HorizontalOfferTile offer={offer} analyticsParams={mockAnalyticsParams} />)
+      render(
+        reactQueryProviderHOC(
+          <HorizontalOfferTile offer={offer} analyticsParams={mockAnalyticsParams} />
+        )
+      )
       fireEvent.press(screen.getByRole('link'))
 
       expect(navigate).not.toHaveBeenCalled()
     })
 
     it('should not log analytics event', async () => {
-      render(<HorizontalOfferTile offer={offer} analyticsParams={mockAnalyticsParams} />)
+      render(
+        reactQueryProviderHOC(
+          <HorizontalOfferTile offer={offer} analyticsParams={mockAnalyticsParams} />
+        )
+      )
       fireEvent.press(screen.getByRole('link'))
 
       expect(analytics.logConsultOffer).not.toHaveBeenCalled()


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28041

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
