### PR TITLE
(PC-28117) fix(OfferContent): fix spacing

### DIFF
--- a/src/features/offerv2/components/OfferAbout/OfferAbout.tsx
+++ b/src/features/offerv2/components/OfferAbout/OfferAbout.tsx
@@ -59,5 +59,7 @@ export const OfferAbout: FunctionComponent<Props> = ({ offer }) => {
         </React.Fragment>
       ) : null}
     </View>
-  ) : null
+  ) : (
+    <Spacer.Column numberOfSpaces={2} />
+  )
 }


### PR DESCRIPTION
when we don't have offer about section add a spacer of 8px + gap of 24px = 32px

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28117

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |<img width="395" alt="Capture d’écran 2024-02-23 à 12 53 31" src="https://github.com/pass-culture/pass-culture-app-native/assets/62058919/1c0e8c31-a6d5-48d9-8613-814a9b80af6d">|
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
