### PR TITLE
(PC-28805) fix(LinearGradient): update of lib to fix crash UIGraphicsBeginImageContext

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -16,8 +16,8 @@ PODS:
     - Batch (~> 1.19)
     - Firebase/Analytics
   - boost (1.76.0)
-  - BVLinearGradient (2.5.6):
-    - React
+  - BVLinearGradient (2.8.3):
+    - React-Core
   - CocoaAsyncSocket (7.6.5)
   - CodePush (8.1.0):
     - Base64 (~> 1.1)
@@ -1071,7 +1071,7 @@ SPEC CHECKSUMS:
   Batch: 0a7afbf8bcbc2f1a97c7a599760ad998e5ee4ebb
   BatchFirebaseDispatcher: 6758d8dc969b75c667908d922b708ab942690fc0
   boost: 7dcd2de282d72e344012f7d6564d024930a6a440
-  BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
+  BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CodePush: 255d7607f428dcbec39085f81a206b170e01d012
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "react-native-intersection-observer": "^0.2.0",
     "react-native-keychain": "^8.0.0",
     "react-native-launch-navigator": "^1.0.8",
-    "react-native-linear-gradient": "^2.5.6",
+    "react-native-linear-gradient": "^2.8.3",
     "react-native-lottie-splash-screen": "^1.1.2",
     "react-native-map-clustering": "^3.4.2",
     "react-native-maps": "^1.11.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22346,10 +22346,10 @@ react-native-launch-navigator@^1.0.8:
   resolved "https://registry.yarnpkg.com/react-native-launch-navigator/-/react-native-launch-navigator-1.0.8.tgz#c86f45406d37c0942a9d1a3e54a6d4e28c91ee81"
   integrity sha512-9/xsmcoXa02waKYX37Fx86U3e9FUDeNz0RmWiZ/JeBRAO1U0J2yK0xmTLiGyP4J9txZ9Qc9iZBJF+qMq8LXsEQ==
 
-react-native-linear-gradient@^2.5.6:
-  version "2.5.6"
-  resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.5.6.tgz#96215cbc5ec7a01247a20890888aa75b834d44a0"
-  integrity sha512-HDwEaXcQIuXXCV70O+bK1rizFong3wj+5Q/jSyifKFLg0VWF95xh8XQgfzXwtq0NggL9vNjPKXa016KuFu+VFg==
+react-native-linear-gradient@^2.8.3:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.8.3.tgz#9a116649f86d74747304ee13db325e20b21e564f"
+  integrity sha512-KflAXZcEg54PXkLyflaSZQ3PJp4uC4whM7nT/Uot9m0e/qxFV3p6uor1983D1YOBJbJN7rrWdqIjq0T42jOJyA==
 
 react-native-lottie-splash-screen@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28805

BEFORE PR: for iOS 17, crash on press of start the cultural survey due to UIGraphicsBeginImageContext, discussed here: https://github.com/react-native-linear-gradient/react-native-linear-gradient/issues/637#issuecomment-1725219069

AFTER PR: no more crash

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
