### PR TITLE
(PC-25863) feat(offer): use LinearGradient on offer image when enableOfferPreview FF is activated

### DIFF
--- a/src/features/offerv2/components/OfferContent/OfferContent.tsx
+++ b/src/features/offerv2/components/OfferContent/OfferContent.tsx
@@ -23,6 +23,8 @@ import { OfferVenueButton } from 'features/offerv2/components/OfferVenueButton/O
 import { getOfferArtists } from 'features/offerv2/helpers/getOfferArtists/getOfferArtists'
 import { getOfferTags } from 'features/offerv2/helpers/getOfferTags/getOfferTags'
 import { analytics, isCloseToBottom } from 'libs/analytics'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { useFunctionOnce } from 'libs/hooks'
 import { useLocation } from 'libs/location'
 import { Subcategory } from 'libs/subcategories/types'
@@ -45,6 +47,7 @@ const isWeb = Platform.OS === 'web'
 
 export const OfferContent: FunctionComponent<Props> = ({ offer, searchGroupList, subcategory }) => {
   const { userLocation } = useLocation()
+  const enableOfferPreview = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ENABLE_GOOGLE_SSO)
 
   const extraData = offer.extraData ?? undefined
   const tags = getOfferTags(subcategory.appLabel, extraData)
@@ -109,7 +112,12 @@ export const OfferContent: FunctionComponent<Props> = ({ offer, searchGroupList,
         scrollIndicatorInsets={scrollIndicatorInsets}
         bounces={false}
         onScroll={onScroll}>
-        <Hero imageUrl={offer.image?.url} type="offerv2" categoryId={subcategory.categoryId} />
+        <Hero
+          imageUrl={offer.image?.url}
+          type="offerv2"
+          categoryId={subcategory.categoryId}
+          enableOfferPreview={enableOfferPreview}
+        />
         <Spacer.Column numberOfSpaces={8} />
         <InfoContainer>
           <GroupWithoutGap>

--- a/src/ui/components/hero/Hero.stories.tsx
+++ b/src/ui/components/hero/Hero.stories.tsx
@@ -35,6 +35,14 @@ Offer.args = {
   categoryId: CategoryIdEnum.CINEMA,
 }
 
+export const OfferWithGradient = Template.bind({})
+OfferWithGradient.args = {
+  imageUrl: 'https://images.pexels.com/photos/2421953/pexels-photo-2421953.jpeg',
+  type: 'offerv2',
+  categoryId: CategoryIdEnum.CINEMA,
+  enableOfferPreview: true,
+}
+
 export const OfferWithoutImage = Template.bind({})
 OfferWithoutImage.args = {
   imageUrl: undefined,

--- a/src/ui/components/hero/Hero.stories.tsx
+++ b/src/ui/components/hero/Hero.stories.tsx
@@ -35,14 +35,6 @@ Offer.args = {
   categoryId: CategoryIdEnum.CINEMA,
 }
 
-export const OfferWithGradient = Template.bind({})
-OfferWithGradient.args = {
-  imageUrl: 'https://images.pexels.com/photos/2421953/pexels-photo-2421953.jpeg',
-  type: 'offerv2',
-  categoryId: CategoryIdEnum.CINEMA,
-  enableOfferPreview: true,
-}
-
 export const OfferWithoutImage = Template.bind({})
 OfferWithoutImage.args = {
   imageUrl: undefined,

--- a/src/ui/components/hero/Hero.tsx
+++ b/src/ui/components/hero/Hero.tsx
@@ -2,6 +2,7 @@ import React, { ComponentProps } from 'react'
 // we import FastImage to get the resizeMode, not to use it as a component
 // eslint-disable-next-line no-restricted-imports
 import FastImage from 'react-native-fast-image'
+import LinearGradient from 'react-native-linear-gradient'
 import styled from 'styled-components/native'
 
 import { CategoryIdEnum } from 'api/gen'
@@ -19,8 +20,10 @@ type HeroProps =
 // Special case where theme.icons.sizes is not used
 const PLACEHOLDER_ICON_SIZE = getSpacing(24)
 
-export const Hero: React.FC<HeroProps & { imageUrl?: string }> = (props) => {
-  const { imageUrl, ...placeholderProps } = props
+export const Hero: React.FC<HeroProps & { imageUrl?: string; enableOfferPreview?: boolean }> = (
+  props
+) => {
+  const { imageUrl, enableOfferPreview, ...placeholderProps } = props
   const { heroBackgroundHeight, imageStyle } = useHeroDimensions({
     type: placeholderProps.type,
     hasImage: !!imageUrl,
@@ -41,18 +44,27 @@ export const Hero: React.FC<HeroProps & { imageUrl?: string }> = (props) => {
             iconColor: theme.colors.white,
             size: PLACEHOLDER_ICON_SIZE,
           }
-  )``
+  )({
+    position: 'absolute',
+    zIndex: 1,
+  })
+
+  const shouldDisplayLinearGradient = enableOfferPreview && placeholderProps.type === 'offerv2'
 
   return (
     <HeroHeader type={placeholderProps.type} imageHeight={heroBackgroundHeight} imageUrl={imageUrl}>
       <Spacer.Column numberOfSpaces={heroMarginTop} />
       <ImageContainer style={imageStyle} testID="image-container">
         {imageUrl ? (
-          <StyledFastImage
-            style={imageStyle}
-            url={imageUrl}
-            resizeMode={FastImage.resizeMode?.cover}
-          />
+          <React.Fragment>
+            {shouldDisplayLinearGradient ? <StyledLinearGradient testID="image-gradient" /> : null}
+            <StyledFastImage
+              style={imageStyle}
+              url={imageUrl}
+              resizeMode={FastImage.resizeMode?.cover}
+              enableOfferPreview={enableOfferPreview}
+            />
+          </React.Fragment>
         ) : (
           <ImagePlaceholder />
         )}
@@ -61,9 +73,12 @@ export const Hero: React.FC<HeroProps & { imageUrl?: string }> = (props) => {
   )
 }
 
-const StyledFastImage = styled(ResizedFastImage)(({ theme }) => ({
-  backgroundColor: theme.colors.greyLight,
-}))
+const StyledFastImage = styled(ResizedFastImage)<{ enableOfferPreview?: boolean }>(
+  ({ theme, enableOfferPreview }) => ({
+    backgroundColor: theme.colors.greyLight,
+    ...(enableOfferPreview ? { position: 'absolute', zIndex: 1 } : {}),
+  })
+)
 
 const ImageContainer = styled.View(({ theme }) => ({
   bottom: 0,
@@ -76,4 +91,16 @@ const ImageContainer = styled.View(({ theme }) => ({
     shadowColor: theme.colors.black,
     shadowOpacity: 0.2,
   }),
+}))
+
+const StyledLinearGradient = styled(LinearGradient).attrs({
+  useAngle: true,
+  angle: 180,
+  locations: [0.362, 0.6356, 1],
+  colors: ['rgba(0, 0, 0, 0.00)', 'rgba(0, 0, 0, 0.12)', 'rgba(0, 0, 0, 0.32)'],
+})(({ theme }) => ({
+  height: '100%',
+  width: '100%',
+  borderRadius: theme.borderRadius.radius,
+  zIndex: 2,
 }))

--- a/src/ui/components/hero/Hero.tsx
+++ b/src/ui/components/hero/Hero.tsx
@@ -1,4 +1,5 @@
 import React, { ComponentProps } from 'react'
+import { Platform } from 'react-native'
 // we import FastImage to get the resizeMode, not to use it as a component
 // eslint-disable-next-line no-restricted-imports
 import FastImage from 'react-native-fast-image'
@@ -49,7 +50,8 @@ export const Hero: React.FC<HeroProps & { imageUrl?: string; enableOfferPreview?
     zIndex: 1,
   })
 
-  const shouldDisplayLinearGradient = enableOfferPreview && placeholderProps.type === 'offerv2'
+  const shouldDisplayLinearGradient =
+    enableOfferPreview && placeholderProps.type === 'offerv2' && Platform.OS !== 'web'
 
   return (
     <HeroHeader type={placeholderProps.type} imageHeight={heroBackgroundHeight} imageUrl={imageUrl}>

--- a/src/ui/components/hero/__tests__/Hero.native.test.tsx
+++ b/src/ui/components/hero/__tests__/Hero.native.test.tsx
@@ -31,4 +31,76 @@ describe('HeroImage', () => {
     expect(screen.queryByTestId('categoryIcon')).not.toBeOnTheScreen()
     expect(screen.queryByTestId('imagePlaceholder')).not.toBeOnTheScreen()
   })
+
+  it('should not display linear gradient when enableOfferPreview is not defined and url is defined', () => {
+    render(
+      <Hero
+        imageUrl="some_url_to_some_resource"
+        type="offerv2"
+        categoryId={CategoryIdEnum.CINEMA}
+      />
+    )
+
+    expect(screen.queryByTestId('image-gradient')).not.toBeOnTheScreen()
+  })
+
+  it('should not display linear gradient when enableOfferPreview is false and url is defined', () => {
+    render(
+      <Hero
+        imageUrl="some_url_to_some_resource"
+        type="offerv2"
+        categoryId={CategoryIdEnum.CINEMA}
+        enableOfferPreview={false}
+      />
+    )
+
+    expect(screen.queryByTestId('image-gradient')).not.toBeOnTheScreen()
+  })
+
+  it('should display linear gradient when enableOfferPreview is true and url is defined', () => {
+    render(
+      <Hero
+        imageUrl="some_url_to_some_resource"
+        type="offerv2"
+        categoryId={CategoryIdEnum.CINEMA}
+        enableOfferPreview
+      />
+    )
+
+    expect(screen.getByTestId('image-gradient')).toBeOnTheScreen()
+  })
+
+  it('should not display linear gradient when enableOfferPreview is true, url is defined and type is not offerv2', () => {
+    render(
+      <Hero
+        imageUrl="some_url_to_some_resource"
+        type="offer"
+        categoryId={CategoryIdEnum.CINEMA}
+        enableOfferPreview
+      />
+    )
+
+    expect(screen.queryByTestId('image-gradient')).not.toBeOnTheScreen()
+  })
+
+  it('should not display linear gradient when enableOfferPreview is true and url is not defined', () => {
+    render(
+      <Hero
+        imageUrl={undefined}
+        type="offerv2"
+        categoryId={CategoryIdEnum.CINEMA}
+        enableOfferPreview
+      />
+    )
+
+    expect(screen.queryByTestId('image-gradient')).not.toBeOnTheScreen()
+  })
+
+  it('should not display linear gradient when enableOfferPreview is true and url is empty', () => {
+    render(
+      <Hero imageUrl="" type="offerv2" categoryId={CategoryIdEnum.CINEMA} enableOfferPreview />
+    )
+
+    expect(screen.queryByTestId('image-gradient')).not.toBeOnTheScreen()
+  })
 })

--- a/src/ui/components/hero/__tests__/Hero.web.test.tsx
+++ b/src/ui/components/hero/__tests__/Hero.web.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import { CategoryIdEnum } from 'api/gen'
+import { render, screen } from 'tests/utils/web'
+
+import { Hero } from '../Hero'
+
+describe('HeroImage', () => {
+  it('should not display linear gradient when enableOfferPreview is true and url is defined', () => {
+    render(
+      <Hero
+        imageUrl="some_url_to_some_resource"
+        type="offerv2"
+        categoryId={CategoryIdEnum.CINEMA}
+        enableOfferPreview
+      />
+    )
+
+    expect(screen.queryByTestId('image-gradient')).not.toBeOnTheScreen()
+  })
+})


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25863

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="363" alt="Capture d’écran 2024-03-01 à 12 04 49" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/5e9a511d-90ba-489e-89f5-fce2e4eb4292">|<img width="437" alt="Capture d’écran 2024-02-29 à 17 41 44" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/627454b6-d900-4014-8463-38108bb6e41b">|
| Android          |               |<img width="419" alt="Capture d’écran 2024-02-29 à 17 41 51" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/8f5c3f3e-8584-4116-99ae-b1ff908f1d50">|
| Phone - Chrome   |               |![Capture d’écran 2024-03-01 à 12 10 34](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/66aa8133-3997-4990-93db-5cb6165fdd7e)|
| Desktop - Chrome |               |![Capture d’écran 2024-03-01 à 12 10 24](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/91dd0568-5364-4733-ad2e-8c3a790a20ad)|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
