### PR TITLE
(PC-28461) feat(PersonalData): Hide email edit button  when user has no password

### DIFF
--- a/src/features/profile/pages/PersonalData/PersonalData.native.test.tsx
+++ b/src/features/profile/pages/PersonalData/PersonalData.native.test.tsx
@@ -136,6 +136,15 @@ describe('PersonalData', () => {
 
     expect(screen.queryByText('Mot de passe')).not.toBeOnTheScreen()
   })
+
+  it('should not show email change button when user has no password', () => {
+    renderPersonalData({
+      ...mockedUser,
+      hasPassword: false,
+    })
+
+    expect(screen.queryByLabelText('Modifier e-mail')).not.toBeOnTheScreen()
+  })
 })
 
 function renderPersonalData(response: UserProfileResponse) {

--- a/src/features/profile/pages/PersonalData/PersonalData.tsx
+++ b/src/features/profile/pages/PersonalData/PersonalData.tsx
@@ -48,12 +48,14 @@ export function PersonalData() {
       <Spacer.Column numberOfSpaces={2} />
       <EditContainer>
         <EditText>{user?.email}</EditText>
-        <EditButton
-          navigateTo={{ screen: updateEmailRoute }}
-          onPress={onEmailChangeClick}
-          wording="Modifier"
-          accessibilityLabel="Modifier e-mail"
-        />
+        {user?.hasPassword ? (
+          <EditButton
+            navigateTo={{ screen: updateEmailRoute }}
+            onPress={onEmailChangeClick}
+            wording="Modifier"
+            accessibilityLabel="Modifier e-mail"
+          />
+        ) : null}
       </EditContainer>
 
       <StyledSeparator />


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28461

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots
| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |    ![Simulator Screenshot - iPhone 5 - 2024-03-12 at 08 20 44](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/314ed1dd-2a72-4c67-8fe7-30a4eb1874d3)   |
| Desktop - Chrome |               |   <img width="1440" alt="Capture d’écran 2024-03-12 à 08 22 35" src="https://github.com/pass-culture/pass-culture-app-native/assets/46637324/01b8f019-47e3-434c-b39f-282ddb2119d7">    |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
