### PR TITLE
(PC-28303) fix(eslint): restricted react native imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,8 +78,9 @@ module.exports = {
           { name: 'react-device-detect', message: 'use libs/react-device-detect instead' },
           {
             name: 'react-native',
-            importNames: ['TouchableOpacity'],
-            message: 'use ui/components/TouchableOpacity instead',
+            importNames: ['TouchableOpacity', 'Image', 'ImageBackground'],
+            message:
+              'use instead : ui/components/TouchableOpacity for TouchableOpacity. Image (|| ImageBackground) comes from our backend ? libs/resizing-image-on-demand/Image(||ImageBackground) : Image(||ImageBackground) from react-native',
           },
           {
             name: 'react-native-animatable',
@@ -165,18 +166,6 @@ module.exports = {
             message: 'use modal.spacing from theme/index.ts',
           },
           {
-            name: 'react-native',
-            importNames: ['Image'],
-            message:
-              'If images come from our backend, use libs/resizing-image-on-demand/Image instead. Otherwise you can use Image from react-native',
-          },
-          {
-            name: 'react-native',
-            importNames: ['ImageBackground'],
-            message:
-              'If images come from our backend, use libs/resizing-image-on-demand/ImageBackground instead. Otherwise you can use ImageBackground from react-native',
-          },
-          {
             name: 'react-native-fast-image',
             importNames: ['default'],
             message:
@@ -184,8 +173,7 @@ module.exports = {
           },
           {
             name: 'react-native-maps',
-            message:
-              'react-native-maps is not supported on the web. Use libs/maps/maps instead',
+            message: 'react-native-maps is not supported on the web. Use libs/maps/maps instead',
           },
         ],
         patterns: [

--- a/doc/development/how-to/eslint-custom-rule.md
+++ b/doc/development/how-to/eslint-custom-rule.md
@@ -2,7 +2,7 @@
 
 ## Mode opératoire
 
-En cas de doute, la règle [use-the-right-test-utils](../eslint-custom-rules/use-the-right-test-utils.js) est bon exemple de règle ESLint custom.
+En cas de doute, la règle [use-the-right-test-utils](/eslint-custom-rules/use-the-right-test-utils.js) est bon exemple de règle ESLint custom.
 
 ### 1. Vérifier qu'il n'y a pas une règle existante
 
@@ -14,9 +14,9 @@ Sinon, continuer ce mode opératoire.
 
 - Créer un fichier JS dans `/eslint-custom-rules` et utiliser le snippet `eslint-rule` pour générer une règle vide.
 
-- Dans [eslint-local-rules.js](../eslint-local-rules.js), importer sa règle du fichier créé, et l'exporter.
+- Dans [eslint-local-rules.js](/eslint-local-rules.js), importer sa règle du fichier créé, et l'exporter.
 
-- Dans [.eslintrc.js](../.eslintrc.js), ajouter dans `rules` : `'local-rules/<ma-règle-ESLint>': ['error'],`
+- Dans [.eslintrc.js](/.eslintrc.js), ajouter dans `rules` : `'local-rules/<ma-règle-ESLint>': ['error'],`
 
 - Créer un fichier de test dans `/eslint-custom-rules/__tests__` : `<ma-règle-ESLint>.test.js`, et utiliser le snippet `eslint-test` pour générer des tests à remplir.
 

--- a/src/features/venuemap/components/VenueMapCluster/VenueMapCluster.tsx
+++ b/src/features/venuemap/components/VenueMapCluster/VenueMapCluster.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+// eslint-disable-next-line no-restricted-imports
 import { TouchableOpacity } from 'react-native'
 
 import { MapPinWithCounter } from 'features/venuemap/components/MapPinWithCounter/MapPinWithCounter'

--- a/src/libs/resizing-image-on-demand/Image.tsx
+++ b/src/libs/resizing-image-on-demand/Image.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, useMemo } from 'react'
+// eslint-disable-next-line no-restricted-imports
 import { Image as RNImage, ImageProps } from 'react-native'
 
 import { useResizeImageURL } from 'libs/resizing-image-on-demand/useResizeImageURL'

--- a/src/ui/components/__tests__/AnimatedIcon.native.test.tsx
+++ b/src/ui/components/__tests__/AnimatedIcon.native.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+// eslint-disable-next-line no-restricted-imports
 import { Animated, TouchableOpacity } from 'react-native'
 
 import { fireEvent, render, screen, waitFor } from 'tests/utils'

--- a/src/ui/components/buttons/RoundedButton.native.test.tsx
+++ b/src/ui/components/buttons/RoundedButton.native.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+// eslint-disable-next-line no-restricted-imports
 import { Animated, TouchableOpacity } from 'react-native'
 import { ReactTestInstance } from 'react-test-renderer'
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28303

si il y a plusieurs objets avec le name 'react-native', le dernier est le seul à être appliqué par react-native. Ils sont dons maintenant regroupé dans un seul objet qui malheureusement a donc un seul message avec les différentes consignes.