### PR TITLE
(PC-28339) feat(NotifSettings): added modal on go back unsaved changes

### DIFF
--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -2137,6 +2137,37 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
             </View>
           </View>
         </View>
+        <Modal
+          accessibilityLabelledBy="testUuidV4"
+          accessibilityModal={true}
+          accessibilityRole="none"
+          animationType="none"
+          deviceHeight={1334}
+          deviceWidth={750}
+          hardwareAccelerated={false}
+          hideModalContentWhileAnimating={false}
+          onBackdropPress={[Function]}
+          onModalHide={[Function]}
+          onModalWillHide={[Function]}
+          onModalWillShow={[Function]}
+          onRequestClose={[Function]}
+          panResponderThreshold={4}
+          scrollHorizontal={false}
+          scrollOffset={0}
+          scrollOffsetMax={0}
+          scrollTo={null}
+          statusBarTranslucent={true}
+          supportedOrientations={
+            [
+              "portrait",
+              "landscape",
+            ]
+          }
+          swipeThreshold={100}
+          testID="modal"
+          transparent={true}
+          visible={false}
+        />
       </View>
     </View>
   </RCTScrollView>,
@@ -4307,6 +4338,37 @@ exports[`NotificationSettings should render correctly when user is not logged in
             </View>
           </View>
         </View>
+        <Modal
+          accessibilityLabelledBy="testUuidV4"
+          accessibilityModal={true}
+          accessibilityRole="none"
+          animationType="none"
+          deviceHeight={1334}
+          deviceWidth={750}
+          hardwareAccelerated={false}
+          hideModalContentWhileAnimating={false}
+          onBackdropPress={[Function]}
+          onModalHide={[Function]}
+          onModalWillHide={[Function]}
+          onModalWillShow={[Function]}
+          onRequestClose={[Function]}
+          panResponderThreshold={4}
+          scrollHorizontal={false}
+          scrollOffset={0}
+          scrollOffsetMax={0}
+          scrollTo={null}
+          statusBarTranslucent={true}
+          supportedOrientations={
+            [
+              "portrait",
+              "landscape",
+            ]
+          }
+          swipeThreshold={100}
+          testID="modal"
+          transparent={true}
+          visible={false}
+        />
       </View>
     </View>
   </RCTScrollView>,

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -152,7 +152,7 @@ exports[`NotificationSettings should render correctly 1`] = `
         >
           <button
             aria-label="Revenir en arrière"
-            class="c0 c1 sc-jXbUNg c1"
+            class="c0 c1 sc-dhKdcB c1"
             data-testid="Revenir en arrière"
             tabindex="0"
             title="Revenir en arrière"

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx
@@ -396,4 +396,19 @@ describe('NotificationSettings', () => {
       expect(toggleSwitch).toHaveAccessibilityState({ checked: true })
     })
   })
+
+  describe('When user has unsaved changes and attempts to go back', () => {
+    it('should display a modal', async () => {
+      mockUseAuthContext.mockReturnValueOnce(baseAuthContext)
+      render(reactQueryProviderHOC(<NotificationsSettings />))
+
+      const toggleEmail = screen.getByTestId('Interrupteur Autoriser l’envoi d’e-mails')
+      fireEvent.press(toggleEmail)
+
+      const goBackButton = screen.getByTestId('Revenir en arrière')
+      fireEvent.press(goBackButton)
+
+      expect(screen.getByText('Quitter sans enregistrer')).toBeOnTheScreen()
+    })
+  })
 })

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -4,9 +4,12 @@ import { PermissionStatus } from 'react-native-permissions'
 import styled from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { useGoBack } from 'features/navigation/useGoBack'
 import { PushNotificationsModal } from 'features/notifications/pages/PushNotificationsModal'
 import { useUpdateProfileMutation } from 'features/profile/api/useUpdateProfileMutation'
 import { SectionWithSwitch } from 'features/profile/components/SectionWithSwitch/SectionWithSwitch'
+import { UnsavedSettingsModal } from 'features/profile/pages/NotificationSettings/components/UnsavedSettingsModal'
 import { hasUserChangedParameters } from 'features/profile/pages/NotificationSettings/helpers/hasUserChangedParameters'
 import { usePushPermission } from 'features/profile/pages/NotificationSettings/usePushPermission'
 import { mapSubscriptionThemeToName } from 'features/subscription/mapSubscriptionThemeToName'
@@ -76,6 +79,12 @@ export const NotificationsSettings = () => {
   }
 
   const {
+    visible: isUnsavedModalVisible,
+    showModal: showUnsavedModal,
+    hideModal: hideUnsavedModal,
+  } = useModal(false)
+
+  const {
     visible: isPushModalVisible,
     showModal: showPushModal,
     hideModal: hidePushModal,
@@ -108,8 +117,19 @@ export const NotificationsSettings = () => {
     }
   }
 
+  const { goBack: goBackAndLeaveNotificationSettings } = useGoBack(...getTabNavConfig('Profile'))
+
   return (
-    <SecondaryPageWithBlurHeader title="Suivi et notifications" scrollable>
+    <SecondaryPageWithBlurHeader
+      title="Suivi et notifications"
+      scrollable
+      onGoBack={() => {
+        if (hasUserChanged) {
+          showUnsavedModal()
+        } else {
+          goBackAndLeaveNotificationSettings()
+        }
+      }}>
       <Container>
         {isLoggedIn ? null : (
           <React.Fragment>
@@ -191,6 +211,11 @@ export const NotificationsSettings = () => {
           visible={isPushModalVisible}
           onRequestPermission={onRequestNotificationPermissionFromModal}
           onDismiss={hidePushModal}
+        />
+        <UnsavedSettingsModal
+          visible={isUnsavedModalVisible}
+          dismissModal={hideUnsavedModal}
+          onPressSaveChanges={submitProfile}
         />
       </Container>
     </SecondaryPageWithBlurHeader>

--- a/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
+++ b/src/features/profile/pages/NotificationSettings/NotificationsSettings.tsx
@@ -117,7 +117,7 @@ export const NotificationsSettings = () => {
     }
   }
 
-  const { goBack: goBackAndLeaveNotificationSettings } = useGoBack(...getTabNavConfig('Profile'))
+  const { goBack } = useGoBack(...getTabNavConfig('Profile'))
 
   return (
     <SecondaryPageWithBlurHeader
@@ -127,7 +127,7 @@ export const NotificationsSettings = () => {
         if (hasUserChanged) {
           showUnsavedModal()
         } else {
-          goBackAndLeaveNotificationSettings()
+          goBack()
         }
       }}>
       <Container>

--- a/src/features/profile/pages/NotificationSettings/components/UnsavedSettingsModal.native.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/components/UnsavedSettingsModal.native.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+
+import { UnsavedSettingsModal } from 'features/profile/pages/NotificationSettings/components/UnsavedSettingsModal'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { fireEvent, render, screen, act } from 'tests/utils'
+
+const mockDismissModal = jest.fn()
+
+describe('<UnsavedSettingsModal />', () => {
+  it('should dismiss modal on press rightIconButton', () => {
+    renderModal(true)
+
+    const dismissModalButton = screen.getByTestId('Ne pas quitter')
+
+    fireEvent.press(dismissModalButton)
+
+    expect(mockDismissModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('should dismiss modal on press "Quitter sans enregistrer"', () => {
+    renderModal(true)
+
+    const goBackButton = screen.getByText('Quitter sans enregistrer')
+
+    fireEvent.press(goBackButton)
+
+    expect(mockDismissModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('should dismiss modal when saving changes', async () => {
+    renderModal(true)
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('Enregistrer mes modifications'))
+    })
+
+    expect(mockDismissModal).toHaveBeenCalledTimes(1)
+  })
+})
+
+const renderModal = (visible: boolean) => {
+  render(
+    reactQueryProviderHOC(
+      <UnsavedSettingsModal
+        visible={visible}
+        dismissModal={mockDismissModal}
+        onPressSaveChanges={() => {}}
+      />
+    )
+  )
+}

--- a/src/features/profile/pages/NotificationSettings/components/UnsavedSettingsModal.native.test.tsx
+++ b/src/features/profile/pages/NotificationSettings/components/UnsavedSettingsModal.native.test.tsx
@@ -5,6 +5,7 @@ import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { fireEvent, render, screen, act } from 'tests/utils'
 
 const mockDismissModal = jest.fn()
+const mockOnPressSaveChanges = jest.fn()
 
 describe('<UnsavedSettingsModal />', () => {
   it('should dismiss modal on press rightIconButton', () => {
@@ -36,6 +37,16 @@ describe('<UnsavedSettingsModal />', () => {
 
     expect(mockDismissModal).toHaveBeenCalledTimes(1)
   })
+
+  it('should call onPressSaveChanges when saving changes', async () => {
+    renderModal(true)
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('Enregistrer mes modifications'))
+    })
+
+    expect(mockOnPressSaveChanges).toHaveBeenCalledTimes(1)
+  })
 })
 
 const renderModal = (visible: boolean) => {
@@ -44,7 +55,7 @@ const renderModal = (visible: boolean) => {
       <UnsavedSettingsModal
         visible={visible}
         dismissModal={mockDismissModal}
-        onPressSaveChanges={() => {}}
+        onPressSaveChanges={mockOnPressSaveChanges}
       />
     )
   )

--- a/src/features/profile/pages/NotificationSettings/components/UnsavedSettingsModal.tsx
+++ b/src/features/profile/pages/NotificationSettings/components/UnsavedSettingsModal.tsx
@@ -1,0 +1,68 @@
+import React, { FunctionComponent } from 'react'
+import styled from 'styled-components/native'
+
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { useGoBack } from 'features/navigation/useGoBack'
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
+import { AppModal } from 'ui/components/modals/AppModal'
+import { Close } from 'ui/svg/icons/Close'
+import { Invalidate } from 'ui/svg/icons/Invalidate'
+import { getSpacing, Spacer, Typo } from 'ui/theme'
+
+interface Props {
+  visible: boolean
+  dismissModal: () => void
+  onPressSaveChanges: () => void
+}
+
+export const UnsavedSettingsModal: FunctionComponent<Props> = ({
+  visible,
+  dismissModal,
+  onPressSaveChanges,
+}) => {
+  const { goBack: goBackAndLeaveNotificationSettings } = useGoBack(...getTabNavConfig('Profile'))
+
+  return (
+    <AppModal
+      animationOutTiming={1}
+      visible={visible}
+      title="Quitter sans enregistrer&nbsp;?"
+      rightIconAccessibilityLabel="Ne pas quitter"
+      rightIcon={Close}
+      onRightIconPress={dismissModal}>
+      <ModalContent>
+        <Spacer.Column numberOfSpaces={2} />
+        <InformationText>Tes modifications ne seront pas prises en compte.</InformationText>
+        <Spacer.Column numberOfSpaces={8} />
+        <ButtonPrimary
+          wording="Enregistrer mes modifications"
+          onPress={() => {
+            onPressSaveChanges()
+            dismissModal()
+            goBackAndLeaveNotificationSettings()
+          }}
+        />
+        <Spacer.Column numberOfSpaces={5} />
+        <ButtonTertiaryBlack
+          wording="Quitter sans enregistrer"
+          onPress={() => {
+            dismissModal()
+            goBackAndLeaveNotificationSettings()
+          }}
+          icon={Invalidate}
+        />
+        <Spacer.Column numberOfSpaces={1} />
+      </ModalContent>
+    </AppModal>
+  )
+}
+
+const InformationText = styled(Typo.Body)({
+  textAlign: 'center',
+})
+
+const ModalContent = styled.View({
+  paddingHorizontal: getSpacing(5.5),
+  width: '100%',
+})


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28339

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change

## Screenshots

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               | ![image](https://github.com/pass-culture/pass-culture-app-native/assets/75068235/a74bff1c-a193-434e-9ef8-40df1eed90da) |
| Android          |               |       |
| Phone - Chrome   |               | <img width="1552" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/75068235/b46b7868-08f6-4797-8065-1eb6800c9ce6"> |
| Desktop - Chrome |               | <img width="1440" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/75068235/1f57c43c-2b73-4498-92a0-f582754893bd"> |

