### PR TITLE
(PC-28479) feat(offer): remove divider for desktop viewport

### DIFF
--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -803,21 +803,21 @@ describe('<OfferContent />', () => {
     })
   })
 
-  it('should display container with divider when viewport is not desktop', async () => {
+  it('should display container with divider on mobile', async () => {
     renderOfferContent({})
     await screen.findByText('Réserver l’offre')
 
     expect(screen.getByTestId('messagingApp-container-with-divider')).toBeOnTheScreen()
   })
 
-  it('should not display container with divider when viewport is desktop', async () => {
+  it('should not display container with divider on desktop', async () => {
     renderOfferContent({ isDesktopViewport: true })
     await screen.findByText('Réserver l’offre')
 
     expect(screen.queryByTestId('messagingApp-container-with-divider')).not.toBeOnTheScreen()
   })
 
-  it('should display container without divider when viewport is desktop', async () => {
+  it('should display container without divider on desktop', async () => {
     renderOfferContent({
       isDesktopViewport: true,
     })
@@ -826,7 +826,7 @@ describe('<OfferContent />', () => {
     expect(screen.getByTestId('messagingApp-container-without-divider')).toBeOnTheScreen()
   })
 
-  it('should not display container without divider when viewport is not desktop', async () => {
+  it('should not display container without divider on mobile', async () => {
     renderOfferContent({})
     await screen.findByText('Réserver l’offre')
 

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -802,13 +802,46 @@ describe('<OfferContent />', () => {
       expect(await screen.findByLabelText('Mardi 27 février')).toBeOnTheScreen()
     })
   })
+
+  it('should display container with divider when viewport is not desktop', async () => {
+    renderOfferContent({})
+    await screen.findByText('Réserver l’offre')
+
+    expect(screen.getByTestId('messagingApp-container-with-divider')).toBeOnTheScreen()
+  })
+
+  it('should not display container with divider when viewport is desktop', async () => {
+    renderOfferContent({ isDesktopViewport: true })
+    await screen.findByText('Réserver l’offre')
+
+    expect(screen.queryByTestId('messagingApp-container-with-divider')).not.toBeOnTheScreen()
+  })
+
+  it('should display container without divider when viewport is desktop', async () => {
+    renderOfferContent({
+      isDesktopViewport: true,
+    })
+    await screen.findByText('Réserver l’offre')
+
+    expect(screen.getByTestId('messagingApp-container-without-divider')).toBeOnTheScreen()
+  })
+
+  it('should not display container without divider when viewport is not desktop', async () => {
+    renderOfferContent({})
+    await screen.findByText('Réserver l’offre')
+
+    expect(screen.queryByTestId('messagingApp-container-without-divider')).not.toBeOnTheScreen()
+  })
 })
 
-type RenderOfferContentType = Partial<ComponentProps<typeof OfferContent>>
+type RenderOfferContentType = Partial<ComponentProps<typeof OfferContent>> & {
+  isDesktopViewport?: boolean
+}
 
 function renderOfferContent({
   offer = offerResponseSnap,
   subcategory = mockSubcategory,
+  isDesktopViewport,
 }: RenderOfferContentType) {
   render(
     reactQueryProviderHOC(
@@ -817,6 +850,9 @@ function renderOfferContent({
         searchGroupList={placeholderData.searchGroups}
         subcategory={subcategory}
       />
-    )
+    ),
+    {
+      theme: { isDesktopViewport: isDesktopViewport ?? false },
+    }
   )
 }

--- a/src/features/offer/components/OfferContent/OfferContent.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.tsx
@@ -226,8 +226,8 @@ const InfoContainer = styled.View({
   gap: getSpacing(6),
 })
 
-const ContainerWithoutDivider = styled.View({
-  marginHorizontal: getSpacing(6),
-})
+const ContainerWithoutDivider = styled.View(({ theme }) => ({
+  marginHorizontal: theme.contentPage.marginHorizontal,
+}))
 
 const GroupWithoutGap = View

--- a/src/features/offer/components/OfferContent/OfferContent.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.tsx
@@ -2,7 +2,7 @@ import { useNavigation } from '@react-navigation/native'
 import React, { FunctionComponent, useCallback, useEffect } from 'react'
 import { NativeScrollEvent, NativeSyntheticEvent, Platform, View } from 'react-native'
 import { IOScrollView as IntersectionObserverScrollView } from 'react-native-intersection-observer'
-import styled from 'styled-components/native'
+import styled, { useTheme } from 'styled-components/native'
 
 import { OfferResponse, SearchGroupResponseModelv2, SubcategoryIdEnum } from 'api/gen'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
@@ -53,6 +53,7 @@ export const OfferContent: FunctionComponent<Props> = ({ offer, searchGroupList,
   const { userLocation } = useLocation()
   const { navigate } = useNavigation<UseNavigationType>()
   const enableOfferPreview = useFeatureFlag(RemoteStoreFeatureFlags.WIP_OFFER_PREVIEW)
+  const { isDesktopViewport } = useTheme()
 
   const extraData = offer.extraData ?? undefined
   const tags = getOfferTags(subcategory.appLabel, extraData)
@@ -176,10 +177,17 @@ export const OfferContent: FunctionComponent<Props> = ({ offer, searchGroupList,
           </FeatureFlag>
         ) : null}
 
-        <SectionWithDivider visible margin>
-          <Spacer.Column numberOfSpaces={2} />
-          <OfferMessagingApps offer={offer} />
-        </SectionWithDivider>
+        {isDesktopViewport ? (
+          <ContainerWithoutDivider testID="messagingApp-container-without-divider">
+            <Spacer.Column numberOfSpaces={2} />
+            <OfferMessagingApps offer={offer} />
+          </ContainerWithoutDivider>
+        ) : (
+          <SectionWithDivider visible margin testID="messagingApp-container-with-divider">
+            <Spacer.Column numberOfSpaces={2} />
+            <OfferMessagingApps offer={offer} />
+          </SectionWithDivider>
+        )}
 
         <OfferPlaylistList
           offer={offer}
@@ -216,6 +224,10 @@ const ScrollViewContainer = styled(IntersectionObserverScrollView)({ overflow: '
 const InfoContainer = styled.View({
   marginHorizontal: getSpacing(6),
   gap: getSpacing(6),
+})
+
+const ContainerWithoutDivider = styled.View({
+  marginHorizontal: getSpacing(6),
 })
 
 const GroupWithoutGap = View

--- a/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
@@ -500,7 +500,7 @@ describe('<OfferPlace />', () => {
     )
   })
 
-  it('should display container with divider when viewport is not desktop', () => {
+  it('should display container with divider on mobile', () => {
     renderOfferPlace({
       ...offerPlaceProps,
       offer: {
@@ -513,7 +513,7 @@ describe('<OfferPlace />', () => {
     expect(screen.getByTestId('place-container-with-divider')).toBeOnTheScreen()
   })
 
-  it('should not display container with divider when viewport is desktop', () => {
+  it('should not display container with divider on desktop', () => {
     renderOfferPlace({
       ...offerPlaceProps,
       offer: {
@@ -527,7 +527,7 @@ describe('<OfferPlace />', () => {
     expect(screen.queryByTestId('place-container-with-divider')).not.toBeOnTheScreen()
   })
 
-  it('should display container without divider when viewport is desktop', () => {
+  it('should display container without divider on desktop', () => {
     renderOfferPlace({
       ...offerPlaceProps,
       offer: {
@@ -541,7 +541,7 @@ describe('<OfferPlace />', () => {
     expect(screen.getByTestId('place-container-without-divider')).toBeOnTheScreen()
   })
 
-  it('should not display container without divider when viewport is not desktop', () => {
+  it('should not display container without divider on mobile', () => {
     renderOfferPlace({
       ...offerPlaceProps,
       offer: {

--- a/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
@@ -499,9 +499,71 @@ describe('<OfferPlace />', () => {
       }
     )
   })
+
+  it('should display container with divider when viewport is not desktop', () => {
+    renderOfferPlace({
+      ...offerPlaceProps,
+      offer: {
+        ...mockOffer,
+        subcategoryId: SubcategoryIdEnum.LIVRE_AUDIO_PHYSIQUE,
+        extraData: { ean: '2765410054' },
+      },
+    })
+
+    expect(screen.getByTestId('place-container-with-divider')).toBeOnTheScreen()
+  })
+
+  it('should not display container with divider when viewport is desktop', () => {
+    renderOfferPlace({
+      ...offerPlaceProps,
+      offer: {
+        ...mockOffer,
+        subcategoryId: SubcategoryIdEnum.LIVRE_AUDIO_PHYSIQUE,
+        extraData: { ean: '2765410054' },
+      },
+      isDesktopViewport: true,
+    })
+
+    expect(screen.queryByTestId('place-container-with-divider')).not.toBeOnTheScreen()
+  })
+
+  it('should display container without divider when viewport is desktop', () => {
+    renderOfferPlace({
+      ...offerPlaceProps,
+      offer: {
+        ...mockOffer,
+        subcategoryId: SubcategoryIdEnum.LIVRE_AUDIO_PHYSIQUE,
+        extraData: { ean: '2765410054' },
+      },
+      isDesktopViewport: true,
+    })
+
+    expect(screen.getByTestId('place-container-without-divider')).toBeOnTheScreen()
+  })
+
+  it('should not display container without divider when viewport is not desktop', () => {
+    renderOfferPlace({
+      ...offerPlaceProps,
+      offer: {
+        ...mockOffer,
+        subcategoryId: SubcategoryIdEnum.LIVRE_AUDIO_PHYSIQUE,
+        extraData: { ean: '2765410054' },
+      },
+    })
+
+    expect(screen.queryByTestId('place-container-without-divider')).not.toBeOnTheScreen()
+  })
 })
 
-type RenderOfferPlaceType = Partial<ComponentProps<typeof OfferPlace>>
+type RenderOfferPlaceType = Partial<ComponentProps<typeof OfferPlace>> & {
+  isDesktopViewport?: boolean
+}
 
-const renderOfferPlace = ({ offer = mockOffer, isEvent = false }: RenderOfferPlaceType) =>
-  render(reactQueryProviderHOC(<OfferPlace offer={offer} isEvent={isEvent} />))
+const renderOfferPlace = ({
+  offer = mockOffer,
+  isEvent = false,
+  isDesktopViewport,
+}: RenderOfferPlaceType) =>
+  render(reactQueryProviderHOC(<OfferPlace offer={offer} isEvent={isEvent} />), {
+    theme: { isDesktopViewport: isDesktopViewport ?? false },
+  })

--- a/src/features/offer/components/OfferPlace/OfferPlace.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.tsx
@@ -22,7 +22,7 @@ import { getIsMultiVenueCompatibleOffer } from 'shared/multiVenueOffer/getIsMult
 import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
 import { useModal } from 'ui/components/modals/useModal'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
-import { getSpacing, Spacer } from 'ui/theme'
+import { Spacer } from 'ui/theme'
 
 export type OfferPlaceProps = {
   offer: OfferResponse
@@ -214,6 +214,6 @@ export function OfferPlace({ offer, isEvent }: Readonly<OfferPlaceProps>) {
   )
 }
 
-const ContainerWithoutDivider = styled.View({
-  marginHorizontal: getSpacing(6),
-})
+const ContainerWithoutDivider = styled.View(({ theme }) => ({
+  marginHorizontal: theme.contentPage.marginHorizontal,
+}))

--- a/src/features/offer/components/OfferPlace/OfferPlace.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.tsx
@@ -1,6 +1,7 @@
 import { useNavigation } from '@react-navigation/native'
 import React, { useCallback } from 'react'
 import { useQueryClient } from 'react-query'
+import styled, { useTheme } from 'styled-components/native'
 
 import { OfferResponse, VenueResponse } from 'api/gen'
 import { useSearchVenueOffers } from 'api/useSearchVenuesOffer/useSearchVenueOffers'
@@ -21,7 +22,7 @@ import { getIsMultiVenueCompatibleOffer } from 'shared/multiVenueOffer/getIsMult
 import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
 import { useModal } from 'ui/components/modals/useModal'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
-import { Spacer } from 'ui/theme'
+import { getSpacing, Spacer } from 'ui/theme'
 
 export type OfferPlaceProps = {
   offer: OfferResponse
@@ -52,6 +53,7 @@ export function OfferPlace({ offer, isEvent }: Readonly<OfferPlaceProps>) {
   const { navigate } = useNavigation<UseNavigationType>()
   const queryClient = useQueryClient()
   const { selectedLocationMode, place, userLocation } = useLocation()
+  const { isDesktopViewport } = useTheme()
 
   const hasNewOfferVenueBlock = useFeatureFlag(RemoteStoreFeatureFlags.WIP_CINEMA_OFFER_VENUE_BLOCK)
 
@@ -144,9 +146,9 @@ export function OfferPlace({ offer, isEvent }: Readonly<OfferPlaceProps>) {
   const venueName = offer.venue.publicName || offer.venue.name
   const headerMessage = getVenueSelectionHeaderMessage(selectedLocationMode, place, venueName)
 
-  return (
-    <React.Fragment>
-      <SectionWithDivider visible={!offer.isDigital} margin>
+  const renderOfferVenueBlock = () => {
+    return (
+      <React.Fragment>
         <Spacer.Column numberOfSpaces={8} />
         {hasNewOfferVenueBlock ? (
           <OfferVenueBlock
@@ -171,7 +173,21 @@ export function OfferPlace({ offer, isEvent }: Readonly<OfferPlaceProps>) {
             }
           />
         )}
-      </SectionWithDivider>
+      </React.Fragment>
+    )
+  }
+
+  return (
+    <React.Fragment>
+      {isDesktopViewport ? (
+        <ContainerWithoutDivider testID="place-container-without-divider">
+          {renderOfferVenueBlock()}
+        </ContainerWithoutDivider>
+      ) : (
+        <SectionWithDivider visible={!offer.isDigital} margin testID="place-container-with-divider">
+          {renderOfferVenueBlock()}
+        </SectionWithDivider>
+      )}
 
       {shouldDisplayChangeVenueButton ? (
         <VenueSelectionModal
@@ -197,3 +213,7 @@ export function OfferPlace({ offer, isEvent }: Readonly<OfferPlaceProps>) {
     </React.Fragment>
   )
 }
+
+const ContainerWithoutDivider = styled.View({
+  marginHorizontal: getSpacing(6),
+})


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28479

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |<img width="405" alt="Capture d’écran 2024-03-18 à 11 10 28" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/1ddbf8f0-398c-420a-bbde-d3be2829a10d">|
| Android          |               |<img width="424" alt="Capture d’écran 2024-03-18 à 11 10 18" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/a50b455d-c6df-4e8b-8cbf-d8071f6ba0ed">|
| Phone - Chrome   |               |<img width="424" alt="Capture d’écran 2024-03-18 à 11 09 12" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/17898636-37e0-401f-99ef-ad1a2a5530ba"> <img width="414" alt="Capture d’écran 2024-03-18 à 11 09 19" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/6a7e7caa-26fd-4db4-a358-3ec985da1e17">|
| Desktop - Chrome |![Capture d’écran 2024-03-18 à 12 10 35](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/38207902-fb75-4bbf-ad92-783e1f3c96c0)|<img width="865" alt="Capture d’écran 2024-03-18 à 11 09 01" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/380967b7-a560-4138-af52-eaa502072282">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
