### PR TITLE
(PC-28222) fix(scroll): fix focus when movie location changes

### DIFF
--- a/src/features/offerv2/components/MovieCalendar/MovieCalendar.tsx
+++ b/src/features/offerv2/components/MovieCalendar/MovieCalendar.tsx
@@ -40,13 +40,20 @@ type Props = {
   dates: Date[]
   selectedDate: Date | undefined
   onTabChange: (date: Date) => void
+  scrollViewRef?: React.MutableRefObject<ScrollView | null>
 }
 
-export const MovieCalendar: React.FC<Props> = ({ dates, selectedDate, onTabChange }) => {
+export const MovieCalendar: React.FC<Props> = ({
+  dates,
+  selectedDate,
+  onTabChange,
+  scrollViewRef,
+}) => {
   return (
     <Container>
       <BottomBar />
       <ScrollView
+        ref={scrollViewRef}
         horizontal
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={scrollViewContainer}>

--- a/src/features/offerv2/components/MovieScreeningCalendar/MovieScreeningCalendar.native.test.tsx
+++ b/src/features/offerv2/components/MovieScreeningCalendar/MovieScreeningCalendar.native.test.tsx
@@ -65,7 +65,7 @@ describe('Movie screening calendar', () => {
 const renderMovieScreeningCalendar = ({
   stocks = [defaultOfferStockResponse],
 }: {
-  stocks?: OfferStockResponse[]
+  stocks: OfferStockResponse[]
 }) => {
   render(<MovieScreeningCalendar stocks={stocks} />)
 }

--- a/src/features/offerv2/components/MovieScreeningCalendar/MovieScreeningCalendar.tsx
+++ b/src/features/offerv2/components/MovieScreeningCalendar/MovieScreeningCalendar.tsx
@@ -1,4 +1,5 @@
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useEffect, useRef } from 'react'
+import { ScrollView } from 'react-native'
 
 import { OfferStockResponse } from 'api/gen'
 import { MovieCalendar } from 'features/offerv2/components/MovieCalendar/MovieCalendar'
@@ -7,9 +8,18 @@ import { Spacer } from 'ui/theme'
 
 type Props = {
   stocks: OfferStockResponse[]
+  offerId?: number
 }
-export const MovieScreeningCalendar: FunctionComponent<Props> = ({ stocks }) => {
+export const MovieScreeningCalendar: FunctionComponent<Props> = ({ stocks, offerId }) => {
   const { movieScreeningDates, selectedDate, setSelectedDate } = useMovieScreeningCalendar(stocks)
+
+  const scrollViewRef = useRef<ScrollView | null>(null)
+
+  useEffect(() => {
+    if (scrollViewRef?.current) {
+      scrollViewRef.current.scrollTo({ x: 0 })
+    }
+  }, [scrollViewRef, offerId])
 
   return (
     <React.Fragment>
@@ -17,6 +27,7 @@ export const MovieScreeningCalendar: FunctionComponent<Props> = ({ stocks }) => 
         dates={movieScreeningDates}
         selectedDate={selectedDate}
         onTabChange={setSelectedDate}
+        scrollViewRef={scrollViewRef}
       />
       <Spacer.Column numberOfSpaces={6} />
     </React.Fragment>

--- a/src/features/offerv2/components/OfferContent/OfferContent.tsx
+++ b/src/features/offerv2/components/OfferContent/OfferContent.tsx
@@ -163,7 +163,7 @@ export const OfferContent: FunctionComponent<Props> = ({ offer, searchGroupList,
 
         {isOfferAMovieScreening ? (
           <FeatureFlag featureFlag={RemoteStoreFeatureFlags.WIP_ENABLE_NEW_XP_CINE_FROM_OFFER}>
-            <MovieScreeningCalendar stocks={offer.stocks} />
+            <MovieScreeningCalendar offerId={offer.id} stocks={offer.stocks} />
           </FeatureFlag>
         ) : null}
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28222

## Checklist

I have:

- [X] Made sure my feature is working on the relevant real / virtual devices (native and web).

[AVANT - IOS]

https://github.com/pass-culture/pass-culture-app-native/assets/158567429/f00b1259-a19b-4d3e-bbdf-ef30c10697e1

[APRES - IOS]
https://github.com/pass-culture/pass-culture-app-native/assets/158567429/33aa9319-99e7-4f2a-a04b-560f59311a51

Pour tester :

- Rechercher le film "Dune" (le deuxième)
- Changer de lieu de projection (les cinémas **cinéma Boost** et **Madiana congres** ont beaucoup de dates de séances).
- Choisir la date la plus à droite puis changer de cinéma et constater que la première date du calendrier est selected + que le scroll est au début du calendrier.