### PR TITLE
(PC-24068) fix(auth): Redirect to login with info banner when refresh token expires

### DIFF
--- a/src/api/apiHelpers.native.test.ts
+++ b/src/api/apiHelpers.native.test.ts
@@ -14,7 +14,6 @@ import {
   createNeedsAuthenticationResponse,
   handleGeneratedApiResponse,
   isAPIExceptionCapturedAsInfo,
-  RefreshTokenExpiredResponse,
   safeFetch,
 } from './apiHelpers'
 import { Configuration, DefaultApi, RefreshResponse } from './gen'
@@ -131,7 +130,7 @@ describe('[api] helpers', () => {
 
       const response = await safeFetch(apiUrl, optionsWithAccessToken, api)
 
-      expect(response).toEqual(RefreshTokenExpiredResponse)
+      expect(response).toEqual(createNeedsAuthenticationResponse(apiUrl))
     })
 
     it('regenerates the access token and fetch the real url after when the access token is expired', async () => {
@@ -398,19 +397,10 @@ describe('[api] helpers', () => {
       await expect(getResult).rejects.toThrow(error)
     })
 
-    it('should navigate to login when access token is invalid', async () => {
+    it('should navigate to login when access and refresh tokens are invalid', async () => {
       const result = await handleGeneratedApiResponse(createNeedsAuthenticationResponse(apiUrl))
 
       expect(navigateFromRef).toHaveBeenCalledWith('Login', undefined)
-      expect(result).toEqual({})
-    })
-
-    it('should navigate to login with displayForcedLoginHelpMessage param when refresh token is expired', async () => {
-      const response = await respondWith('', 401, 'RefreshTokenExpired')
-
-      const result = await handleGeneratedApiResponse(response)
-
-      expect(navigateFromRef).toHaveBeenCalledWith('Login', { displayForcedLoginHelpMessage: true })
       expect(result).toEqual({})
     })
   })

--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -45,11 +45,6 @@ const NeedsAuthenticationStatus = {
 export const createNeedsAuthenticationResponse = (url: string) =>
   new Response(url, NeedsAuthenticationStatus)
 
-export const RefreshTokenExpiredResponse = new Response('', {
-  status: 401,
-  statusText: 'RefreshTokenExpired',
-})
-
 /**
  * For each http calls to the api, retrieves the access token and fetchs.
  * Ignores native/v1/refresh_access_token.
@@ -93,7 +88,6 @@ export const safeFetch = async (
 
       switch (error) {
         case REFRESH_TOKEN_IS_EXPIRED_ERROR:
-          return RefreshTokenExpiredResponse
         case FAILED_TO_GET_REFRESH_TOKEN_ERROR:
           return createNeedsAuthenticationResponse(url)
         case UNKNOWN_ERROR_WHILE_REFRESHING_ACCESS_TOKEN:
@@ -154,14 +148,6 @@ export async function handleGeneratedApiResponse(response: Response): Promise<an
     response.statusText === NeedsAuthenticationStatus.statusText
   ) {
     navigateToLogin()
-    return {}
-  }
-
-  if (
-    response.status === RefreshTokenExpiredResponse.status &&
-    response.statusText === RefreshTokenExpiredResponse.statusText
-  ) {
-    navigateToLogin({ displayForcedLoginHelpMessage: true })
     return {}
   }
 

--- a/src/features/auth/pages/login/Login.native.test.tsx
+++ b/src/features/auth/pages/login/Login.native.test.tsx
@@ -418,8 +418,16 @@ describe('<Login/>', () => {
     })
   })
 
+  it('should log analytics when displaying forced login help message', async () => {
+    useRoute.mockReturnValueOnce({ params: { displayForcedLoginHelpMessage: true } })
+    renderLogin()
+
+    await act(() => {})
+
+    expect(analytics.logDisplayForcedLoginHelpMessage).toHaveBeenCalledTimes(1)
+  })
+
   it('should not display the login help message when the query param is not given', async () => {
-    useRoute.mockReturnValueOnce({})
     renderLogin()
 
     await act(async () => {})

--- a/src/features/auth/pages/login/Login.native.test.tsx
+++ b/src/features/auth/pages/login/Login.native.test.tsx
@@ -49,9 +49,11 @@ jest.mock('features/identityCheck/context/SubscriptionContextProvider', () => ({
 }))
 
 const mockShowErrorSnackBar = jest.fn()
+const mockShowInfoSnackBar = jest.fn()
 jest.mock('ui/components/snackBar/SnackBarContext', () => ({
   useSnackBarContext: () => ({
     showErrorSnackBar: mockShowErrorSnackBar,
+    showInfoSnackBar: mockShowInfoSnackBar,
   }),
 }))
 
@@ -402,6 +404,27 @@ describe('<Login/>', () => {
     })
 
     expect(analytics.logSignUpClicked).toHaveBeenNthCalledWith(1, { from: 'login' })
+  })
+
+  it('should display forced login help message when the query param is given', async () => {
+    useRoute.mockReturnValueOnce({ params: { displayForcedLoginHelpMessage: true } })
+    renderLogin()
+
+    await act(() => {})
+
+    expect(mockShowInfoSnackBar).toHaveBeenCalledWith({
+      message: 'Pour sécuriser ton pass Culture, tu dois régulièrement confirmer tes identifiants.',
+      timeout: SNACK_BAR_TIME_OUT_LONG,
+    })
+  })
+
+  it('should not display the login help message when the query param is not given', async () => {
+    useRoute.mockReturnValueOnce({})
+    renderLogin()
+
+    await act(async () => {})
+
+    expect(mockShowInfoSnackBar).not.toHaveBeenCalled()
   })
 
   describe('Login comes from adding an offer to favorite', () => {

--- a/src/features/auth/pages/login/Login.tsx
+++ b/src/features/auth/pages/login/Login.tsx
@@ -75,7 +75,7 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
     if (params?.displayForcedLoginHelpMessage) {
       showInfoSnackBar({
         message:
-          'Pour sécuriser ton pass Culture, tu dois confirmer tes identifiants tous les 30 jours.',
+          'Pour sécuriser ton pass Culture, tu dois régulièrement confirmer tes identifiants.',
         timeout: SNACK_BAR_TIME_OUT_LONG,
       })
     }

--- a/src/features/auth/pages/login/Login.tsx
+++ b/src/features/auth/pages/login/Login.tsx
@@ -78,6 +78,7 @@ export const Login: FunctionComponent<Props> = memo(function Login(props) {
           'Pour sécuriser ton pass Culture, tu dois régulièrement confirmer tes identifiants.',
         timeout: SNACK_BAR_TIME_OUT_LONG,
       })
+      analytics.logDisplayForcedLoginHelpMessage()
     }
   }, [params?.displayForcedLoginHelpMessage, showInfoSnackBar])
 

--- a/src/features/auth/pages/login/Login.web.test.tsx
+++ b/src/features/auth/pages/login/Login.web.test.tsx
@@ -9,7 +9,7 @@ import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeat
 import { GoogleOAuthProvider } from 'libs/react-native-google-sso/GoogleOAuthProvider'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, checkAccessibilityFor, render, screen } from 'tests/utils/web'
+import { act, checkAccessibilityFor, render } from 'tests/utils/web'
 import { SnackBarProvider } from 'ui/components/snackBar/SnackBarContext'
 
 import { Login } from './Login'
@@ -48,32 +48,6 @@ describe('<Login/>', () => {
         expect(results).toHaveNoViolations()
       })
     })
-  })
-
-  it('should display forced login help message when the query param is given', async () => {
-    useRoute.mockReturnValueOnce({ params: { displayForcedLoginHelpMessage: true } })
-    renderLogin()
-
-    await act(async () => {}) // Warning: An update to Login inside a test was not wrapped in act(...)
-
-    const snackBar = await screen.findByRole('status')
-
-    expect(snackBar).toHaveTextContent(
-      'Pour sécuriser ton pass Culture, tu dois confirmer tes identifiants tous les 30 jours.'
-    )
-  })
-
-  it('should not display the login help message when the query param is not given', async () => {
-    useRoute.mockReturnValueOnce({})
-    renderLogin()
-
-    await act(async () => {}) // Warning: An update to Login inside a test was not wrapped in act(...)
-
-    const snackBar = await screen.findByRole('status')
-
-    expect(snackBar).not.toHaveTextContent(
-      'Pour sécuriser ton pass Culture, tu dois confirmer tes identifiants tous les 30 jours.'
-    )
   })
 })
 

--- a/src/libs/analytics/__mocks__/logEventAnalytics.ts
+++ b/src/libs/analytics/__mocks__/logEventAnalytics.ts
@@ -63,6 +63,7 @@ export const logEventAnalytics: typeof actualLogEventAnalytics = {
   logDismissAccountSecurity: jest.fn(),
   logDismissNotifications: jest.fn(),
   logDismissShareApp: jest.fn(),
+  logDisplayForcedLoginHelpMessage: jest.fn(),
   logEduconnectExplanationClicked: jest.fn(),
   logEmailConfirmationConsultEmailClicked: jest.fn(),
   logEmailValidated: jest.fn(),

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -253,6 +253,8 @@ export const logEventAnalytics = {
     analytics.logEvent({ firebase: AnalyticsEvent.DISMISS_NOTIFICATIONS }),
   logDismissShareApp: (type: ShareAppModalType) =>
     analytics.logEvent({ firebase: AnalyticsEvent.DISMISS_SHARE_APP }, { type }),
+  logDisplayForcedLoginHelpMessage: () =>
+    analytics.logEvent({ firebase: AnalyticsEvent.DISPLAY_FORCED_LOGIN_HELP_MESSAGE }),
   logEduconnectExplanationClicked: () =>
     analytics.logEvent({ amplitude: AmplitudeEvent.EDUCONNECT_EXPLANATION_CLICKED }),
   logEmailConfirmationConsultEmailClicked: () =>

--- a/src/libs/firebase/analytics/events.ts
+++ b/src/libs/firebase/analytics/events.ts
@@ -62,6 +62,7 @@ export enum AnalyticsEvent {
   DISMISS_ACCOUNT_SECURITY = 'DismissAccountSecurity',
   DISMISS_NOTIFICATIONS = 'DismissNotifications',
   DISMISS_SHARE_APP = 'DismissShareApp',
+  DISPLAY_FORCED_LOGIN_HELP_MESSAGE = 'DisplayForcedLoginHelpMessage',
   ERROR_SAVING_NEW_EMAIL = 'ErrorSavingNewMail',
   EXCLUSIVITY_BLOCK_CLICKED = 'ExclusivityBlockClicked',
   FAVORITE_LIST_BUTTON_CLICKED = 'FavoriteListButtonClicked',


### PR DESCRIPTION
JIRA ticket: https://passculture.atlassian.net/browse/PC-24068

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots
| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
