### PR TITLE
(PC-27596) fix(search): not display counter when count = 1

### DIFF
--- a/src/features/search/components/VenueMapPin/VenueMapPin.native.test.tsx
+++ b/src/features/search/components/VenueMapPin/VenueMapPin.native.test.tsx
@@ -10,7 +10,19 @@ describe('<VenueMapPin />', () => {
     expect(screen.queryByTestId('numberContainer')).not.toBeOnTheScreen()
   })
 
-  it('should display the number of venues in the cluster when count informed', () => {
+  it('should not display number container when count informed and is equal to 0', () => {
+    render(<VenueMapPin count={0} />)
+
+    expect(screen.queryByTestId('numberContainer')).not.toBeOnTheScreen()
+  })
+
+  it('should not display number container when count informed and is equal to 1', () => {
+    render(<VenueMapPin count={1} />)
+
+    expect(screen.queryByTestId('numberContainer')).not.toBeOnTheScreen()
+  })
+
+  it('should display the number of venues in the cluster when count informed and is greater than 1', () => {
     render(<VenueMapPin count={50} />)
 
     expect(screen.getByText('50')).toBeOnTheScreen()

--- a/src/features/search/components/VenueMapPin/VenueMapPin.tsx
+++ b/src/features/search/components/VenueMapPin/VenueMapPin.tsx
@@ -12,11 +12,13 @@ const NUMBER_LEFT_POSITION = 15
 const NUMBER_TOP_POSITION = -10
 
 export const VenueMapPin: FunctionComponent<Props> = ({ count }) => {
+  const shouldDisplayCounter = count && count > 1
+
   return (
     <React.Fragment>
       <MapPin />
 
-      {count ? (
+      {shouldDisplayCounter ? (
         <NumberContainer testID="numberContainer">
           <Typo.Caption>{count < 100 ? String(count) : '99+'}</Typo.Caption>
         </NumberContainer>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-27596

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
