### PR TITLE
(PC-28324) fix(CulturalSurveyIntro): Added reset on navigation from QPI

### DIFF
--- a/__mocks__/@react-navigation/native.ts
+++ b/__mocks__/@react-navigation/native.ts
@@ -1,4 +1,6 @@
-export const { getStateFromPath, getPathFromState } = jest.requireActual('@react-navigation/native')
+export const { getStateFromPath, getPathFromState, CommonActions } = jest.requireActual(
+  '@react-navigation/native'
+)
 import { useEffect } from 'react'
 
 export const addListener = jest.fn()
@@ -51,6 +53,3 @@ export const useFocusEffect = useEffect
 export const NavigationContainer = jest.fn()
 export const useNavigationState = jest.fn()
 export const useScrollToTop = jest.fn()
-
-const commonActionsReset = jest.fn()
-export const CommonActions = { reset: commonActionsReset }

--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -352,7 +352,7 @@
 ./src/features/identityCheck/pages/profile/SetCity.native.test.tsx:99
 ./src/features/identityCheck/pages/profile/SetStatus.native.test.tsx:69
 ./src/features/identityCheck/pages/profile/SetStatus.native.test.tsx:73
-./src/features/identityCheck/pages/profile/SetStatus.native.test.tsx:95
+./src/features/identityCheck/pages/profile/SetStatus.native.test.tsx:94
 ./src/features/internal/cheatcodes/hooks/useSomeOfferId.ts:24
 ./src/features/internal/cheatcodes/hooks/useSomeVenueId.ts:23
 ./src/features/internal/cheatcodes/pages/AppComponents/AppComponents.tsx:768

--- a/src/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { dispatch, navigate } from '__mocks__/@react-navigation/native'
+import { navigate, reset } from '__mocks__/@react-navigation/native'
 import { CulturalSurveyQuestionEnum } from 'api/gen'
 import { CulturalSurveyIntro } from 'features/culturalSurvey/pages/CulturalSurveyIntro'
 import { analytics } from 'libs/analytics'
@@ -47,9 +47,9 @@ describe('CulturalSurveyIntro page', () => {
     fireEvent.press(LaterButton)
 
     await waitFor(() => {
-      expect(dispatch).toHaveBeenCalledWith({
-        payload: { index: 0, routes: [{ name: 'TabNavigator' }] },
-        type: 'RESET',
+      expect(reset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: 'TabNavigator' }],
       })
     })
   })

--- a/src/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx
@@ -1,10 +1,8 @@
 import React from 'react'
 
-import { navigate } from '__mocks__/@react-navigation/native'
+import { dispatch, navigate } from '__mocks__/@react-navigation/native'
 import { CulturalSurveyQuestionEnum } from 'api/gen'
 import { CulturalSurveyIntro } from 'features/culturalSurvey/pages/CulturalSurveyIntro'
-import { navigateToHomeConfig } from 'features/navigation/helpers'
-import { navigateFromRef } from 'features/navigation/navigationRef'
 import { analytics } from 'libs/analytics'
 import { render, fireEvent, screen, waitFor } from 'tests/utils'
 
@@ -42,17 +40,17 @@ describe('CulturalSurveyIntro page', () => {
     expect(analytics.logHasStartedCulturalSurvey).toHaveBeenCalledTimes(1)
   })
 
-  it('should navigate to home when pressing Plus tard', async () => {
+  it('should reset navigation and navigate to home when pressing Plus tard', async () => {
     render(<CulturalSurveyIntro />)
 
     const LaterButton = screen.getByText('Plus tard')
     fireEvent.press(LaterButton)
 
     await waitFor(() => {
-      expect(navigateFromRef).toHaveBeenCalledWith(
-        navigateToHomeConfig.screen,
-        navigateToHomeConfig.params
-      )
+      expect(dispatch).toHaveBeenCalledWith({
+        payload: { index: 0, routes: [{ name: 'TabNavigator' }] },
+        type: 'RESET',
+      })
     })
   })
 

--- a/src/features/culturalSurvey/pages/CulturalSurveyIntro.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyIntro.tsx
@@ -1,4 +1,4 @@
-import { CommonActions, useNavigation } from '@react-navigation/native'
+import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 import { Platform, View } from 'react-native'
 import styled from 'styled-components/native'
@@ -6,6 +6,7 @@ import styled from 'styled-components/native'
 import { FAQ_LINK_USER_DATA } from 'features/culturalSurvey/constants'
 import { useCulturalSurveyContext } from 'features/culturalSurvey/context/CulturalSurveyContextProvider'
 import { navigateToHomeConfig } from 'features/navigation/helpers'
+import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { analytics } from 'libs/analytics'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
@@ -26,7 +27,7 @@ const FAQTouchableLinkProps = {
 
 export const CulturalSurveyIntro = (): React.JSX.Element => {
   const { questionsToDisplay: initialQuestions } = useCulturalSurveyContext()
-  const { dispatch } = useNavigation()
+  const { reset } = useNavigation<UseNavigationType>()
 
   return (
     <GenericInfoPageWhite
@@ -70,22 +71,18 @@ export const CulturalSurveyIntro = (): React.JSX.Element => {
           }}
         />
         <Spacer.Column numberOfSpaces={3} />
-        <InternalTouchableLink
+        <ButtonTertiaryBlack
           key={3}
-          as={ButtonTertiaryBlack}
           wording="Plus tard"
           icon={ClockFilled}
-          onBeforeNavigate={() => {
-            // The double navigation (reset + navigate) is unperceivable to the user and avoids complexifying the handleNavigation of InternalTouchableLink
-            dispatch(
-              CommonActions.reset({
-                index: 0,
-                routes: [{ name: navigateToHomeConfig.screen }],
-              })
-            )
+          onPress={() => {
+            reset({
+              index: 0,
+              routes: [{ name: navigateToHomeConfig.screen }],
+            })
+
             analytics.logHasSkippedCulturalSurvey()
           }}
-          navigateTo={navigateToHomeConfig}
         />
       </View>
     </GenericInfoPageWhite>

--- a/src/features/culturalSurvey/pages/CulturalSurveyIntro.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyIntro.tsx
@@ -1,3 +1,4 @@
+import { CommonActions, useNavigation } from '@react-navigation/native'
 import React from 'react'
 import { Platform, View } from 'react-native'
 import styled from 'styled-components/native'
@@ -25,6 +26,7 @@ const FAQTouchableLinkProps = {
 
 export const CulturalSurveyIntro = (): React.JSX.Element => {
   const { questionsToDisplay: initialQuestions } = useCulturalSurveyContext()
+  const { dispatch } = useNavigation()
 
   return (
     <GenericInfoPageWhite
@@ -73,7 +75,16 @@ export const CulturalSurveyIntro = (): React.JSX.Element => {
           as={ButtonTertiaryBlack}
           wording="Plus tard"
           icon={ClockFilled}
-          onBeforeNavigate={analytics.logHasSkippedCulturalSurvey}
+          onBeforeNavigate={() => {
+            // The double navigation (reset + navigate) is unperceivable to the user and avoids complexifying the handleNavigation of InternalTouchableLink
+            dispatch(
+              CommonActions.reset({
+                index: 0,
+                routes: [{ name: navigateToHomeConfig.screen }],
+              })
+            )
+            analytics.logHasSkippedCulturalSurvey()
+          }}
           navigateTo={navigateToHomeConfig}
         />
       </View>

--- a/src/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
+import { reset } from '__mocks__/@react-navigation/native'
 import { CulturalSurveyThanks } from 'features/culturalSurvey/pages/CulturalSurveyThanks'
-import { navigateToHome } from 'features/navigation/helpers'
 import { render, fireEvent, screen } from 'tests/utils'
 
 jest.mock('features/navigation/helpers')
@@ -18,6 +18,9 @@ describe('CulturalSurveyThanksPage page', () => {
     const DiscoverButton = screen.getByTestId('Découvrir le catalogue')
     fireEvent.press(DiscoverButton)
 
-    expect(navigateToHome).toHaveBeenCalledTimes(1)
+    expect(reset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [{ name: 'TabNavigator' }],
+    })
   })
 })

--- a/src/features/culturalSurvey/pages/CulturalSurveyThanks.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyThanks.tsx
@@ -1,13 +1,17 @@
+import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { navigateToHome } from 'features/navigation/helpers'
+import { navigateToHomeConfig } from 'features/navigation/helpers'
+import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import QpiThanks from 'ui/animations/qpi_thanks.json'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 
 export const CulturalSurveyThanks: React.FC = () => {
+  const { reset } = useNavigation<UseNavigationType>()
+
   return (
     <GenericInfoPageWhite
       mobileBottomFlex={0.1}
@@ -17,7 +21,15 @@ export const CulturalSurveyThanks: React.FC = () => {
       <StyledBody>Tu peux dès maintenant découvrir l’étendue du catalogue pass Culture.</StyledBody>
       <Spacer.Flex flex={2} />
       <ButtonContainer>
-        <ButtonPrimary wording="Découvrir le catalogue" onPress={navigateToHome} />
+        <ButtonPrimary
+          wording="Découvrir le catalogue"
+          onPress={() => {
+            reset({
+              index: 0,
+              routes: [{ name: navigateToHomeConfig.screen }],
+            })
+          }}
+        />
       </ButtonContainer>
     </GenericInfoPageWhite>
   )

--- a/src/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { CommonActions, dispatch, useRoute } from '__mocks__/@react-navigation/native'
+import { dispatch, useRoute } from '__mocks__/@react-navigation/native'
 import { analytics } from 'libs/analytics'
 import { fireEvent, render, waitFor, screen } from 'tests/utils'
 
@@ -33,10 +33,9 @@ describe('<EduConnectValidation />', () => {
     fireEvent.press(validateButton)
 
     await waitFor(() => {
-      expect(dispatch).toHaveBeenCalledTimes(1)
-      expect(CommonActions.reset).toHaveBeenCalledWith({
-        index: 1,
-        routes: [{ name: 'TabNavigator' }, { name: 'Stepper' }],
+      expect(dispatch).toHaveBeenCalledWith({
+        payload: { index: 1, routes: [{ name: 'TabNavigator' }, { name: 'Stepper' }] },
+        type: 'RESET',
       })
     })
   })

--- a/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { CommonActions, dispatch, navigate } from '__mocks__/@react-navigation/native'
+import { dispatch, navigate } from '__mocks__/@react-navigation/native'
 import { NextSubscriptionStepResponse, SubscriptionStep } from 'api/gen'
 import { nextSubscriptionStepFixture as mockStep } from 'features/identityCheck/fixtures/nextSubscriptionStepFixture'
 import { IdentityCheckEnd } from 'features/identityCheck/pages/identification/ubble/IdentityCheckEnd'
@@ -52,10 +52,9 @@ describe('<IdentityCheckEnd/>', () => {
     jest.advanceTimersByTime(3000)
 
     await waitFor(() => {
-      expect(dispatch).toHaveBeenCalledTimes(1)
-      expect(CommonActions.reset).toHaveBeenCalledWith({
-        index: 1,
-        routes: [{ name: 'TabNavigator' }, { name: 'Stepper' }],
+      expect(dispatch).toHaveBeenCalledWith({
+        payload: { index: 1, routes: [{ name: 'TabNavigator' }, { name: 'Stepper' }] },
+        type: 'RESET',
       })
     })
   })

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { navigate, dispatch, CommonActions } from '__mocks__/@react-navigation/native'
+import { navigate, dispatch } from '__mocks__/@react-navigation/native'
 import { ApiError } from 'api/ApiError'
 import {
   hasCodeCorrectFormat,
@@ -149,10 +149,9 @@ describe('SetPhoneValidationCode', () => {
     fireEvent.press(continueButton)
 
     await waitFor(() => {
-      expect(dispatch).toHaveBeenCalledTimes(1)
-      expect(CommonActions.reset).toHaveBeenCalledWith({
-        index: 1,
-        routes: [{ name: 'TabNavigator' }, { name: 'Stepper' }],
+      expect(dispatch).toHaveBeenCalledWith({
+        payload: { index: 1, routes: [{ name: 'TabNavigator' }, { name: 'Stepper' }] },
+        type: 'RESET',
       })
     })
   })

--- a/src/features/identityCheck/pages/profile/SetStatus.native.test.tsx
+++ b/src/features/identityCheck/pages/profile/SetStatus.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { CommonActions, dispatch } from '__mocks__/@react-navigation/native'
+import { dispatch } from '__mocks__/@react-navigation/native'
 import { ActivityIdEnum } from 'api/gen'
 import { initialSubscriptionState as mockState } from 'features/identityCheck/context/reducer'
 import { ActivityTypesSnap } from 'features/identityCheck/pages/profile/fixtures/mockedActivityTypes'
@@ -75,10 +75,9 @@ describe('<SetStatus/>', () => {
     fireEvent.press(screen.getByText('Continuer'))
 
     await waitFor(() => {
-      expect(dispatch).toHaveBeenCalledTimes(1)
-      expect(CommonActions.reset).toHaveBeenCalledWith({
-        index: 1,
-        routes: [{ name: 'TabNavigator' }, { name: 'Stepper' }],
+      expect(dispatch).toHaveBeenCalledWith({
+        payload: { index: 1, routes: [{ name: 'TabNavigator' }, { name: 'Stepper' }] },
+        type: 'RESET',
       })
     })
   })

--- a/src/ui/components/touchableLink/InternalTouchableLink.tsx
+++ b/src/ui/components/touchableLink/InternalTouchableLink.tsx
@@ -23,7 +23,7 @@ export const InternalTouchableLink: FunctionComponent<InternalTouchableLinkProps
         fromRef ? navigateFromRef(screen, params) : navigate(screen, params)
       }
     }
-  }, [enableNavigate, navigateTo, push, navigate])
+  }, [enableNavigate, navigateTo, navigate, push])
   return (
     <TouchableLink handleNavigation={handleNavigation} linkProps={internalLinkProps} {...rest} />
   )


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28324

## Checklist

I have:

- [ ] Tested on a real iOS device
- [x] Tested on a iOS simulator
- [x] Written **unit tests** native (and web when implementation is different) for my feature.

**_PROCEDURE TO SEE THE QPI:_**
Go to the backoffice testing - generate a test user.
Choose, 18, Ubble, and Identity verified.
Connect with the generated credentials.
Activate the credit within app.
The QPI should appear.

Web app after change to `ButtonTertiaryBlack`:
![image](https://github.com/pass-culture/pass-culture-app-native/assets/75068235/887224d1-25f8-41f4-be87-f4574b3474ac)
Navigation with TAB:
![image](https://github.com/pass-culture/pass-culture-app-native/assets/75068235/7417368a-f9ca-4e0c-8048-db954da0cc8a)

