### PR TITLE
(PC-25665) refactor(offer): prepare use of booking button for web displaying

### DIFF
--- a/src/features/offer/components/BookingButton/BookingButton.stories.tsx
+++ b/src/features/offer/components/BookingButton/BookingButton.stories.tsx
@@ -1,0 +1,64 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import React from 'react'
+
+import { BookingButton } from 'features/offer/components/BookingButton/BookingButton'
+
+const meta: ComponentMeta<typeof BookingButton> = {
+  title: 'features/offer/BookingButton',
+  component: BookingButton,
+}
+export default meta
+
+const Template: ComponentStory<typeof BookingButton> = (props) => <BookingButton {...props} />
+
+export const Default = Template.bind({})
+Default.args = {
+  ctaWordingAndAction: {
+    wording: 'Réserver l’offre',
+    isDisabled: false,
+  },
+  isFreeDigitalOffer: false,
+  isLoggedIn: false,
+}
+
+export const IsFreeDigitalOfferAndIsLoggedIn = Template.bind({})
+IsFreeDigitalOfferAndIsLoggedIn.args = {
+  ctaWordingAndAction: {
+    wording: 'C’est gratuit',
+    isDisabled: false,
+  },
+  isFreeDigitalOffer: true,
+  isLoggedIn: true,
+}
+
+export const Disable = Template.bind({})
+Disable.args = {
+  ctaWordingAndAction: {
+    wording: 'Réserver l’offre',
+    isDisabled: true,
+  },
+  isFreeDigitalOffer: false,
+  isLoggedIn: false,
+}
+
+export const DisableAndWithBottomBanner = Template.bind({})
+DisableAndWithBottomBanner.args = {
+  ctaWordingAndAction: {
+    wording: 'Réserver l’offre',
+    isDisabled: true,
+    bottomBannerText: 'Disable et avec la bannière de warning',
+  },
+  isFreeDigitalOffer: false,
+  isLoggedIn: false,
+}
+
+export const WithBottomBanner = Template.bind({})
+WithBottomBanner.args = {
+  ctaWordingAndAction: {
+    wording: 'Réserver l’offre',
+    isDisabled: false,
+    bottomBannerText: 'Avec la bannière de warning',
+  },
+  isFreeDigitalOffer: false,
+  isLoggedIn: false,
+}

--- a/src/features/offer/components/BookingButton/BookingButton.tsx
+++ b/src/features/offer/components/BookingButton/BookingButton.tsx
@@ -1,8 +1,10 @@
 import React, { FunctionComponent } from 'react'
+import styled from 'styled-components/native'
 
 import { BottomBanner } from 'features/offer/components/BottomBanner/BottomBanner'
 import { CTAButton } from 'features/offer/components/CTAButton/CTAButton'
 import { ICTAWordingAndAction } from 'features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction'
+import { getSpacing } from 'ui/theme'
 
 type Props = {
   ctaWordingAndAction: ICTAWordingAndAction
@@ -24,17 +26,23 @@ export const BookingButton: FunctionComponent<Props> = ({
 
   return (
     <React.Fragment>
-      <CTAButton
-        wording={wording}
-        onPress={onPress}
-        navigateTo={navigateTo}
-        externalNav={externalNav}
-        isDisabled={isDisabled}
-        isFreeDigitalOffer={isFreeDigitalOffer}
-        isLoggedIn={isLoggedIn}
-      />
+      <CallToActionContainer>
+        <CTAButton
+          wording={wording}
+          onPress={onPress}
+          navigateTo={navigateTo}
+          externalNav={externalNav}
+          isDisabled={isDisabled}
+          isFreeDigitalOffer={isFreeDigitalOffer}
+          isLoggedIn={isLoggedIn}
+        />
+      </CallToActionContainer>
 
       {bottomBannerText ? <BottomBanner text={bottomBannerText} /> : null}
     </React.Fragment>
   )
 }
+
+const CallToActionContainer = styled.View({
+  marginBottom: getSpacing(8),
+})

--- a/src/features/offer/components/BookingButton/BookingButton.tsx
+++ b/src/features/offer/components/BookingButton/BookingButton.tsx
@@ -1,0 +1,40 @@
+import React, { FunctionComponent } from 'react'
+
+import { BottomBanner } from 'features/offer/components/BottomBanner/BottomBanner'
+import { CTAButton } from 'features/offer/components/CTAButton/CTAButton'
+import { ICTAWordingAndAction } from 'features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction'
+
+type Props = {
+  ctaWordingAndAction: ICTAWordingAndAction
+  isFreeDigitalOffer?: boolean
+  isLoggedIn?: boolean
+}
+
+export const BookingButton: FunctionComponent<Props> = ({
+  ctaWordingAndAction,
+  isFreeDigitalOffer,
+  isLoggedIn,
+}) => {
+  const { wording, onPress, navigateTo, externalNav, isDisabled, bottomBannerText } =
+    ctaWordingAndAction
+
+  if (!wording) {
+    return null
+  }
+
+  return (
+    <React.Fragment>
+      <CTAButton
+        wording={wording}
+        onPress={onPress}
+        navigateTo={navigateTo}
+        externalNav={externalNav}
+        isDisabled={isDisabled}
+        isFreeDigitalOffer={isFreeDigitalOffer}
+        isLoggedIn={isLoggedIn}
+      />
+
+      {bottomBannerText ? <BottomBanner text={bottomBannerText} /> : null}
+    </React.Fragment>
+  )
+}

--- a/src/features/offer/components/CTAButton/CTAButton.tsx
+++ b/src/features/offer/components/CTAButton/CTAButton.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { FunctionComponent, useMemo } from 'react'
 
 import { ButtonWithLinearGradient } from 'ui/components/buttons/buttonWithLinearGradient/ButtonWithLinearGradient'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
@@ -6,7 +6,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { ExternalNavigationProps, InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { ExternalSiteFilled as ExternalSiteFilledIcon } from 'ui/svg/icons/ExternalSiteFilled'
 
-type CTAButtonProps = {
+type Props = {
   wording: string
   onPress?: () => void
   isDisabled?: boolean
@@ -16,7 +16,7 @@ type CTAButtonProps = {
   isLoggedIn?: boolean
 }
 
-export function CTAButton({
+export const CTAButton: FunctionComponent<Props> = ({
   wording,
   onPress,
   isDisabled,
@@ -24,7 +24,7 @@ export function CTAButton({
   navigateTo,
   isFreeDigitalOffer,
   isLoggedIn,
-}: CTAButtonProps) {
+}) => {
   const commonLinkProps = {
     as: ButtonWithLinearGradient,
     wording: wording,
@@ -50,6 +50,7 @@ export function CTAButton({
       />
     )
   }
+
   return (
     <ButtonWithLinearGradient
       wording={wording}

--- a/src/features/offer/components/OfferBookingButton/OfferBookingButton.tsx
+++ b/src/features/offer/components/OfferBookingButton/OfferBookingButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
 import { BottomBanner } from 'features/offer/components/BottomBanner/BottomBanner'
@@ -8,17 +8,17 @@ import { BlurryWrapper } from 'ui/components/BlurryWrapper/BlurryWrapper'
 import { StickyBottomWrapper } from 'ui/components/StickyBottomWrapper/StickyBottomWrapper'
 import { Spacer, getSpacing } from 'ui/theme'
 
-type OfferBookingButtonProps = {
+type Props = {
   ctaWordingAndAction: ICTAWordingAndAction
   isFreeDigitalOffer?: boolean
   isLoggedIn?: boolean
 }
 
-export function OfferBookingButton({
+export const OfferBookingButton: FunctionComponent<Props> = ({
   ctaWordingAndAction,
   isFreeDigitalOffer,
   isLoggedIn,
-}: OfferBookingButtonProps) {
+}) => {
   const { wording, onPress, navigateTo, externalNav, isDisabled, bottomBannerText } =
     ctaWordingAndAction
 

--- a/src/features/offer/components/OfferCTAButton/OfferCTAButton.tsx
+++ b/src/features/offer/components/OfferCTAButton/OfferCTAButton.tsx
@@ -4,7 +4,7 @@ import React, { FunctionComponent, useCallback } from 'react'
 import { OfferResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { StepperOrigin, UseRouteType } from 'features/navigation/RootNavigator/types'
-import { OfferBookingButton } from 'features/offer/components/OfferBookingButton/OfferBookingButton'
+import { StickyBookingButton } from 'features/offer/components/StickyBookingButton/StickyBookingButton'
 import { getIsFreeDigitalOffer } from 'features/offer/helpers/getIsFreeDigitalOffer/getIsFreeDigitalOffer'
 import { useCtaWordingAndAction } from 'features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction'
 import { Subcategory } from 'libs/subcategories/types'
@@ -61,7 +61,7 @@ export const OfferCTAButton: FunctionComponent<Props> = ({
 
   return (
     <React.Fragment>
-      <OfferBookingButton
+      <StickyBookingButton
         ctaWordingAndAction={{
           wording,
           onPress,

--- a/src/features/offer/components/StickyBookingButton/StickyBookingButton.native.test.tsx
+++ b/src/features/offer/components/StickyBookingButton/StickyBookingButton.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { OfferBookingButton } from 'features/offer/components/OfferBookingButton/OfferBookingButton'
+import { StickyBookingButton } from 'features/offer/components/StickyBookingButton/StickyBookingButton'
 import { render, screen } from 'tests/utils'
 
 describe('<OfferBookingButton />', () => {
@@ -14,19 +14,19 @@ describe('<OfferBookingButton />', () => {
   }
 
   it('should display the correct wording "Réserver l’offre"', () => {
-    render(<OfferBookingButton ctaWordingAndAction={mockCtaWordingAndAction} />)
+    render(<StickyBookingButton ctaWordingAndAction={mockCtaWordingAndAction} />)
 
     expect(screen.getByText('Réserver l’offre')).toBeOnTheScreen()
   })
 
   it('should display the blurry style', () => {
-    render(<OfferBookingButton ctaWordingAndAction={mockCtaWordingAndAction} />)
+    render(<StickyBookingButton ctaWordingAndAction={mockCtaWordingAndAction} />)
 
     expect(screen.getByTestId('blurry-wrapper')).toHaveStyle({ backgroundColor: 'transparent' })
   })
 
   it('should display the bottom banner text', () => {
-    render(<OfferBookingButton ctaWordingAndAction={mockCtaWordingAndAction} />)
+    render(<StickyBookingButton ctaWordingAndAction={mockCtaWordingAndAction} />)
 
     const bottomBanner = screen.getByText('Attention !')
 
@@ -35,21 +35,21 @@ describe('<OfferBookingButton />', () => {
 
   it('should display the button disabled', () => {
     const disabledCtaWordingAndAction = { ...mockCtaWordingAndAction, isDisabled: true }
-    render(<OfferBookingButton ctaWordingAndAction={disabledCtaWordingAndAction} />)
+    render(<StickyBookingButton ctaWordingAndAction={disabledCtaWordingAndAction} />)
 
     expect(screen.getByText('Réserver l’offre')).toHaveStyle({ color: '#696A6F' })
   })
 
   it("shouldn't return the button when it hasn't wording", () => {
     const withoutWording = { ...mockCtaWordingAndAction, wording: undefined }
-    render(<OfferBookingButton ctaWordingAndAction={withoutWording} />)
+    render(<StickyBookingButton ctaWordingAndAction={withoutWording} />)
 
     expect(screen.queryByText('Réserver l’offre')).toBeNull()
   })
 
   it("shouldn't return the bottom banner when it is undefined", () => {
     const withoutBottomBanner = { ...mockCtaWordingAndAction, bottomBannerText: undefined }
-    render(<OfferBookingButton ctaWordingAndAction={withoutBottomBanner} />)
+    render(<StickyBookingButton ctaWordingAndAction={withoutBottomBanner} />)
 
     expect(screen.queryByText('Attention !')).toBeNull()
   })

--- a/src/features/offer/components/StickyBookingButton/StickyBookingButton.stories.tsx
+++ b/src/features/offer/components/StickyBookingButton/StickyBookingButton.stories.tsx
@@ -2,11 +2,11 @@ import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
 import { View, StyleSheet } from 'react-native'
 
-import { OfferBookingButton } from 'features/offer/components/OfferBookingButton/OfferBookingButton'
+import { StickyBookingButton } from 'features/offer/components/StickyBookingButton/StickyBookingButton'
 
-const meta: ComponentMeta<typeof OfferBookingButton> = {
-  title: 'features/offer/OfferBookingButton',
-  component: OfferBookingButton,
+const meta: ComponentMeta<typeof StickyBookingButton> = {
+  title: 'features/offer/StickyBookingButton',
+  component: StickyBookingButton,
 }
 export default meta
 
@@ -21,9 +21,9 @@ const styles = StyleSheet.create({
   },
 })
 
-const Template: ComponentStory<typeof OfferBookingButton> = (props) => (
+const Template: ComponentStory<typeof StickyBookingButton> = (props) => (
   <View style={styles.container}>
-    <OfferBookingButton {...props} />
+    <StickyBookingButton {...props} />
   </View>
 )
 

--- a/src/features/offer/components/StickyBookingButton/StickyBookingButton.tsx
+++ b/src/features/offer/components/StickyBookingButton/StickyBookingButton.tsx
@@ -14,7 +14,7 @@ type Props = {
   isLoggedIn?: boolean
 }
 
-export const OfferBookingButton: FunctionComponent<Props> = ({
+export const StickyBookingButton: FunctionComponent<Props> = ({
   ctaWordingAndAction,
   isFreeDigitalOffer,
   isLoggedIn,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-25665

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |![Capture d’écran 2024-03-18 à 09 45 39](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/dbfb3381-b725-4032-bb4b-de6f522181b4)|![Capture d’écran 2024-03-18 à 09 48 42](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/d38ef613-2a19-489a-87ec-d78e6829da39)|
| Android          |<img width="418" alt="Capture d’écran 2024-03-18 à 09 47 23" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/0113424f-24f1-4bb1-9aa0-4a7f7f5b6d12">|<img width="418" alt="Capture d’écran 2024-03-18 à 09 48 33" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/68d3e8df-d9df-4c9d-9fd5-5ec5687aaace">|
| Phone - Chrome   |![Capture d’écran 2024-03-18 à 09 44 29](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/3efc22df-13b9-4b5c-9955-30fee4471360)|![Capture d’écran 2024-03-18 à 09 48 53](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/e2a66ee9-25f9-40ba-9f36-89af47d99a7c)|
| Desktop - Chrome |![Capture d’écran 2024-03-18 à 09 44 21](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/d236b930-8609-45ea-a1b9-00ca963c0c2d)|![Capture d’écran 2024-03-18 à 09 49 04](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/9f0f8c95-5e74-4e0c-9a09-e20bf4e3514d)|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
