### PR TITLE
(BSR) fix(NotifSettings): fix padding modal unsavedChanges

### DIFF
--- a/src/features/profile/pages/NotificationSettings/components/UnsavedSettingsModal.tsx
+++ b/src/features/profile/pages/NotificationSettings/components/UnsavedSettingsModal.tsx
@@ -8,7 +8,7 @@ import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { Close } from 'ui/svg/icons/Close'
 import { Invalidate } from 'ui/svg/icons/Invalidate'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Typo } from 'ui/theme'
 
 interface Props {
   visible: boolean
@@ -32,9 +32,7 @@ export const UnsavedSettingsModal: FunctionComponent<Props> = ({
       rightIcon={Close}
       onRightIconPress={dismissModal}>
       <ModalContent>
-        <Spacer.Column numberOfSpaces={2} />
         <InformationText>Tes modifications ne seront pas prises en compte.</InformationText>
-        <Spacer.Column numberOfSpaces={8} />
         <ButtonPrimary
           wording="Enregistrer mes modifications"
           onPress={() => {
@@ -43,7 +41,6 @@ export const UnsavedSettingsModal: FunctionComponent<Props> = ({
             goBackAndLeaveNotificationSettings()
           }}
         />
-        <Spacer.Column numberOfSpaces={5} />
         <ButtonTertiaryBlack
           wording="Quitter sans enregistrer"
           onPress={() => {
@@ -52,7 +49,6 @@ export const UnsavedSettingsModal: FunctionComponent<Props> = ({
           }}
           icon={Invalidate}
         />
-        <Spacer.Column numberOfSpaces={1} />
       </ModalContent>
     </AppModal>
   )
@@ -63,6 +59,6 @@ const InformationText = styled(Typo.Body)({
 })
 
 const ModalContent = styled.View({
-  paddingHorizontal: getSpacing(5.5),
+  gap: getSpacing(6),
   width: '100%',
 })


### PR DESCRIPTION
## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change

## Screenshots

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-03-25 at 15 40 15](https://github.com/pass-culture/pass-culture-app-native/assets/75068235/761bcfc3-2755-4d8c-868c-569682c69894)  |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |