### PR TITLE
(PC-28287) feat(useSearchResults): fix algolia nbHits when nbHits=0 even when there is hits

### DIFF
--- a/src/features/search/api/useSearchResults/useSearchResults.native.test.ts
+++ b/src/features/search/api/useSearchResults/useSearchResults.native.test.ts
@@ -44,5 +44,22 @@ describe('useSearchResults', () => {
 
       expect(fetchAlgoliaOffersAndVenuesSpy).toHaveBeenCalledTimes(1)
     })
+
+    it('should show hit numbers even if nbHits is at 0 but its are not null', async () => {
+      fetchAlgoliaOffersAndVenuesSpy.mockResolvedValueOnce({
+        offersResponse: { ...mockedAlgoliaResponse, nbHits: 0 },
+        venuesResponse: mockedAlgoliaVenueResponse,
+        facetsResponse: mockedFacets,
+      })
+      const { result } = renderHook(
+        (searchState: SearchState = initialSearchState) => useSearchInfiniteQuery(searchState),
+        {
+          wrapper: ({ children }) => reactQueryProviderHOC(children),
+        }
+      )
+      await flushAllPromisesWithAct()
+
+      expect(result.current.nbHits).toEqual(mockedAlgoliaResponse.hits.length)
+    })
   })
 })

--- a/src/features/search/api/useSearchResults/useSearchResults.ts
+++ b/src/features/search/api/useSearchResults/useSearchResults.ts
@@ -80,7 +80,15 @@ export const useSearchInfiniteQuery = (searchState: SearchState) => {
   const venuesUserData = data?.pages?.[0]?.venues?.userData
   const facets = data?.pages?.[0]?.facets.facets as FacetData
 
-  return { data, hits, nbHits, userData, venuesUserData, facets, ...infiniteQuery }
+  return {
+    data,
+    hits,
+    nbHits: nbHits === 0 ? hits.offers.length : nbHits, // (PC-28287) there is an algolia bugs that return 0 nbHits but there are hits
+    userData,
+    venuesUserData,
+    facets,
+    ...infiniteQuery,
+  }
 }
 
 export const useSearchResults = () => {


### PR DESCRIPTION
Link to JIRA ticket:  https://passculture.atlassian.net/jira/software/c/projects/PC/boards/72?selectedIssue=PC-28287

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change

## Screenshots

**delete** _if no UI change_

<img width="1464" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/70148476/98bd631e-de75-4ba3-a897-b867843ba2af">

