### PR TITLE
(PC-28405) chore(babel): add numeric separator plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -23,6 +23,7 @@ module.exports = {
         },
       },
     ],
+    "@babel/plugin-transform-numeric-separator",
     '@babel/plugin-proposal-unicode-property-regex',
     '@babel/plugin-proposal-export-namespace-from',
     'react-native-reanimated/plugin',

--- a/package.json
+++ b/package.json
@@ -201,6 +201,7 @@
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-export-default-from": "^7.12.13",
     "@babel/plugin-proposal-unicode-property-regex": "^7.16.7",
+    "@babel/plugin-transform-numeric-separator": "^7.23.4",
     "@babel/plugin-transform-react-jsx-source": "^7.14.5",
     "@babel/preset-env": "^7.20.0",
     "@babel/preset-react": "^7.12.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3105,6 +3105,14 @@
     "@babel/helper-plugin-utils" "^7.22.5"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
 
+"@babel/plugin-transform-numeric-separator@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.23.4.tgz#03d08e3691e405804ecdd19dd278a40cca531f29"
+  integrity sha512-mps6auzgwjRrwKEZA05cOwuDc9FAzoyFS4ZsG/8F43bTLf/TgkJg7QXOrPO1JO599iA3qgK9MXdMGOEC8O1h6Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.22.5"
+    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
+
 "@babel/plugin-transform-object-assign@^7.16.7":
   version "7.23.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.23.3.tgz#64177e8cf943460c7f0e1c410277546804f59625"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28405

So that can have : 
```js
const EARTH_RADIUS = 6_378_137
```
instead of 
```js
const EARTH_RADIUS = 6378137
```
and improve readability