### PR TITLE
(PC-28386) fix(IdentificationFork): changed icon for link to EduConnect

### DIFF
--- a/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
@@ -503,7 +503,7 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                     }
                   >
                     <View
-                      fill="#161617"
+                      accessibilityLabel="Nouvelle fenêtre"
                       height={16}
                       testID="button-icon"
                       width={16}

--- a/src/features/identityCheck/pages/identification/IdentificationFork.tsx
+++ b/src/features/identityCheck/pages/identification/IdentificationFork.tsx
@@ -11,7 +11,7 @@ import { theme } from 'theme'
 import { ButtonQuaternaryBlack } from 'ui/components/buttons/ButtonQuaternaryBlack'
 import { SeparatorWithText } from 'ui/components/SeparatorWithText'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
-import { InfoPlain } from 'ui/svg/icons/InfoPlain'
+import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Marianne } from 'ui/svg/icons/Marianne'
 import { Ubble } from 'ui/svg/icons/Ubble'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
@@ -46,7 +46,7 @@ const IdentificationForkEduconnectContent: FunctionComponent = () => {
           as={ButtonQuaternaryBlack}
           externalNav={{ url: env.FAQ_LINK_EDUCONNECT_URL }}
           onBeforeNavigate={analytics.logEduconnectExplanationClicked}
-          icon={InfoPlain}
+          icon={ExternalSiteFilled}
           wording="C’est quoi ÉduConnect&nbsp;?"
           inline
         />


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28386

## Checklist

I have:

- [x] Made sure my feature is working on ios virtual device.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change

## Screenshots

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              | <img width="305" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/75068235/7b2b0db9-15ef-4cdb-85e8-6aacdff6bbd3"> | <img width="303" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/75068235/e50a44f0-80d2-4d25-874a-e0ec7b70c096"> |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |