### PR TITLE
(PC-28337) feat(NotificationsSettings): add disabled cases in notif settings

### DIFF
--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -694,6 +694,80 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
             Tes thème suivis
           </Text>
           <View
+            numberOfSpaces={4}
+            style={
+              [
+                {
+                  "height": 16,
+                },
+              ]
+            }
+          />
+          <View
+            backgroundColor="#f3ecff"
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "backgroundColor": "#f3ecff",
+                  "borderRadius": 8,
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                  "paddingBottom": 16,
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
+                  "paddingTop": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "paddingRight": 16,
+                  },
+                ]
+              }
+            >
+              <View
+                height={24}
+                width={24}
+              >
+                <Text>
+                  undefined-SVG-Mock
+                </Text>
+              </View>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-SemiBold",
+                      "fontSize": 12,
+                      "lineHeight": 16,
+                    },
+                  ]
+                }
+                textColor="#161617"
+              >
+                Pour suivre un thème, tu dois accepter l’envoi d’e-mails ou de notifications.
+              </Text>
+            </View>
+          </View>
+          <View
             numberOfSpaces={6}
             style={
               [

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -456,6 +456,20 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
               </View>
             </View>
           </View>
+          <Text
+            style={
+              [
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-SemiBold",
+                  "fontSize": 12,
+                  "lineHeight": 16,
+                },
+              ]
+            }
+          >
+            Tu continueras à recevoir par e-mail des informations essentielles concernant ton compte.
+          </Text>
           <View
             style={
               [

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -794,7 +794,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                     {
                       "busy": undefined,
                       "checked": false,
-                      "disabled": false,
+                      "disabled": true,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -841,7 +841,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                   >
                     <View
                       collapsable={false}
-                      disabled={false}
+                      disabled={true}
                       style={
                         {
                           "alignItems": "center",
@@ -851,17 +851,20 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                           "height": 28,
                           "justifyContent": "center",
                           "marginLeft": 2,
-                          "shadowColor": "#161617",
-                          "shadowOffset": {
-                            "height": 2,
-                            "width": 0,
-                          },
-                          "shadowOpacity": 0.2,
-                          "shadowRadius": 2.5,
                           "width": 28,
                         }
                       }
-                    />
+                    >
+                      <View
+                        accessibilityLabel="Désactivé"
+                        height={16}
+                        width={16}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
+                    </View>
                   </View>
                 </View>
               </View>
@@ -982,7 +985,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                     {
                       "busy": undefined,
                       "checked": false,
-                      "disabled": false,
+                      "disabled": true,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -1029,7 +1032,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                   >
                     <View
                       collapsable={false}
-                      disabled={false}
+                      disabled={true}
                       style={
                         {
                           "alignItems": "center",
@@ -1039,17 +1042,20 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                           "height": 28,
                           "justifyContent": "center",
                           "marginLeft": 2,
-                          "shadowColor": "#161617",
-                          "shadowOffset": {
-                            "height": 2,
-                            "width": 0,
-                          },
-                          "shadowOpacity": 0.2,
-                          "shadowRadius": 2.5,
                           "width": 28,
                         }
                       }
-                    />
+                    >
+                      <View
+                        accessibilityLabel="Désactivé"
+                        height={16}
+                        width={16}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
+                    </View>
                   </View>
                 </View>
               </View>
@@ -1160,7 +1166,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                     {
                       "busy": undefined,
                       "checked": false,
-                      "disabled": false,
+                      "disabled": true,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -1207,7 +1213,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                   >
                     <View
                       collapsable={false}
-                      disabled={false}
+                      disabled={true}
                       style={
                         {
                           "alignItems": "center",
@@ -1217,17 +1223,20 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                           "height": 28,
                           "justifyContent": "center",
                           "marginLeft": 2,
-                          "shadowColor": "#161617",
-                          "shadowOffset": {
-                            "height": 2,
-                            "width": 0,
-                          },
-                          "shadowOpacity": 0.2,
-                          "shadowRadius": 2.5,
                           "width": 28,
                         }
                       }
-                    />
+                    >
+                      <View
+                        accessibilityLabel="Désactivé"
+                        height={16}
+                        width={16}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
+                    </View>
                   </View>
                 </View>
               </View>
@@ -1338,7 +1347,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                     {
                       "busy": undefined,
                       "checked": false,
-                      "disabled": false,
+                      "disabled": true,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -1385,7 +1394,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                   >
                     <View
                       collapsable={false}
-                      disabled={false}
+                      disabled={true}
                       style={
                         {
                           "alignItems": "center",
@@ -1395,17 +1404,20 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                           "height": 28,
                           "justifyContent": "center",
                           "marginLeft": 2,
-                          "shadowColor": "#161617",
-                          "shadowOffset": {
-                            "height": 2,
-                            "width": 0,
-                          },
-                          "shadowOpacity": 0.2,
-                          "shadowRadius": 2.5,
                           "width": 28,
                         }
                       }
-                    />
+                    >
+                      <View
+                        accessibilityLabel="Désactivé"
+                        height={16}
+                        width={16}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
+                    </View>
                   </View>
                 </View>
               </View>
@@ -1516,7 +1528,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                     {
                       "busy": undefined,
                       "checked": false,
-                      "disabled": false,
+                      "disabled": true,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -1563,7 +1575,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                   >
                     <View
                       collapsable={false}
-                      disabled={false}
+                      disabled={true}
                       style={
                         {
                           "alignItems": "center",
@@ -1573,17 +1585,20 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                           "height": 28,
                           "justifyContent": "center",
                           "marginLeft": 2,
-                          "shadowColor": "#161617",
-                          "shadowOffset": {
-                            "height": 2,
-                            "width": 0,
-                          },
-                          "shadowOpacity": 0.2,
-                          "shadowRadius": 2.5,
                           "width": 28,
                         }
                       }
-                    />
+                    >
+                      <View
+                        accessibilityLabel="Désactivé"
+                        height={16}
+                        width={16}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
+                    </View>
                   </View>
                 </View>
               </View>
@@ -1694,7 +1709,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                     {
                       "busy": undefined,
                       "checked": false,
-                      "disabled": false,
+                      "disabled": true,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -1741,7 +1756,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                   >
                     <View
                       collapsable={false}
-                      disabled={false}
+                      disabled={true}
                       style={
                         {
                           "alignItems": "center",
@@ -1751,17 +1766,20 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                           "height": 28,
                           "justifyContent": "center",
                           "marginLeft": 2,
-                          "shadowColor": "#161617",
-                          "shadowOffset": {
-                            "height": 2,
-                            "width": 0,
-                          },
-                          "shadowOpacity": 0.2,
-                          "shadowRadius": 2.5,
                           "width": 28,
                         }
                       }
-                    />
+                    >
+                      <View
+                        accessibilityLabel="Désactivé"
+                        height={16}
+                        width={16}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
+                    </View>
                   </View>
                 </View>
               </View>
@@ -1872,7 +1890,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                     {
                       "busy": undefined,
                       "checked": false,
-                      "disabled": false,
+                      "disabled": true,
                       "expanded": undefined,
                       "selected": undefined,
                     }
@@ -1919,7 +1937,7 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                   >
                     <View
                       collapsable={false}
-                      disabled={false}
+                      disabled={true}
                       style={
                         {
                           "alignItems": "center",
@@ -1929,17 +1947,20 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                           "height": 28,
                           "justifyContent": "center",
                           "marginLeft": 2,
-                          "shadowColor": "#161617",
-                          "shadowOffset": {
-                            "height": 2,
-                            "width": 0,
-                          },
-                          "shadowOpacity": 0.2,
-                          "shadowRadius": 2.5,
                           "width": 28,
                         }
                       }
-                    />
+                    >
+                      <View
+                        accessibilityLabel="Désactivé"
+                        height={16}
+                        width={16}
+                      >
+                        <Text>
+                          undefined-SVG-Mock
+                        </Text>
+                      </View>
+                    </View>
                   </View>
                 </View>
               </View>

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
@@ -122,7 +122,7 @@ describe('NotificationSettings', () => {
     render(<NotificationsSettings />)
 
     expect(
-      screen.queryByText(
+      screen.getByText(
         'Tu continueras à recevoir par e-mail des informations essentielles concernant ton compte.'
       )
     ).toBeOnTheScreen()

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
@@ -47,6 +47,9 @@ describe('NotificationSettings', () => {
     mockUseAuthContext.mockReturnValueOnce(baseAuthContext)
     render(<NotificationsSettings />)
 
+    const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
+    fireEvent.press(toggleEmail)
+
     const toggleSwitch = screen.getByTestId('Interrupteur Suivre tous les thèmes')
     fireEvent.press(toggleSwitch)
 
@@ -67,6 +70,9 @@ describe('NotificationSettings', () => {
   it('should switch off all thematic toggles when the "Suivre tous les thèmes" toggle is pressed when active', async () => {
     mockUseAuthContext.mockReturnValueOnce(baseAuthContext)
     render(<NotificationsSettings />)
+
+    const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
+    fireEvent.press(toggleEmail)
 
     const toggleSwitch = screen.getByTestId('Interrupteur Suivre tous les thèmes')
     fireEvent.press(toggleSwitch)
@@ -89,6 +95,9 @@ describe('NotificationSettings', () => {
   it('should toggle on specific theme when its toggle is pressed', async () => {
     mockUseAuthContext.mockReturnValueOnce(baseAuthContext)
     render(<NotificationsSettings />)
+
+    const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
+    fireEvent.press(toggleEmail)
 
     const toggleSwitch = screen.getByTestId('Interrupteur Cinéma')
     fireEvent.press(toggleSwitch)

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
@@ -128,6 +128,46 @@ describe('NotificationSettings', () => {
     ).toBeOnTheScreen()
   })
 
+  it('should display info banner when email and push toggles are inactive', () => {
+    mockUseAuthContext.mockReturnValueOnce(baseAuthContext)
+    render(<NotificationsSettings />)
+
+    expect(
+      screen.queryByText(
+        'Pour suivre un thème, tu dois accepter l’envoi d’e-mails ou de notifications.'
+      )
+    ).toBeOnTheScreen()
+  })
+
+  it('should not display info banner when at least email or push toggles is active', () => {
+    mockUseAuthContext.mockReturnValueOnce(baseAuthContext)
+    render(<NotificationsSettings />)
+
+    const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
+    fireEvent.press(toggleEmail)
+
+    expect(
+      screen.queryByText(
+        'Pour suivre un thème, tu dois accepter l’envoi d’e-mails ou de notifications.'
+      )
+    ).not.toBeOnTheScreen()
+  })
+
+  it('should not display info banner when user is not logged in', () => {
+    mockUseAuthContext.mockReturnValueOnce({
+      ...baseAuthContext,
+      isLoggedIn: false,
+      user: undefined,
+    })
+    render(<NotificationsSettings />)
+
+    expect(
+      screen.queryByText(
+        'Pour suivre un thème, tu dois accepter l’envoi d’e-mails ou de notifications.'
+      )
+    ).not.toBeOnTheScreen()
+  })
+
   describe('The behavior of the push switch', () => {
     it('should open the push notification modal when the push toggle is pressed and the permission is not granted', () => {
       mockUseAuthContext.mockReturnValueOnce(baseAuthContext)

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
@@ -105,6 +105,29 @@ describe('NotificationSettings', () => {
     expect(screen.getByTestId('Interrupteur Cinéma')).toHaveAccessibilityState({ checked: true })
   })
 
+  it('should disabled all thematic toggles when email toggle and push toggle are inactive', () => {
+    mockUseAuthContext.mockReturnValueOnce(baseAuthContext)
+    render(<NotificationsSettings />)
+
+    expect(screen.getByTestId('Interrupteur Cinéma')).toBeDisabled()
+    expect(screen.getByTestId('Interrupteur Lecture')).toBeDisabled()
+    expect(screen.getByTestId('Interrupteur Musique')).toBeDisabled()
+    expect(screen.getByTestId('Interrupteur Spectacles')).toBeDisabled()
+    expect(screen.getByTestId('Interrupteur Visites et sorties')).toBeDisabled()
+    expect(screen.getByTestId('Interrupteur Cours et Ateliers')).toBeDisabled()
+  })
+
+  it('should display help message when the email toggle is inactive and user is logged in', () => {
+    mockUseAuthContext.mockReturnValueOnce(baseAuthContext)
+    render(<NotificationsSettings />)
+
+    expect(
+      screen.queryByText(
+        'Tu continueras à recevoir par e-mail des informations essentielles concernant ton compte.'
+      )
+    ).toBeOnTheScreen()
+  })
+
   describe('The behavior of the push switch', () => {
     it('should open the push notification modal when the push toggle is pressed and the permission is not granted', () => {
       mockUseAuthContext.mockReturnValueOnce(baseAuthContext)

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -93,6 +93,12 @@ export const NotificationsSettings = () => {
             toggle={() => dispatch('email')}
             disabled={!isLoggedIn}
           />
+          {!state.allowEmails && isLoggedIn ? (
+            <Typo.Caption>
+              Tu continueras à recevoir par e-mail des informations essentielles concernant ton
+              compte.
+            </Typo.Caption>
+          ) : null}
           {Platform.OS !== 'web' && (
             <SectionWithSwitch
               title="Autoriser les notifications"
@@ -110,7 +116,7 @@ export const NotificationsSettings = () => {
             title="Suivre tous les thèmes"
             active={state.themePreferences.length === TOTAL_NUMBER_OF_THEME}
             toggle={() => dispatch('allTheme')}
-            disabled={!isLoggedIn}
+            disabled={areThemeToggledDisabled}
           />
           <Spacer.Column numberOfSpaces={2} />
           {Object.values(SubscriptionTheme).map((theme) => (
@@ -118,7 +124,7 @@ export const NotificationsSettings = () => {
               key={theme}
               title={theme}
               active={isThemeToggled(theme)}
-              disabled={!isLoggedIn}
+              disabled={areThemeToggledDisabled}
               toggle={() => dispatch(theme)}
             />
           ))}

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -64,6 +64,10 @@ export const NotificationsSettings = () => {
     }
   }
 
+  const areNotificationsEnabled = state.allowEmails || state.allowPush
+
+  const areThemeToggledDisabled = !areNotificationsEnabled || !isLoggedIn
+
   return (
     <PageProfileSection title="Suivi et notifications" scrollable>
       <Container>

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -66,7 +66,7 @@ export const NotificationsSettings = () => {
 
   const areNotificationsEnabled = state.allowEmails || state.allowPush
 
-  const areThemeToggledDisabled = !areNotificationsEnabled || !isLoggedIn
+  const areThemeTogglesDisabled = !areNotificationsEnabled || !isLoggedIn
 
   return (
     <PageProfileSection title="Suivi et notifications" scrollable>
@@ -125,7 +125,7 @@ export const NotificationsSettings = () => {
             title="Suivre tous les thèmes"
             active={state.themePreferences.length === TOTAL_NUMBER_OF_THEME}
             toggle={() => dispatch('allTheme')}
-            disabled={areThemeToggledDisabled}
+            disabled={areThemeTogglesDisabled}
           />
           <Spacer.Column numberOfSpaces={2} />
           {Object.values(SubscriptionTheme).map((theme) => (
@@ -133,7 +133,7 @@ export const NotificationsSettings = () => {
               key={theme}
               title={theme}
               active={isThemeToggled(theme)}
-              disabled={areThemeToggledDisabled}
+              disabled={areThemeTogglesDisabled}
               toggle={() => dispatch(theme)}
             />
           ))}

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -111,6 +111,15 @@ export const NotificationsSettings = () => {
           <Separator.Horizontal />
           <Spacer.Column numberOfSpaces={8} />
           <Typo.Title4 {...getHeadingAttrs(2)}>Tes thème suivis</Typo.Title4>
+          {!isLoggedIn || areNotificationsEnabled ? null : (
+            <React.Fragment>
+              <Spacer.Column numberOfSpaces={4} />
+              <InfoBanner
+                message="Pour suivre un thème, tu dois accepter l’envoi d’e-mails ou de notifications."
+                icon={Info}
+              />
+            </React.Fragment>
+          )}
           <Spacer.Column numberOfSpaces={6} />
           <SectionWithSwitch
             title="Suivre tous les thèmes"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28337

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="347" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/4121f367-cd8d-49f7-a9ac-21bcd8241e45">|<img width="314" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/1b8b9a6a-cdd3-4e27-9c5e-d0a266ce913c">|
| Android          |<img width="347" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/8963d4e0-b63e-43ab-88cc-4c3e6c33751d">|<img width="403" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/56430339-bc9b-44b7-96e9-8a9c912175ce">|
| Phone - Chrome   |<img width="347" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/1b77f64f-3047-412e-9d54-b0823391299b">|<img width="367" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/98b46343-e41e-4725-8851-408199fce6b6">|
| Desktop - Chrome |<img width="466" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/d7141b00-ac29-4693-bcd7-4fd149dc3608">|<img width="1022" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/68000368/f1211565-60ef-47ce-b61a-44e7dfa9610e">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
