### PR TITLE
(BSR) chore(algolia): Remove unused OFFER_STOCKS_DATE_CREATED

### DIFF
--- a/src/libs/algolia/enums/facetsEnums.ts
+++ b/src/libs/algolia/enums/facetsEnums.ts
@@ -24,7 +24,6 @@ export enum NUMERIC_FILTERS_ENUM {
   OFFER_PRICES = 'offer.prices',
   OFFER_DATES = 'offer.dates',
   OFFER_TIMES = 'offer.times',
-  OFFER_STOCKS_DATE_CREATED = 'offer.stocksDateCreated',
   OFFER_LAST_30_DAYS_BOOKINGS = 'offer.last30DaysBookings',
 }
 


### PR DESCRIPTION
Unused since c07423326c551c7031f17c9cdf3 (and the corresponding
`stocksDateCreated` attribute will soon be removed from Algolia).