### PR TITLE
(PC-28334) feat(NotificationSettings): Make notification switch available on ios & android

### DIFF
--- a/src/features/profile/pages/NotificationSettings/NotificationSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationSettings.tsx
@@ -162,7 +162,7 @@ export function NotificationSettings() {
           toggle={toggleEmails}
           disabled={!isLoggedIn}
         />
-        {Platform.OS === 'ios' && (
+        {Platform.OS !== 'web' && (
           <React.Fragment>
             <Separator.Horizontal />
             <Spacer.Column numberOfSpaces={4} />

--- a/src/features/profile/pages/NotificationSettings/NotificationSettings.web.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationSettings.web.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import * as RNP from 'react-native-permissions'
 
 import { useRoute } from '__mocks__/@react-navigation/native'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -10,13 +9,9 @@ import { NotificationSettings } from './NotificationSettings'
 jest.mock('features/auth/context/AuthContext')
 
 useRoute.mockReturnValue({ key: 'ksdqldkmqdmqdq' })
-jest.spyOn(RNP, 'checkNotifications').mockResolvedValue({
-  status: 'granted',
-  settings: {},
-})
 
 describe('<NotificationSettings/>', () => {
-  it('should display first switch', async () => {
+  it('should only display switch to authorize emails', async () => {
     render(reactQueryProviderHOC(<NotificationSettings />))
 
     expect(await screen.findByText('Autoriser l’envoi d’e-mails')).toBeTruthy()

--- a/src/features/profile/pages/NotificationSettings/NotificationSettings.web.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationSettings.web.test.tsx
@@ -1,11 +1,28 @@
 import React from 'react'
+import * as RNP from 'react-native-permissions'
 
+import { useRoute } from '__mocks__/@react-navigation/native'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { render, checkAccessibilityFor, act } from 'tests/utils/web'
+import { render, checkAccessibilityFor, act, screen } from 'tests/utils/web'
 
 import { NotificationSettings } from './NotificationSettings'
 
+jest.mock('features/auth/context/AuthContext')
+
+useRoute.mockReturnValue({ key: 'ksdqldkmqdmqdq' })
+jest.spyOn(RNP, 'checkNotifications').mockResolvedValue({
+  status: 'granted',
+  settings: {},
+})
+
 describe('<NotificationSettings/>', () => {
+  it('should display first switch', async () => {
+    render(reactQueryProviderHOC(<NotificationSettings />))
+
+    expect(await screen.findByText('Autoriser l’envoi d’e-mails')).toBeTruthy()
+    expect(screen.queryByText('Autoriser les notifications marketing')).not.toBeOnTheScreen()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(reactQueryProviderHOC(<NotificationSettings />))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28334

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change

## Screenshots

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |![Screenshot_1709905863](https://github.com/pass-culture/pass-culture-app-native/assets/75068235/20b651a9-5eb9-4c72-b1f0-5fe9dba10f5f) | ![Screenshot_1709905850](https://github.com/pass-culture/pass-culture-app-native/assets/75068235/1e2fa015-783c-4b10-b81b-aa533dadcb53) |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |