### PR TITLE
(PC-28157) fix(DeleteProfile): Reset navigation on profile deletion success

### DIFF
--- a/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { navigate } from '__mocks__/@react-navigation/native'
+import { reset } from '__mocks__/@react-navigation/native'
 import { mockGoBack } from 'features/navigation/__mocks__/useGoBack'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { analytics } from 'libs/analytics'
@@ -11,11 +11,6 @@ import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
 import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
 
 import { ConfirmDeleteProfile } from './ConfirmDeleteProfile'
-
-const mockSignOut = jest.fn()
-jest.mock('features/auth/helpers/useLogoutRoutine', () => ({
-  useLogoutRoutine: () => mockSignOut,
-}))
 
 jest.mock('features/auth/context/AuthContext', () => ({
   useAuthContext: jest.fn(() => ({ isLoggedIn: true })),
@@ -41,8 +36,7 @@ describe('ConfirmDeleteProfile component', () => {
 
     await act(async () => fireEvent.press(screen.getByText('Supprimer mon compte')))
 
-    expect(navigate).toHaveBeenNthCalledWith(1, 'DeleteProfileSuccess')
-    expect(mockSignOut).toHaveBeenCalledTimes(1)
+    expect(reset).toHaveBeenCalledWith({ index: 0, routes: [{ name: 'DeleteProfileSuccess' }] })
   })
 
   it('should show error snackbar if suspend account request fails when clicking on "Supprimer mon compte" button', async () => {

--- a/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.tsx
+++ b/src/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { useAccountSuspend } from 'features/auth/api/useAccountSuspend'
-import { useLogoutRoutine } from 'features/auth/helpers/useLogoutRoutine'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { analytics } from 'libs/analytics'
@@ -22,14 +21,14 @@ import { getSpacing, Spacer, Typo } from 'ui/theme'
 import { LINE_BREAK } from 'ui/theme/constants'
 
 export function ConfirmDeleteProfile() {
-  const { navigate } = useNavigation<UseNavigationType>()
-
-  const signOut = useLogoutRoutine()
+  const { reset } = useNavigation<UseNavigationType>()
   const { showErrorSnackBar } = useSnackBarContext()
 
-  async function onAccountSuspendSuccess() {
-    navigate('DeleteProfileSuccess')
-    await signOut()
+  function onAccountSuspendSuccess() {
+    reset({
+      index: 0,
+      routes: [{ name: 'DeleteProfileSuccess' }],
+    })
   }
 
   function onAccountSuspendFailure() {

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
+import * as LogoutRoutine from 'features/auth/helpers/useLogoutRoutine'
 import { navigateToHomeConfig } from 'features/navigation/helpers'
 import { navigateFromRef } from 'features/navigation/navigationRef'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
@@ -13,11 +14,20 @@ jest.mock('features/navigation/helpers')
 jest.mock('features/navigation/navigationRef')
 jest.mock('features/auth/context/SettingsContext')
 
+const signOutMock = jest.fn()
+jest.spyOn(LogoutRoutine, 'useLogoutRoutine').mockReturnValue(signOutMock)
+
 describe('DeleteProfileSuccess component', () => {
   it('should render delete profile success', () => {
     render(<DeleteProfileSuccess />)
 
     expect(screen).toMatchSnapshot()
+  })
+
+  it('should log out user', () => {
+    render(<DeleteProfileSuccess />)
+
+    expect(signOutMock).toHaveBeenCalledTimes(1)
   })
 
   it('should redirect to Home page when clicking on "Retourner à l’accueil" button', () => {

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import styled from 'styled-components/native'
 
 import { useSettingsContext } from 'features/auth/context/SettingsContext'
+import { useLogoutRoutine } from 'features/auth/helpers/useLogoutRoutine'
 import { navigateToHomeConfig } from 'features/navigation/helpers'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
 import { analytics } from 'libs/analytics'
@@ -15,8 +16,14 @@ import { ProfileDeletionIllustration } from 'ui/svg/icons/ProfileDeletionIllustr
 import { Spacer, Typo } from 'ui/theme'
 
 export function DeleteProfileSuccess() {
+  const signOut = useLogoutRoutine()
   const { data: settings } = useSettingsContext()
   const reactivationLimit = settings?.accountUnsuspensionLimit
+
+  useEffect(() => {
+    signOut()
+  }, [signOut])
+
   return (
     <GenericInfoPage
       title="Ton compte a été désactivé"

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.web.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.web.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, checkAccessibilityFor } from 'tests/utils/web'
 
 import { DeleteProfileSuccess } from './DeleteProfileSuccess'
@@ -7,7 +8,7 @@ import { DeleteProfileSuccess } from './DeleteProfileSuccess'
 describe('<DeleteProfileSuccess/>', () => {
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
-      const { container } = render(<DeleteProfileSuccess />)
+      const { container } = render(reactQueryProviderHOC(<DeleteProfileSuccess />))
       const results = await checkAccessibilityFor(container)
 
       expect(results).toHaveNoViolations()


### PR DESCRIPTION
…ofile deletion success

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28157

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots
| Platform      | After |
| :--------------- |  :---: |
| iOS              |         [fix-ios.mp4](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/af04659c-3b4d-47f3-a790-409099d845e9)            |
| Android          |          [android-fix.mp4](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/379378c9-c60b-4f05-bdd1-c513ebd129ce)         |
| Desktop - Chrome |            [fix-web.mov](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/083d83b2-3263-4c4c-ba23-018778098739)     |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
