### PR TITLE
(PC-28336) feat(Notifications): add new notifs settings page

### DIFF
--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -1,0 +1,1541 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotificationSettings should render correctly when user is logged in 1`] = `
+[
+  <View
+    accessibilityRole="header"
+    style={
+      [
+        {
+          "backgroundColor": "rgba(255,255,255,0)",
+          "borderBottomColor": "#F1F1F4",
+          "borderBottomWidth": 1,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1,
+        },
+      ]
+    }
+  >
+    <View
+      customHeight={16}
+      enable={true}
+      style={
+        [
+          {
+            "height": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "height": 48,
+            "justifyContent": "center",
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+              "width": "100%",
+            },
+          ]
+        }
+      >
+        <View
+          positionInHeader="left"
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "flex-start",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+              },
+            ]
+          }
+          testID="back-button-container"
+        >
+          <View
+            accessibilityLabel="Revenir en arrière"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "height": 40,
+                "justifyContent": "center",
+                "maxWidth": 40,
+                "opacity": 1,
+                "userSelect": "auto",
+              }
+            }
+            testID="Revenir en arrière"
+          >
+            <View
+              height={24}
+              testID="icon-back"
+              width={24}
+            >
+              <Text>
+                icon-back-SVG-Mock
+              </Text>
+            </View>
+            <Text
+              style={
+                [
+                  {
+                    "display": "none",
+                  },
+                ]
+              }
+            >
+              Retour
+            </Text>
+          </View>
+        </View>
+        <Text
+          numberOfLines={1}
+          style={
+            [
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Regular",
+                "fontSize": 15,
+                "lineHeight": 20,
+                "textAlign": "center",
+              },
+            ]
+          }
+        >
+          Suivi et notifications
+        </Text>
+        <View
+          positionInHeader="right"
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "flex-end",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+              },
+            ]
+          }
+          testID="close-button-container"
+        />
+      </View>
+    </View>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "#ffffff",
+          "flexBasis": 0,
+          "flexDirection": "column",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "paddingHorizontal": 24,
+        },
+      ]
+    }
+  >
+    <View
+      height={65}
+      style={
+        [
+          {
+            "height": 65,
+          },
+        ]
+      }
+    />
+    <View
+      numberOfSpaces={6}
+      style={
+        [
+          {
+            "height": 24,
+          },
+        ]
+      }
+    />
+    <Text
+      style={
+        [
+          {
+            "color": "#161617",
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 18,
+            "lineHeight": 22,
+          },
+        ]
+      }
+    >
+      Type d’alerte
+    </Text>
+    <View
+      numberOfSpaces={4}
+      style={
+        [
+          {
+            "height": 16,
+          },
+        ]
+      }
+    />
+    <Text
+      style={
+        [
+          {
+            "color": "#161617",
+            "fontFamily": "Montserrat-Regular",
+            "fontSize": 15,
+            "lineHeight": 20,
+          },
+        ]
+      }
+    >
+      Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
+    </Text>
+    <View
+      numberOfSpaces={2}
+      style={
+        [
+          {
+            "height": 8,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        [
+          {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "paddingVertical": 16,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+            ]
+          }
+          toggleLabel={false}
+        >
+          <Text
+            htmlFor="testUuidV4"
+            style={
+              [
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 20,
+                },
+              ]
+            }
+          >
+            <Text
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Bold",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              Autoriser l’envoi d’e-mails
+            </Text>
+          </Text>
+        </View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+            ]
+          }
+        >
+          <View
+            numberOfSpaces={5}
+            style={
+              [
+                {
+                  "width": 20,
+                },
+              ]
+            }
+          />
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityHidden={true}
+              style={
+                [
+                  {
+                    "display": "none",
+                  },
+                ]
+              }
+            >
+              Case à cocher - 
+              non cochée
+            </Text>
+            <View
+              accessibilityRole="checkbox"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": false,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={false}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "opacity": 1,
+                  "userSelect": "auto",
+                }
+              }
+              testID="Interrupteur Autoriser l’envoi d’e-mails"
+            >
+              <View
+                active={false}
+                style={
+                  [
+                    {
+                      "backgroundColor": "#90949D",
+                      "borderRadius": 16,
+                      "height": 32,
+                      "justifyContent": "center",
+                      "width": 56,
+                    },
+                  ]
+                }
+              >
+                <View
+                  collapsable={false}
+                  disabled={false}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "aspectRatio": 1,
+                      "backgroundColor": "#ffffff",
+                      "borderRadius": 28,
+                      "height": 28,
+                      "justifyContent": "center",
+                      "marginLeft": 2,
+                      "shadowColor": "#161617",
+                      "shadowOffset": {
+                        "height": 2,
+                        "width": 0,
+                      },
+                      "shadowOpacity": 0.2,
+                      "shadowRadius": 2.5,
+                      "width": 28,
+                    }
+                  }
+                />
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "paddingVertical": 16,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+            ]
+          }
+          toggleLabel={false}
+        >
+          <Text
+            htmlFor="testUuidV4"
+            style={
+              [
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 20,
+                },
+              ]
+            }
+          >
+            <Text
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Bold",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              Autoriser les notifications
+            </Text>
+          </Text>
+        </View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+            ]
+          }
+        >
+          <View
+            numberOfSpaces={5}
+            style={
+              [
+                {
+                  "width": 20,
+                },
+              ]
+            }
+          />
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityHidden={true}
+              style={
+                [
+                  {
+                    "display": "none",
+                  },
+                ]
+              }
+            >
+              Case à cocher - 
+              non cochée
+            </Text>
+            <View
+              accessibilityRole="checkbox"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": false,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={false}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "opacity": 1,
+                  "userSelect": "auto",
+                }
+              }
+              testID="Interrupteur Autoriser les notifications"
+            >
+              <View
+                active={false}
+                style={
+                  [
+                    {
+                      "backgroundColor": "#90949D",
+                      "borderRadius": 16,
+                      "height": 32,
+                      "justifyContent": "center",
+                      "width": 56,
+                    },
+                  ]
+                }
+              >
+                <View
+                  collapsable={false}
+                  disabled={false}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "aspectRatio": 1,
+                      "backgroundColor": "#ffffff",
+                      "borderRadius": 28,
+                      "height": 28,
+                      "justifyContent": "center",
+                      "marginLeft": 2,
+                      "shadowColor": "#161617",
+                      "shadowOffset": {
+                        "height": 2,
+                        "width": 0,
+                      },
+                      "shadowOpacity": 0.2,
+                      "shadowRadius": 2.5,
+                      "width": 28,
+                    }
+                  }
+                />
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        numberOfSpaces={4}
+        style={
+          [
+            {
+              "height": 16,
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "backgroundColor": "#F1F1F4",
+              "height": 1,
+              "width": "100%",
+            },
+          ]
+        }
+      />
+      <View
+        numberOfSpaces={8}
+        style={
+          [
+            {
+              "height": 32,
+            },
+          ]
+        }
+      />
+      <View
+        accessibilityLabel="Enregistrer les modifications"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={false}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#eb0055",
+            "borderRadius": 24,
+            "flexDirection": "row",
+            "justifyContent": "center",
+            "maxWidth": 500,
+            "minHeight": 40,
+            "opacity": 1,
+            "paddingBottom": 2,
+            "paddingLeft": 20,
+            "paddingRight": 20,
+            "paddingTop": 2,
+            "userSelect": "auto",
+            "width": "100%",
+          }
+        }
+        testID="Enregistrer les modifications"
+      >
+        <Text
+          adjustsFontSizeToFit={false}
+          numberOfLines={1}
+          style={
+            [
+              {
+                "color": "#ffffff",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 15,
+                "lineHeight": 20,
+                "marginLeft": 0,
+                "maxWidth": "100%",
+              },
+            ]
+          }
+        >
+          Enregistrer
+        </Text>
+      </View>
+    </View>
+    <View
+      numberOfSpaces={6}
+      style={
+        [
+          {
+            "height": 24,
+          },
+        ]
+      }
+    />
+  </View>,
+  <View
+    height={65}
+    style={
+      [
+        {
+          "backdropFilter": "blur(20px)",
+          "height": 65,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  >
+    <BlurView
+      blurAmount={8}
+      blurType="light"
+      style={
+        [
+          {
+            "backgroundColor": "transparent",
+          },
+          [
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+            },
+          ],
+        ]
+      }
+    />
+  </View>,
+]
+`;
+
+exports[`NotificationSettings should render correctly when user is not logged in 1`] = `
+[
+  <View
+    accessibilityRole="header"
+    style={
+      [
+        {
+          "backgroundColor": "rgba(255,255,255,0)",
+          "borderBottomColor": "#F1F1F4",
+          "borderBottomWidth": 1,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1,
+        },
+      ]
+    }
+  >
+    <View
+      customHeight={16}
+      enable={true}
+      style={
+        [
+          {
+            "height": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "height": 48,
+            "justifyContent": "center",
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+              "width": "100%",
+            },
+          ]
+        }
+      >
+        <View
+          positionInHeader="left"
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "flex-start",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+              },
+            ]
+          }
+          testID="back-button-container"
+        >
+          <View
+            accessibilityLabel="Revenir en arrière"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "height": 40,
+                "justifyContent": "center",
+                "maxWidth": 40,
+                "opacity": 1,
+                "userSelect": "auto",
+              }
+            }
+            testID="Revenir en arrière"
+          >
+            <View
+              height={24}
+              testID="icon-back"
+              width={24}
+            >
+              <Text>
+                icon-back-SVG-Mock
+              </Text>
+            </View>
+            <Text
+              style={
+                [
+                  {
+                    "display": "none",
+                  },
+                ]
+              }
+            >
+              Retour
+            </Text>
+          </View>
+        </View>
+        <Text
+          numberOfLines={1}
+          style={
+            [
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Regular",
+                "fontSize": 15,
+                "lineHeight": 20,
+                "textAlign": "center",
+              },
+            ]
+          }
+        >
+          Suivi et notifications
+        </Text>
+        <View
+          positionInHeader="right"
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "flex-end",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+              },
+            ]
+          }
+          testID="close-button-container"
+        />
+      </View>
+    </View>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "#ffffff",
+          "flexBasis": 0,
+          "flexDirection": "column",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "paddingHorizontal": 24,
+        },
+      ]
+    }
+  >
+    <View
+      height={65}
+      style={
+        [
+          {
+            "height": 65,
+          },
+        ]
+      }
+    />
+    <View
+      numberOfSpaces={6}
+      style={
+        [
+          {
+            "height": 24,
+          },
+        ]
+      }
+    />
+    <Text
+      style={
+        [
+          {
+            "color": "#161617",
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 18,
+            "lineHeight": 22,
+          },
+        ]
+      }
+    >
+      Type d’alerte
+    </Text>
+    <View
+      numberOfSpaces={4}
+      style={
+        [
+          {
+            "height": 16,
+          },
+        ]
+      }
+    />
+    <Text
+      style={
+        [
+          {
+            "color": "#161617",
+            "fontFamily": "Montserrat-Regular",
+            "fontSize": 15,
+            "lineHeight": 20,
+          },
+        ]
+      }
+    >
+      Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
+    </Text>
+    <View
+      numberOfSpaces={2}
+      style={
+        [
+          {
+            "height": 8,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        [
+          {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "paddingVertical": 16,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+            ]
+          }
+          toggleLabel={false}
+        >
+          <Text
+            htmlFor="testUuidV4"
+            style={
+              [
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 20,
+                },
+              ]
+            }
+          >
+            <Text
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Bold",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              Autoriser l’envoi d’e-mails
+            </Text>
+          </Text>
+        </View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+            ]
+          }
+        >
+          <View
+            numberOfSpaces={5}
+            style={
+              [
+                {
+                  "width": 20,
+                },
+              ]
+            }
+          />
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityHidden={true}
+              style={
+                [
+                  {
+                    "display": "none",
+                  },
+                ]
+              }
+            >
+              Case à cocher - 
+              non cochée
+            </Text>
+            <View
+              accessibilityRole="checkbox"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": false,
+                  "disabled": true,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={false}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "opacity": 1,
+                  "userSelect": "auto",
+                }
+              }
+              testID="Interrupteur Autoriser l’envoi d’e-mails"
+            >
+              <View
+                active={false}
+                style={
+                  [
+                    {
+                      "backgroundColor": "#90949D",
+                      "borderRadius": 16,
+                      "height": 32,
+                      "justifyContent": "center",
+                      "width": 56,
+                    },
+                  ]
+                }
+              >
+                <View
+                  collapsable={false}
+                  disabled={true}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "aspectRatio": 1,
+                      "backgroundColor": "#ffffff",
+                      "borderRadius": 28,
+                      "height": 28,
+                      "justifyContent": "center",
+                      "marginLeft": 2,
+                      "width": 28,
+                    }
+                  }
+                >
+                  <View
+                    accessibilityLabel="Désactivé"
+                    height={16}
+                    width={16}
+                  >
+                    <Text>
+                      undefined-SVG-Mock
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "paddingVertical": 16,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexBasis": 0,
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+            ]
+          }
+          toggleLabel={false}
+        >
+          <Text
+            htmlFor="testUuidV4"
+            style={
+              [
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Regular",
+                  "fontSize": 15,
+                  "lineHeight": 20,
+                },
+              ]
+            }
+          >
+            <Text
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Bold",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              Autoriser les notifications
+            </Text>
+          </Text>
+        </View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+            ]
+          }
+        >
+          <View
+            numberOfSpaces={5}
+            style={
+              [
+                {
+                  "width": 20,
+                },
+              ]
+            }
+          />
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityHidden={true}
+              style={
+                [
+                  {
+                    "display": "none",
+                  },
+                ]
+              }
+            >
+              Case à cocher - 
+              non cochée
+            </Text>
+            <View
+              accessibilityRole="checkbox"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": false,
+                  "disabled": true,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={false}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "opacity": 1,
+                  "userSelect": "auto",
+                }
+              }
+              testID="Interrupteur Autoriser les notifications"
+            >
+              <View
+                active={false}
+                style={
+                  [
+                    {
+                      "backgroundColor": "#90949D",
+                      "borderRadius": 16,
+                      "height": 32,
+                      "justifyContent": "center",
+                      "width": 56,
+                    },
+                  ]
+                }
+              >
+                <View
+                  collapsable={false}
+                  disabled={true}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "aspectRatio": 1,
+                      "backgroundColor": "#ffffff",
+                      "borderRadius": 28,
+                      "height": 28,
+                      "justifyContent": "center",
+                      "marginLeft": 2,
+                      "width": 28,
+                    }
+                  }
+                >
+                  <View
+                    accessibilityLabel="Désactivé"
+                    height={16}
+                    width={16}
+                  >
+                    <Text>
+                      undefined-SVG-Mock
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        numberOfSpaces={4}
+        style={
+          [
+            {
+              "height": 16,
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "backgroundColor": "#F1F1F4",
+              "height": 1,
+              "width": "100%",
+            },
+          ]
+        }
+      />
+      <View
+        numberOfSpaces={8}
+        style={
+          [
+            {
+              "height": 32,
+            },
+          ]
+        }
+      />
+      <View
+        accessibilityLabel="Enregistrer les modifications"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={false}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#eb0055",
+            "borderRadius": 24,
+            "flexDirection": "row",
+            "justifyContent": "center",
+            "maxWidth": 500,
+            "minHeight": 40,
+            "opacity": 1,
+            "paddingBottom": 2,
+            "paddingLeft": 20,
+            "paddingRight": 20,
+            "paddingTop": 2,
+            "userSelect": "auto",
+            "width": "100%",
+          }
+        }
+        testID="Enregistrer les modifications"
+      >
+        <Text
+          adjustsFontSizeToFit={false}
+          numberOfLines={1}
+          style={
+            [
+              {
+                "color": "#ffffff",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 15,
+                "lineHeight": 20,
+                "marginLeft": 0,
+                "maxWidth": "100%",
+              },
+            ]
+          }
+        >
+          Enregistrer
+        </Text>
+      </View>
+    </View>
+    <View
+      numberOfSpaces={6}
+      style={
+        [
+          {
+            "height": 24,
+          },
+        ]
+      }
+    />
+  </View>,
+  <View
+    height={65}
+    style={
+      [
+        {
+          "backdropFilter": "blur(20px)",
+          "height": 65,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  >
+    <BlurView
+      blurAmount={8}
+      blurType="light"
+      style={
+        [
+          {
+            "backgroundColor": "transparent",
+          },
+          [
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+            },
+          ],
+        ]
+      }
+    />
+  </View>,
+]
+`;

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -284,10 +284,12 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -301,6 +303,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -332,6 +335,16 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -341,16 +354,6 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -459,10 +462,12 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -476,6 +481,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -507,6 +513,16 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -516,16 +532,6 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -689,10 +695,12 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -706,6 +714,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -737,6 +746,16 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -746,16 +765,6 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -874,10 +883,12 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -891,6 +902,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -922,6 +934,16 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -931,16 +953,6 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -1049,10 +1061,12 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -1066,6 +1080,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -1097,6 +1112,16 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -1106,16 +1131,6 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -1224,10 +1239,12 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -1241,6 +1258,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -1272,6 +1290,16 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -1281,16 +1309,6 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -1399,10 +1417,12 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -1416,6 +1436,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -1447,6 +1468,16 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -1456,16 +1487,6 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -1574,10 +1595,12 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -1591,6 +1614,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -1622,6 +1646,16 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -1631,16 +1665,6 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -1749,10 +1773,12 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -1766,6 +1792,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -1797,6 +1824,16 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -1806,16 +1843,6 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -2406,10 +2433,12 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -2423,6 +2452,7 @@ exports[`NotificationSettings should render correctly when user is not logged in
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -2454,6 +2484,16 @@ exports[`NotificationSettings should render correctly when user is not logged in
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -2463,16 +2503,6 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -2584,10 +2614,12 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -2601,6 +2633,7 @@ exports[`NotificationSettings should render correctly when user is not logged in
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -2632,6 +2665,16 @@ exports[`NotificationSettings should render correctly when user is not logged in
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -2641,16 +2684,6 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -2817,10 +2850,12 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -2834,6 +2869,7 @@ exports[`NotificationSettings should render correctly when user is not logged in
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -2865,6 +2901,16 @@ exports[`NotificationSettings should render correctly when user is not logged in
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -2874,16 +2920,6 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -3005,10 +3041,12 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -3022,6 +3060,7 @@ exports[`NotificationSettings should render correctly when user is not logged in
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -3053,6 +3092,16 @@ exports[`NotificationSettings should render correctly when user is not logged in
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -3062,16 +3111,6 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -3183,10 +3222,12 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -3200,6 +3241,7 @@ exports[`NotificationSettings should render correctly when user is not logged in
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -3231,6 +3273,16 @@ exports[`NotificationSettings should render correctly when user is not logged in
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -3240,16 +3292,6 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -3361,10 +3403,12 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -3378,6 +3422,7 @@ exports[`NotificationSettings should render correctly when user is not logged in
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -3409,6 +3454,16 @@ exports[`NotificationSettings should render correctly when user is not logged in
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -3418,16 +3473,6 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -3539,10 +3584,12 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -3556,6 +3603,7 @@ exports[`NotificationSettings should render correctly when user is not logged in
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -3587,6 +3635,16 @@ exports[`NotificationSettings should render correctly when user is not logged in
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -3596,16 +3654,6 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -3717,10 +3765,12 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -3734,6 +3784,7 @@ exports[`NotificationSettings should render correctly when user is not logged in
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -3765,6 +3816,16 @@ exports[`NotificationSettings should render correctly when user is not logged in
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -3774,16 +3835,6 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [
@@ -3895,10 +3946,12 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 {
                   "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "flex-start",
                   "paddingVertical": 16,
                 },
               ]
             }
+            toggleLabel={false}
           >
             <View
               style={
@@ -3912,6 +3965,7 @@ exports[`NotificationSettings should render correctly when user is not logged in
                   },
                 ]
               }
+              toggleLabel={false}
             >
               <Text
                 htmlFor="testUuidV4"
@@ -3943,6 +3997,16 @@ exports[`NotificationSettings should render correctly when user is not logged in
               </Text>
             </View>
             <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "width": 16,
+                  },
+                ]
+              }
+            />
+            <View
               style={
                 [
                   {
@@ -3952,16 +4016,6 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 ]
               }
             >
-              <View
-                numberOfSpaces={5}
-                style={
-                  [
-                    {
-                      "width": 20,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -208,448 +208,17 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
           ]
         }
       />
-      <Text
-        style={
-          [
-            {
-              "color": "#161617",
-              "fontFamily": "Montserrat-Medium",
-              "fontSize": 18,
-              "lineHeight": 22,
-            },
-          ]
-        }
-      >
-        Type d’alerte
-      </Text>
-      <View
-        numberOfSpaces={4}
-        style={
-          [
-            {
-              "height": 16,
-            },
-          ]
-        }
-      />
-      <Text
-        style={
-          [
-            {
-              "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
-            },
-          ]
-        }
-      >
-        Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
-      </Text>
-      <View
-        numberOfSpaces={2}
-        style={
-          [
-            {
-              "height": 8,
-            },
-          ]
-        }
-      />
       <View
         style={
           [
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
+              "alignSelf": "center",
+              "maxWidth": 500,
+              "width": "100%",
             },
           ]
         }
       >
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexBasis": 0,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-              ]
-            }
-            toggleLabel={false}
-          >
-            <Text
-              htmlFor="testUuidV4"
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
-                    },
-                  ]
-                }
-              >
-                Autoriser l’envoi d’e-mails
-              </Text>
-            </Text>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                  },
-                ]
-              }
-            >
-              <Text
-                accessibilityHidden={true}
-                style={
-                  [
-                    {
-                      "display": "none",
-                    },
-                  ]
-                }
-              >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Autoriser l’envoi d’e-mails"
-              >
-                <View
-                  active={false}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    disabled={false}
-                    style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "shadowColor": "#161617",
-                        "shadowOffset": {
-                          "height": 2,
-                          "width": 0,
-                        },
-                        "shadowOpacity": 0.2,
-                        "shadowRadius": 2.5,
-                        "width": 28,
-                      }
-                    }
-                  />
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexBasis": 0,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-              ]
-            }
-            toggleLabel={false}
-          >
-            <Text
-              htmlFor="testUuidV4"
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
-                    },
-                  ]
-                }
-              >
-                Autoriser les notifications
-              </Text>
-            </Text>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                  },
-                ]
-              }
-            >
-              <Text
-                accessibilityHidden={true}
-                style={
-                  [
-                    {
-                      "display": "none",
-                    },
-                  ]
-                }
-              >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Autoriser les notifications"
-              >
-                <View
-                  active={false}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    disabled={false}
-                    style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "shadowColor": "#161617",
-                        "shadowOffset": {
-                          "height": 2,
-                          "width": 0,
-                        },
-                        "shadowOpacity": 0.2,
-                        "shadowRadius": 2.5,
-                        "width": 28,
-                      }
-                    }
-                  />
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-        <View
-          numberOfSpaces={4}
-          style={
-            [
-              {
-                "height": 16,
-              },
-            ]
-          }
-        />
-        <View
-          style={
-            [
-              {
-                "backgroundColor": "#F1F1F4",
-                "height": 1,
-                "width": "100%",
-              },
-            ]
-          }
-        />
-        <View
-          numberOfSpaces={8}
-          style={
-            [
-              {
-                "height": 32,
-              },
-            ]
-          }
-        />
         <Text
           style={
             [
@@ -662,194 +231,32 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
             ]
           }
         >
-          Tes thème suivis
+          Type d’alerte
         </Text>
         <View
-          numberOfSpaces={6}
+          numberOfSpaces={4}
           style={
             [
               {
-                "height": 24,
+                "height": 16,
               },
             ]
           }
         />
-        <View
+        <Text
           style={
             [
               {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
+                "color": "#161617",
+                "fontFamily": "Montserrat-Regular",
+                "fontSize": 15,
+                "lineHeight": 20,
               },
             ]
           }
         >
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexBasis": 0,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-              ]
-            }
-            toggleLabel={false}
-          >
-            <Text
-              htmlFor="testUuidV4"
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
-                    },
-                  ]
-                }
-              >
-                Suivre tous les thèmes
-              </Text>
-            </Text>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                  },
-                ]
-              }
-            >
-              <Text
-                accessibilityHidden={true}
-                style={
-                  [
-                    {
-                      "display": "none",
-                    },
-                  ]
-                }
-              >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Suivre tous les thèmes"
-              >
-                <View
-                  active={false}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    disabled={false}
-                    style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "shadowColor": "#161617",
-                        "shadowOffset": {
-                          "height": 2,
-                          "width": 0,
-                        },
-                        "shadowOpacity": 0.2,
-                        "shadowRadius": 2.5,
-                        "width": 28,
-                      }
-                    }
-                  />
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
+          Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
+        </Text>
         <View
           numberOfSpaces={2}
           style={
@@ -864,9 +271,9 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
           style={
             [
               {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
               },
             ]
           }
@@ -876,64 +283,54 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
               [
                 {
                   "alignItems": "center",
-                  "flexBasis": 0,
                   "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "paddingVertical": 16,
                 },
               ]
             }
-            toggleLabel={false}
           >
-            <Text
-              htmlFor="testUuidV4"
+            <View
               style={
                 [
                   {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                 ]
               }
             >
               <Text
+                htmlFor="testUuidV4"
                 style={
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
+                      "fontFamily": "Montserrat-Regular",
                       "fontSize": 15,
                       "lineHeight": 20,
                     },
                   ]
                 }
               >
-                Cinéma
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Autoriser l’envoi d’e-mails
+                </Text>
               </Text>
-            </Text>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
+            </View>
             <View
               style={
                 [
@@ -944,172 +341,171 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 ]
               }
             >
-              <Text
-                accessibilityHidden={true}
+              <View
+                numberOfSpaces={5}
                 style={
                   [
                     {
-                      "display": "none",
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
                     },
                   ]
                 }
               >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Cinéma"
-              >
-                <View
-                  active={false}
+                <Text
+                  accessibilityHidden={true}
                   style={
                     [
                       {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
+                        "display": "none",
                       },
                     ]
                   }
                 >
-                  <View
-                    collapsable={false}
-                    disabled={false}
-                    style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "shadowColor": "#161617",
-                        "shadowOffset": {
-                          "height": 2,
-                          "width": 0,
-                        },
-                        "shadowOpacity": 0.2,
-                        "shadowRadius": 2.5,
-                        "width": 28,
-                      }
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
                     }
-                  />
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Autoriser l’envoi d’e-mails"
+                >
+                  <View
+                    active={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      disabled={false}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "shadowColor": "#161617",
+                          "shadowOffset": {
+                            "height": 2,
+                            "width": 0,
+                          },
+                          "shadowOpacity": 0.2,
+                          "shadowRadius": 2.5,
+                          "width": 28,
+                        }
+                      }
+                    />
+                  </View>
                 </View>
               </View>
             </View>
           </View>
-        </View>
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
-              },
-            ]
-          }
-        >
           <View
             style={
               [
                 {
                   "alignItems": "center",
-                  "flexBasis": 0,
                   "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "paddingVertical": 16,
                 },
               ]
             }
-            toggleLabel={false}
           >
-            <Text
-              htmlFor="testUuidV4"
+            <View
               style={
                 [
                   {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                 ]
               }
             >
               <Text
+                htmlFor="testUuidV4"
                 style={
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
+                      "fontFamily": "Montserrat-Regular",
                       "fontSize": 15,
                       "lineHeight": 20,
                     },
                   ]
                 }
               >
-                Lecture
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Autoriser les notifications
+                </Text>
               </Text>
-            </Text>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
+            </View>
             <View
               style={
                 [
@@ -1120,879 +516,1486 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                 ]
               }
             >
-              <Text
-                accessibilityHidden={true}
+              <View
+                numberOfSpaces={5}
                 style={
                   [
                     {
-                      "display": "none",
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
                     },
                   ]
                 }
               >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Lecture"
-              >
-                <View
-                  active={false}
+                <Text
+                  accessibilityHidden={true}
                   style={
                     [
                       {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
+                        "display": "none",
                       },
                     ]
                   }
                 >
-                  <View
-                    collapsable={false}
-                    disabled={false}
-                    style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "shadowColor": "#161617",
-                        "shadowOffset": {
-                          "height": 2,
-                          "width": 0,
-                        },
-                        "shadowOpacity": 0.2,
-                        "shadowRadius": 2.5,
-                        "width": 28,
-                      }
-                    }
-                  />
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexBasis": 0,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-              ]
-            }
-            toggleLabel={false}
-          >
-            <Text
-              htmlFor="testUuidV4"
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
-                    },
-                  ]
-                }
-              >
-                Musique
-              </Text>
-            </Text>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                  },
-                ]
-              }
-            >
-              <Text
-                accessibilityHidden={true}
-                style={
-                  [
-                    {
-                      "display": "none",
-                    },
-                  ]
-                }
-              >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Musique"
-              >
+                  Case à cocher - 
+                  non cochée
+                </Text>
                 <View
-                  active={false}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
-                      },
-                    ]
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
                   }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Autoriser les notifications"
                 >
                   <View
-                    collapsable={false}
-                    disabled={false}
+                    active={false}
                     style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "shadowColor": "#161617",
-                        "shadowOffset": {
-                          "height": 2,
-                          "width": 0,
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
                         },
-                        "shadowOpacity": 0.2,
-                        "shadowRadius": 2.5,
-                        "width": 28,
-                      }
+                      ]
                     }
-                  />
+                  >
+                    <View
+                      collapsable={false}
+                      disabled={false}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "shadowColor": "#161617",
+                          "shadowOffset": {
+                            "height": 2,
+                            "width": 0,
+                          },
+                          "shadowOpacity": 0.2,
+                          "shadowRadius": 2.5,
+                          "width": 28,
+                        }
+                      }
+                    />
+                  </View>
                 </View>
               </View>
             </View>
           </View>
-        </View>
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
-              },
-            ]
-          }
-        >
+          <View
+            numberOfSpaces={4}
+            style={
+              [
+                {
+                  "height": 16,
+                },
+              ]
+            }
+          />
           <View
             style={
               [
                 {
-                  "alignItems": "center",
-                  "flexBasis": 0,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "backgroundColor": "#F1F1F4",
+                  "height": 1,
+                  "width": "100%",
                 },
               ]
             }
-            toggleLabel={false}
-          >
-            <Text
-              htmlFor="testUuidV4"
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
-                    },
-                  ]
-                }
-              >
-                Spectacles
-              </Text>
-            </Text>
-          </View>
+          />
           <View
+            numberOfSpaces={8}
             style={
               [
                 {
-                  "alignItems": "center",
-                  "flexDirection": "row",
+                  "height": 32,
                 },
               ]
             }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                  },
-                ]
-              }
-            >
-              <Text
-                accessibilityHidden={true}
-                style={
-                  [
-                    {
-                      "display": "none",
-                    },
-                  ]
-                }
-              >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Spectacles"
-              >
-                <View
-                  active={false}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    disabled={false}
-                    style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "shadowColor": "#161617",
-                        "shadowOffset": {
-                          "height": 2,
-                          "width": 0,
-                        },
-                        "shadowOpacity": 0.2,
-                        "shadowRadius": 2.5,
-                        "width": 28,
-                      }
-                    }
-                  />
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexBasis": 0,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-              ]
-            }
-            toggleLabel={false}
-          >
-            <Text
-              htmlFor="testUuidV4"
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
-                    },
-                  ]
-                }
-              >
-                Visites et sorties
-              </Text>
-            </Text>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                  },
-                ]
-              }
-            >
-              <Text
-                accessibilityHidden={true}
-                style={
-                  [
-                    {
-                      "display": "none",
-                    },
-                  ]
-                }
-              >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Visites et sorties"
-              >
-                <View
-                  active={false}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    disabled={false}
-                    style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "shadowColor": "#161617",
-                        "shadowOffset": {
-                          "height": 2,
-                          "width": 0,
-                        },
-                        "shadowOpacity": 0.2,
-                        "shadowRadius": 2.5,
-                        "width": 28,
-                      }
-                    }
-                  />
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexBasis": 0,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-              ]
-            }
-            toggleLabel={false}
-          >
-            <Text
-              htmlFor="testUuidV4"
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
-                    },
-                  ]
-                }
-              >
-                Cours et Ateliers
-              </Text>
-            </Text>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                  },
-                ]
-              }
-            >
-              <Text
-                accessibilityHidden={true}
-                style={
-                  [
-                    {
-                      "display": "none",
-                    },
-                  ]
-                }
-              >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Cours et Ateliers"
-              >
-                <View
-                  active={false}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    disabled={false}
-                    style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "shadowColor": "#161617",
-                        "shadowOffset": {
-                          "height": 2,
-                          "width": 0,
-                        },
-                        "shadowOpacity": 0.2,
-                        "shadowRadius": 2.5,
-                        "width": 28,
-                      }
-                    }
-                  />
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-        <View
-          numberOfSpaces={2}
-          style={
-            [
-              {
-                "height": 8,
-              },
-            ]
-          }
-        />
-        <View
-          accessibilityLabel="Enregistrer les modifications"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          focusable={false}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#eb0055",
-              "borderRadius": 24,
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": 500,
-              "minHeight": 40,
-              "opacity": 1,
-              "paddingBottom": 2,
-              "paddingLeft": 20,
-              "paddingRight": 20,
-              "paddingTop": 2,
-              "userSelect": "auto",
-              "width": "100%",
-            }
-          }
-          testID="Enregistrer les modifications"
-        >
+          />
           <Text
-            adjustsFontSizeToFit={false}
-            numberOfLines={1}
             style={
               [
                 {
-                  "color": "#ffffff",
-                  "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
-                  "marginLeft": 0,
-                  "maxWidth": "100%",
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 18,
+                  "lineHeight": 22,
                 },
               ]
             }
           >
-            Enregistrer
+            Tes thème suivis
           </Text>
+          <View
+            numberOfSpaces={6}
+            style={
+              [
+                {
+                  "height": 24,
+                },
+              ]
+            }
+          />
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                ]
+              }
+            >
+              <Text
+                htmlFor="testUuidV4"
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Suivre tous les thèmes
+                </Text>
+              </Text>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                numberOfSpaces={5}
+                style={
+                  [
+                    {
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <Text
+                  accessibilityHidden={true}
+                  style={
+                    [
+                      {
+                        "display": "none",
+                      },
+                    ]
+                  }
+                >
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Suivre tous les thèmes"
+                >
+                  <View
+                    active={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      disabled={false}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "shadowColor": "#161617",
+                          "shadowOffset": {
+                            "height": 2,
+                            "width": 0,
+                          },
+                          "shadowOpacity": 0.2,
+                          "shadowRadius": 2.5,
+                          "width": 28,
+                        }
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "height": 8,
+                },
+              ]
+            }
+          />
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                ]
+              }
+            >
+              <Text
+                htmlFor="testUuidV4"
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Cinéma
+                </Text>
+              </Text>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                numberOfSpaces={5}
+                style={
+                  [
+                    {
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <Text
+                  accessibilityHidden={true}
+                  style={
+                    [
+                      {
+                        "display": "none",
+                      },
+                    ]
+                  }
+                >
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Cinéma"
+                >
+                  <View
+                    active={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      disabled={false}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "shadowColor": "#161617",
+                          "shadowOffset": {
+                            "height": 2,
+                            "width": 0,
+                          },
+                          "shadowOpacity": 0.2,
+                          "shadowRadius": 2.5,
+                          "width": 28,
+                        }
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                ]
+              }
+            >
+              <Text
+                htmlFor="testUuidV4"
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Lecture
+                </Text>
+              </Text>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                numberOfSpaces={5}
+                style={
+                  [
+                    {
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <Text
+                  accessibilityHidden={true}
+                  style={
+                    [
+                      {
+                        "display": "none",
+                      },
+                    ]
+                  }
+                >
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Lecture"
+                >
+                  <View
+                    active={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      disabled={false}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "shadowColor": "#161617",
+                          "shadowOffset": {
+                            "height": 2,
+                            "width": 0,
+                          },
+                          "shadowOpacity": 0.2,
+                          "shadowRadius": 2.5,
+                          "width": 28,
+                        }
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                ]
+              }
+            >
+              <Text
+                htmlFor="testUuidV4"
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Musique
+                </Text>
+              </Text>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                numberOfSpaces={5}
+                style={
+                  [
+                    {
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <Text
+                  accessibilityHidden={true}
+                  style={
+                    [
+                      {
+                        "display": "none",
+                      },
+                    ]
+                  }
+                >
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Musique"
+                >
+                  <View
+                    active={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      disabled={false}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "shadowColor": "#161617",
+                          "shadowOffset": {
+                            "height": 2,
+                            "width": 0,
+                          },
+                          "shadowOpacity": 0.2,
+                          "shadowRadius": 2.5,
+                          "width": 28,
+                        }
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                ]
+              }
+            >
+              <Text
+                htmlFor="testUuidV4"
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Spectacles
+                </Text>
+              </Text>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                numberOfSpaces={5}
+                style={
+                  [
+                    {
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <Text
+                  accessibilityHidden={true}
+                  style={
+                    [
+                      {
+                        "display": "none",
+                      },
+                    ]
+                  }
+                >
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Spectacles"
+                >
+                  <View
+                    active={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      disabled={false}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "shadowColor": "#161617",
+                          "shadowOffset": {
+                            "height": 2,
+                            "width": 0,
+                          },
+                          "shadowOpacity": 0.2,
+                          "shadowRadius": 2.5,
+                          "width": 28,
+                        }
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                ]
+              }
+            >
+              <Text
+                htmlFor="testUuidV4"
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Visites et sorties
+                </Text>
+              </Text>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                numberOfSpaces={5}
+                style={
+                  [
+                    {
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <Text
+                  accessibilityHidden={true}
+                  style={
+                    [
+                      {
+                        "display": "none",
+                      },
+                    ]
+                  }
+                >
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Visites et sorties"
+                >
+                  <View
+                    active={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      disabled={false}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "shadowColor": "#161617",
+                          "shadowOffset": {
+                            "height": 2,
+                            "width": 0,
+                          },
+                          "shadowOpacity": 0.2,
+                          "shadowRadius": 2.5,
+                          "width": 28,
+                        }
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                ]
+              }
+            >
+              <Text
+                htmlFor="testUuidV4"
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Cours et Ateliers
+                </Text>
+              </Text>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                numberOfSpaces={5}
+                style={
+                  [
+                    {
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <Text
+                  accessibilityHidden={true}
+                  style={
+                    [
+                      {
+                        "display": "none",
+                      },
+                    ]
+                  }
+                >
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Cours et Ateliers"
+                >
+                  <View
+                    active={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      disabled={false}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "shadowColor": "#161617",
+                          "shadowOffset": {
+                            "height": 2,
+                            "width": 0,
+                          },
+                          "shadowOpacity": 0.2,
+                          "shadowRadius": 2.5,
+                          "width": 28,
+                        }
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "height": 8,
+                },
+              ]
+            }
+          />
+          <View
+            accessibilityLabel="Enregistrer les modifications"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={false}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "backgroundColor": "#eb0055",
+                "borderRadius": 24,
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": 500,
+                "minHeight": 40,
+                "opacity": 1,
+                "paddingBottom": 2,
+                "paddingLeft": 20,
+                "paddingRight": 20,
+                "paddingTop": 2,
+                "userSelect": "auto",
+                "width": "100%",
+              }
+            }
+            testID="Enregistrer les modifications"
+          >
+            <Text
+              adjustsFontSizeToFit={false}
+              numberOfLines={1}
+              style={
+                [
+                  {
+                    "color": "#ffffff",
+                    "fontFamily": "Montserrat-Bold",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                    "marginLeft": 0,
+                    "maxWidth": "100%",
+                  },
+                ]
+              }
+            >
+              Enregistrer
+            </Text>
+          </View>
         </View>
       </View>
       <View
@@ -2254,523 +2257,86 @@ exports[`NotificationSettings should render correctly when user is not logged in
         }
       />
       <View
-        backgroundColor="#f3ecff"
         style={
           [
             {
-              "alignItems": "center",
-              "backgroundColor": "#f3ecff",
-              "borderRadius": 8,
-              "flexDirection": "row",
-              "justifyContent": "space-between",
-              "paddingBottom": 16,
-              "paddingLeft": 16,
-              "paddingRight": 16,
-              "paddingTop": 16,
+              "alignSelf": "center",
+              "maxWidth": 500,
+              "width": "100%",
             },
           ]
         }
       >
         <View
+          backgroundColor="#f3ecff"
           style={
             [
               {
+                "alignItems": "center",
+                "backgroundColor": "#f3ecff",
+                "borderRadius": 8,
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": 16,
+                "paddingLeft": 16,
                 "paddingRight": 16,
+                "paddingTop": 16,
               },
             ]
           }
         >
           <View
-            height={24}
-            width={24}
-          >
-            <Text>
-              undefined-SVG-Mock
-            </Text>
-          </View>
-        </View>
-        <View
-          style={
-            [
-              {
-                "flexBasis": 0,
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-            ]
-          }
-        >
-          <Text
             style={
               [
                 {
-                  "color": "#161617",
-                  "fontFamily": "Montserrat-SemiBold",
-                  "fontSize": 12,
-                  "lineHeight": 16,
+                  "paddingRight": 16,
                 },
               ]
             }
-            textColor="#161617"
           >
-            Tu dois être connecté pour activer les notifications et rester informé des bons plans sur le pass Culture.
-          </Text>
-        </View>
-      </View>
-      <View
-        numberOfSpaces={6}
-        style={
-          [
-            {
-              "height": 24,
-            },
-          ]
-        }
-      />
-      <Text
-        style={
-          [
-            {
-              "color": "#161617",
-              "fontFamily": "Montserrat-Medium",
-              "fontSize": 18,
-              "lineHeight": 22,
-            },
-          ]
-        }
-      >
-        Type d’alerte
-      </Text>
-      <View
-        numberOfSpaces={4}
-        style={
-          [
-            {
-              "height": 16,
-            },
-          ]
-        }
-      />
-      <Text
-        style={
-          [
-            {
-              "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
-            },
-          ]
-        }
-      >
-        Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
-      </Text>
-      <View
-        numberOfSpaces={2}
-        style={
-          [
-            {
-              "height": 8,
-            },
-          ]
-        }
-      />
-      <View
-        style={
-          [
-            {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-          ]
-        }
-      >
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
-              },
-            ]
-          }
-        >
+            <View
+              height={24}
+              width={24}
+            >
+              <Text>
+                undefined-SVG-Mock
+              </Text>
+            </View>
+          </View>
           <View
             style={
               [
                 {
-                  "alignItems": "center",
                   "flexBasis": 0,
-                  "flexDirection": "row",
                   "flexGrow": 1,
                   "flexShrink": 1,
                 },
               ]
             }
-            toggleLabel={false}
           >
             <Text
-              htmlFor="testUuidV4"
               style={
                 [
                   {
                     "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 12,
+                    "lineHeight": 16,
                   },
                 ]
               }
+              textColor="#161617"
             >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
-                    },
-                  ]
-                }
-              >
-                Autoriser l’envoi d’e-mails
-              </Text>
+              Tu dois être connecté pour activer les notifications et rester informé des bons plans sur le pass Culture.
             </Text>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                  },
-                ]
-              }
-            >
-              <Text
-                accessibilityHidden={true}
-                style={
-                  [
-                    {
-                      "display": "none",
-                    },
-                  ]
-                }
-              >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": true,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Autoriser l’envoi d’e-mails"
-              >
-                <View
-                  active={false}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    disabled={true}
-                    style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "width": 28,
-                      }
-                    }
-                  >
-                    <View
-                      accessibilityLabel="Désactivé"
-                      height={16}
-                      width={16}
-                    >
-                      <Text>
-                        undefined-SVG-Mock
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
           </View>
         </View>
         <View
+          numberOfSpaces={6}
           style={
             [
               {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexBasis": 0,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-              ]
-            }
-            toggleLabel={false}
-          >
-            <Text
-              htmlFor="testUuidV4"
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
-                    },
-                  ]
-                }
-              >
-                Autoriser les notifications
-              </Text>
-            </Text>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                  },
-                ]
-              }
-            >
-              <Text
-                accessibilityHidden={true}
-                style={
-                  [
-                    {
-                      "display": "none",
-                    },
-                  ]
-                }
-              >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": true,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Autoriser les notifications"
-              >
-                <View
-                  active={false}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    disabled={true}
-                    style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "width": 28,
-                      }
-                    }
-                  >
-                    <View
-                      accessibilityLabel="Désactivé"
-                      height={16}
-                      width={16}
-                    >
-                      <Text>
-                        undefined-SVG-Mock
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-        <View
-          numberOfSpaces={4}
-          style={
-            [
-              {
-                "height": 16,
-              },
-            ]
-          }
-        />
-        <View
-          style={
-            [
-              {
-                "backgroundColor": "#F1F1F4",
-                "height": 1,
-                "width": "100%",
-              },
-            ]
-          }
-        />
-        <View
-          numberOfSpaces={8}
-          style={
-            [
-              {
-                "height": 32,
+                "height": 24,
               },
             ]
           }
@@ -2787,197 +2353,32 @@ exports[`NotificationSettings should render correctly when user is not logged in
             ]
           }
         >
-          Tes thème suivis
+          Type d’alerte
         </Text>
         <View
-          numberOfSpaces={6}
+          numberOfSpaces={4}
           style={
             [
               {
-                "height": 24,
+                "height": 16,
               },
             ]
           }
         />
-        <View
+        <Text
           style={
             [
               {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
+                "color": "#161617",
+                "fontFamily": "Montserrat-Regular",
+                "fontSize": 15,
+                "lineHeight": 20,
               },
             ]
           }
         >
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexBasis": 0,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-              ]
-            }
-            toggleLabel={false}
-          >
-            <Text
-              htmlFor="testUuidV4"
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
-                    },
-                  ]
-                }
-              >
-                Suivre tous les thèmes
-              </Text>
-            </Text>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                  },
-                ]
-              }
-            >
-              <Text
-                accessibilityHidden={true}
-                style={
-                  [
-                    {
-                      "display": "none",
-                    },
-                  ]
-                }
-              >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": true,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Suivre tous les thèmes"
-              >
-                <View
-                  active={false}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    disabled={true}
-                    style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "width": 28,
-                      }
-                    }
-                  >
-                    <View
-                      accessibilityLabel="Désactivé"
-                      height={16}
-                      width={16}
-                    >
-                      <Text>
-                        undefined-SVG-Mock
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
+          Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
+        </Text>
         <View
           numberOfSpaces={2}
           style={
@@ -2992,9 +2393,9 @@ exports[`NotificationSettings should render correctly when user is not logged in
           style={
             [
               {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
               },
             ]
           }
@@ -3004,64 +2405,54 @@ exports[`NotificationSettings should render correctly when user is not logged in
               [
                 {
                   "alignItems": "center",
-                  "flexBasis": 0,
                   "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "paddingVertical": 16,
                 },
               ]
             }
-            toggleLabel={false}
           >
-            <Text
-              htmlFor="testUuidV4"
+            <View
               style={
                 [
                   {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                 ]
               }
             >
               <Text
+                htmlFor="testUuidV4"
                 style={
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
+                      "fontFamily": "Montserrat-Regular",
                       "fontSize": 15,
                       "lineHeight": 20,
                     },
                   ]
                 }
               >
-                Cinéma
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Autoriser l’envoi d’e-mails
+                </Text>
               </Text>
-            </Text>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
+            </View>
             <View
               style={
                 [
@@ -3072,175 +2463,174 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 ]
               }
             >
-              <Text
-                accessibilityHidden={true}
+              <View
+                numberOfSpaces={5}
                 style={
                   [
                     {
-                      "display": "none",
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
                     },
                   ]
                 }
               >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": true,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Cinéma"
-              >
-                <View
-                  active={false}
+                <Text
+                  accessibilityHidden={true}
                   style={
                     [
                       {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
+                        "display": "none",
                       },
                     ]
                   }
                 >
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": true,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Autoriser l’envoi d’e-mails"
+                >
                   <View
-                    collapsable={false}
-                    disabled={true}
+                    active={false}
                     style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "width": 28,
-                      }
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
                     }
                   >
                     <View
-                      accessibilityLabel="Désactivé"
-                      height={16}
-                      width={16}
+                      collapsable={false}
+                      disabled={true}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "width": 28,
+                        }
+                      }
                     >
-                      <Text>
-                        undefined-SVG-Mock
-                      </Text>
+                      <View
+                        accessibilityLabel="Désactivé"
+                        height={16}
+                        width={16}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
                     </View>
                   </View>
                 </View>
               </View>
             </View>
           </View>
-        </View>
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
-              },
-            ]
-          }
-        >
           <View
             style={
               [
                 {
                   "alignItems": "center",
-                  "flexBasis": 0,
                   "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "paddingVertical": 16,
                 },
               ]
             }
-            toggleLabel={false}
           >
-            <Text
-              htmlFor="testUuidV4"
+            <View
               style={
                 [
                   {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
                   },
                 ]
               }
             >
               <Text
+                htmlFor="testUuidV4"
                 style={
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
+                      "fontFamily": "Montserrat-Regular",
                       "fontSize": 15,
                       "lineHeight": 20,
                     },
                   ]
                 }
               >
-                Lecture
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Autoriser les notifications
+                </Text>
               </Text>
-            </Text>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
+            </View>
             <View
               style={
                 [
@@ -3251,894 +2641,1510 @@ exports[`NotificationSettings should render correctly when user is not logged in
                 ]
               }
             >
-              <Text
-                accessibilityHidden={true}
+              <View
+                numberOfSpaces={5}
                 style={
                   [
                     {
-                      "display": "none",
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
                     },
                   ]
                 }
               >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": true,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Lecture"
-              >
-                <View
-                  active={false}
+                <Text
+                  accessibilityHidden={true}
                   style={
                     [
                       {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
+                        "display": "none",
                       },
                     ]
                   }
                 >
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": true,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Autoriser les notifications"
+                >
                   <View
-                    collapsable={false}
-                    disabled={true}
+                    active={false}
                     style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "width": 28,
-                      }
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
                     }
                   >
                     <View
-                      accessibilityLabel="Désactivé"
-                      height={16}
-                      width={16}
+                      collapsable={false}
+                      disabled={true}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "width": 28,
+                        }
+                      }
                     >
-                      <Text>
-                        undefined-SVG-Mock
-                      </Text>
+                      <View
+                        accessibilityLabel="Désactivé"
+                        height={16}
+                        width={16}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
                     </View>
                   </View>
                 </View>
               </View>
             </View>
           </View>
-        </View>
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
-              },
-            ]
-          }
-        >
+          <View
+            numberOfSpaces={4}
+            style={
+              [
+                {
+                  "height": 16,
+                },
+              ]
+            }
+          />
           <View
             style={
               [
                 {
-                  "alignItems": "center",
-                  "flexBasis": 0,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "backgroundColor": "#F1F1F4",
+                  "height": 1,
+                  "width": "100%",
                 },
               ]
             }
-            toggleLabel={false}
-          >
-            <Text
-              htmlFor="testUuidV4"
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
-                    },
-                  ]
-                }
-              >
-                Musique
-              </Text>
-            </Text>
-          </View>
+          />
           <View
+            numberOfSpaces={8}
             style={
               [
                 {
-                  "alignItems": "center",
-                  "flexDirection": "row",
+                  "height": 32,
                 },
               ]
             }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                  },
-                ]
-              }
-            >
-              <Text
-                accessibilityHidden={true}
-                style={
-                  [
-                    {
-                      "display": "none",
-                    },
-                  ]
-                }
-              >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": true,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Musique"
-              >
-                <View
-                  active={false}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    disabled={true}
-                    style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "width": 28,
-                      }
-                    }
-                  >
-                    <View
-                      accessibilityLabel="Désactivé"
-                      height={16}
-                      width={16}
-                    >
-                      <Text>
-                        undefined-SVG-Mock
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexBasis": 0,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-              ]
-            }
-            toggleLabel={false}
-          >
-            <Text
-              htmlFor="testUuidV4"
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
-                    },
-                  ]
-                }
-              >
-                Spectacles
-              </Text>
-            </Text>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                  },
-                ]
-              }
-            >
-              <Text
-                accessibilityHidden={true}
-                style={
-                  [
-                    {
-                      "display": "none",
-                    },
-                  ]
-                }
-              >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": true,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Spectacles"
-              >
-                <View
-                  active={false}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    disabled={true}
-                    style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "width": 28,
-                      }
-                    }
-                  >
-                    <View
-                      accessibilityLabel="Désactivé"
-                      height={16}
-                      width={16}
-                    >
-                      <Text>
-                        undefined-SVG-Mock
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexBasis": 0,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-              ]
-            }
-            toggleLabel={false}
-          >
-            <Text
-              htmlFor="testUuidV4"
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
-                    },
-                  ]
-                }
-              >
-                Visites et sorties
-              </Text>
-            </Text>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                  },
-                ]
-              }
-            >
-              <Text
-                accessibilityHidden={true}
-                style={
-                  [
-                    {
-                      "display": "none",
-                    },
-                  ]
-                }
-              >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": true,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Visites et sorties"
-              >
-                <View
-                  active={false}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    disabled={true}
-                    style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "width": 28,
-                      }
-                    }
-                  >
-                    <View
-                      accessibilityLabel="Désactivé"
-                      height={16}
-                      width={16}
-                    >
-                      <Text>
-                        undefined-SVG-Mock
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "paddingVertical": 16,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexBasis": 0,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-              ]
-            }
-            toggleLabel={false}
-          >
-            <Text
-              htmlFor="testUuidV4"
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
-                    },
-                  ]
-                }
-              >
-                Cours et Ateliers
-              </Text>
-            </Text>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <View
-              numberOfSpaces={5}
-              style={
-                [
-                  {
-                    "width": 20,
-                  },
-                ]
-              }
-            />
-            <View
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                  },
-                ]
-              }
-            >
-              <Text
-                accessibilityHidden={true}
-                style={
-                  [
-                    {
-                      "display": "none",
-                    },
-                  ]
-                }
-              >
-                Case à cocher - 
-                non cochée
-              </Text>
-              <View
-                accessibilityRole="checkbox"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": false,
-                    "disabled": true,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-                testID="Interrupteur Cours et Ateliers"
-              >
-                <View
-                  active={false}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#90949D",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "justifyContent": "center",
-                        "width": 56,
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    disabled={true}
-                    style={
-                      {
-                        "alignItems": "center",
-                        "aspectRatio": 1,
-                        "backgroundColor": "#ffffff",
-                        "borderRadius": 28,
-                        "height": 28,
-                        "justifyContent": "center",
-                        "marginLeft": 2,
-                        "width": 28,
-                      }
-                    }
-                  >
-                    <View
-                      accessibilityLabel="Désactivé"
-                      height={16}
-                      width={16}
-                    >
-                      <Text>
-                        undefined-SVG-Mock
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-        <View
-          numberOfSpaces={2}
-          style={
-            [
-              {
-                "height": 8,
-              },
-            ]
-          }
-        />
-        <View
-          accessibilityLabel="Enregistrer les modifications"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          focusable={false}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#eb0055",
-              "borderRadius": 24,
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "maxWidth": 500,
-              "minHeight": 40,
-              "opacity": 1,
-              "paddingBottom": 2,
-              "paddingLeft": 20,
-              "paddingRight": 20,
-              "paddingTop": 2,
-              "userSelect": "auto",
-              "width": "100%",
-            }
-          }
-          testID="Enregistrer les modifications"
-        >
+          />
           <Text
-            adjustsFontSizeToFit={false}
-            numberOfLines={1}
             style={
               [
                 {
-                  "color": "#ffffff",
-                  "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
-                  "marginLeft": 0,
-                  "maxWidth": "100%",
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 18,
+                  "lineHeight": 22,
                 },
               ]
             }
           >
-            Enregistrer
+            Tes thème suivis
           </Text>
+          <View
+            numberOfSpaces={6}
+            style={
+              [
+                {
+                  "height": 24,
+                },
+              ]
+            }
+          />
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                ]
+              }
+            >
+              <Text
+                htmlFor="testUuidV4"
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Suivre tous les thèmes
+                </Text>
+              </Text>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                numberOfSpaces={5}
+                style={
+                  [
+                    {
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <Text
+                  accessibilityHidden={true}
+                  style={
+                    [
+                      {
+                        "display": "none",
+                      },
+                    ]
+                  }
+                >
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": true,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Suivre tous les thèmes"
+                >
+                  <View
+                    active={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      disabled={true}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "width": 28,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityLabel="Désactivé"
+                        height={16}
+                        width={16}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "height": 8,
+                },
+              ]
+            }
+          />
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                ]
+              }
+            >
+              <Text
+                htmlFor="testUuidV4"
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Cinéma
+                </Text>
+              </Text>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                numberOfSpaces={5}
+                style={
+                  [
+                    {
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <Text
+                  accessibilityHidden={true}
+                  style={
+                    [
+                      {
+                        "display": "none",
+                      },
+                    ]
+                  }
+                >
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": true,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Cinéma"
+                >
+                  <View
+                    active={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      disabled={true}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "width": 28,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityLabel="Désactivé"
+                        height={16}
+                        width={16}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                ]
+              }
+            >
+              <Text
+                htmlFor="testUuidV4"
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Lecture
+                </Text>
+              </Text>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                numberOfSpaces={5}
+                style={
+                  [
+                    {
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <Text
+                  accessibilityHidden={true}
+                  style={
+                    [
+                      {
+                        "display": "none",
+                      },
+                    ]
+                  }
+                >
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": true,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Lecture"
+                >
+                  <View
+                    active={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      disabled={true}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "width": 28,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityLabel="Désactivé"
+                        height={16}
+                        width={16}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                ]
+              }
+            >
+              <Text
+                htmlFor="testUuidV4"
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Musique
+                </Text>
+              </Text>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                numberOfSpaces={5}
+                style={
+                  [
+                    {
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <Text
+                  accessibilityHidden={true}
+                  style={
+                    [
+                      {
+                        "display": "none",
+                      },
+                    ]
+                  }
+                >
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": true,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Musique"
+                >
+                  <View
+                    active={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      disabled={true}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "width": 28,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityLabel="Désactivé"
+                        height={16}
+                        width={16}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                ]
+              }
+            >
+              <Text
+                htmlFor="testUuidV4"
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Spectacles
+                </Text>
+              </Text>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                numberOfSpaces={5}
+                style={
+                  [
+                    {
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <Text
+                  accessibilityHidden={true}
+                  style={
+                    [
+                      {
+                        "display": "none",
+                      },
+                    ]
+                  }
+                >
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": true,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Spectacles"
+                >
+                  <View
+                    active={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      disabled={true}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "width": 28,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityLabel="Désactivé"
+                        height={16}
+                        width={16}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                ]
+              }
+            >
+              <Text
+                htmlFor="testUuidV4"
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Visites et sorties
+                </Text>
+              </Text>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                numberOfSpaces={5}
+                style={
+                  [
+                    {
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <Text
+                  accessibilityHidden={true}
+                  style={
+                    [
+                      {
+                        "display": "none",
+                      },
+                    ]
+                  }
+                >
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": true,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Visites et sorties"
+                >
+                  <View
+                    active={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      disabled={true}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "width": 28,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityLabel="Désactivé"
+                        height={16}
+                        width={16}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingVertical": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                ]
+              }
+            >
+              <Text
+                htmlFor="testUuidV4"
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                      },
+                    ]
+                  }
+                >
+                  Cours et Ateliers
+                </Text>
+              </Text>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                numberOfSpaces={5}
+                style={
+                  [
+                    {
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <Text
+                  accessibilityHidden={true}
+                  style={
+                    [
+                      {
+                        "display": "none",
+                      },
+                    ]
+                  }
+                >
+                  Case à cocher - 
+                  non cochée
+                </Text>
+                <View
+                  accessibilityRole="checkbox"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": true,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                  testID="Interrupteur Cours et Ateliers"
+                >
+                  <View
+                    active={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#90949D",
+                          "borderRadius": 16,
+                          "height": 32,
+                          "justifyContent": "center",
+                          "width": 56,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      disabled={true}
+                      style={
+                        {
+                          "alignItems": "center",
+                          "aspectRatio": 1,
+                          "backgroundColor": "#ffffff",
+                          "borderRadius": 28,
+                          "height": 28,
+                          "justifyContent": "center",
+                          "marginLeft": 2,
+                          "width": 28,
+                        }
+                      }
+                    >
+                      <View
+                        accessibilityLabel="Désactivé"
+                        height={16}
+                        width={16}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "height": 8,
+                },
+              ]
+            }
+          />
+          <View
+            accessibilityLabel="Enregistrer les modifications"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={false}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "backgroundColor": "#eb0055",
+                "borderRadius": 24,
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": 500,
+                "minHeight": 40,
+                "opacity": 1,
+                "paddingBottom": 2,
+                "paddingLeft": 20,
+                "paddingRight": 20,
+                "paddingTop": 2,
+                "userSelect": "auto",
+                "width": "100%",
+              }
+            }
+            testID="Enregistrer les modifications"
+          >
+            <Text
+              adjustsFontSizeToFit={false}
+              numberOfLines={1}
+              style={
+                [
+                  {
+                    "color": "#ffffff",
+                    "fontFamily": "Montserrat-Bold",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                    "marginLeft": 0,
+                    "maxWidth": "100%",
+                  },
+                ]
+              }
+            >
+              Enregistrer
+            </Text>
+          </View>
         </View>
       </View>
       <View

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -173,7 +173,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
       </View>
     </View>
   </View>,
-  <View
+  <RCTScrollView
     style={
       [
         {
@@ -187,437 +187,41 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
       ]
     }
   >
-    <View
-      height={65}
-      style={
-        [
-          {
-            "height": 65,
-          },
-        ]
-      }
-    />
-    <View
-      numberOfSpaces={6}
-      style={
-        [
-          {
-            "height": 24,
-          },
-        ]
-      }
-    />
-    <Text
-      style={
-        [
-          {
-            "color": "#161617",
-            "fontFamily": "Montserrat-Medium",
-            "fontSize": 18,
-            "lineHeight": 22,
-          },
-        ]
-      }
-    >
-      Type d’alerte
-    </Text>
-    <View
-      numberOfSpaces={4}
-      style={
-        [
-          {
-            "height": 16,
-          },
-        ]
-      }
-    />
-    <Text
-      style={
-        [
-          {
-            "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
-          },
-        ]
-      }
-    >
-      Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
-    </Text>
-    <View
-      numberOfSpaces={2}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
-    <View
-      style={
-        [
-          {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
-          },
-        ]
-      }
-    >
+    <View>
       <View
+        height={65}
         style={
           [
             {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "paddingVertical": 16,
+              "height": 65,
+            },
+          ]
+        }
+      />
+      <View
+        numberOfSpaces={6}
+        style={
+          [
+            {
+              "height": 24,
+            },
+          ]
+        }
+      />
+      <Text
+        style={
+          [
+            {
+              "color": "#161617",
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 18,
+              "lineHeight": 22,
             },
           ]
         }
       >
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexBasis": 0,
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-            ]
-          }
-          toggleLabel={false}
-        >
-          <Text
-            htmlFor="testUuidV4"
-            style={
-              [
-                {
-                  "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
-                },
-              ]
-            }
-          >
-            <Text
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              Autoriser l’envoi d’e-mails
-            </Text>
-          </Text>
-        </View>
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            numberOfSpaces={5}
-            style={
-              [
-                {
-                  "width": 20,
-                },
-              ]
-            }
-          />
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <Text
-              accessibilityHidden={true}
-              style={
-                [
-                  {
-                    "display": "none",
-                  },
-                ]
-              }
-            >
-              Case à cocher - 
-              non cochée
-            </Text>
-            <View
-              accessibilityRole="checkbox"
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": false,
-                  "disabled": false,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
-              }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
-              accessible={false}
-              collapsable={false}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                {
-                  "opacity": 1,
-                  "userSelect": "auto",
-                }
-              }
-              testID="Interrupteur Autoriser l’envoi d’e-mails"
-            >
-              <View
-                active={false}
-                style={
-                  [
-                    {
-                      "backgroundColor": "#90949D",
-                      "borderRadius": 16,
-                      "height": 32,
-                      "justifyContent": "center",
-                      "width": 56,
-                    },
-                  ]
-                }
-              >
-                <View
-                  collapsable={false}
-                  disabled={false}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "aspectRatio": 1,
-                      "backgroundColor": "#ffffff",
-                      "borderRadius": 28,
-                      "height": 28,
-                      "justifyContent": "center",
-                      "marginLeft": 2,
-                      "shadowColor": "#161617",
-                      "shadowOffset": {
-                        "height": 2,
-                        "width": 0,
-                      },
-                      "shadowOpacity": 0.2,
-                      "shadowRadius": 2.5,
-                      "width": 28,
-                    }
-                  }
-                />
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-      <View
-        style={
-          [
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "paddingVertical": 16,
-            },
-          ]
-        }
-      >
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexBasis": 0,
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-            ]
-          }
-          toggleLabel={false}
-        >
-          <Text
-            htmlFor="testUuidV4"
-            style={
-              [
-                {
-                  "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
-                },
-              ]
-            }
-          >
-            <Text
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              Autoriser les notifications
-            </Text>
-          </Text>
-        </View>
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            numberOfSpaces={5}
-            style={
-              [
-                {
-                  "width": 20,
-                },
-              ]
-            }
-          />
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <Text
-              accessibilityHidden={true}
-              style={
-                [
-                  {
-                    "display": "none",
-                  },
-                ]
-              }
-            >
-              Case à cocher - 
-              non cochée
-            </Text>
-            <View
-              accessibilityRole="checkbox"
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": false,
-                  "disabled": false,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
-              }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
-              accessible={false}
-              collapsable={false}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                {
-                  "opacity": 1,
-                  "userSelect": "auto",
-                }
-              }
-              testID="Interrupteur Autoriser les notifications"
-            >
-              <View
-                active={false}
-                style={
-                  [
-                    {
-                      "backgroundColor": "#90949D",
-                      "borderRadius": 16,
-                      "height": 32,
-                      "justifyContent": "center",
-                      "width": 56,
-                    },
-                  ]
-                }
-              >
-                <View
-                  collapsable={false}
-                  disabled={false}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "aspectRatio": 1,
-                      "backgroundColor": "#ffffff",
-                      "borderRadius": 28,
-                      "height": 28,
-                      "justifyContent": "center",
-                      "marginLeft": 2,
-                      "shadowColor": "#161617",
-                      "shadowOffset": {
-                        "height": 2,
-                        "width": 0,
-                      },
-                      "shadowOpacity": 0.2,
-                      "shadowRadius": 2.5,
-                      "width": 28,
-                    }
-                  }
-                />
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
+        Type d’alerte
+      </Text>
       <View
         numberOfSpaces={4}
         style={
@@ -628,107 +232,1781 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
           ]
         }
       />
-      <View
+      <Text
         style={
           [
             {
-              "backgroundColor": "#F1F1F4",
-              "height": 1,
-              "width": "100%",
+              "color": "#161617",
+              "fontFamily": "Montserrat-Regular",
+              "fontSize": 15,
+              "lineHeight": 20,
             },
           ]
         }
-      />
-      <View
-        numberOfSpaces={8}
-        style={
-          [
-            {
-              "height": 32,
-            },
-          ]
-        }
-      />
-      <View
-        accessibilityLabel="Enregistrer les modifications"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": undefined,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={false}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "#eb0055",
-            "borderRadius": 24,
-            "flexDirection": "row",
-            "justifyContent": "center",
-            "maxWidth": 500,
-            "minHeight": 40,
-            "opacity": 1,
-            "paddingBottom": 2,
-            "paddingLeft": 20,
-            "paddingRight": 20,
-            "paddingTop": 2,
-            "userSelect": "auto",
-            "width": "100%",
-          }
-        }
-        testID="Enregistrer les modifications"
       >
-        <Text
-          adjustsFontSizeToFit={false}
-          numberOfLines={1}
+        Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
+      </Text>
+      <View
+        numberOfSpaces={2}
+        style={
+          [
+            {
+              "height": 8,
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+            },
+          ]
+        }
+      >
+        <View
           style={
             [
               {
-                "color": "#ffffff",
-                "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
-                "marginLeft": 0,
-                "maxWidth": "100%",
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
               },
             ]
           }
         >
-          Enregistrer
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Autoriser l’envoi d’e-mails
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Autoriser l’envoi d’e-mails"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={false}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "shadowColor": "#161617",
+                        "shadowOffset": {
+                          "height": 2,
+                          "width": 0,
+                        },
+                        "shadowOpacity": 0.2,
+                        "shadowRadius": 2.5,
+                        "width": 28,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Autoriser les notifications
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Autoriser les notifications"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={false}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "shadowColor": "#161617",
+                        "shadowOffset": {
+                          "height": 2,
+                          "width": 0,
+                        },
+                        "shadowOpacity": 0.2,
+                        "shadowRadius": 2.5,
+                        "width": 28,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          numberOfSpaces={4}
+          style={
+            [
+              {
+                "height": 16,
+              },
+            ]
+          }
+        />
+        <View
+          style={
+            [
+              {
+                "backgroundColor": "#F1F1F4",
+                "height": 1,
+                "width": "100%",
+              },
+            ]
+          }
+        />
+        <View
+          numberOfSpaces={8}
+          style={
+            [
+              {
+                "height": 32,
+              },
+            ]
+          }
+        />
+        <Text
+          style={
+            [
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 18,
+                "lineHeight": 22,
+              },
+            ]
+          }
+        >
+          Tes thème suivis
         </Text>
+        <View
+          numberOfSpaces={6}
+          style={
+            [
+              {
+                "height": 24,
+              },
+            ]
+          }
+        />
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Suivre tous les thèmes
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Suivre tous les thèmes"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={false}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "shadowColor": "#161617",
+                        "shadowOffset": {
+                          "height": 2,
+                          "width": 0,
+                        },
+                        "shadowOpacity": 0.2,
+                        "shadowRadius": 2.5,
+                        "width": 28,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          numberOfSpaces={2}
+          style={
+            [
+              {
+                "height": 8,
+              },
+            ]
+          }
+        />
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Cinéma
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Cinéma"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={false}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "shadowColor": "#161617",
+                        "shadowOffset": {
+                          "height": 2,
+                          "width": 0,
+                        },
+                        "shadowOpacity": 0.2,
+                        "shadowRadius": 2.5,
+                        "width": 28,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Lecture
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Lecture"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={false}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "shadowColor": "#161617",
+                        "shadowOffset": {
+                          "height": 2,
+                          "width": 0,
+                        },
+                        "shadowOpacity": 0.2,
+                        "shadowRadius": 2.5,
+                        "width": 28,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Musique
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Musique"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={false}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "shadowColor": "#161617",
+                        "shadowOffset": {
+                          "height": 2,
+                          "width": 0,
+                        },
+                        "shadowOpacity": 0.2,
+                        "shadowRadius": 2.5,
+                        "width": 28,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Spectacles
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Spectacles"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={false}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "shadowColor": "#161617",
+                        "shadowOffset": {
+                          "height": 2,
+                          "width": 0,
+                        },
+                        "shadowOpacity": 0.2,
+                        "shadowRadius": 2.5,
+                        "width": 28,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Visites et sorties
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Visites et sorties"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={false}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "shadowColor": "#161617",
+                        "shadowOffset": {
+                          "height": 2,
+                          "width": 0,
+                        },
+                        "shadowOpacity": 0.2,
+                        "shadowRadius": 2.5,
+                        "width": 28,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Cours et Ateliers
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Cours et Ateliers"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={false}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "shadowColor": "#161617",
+                        "shadowOffset": {
+                          "height": 2,
+                          "width": 0,
+                        },
+                        "shadowOpacity": 0.2,
+                        "shadowRadius": 2.5,
+                        "width": 28,
+                      }
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          numberOfSpaces={2}
+          style={
+            [
+              {
+                "height": 8,
+              },
+            ]
+          }
+        />
+        <View
+          accessibilityLabel="Enregistrer les modifications"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={false}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "#eb0055",
+              "borderRadius": 24,
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "maxWidth": 500,
+              "minHeight": 40,
+              "opacity": 1,
+              "paddingBottom": 2,
+              "paddingLeft": 20,
+              "paddingRight": 20,
+              "paddingTop": 2,
+              "userSelect": "auto",
+              "width": "100%",
+            }
+          }
+          testID="Enregistrer les modifications"
+        >
+          <Text
+            adjustsFontSizeToFit={false}
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "color": "#ffffff",
+                  "fontFamily": "Montserrat-Bold",
+                  "fontSize": 15,
+                  "lineHeight": 20,
+                  "marginLeft": 0,
+                  "maxWidth": "100%",
+                },
+              ]
+            }
+          >
+            Enregistrer
+          </Text>
+        </View>
       </View>
+      <View
+        numberOfSpaces={6}
+        style={
+          [
+            {
+              "height": 24,
+            },
+          ]
+        }
+      />
     </View>
-    <View
-      numberOfSpaces={6}
-      style={
-        [
-          {
-            "height": 24,
-          },
-        ]
-      }
-    />
-  </View>,
+  </RCTScrollView>,
   <View
     height={65}
     style={
@@ -940,7 +2218,7 @@ exports[`NotificationSettings should render correctly when user is not logged in
       </View>
     </View>
   </View>,
-  <View
+  <RCTScrollView
     style={
       [
         {
@@ -954,443 +2232,41 @@ exports[`NotificationSettings should render correctly when user is not logged in
       ]
     }
   >
-    <View
-      height={65}
-      style={
-        [
-          {
-            "height": 65,
-          },
-        ]
-      }
-    />
-    <View
-      numberOfSpaces={6}
-      style={
-        [
-          {
-            "height": 24,
-          },
-        ]
-      }
-    />
-    <Text
-      style={
-        [
-          {
-            "color": "#161617",
-            "fontFamily": "Montserrat-Medium",
-            "fontSize": 18,
-            "lineHeight": 22,
-          },
-        ]
-      }
-    >
-      Type d’alerte
-    </Text>
-    <View
-      numberOfSpaces={4}
-      style={
-        [
-          {
-            "height": 16,
-          },
-        ]
-      }
-    />
-    <Text
-      style={
-        [
-          {
-            "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
-          },
-        ]
-      }
-    >
-      Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
-    </Text>
-    <View
-      numberOfSpaces={2}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
-    <View
-      style={
-        [
-          {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
-          },
-        ]
-      }
-    >
+    <View>
       <View
+        height={65}
         style={
           [
             {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "paddingVertical": 16,
+              "height": 65,
+            },
+          ]
+        }
+      />
+      <View
+        numberOfSpaces={6}
+        style={
+          [
+            {
+              "height": 24,
+            },
+          ]
+        }
+      />
+      <Text
+        style={
+          [
+            {
+              "color": "#161617",
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 18,
+              "lineHeight": 22,
             },
           ]
         }
       >
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexBasis": 0,
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-            ]
-          }
-          toggleLabel={false}
-        >
-          <Text
-            htmlFor="testUuidV4"
-            style={
-              [
-                {
-                  "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
-                },
-              ]
-            }
-          >
-            <Text
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              Autoriser l’envoi d’e-mails
-            </Text>
-          </Text>
-        </View>
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            numberOfSpaces={5}
-            style={
-              [
-                {
-                  "width": 20,
-                },
-              ]
-            }
-          />
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <Text
-              accessibilityHidden={true}
-              style={
-                [
-                  {
-                    "display": "none",
-                  },
-                ]
-              }
-            >
-              Case à cocher - 
-              non cochée
-            </Text>
-            <View
-              accessibilityRole="checkbox"
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": false,
-                  "disabled": true,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
-              }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
-              accessible={false}
-              collapsable={false}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                {
-                  "opacity": 1,
-                  "userSelect": "auto",
-                }
-              }
-              testID="Interrupteur Autoriser l’envoi d’e-mails"
-            >
-              <View
-                active={false}
-                style={
-                  [
-                    {
-                      "backgroundColor": "#90949D",
-                      "borderRadius": 16,
-                      "height": 32,
-                      "justifyContent": "center",
-                      "width": 56,
-                    },
-                  ]
-                }
-              >
-                <View
-                  collapsable={false}
-                  disabled={true}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "aspectRatio": 1,
-                      "backgroundColor": "#ffffff",
-                      "borderRadius": 28,
-                      "height": 28,
-                      "justifyContent": "center",
-                      "marginLeft": 2,
-                      "width": 28,
-                    }
-                  }
-                >
-                  <View
-                    accessibilityLabel="Désactivé"
-                    height={16}
-                    width={16}
-                  >
-                    <Text>
-                      undefined-SVG-Mock
-                    </Text>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-      <View
-        style={
-          [
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "paddingVertical": 16,
-            },
-          ]
-        }
-      >
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexBasis": 0,
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-            ]
-          }
-          toggleLabel={false}
-        >
-          <Text
-            htmlFor="testUuidV4"
-            style={
-              [
-                {
-                  "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
-                },
-              ]
-            }
-          >
-            <Text
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
-                  },
-                ]
-              }
-            >
-              Autoriser les notifications
-            </Text>
-          </Text>
-        </View>
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-              },
-            ]
-          }
-        >
-          <View
-            numberOfSpaces={5}
-            style={
-              [
-                {
-                  "width": 20,
-                },
-              ]
-            }
-          />
-          <View
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-              ]
-            }
-          >
-            <Text
-              accessibilityHidden={true}
-              style={
-                [
-                  {
-                    "display": "none",
-                  },
-                ]
-              }
-            >
-              Case à cocher - 
-              non cochée
-            </Text>
-            <View
-              accessibilityRole="checkbox"
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": false,
-                  "disabled": true,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
-              }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
-              accessible={false}
-              collapsable={false}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                {
-                  "opacity": 1,
-                  "userSelect": "auto",
-                }
-              }
-              testID="Interrupteur Autoriser les notifications"
-            >
-              <View
-                active={false}
-                style={
-                  [
-                    {
-                      "backgroundColor": "#90949D",
-                      "borderRadius": 16,
-                      "height": 32,
-                      "justifyContent": "center",
-                      "width": 56,
-                    },
-                  ]
-                }
-              >
-                <View
-                  collapsable={false}
-                  disabled={true}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "aspectRatio": 1,
-                      "backgroundColor": "#ffffff",
-                      "borderRadius": 28,
-                      "height": 28,
-                      "justifyContent": "center",
-                      "marginLeft": 2,
-                      "width": 28,
-                    }
-                  }
-                >
-                  <View
-                    accessibilityLabel="Désactivé"
-                    height={16}
-                    width={16}
-                  >
-                    <Text>
-                      undefined-SVG-Mock
-                    </Text>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
+        Type d’alerte
+      </Text>
       <View
         numberOfSpaces={4}
         style={
@@ -1401,107 +2277,1808 @@ exports[`NotificationSettings should render correctly when user is not logged in
           ]
         }
       />
-      <View
+      <Text
         style={
           [
             {
-              "backgroundColor": "#F1F1F4",
-              "height": 1,
-              "width": "100%",
+              "color": "#161617",
+              "fontFamily": "Montserrat-Regular",
+              "fontSize": 15,
+              "lineHeight": 20,
             },
           ]
         }
-      />
-      <View
-        numberOfSpaces={8}
-        style={
-          [
-            {
-              "height": 32,
-            },
-          ]
-        }
-      />
-      <View
-        accessibilityLabel="Enregistrer les modifications"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": undefined,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={false}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "#eb0055",
-            "borderRadius": 24,
-            "flexDirection": "row",
-            "justifyContent": "center",
-            "maxWidth": 500,
-            "minHeight": 40,
-            "opacity": 1,
-            "paddingBottom": 2,
-            "paddingLeft": 20,
-            "paddingRight": 20,
-            "paddingTop": 2,
-            "userSelect": "auto",
-            "width": "100%",
-          }
-        }
-        testID="Enregistrer les modifications"
       >
-        <Text
-          adjustsFontSizeToFit={false}
-          numberOfLines={1}
+        Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
+      </Text>
+      <View
+        numberOfSpaces={2}
+        style={
+          [
+            {
+              "height": 8,
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+            },
+          ]
+        }
+      >
+        <View
           style={
             [
               {
-                "color": "#ffffff",
-                "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
-                "marginLeft": 0,
-                "maxWidth": "100%",
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
               },
             ]
           }
         >
-          Enregistrer
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Autoriser l’envoi d’e-mails
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": true,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Autoriser l’envoi d’e-mails"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={true}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "width": 28,
+                      }
+                    }
+                  >
+                    <View
+                      accessibilityLabel="Désactivé"
+                      height={16}
+                      width={16}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Autoriser les notifications
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": true,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Autoriser les notifications"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={true}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "width": 28,
+                      }
+                    }
+                  >
+                    <View
+                      accessibilityLabel="Désactivé"
+                      height={16}
+                      width={16}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          numberOfSpaces={4}
+          style={
+            [
+              {
+                "height": 16,
+              },
+            ]
+          }
+        />
+        <View
+          style={
+            [
+              {
+                "backgroundColor": "#F1F1F4",
+                "height": 1,
+                "width": "100%",
+              },
+            ]
+          }
+        />
+        <View
+          numberOfSpaces={8}
+          style={
+            [
+              {
+                "height": 32,
+              },
+            ]
+          }
+        />
+        <Text
+          style={
+            [
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 18,
+                "lineHeight": 22,
+              },
+            ]
+          }
+        >
+          Tes thème suivis
         </Text>
+        <View
+          numberOfSpaces={6}
+          style={
+            [
+              {
+                "height": 24,
+              },
+            ]
+          }
+        />
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Suivre tous les thèmes
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": true,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Suivre tous les thèmes"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={true}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "width": 28,
+                      }
+                    }
+                  >
+                    <View
+                      accessibilityLabel="Désactivé"
+                      height={16}
+                      width={16}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          numberOfSpaces={2}
+          style={
+            [
+              {
+                "height": 8,
+              },
+            ]
+          }
+        />
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Cinéma
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": true,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Cinéma"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={true}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "width": 28,
+                      }
+                    }
+                  >
+                    <View
+                      accessibilityLabel="Désactivé"
+                      height={16}
+                      width={16}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Lecture
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": true,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Lecture"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={true}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "width": 28,
+                      }
+                    }
+                  >
+                    <View
+                      accessibilityLabel="Désactivé"
+                      height={16}
+                      width={16}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Musique
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": true,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Musique"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={true}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "width": 28,
+                      }
+                    }
+                  >
+                    <View
+                      accessibilityLabel="Désactivé"
+                      height={16}
+                      width={16}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Spectacles
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": true,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Spectacles"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={true}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "width": 28,
+                      }
+                    }
+                  >
+                    <View
+                      accessibilityLabel="Désactivé"
+                      height={16}
+                      width={16}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Visites et sorties
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": true,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Visites et sorties"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={true}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "width": 28,
+                      }
+                    }
+                  >
+                    <View
+                      accessibilityLabel="Désactivé"
+                      height={16}
+                      width={16}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "paddingVertical": 16,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+              ]
+            }
+            toggleLabel={false}
+          >
+            <Text
+              htmlFor="testUuidV4"
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+              >
+                Cours et Ateliers
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              numberOfSpaces={5}
+              style={
+                [
+                  {
+                    "width": 20,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityHidden={true}
+                style={
+                  [
+                    {
+                      "display": "none",
+                    },
+                  ]
+                }
+              >
+                Case à cocher - 
+                non cochée
+              </Text>
+              <View
+                accessibilityRole="checkbox"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": false,
+                    "disabled": true,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={false}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "opacity": 1,
+                    "userSelect": "auto",
+                  }
+                }
+                testID="Interrupteur Cours et Ateliers"
+              >
+                <View
+                  active={false}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#90949D",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "justifyContent": "center",
+                        "width": 56,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    collapsable={false}
+                    disabled={true}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "aspectRatio": 1,
+                        "backgroundColor": "#ffffff",
+                        "borderRadius": 28,
+                        "height": 28,
+                        "justifyContent": "center",
+                        "marginLeft": 2,
+                        "width": 28,
+                      }
+                    }
+                  >
+                    <View
+                      accessibilityLabel="Désactivé"
+                      height={16}
+                      width={16}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          numberOfSpaces={2}
+          style={
+            [
+              {
+                "height": 8,
+              },
+            ]
+          }
+        />
+        <View
+          accessibilityLabel="Enregistrer les modifications"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={false}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "#eb0055",
+              "borderRadius": 24,
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "maxWidth": 500,
+              "minHeight": 40,
+              "opacity": 1,
+              "paddingBottom": 2,
+              "paddingLeft": 20,
+              "paddingRight": 20,
+              "paddingTop": 2,
+              "userSelect": "auto",
+              "width": "100%",
+            }
+          }
+          testID="Enregistrer les modifications"
+        >
+          <Text
+            adjustsFontSizeToFit={false}
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "color": "#ffffff",
+                  "fontFamily": "Montserrat-Bold",
+                  "fontSize": 15,
+                  "lineHeight": 20,
+                  "marginLeft": 0,
+                  "maxWidth": "100%",
+                },
+              ]
+            }
+          >
+            Enregistrer
+          </Text>
+        </View>
       </View>
+      <View
+        numberOfSpaces={6}
+        style={
+          [
+            {
+              "height": 24,
+            },
+          ]
+        }
+      />
     </View>
-    <View
-      numberOfSpaces={6}
-      style={
-        [
-          {
-            "height": 24,
-          },
-        ]
-      }
-    />
-  </View>,
+  </RCTScrollView>,
   <View
     height={65}
     style={

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -2253,6 +2253,80 @@ exports[`NotificationSettings should render correctly when user is not logged in
           ]
         }
       />
+      <View
+        backgroundColor="#f3ecff"
+        style={
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "#f3ecff",
+              "borderRadius": 8,
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+              "paddingBottom": 16,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "paddingTop": 16,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "paddingRight": 16,
+              },
+            ]
+          }
+        >
+          <View
+            height={24}
+            width={24}
+          >
+            <Text>
+              undefined-SVG-Mock
+            </Text>
+          </View>
+        </View>
+        <View
+          style={
+            [
+              {
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+            ]
+          }
+        >
+          <Text
+            style={
+              [
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-SemiBold",
+                  "fontSize": 12,
+                  "lineHeight": 16,
+                },
+              ]
+            }
+            textColor="#161617"
+          >
+            Tu dois être connecté pour activer les notifications et rester informé des bons plans sur le pass Culture.
+          </Text>
+        </View>
+      </View>
+      <View
+        numberOfSpaces={6}
+        style={
+          [
+            {
+              "height": 24,
+            },
+          ]
+        }
+      />
       <Text
         style={
           [

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -262,7 +262,7 @@ exports[`NotificationSettings should render correctly 1`] = `
           class="c2"
         >
           <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1h0z5md r-paddingVertical-1yzf0co"
           >
             <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
@@ -280,11 +280,11 @@ exports[`NotificationSettings should render correctly 1`] = `
               </label>
             </div>
             <div
+              class="css-view-175oi2r r-width-1janqcz"
+            />
+            <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
-              <div
-                class="css-view-175oi2r r-width-19wmn03"
-              />
               <div
                 class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
               >
@@ -357,7 +357,7 @@ exports[`NotificationSettings should render correctly 1`] = `
             class="css-view-175oi2r r-height-1472mwg"
           />
           <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1h0z5md r-paddingVertical-1yzf0co"
           >
             <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
@@ -375,11 +375,11 @@ exports[`NotificationSettings should render correctly 1`] = `
               </label>
             </div>
             <div
+              class="css-view-175oi2r r-width-1janqcz"
+            />
+            <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
-              <div
-                class="css-view-175oi2r r-width-19wmn03"
-              />
               <div
                 class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
               >
@@ -435,7 +435,7 @@ exports[`NotificationSettings should render correctly 1`] = `
             class="css-view-175oi2r r-height-3da1kt"
           />
           <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1h0z5md r-paddingVertical-1yzf0co"
           >
             <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
@@ -453,11 +453,11 @@ exports[`NotificationSettings should render correctly 1`] = `
               </label>
             </div>
             <div
+              class="css-view-175oi2r r-width-1janqcz"
+            />
+            <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
-              <div
-                class="css-view-175oi2r r-width-19wmn03"
-              />
               <div
                 class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
               >
@@ -510,7 +510,7 @@ exports[`NotificationSettings should render correctly 1`] = `
             </div>
           </div>
           <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1h0z5md r-paddingVertical-1yzf0co"
           >
             <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
@@ -528,11 +528,11 @@ exports[`NotificationSettings should render correctly 1`] = `
               </label>
             </div>
             <div
+              class="css-view-175oi2r r-width-1janqcz"
+            />
+            <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
-              <div
-                class="css-view-175oi2r r-width-19wmn03"
-              />
               <div
                 class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
               >
@@ -585,7 +585,7 @@ exports[`NotificationSettings should render correctly 1`] = `
             </div>
           </div>
           <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1h0z5md r-paddingVertical-1yzf0co"
           >
             <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
@@ -603,11 +603,11 @@ exports[`NotificationSettings should render correctly 1`] = `
               </label>
             </div>
             <div
+              class="css-view-175oi2r r-width-1janqcz"
+            />
+            <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
-              <div
-                class="css-view-175oi2r r-width-19wmn03"
-              />
               <div
                 class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
               >
@@ -660,7 +660,7 @@ exports[`NotificationSettings should render correctly 1`] = `
             </div>
           </div>
           <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1h0z5md r-paddingVertical-1yzf0co"
           >
             <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
@@ -678,11 +678,11 @@ exports[`NotificationSettings should render correctly 1`] = `
               </label>
             </div>
             <div
+              class="css-view-175oi2r r-width-1janqcz"
+            />
+            <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
-              <div
-                class="css-view-175oi2r r-width-19wmn03"
-              />
               <div
                 class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
               >
@@ -735,7 +735,7 @@ exports[`NotificationSettings should render correctly 1`] = `
             </div>
           </div>
           <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1h0z5md r-paddingVertical-1yzf0co"
           >
             <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
@@ -753,11 +753,11 @@ exports[`NotificationSettings should render correctly 1`] = `
               </label>
             </div>
             <div
+              class="css-view-175oi2r r-width-1janqcz"
+            />
+            <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
-              <div
-                class="css-view-175oi2r r-width-19wmn03"
-              />
               <div
                 class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
               >
@@ -810,7 +810,7 @@ exports[`NotificationSettings should render correctly 1`] = `
             </div>
           </div>
           <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1h0z5md r-paddingVertical-1yzf0co"
           >
             <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
@@ -828,11 +828,11 @@ exports[`NotificationSettings should render correctly 1`] = `
               </label>
             </div>
             <div
+              class="css-view-175oi2r r-width-1janqcz"
+            />
+            <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
-              <div
-                class="css-view-175oi2r r-width-19wmn03"
-              />
               <div
                 class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
               >

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -193,139 +193,685 @@ exports[`NotificationSettings should render correctly 1`] = `
     </div>
   </header>
   <div
-    class="css-view-175oi2r r-backgroundColor-14lw9ot r-flexBasis-1iusvr4 r-flexDirection-eqz5dr r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-paddingHorizontal-1guathk"
+    class="css-view-175oi2r r-WebkitOverflowScrolling-150rngu r-overflowX-11yh6sk r-overflowY-1rnoaur r-transform-1sncvnh r-backgroundColor-14lw9ot r-flexBasis-1iusvr4 r-flexDirection-eqz5dr r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-paddingHorizontal-1guathk"
   >
     <div
-      class="css-view-175oi2r r-height-17lwhjb"
-    />
-    <div
-      class="css-view-175oi2r r-height-1472mwg"
-    />
-    <h2
-      aria-level="2"
-      class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-1i10wst r-lineHeight-hbpseb"
-      dir="ltr"
-      role="heading"
-    >
-      Type d’alerte
-    </h2>
-    <div
-      class="css-view-175oi2r r-height-10ptun7"
-    />
-    <div
-      class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe"
-      dir="ltr"
-    >
-      Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
-    </div>
-    <div
-      class="css-view-175oi2r r-height-3da1kt"
-    />
-    <form
-      class="c2"
+      class="css-view-175oi2r"
     >
       <div
-        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+        class="css-view-175oi2r r-height-17lwhjb"
+      />
+      <div
+        class="css-view-175oi2r r-height-1472mwg"
+      />
+      <h2
+        aria-level="2"
+        class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-1i10wst r-lineHeight-hbpseb"
+        dir="ltr"
+        role="heading"
       >
-        <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
-        >
-          <label
-            class="c3"
-            for="testUuidV4"
-          >
-            <div
-              class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
-              dir="ltr"
-            >
-              Autoriser l’envoi d’e-mails
-            </div>
-          </label>
-        </div>
-        <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-        >
-          <div
-            class="css-view-175oi2r r-width-19wmn03"
-          />
-          <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-          >
-            <div
-              aria-hidden="true"
-              class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
-              dir="ltr"
-            >
-              Case à cocher - 
-              non cochée
-            </div>
-            <div
-              aria-checked="false"
-              aria-disabled="true"
-              aria-labelledby="testUuidV4"
-              class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
-              data-testid="Interrupteur Autoriser l’envoi d’e-mails"
-              role="checkbox"
-              style="transition-duration: 0s;"
-              tabindex="-1"
-            >
-              <div
-                class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
-              >
-                <div
-                  class="css-view-175oi2r"
-                  style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
-                >
-                  <div
-                    aria-label="Désactivé"
-                    class="css-view-175oi2r"
-                  >
-                    <div
-                      class="css-text-1rynq56"
-                      dir="ltr"
-                    >
-                      undefined-SVG-Mock
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <input
-              hidden=""
-              id="testUuidV4"
-              readonly=""
-              type="checkbox"
-            />
-          </div>
-        </div>
-      </div>
+        Type d’alerte
+      </h2>
       <div
         class="css-view-175oi2r r-height-10ptun7"
       />
       <div
-        class="css-view-175oi2r r-backgroundColor-14a9t8x r-height-109y4c4 r-width-13qz1uu"
-      />
+        class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe"
+        dir="ltr"
+      >
+        Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
+      </div>
       <div
-        class="css-view-175oi2r r-height-mabqd8"
+        class="css-view-175oi2r r-height-3da1kt"
       />
-      <button
-        aria-label="Enregistrer les modifications"
-        class="c4 c5"
-        data-testid="Enregistrer les modifications"
-        tabindex="0"
-        type="button"
+      <form
+        class="c2"
       >
         <div
-          class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
-          dir="ltr"
+          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
         >
-          Enregistrer
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+          >
+            <label
+              class="c3"
+              for="1"
+            >
+              <div
+                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                dir="ltr"
+              >
+                Autoriser l’envoi d’e-mails
+              </div>
+            </label>
+          </div>
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+          >
+            <div
+              class="css-view-175oi2r r-width-19wmn03"
+            />
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            >
+              <div
+                aria-hidden="true"
+                class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+                dir="ltr"
+              >
+                Case à cocher - 
+                non cochée
+              </div>
+              <div
+                aria-checked="false"
+                aria-disabled="true"
+                aria-labelledby="0"
+                class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+                data-testid="Interrupteur Autoriser l’envoi d’e-mails"
+                role="checkbox"
+                style="transition-duration: 0s;"
+                tabindex="-1"
+              >
+                <div
+                  class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+                >
+                  <div
+                    class="css-view-175oi2r"
+                    style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                  >
+                    <div
+                      aria-label="Désactivé"
+                      class="css-view-175oi2r"
+                    >
+                      <div
+                        class="css-text-1rynq56"
+                        dir="ltr"
+                      >
+                        undefined-SVG-Mock
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <input
+                hidden=""
+                id="1"
+                readonly=""
+                type="checkbox"
+              />
+            </div>
+          </div>
         </div>
-      </button>
-    </form>
-    <div
-      class="css-view-175oi2r r-height-1472mwg"
-    />
+        <div
+          class="css-view-175oi2r r-height-10ptun7"
+        />
+        <div
+          class="css-view-175oi2r r-backgroundColor-14a9t8x r-height-109y4c4 r-width-13qz1uu"
+        />
+        <div
+          class="css-view-175oi2r r-height-mabqd8"
+        />
+        <h2
+          aria-level="2"
+          class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-1i10wst r-lineHeight-hbpseb"
+          dir="ltr"
+          role="heading"
+        >
+          Tes thème suivis
+        </h2>
+        <div
+          class="css-view-175oi2r r-height-1472mwg"
+        />
+        <div
+          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+        >
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+          >
+            <label
+              class="c3"
+              for="3"
+            >
+              <div
+                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                dir="ltr"
+              >
+                Suivre tous les thèmes
+              </div>
+            </label>
+          </div>
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+          >
+            <div
+              class="css-view-175oi2r r-width-19wmn03"
+            />
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            >
+              <div
+                aria-hidden="true"
+                class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+                dir="ltr"
+              >
+                Case à cocher - 
+                non cochée
+              </div>
+              <div
+                aria-checked="false"
+                aria-disabled="true"
+                aria-labelledby="2"
+                class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+                data-testid="Interrupteur Suivre tous les thèmes"
+                role="checkbox"
+                style="transition-duration: 0s;"
+                tabindex="-1"
+              >
+                <div
+                  class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+                >
+                  <div
+                    class="css-view-175oi2r"
+                    style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                  >
+                    <div
+                      aria-label="Désactivé"
+                      class="css-view-175oi2r"
+                    >
+                      <div
+                        class="css-text-1rynq56"
+                        dir="ltr"
+                      >
+                        undefined-SVG-Mock
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <input
+                hidden=""
+                id="3"
+                readonly=""
+                type="checkbox"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="css-view-175oi2r r-height-3da1kt"
+        />
+        <div
+          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+        >
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+          >
+            <label
+              class="c3"
+              for="5"
+            >
+              <div
+                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                dir="ltr"
+              >
+                Cinéma
+              </div>
+            </label>
+          </div>
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+          >
+            <div
+              class="css-view-175oi2r r-width-19wmn03"
+            />
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            >
+              <div
+                aria-hidden="true"
+                class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+                dir="ltr"
+              >
+                Case à cocher - 
+                non cochée
+              </div>
+              <div
+                aria-checked="false"
+                aria-disabled="true"
+                aria-labelledby="4"
+                class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+                data-testid="Interrupteur Cinéma"
+                role="checkbox"
+                style="transition-duration: 0s;"
+                tabindex="-1"
+              >
+                <div
+                  class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+                >
+                  <div
+                    class="css-view-175oi2r"
+                    style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                  >
+                    <div
+                      aria-label="Désactivé"
+                      class="css-view-175oi2r"
+                    >
+                      <div
+                        class="css-text-1rynq56"
+                        dir="ltr"
+                      >
+                        undefined-SVG-Mock
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <input
+                hidden=""
+                id="5"
+                readonly=""
+                type="checkbox"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+        >
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+          >
+            <label
+              class="c3"
+              for="7"
+            >
+              <div
+                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                dir="ltr"
+              >
+                Lecture
+              </div>
+            </label>
+          </div>
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+          >
+            <div
+              class="css-view-175oi2r r-width-19wmn03"
+            />
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            >
+              <div
+                aria-hidden="true"
+                class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+                dir="ltr"
+              >
+                Case à cocher - 
+                non cochée
+              </div>
+              <div
+                aria-checked="false"
+                aria-disabled="true"
+                aria-labelledby="6"
+                class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+                data-testid="Interrupteur Lecture"
+                role="checkbox"
+                style="transition-duration: 0s;"
+                tabindex="-1"
+              >
+                <div
+                  class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+                >
+                  <div
+                    class="css-view-175oi2r"
+                    style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                  >
+                    <div
+                      aria-label="Désactivé"
+                      class="css-view-175oi2r"
+                    >
+                      <div
+                        class="css-text-1rynq56"
+                        dir="ltr"
+                      >
+                        undefined-SVG-Mock
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <input
+                hidden=""
+                id="7"
+                readonly=""
+                type="checkbox"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+        >
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+          >
+            <label
+              class="c3"
+              for="9"
+            >
+              <div
+                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                dir="ltr"
+              >
+                Musique
+              </div>
+            </label>
+          </div>
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+          >
+            <div
+              class="css-view-175oi2r r-width-19wmn03"
+            />
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            >
+              <div
+                aria-hidden="true"
+                class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+                dir="ltr"
+              >
+                Case à cocher - 
+                non cochée
+              </div>
+              <div
+                aria-checked="false"
+                aria-disabled="true"
+                aria-labelledby="8"
+                class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+                data-testid="Interrupteur Musique"
+                role="checkbox"
+                style="transition-duration: 0s;"
+                tabindex="-1"
+              >
+                <div
+                  class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+                >
+                  <div
+                    class="css-view-175oi2r"
+                    style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                  >
+                    <div
+                      aria-label="Désactivé"
+                      class="css-view-175oi2r"
+                    >
+                      <div
+                        class="css-text-1rynq56"
+                        dir="ltr"
+                      >
+                        undefined-SVG-Mock
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <input
+                hidden=""
+                id="9"
+                readonly=""
+                type="checkbox"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+        >
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+          >
+            <label
+              class="c3"
+              for="11"
+            >
+              <div
+                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                dir="ltr"
+              >
+                Spectacles
+              </div>
+            </label>
+          </div>
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+          >
+            <div
+              class="css-view-175oi2r r-width-19wmn03"
+            />
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            >
+              <div
+                aria-hidden="true"
+                class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+                dir="ltr"
+              >
+                Case à cocher - 
+                non cochée
+              </div>
+              <div
+                aria-checked="false"
+                aria-disabled="true"
+                aria-labelledby="10"
+                class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+                data-testid="Interrupteur Spectacles"
+                role="checkbox"
+                style="transition-duration: 0s;"
+                tabindex="-1"
+              >
+                <div
+                  class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+                >
+                  <div
+                    class="css-view-175oi2r"
+                    style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                  >
+                    <div
+                      aria-label="Désactivé"
+                      class="css-view-175oi2r"
+                    >
+                      <div
+                        class="css-text-1rynq56"
+                        dir="ltr"
+                      >
+                        undefined-SVG-Mock
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <input
+                hidden=""
+                id="11"
+                readonly=""
+                type="checkbox"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+        >
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+          >
+            <label
+              class="c3"
+              for="13"
+            >
+              <div
+                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                dir="ltr"
+              >
+                Visites et sorties
+              </div>
+            </label>
+          </div>
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+          >
+            <div
+              class="css-view-175oi2r r-width-19wmn03"
+            />
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            >
+              <div
+                aria-hidden="true"
+                class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+                dir="ltr"
+              >
+                Case à cocher - 
+                non cochée
+              </div>
+              <div
+                aria-checked="false"
+                aria-disabled="true"
+                aria-labelledby="12"
+                class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+                data-testid="Interrupteur Visites et sorties"
+                role="checkbox"
+                style="transition-duration: 0s;"
+                tabindex="-1"
+              >
+                <div
+                  class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+                >
+                  <div
+                    class="css-view-175oi2r"
+                    style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                  >
+                    <div
+                      aria-label="Désactivé"
+                      class="css-view-175oi2r"
+                    >
+                      <div
+                        class="css-text-1rynq56"
+                        dir="ltr"
+                      >
+                        undefined-SVG-Mock
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <input
+                hidden=""
+                id="13"
+                readonly=""
+                type="checkbox"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+        >
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+          >
+            <label
+              class="c3"
+              for="15"
+            >
+              <div
+                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                dir="ltr"
+              >
+                Cours et Ateliers
+              </div>
+            </label>
+          </div>
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+          >
+            <div
+              class="css-view-175oi2r r-width-19wmn03"
+            />
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            >
+              <div
+                aria-hidden="true"
+                class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+                dir="ltr"
+              >
+                Case à cocher - 
+                non cochée
+              </div>
+              <div
+                aria-checked="false"
+                aria-disabled="true"
+                aria-labelledby="14"
+                class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+                data-testid="Interrupteur Cours et Ateliers"
+                role="checkbox"
+                style="transition-duration: 0s;"
+                tabindex="-1"
+              >
+                <div
+                  class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+                >
+                  <div
+                    class="css-view-175oi2r"
+                    style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                  >
+                    <div
+                      aria-label="Désactivé"
+                      class="css-view-175oi2r"
+                    >
+                      <div
+                        class="css-text-1rynq56"
+                        dir="ltr"
+                      >
+                        undefined-SVG-Mock
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <input
+                hidden=""
+                id="15"
+                readonly=""
+                type="checkbox"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="css-view-175oi2r r-height-3da1kt"
+        />
+        <button
+          aria-label="Enregistrer les modifications"
+          class="c4 c5"
+          data-testid="Enregistrer les modifications"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+            dir="ltr"
+          >
+            Enregistrer
+          </div>
+        </button>
+      </form>
+      <div
+        class="css-view-175oi2r r-height-1472mwg"
+      />
+    </div>
   </div>
   <div
     class="css-view-175oi2r r-backdropFilter-1jy2u1p r-height-17lwhjb r-left-1d2f490 r-overflow-1udh08x r-position-u8s1d r-right-zchlnj r-top-ipm5af"

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -1,0 +1,334 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotificationSettings should render correctly 1`] = `
+.c0 {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  cursor: pointer;
+  border-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background-color: transparent;
+  padding: 0;
+}
+
+.c0:active {
+  opacity: 0.7;
+  outline: none;
+}
+
+.c0:focus {
+  outline: auto;
+}
+
+.c0:disabled {
+  cursor: initial;
+}
+
+.c0:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  -webkit-text-decoration-color: #161617;
+  text-decoration-color: #161617;
+}
+
+.c0:hover:disabled {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c1 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  max-width: 40px;
+  height: 40px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  font-family: Montserrat-Regular;
+  font-size: 15px;
+  line-height: 20px;
+  color: #161617;
+  cursor: pointer;
+}
+
+.c4 {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 24px;
+  padding: 2px;
+  padding-left: 20px;
+  padding-right: 20px;
+  min-height: 40px;
+  width: 100%;
+  background-color: #eb0055;
+  max-width: 500px;
+  cursor: pointer;
+  outline: none;
+  border-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  box-sizing: border-box;
+}
+
+.c4:disabled {
+  cursor: initial;
+  background: none;
+}
+
+.c4:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  -webkit-text-decoration-color: #ffffff;
+  text-decoration-color: #ffffff;
+}
+
+.c4:hover:disabled {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5:disabled {
+  background-color: #F1F1F4;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+<div>
+  <header
+    class="css-view-175oi2r r-backgroundColor-1stjixc r-borderBottomColor-8fzpo5 r-borderBottomWidth-qklmqi r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af r-zIndex-184en5c"
+    role="banner"
+  >
+    <div
+      class="css-view-175oi2r r-height-10ptun7"
+    />
+    <div
+      class="css-view-175oi2r r-alignItems-1awozwy r-height-h3s6tt r-justifyContent-1777fci"
+    >
+      <div
+        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-width-13qz1uu"
+      >
+        <div
+          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-justifyContent-1h0z5md r-paddingLeft-f727ji r-paddingRight-j2kj52"
+          data-testid="back-button-container"
+        >
+          <button
+            aria-label="Revenir en arrière"
+            class="c0 c1 sc-gEvEer c1"
+            data-testid="Revenir en arrière"
+            tabindex="0"
+            title="Revenir en arrière"
+            type="button"
+          >
+            <div
+              class="css-view-175oi2r"
+              data-testid="icon-back"
+            >
+              <div
+                class="css-text-1rynq56"
+                dir="ltr"
+              >
+                icon-back-SVG-Mock
+              </div>
+            </div>
+            <div
+              class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+              dir="ltr"
+            >
+              Retour
+            </div>
+          </button>
+        </div>
+        <h1
+          aria-level="1"
+          class="css-text-1rynq56 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe r-textAlign-q4m81j"
+          dir="ltr"
+          role="heading"
+        >
+          Suivi et notifications
+        </h1>
+        <div
+          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-justifyContent-17s6mgv r-paddingLeft-f727ji r-paddingRight-j2kj52"
+          data-testid="close-button-container"
+        />
+      </div>
+    </div>
+  </header>
+  <div
+    class="css-view-175oi2r r-backgroundColor-14lw9ot r-flexBasis-1iusvr4 r-flexDirection-eqz5dr r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-paddingHorizontal-1guathk"
+  >
+    <div
+      class="css-view-175oi2r r-height-17lwhjb"
+    />
+    <div
+      class="css-view-175oi2r r-height-1472mwg"
+    />
+    <h2
+      aria-level="2"
+      class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-1i10wst r-lineHeight-hbpseb"
+      dir="ltr"
+      role="heading"
+    >
+      Type d’alerte
+    </h2>
+    <div
+      class="css-view-175oi2r r-height-10ptun7"
+    />
+    <div
+      class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe"
+      dir="ltr"
+    >
+      Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
+    </div>
+    <div
+      class="css-view-175oi2r r-height-3da1kt"
+    />
+    <form
+      class="c2"
+    >
+      <div
+        class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+      >
+        <div
+          class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+        >
+          <label
+            class="c3"
+            for="testUuidV4"
+          >
+            <div
+              class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+              dir="ltr"
+            >
+              Autoriser l’envoi d’e-mails
+            </div>
+          </label>
+        </div>
+        <div
+          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+        >
+          <div
+            class="css-view-175oi2r r-width-19wmn03"
+          />
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+          >
+            <div
+              aria-hidden="true"
+              class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+              dir="ltr"
+            >
+              Case à cocher - 
+              non cochée
+            </div>
+            <div
+              aria-checked="false"
+              aria-disabled="true"
+              aria-labelledby="testUuidV4"
+              class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+              data-testid="Interrupteur Autoriser l’envoi d’e-mails"
+              role="checkbox"
+              style="transition-duration: 0s;"
+              tabindex="-1"
+            >
+              <div
+                class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+              >
+                <div
+                  class="css-view-175oi2r"
+                  style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                >
+                  <div
+                    aria-label="Désactivé"
+                    class="css-view-175oi2r"
+                  >
+                    <div
+                      class="css-text-1rynq56"
+                      dir="ltr"
+                    >
+                      undefined-SVG-Mock
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <input
+              hidden=""
+              id="testUuidV4"
+              readonly=""
+              type="checkbox"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="css-view-175oi2r r-height-10ptun7"
+      />
+      <div
+        class="css-view-175oi2r r-backgroundColor-14a9t8x r-height-109y4c4 r-width-13qz1uu"
+      />
+      <div
+        class="css-view-175oi2r r-height-mabqd8"
+      />
+      <button
+        aria-label="Enregistrer les modifications"
+        class="c4 c5"
+        data-testid="Enregistrer les modifications"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+          dir="ltr"
+        >
+          Enregistrer
+        </div>
+      </button>
+    </form>
+    <div
+      class="css-view-175oi2r r-height-1472mwg"
+    />
+  </div>
+  <div
+    class="css-view-175oi2r r-backdropFilter-1jy2u1p r-height-17lwhjb r-left-1d2f490 r-overflow-1udh08x r-position-u8s1d r-right-zchlnj r-top-ipm5af"
+  />
+</div>
+`;

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -1,6 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NotificationSettings should render correctly 1`] = `
+.c4 {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 24px;
+  padding: 2px;
+  padding-left: 20px;
+  padding-right: 20px;
+  min-height: 40px;
+  width: 100%;
+  background-color: #eb0055;
+  max-width: 500px;
+  cursor: pointer;
+  outline: none;
+  border-width: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  overflow: hidden;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  box-sizing: border-box;
+}
+
+.c4:disabled {
+  cursor: initial;
+  background: none;
+}
+
+.c4:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  -webkit-text-decoration-color: #ffffff;
+  text-decoration-color: #ffffff;
+}
+
+.c4:hover:disabled {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5:disabled {
+  background-color: #F1F1F4;
+}
+
 .c0 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -65,60 +119,6 @@ exports[`NotificationSettings should render correctly 1`] = `
   cursor: pointer;
 }
 
-.c4 {
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  border-radius: 24px;
-  padding: 2px;
-  padding-left: 20px;
-  padding-right: 20px;
-  min-height: 40px;
-  width: 100%;
-  background-color: #eb0055;
-  max-width: 500px;
-  cursor: pointer;
-  outline: none;
-  border-width: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  overflow: hidden;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  box-sizing: border-box;
-}
-
-.c4:disabled {
-  cursor: initial;
-  background: none;
-}
-
-.c4:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  -webkit-text-decoration-color: #ffffff;
-  text-decoration-color: #ffffff;
-}
-
-.c4:hover:disabled {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c5:disabled {
-  background-color: #F1F1F4;
-}
-
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -152,7 +152,7 @@ exports[`NotificationSettings should render correctly 1`] = `
         >
           <button
             aria-label="Revenir en arrière"
-            class="c0 c1 sc-gEvEer c1"
+            class="c0 c1 sc-iGgWBj c1"
             data-testid="Revenir en arrière"
             tabindex="0"
             title="Revenir en arrière"
@@ -204,112 +204,39 @@ exports[`NotificationSettings should render correctly 1`] = `
       <div
         class="css-view-175oi2r r-height-1472mwg"
       />
-      <h2
-        aria-level="2"
-        class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-1i10wst r-lineHeight-hbpseb"
-        dir="ltr"
-        role="heading"
-      >
-        Type d’alerte
-      </h2>
       <div
-        class="css-view-175oi2r r-height-10ptun7"
-      />
-      <div
-        class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe"
-        dir="ltr"
-      >
-        Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
-      </div>
-      <div
-        class="css-view-175oi2r r-height-3da1kt"
-      />
-      <form
-        class="c2"
+        class="css-view-175oi2r r-alignSelf-1kihuf0 r-maxWidth-1ik5qf4 r-width-13qz1uu"
       >
         <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+          class="css-view-175oi2r r-alignItems-1awozwy r-backgroundColor-nyej4v r-borderRadius-1xfd6ze r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-paddingBottom-1l7z4oj r-paddingLeft-1qhn6m8 r-paddingRight-i023vh r-paddingTop-95jzfe"
         >
           <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+            class="css-view-175oi2r r-paddingRight-i023vh"
           >
-            <label
-              class="c3"
-              for="1"
+            <div
+              class="css-view-175oi2r"
             >
               <div
-                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                class="css-text-1rynq56"
                 dir="ltr"
               >
-                Autoriser l’envoi d’e-mails
+                undefined-SVG-Mock
               </div>
-            </label>
+            </div>
           </div>
           <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            class="css-view-175oi2r r-flexBasis-1iusvr4 r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
           >
             <div
-              class="css-view-175oi2r r-width-19wmn03"
-            />
-            <div
-              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+              class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+              dir="ltr"
             >
-              <div
-                aria-hidden="true"
-                class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
-                dir="ltr"
-              >
-                Case à cocher - 
-                non cochée
-              </div>
-              <div
-                aria-checked="false"
-                aria-disabled="true"
-                aria-labelledby="0"
-                class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
-                data-testid="Interrupteur Autoriser l’envoi d’e-mails"
-                role="checkbox"
-                style="transition-duration: 0s;"
-                tabindex="-1"
-              >
-                <div
-                  class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
-                >
-                  <div
-                    class="css-view-175oi2r"
-                    style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
-                  >
-                    <div
-                      aria-label="Désactivé"
-                      class="css-view-175oi2r"
-                    >
-                      <div
-                        class="css-text-1rynq56"
-                        dir="ltr"
-                      >
-                        undefined-SVG-Mock
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <input
-                hidden=""
-                id="1"
-                readonly=""
-                type="checkbox"
-              />
+              Tu dois être connecté pour activer les notifications et rester informé des bons plans sur le pass Culture.
             </div>
           </div>
         </div>
         <div
-          class="css-view-175oi2r r-height-10ptun7"
-        />
-        <div
-          class="css-view-175oi2r r-backgroundColor-14a9t8x r-height-109y4c4 r-width-13qz1uu"
-        />
-        <div
-          class="css-view-175oi2r r-height-mabqd8"
+          class="css-view-175oi2r r-height-1472mwg"
         />
         <h2
           aria-level="2"
@@ -317,557 +244,665 @@ exports[`NotificationSettings should render correctly 1`] = `
           dir="ltr"
           role="heading"
         >
-          Tes thème suivis
+          Type d’alerte
         </h2>
         <div
-          class="css-view-175oi2r r-height-1472mwg"
+          class="css-view-175oi2r r-height-10ptun7"
         />
         <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+          class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe"
+          dir="ltr"
         >
-          <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
-          >
-            <label
-              class="c3"
-              for="3"
-            >
-              <div
-                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
-                dir="ltr"
-              >
-                Suivre tous les thèmes
-              </div>
-            </label>
-          </div>
-          <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-          >
-            <div
-              class="css-view-175oi2r r-width-19wmn03"
-            />
-            <div
-              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-            >
-              <div
-                aria-hidden="true"
-                class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
-                dir="ltr"
-              >
-                Case à cocher - 
-                non cochée
-              </div>
-              <div
-                aria-checked="false"
-                aria-disabled="true"
-                aria-labelledby="2"
-                class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
-                data-testid="Interrupteur Suivre tous les thèmes"
-                role="checkbox"
-                style="transition-duration: 0s;"
-                tabindex="-1"
-              >
-                <div
-                  class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
-                >
-                  <div
-                    class="css-view-175oi2r"
-                    style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
-                  >
-                    <div
-                      aria-label="Désactivé"
-                      class="css-view-175oi2r"
-                    >
-                      <div
-                        class="css-text-1rynq56"
-                        dir="ltr"
-                      >
-                        undefined-SVG-Mock
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <input
-                hidden=""
-                id="3"
-                readonly=""
-                type="checkbox"
-              />
-            </div>
-          </div>
+          Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
         </div>
         <div
           class="css-view-175oi2r r-height-3da1kt"
         />
-        <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+        <form
+          class="c2"
         >
           <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
-          >
-            <label
-              class="c3"
-              for="5"
-            >
-              <div
-                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
-                dir="ltr"
-              >
-                Cinéma
-              </div>
-            </label>
-          </div>
-          <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
           >
             <div
-              class="css-view-175oi2r r-width-19wmn03"
-            />
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+            >
+              <label
+                class="c3"
+                for="1"
+              >
+                <div
+                  class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                  dir="ltr"
+                >
+                  Autoriser l’envoi d’e-mails
+                </div>
+              </label>
+            </div>
             <div
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
               <div
-                aria-hidden="true"
-                class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
-                dir="ltr"
-              >
-                Case à cocher - 
-                non cochée
-              </div>
+                class="css-view-175oi2r r-width-19wmn03"
+              />
               <div
-                aria-checked="false"
-                aria-disabled="true"
-                aria-labelledby="4"
-                class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
-                data-testid="Interrupteur Cinéma"
-                role="checkbox"
-                style="transition-duration: 0s;"
-                tabindex="-1"
+                class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
               >
                 <div
-                  class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+                  aria-hidden="true"
+                  class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+                  dir="ltr"
+                >
+                  Case à cocher - 
+                  non cochée
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-disabled="true"
+                  aria-labelledby="0"
+                  class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+                  data-testid="Interrupteur Autoriser l’envoi d’e-mails"
+                  role="checkbox"
+                  style="transition-duration: 0s;"
+                  tabindex="-1"
                 >
                   <div
-                    class="css-view-175oi2r"
-                    style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                    class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
                   >
                     <div
-                      aria-label="Désactivé"
                       class="css-view-175oi2r"
+                      style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
                     >
                       <div
-                        class="css-text-1rynq56"
-                        dir="ltr"
+                        aria-label="Désactivé"
+                        class="css-view-175oi2r"
                       >
-                        undefined-SVG-Mock
+                        <div
+                          class="css-text-1rynq56"
+                          dir="ltr"
+                        >
+                          undefined-SVG-Mock
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
+                <input
+                  hidden=""
+                  id="1"
+                  readonly=""
+                  type="checkbox"
+                />
               </div>
-              <input
-                hidden=""
-                id="5"
-                readonly=""
-                type="checkbox"
-              />
             </div>
           </div>
-        </div>
-        <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
-        >
           <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
-          >
-            <label
-              class="c3"
-              for="7"
-            >
-              <div
-                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
-                dir="ltr"
-              >
-                Lecture
-              </div>
-            </label>
-          </div>
+            class="css-view-175oi2r r-height-10ptun7"
+          />
           <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-          >
-            <div
-              class="css-view-175oi2r r-width-19wmn03"
-            />
-            <div
-              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-            >
-              <div
-                aria-hidden="true"
-                class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
-                dir="ltr"
-              >
-                Case à cocher - 
-                non cochée
-              </div>
-              <div
-                aria-checked="false"
-                aria-disabled="true"
-                aria-labelledby="6"
-                class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
-                data-testid="Interrupteur Lecture"
-                role="checkbox"
-                style="transition-duration: 0s;"
-                tabindex="-1"
-              >
-                <div
-                  class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
-                >
-                  <div
-                    class="css-view-175oi2r"
-                    style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
-                  >
-                    <div
-                      aria-label="Désactivé"
-                      class="css-view-175oi2r"
-                    >
-                      <div
-                        class="css-text-1rynq56"
-                        dir="ltr"
-                      >
-                        undefined-SVG-Mock
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <input
-                hidden=""
-                id="7"
-                readonly=""
-                type="checkbox"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
-        >
+            class="css-view-175oi2r r-backgroundColor-14a9t8x r-height-109y4c4 r-width-13qz1uu"
+          />
           <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
-          >
-            <label
-              class="c3"
-              for="9"
-            >
-              <div
-                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
-                dir="ltr"
-              >
-                Musique
-              </div>
-            </label>
-          </div>
-          <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-          >
-            <div
-              class="css-view-175oi2r r-width-19wmn03"
-            />
-            <div
-              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-            >
-              <div
-                aria-hidden="true"
-                class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
-                dir="ltr"
-              >
-                Case à cocher - 
-                non cochée
-              </div>
-              <div
-                aria-checked="false"
-                aria-disabled="true"
-                aria-labelledby="8"
-                class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
-                data-testid="Interrupteur Musique"
-                role="checkbox"
-                style="transition-duration: 0s;"
-                tabindex="-1"
-              >
-                <div
-                  class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
-                >
-                  <div
-                    class="css-view-175oi2r"
-                    style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
-                  >
-                    <div
-                      aria-label="Désactivé"
-                      class="css-view-175oi2r"
-                    >
-                      <div
-                        class="css-text-1rynq56"
-                        dir="ltr"
-                      >
-                        undefined-SVG-Mock
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <input
-                hidden=""
-                id="9"
-                readonly=""
-                type="checkbox"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
-        >
-          <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
-          >
-            <label
-              class="c3"
-              for="11"
-            >
-              <div
-                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
-                dir="ltr"
-              >
-                Spectacles
-              </div>
-            </label>
-          </div>
-          <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-          >
-            <div
-              class="css-view-175oi2r r-width-19wmn03"
-            />
-            <div
-              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-            >
-              <div
-                aria-hidden="true"
-                class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
-                dir="ltr"
-              >
-                Case à cocher - 
-                non cochée
-              </div>
-              <div
-                aria-checked="false"
-                aria-disabled="true"
-                aria-labelledby="10"
-                class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
-                data-testid="Interrupteur Spectacles"
-                role="checkbox"
-                style="transition-duration: 0s;"
-                tabindex="-1"
-              >
-                <div
-                  class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
-                >
-                  <div
-                    class="css-view-175oi2r"
-                    style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
-                  >
-                    <div
-                      aria-label="Désactivé"
-                      class="css-view-175oi2r"
-                    >
-                      <div
-                        class="css-text-1rynq56"
-                        dir="ltr"
-                      >
-                        undefined-SVG-Mock
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <input
-                hidden=""
-                id="11"
-                readonly=""
-                type="checkbox"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
-        >
-          <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
-          >
-            <label
-              class="c3"
-              for="13"
-            >
-              <div
-                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
-                dir="ltr"
-              >
-                Visites et sorties
-              </div>
-            </label>
-          </div>
-          <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-          >
-            <div
-              class="css-view-175oi2r r-width-19wmn03"
-            />
-            <div
-              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-            >
-              <div
-                aria-hidden="true"
-                class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
-                dir="ltr"
-              >
-                Case à cocher - 
-                non cochée
-              </div>
-              <div
-                aria-checked="false"
-                aria-disabled="true"
-                aria-labelledby="12"
-                class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
-                data-testid="Interrupteur Visites et sorties"
-                role="checkbox"
-                style="transition-duration: 0s;"
-                tabindex="-1"
-              >
-                <div
-                  class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
-                >
-                  <div
-                    class="css-view-175oi2r"
-                    style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
-                  >
-                    <div
-                      aria-label="Désactivé"
-                      class="css-view-175oi2r"
-                    >
-                      <div
-                        class="css-text-1rynq56"
-                        dir="ltr"
-                      >
-                        undefined-SVG-Mock
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <input
-                hidden=""
-                id="13"
-                readonly=""
-                type="checkbox"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
-        >
-          <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
-          >
-            <label
-              class="c3"
-              for="15"
-            >
-              <div
-                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
-                dir="ltr"
-              >
-                Cours et Ateliers
-              </div>
-            </label>
-          </div>
-          <div
-            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-          >
-            <div
-              class="css-view-175oi2r r-width-19wmn03"
-            />
-            <div
-              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
-            >
-              <div
-                aria-hidden="true"
-                class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
-                dir="ltr"
-              >
-                Case à cocher - 
-                non cochée
-              </div>
-              <div
-                aria-checked="false"
-                aria-disabled="true"
-                aria-labelledby="14"
-                class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
-                data-testid="Interrupteur Cours et Ateliers"
-                role="checkbox"
-                style="transition-duration: 0s;"
-                tabindex="-1"
-              >
-                <div
-                  class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
-                >
-                  <div
-                    class="css-view-175oi2r"
-                    style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
-                  >
-                    <div
-                      aria-label="Désactivé"
-                      class="css-view-175oi2r"
-                    >
-                      <div
-                        class="css-text-1rynq56"
-                        dir="ltr"
-                      >
-                        undefined-SVG-Mock
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <input
-                hidden=""
-                id="15"
-                readonly=""
-                type="checkbox"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="css-view-175oi2r r-height-3da1kt"
-        />
-        <button
-          aria-label="Enregistrer les modifications"
-          class="c4 c5"
-          data-testid="Enregistrer les modifications"
-          tabindex="0"
-          type="button"
-        >
-          <div
-            class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+            class="css-view-175oi2r r-height-mabqd8"
+          />
+          <h2
+            aria-level="2"
+            class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-1i10wst r-lineHeight-hbpseb"
             dir="ltr"
+            role="heading"
           >
-            Enregistrer
+            Tes thème suivis
+          </h2>
+          <div
+            class="css-view-175oi2r r-height-1472mwg"
+          />
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+          >
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+            >
+              <label
+                class="c3"
+                for="3"
+              >
+                <div
+                  class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                  dir="ltr"
+                >
+                  Suivre tous les thèmes
+                </div>
+              </label>
+            </div>
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            >
+              <div
+                class="css-view-175oi2r r-width-19wmn03"
+              />
+              <div
+                class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+              >
+                <div
+                  aria-hidden="true"
+                  class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+                  dir="ltr"
+                >
+                  Case à cocher - 
+                  non cochée
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-disabled="true"
+                  aria-labelledby="2"
+                  class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+                  data-testid="Interrupteur Suivre tous les thèmes"
+                  role="checkbox"
+                  style="transition-duration: 0s;"
+                  tabindex="-1"
+                >
+                  <div
+                    class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+                  >
+                    <div
+                      class="css-view-175oi2r"
+                      style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                    >
+                      <div
+                        aria-label="Désactivé"
+                        class="css-view-175oi2r"
+                      >
+                        <div
+                          class="css-text-1rynq56"
+                          dir="ltr"
+                        >
+                          undefined-SVG-Mock
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <input
+                  hidden=""
+                  id="3"
+                  readonly=""
+                  type="checkbox"
+                />
+              </div>
+            </div>
           </div>
-        </button>
-      </form>
+          <div
+            class="css-view-175oi2r r-height-3da1kt"
+          />
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+          >
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+            >
+              <label
+                class="c3"
+                for="5"
+              >
+                <div
+                  class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                  dir="ltr"
+                >
+                  Cinéma
+                </div>
+              </label>
+            </div>
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            >
+              <div
+                class="css-view-175oi2r r-width-19wmn03"
+              />
+              <div
+                class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+              >
+                <div
+                  aria-hidden="true"
+                  class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+                  dir="ltr"
+                >
+                  Case à cocher - 
+                  non cochée
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-disabled="true"
+                  aria-labelledby="4"
+                  class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+                  data-testid="Interrupteur Cinéma"
+                  role="checkbox"
+                  style="transition-duration: 0s;"
+                  tabindex="-1"
+                >
+                  <div
+                    class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+                  >
+                    <div
+                      class="css-view-175oi2r"
+                      style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                    >
+                      <div
+                        aria-label="Désactivé"
+                        class="css-view-175oi2r"
+                      >
+                        <div
+                          class="css-text-1rynq56"
+                          dir="ltr"
+                        >
+                          undefined-SVG-Mock
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <input
+                  hidden=""
+                  id="5"
+                  readonly=""
+                  type="checkbox"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+          >
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+            >
+              <label
+                class="c3"
+                for="7"
+              >
+                <div
+                  class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                  dir="ltr"
+                >
+                  Lecture
+                </div>
+              </label>
+            </div>
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            >
+              <div
+                class="css-view-175oi2r r-width-19wmn03"
+              />
+              <div
+                class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+              >
+                <div
+                  aria-hidden="true"
+                  class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+                  dir="ltr"
+                >
+                  Case à cocher - 
+                  non cochée
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-disabled="true"
+                  aria-labelledby="6"
+                  class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+                  data-testid="Interrupteur Lecture"
+                  role="checkbox"
+                  style="transition-duration: 0s;"
+                  tabindex="-1"
+                >
+                  <div
+                    class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+                  >
+                    <div
+                      class="css-view-175oi2r"
+                      style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                    >
+                      <div
+                        aria-label="Désactivé"
+                        class="css-view-175oi2r"
+                      >
+                        <div
+                          class="css-text-1rynq56"
+                          dir="ltr"
+                        >
+                          undefined-SVG-Mock
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <input
+                  hidden=""
+                  id="7"
+                  readonly=""
+                  type="checkbox"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+          >
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+            >
+              <label
+                class="c3"
+                for="9"
+              >
+                <div
+                  class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                  dir="ltr"
+                >
+                  Musique
+                </div>
+              </label>
+            </div>
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            >
+              <div
+                class="css-view-175oi2r r-width-19wmn03"
+              />
+              <div
+                class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+              >
+                <div
+                  aria-hidden="true"
+                  class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+                  dir="ltr"
+                >
+                  Case à cocher - 
+                  non cochée
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-disabled="true"
+                  aria-labelledby="8"
+                  class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+                  data-testid="Interrupteur Musique"
+                  role="checkbox"
+                  style="transition-duration: 0s;"
+                  tabindex="-1"
+                >
+                  <div
+                    class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+                  >
+                    <div
+                      class="css-view-175oi2r"
+                      style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                    >
+                      <div
+                        aria-label="Désactivé"
+                        class="css-view-175oi2r"
+                      >
+                        <div
+                          class="css-text-1rynq56"
+                          dir="ltr"
+                        >
+                          undefined-SVG-Mock
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <input
+                  hidden=""
+                  id="9"
+                  readonly=""
+                  type="checkbox"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+          >
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+            >
+              <label
+                class="c3"
+                for="11"
+              >
+                <div
+                  class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                  dir="ltr"
+                >
+                  Spectacles
+                </div>
+              </label>
+            </div>
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            >
+              <div
+                class="css-view-175oi2r r-width-19wmn03"
+              />
+              <div
+                class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+              >
+                <div
+                  aria-hidden="true"
+                  class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+                  dir="ltr"
+                >
+                  Case à cocher - 
+                  non cochée
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-disabled="true"
+                  aria-labelledby="10"
+                  class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+                  data-testid="Interrupteur Spectacles"
+                  role="checkbox"
+                  style="transition-duration: 0s;"
+                  tabindex="-1"
+                >
+                  <div
+                    class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+                  >
+                    <div
+                      class="css-view-175oi2r"
+                      style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                    >
+                      <div
+                        aria-label="Désactivé"
+                        class="css-view-175oi2r"
+                      >
+                        <div
+                          class="css-text-1rynq56"
+                          dir="ltr"
+                        >
+                          undefined-SVG-Mock
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <input
+                  hidden=""
+                  id="11"
+                  readonly=""
+                  type="checkbox"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+          >
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+            >
+              <label
+                class="c3"
+                for="13"
+              >
+                <div
+                  class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                  dir="ltr"
+                >
+                  Visites et sorties
+                </div>
+              </label>
+            </div>
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            >
+              <div
+                class="css-view-175oi2r r-width-19wmn03"
+              />
+              <div
+                class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+              >
+                <div
+                  aria-hidden="true"
+                  class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+                  dir="ltr"
+                >
+                  Case à cocher - 
+                  non cochée
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-disabled="true"
+                  aria-labelledby="12"
+                  class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+                  data-testid="Interrupteur Visites et sorties"
+                  role="checkbox"
+                  style="transition-duration: 0s;"
+                  tabindex="-1"
+                >
+                  <div
+                    class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+                  >
+                    <div
+                      class="css-view-175oi2r"
+                      style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                    >
+                      <div
+                        aria-label="Désactivé"
+                        class="css-view-175oi2r"
+                      >
+                        <div
+                          class="css-text-1rynq56"
+                          dir="ltr"
+                        >
+                          undefined-SVG-Mock
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <input
+                  hidden=""
+                  id="13"
+                  readonly=""
+                  type="checkbox"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-paddingVertical-1yzf0co"
+          >
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexBasis-1iusvr4 r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2"
+            >
+              <label
+                class="c3"
+                for="15"
+              >
+                <div
+                  class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                  dir="ltr"
+                >
+                  Cours et Ateliers
+                </div>
+              </label>
+            </div>
+            <div
+              class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+            >
+              <div
+                class="css-view-175oi2r r-width-19wmn03"
+              />
+              <div
+                class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
+              >
+                <div
+                  aria-hidden="true"
+                  class="css-text-1rynq56 r-clipPath-129q975 r-height-109y4c4 r-overflow-1udh08x r-width-92ng3h"
+                  dir="ltr"
+                >
+                  Case à cocher - 
+                  non cochée
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-disabled="true"
+                  aria-labelledby="14"
+                  class="css-view-175oi2r r-transitionProperty-1i6wzkk r-userSelect-bj6uhd r-pointerEvents-633pao"
+                  data-testid="Interrupteur Cours et Ateliers"
+                  role="checkbox"
+                  style="transition-duration: 0s;"
+                  tabindex="-1"
+                >
+                  <div
+                    class="css-view-175oi2r r-backgroundColor-1c6vf7j r-borderRadius-1867qdf r-height-mabqd8 r-justifyContent-1777fci r-width-18tzken"
+                  >
+                    <div
+                      class="css-view-175oi2r"
+                      style="width: 28px; height: 28px; background-color: rgb(255, 255, 255); border-top-left-radius: 28px; border-top-right-radius: 28px; border-bottom-right-radius: 28px; border-bottom-left-radius: 28px; align-items: center; justify-content: center; margin-left: 2px;"
+                    >
+                      <div
+                        aria-label="Désactivé"
+                        class="css-view-175oi2r"
+                      >
+                        <div
+                          class="css-text-1rynq56"
+                          dir="ltr"
+                        >
+                          undefined-SVG-Mock
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <input
+                  hidden=""
+                  id="15"
+                  readonly=""
+                  type="checkbox"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="css-view-175oi2r r-height-3da1kt"
+          />
+          <button
+            aria-label="Enregistrer les modifications"
+            class="c4 c5"
+            data-testid="Enregistrer les modifications"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+              dir="ltr"
+            >
+              Enregistrer
+            </div>
+          </button>
+        </form>
+      </div>
       <div
         class="css-view-175oi2r r-height-1472mwg"
       />

--- a/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
@@ -544,7 +544,6 @@ exports[`Profile component should render correctly 1`] = `
                       },
                     ]
                   }
-                  toggleLabel={true}
                 >
                   <View
                     height={24}

--- a/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
@@ -527,10 +527,12 @@ exports[`Profile component should render correctly 1`] = `
                     {
                       "alignItems": "center",
                       "flexDirection": "row",
+                      "justifyContent": "flex-start",
                       "paddingVertical": 16,
                     },
                   ]
                 }
+                toggleLabel={true}
               >
                 <View
                   style={
@@ -544,6 +546,7 @@ exports[`Profile component should render correctly 1`] = `
                       },
                     ]
                   }
+                  toggleLabel={true}
                 >
                   <View
                     height={24}
@@ -593,6 +596,16 @@ exports[`Profile component should render correctly 1`] = `
                   </Text>
                 </View>
                 <View
+                  numberOfSpaces={4}
+                  style={
+                    [
+                      {
+                        "width": 16,
+                      },
+                    ]
+                  }
+                />
+                <View
                   style={
                     [
                       {
@@ -602,16 +615,6 @@ exports[`Profile component should render correctly 1`] = `
                     ]
                   }
                 >
-                  <View
-                    numberOfSpaces={5}
-                    style={
-                      [
-                        {
-                          "width": 20,
-                        },
-                      ]
-                    }
-                  />
                   <View
                     style={
                       [

--- a/src/features/internal/cheatcodes/pages/NavigationProfile/NavigationProfile.tsx
+++ b/src/features/internal/cheatcodes/pages/NavigationProfile/NavigationProfile.tsx
@@ -39,6 +39,7 @@ export function NavigationProfile(): React.JSX.Element {
         <LinkToComponent name="ChangeEmail" />
         <LinkToComponent name="ConsentSettings" />
         <LinkToComponent name="NotificationSettings" />
+        <LinkToComponent name="NotificationsSettingsWIP" />
         <Row half>
           <ButtonPrimary wording="Modal Limite 500&nbsp;€" onPress={showPhysicalCeilingModal} />
           <CreditCeilingsModal

--- a/src/features/navigation/RootNavigator/routes.ts
+++ b/src/features/navigation/RootNavigator/routes.ts
@@ -57,7 +57,7 @@ import { ConfirmDeleteProfile } from 'features/profile/pages/DeleteProfile/Confi
 import { DeleteProfileSuccess } from 'features/profile/pages/DeleteProfile/DeleteProfileSuccess'
 import { LegalNotices } from 'features/profile/pages/LegalNotices/LegalNotices'
 import { NewEmailSelection } from 'features/profile/pages/NewEmailSelection/NewEmailSelection'
-import { NotificationSettings } from 'features/profile/pages/NotificationSettings/NotificationSettings'
+import { NotificationSettingsDeprecated } from 'features/profile/pages/NotificationSettings/NotificationSettingsDeprecated'
 import { PersonalData } from 'features/profile/pages/PersonalData/PersonalData'
 import { SuspendAccountConfirmation } from 'features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation'
 import { TrackEmailChange } from 'features/profile/pages/TrackEmailChange/TrackEmailChange'
@@ -280,7 +280,7 @@ export const routes: Route[] = [
   },
   {
     name: 'NotificationSettings',
-    component: NotificationSettings,
+    component: NotificationSettingsDeprecated,
     path: 'profil/notifications',
     options: { title: 'Réglages de notifications' },
   },

--- a/src/features/navigation/RootNavigator/subscriptionRoutes.ts
+++ b/src/features/navigation/RootNavigator/subscriptionRoutes.ts
@@ -71,7 +71,6 @@ export const subscriptionRoutes: GenericRoute<SubscriptionRootStackParamList>[] 
     // debug route: in navigation component
     name: 'NotificationsSettingsWIP',
     component: NotificationsSettings,
-    hoc: withAsyncErrorBoundary,
     path: 'cheat-navigation-new-notification-settings',
   },
   // Stepper

--- a/src/features/navigation/RootNavigator/subscriptionRoutes.ts
+++ b/src/features/navigation/RootNavigator/subscriptionRoutes.ts
@@ -35,6 +35,7 @@ import {
   GenericRoute,
   SubscriptionRootStackParamList,
 } from 'features/navigation/RootNavigator/types'
+import { NotificationsSettings } from 'features/profile/pages/NotificationSettings/NotificationsSettings'
 
 // Try to keep those routes in the same order as the user flow
 export const subscriptionRoutes: GenericRoute<SubscriptionRootStackParamList>[] = [
@@ -65,6 +66,13 @@ export const subscriptionRoutes: GenericRoute<SubscriptionRootStackParamList>[] 
     component: NewIdentificationFlow,
     hoc: withAsyncErrorBoundary,
     path: 'cheat-navigation-new-identification-flow',
+  },
+  {
+    // debug route: in navigation component
+    name: 'NotificationsSettingsWIP',
+    component: NotificationsSettings,
+    hoc: withAsyncErrorBoundary,
+    path: 'cheat-navigation-new-notification-settings',
   },
   // Stepper
   {

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -123,6 +123,7 @@ export type SubscriptionRootStackParamList = {
   NavigationShareApp: undefined
   NavigationSignUp: undefined
   NewIdentificationFlow: undefined
+  NotificationsSettingsWIP: undefined
   // Stepper
   Stepper: { from: StepperOrigin } | undefined
   // PhoneValidation

--- a/src/features/profile/components/SectionWithSwitch/SectionWithSwitch.tsx
+++ b/src/features/profile/components/SectionWithSwitch/SectionWithSwitch.tsx
@@ -36,8 +36,8 @@ export const SectionWithSwitch: React.FC<Props> = (props: Props) => {
   const Icon = icon
 
   return (
-    <Container>
-      <TitleContainer>
+    <Container toggleLabel={!!toggleLabel}>
+      <TitleContainer toggleLabel={!!toggleLabel}>
         {!!Icon && (
           <React.Fragment>
             <Icon size={iconSize} />
@@ -48,13 +48,16 @@ export const SectionWithSwitch: React.FC<Props> = (props: Props) => {
           <Typo.ButtonText>{title}</Typo.ButtonText>
         </InputLabel>
       </TitleContainer>
+      <Spacer.Row numberOfSpaces={4} />
       <FilterSwitchLabelContainer>
         {toggleLabel && !isMobileViewport ? (
-          <ToggleLabel id={labelID} htmlFor={checkboxID}>
-            {toggleLabel}
-          </ToggleLabel>
+          <React.Fragment>
+            <ToggleLabel id={labelID} htmlFor={checkboxID}>
+              {toggleLabel}
+            </ToggleLabel>
+            <Spacer.Row numberOfSpaces={4} />
+          </React.Fragment>
         ) : null}
-        <Spacer.Row numberOfSpaces={5} />
         <FilterSwitch
           checkboxID={checkboxID}
           active={active}
@@ -69,17 +72,18 @@ export const SectionWithSwitch: React.FC<Props> = (props: Props) => {
   )
 }
 
-const Container = styled.View({
+const Container = styled.View<{ toggleLabel?: boolean }>(({ theme, toggleLabel }) => ({
   paddingVertical: getSpacing(4),
-  flexDirection: 'row',
+  flexDirection: theme.isMobileViewport || toggleLabel ? 'row' : 'row-reverse',
+  justifyContent: theme.isMobileViewport || toggleLabel ? 'flex-start' : 'flex-end',
   alignItems: 'center',
-})
+}))
 
-const TitleContainer = styled.View({
-  flex: 1,
+const TitleContainer = styled.View<{ toggleLabel?: boolean }>(({ theme, toggleLabel }) => ({
+  flex: theme.isMobileViewport || toggleLabel ? 1 : undefined,
   flexDirection: 'row',
   alignItems: 'center',
-})
+}))
 
 const FilterSwitchLabelContainer = styled.View({
   flexDirection: 'row',

--- a/src/features/profile/components/SectionWithSwitch/SectionWithSwitch.tsx
+++ b/src/features/profile/components/SectionWithSwitch/SectionWithSwitch.tsx
@@ -37,7 +37,7 @@ export const SectionWithSwitch: React.FC<Props> = (props: Props) => {
 
   return (
     <Container>
-      <TitleContainer toggleLabel={!!toggleLabel}>
+      <TitleContainer>
         {!!Icon && (
           <React.Fragment>
             <Icon size={iconSize} />
@@ -75,11 +75,11 @@ const Container = styled.View({
   alignItems: 'center',
 })
 
-const TitleContainer = styled.View<{ toggleLabel?: boolean }>(({ theme, toggleLabel }) => ({
-  flex: theme.isMobileViewport || toggleLabel ? 1 : undefined,
+const TitleContainer = styled.View({
+  flex: 1,
   flexDirection: 'row',
   alignItems: 'center',
-}))
+})
 
 const FilterSwitchLabelContainer = styled.View({
   flexDirection: 'row',

--- a/src/features/profile/pages/NotificationSettings/NotificationSettingsDeprecated.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationSettingsDeprecated.tsx
@@ -28,7 +28,7 @@ type State = {
   pushTouched: boolean
 }
 
-export function NotificationSettings() {
+export function NotificationSettingsDeprecated() {
   const { showSuccessSnackBar, showErrorSnackBar } = useSnackBarContext()
   const { isLoggedIn, user } = useAuthContext()
 

--- a/src/features/profile/pages/NotificationSettings/NotificationSettingsDeprecated.web.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationSettingsDeprecated.web.test.tsx
@@ -4,7 +4,7 @@ import { useRoute } from '__mocks__/@react-navigation/native'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, checkAccessibilityFor, act, screen } from 'tests/utils/web'
 
-import { NotificationSettings } from './NotificationSettings'
+import { NotificationSettingsDeprecated } from './NotificationSettingsDeprecated'
 
 jest.mock('features/auth/context/AuthContext')
 
@@ -12,7 +12,7 @@ useRoute.mockReturnValue({ key: 'ksdqldkmqdmqdq' })
 
 describe('<NotificationSettings/>', () => {
   it('should only display switch to authorize emails', async () => {
-    render(reactQueryProviderHOC(<NotificationSettings />))
+    render(reactQueryProviderHOC(<NotificationSettingsDeprecated />))
 
     expect(await screen.findByText('Autoriser l’envoi d’e-mails')).toBeTruthy()
     expect(screen.queryByText('Autoriser les notifications marketing')).not.toBeOnTheScreen()
@@ -20,7 +20,7 @@ describe('<NotificationSettings/>', () => {
 
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
-      const { container } = render(reactQueryProviderHOC(<NotificationSettings />))
+      const { container } = render(reactQueryProviderHOC(<NotificationSettingsDeprecated />))
 
       await act(async () => {
         const results = await checkAccessibilityFor(container)

--- a/src/features/profile/pages/NotificationSettings/NotificationSettingsDeprectated.native.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationSettingsDeprectated.native.test.tsx
@@ -12,7 +12,7 @@ import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { fireEvent, render, screen, act } from 'tests/utils'
 
-import { NotificationSettings } from './NotificationSettings'
+import { NotificationSettingsDeprecated } from './NotificationSettingsDeprecated'
 
 jest.mock('features/auth/context/AuthContext')
 const mockUseAuthContext = Auth.useAuthContext as jest.Mock
@@ -245,7 +245,7 @@ function renderNotificationSettings(
     settings: {},
   })
 
-  return render(reactQueryProviderHOC(<NotificationSettings />))
+  return render(reactQueryProviderHOC(<NotificationSettingsDeprecated />))
 }
 
 const mockApiUpdateProfile = (user?: UserProfileResponse) => {

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { IAuthContext, useAuthContext } from 'features/auth/context/AuthContext'
 import { beneficiaryUser } from 'fixtures/user'
-import { render, screen } from 'tests/utils'
+import { fireEvent, render, screen } from 'tests/utils'
 
 import { NotificationsSettings } from './NotificationsSettings'
 
@@ -34,5 +34,58 @@ describe('NotificationSettings', () => {
     render(<NotificationsSettings />)
 
     expect(screen).toMatchSnapshot()
+  })
+
+  it('should switch on all thematic toggles when the "Suivre tous les thèmes" toggle is pressed', () => {
+    mockUseAuthContext.mockReturnValueOnce(baseAuthContext)
+    render(<NotificationsSettings />)
+
+    const toggleSwitch = screen.getByTestId('Interrupteur Suivre tous les thèmes')
+    fireEvent.press(toggleSwitch)
+
+    expect(screen.getByTestId('Interrupteur Cinéma')).toHaveAccessibilityState({ checked: true })
+    expect(screen.getByTestId('Interrupteur Lecture')).toHaveAccessibilityState({ checked: true })
+    expect(screen.getByTestId('Interrupteur Musique')).toHaveAccessibilityState({ checked: true })
+    expect(screen.getByTestId('Interrupteur Spectacles')).toHaveAccessibilityState({
+      checked: true,
+    })
+    expect(screen.getByTestId('Interrupteur Visites et sorties')).toHaveAccessibilityState({
+      checked: true,
+    })
+    expect(screen.getByTestId('Interrupteur Cours et Ateliers')).toHaveAccessibilityState({
+      checked: true,
+    })
+  })
+
+  it('should switch off all thematic toggles when the "Suivre tous les thèmes" toggle is pressed when active', () => {
+    mockUseAuthContext.mockReturnValueOnce(baseAuthContext)
+    render(<NotificationsSettings />)
+
+    const toggleSwitch = screen.getByTestId('Interrupteur Suivre tous les thèmes')
+    fireEvent.press(toggleSwitch)
+    fireEvent.press(toggleSwitch)
+
+    expect(screen.getByTestId('Interrupteur Cinéma')).toHaveAccessibilityState({ checked: false })
+    expect(screen.getByTestId('Interrupteur Lecture')).toHaveAccessibilityState({ checked: false })
+    expect(screen.getByTestId('Interrupteur Musique')).toHaveAccessibilityState({ checked: false })
+    expect(screen.getByTestId('Interrupteur Spectacles')).toHaveAccessibilityState({
+      checked: false,
+    })
+    expect(screen.getByTestId('Interrupteur Visites et sorties')).toHaveAccessibilityState({
+      checked: false,
+    })
+    expect(screen.getByTestId('Interrupteur Cours et Ateliers')).toHaveAccessibilityState({
+      checked: false,
+    })
+  })
+
+  it('should toggle on specific theme when its toggle is pressed', async () => {
+    mockUseAuthContext.mockReturnValueOnce(baseAuthContext)
+    render(<NotificationsSettings />)
+
+    const toggleSwitch = screen.getByTestId('Interrupteur Cinéma')
+    fireEvent.press(toggleSwitch)
+
+    expect(screen.getByTestId('Interrupteur Cinéma')).toHaveAccessibilityState({ checked: true })
   })
 })

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+import { IAuthContext, useAuthContext } from 'features/auth/context/AuthContext'
+import { beneficiaryUser } from 'fixtures/user'
+import { render, screen } from 'tests/utils'
+
+import { NotificationsSettings } from './NotificationsSettings'
+
+jest.mock('features/auth/context/AuthContext')
+const mockUseAuthContext = useAuthContext as jest.MockedFunction<typeof useAuthContext>
+
+const baseAuthContext: IAuthContext = {
+  isLoggedIn: true,
+  user: beneficiaryUser,
+  isUserLoading: false,
+  refetchUser: jest.fn(),
+  setIsLoggedIn: jest.fn(),
+}
+
+describe('NotificationSettings', () => {
+  it('should render correctly when user is logged in', () => {
+    mockUseAuthContext.mockReturnValueOnce(baseAuthContext)
+    render(<NotificationsSettings />)
+
+    expect(screen).toMatchSnapshot()
+  })
+
+  it('should render correctly when user is not logged in', () => {
+    mockUseAuthContext.mockReturnValueOnce({
+      ...baseAuthContext,
+      user: undefined,
+      isLoggedIn: false,
+    })
+    render(<NotificationsSettings />)
+
+    expect(screen).toMatchSnapshot()
+  })
+})

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
@@ -123,6 +123,7 @@ describe('NotificationSettings', () => {
       fireEvent.press(toggleSwitch)
 
       const openSettingsButton = await screen.findAllByText('Autoriser les notifications')
+      // @ts-expect-error: we know that this is not undefined
       fireEvent.press(openSettingsButton[1])
 
       expect(Linking.openSettings).toHaveBeenCalledTimes(1)

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
@@ -122,9 +122,8 @@ describe('NotificationSettings', () => {
       const toggleSwitch = screen.getByTestId('Interrupteur Autoriser les notifications')
       fireEvent.press(toggleSwitch)
 
-      const openSettingsButton = await screen.findAllByText('Autoriser les notifications')
-      // @ts-expect-error: we know that this is not undefined
-      fireEvent.press(openSettingsButton[1])
+      const openSettingsButton = await screen.findByLabelText('Autoriser les notifications')
+      fireEvent.press(openSettingsButton)
 
       expect(Linking.openSettings).toHaveBeenCalledTimes(1)
     })

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -1,0 +1,74 @@
+import React, { useCallback, useState } from 'react'
+import { Platform } from 'react-native'
+
+import { useAuthContext } from 'features/auth/context/AuthContext'
+import { PageProfileSection } from 'features/profile/components/PageProfileSection/PageProfileSection'
+import { SectionWithSwitch } from 'features/profile/components/SectionWithSwitch/SectionWithSwitch'
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { Form } from 'ui/components/Form'
+import { Separator } from 'ui/components/Separator'
+import { Spacer, Typo } from 'ui/theme'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+
+type State = {
+  allowEmails: boolean | undefined
+  allowPush: boolean | undefined
+}
+
+export const NotificationsSettings = () => {
+  const { isLoggedIn } = useAuthContext()
+
+  const [state, setState] = useState<State>({
+    allowEmails: undefined,
+    allowPush: undefined,
+  })
+
+  const toggleEmails = useCallback(() => {
+    if (!isLoggedIn) return
+    setState((prevState) => ({
+      ...prevState,
+      allowEmails: !prevState.allowEmails,
+    }))
+  }, [isLoggedIn])
+
+  const togglePush = useCallback(() => {
+    if (!isLoggedIn) return
+    setState((prevState) => {
+      return {
+        ...prevState,
+        allowPush: !prevState.allowPush,
+      }
+    })
+  }, [isLoggedIn])
+
+  return (
+    <PageProfileSection title="Suivi et notifications">
+      <Typo.Title4 {...getHeadingAttrs(2)}>Type d’alerte</Typo.Title4>
+      <Spacer.Column numberOfSpaces={4} />
+      <Typo.Body>
+        Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
+      </Typo.Body>
+      <Spacer.Column numberOfSpaces={2} />
+      <Form.Flex>
+        <SectionWithSwitch
+          title="Autoriser l’envoi d’e-mails"
+          active={state.allowEmails}
+          toggle={toggleEmails}
+          disabled={!isLoggedIn}
+        />
+        {!(Platform.OS === 'web') && (
+          <SectionWithSwitch
+            title="Autoriser les notifications"
+            active={state.allowPush}
+            toggle={togglePush}
+            disabled={!isLoggedIn}
+          />
+        )}
+        <Spacer.Column numberOfSpaces={4} />
+        <Separator.Horizontal />
+        <Spacer.Column numberOfSpaces={8} />
+        <ButtonPrimary wording="Enregistrer" accessibilityLabel="Enregistrer les modifications" />
+      </Form.Flex>
+    </PageProfileSection>
+  )
+}

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -5,9 +5,11 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { PageProfileSection } from 'features/profile/components/PageProfileSection/PageProfileSection'
 import { SectionWithSwitch } from 'features/profile/components/SectionWithSwitch/SectionWithSwitch'
 import { SubscriptionTheme, TOTAL_NUMBER_OF_THEME } from 'features/subscription/types'
+import { InfoBanner } from 'ui/components/banners/InfoBanner'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { Form } from 'ui/components/Form'
 import { Separator } from 'ui/components/Separator'
+import { Info } from 'ui/svg/icons/Info'
 import { Spacer, Typo } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
@@ -32,6 +34,15 @@ export const NotificationsSettings = () => {
 
   return (
     <PageProfileSection title="Suivi et notifications" scrollable>
+      {isLoggedIn ? null : (
+        <React.Fragment>
+          <InfoBanner
+            message="Tu dois être connecté pour activer les notifications et rester informé des bons plans sur le pass Culture."
+            icon={Info}
+          />
+          <Spacer.Column numberOfSpaces={6} />
+        </React.Fragment>
+      )}
       <Typo.Title4 {...getHeadingAttrs(2)}>Type d’alerte</Typo.Title4>
       <Spacer.Column numberOfSpaces={4} />
       <Typo.Body>

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -19,8 +19,8 @@ import { Spacer, Typo } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type State = {
-  allowEmails: boolean | undefined
-  allowPush: boolean | undefined
+  allowEmails?: boolean
+  allowPush?: boolean
   themePreferences: SubscriptionTheme[]
 }
 
@@ -110,14 +110,13 @@ export const NotificationsSettings = () => {
           />
           <Spacer.Column numberOfSpaces={2} />
           {Object.values(SubscriptionTheme).map((theme) => (
-            <React.Fragment key={theme}>
-              <SectionWithSwitch
-                title={theme}
-                active={isThemeToggled(theme)}
-                disabled={!isLoggedIn}
-                toggle={() => dispatch(theme)}
-              />
-            </React.Fragment>
+            <SectionWithSwitch
+              key={theme}
+              title={theme}
+              active={isThemeToggled(theme)}
+              disabled={!isLoggedIn}
+              toggle={() => dispatch(theme)}
+            />
           ))}
           <Spacer.Column numberOfSpaces={2} />
           <ButtonPrimary wording="Enregistrer" accessibilityLabel="Enregistrer les modifications" />

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -89,7 +89,7 @@ export const NotificationsSettings = () => {
             toggle={() => dispatch('email')}
             disabled={!isLoggedIn}
           />
-          {!(Platform.OS === 'web') && (
+          {Platform.OS !== 'web' && (
             <SectionWithSwitch
               title="Autoriser les notifications"
               active={state.allowPush}

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useReducer } from 'react'
 import { Linking, Platform } from 'react-native'
 import { PermissionStatus } from 'react-native-permissions'
+import styled from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { PushNotificationsModal } from 'features/notifications/pages/PushNotificationsModal'
@@ -65,69 +66,77 @@ export const NotificationsSettings = () => {
 
   return (
     <PageProfileSection title="Suivi et notifications" scrollable>
-      {isLoggedIn ? null : (
-        <React.Fragment>
-          <InfoBanner
-            message="Tu dois être connecté pour activer les notifications et rester informé des bons plans sur le pass Culture."
-            icon={Info}
-          />
-          <Spacer.Column numberOfSpaces={6} />
-        </React.Fragment>
-      )}
-      <Typo.Title4 {...getHeadingAttrs(2)}>Type d’alerte</Typo.Title4>
-      <Spacer.Column numberOfSpaces={4} />
-      <Typo.Body>
-        Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
-      </Typo.Body>
-      <Spacer.Column numberOfSpaces={2} />
-      <Form.Flex>
-        <SectionWithSwitch
-          title="Autoriser l’envoi d’e-mails"
-          active={state.allowEmails}
-          toggle={() => dispatch('email')}
-          disabled={!isLoggedIn}
-        />
-        {!(Platform.OS === 'web') && (
+      <Container>
+        {isLoggedIn ? null : (
+          <React.Fragment>
+            <InfoBanner
+              message="Tu dois être connecté pour activer les notifications et rester informé des bons plans sur le pass Culture."
+              icon={Info}
+            />
+            <Spacer.Column numberOfSpaces={6} />
+          </React.Fragment>
+        )}
+        <Typo.Title4 {...getHeadingAttrs(2)}>Type d’alerte</Typo.Title4>
+        <Spacer.Column numberOfSpaces={4} />
+        <Typo.Body>
+          Reste informé des actualités du pass Culture et ne rate aucun de nos bons plans.
+        </Typo.Body>
+        <Spacer.Column numberOfSpaces={2} />
+        <Form.Flex>
           <SectionWithSwitch
-            title="Autoriser les notifications"
-            active={state.allowPush}
-            toggle={togglePush}
+            title="Autoriser l’envoi d’e-mails"
+            active={state.allowEmails}
+            toggle={() => dispatch('email')}
             disabled={!isLoggedIn}
           />
-        )}
-        <Spacer.Column numberOfSpaces={4} />
-        <Separator.Horizontal />
-        <Spacer.Column numberOfSpaces={8} />
-        <Typo.Title4 {...getHeadingAttrs(2)}>Tes thème suivis</Typo.Title4>
-        <Spacer.Column numberOfSpaces={6} />
-        <SectionWithSwitch
-          title="Suivre tous les thèmes"
-          active={state.themePreferences.length === TOTAL_NUMBER_OF_THEME}
-          toggle={() => dispatch('allTheme')}
-          disabled={!isLoggedIn}
-        />
-        <Spacer.Column numberOfSpaces={2} />
-        {Object.values(SubscriptionTheme).map((theme) => (
-          <React.Fragment key={theme}>
+          {!(Platform.OS === 'web') && (
             <SectionWithSwitch
-              title={theme}
-              active={isThemeToggled(theme)}
+              title="Autoriser les notifications"
+              active={state.allowPush}
+              toggle={togglePush}
               disabled={!isLoggedIn}
-              toggle={() => dispatch(theme)}
             />
-          </React.Fragment>
-        ))}
-        <Spacer.Column numberOfSpaces={2} />
-        <ButtonPrimary wording="Enregistrer" accessibilityLabel="Enregistrer les modifications" />
-      </Form.Flex>
-      <PushNotificationsModal
-        visible={isPushModalVisible}
-        onRequestPermission={onRequestNotificationPermissionFromModal}
-        onDismiss={hidePushModal}
-      />
+          )}
+          <Spacer.Column numberOfSpaces={4} />
+          <Separator.Horizontal />
+          <Spacer.Column numberOfSpaces={8} />
+          <Typo.Title4 {...getHeadingAttrs(2)}>Tes thème suivis</Typo.Title4>
+          <Spacer.Column numberOfSpaces={6} />
+          <SectionWithSwitch
+            title="Suivre tous les thèmes"
+            active={state.themePreferences.length === TOTAL_NUMBER_OF_THEME}
+            toggle={() => dispatch('allTheme')}
+            disabled={!isLoggedIn}
+          />
+          <Spacer.Column numberOfSpaces={2} />
+          {Object.values(SubscriptionTheme).map((theme) => (
+            <React.Fragment key={theme}>
+              <SectionWithSwitch
+                title={theme}
+                active={isThemeToggled(theme)}
+                disabled={!isLoggedIn}
+                toggle={() => dispatch(theme)}
+              />
+            </React.Fragment>
+          ))}
+          <Spacer.Column numberOfSpaces={2} />
+          <ButtonPrimary wording="Enregistrer" accessibilityLabel="Enregistrer les modifications" />
+        </Form.Flex>
+        <PushNotificationsModal
+          visible={isPushModalVisible}
+          onRequestPermission={onRequestNotificationPermissionFromModal}
+          onDismiss={hidePushModal}
+        />
+      </Container>
     </PageProfileSection>
   )
 }
+
+const Container = styled.View(({ theme }) => ({
+  maxWidth: theme.contentPage.maxWidth,
+  width: '100%',
+  alignSelf: 'center',
+}))
 
 type ToggleActions = SubscriptionTheme | 'email' | 'push' | 'allTheme'
 

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback, useState } from 'react'
+import React, { useReducer } from 'react'
 import { Platform } from 'react-native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { PageProfileSection } from 'features/profile/components/PageProfileSection/PageProfileSection'
 import { SectionWithSwitch } from 'features/profile/components/SectionWithSwitch/SectionWithSwitch'
+import { SubscriptionTheme, TOTAL_NUMBER_OF_THEME } from 'features/subscription/types'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { Form } from 'ui/components/Form'
 import { Separator } from 'ui/components/Separator'
@@ -13,36 +14,24 @@ import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 type State = {
   allowEmails: boolean | undefined
   allowPush: boolean | undefined
+  themePreferences: SubscriptionTheme[]
 }
 
 export const NotificationsSettings = () => {
   const { isLoggedIn } = useAuthContext()
 
-  const [state, setState] = useState<State>({
+  const [state, dispatch] = useReducer(settingsReducer, {
     allowEmails: undefined,
     allowPush: undefined,
+    themePreferences: [],
   })
 
-  const toggleEmails = useCallback(() => {
-    if (!isLoggedIn) return
-    setState((prevState) => ({
-      ...prevState,
-      allowEmails: !prevState.allowEmails,
-    }))
-  }, [isLoggedIn])
-
-  const togglePush = useCallback(() => {
-    if (!isLoggedIn) return
-    setState((prevState) => {
-      return {
-        ...prevState,
-        allowPush: !prevState.allowPush,
-      }
-    })
-  }, [isLoggedIn])
+  const isThemeToggled = (theme: SubscriptionTheme) => {
+    return state.themePreferences.includes(theme)
+  }
 
   return (
-    <PageProfileSection title="Suivi et notifications">
+    <PageProfileSection title="Suivi et notifications" scrollable>
       <Typo.Title4 {...getHeadingAttrs(2)}>Type d’alerte</Typo.Title4>
       <Spacer.Column numberOfSpaces={4} />
       <Typo.Body>
@@ -53,22 +42,74 @@ export const NotificationsSettings = () => {
         <SectionWithSwitch
           title="Autoriser l’envoi d’e-mails"
           active={state.allowEmails}
-          toggle={toggleEmails}
+          toggle={() => dispatch('email')}
           disabled={!isLoggedIn}
         />
         {!(Platform.OS === 'web') && (
           <SectionWithSwitch
             title="Autoriser les notifications"
             active={state.allowPush}
-            toggle={togglePush}
+            toggle={() => dispatch('push')}
             disabled={!isLoggedIn}
           />
         )}
         <Spacer.Column numberOfSpaces={4} />
         <Separator.Horizontal />
         <Spacer.Column numberOfSpaces={8} />
+        <Typo.Title4 {...getHeadingAttrs(2)}>Tes thème suivis</Typo.Title4>
+        <Spacer.Column numberOfSpaces={6} />
+        <SectionWithSwitch
+          title="Suivre tous les thèmes"
+          active={state.themePreferences.length === TOTAL_NUMBER_OF_THEME}
+          toggle={() => dispatch('allTheme')}
+          disabled={!isLoggedIn}
+        />
+        <Spacer.Column numberOfSpaces={2} />
+        {Object.values(SubscriptionTheme).map((theme) => (
+          <React.Fragment key={theme}>
+            <SectionWithSwitch
+              title={theme}
+              active={isThemeToggled(theme)}
+              disabled={!isLoggedIn}
+              toggle={() => dispatch(theme)}
+            />
+          </React.Fragment>
+        ))}
+        <Spacer.Column numberOfSpaces={2} />
         <ButtonPrimary wording="Enregistrer" accessibilityLabel="Enregistrer les modifications" />
       </Form.Flex>
     </PageProfileSection>
   )
+}
+
+type ToggleActions = SubscriptionTheme | 'email' | 'push' | 'allTheme'
+
+const settingsReducer = (state: State, toggle: ToggleActions) => {
+  switch (toggle) {
+    case 'email':
+      return {
+        ...state,
+        allowEmails: !state.allowEmails,
+      }
+    case 'push':
+      return {
+        ...state,
+        allowPush: !state.allowPush,
+      }
+    case 'allTheme':
+      return {
+        ...state,
+        themePreferences:
+          state.themePreferences.length === TOTAL_NUMBER_OF_THEME
+            ? []
+            : Object.values(SubscriptionTheme),
+      }
+    default:
+      return {
+        ...state,
+        themePreferences: state.themePreferences.includes(toggle)
+          ? state.themePreferences.filter((t) => t !== toggle)
+          : [...state.themePreferences, toggle],
+      }
+  }
 }

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx
@@ -3,6 +3,15 @@ import React from 'react'
 import { NotificationsSettings } from 'features/profile/pages/NotificationSettings/NotificationsSettings'
 import { checkAccessibilityFor, render, waitFor } from 'tests/utils/web'
 
+// Fix the error "IDs used in ARIA and labels must be unique (duplicate-id-aria)" because the UUIDV4 mock return "testUuidV4"
+jest.mock('uuid', () => {
+  let value = 0
+  return {
+    v1: jest.fn(),
+    v4: jest.fn(() => value++),
+  }
+})
+
 describe('NotificationSettings', () => {
   it('should render correctly', () => {
     const { container } = render(<NotificationsSettings />)

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { NotificationsSettings } from 'features/profile/pages/NotificationSettings/NotificationsSettings'
+import * as usePushPermission from 'features/profile/pages/NotificationSettings/usePushPermission'
 import { checkAccessibilityFor, render, waitFor } from 'tests/utils/web'
 
 // Fix the error "IDs used in ARIA and labels must be unique (duplicate-id-aria)" because the UUIDV4 mock return "testUuidV4"
@@ -10,6 +11,11 @@ jest.mock('uuid', () => {
     v1: jest.fn(),
     v4: jest.fn(() => value++),
   }
+})
+
+jest.spyOn(usePushPermission, 'usePushPermission').mockReturnValue({
+  pushPermission: 'granted',
+  refreshPermission: jest.fn(),
 })
 
 describe('NotificationSettings', () => {

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+import { NotificationsSettings } from 'features/profile/pages/NotificationSettings/NotificationsSettings'
+import { checkAccessibilityFor, render, waitFor } from 'tests/utils/web'
+
+describe('NotificationSettings', () => {
+  it('should render correctly', () => {
+    const { container } = render(<NotificationsSettings />)
+
+    expect(container).toMatchSnapshot()
+  })
+
+  describe('Accessibility', () => {
+    it('should not have basic accessibility issues', async () => {
+      const { container } = render(<NotificationsSettings />)
+
+      const results = await checkAccessibilityFor(container)
+
+      await waitFor(async () => {
+        expect(results).toHaveNoViolations()
+      })
+    })
+  })
+})

--- a/src/features/profile/pages/NotificationSettings/usePushPermission.ts
+++ b/src/features/profile/pages/NotificationSettings/usePushPermission.ts
@@ -1,5 +1,4 @@
-import { useFocusEffect } from '@react-navigation/native'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { checkNotifications, PermissionStatus } from 'react-native-permissions'
 
 import { useAppStateChange } from 'libs/appState'
@@ -15,9 +14,9 @@ export const usePushPermission = (
     return permission.status
   }, [])
 
-  useFocusEffect(() => {
+  useEffect(() => {
     refreshPermission()
-  })
+  }, [refreshPermission])
 
   useAppStateChange(
     async () => {

--- a/src/features/profile/pages/NotificationSettings/usePushPermission.ts
+++ b/src/features/profile/pages/NotificationSettings/usePushPermission.ts
@@ -1,0 +1,34 @@
+import { useFocusEffect } from '@react-navigation/native'
+import { useCallback, useState } from 'react'
+import { checkNotifications, PermissionStatus } from 'react-native-permissions'
+
+import { useAppStateChange } from 'libs/appState'
+
+export const usePushPermission = (
+  updatePushPermissionFromSettings: (permission: PermissionStatus) => void
+) => {
+  const [pushPermission, setPushPermission] = useState<PermissionStatus | undefined>(undefined)
+
+  const refreshPermission = useCallback(async () => {
+    const permission = await checkNotifications()
+    setPushPermission(permission.status)
+    return permission.status
+  }, [])
+
+  useFocusEffect(() => {
+    refreshPermission()
+  })
+
+  useAppStateChange(
+    async () => {
+      const permission = await refreshPermission()
+      updatePushPermissionFromSettings(permission)
+    },
+    () => undefined
+  )
+
+  return {
+    pushPermission,
+    refreshPermission,
+  }
+}

--- a/src/features/subscription/types.ts
+++ b/src/features/subscription/types.ts
@@ -1,0 +1,10 @@
+export enum SubscriptionTheme {
+  CINEMA = 'Cinéma',
+  LECTURE = 'Lecture',
+  MUSIQUE = 'Musique',
+  SPECTACLES = 'Spectacles',
+  VISITES = 'Visites et sorties',
+  COURS = 'Cours et Ateliers',
+}
+
+export const TOTAL_NUMBER_OF_THEME = 6

--- a/src/features/subscription/types.ts
+++ b/src/features/subscription/types.ts
@@ -7,4 +7,4 @@ export enum SubscriptionTheme {
   COURS = 'Cours et Ateliers',
 }
 
-export const TOTAL_NUMBER_OF_THEME = 6
+export const TOTAL_NUMBER_OF_THEME = Object.values(SubscriptionTheme).length


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28336

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |![image](https://github.com/pass-culture/pass-culture-app-native/assets/68000368/539e82ff-3399-4202-b048-d20f73f82b9e)|![image](https://github.com/pass-culture/pass-culture-app-native/assets/68000368/969382d4-705d-46ae-ae00-b218dd939975)|
| Android          |![image](https://github.com/pass-culture/pass-culture-app-native/assets/68000368/eeb9c09e-d401-4593-9895-3f7b7ce33e2a) ![image](https://github.com/pass-culture/pass-culture-app-native/assets/68000368/c5926ff1-de4e-4c76-a691-23c455d7f67a)|<img width="404" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/39f8dcfb-6380-4801-8405-944fae8a270a"> <img width="405" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/de5a320c-c065-4c9a-8864-18ac168d1218">|
| Phone - Chrome   |               |       |
| Desktop - Chrome |<img width="659" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/b0232322-b45e-4262-99bc-a8e7ea0fa44e">|<img width="1025" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/3722c6b6-7ce6-4680-8bd0-9889691c8cf0">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
