### PR TITLE
(PC-28800) refactor(AppButton): refacto spacing on app button when we have a left icon

### DIFF
--- a/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
@@ -893,6 +893,16 @@ exports[`<AccessibilityFiltersModal /> should not reset filter when reset button
                         button-icon-left-SVG-Mock
                       </Text>
                     </View>
+                    <View
+                      numberOfSpaces={2}
+                      style={
+                        [
+                          {
+                            "width": 8,
+                          },
+                        ]
+                      }
+                    />
                   </View>
                   <Text
                     adjustsFontSizeToFit={false}
@@ -904,7 +914,6 @@ exports[`<AccessibilityFiltersModal /> should not reset filter when reset button
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
                           "lineHeight": 16,
-                          "marginLeft": 4,
                           "maxWidth": "100%",
                         },
                       ]
@@ -994,7 +1003,6 @@ exports[`<AccessibilityFiltersModal /> should not reset filter when reset button
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]
@@ -1917,6 +1925,16 @@ exports[`<AccessibilityFiltersModal /> should not save modified disabilities whe
                         button-icon-left-SVG-Mock
                       </Text>
                     </View>
+                    <View
+                      numberOfSpaces={2}
+                      style={
+                        [
+                          {
+                            "width": 8,
+                          },
+                        ]
+                      }
+                    />
                   </View>
                   <Text
                     adjustsFontSizeToFit={false}
@@ -1928,7 +1946,6 @@ exports[`<AccessibilityFiltersModal /> should not save modified disabilities whe
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
                           "lineHeight": 16,
-                          "marginLeft": 4,
                           "maxWidth": "100%",
                         },
                       ]
@@ -2018,7 +2035,6 @@ exports[`<AccessibilityFiltersModal /> should not save modified disabilities whe
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]
@@ -2941,6 +2957,16 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                         button-icon-left-SVG-Mock
                       </Text>
                     </View>
+                    <View
+                      numberOfSpaces={2}
+                      style={
+                        [
+                          {
+                            "width": 8,
+                          },
+                        ]
+                      }
+                    />
                   </View>
                   <Text
                     adjustsFontSizeToFit={false}
@@ -2952,7 +2978,6 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
                           "lineHeight": 16,
-                          "marginLeft": 4,
                           "maxWidth": "100%",
                         },
                       ]
@@ -3042,7 +3067,6 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]
@@ -3965,6 +3989,16 @@ exports[`<AccessibilityFiltersModal /> should reset filter when reset button and
                         button-icon-left-SVG-Mock
                       </Text>
                     </View>
+                    <View
+                      numberOfSpaces={2}
+                      style={
+                        [
+                          {
+                            "width": 8,
+                          },
+                        ]
+                      }
+                    />
                   </View>
                   <Text
                     adjustsFontSizeToFit={false}
@@ -3976,7 +4010,6 @@ exports[`<AccessibilityFiltersModal /> should reset filter when reset button and
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
                           "lineHeight": 16,
-                          "marginLeft": 4,
                           "maxWidth": "100%",
                         },
                       ]
@@ -4066,7 +4099,6 @@ exports[`<AccessibilityFiltersModal /> should reset filter when reset button and
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]
@@ -4998,6 +5030,16 @@ exports[`<AccessibilityFiltersModal /> should save selected disabilities when se
                         button-icon-left-SVG-Mock
                       </Text>
                     </View>
+                    <View
+                      numberOfSpaces={2}
+                      style={
+                        [
+                          {
+                            "width": 8,
+                          },
+                        ]
+                      }
+                    />
                   </View>
                   <Text
                     adjustsFontSizeToFit={false}
@@ -5009,7 +5051,6 @@ exports[`<AccessibilityFiltersModal /> should save selected disabilities when se
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
                           "lineHeight": 16,
-                          "marginLeft": 4,
                           "maxWidth": "100%",
                         },
                       ]
@@ -5099,7 +5140,6 @@ exports[`<AccessibilityFiltersModal /> should save selected disabilities when se
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
@@ -461,7 +461,6 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
@@ -1131,7 +1131,6 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -431,6 +431,16 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -442,7 +452,6 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]
@@ -540,6 +549,16 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -551,7 +570,6 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
@@ -676,6 +676,16 @@ exports[`<Login/> should render correctly 1`] = `
                     button-icon-left-SVG-Mock
                   </Text>
                 </View>
+                <View
+                  numberOfSpaces={2}
+                  style={
+                    [
+                      {
+                        "width": 8,
+                      },
+                    ]
+                  }
+                />
               </View>
               <Text
                 adjustsFontSizeToFit={false}
@@ -687,7 +697,6 @@ exports[`<Login/> should render correctly 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 8,
                       "maxWidth": "100%",
                     },
                   ]
@@ -777,7 +786,6 @@ exports[`<Login/> should render correctly 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]
@@ -1641,6 +1649,16 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
                     button-icon-left-SVG-Mock
                   </Text>
                 </View>
+                <View
+                  numberOfSpaces={2}
+                  style={
+                    [
+                      {
+                        "width": 8,
+                      },
+                    ]
+                  }
+                />
               </View>
               <Text
                 adjustsFontSizeToFit={false}
@@ -1652,7 +1670,6 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 8,
                       "maxWidth": "100%",
                     },
                   ]
@@ -1742,7 +1759,6 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]
@@ -1910,6 +1926,16 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
                   button-icon-left-SVG-Mock
                 </Text>
               </View>
+              <View
+                numberOfSpaces={2}
+                style={
+                  [
+                    {
+                      "width": 8,
+                    },
+                  ]
+                }
+              />
             </View>
             <Text
               adjustsFontSizeToFit={false}
@@ -1921,7 +1947,6 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 8,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
@@ -333,6 +333,16 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
             button-icon-left-SVG-Mock
           </Text>
         </View>
+        <View
+          numberOfSpaces={2}
+          style={
+            [
+              {
+                "width": 8,
+              },
+            ]
+          }
+        />
       </View>
       <Text
         adjustsFontSizeToFit={false}
@@ -344,7 +354,6 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
               "fontFamily": "Montserrat-SemiBold",
               "fontSize": 12,
               "lineHeight": 16,
-              "marginLeft": 4,
               "maxWidth": "100%",
             },
           ]
@@ -434,6 +443,16 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
             button-icon-left-SVG-Mock
           </Text>
         </View>
+        <View
+          numberOfSpaces={2}
+          style={
+            [
+              {
+                "width": 8,
+              },
+            ]
+          }
+        />
       </View>
       <Text
         adjustsFontSizeToFit={false}
@@ -445,7 +464,6 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
               "fontFamily": "Montserrat-SemiBold",
               "fontSize": 12,
               "lineHeight": 16,
-              "marginLeft": 4,
               "maxWidth": "100%",
             },
           ]
@@ -645,7 +663,6 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]

--- a/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
@@ -248,7 +248,6 @@ exports[`<AccountCreated /> should render correctly 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
@@ -252,7 +252,6 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
@@ -279,7 +279,6 @@ exports[`QuitSignupModal should render correctly 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]
@@ -378,6 +377,16 @@ exports[`QuitSignupModal should render correctly 1`] = `
                   button-icon-left-SVG-Mock
                 </Text>
               </View>
+              <View
+                numberOfSpaces={2}
+                style={
+                  [
+                    {
+                      "width": 8,
+                    },
+                  ]
+                }
+              />
             </View>
             <Text
               adjustsFontSizeToFit={false}
@@ -389,7 +398,6 @@ exports[`QuitSignupModal should render correctly 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 8,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
@@ -336,7 +336,6 @@ exports[`<SetBirthday /> should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -722,7 +721,6 @@ exports[`<SetBirthday /> should render correctly when account creation token and
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.web.test.tsx.web-snap
@@ -1446,7 +1446,7 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
               <div
-                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                 dir="ltr"
               >
                 Continuer
@@ -2902,7 +2902,7 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
             class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
           >
             <div
-              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
               dir="ltr"
             >
               Continuer
@@ -4084,7 +4084,7 @@ exports[`<SetBirthday /> touch device should render correctly 1`] = `
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
               <div
-                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                 dir="ltr"
               >
                 Continuer
@@ -5209,7 +5209,7 @@ exports[`<SetBirthday /> touch device should render correctly 1`] = `
             class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
           >
             <div
-              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
               dir="ltr"
             >
               Continuer

--- a/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
@@ -663,7 +663,6 @@ exports[`SetPassword Page should render correctly 1`] = `
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
@@ -445,7 +445,6 @@ exports[`<EmailResendModal /> should render correctly 1`] = `
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
@@ -441,6 +441,16 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -452,7 +462,6 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]
@@ -540,6 +549,16 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -551,7 +570,6 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]
@@ -649,6 +667,16 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -660,7 +688,6 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -639,6 +639,16 @@ exports[`Signup Form should render correctly for AcceptCgu 1`] = `
                   button-icon-left-SVG-Mock
                 </Text>
               </View>
+              <View
+                numberOfSpaces={2}
+                style={
+                  [
+                    {
+                      "width": 8,
+                    },
+                  ]
+                }
+              />
             </View>
             <Text
               adjustsFontSizeToFit={false}
@@ -650,7 +660,6 @@ exports[`Signup Form should render correctly for AcceptCgu 1`] = `
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
                     "lineHeight": 16,
-                    "marginLeft": 4,
                     "maxWidth": "100%",
                   },
                 ]
@@ -740,6 +749,16 @@ exports[`Signup Form should render correctly for AcceptCgu 1`] = `
                   button-icon-left-SVG-Mock
                 </Text>
               </View>
+              <View
+                numberOfSpaces={2}
+                style={
+                  [
+                    {
+                      "width": 8,
+                    },
+                  ]
+                }
+              />
             </View>
             <Text
               adjustsFontSizeToFit={false}
@@ -751,7 +770,6 @@ exports[`Signup Form should render correctly for AcceptCgu 1`] = `
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
                     "lineHeight": 16,
-                    "marginLeft": 4,
                     "maxWidth": "100%",
                   },
                 ]
@@ -951,7 +969,6 @@ exports[`Signup Form should render correctly for AcceptCgu 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]
@@ -1685,7 +1702,6 @@ exports[`Signup Form should render correctly for SetBirthday 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]
@@ -2235,7 +2251,6 @@ exports[`Signup Form should render correctly for SetEmail 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]
@@ -3409,7 +3424,6 @@ exports[`Signup Form should render correctly for SetPassword 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.native.test.tsx.native-snap
@@ -323,7 +323,6 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]
@@ -421,6 +420,16 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -432,7 +441,6 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
@@ -205,7 +205,6 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
@@ -294,6 +294,16 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -305,7 +315,6 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]
@@ -403,6 +412,16 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -414,7 +433,6 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
@@ -279,7 +279,6 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]
@@ -377,6 +376,16 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -388,7 +397,6 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -204,7 +204,6 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]
@@ -302,6 +301,16 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
             button-icon-left-SVG-Mock
           </Text>
         </View>
+        <View
+          numberOfSpaces={2}
+          style={
+            [
+              {
+                "width": 8,
+              },
+            ]
+          }
+        />
       </View>
       <Text
         adjustsFontSizeToFit={false}
@@ -313,7 +322,6 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 8,
               "maxWidth": "100%",
             },
           ]

--- a/__snapshots__/features/bookOffer/components/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/BookingDetails.native.test.tsx.native-snap
@@ -689,7 +689,6 @@ exports[`<BookingDetails /> when user has selected options should render correct
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -1409,7 +1408,6 @@ exports[`<BookingDetails /> when user has selected options should render disable
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/bookOffer/components/BookingImpossible.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/components/BookingImpossible.native.test.tsx.native-snap
@@ -152,7 +152,6 @@ exports[`<BookingImpossible /> When offer is already favorite should render with
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]
@@ -327,7 +326,6 @@ exports[`<BookingImpossible /> When offer is not yet favorite should render with
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]
@@ -425,6 +423,16 @@ exports[`<BookingImpossible /> When offer is not yet favorite should render with
             button-icon-left-SVG-Mock
           </Text>
         </View>
+        <View
+          numberOfSpaces={2}
+          style={
+            [
+              {
+                "width": 8,
+              },
+            ]
+          }
+        />
       </View>
       <Text
         adjustsFontSizeToFit={false}
@@ -436,7 +444,6 @@ exports[`<BookingImpossible /> When offer is not yet favorite should render with
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 8,
               "maxWidth": "100%",
             },
           ]

--- a/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
@@ -196,7 +196,6 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -288,7 +287,6 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -386,6 +384,16 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -397,7 +405,6 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/bookings/components/NoBookingsView.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/components/NoBookingsView.native.test.tsx.native-snap
@@ -296,6 +296,16 @@ exports[`<NoBookingsView /> should render online no bookings view when netInfo.i
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -307,7 +317,6 @@ exports[`<NoBookingsView /> should render online no bookings view when netInfo.i
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
@@ -964,6 +964,16 @@ exports[`BookingDetails should render correctly 1`] = `
                       button-icon-left-SVG-Mock
                     </Text>
                   </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
                 </View>
                 <Text
                   adjustsFontSizeToFit={false}
@@ -975,7 +985,6 @@ exports[`BookingDetails should render correctly 1`] = `
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 8,
                         "maxWidth": "100%",
                       },
                     ]
@@ -1074,7 +1083,6 @@ exports[`BookingDetails should render correctly 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
@@ -252,7 +252,6 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]
@@ -341,7 +340,6 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
@@ -442,7 +442,6 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]
@@ -543,7 +542,6 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]
@@ -637,7 +635,6 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
@@ -201,6 +201,16 @@ exports[`CulturalSurveyIntro page should render the page with correct layout 1`]
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -212,7 +222,6 @@ exports[`CulturalSurveyIntro page should render the page with correct layout 1`]
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]
@@ -305,7 +314,6 @@ exports[`CulturalSurveyIntro page should render the page with correct layout 1`]
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -403,6 +411,16 @@ exports[`CulturalSurveyIntro page should render the page with correct layout 1`]
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -414,7 +432,6 @@ exports[`CulturalSurveyIntro page should render the page with correct layout 1`]
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.web.test.tsx.web-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.web.test.tsx.web-snap
@@ -237,9 +237,12 @@ exports[`CulturalSurveyIntro page should render the page with correct layout 1`]
                     button-icon-left-SVG-Mock
                   </div>
                 </div>
+                <div
+                  class="css-view-175oi2r r-width-1jg9483"
+                />
               </div>
               <div
-                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-1jkjb r-maxWidth-dnmrzs"
+                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                 dir="ltr"
               >
                 En savoir plus
@@ -264,7 +267,7 @@ exports[`CulturalSurveyIntro page should render the page with correct layout 1`]
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
               <div
-                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                 dir="ltr"
               >
                 Débuter le questionnaire
@@ -298,9 +301,12 @@ exports[`CulturalSurveyIntro page should render the page with correct layout 1`]
                     button-icon-left-SVG-Mock
                   </div>
                 </div>
+                <div
+                  class="css-view-175oi2r r-width-1jg9483"
+                />
               </div>
               <div
-                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-1jkjb r-maxWidth-dnmrzs"
+                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                 dir="ltr"
               >
                 Plus tard
@@ -547,9 +553,12 @@ exports[`CulturalSurveyIntro page should render the page with correct layout 1`]
                   button-icon-left-SVG-Mock
                 </div>
               </div>
+              <div
+                class="css-view-175oi2r r-width-1jg9483"
+              />
             </div>
             <div
-              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-1jkjb r-maxWidth-dnmrzs"
+              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
               dir="ltr"
             >
               En savoir plus
@@ -574,7 +583,7 @@ exports[`CulturalSurveyIntro page should render the page with correct layout 1`]
             class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
           >
             <div
-              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
               dir="ltr"
             >
               Débuter le questionnaire
@@ -608,9 +617,12 @@ exports[`CulturalSurveyIntro page should render the page with correct layout 1`]
                   button-icon-left-SVG-Mock
                 </div>
               </div>
+              <div
+                class="css-view-175oi2r r-width-1jg9483"
+              />
             </div>
             <div
-              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-1jkjb r-maxWidth-dnmrzs"
+              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
               dir="ltr"
             >
               Plus tard

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx.native-snap
@@ -1971,7 +1971,6 @@ exports[`CulturalSurveysQuestions page should render the page with correct layou
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
@@ -205,7 +205,6 @@ exports[`CulturalSurveyThanksPage page should render the page with correct layou
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/errors/pages/AsyncErrorBoundary.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/AsyncErrorBoundary.native.test.tsx.native-snap
@@ -288,7 +288,6 @@ exports[`AsyncErrorBoundary component should render 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/errors/pages/AsyncErrorBoundary.web.test.tsx.web-snap
+++ b/__snapshots__/features/errors/pages/AsyncErrorBoundary.web.test.tsx.web-snap
@@ -197,7 +197,7 @@ exports[`AsyncErrorBoundary component should render correctly 1`] = `
                 class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
               >
                 <div
-                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-ntw818 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-ntw818 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                   dir="ltr"
                 >
                   Réessayer
@@ -408,7 +408,7 @@ exports[`AsyncErrorBoundary component should render correctly 1`] = `
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
               <div
-                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-ntw818 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-ntw818 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                 dir="ltr"
               >
                 Réessayer

--- a/__snapshots__/features/errors/pages/BannedCountryError.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/BannedCountryError.native.test.tsx.native-snap
@@ -211,7 +211,6 @@ exports[`BannedCountryError should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/favorites/pages/FavoritesSorts.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/FavoritesSorts.native.test.tsx.native-snap
@@ -713,7 +713,6 @@ exports[`<FavoritesSorts/> should render correctly 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/forceUpdate/pages/ForceUpdate.native.test.tsx.native-snap
+++ b/__snapshots__/features/forceUpdate/pages/ForceUpdate.native.test.tsx.native-snap
@@ -253,7 +253,6 @@ exports[`<ForceUpdate/> should match snapshot 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]
@@ -352,6 +351,16 @@ exports[`<ForceUpdate/> should match snapshot 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -363,7 +372,6 @@ exports[`<ForceUpdate/> should match snapshot 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/home/components/NoContentError.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/NoContentError.native.test.tsx.native-snap
@@ -248,6 +248,16 @@ exports[`NoContentError should render correctly 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -259,7 +269,6 @@ exports[`NoContentError should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
@@ -406,6 +406,16 @@ exports[`<DMSModal/> should render correctly 1`] = `
                       button-icon-left-SVG-Mock
                     </Text>
                   </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
                 </View>
                 <Text
                   adjustsFontSizeToFit={false}
@@ -417,7 +427,6 @@ exports[`<DMSModal/> should render correctly 1`] = `
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 8,
                         "maxWidth": "100%",
                       },
                     ]
@@ -530,6 +539,16 @@ exports[`<DMSModal/> should render correctly 1`] = `
                       button-icon-left-SVG-Mock
                     </Text>
                   </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
                 </View>
                 <Text
                   adjustsFontSizeToFit={false}
@@ -541,7 +560,6 @@ exports[`<DMSModal/> should render correctly 1`] = `
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 8,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
@@ -269,7 +269,6 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]
@@ -368,6 +367,16 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
                   button-icon-left-SVG-Mock
                 </Text>
               </View>
+              <View
+                numberOfSpaces={2}
+                style={
+                  [
+                    {
+                      "width": 8,
+                    },
+                  ]
+                }
+              />
             </View>
             <Text
               adjustsFontSizeToFit={false}
@@ -379,7 +388,6 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 8,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
@@ -1198,6 +1198,16 @@ exports[`Stepper navigation should render correctly 1`] = `
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -1209,7 +1219,6 @@ exports[`Stepper navigation should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
@@ -331,7 +331,6 @@ exports[`<BeneficiaryAccountCreated/> should render correctly for 18 year-old be
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]
@@ -698,7 +697,6 @@ exports[`<BeneficiaryAccountCreated/> should render correctly for underage benef
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
@@ -267,7 +267,6 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/pages/confirmation/IdentityCheckHonor.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/IdentityCheckHonor.native.test.tsx.native-snap
@@ -468,7 +468,6 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
                             "fontFamily": "Montserrat-Bold",
                             "fontSize": 15,
                             "lineHeight": 20,
-                            "marginLeft": 0,
                             "maxWidth": "100%",
                           },
                         ]

--- a/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
@@ -523,6 +523,16 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                           button-icon-left-SVG-Mock
                         </Text>
                       </View>
+                      <View
+                        numberOfSpaces={2}
+                        style={
+                          [
+                            {
+                              "width": 8,
+                            },
+                          ]
+                        }
+                      />
                     </View>
                     <Text
                       adjustsFontSizeToFit={false}
@@ -534,7 +544,6 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
                             "lineHeight": 16,
-                            "marginLeft": 4,
                             "maxWidth": "100%",
                           },
                         ]
@@ -902,6 +911,16 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                             button-icon-left-SVG-Mock
                           </Text>
                         </View>
+                        <View
+                          numberOfSpaces={2}
+                          style={
+                            [
+                              {
+                                "width": 8,
+                              },
+                            ]
+                          }
+                        />
                       </View>
                       <Text
                         adjustsFontSizeToFit={false}
@@ -913,7 +932,6 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 12,
                               "lineHeight": 16,
-                              "marginLeft": 4,
                               "maxWidth": "100%",
                             },
                           ]

--- a/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
@@ -327,6 +327,16 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -338,7 +348,6 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
@@ -545,6 +545,16 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -556,7 +566,6 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]
@@ -1061,6 +1070,16 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -1072,7 +1091,6 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
@@ -441,6 +441,16 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                           button-icon-left-SVG-Mock
                         </Text>
                       </View>
+                      <View
+                        numberOfSpaces={2}
+                        style={
+                          [
+                            {
+                              "width": 8,
+                            },
+                          ]
+                        }
+                      />
                     </View>
                     <Text
                       adjustsFontSizeToFit={false}
@@ -452,7 +462,6 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                             "fontFamily": "Montserrat-Bold",
                             "fontSize": 15,
                             "lineHeight": 20,
-                            "marginLeft": 8,
                             "maxWidth": "100%",
                           },
                         ]
@@ -621,6 +630,16 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                           button-icon-left-SVG-Mock
                         </Text>
                       </View>
+                      <View
+                        numberOfSpaces={2}
+                        style={
+                          [
+                            {
+                              "width": 8,
+                            },
+                          ]
+                        }
+                      />
                     </View>
                     <Text
                       adjustsFontSizeToFit={false}
@@ -632,7 +651,6 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                             "fontFamily": "Montserrat-Bold",
                             "fontSize": 15,
                             "lineHeight": 20,
-                            "marginLeft": 8,
                             "maxWidth": "100%",
                           },
                         ]

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.test.tsx.web-snap
@@ -287,9 +287,12 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
                         button-icon-left-SVG-Mock
                       </div>
                     </div>
+                    <div
+                      class="css-view-175oi2r r-width-1jg9483"
+                    />
                   </div>
                   <div
-                    class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-1jkjb r-maxWidth-dnmrzs"
+                    class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                     dir="ltr"
                   >
                     Ouvrir un onglet ÉduConnect
@@ -591,9 +594,12 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
                       button-icon-left-SVG-Mock
                     </div>
                   </div>
+                  <div
+                    class="css-view-175oi2r r-width-1jg9483"
+                  />
                 </div>
                 <div
-                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-1jkjb r-maxWidth-dnmrzs"
+                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                   dir="ltr"
                 >
                   Ouvrir un onglet ÉduConnect

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx.native-snap
@@ -514,7 +514,6 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.web.test.tsx.web-snap
@@ -283,7 +283,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
                   class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
                 >
                   <div
-                    class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+                    class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                     dir="ltr"
                   >
                     Valider mes informations
@@ -581,7 +581,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
                 class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
               >
                 <div
-                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                   dir="ltr"
                 >
                   Valider mes informations

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
@@ -272,7 +272,6 @@ exports[`ComeBackLater should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
@@ -291,6 +291,16 @@ exports[`ExpiredOrLostID should render correctly 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -302,7 +312,6 @@ exports[`ExpiredOrLostID should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
@@ -278,7 +278,6 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/CodeNotReceivedModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/CodeNotReceivedModal.native.test.tsx.native-snap
@@ -455,7 +455,6 @@ exports[`<CodeNotReceivedModal /> should have a different color if one attempt r
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]
@@ -929,7 +928,6 @@ exports[`<CodeNotReceivedModal /> should match snapshot 1`] = `
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
@@ -577,7 +577,6 @@ exports[`<PhoneValidationTipsModal /> should match snapshot 1`] = `
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 0,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
@@ -794,7 +794,6 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 0,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
@@ -565,6 +565,16 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
                             button-icon-left-SVG-Mock
                           </Text>
                         </View>
+                        <View
+                          numberOfSpaces={2}
+                          style={
+                            [
+                              {
+                                "width": 8,
+                              },
+                            ]
+                          }
+                        />
                       </View>
                       <Text
                         adjustsFontSizeToFit={false}
@@ -576,7 +586,6 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
                               "fontFamily": "Montserrat-Bold",
                               "fontSize": 15,
                               "lineHeight": 20,
-                              "marginLeft": 8,
                               "maxWidth": "100%",
                             },
                           ]
@@ -708,7 +717,6 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/profile/SetAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetAddress.native.test.tsx.native-snap
@@ -513,7 +513,6 @@ exports[`<SetAddress/> should render correctly 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/profile/SetAddress.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetAddress.web.test.tsx.web-snap
@@ -292,7 +292,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
                   class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
                 >
                   <div
-                    class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+                    class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                     dir="ltr"
                   >
                     Continuer
@@ -599,7 +599,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
                 class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
               >
                 <div
-                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                   dir="ltr"
                 >
                   Continuer

--- a/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
@@ -526,7 +526,6 @@ exports[`<SetCity/> should render correctly 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/profile/SetCity.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetCity.web.test.tsx.web-snap
@@ -297,7 +297,7 @@ exports[`<SetCity/> should render correctly 1`] = `
                   class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
                 >
                   <div
-                    class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+                    class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                     dir="ltr"
                   >
                     Continuer
@@ -609,7 +609,7 @@ exports[`<SetCity/> should render correctly 1`] = `
                 class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
               >
                 <div
-                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                   dir="ltr"
                 >
                   Continuer

--- a/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
@@ -723,7 +723,6 @@ Nous les vérifions et ils ne pourront plus être modifiés par la suite.
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/profile/SetStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetStatus.native.test.tsx.native-snap
@@ -1968,7 +1968,6 @@ exports[`<SetStatus/> should render correctly 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/internal/marketingAndCommunication/pages/DeeplinksGenerator.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/marketingAndCommunication/pages/DeeplinksGenerator.native.test.tsx.native-snap
@@ -2931,7 +2931,6 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
@@ -754,7 +754,6 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
@@ -813,7 +813,6 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 0,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
@@ -252,7 +252,6 @@ exports[`<PageNotFound/> should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/notifications/pages/AskNotificationsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/notifications/pages/AskNotificationsModal.native.test.tsx.native-snap
@@ -357,7 +357,6 @@ exports[`AskNotificationsModal should render properly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/notifications/pages/PushNotificationsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/notifications/pages/PushNotificationsModal.native.test.tsx.native-snap
@@ -368,7 +368,6 @@ exports[`PushNotificationsModal should render properly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
@@ -252,7 +252,6 @@ exports[`<OfferNotFound /> should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/components/CreditExplanation/CreditExplanation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/CreditExplanation/CreditExplanation.native.test.tsx.native-snap
@@ -82,6 +82,16 @@ exports[`<CreditExplanation/> should render correctly for expired deposit 1`] = 
           button-icon-left-SVG-Mock
         </Text>
       </View>
+      <View
+        numberOfSpaces={2}
+        style={
+          [
+            {
+              "width": 8,
+            },
+          ]
+        }
+      />
     </View>
     <Text
       adjustsFontSizeToFit={false}
@@ -93,7 +103,6 @@ exports[`<CreditExplanation/> should render correctly for expired deposit 1`] = 
             "fontFamily": "Montserrat-SemiBold",
             "fontSize": 12,
             "lineHeight": 16,
-            "marginLeft": 4,
             "maxWidth": "100%",
           },
         ]
@@ -220,6 +229,16 @@ exports[`<CreditExplanation/> should render correctly for valid credit 1`] = `
             button-icon-left-SVG-Mock
           </Text>
         </View>
+        <View
+          numberOfSpaces={2}
+          style={
+            [
+              {
+                "width": 8,
+              },
+            ]
+          }
+        />
       </View>
       <Text
         adjustsFontSizeToFit={false}
@@ -231,7 +250,6 @@ exports[`<CreditExplanation/> should render correctly for valid credit 1`] = `
               "fontFamily": "Montserrat-SemiBold",
               "fontSize": 12,
               "lineHeight": 16,
-              "marginLeft": 4,
               "maxWidth": "100%",
             },
           ]

--- a/__snapshots__/features/profile/components/Header/CreditHeader/CreditHeader.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/Header/CreditHeader/CreditHeader.native.test.tsx.native-snap
@@ -1038,6 +1038,16 @@ exports[`CreditHeader Beneficiary is not underage should render correctly with v
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -1049,7 +1059,6 @@ exports[`CreditHeader Beneficiary is not underage should render correctly with v
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
                 "lineHeight": 16,
-                "marginLeft": 4,
                 "maxWidth": "100%",
               },
             ]
@@ -1528,6 +1537,16 @@ exports[`CreditHeader Beneficiary is underage should render correctly for 15 yea
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -1539,7 +1558,6 @@ exports[`CreditHeader Beneficiary is underage should render correctly for 15 yea
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
                 "lineHeight": 16,
-                "marginLeft": 4,
                 "maxWidth": "100%",
               },
             ]
@@ -2018,6 +2036,16 @@ exports[`CreditHeader Beneficiary is underage should render correctly for 16 yea
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -2029,7 +2057,6 @@ exports[`CreditHeader Beneficiary is underage should render correctly for 16 yea
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
                 "lineHeight": 16,
-                "marginLeft": 4,
                 "maxWidth": "100%",
               },
             ]
@@ -2508,6 +2535,16 @@ exports[`CreditHeader Beneficiary is underage should render correctly for 17 yea
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -2519,7 +2556,6 @@ exports[`CreditHeader Beneficiary is underage should render correctly for 17 yea
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
                 "lineHeight": 16,
-                "marginLeft": 4,
                 "maxWidth": "100%",
               },
             ]
@@ -2919,6 +2955,16 @@ exports[`CreditHeader Beneficiary is underage should render correctly with exhau
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -2930,7 +2976,6 @@ exports[`CreditHeader Beneficiary is underage should render correctly with exhau
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
                 "lineHeight": 16,
-                "marginLeft": 4,
                 "maxWidth": "100%",
               },
             ]
@@ -3330,6 +3375,16 @@ exports[`CreditHeader Beneficiary is underage should render correctly with exhau
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -3341,7 +3396,6 @@ exports[`CreditHeader Beneficiary is underage should render correctly with exhau
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
                 "lineHeight": 16,
-                "marginLeft": 4,
                 "maxWidth": "100%",
               },
             ]
@@ -3741,6 +3795,16 @@ exports[`CreditHeader Beneficiary is underage should render correctly with exhau
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -3752,7 +3816,6 @@ exports[`CreditHeader Beneficiary is underage should render correctly with exhau
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
                 "lineHeight": 16,
-                "marginLeft": 4,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/profile/components/Header/ProfileHeader/ProfileHeader.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/Header/ProfileHeader/ProfileHeader.native.test.tsx.native-snap
@@ -89,7 +89,6 @@ exports[`ProfileHeader should display the LoggedOutHeader if no user 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -564,7 +563,6 @@ exports[`ProfileHeader should display the NonBeneficiaryHeader Header if user is
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -727,7 +725,6 @@ exports[`ProfileHeader should display the NonBeneficiaryHeader Header if user is
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityActionPlan.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityActionPlan.native.test.tsx.native-snap
@@ -1970,6 +1970,16 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -1981,7 +1991,6 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]
@@ -2710,6 +2719,16 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -2721,7 +2740,6 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
                   "lineHeight": 16,
-                  "marginLeft": 4,
                   "maxWidth": "100%",
                 },
               ]
@@ -2824,6 +2842,16 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -2835,7 +2863,6 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
                   "lineHeight": 16,
-                  "marginLeft": 4,
                   "maxWidth": "100%",
                 },
               ]
@@ -2938,6 +2965,16 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -2949,7 +2986,6 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
                   "lineHeight": 16,
-                  "marginLeft": 4,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityEngagement.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityEngagement.native.test.tsx.native-snap
@@ -448,6 +448,16 @@ exports[`AccessibilityEngagement should render correctly 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -459,7 +469,6 @@ exports[`AccessibilityEngagement should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
@@ -775,7 +775,6 @@ exports[`<ChangeEmail/> email change already in progress should render correctly
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 0,
                         "maxWidth": "100%",
                       },
                     ]
@@ -1518,7 +1517,6 @@ exports[`<ChangeEmail/> should render correctly 1`] = `
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 0,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
@@ -279,7 +279,6 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]
@@ -377,6 +376,16 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -388,7 +397,6 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]
@@ -693,7 +701,6 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]
@@ -791,6 +798,16 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -802,7 +819,6 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
@@ -157,7 +157,6 @@ exports[`<ConfirmChangeEmail /> should render correctly when FF is active 1`] = 
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]
@@ -256,6 +255,16 @@ exports[`<ConfirmChangeEmail /> should render correctly when FF is active 1`] = 
             button-icon-left-SVG-Mock
           </Text>
         </View>
+        <View
+          numberOfSpaces={2}
+          style={
+            [
+              {
+                "width": 8,
+              },
+            ]
+          }
+        />
       </View>
       <Text
         adjustsFontSizeToFit={false}
@@ -267,7 +276,6 @@ exports[`<ConfirmChangeEmail /> should render correctly when FF is active 1`] = 
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 8,
               "maxWidth": "100%",
             },
           ]
@@ -449,7 +457,6 @@ exports[`<ConfirmChangeEmail /> should render correctly when FF is disabled 1`] 
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]
@@ -548,6 +555,16 @@ exports[`<ConfirmChangeEmail /> should render correctly when FF is disabled 1`] 
             button-icon-left-SVG-Mock
           </Text>
         </View>
+        <View
+          numberOfSpaces={2}
+          style={
+            [
+              {
+                "width": 8,
+              },
+            ]
+          }
+        />
       </View>
       <Text
         adjustsFontSizeToFit={false}
@@ -559,7 +576,6 @@ exports[`<ConfirmChangeEmail /> should render correctly when FF is disabled 1`] 
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 8,
               "maxWidth": "100%",
             },
           ]

--- a/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
@@ -2185,7 +2185,6 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
@@ -569,7 +569,6 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]
@@ -668,6 +667,16 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
                   button-icon-left-SVG-Mock
                 </Text>
               </View>
+              <View
+                numberOfSpaces={2}
+                style={
+                  [
+                    {
+                      "width": 8,
+                    },
+                  ]
+                }
+              />
             </View>
             <Text
               adjustsFontSizeToFit={false}
@@ -679,7 +688,6 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 8,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
@@ -311,7 +311,6 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]
@@ -409,6 +408,16 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -420,7 +429,6 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
@@ -484,7 +484,6 @@ exports[`<NewEmailSelection /> should match snapshot 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -2126,7 +2126,6 @@ exports[`NotificationSettings should render correctly when user is logged in 1`]
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]
@@ -4327,7 +4326,6 @@ exports[`NotificationSettings should render correctly when user is not logged in
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -896,7 +896,7 @@ exports[`NotificationSettings should render correctly 1`] = `
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
               <div
-                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                 dir="ltr"
               >
                 Enregistrer

--- a/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
@@ -382,6 +382,16 @@ exports[`PersonalData should render personal data success 1`] = `
                   button-icon-left-SVG-Mock
                 </Text>
               </View>
+              <View
+                numberOfSpaces={2}
+                style={
+                  [
+                    {
+                      "width": 8,
+                    },
+                  ]
+                }
+              />
             </View>
             <Text
               adjustsFontSizeToFit={false}
@@ -393,7 +403,6 @@ exports[`PersonalData should render personal data success 1`] = `
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
                     "lineHeight": 16,
-                    "marginLeft": 4,
                     "maxWidth": "100%",
                   },
                 ]
@@ -597,6 +606,16 @@ exports[`PersonalData should render personal data success 1`] = `
                   button-icon-left-SVG-Mock
                 </Text>
               </View>
+              <View
+                numberOfSpaces={2}
+                style={
+                  [
+                    {
+                      "width": 8,
+                    },
+                  ]
+                }
+              />
             </View>
             <Text
               adjustsFontSizeToFit={false}
@@ -608,7 +627,6 @@ exports[`PersonalData should render personal data success 1`] = `
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
                     "lineHeight": 16,
-                    "marginLeft": 4,
                     "maxWidth": "100%",
                   },
                 ]
@@ -766,6 +784,16 @@ exports[`PersonalData should render personal data success 1`] = `
                     button-icon-left-SVG-Mock
                   </Text>
                 </View>
+                <View
+                  numberOfSpaces={2}
+                  style={
+                    [
+                      {
+                        "width": 8,
+                      },
+                    ]
+                  }
+                />
               </View>
               <Text
                 adjustsFontSizeToFit={false}
@@ -777,7 +805,6 @@ exports[`PersonalData should render personal data success 1`] = `
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
                       "lineHeight": 16,
-                      "marginLeft": 4,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
@@ -106,7 +106,6 @@ exports[`Profile component should render correctly 1`] = `
                     "fontFamily": "Montserrat-Bold",
                     "fontSize": 15,
                     "lineHeight": 20,
-                    "marginLeft": 0,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx.native-snap
@@ -722,7 +722,6 @@ exports[`SearchResultsContent component should render correctly 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/search/components/SearchResultsContent/SearchResultsContent.web.test.tsx.web-snap
+++ b/__snapshots__/features/search/components/SearchResultsContent/SearchResultsContent.web.test.tsx.web-snap
@@ -446,7 +446,7 @@ exports[`SearchResultsContent component should render correctly 1`] = `
                   class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
                 >
                   <div
-                    class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+                    class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                     dir="ltr"
                   >
                     Modifier mes filtres
@@ -907,7 +907,7 @@ exports[`SearchResultsContent component should render correctly 1`] = `
                 class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
               >
                 <div
-                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                   dir="ltr"
                 >
                   Modifier mes filtres

--- a/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
@@ -1071,6 +1071,16 @@ exports[`<SearchFilter/> should render correctly 1`] = `
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -1082,7 +1092,6 @@ exports[`<SearchFilter/> should render correctly 1`] = `
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
                 "lineHeight": 16,
-                "marginLeft": 4,
                 "maxWidth": "100%",
               },
             ]
@@ -1172,7 +1181,6 @@ exports[`<SearchFilter/> should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
@@ -1244,7 +1244,6 @@ exports[`<Search/> should render SearchResults 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 0,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
@@ -2431,6 +2431,16 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
                       button-icon-left-SVG-Mock
                     </Text>
                   </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
                 </View>
                 <Text
                   adjustsFontSizeToFit={false}
@@ -2442,7 +2452,6 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 16,
-                        "marginLeft": 4,
                         "maxWidth": "100%",
                       },
                     ]
@@ -2532,7 +2541,6 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 0,
                         "maxWidth": "100%",
                       },
                     ]
@@ -5327,6 +5335,16 @@ exports[`<CategoriesModal/> new book native categories section should display th
                       button-icon-left-SVG-Mock
                     </Text>
                   </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
                 </View>
                 <Text
                   adjustsFontSizeToFit={false}
@@ -5338,7 +5356,6 @@ exports[`<CategoriesModal/> new book native categories section should display th
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 16,
-                        "marginLeft": 4,
                         "maxWidth": "100%",
                       },
                     ]
@@ -5428,7 +5445,6 @@ exports[`<CategoriesModal/> new book native categories section should display th
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 0,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx.native-snap
@@ -891,6 +891,16 @@ exports[`<DatesHoursModal/> should render modal correctly after animation and wi
                       button-icon-left-SVG-Mock
                     </Text>
                   </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
                 </View>
                 <Text
                   adjustsFontSizeToFit={false}
@@ -902,7 +912,6 @@ exports[`<DatesHoursModal/> should render modal correctly after animation and wi
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 16,
-                        "marginLeft": 4,
                         "maxWidth": "100%",
                       },
                     ]
@@ -992,7 +1001,6 @@ exports[`<DatesHoursModal/> should render modal correctly after animation and wi
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 0,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
@@ -644,6 +644,16 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
                       button-icon-left-SVG-Mock
                     </Text>
                   </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
                 </View>
                 <Text
                   adjustsFontSizeToFit={false}
@@ -655,7 +665,6 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 16,
-                        "marginLeft": 4,
                         "maxWidth": "100%",
                       },
                     ]
@@ -745,7 +754,6 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 0,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
@@ -1185,6 +1185,16 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                       button-icon-left-SVG-Mock
                     </Text>
                   </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
                 </View>
                 <Text
                   adjustsFontSizeToFit={false}
@@ -1196,7 +1206,6 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 16,
-                        "marginLeft": 4,
                         "maxWidth": "100%",
                       },
                     ]
@@ -1286,7 +1295,6 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 0,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
@@ -658,6 +658,16 @@ exports[`VenueModal should render correctly 1`] = `
                       button-icon-left-SVG-Mock
                     </Text>
                   </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
                 </View>
                 <Text
                   adjustsFontSizeToFit={false}
@@ -669,7 +679,6 @@ exports[`VenueModal should render correctly 1`] = `
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 16,
-                        "marginLeft": 4,
                         "maxWidth": "100%",
                       },
                     ]
@@ -759,7 +768,6 @@ exports[`VenueModal should render correctly 1`] = `
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 0,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/share/pages/ShareAppModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModal.native.test.tsx.native-snap
@@ -441,6 +441,16 @@ exports[`ShareAppModal should match beneficiary modal snapshot when beneficiary 
                       button-icon-left-SVG-Mock
                     </Text>
                   </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
                 </View>
                 <Text
                   adjustsFontSizeToFit={false}
@@ -452,7 +462,6 @@ exports[`ShareAppModal should match beneficiary modal snapshot when beneficiary 
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 16,
-                        "marginLeft": 4,
                         "maxWidth": "100%",
                       },
                     ]
@@ -923,6 +932,16 @@ exports[`ShareAppModal should match booking modal snapshot when booking 1`] = `
                       button-icon-left-SVG-Mock
                     </Text>
                   </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
                 </View>
                 <Text
                   adjustsFontSizeToFit={false}
@@ -934,7 +953,6 @@ exports[`ShareAppModal should match booking modal snapshot when booking 1`] = `
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 16,
-                        "marginLeft": 4,
                         "maxWidth": "100%",
                       },
                     ]
@@ -1407,6 +1425,16 @@ exports[`ShareAppModal should match underage modal snapshot when underage 1`] = 
                       button-icon-left-SVG-Mock
                     </Text>
                   </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
                 </View>
                 <Text
                   adjustsFontSizeToFit={false}
@@ -1418,7 +1446,6 @@ exports[`ShareAppModal should match underage modal snapshot when underage 1`] = 
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 16,
-                        "marginLeft": 4,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
+++ b/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
@@ -354,9 +354,12 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                                       button-icon-left-SVG-Mock
                                     </div>
                                   </div>
+                                  <div
+                                    class="css-view-175oi2r r-width-1jg9483"
+                                  />
                                 </div>
                                 <div
-                                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-1jkjb r-maxWidth-dnmrzs"
+                                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                                   dir="ltr"
                                 >
                                   Copier
@@ -392,9 +395,12 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                                       button-icon-left-SVG-Mock
                                     </div>
                                   </div>
+                                  <div
+                                    class="css-view-175oi2r r-width-1jg9483"
+                                  />
                                 </div>
                                 <div
-                                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-1jkjb r-maxWidth-dnmrzs"
+                                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                                   dir="ltr"
                                 >
                                   E-mail
@@ -551,7 +557,7 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                             class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
                           >
                             <div
-                              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-marginLeft-11wrixw r-maxWidth-dnmrzs"
+                              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
                               dir="ltr"
                             >
                               Annuler

--- a/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
@@ -363,7 +363,6 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]
@@ -455,7 +454,6 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]
@@ -554,6 +552,16 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
             button-icon-left-SVG-Mock
           </Text>
         </View>
+        <View
+          numberOfSpaces={2}
+          style={
+            [
+              {
+                "width": 8,
+              },
+            ]
+          }
+        />
       </View>
       <Text
         adjustsFontSizeToFit={false}
@@ -565,7 +573,6 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 8,
               "maxWidth": "100%",
             },
           ]
@@ -953,7 +960,6 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]
@@ -1052,6 +1058,16 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
             button-icon-left-SVG-Mock
           </Text>
         </View>
+        <View
+          numberOfSpaces={2}
+          style={
+            [
+              {
+                "width": 8,
+              },
+            ]
+          }
+        />
       </View>
       <Text
         adjustsFontSizeToFit={false}
@@ -1063,7 +1079,6 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 8,
               "maxWidth": "100%",
             },
           ]
@@ -1451,7 +1466,6 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]
@@ -1543,7 +1557,6 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 0,
               "maxWidth": "100%",
             },
           ]
@@ -1642,6 +1655,16 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
             button-icon-left-SVG-Mock
           </Text>
         </View>
+        <View
+          numberOfSpaces={2}
+          style={
+            [
+              {
+                "width": 8,
+              },
+            ]
+          }
+        />
       </View>
       <Text
         adjustsFontSizeToFit={false}
@@ -1653,7 +1676,6 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
               "fontFamily": "Montserrat-Bold",
               "fontSize": 15,
               "lineHeight": 20,
-              "marginLeft": 8,
               "maxWidth": "100%",
             },
           ]

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
@@ -572,7 +572,6 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]
@@ -670,6 +669,16 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -681,7 +690,6 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
@@ -288,6 +288,16 @@ Tu peux toujours contacter le service fraude pour sécuriser ton compte.
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -299,7 +309,6 @@ Tu peux toujours contacter le service fraude pour sécuriser ton compte.
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]
@@ -397,6 +406,16 @@ Tu peux toujours contacter le service fraude pour sécuriser ton compte.
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -408,7 +427,6 @@ Tu peux toujours contacter le service fraude pour sécuriser ton compte.
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
@@ -294,6 +294,16 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -305,7 +315,6 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]
@@ -403,6 +412,16 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -414,7 +433,6 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/tutorial/pages/NonEligibleModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/NonEligibleModal.native.test.tsx.native-snap
@@ -379,7 +379,6 @@ exports[`NonEligibleModal should render correctly for onboarding non-eligible ov
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]
@@ -769,6 +768,16 @@ exports[`NonEligibleModal should render correctly for onboarding non-eligible un
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -780,7 +789,6 @@ exports[`NonEligibleModal should render correctly for onboarding non-eligible un
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]
@@ -894,7 +902,6 @@ exports[`NonEligibleModal should render correctly for onboarding non-eligible un
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]
@@ -1300,7 +1307,6 @@ exports[`NonEligibleModal should render correctly for profile tutorial non-eligi
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]
@@ -1705,7 +1711,6 @@ exports[`NonEligibleModal should render correctly for profile tutorial non-eligi
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/tutorial/pages/TutorialPage.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/TutorialPage.native.test.tsx.native-snap
@@ -284,7 +284,6 @@ exports[`TutorialPage should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/tutorial/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
@@ -1568,6 +1568,16 @@ exports[`OnboardingAgeInformation should render correctly for 15-year-old 1`] = 
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -1579,7 +1589,6 @@ exports[`OnboardingAgeInformation should render correctly for 15-year-old 1`] = 
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]
@@ -3159,6 +3168,16 @@ exports[`OnboardingAgeInformation should render correctly for 16-year-old 1`] = 
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -3170,7 +3189,6 @@ exports[`OnboardingAgeInformation should render correctly for 16-year-old 1`] = 
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]
@@ -4737,6 +4755,16 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -4748,7 +4776,6 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]
@@ -6156,6 +6183,16 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -6167,7 +6204,6 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/tutorial/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
@@ -84,7 +84,6 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 0,
                 "maxWidth": "100%",
               },
             ]
@@ -284,7 +283,6 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation.native.test.tsx.native-snap
@@ -2542,6 +2542,16 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                     button-icon-left-SVG-Mock
                   </Text>
                 </View>
+                <View
+                  numberOfSpaces={2}
+                  style={
+                    [
+                      {
+                        "width": 8,
+                      },
+                    ]
+                  }
+                />
               </View>
               <Text
                 adjustsFontSizeToFit={false}
@@ -2553,7 +2563,6 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
                       "lineHeight": 16,
-                      "marginLeft": 4,
                       "maxWidth": "100%",
                     },
                   ]
@@ -5604,6 +5613,16 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                     button-icon-left-SVG-Mock
                   </Text>
                 </View>
+                <View
+                  numberOfSpaces={2}
+                  style={
+                    [
+                      {
+                        "width": 8,
+                      },
+                    ]
+                  }
+                />
               </View>
               <Text
                 adjustsFontSizeToFit={false}
@@ -5615,7 +5634,6 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
                       "lineHeight": 16,
-                      "marginLeft": 4,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -298,6 +298,16 @@ exports[`<Venue /> should match snapshot 1`] = `
                     button-icon-left-SVG-Mock
                   </Text>
                 </View>
+                <View
+                  numberOfSpaces={2}
+                  style={
+                    [
+                      {
+                        "width": 8,
+                      },
+                    ]
+                  }
+                />
               </View>
               <Text
                 adjustsFontSizeToFit={false}
@@ -309,7 +319,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                       "fontFamily": "Montserrat-Bold",
                       "fontSize": 15,
                       "lineHeight": 20,
-                      "marginLeft": 8,
                       "maxWidth": "100%",
                     },
                   ]
@@ -419,6 +428,16 @@ exports[`<Venue /> should match snapshot 1`] = `
                       button-icon-left-SVG-Mock
                     </Text>
                   </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
                 </View>
                 <Text
                   adjustsFontSizeToFit={false}
@@ -430,7 +449,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                         "fontFamily": "Montserrat-Bold",
                         "fontSize": 15,
                         "lineHeight": 20,
-                        "marginLeft": 8,
                         "maxWidth": "100%",
                       },
                     ]
@@ -3765,6 +3783,16 @@ d’options
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -3776,7 +3804,6 @@ d’options
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
@@ -252,7 +252,6 @@ exports[`<VenueNotFound /> should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/libs/location/geolocation/components/GeolocationActivationModal.native.test.tsx.native-snap
+++ b/__snapshots__/libs/location/geolocation/components/GeolocationActivationModal.native.test.tsx.native-snap
@@ -369,7 +369,6 @@ exports[`GeolocationActivationModal should render properly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.native.test.tsx.native-snap
@@ -429,7 +429,6 @@ exports[`<ApplicationProcessingModal /> should match previous snapshot 1`] = `
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]
@@ -527,6 +526,16 @@ exports[`<ApplicationProcessingModal /> should match previous snapshot 1`] = `
                         button-icon-left-SVG-Mock
                       </Text>
                     </View>
+                    <View
+                      numberOfSpaces={2}
+                      style={
+                        [
+                          {
+                            "width": 8,
+                          },
+                        ]
+                      }
+                    />
                   </View>
                   <Text
                     adjustsFontSizeToFit={false}
@@ -538,7 +547,6 @@ exports[`<ApplicationProcessingModal /> should match previous snapshot 1`] = `
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 8,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx.native-snap
@@ -430,7 +430,6 @@ ton crédit
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]
@@ -528,6 +527,16 @@ ton crédit
                         button-icon-left-SVG-Mock
                       </Text>
                     </View>
+                    <View
+                      numberOfSpaces={2}
+                      style={
+                        [
+                          {
+                            "width": 8,
+                          },
+                        ]
+                      }
+                    />
                   </View>
                   <Text
                     adjustsFontSizeToFit={false}
@@ -539,7 +548,6 @@ ton crédit
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 8,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
@@ -483,7 +483,6 @@ pour réserver cette offre
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]
@@ -985,7 +984,6 @@ pour réserver cette offre
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]
@@ -1457,7 +1455,6 @@ pour réserver cette offre
                           "fontFamily": "Montserrat-Bold",
                           "fontSize": 15,
                           "lineHeight": 20,
-                          "marginLeft": 0,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/ui/components/__tests__/LayoutExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/__tests__/LayoutExpiredLink.native.test.tsx.native-snap
@@ -276,6 +276,16 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -287,7 +297,6 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]
@@ -375,6 +384,16 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
               button-icon-left-SVG-Mock
             </Text>
           </View>
+          <View
+            numberOfSpaces={2}
+            style={
+              [
+                {
+                  "width": 8,
+                },
+              ]
+            }
+          />
         </View>
         <Text
           adjustsFontSizeToFit={false}
@@ -386,7 +405,6 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
                 "fontFamily": "Montserrat-Bold",
                 "fontSize": 15,
                 "lineHeight": 20,
-                "marginLeft": 8,
                 "maxWidth": "100%",
               },
             ]
@@ -501,7 +519,6 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]
@@ -599,6 +616,16 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
                 button-icon-left-SVG-Mock
               </Text>
             </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
           </View>
           <Text
             adjustsFontSizeToFit={false}
@@ -610,7 +637,6 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 8,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/ui/components/buttons/AppButton/AppButton.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/buttons/AppButton/AppButton.native.test.tsx.native-snap
@@ -80,6 +80,16 @@ exports[`AppButton Component * inline property should use inline css style when 
           button-icon-left-SVG-Mock
         </Text>
       </View>
+      <View
+        numberOfSpaces={2}
+        style={
+          [
+            {
+              "width": 8,
+            },
+          ]
+        }
+      />
     </View>
     <Text
       adjustsFontSizeToFit={false}

--- a/__snapshots__/ui/components/buttons/AppButton/AppButton.web.test.tsx.web-snap
+++ b/__snapshots__/ui/components/buttons/AppButton/AppButton.web.test.tsx.web-snap
@@ -81,6 +81,9 @@ exports[`AppButton Component * inline property should use inline css style when 
                 button-icon-left-SVG-Mock
               </div>
             </div>
+            <div
+              class="css-view-175oi2r r-width-1jg9483"
+            />
           </div>
           <div
             class="css-text-1rynq56 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"
@@ -169,6 +172,9 @@ exports[`AppButton Component * inline property should use inline css style when 
               button-icon-left-SVG-Mock
             </div>
           </div>
+          <div
+            class="css-view-175oi2r r-width-1jg9483"
+          />
         </div>
         <div
           class="css-text-1rynq56 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe"

--- a/__snapshots__/web/SupportedBrowsersGate.native.test.tsx.native-snap
+++ b/__snapshots__/web/SupportedBrowsersGate.native.test.tsx.native-snap
@@ -525,7 +525,6 @@ exports[`SupportedBrowsersGate render correctly 1`] = `
                   "fontFamily": "Montserrat-Bold",
                   "fontSize": 15,
                   "lineHeight": 20,
-                  "marginLeft": 0,
                   "maxWidth": "100%",
                 },
               ]

--- a/src/features/offer/components/OfferArtists/OfferArtists.tsx
+++ b/src/features/offer/components/OfferArtists/OfferArtists.tsx
@@ -7,7 +7,7 @@ import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
 import { FakeDoorModal } from 'ui/components/modals/FakeDoorModal'
 import { useModal } from 'ui/components/modals/useModal'
 import { ArrowNext } from 'ui/svg/icons/ArrowNext'
-import { Typo } from 'ui/theme'
+import { Spacer, Typo } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 interface Props {
@@ -30,7 +30,8 @@ export const OfferArtists: FunctionComponent<Props> = ({
 
   return shouldDisplayFakeDoor ? (
     <FakeDoorContainer>
-      <Typo.ButtonTextNeutralInfo>de </Typo.ButtonTextNeutralInfo>
+      <Typo.ButtonTextNeutralInfo>de</Typo.ButtonTextNeutralInfo>
+      <Spacer.Row numberOfSpaces={2} />
       <ButtonTertiaryBlack
         wording={artists}
         icon={ArrowNext}

--- a/src/ui/components/buttons/AppButton/AppButtonInner.tsx
+++ b/src/ui/components/buttons/AppButton/AppButtonInner.tsx
@@ -25,6 +25,7 @@ export function AppButtonInner({
           {!!(iconPosition === 'left' && Icon) && (
             <IconWrapper>
               <Icon testID="button-icon-left" />
+              <Spacer.Row numberOfSpaces={2} />
             </IconWrapper>
           )}
           {!!Title && (
@@ -37,7 +38,7 @@ export function AppButtonInner({
           )}
           {!!(iconPosition === 'right' && Icon) && (
             <IconWrapper>
-              <Spacer.Row numberOfSpaces={1} />
+              <Spacer.Row numberOfSpaces={2} />
               <Icon testID="button-icon-right" />
             </IconWrapper>
           )}

--- a/src/ui/components/buttons/ButtonPrimary.ts
+++ b/src/ui/components/buttons/ButtonPrimary.ts
@@ -5,7 +5,7 @@ import { AppButton } from 'ui/components/buttons/AppButton/AppButton'
 import { BaseButtonProps } from 'ui/components/buttons/AppButton/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { getSpacing, Typo } from 'ui/theme'
+import { Typo } from 'ui/theme'
 
 export const ButtonPrimary = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ isLoading, disabled, textSize, icon, theme, buttonHeight, ...rest }) => {
@@ -31,16 +31,10 @@ export const ButtonPrimary = styledButton(AppButton).attrs<BaseButtonProps>(
       backgroundColor = theme.buttons.disabled.primary.backgroundColor
     }
 
-    const marginLeftWithIcon = () => {
-      if (buttonHeight === 'extraSmall') return getSpacing(1)
-      return theme.buttons.primary.marginLeftWithIcon
-    }
-
     const Title = styled(buttonHeight !== 'extraSmall' ? Typo.ButtonText : Typo.Caption)({
       maxWidth: '100%',
       color: disabled ? theme.buttons.disabled.primary.textColor : theme.buttons.primary.textColor,
       fontSize: textSize,
-      marginLeft: icon ? marginLeftWithIcon() : theme.buttons.primary.marginLeft,
     })
 
     return {

--- a/src/ui/components/buttons/ButtonPrimaryWhite.ts
+++ b/src/ui/components/buttons/ButtonPrimaryWhite.ts
@@ -26,9 +26,6 @@ export const ButtonPrimaryWhite = styledButton(AppButton).attrs<BaseButtonProps>
         ? theme.buttons.disabled.primaryWhite.textColor
         : theme.buttons.primaryWhite.textColor,
       fontSize: textSize,
-      marginLeft: icon
-        ? theme.buttons.primaryWhite.marginLeftWithIcon
-        : theme.buttons.primaryWhite.marginLeft,
     })
 
     return {

--- a/src/ui/components/buttons/ButtonQuarternarySecondary.ts
+++ b/src/ui/components/buttons/ButtonQuarternarySecondary.ts
@@ -29,9 +29,6 @@ export const ButtonQuaternarySecondary = styledButton(AppButton).attrs<BaseButto
       color: disabled
         ? theme.buttons.disabled.quaternarySecondary.textColor
         : theme.buttons.quaternarySecondary.textColor,
-      marginLeft: icon
-        ? theme.buttons.quaternarySecondary.marginLeftWithIcon
-        : theme.buttons.quaternarySecondary.marginLeft,
     })
 
     return {

--- a/src/ui/components/buttons/ButtonQuaternaryBlack.ts
+++ b/src/ui/components/buttons/ButtonQuaternaryBlack.ts
@@ -29,9 +29,6 @@ export const ButtonQuaternaryBlack = styledButton(AppButton).attrs<BaseButtonPro
       color: disabled
         ? theme.buttons.disabled.quaternaryBlack.textColor
         : theme.buttons.quaternaryBlack.textColor,
-      marginLeft: icon
-        ? theme.buttons.quaternaryBlack.marginLeftWithIcon
-        : theme.buttons.quaternaryBlack.marginLeft,
     })
 
     return {

--- a/src/ui/components/buttons/ButtonQuaternaryPrimary.ts
+++ b/src/ui/components/buttons/ButtonQuaternaryPrimary.ts
@@ -29,9 +29,6 @@ export const ButtonQuaternaryPrimary = styledButton(AppButton).attrs<BaseButtonP
       color: disabled
         ? theme.buttons.disabled.quaternaryPrimary.textColor
         : theme.buttons.quaternaryPrimary.textColor,
-      marginLeft: icon
-        ? theme.buttons.quaternaryPrimary.marginLeftWithIcon
-        : theme.buttons.quaternaryPrimary.marginLeft,
     })
 
     return {

--- a/src/ui/components/buttons/ButtonSecondary.ts
+++ b/src/ui/components/buttons/ButtonSecondary.ts
@@ -26,9 +26,6 @@ export const ButtonSecondary = styledButton(AppButton).attrs<BaseButtonProps>(
         ? theme.buttons.disabled.secondary.textColor
         : theme.buttons.secondary.textColor,
       fontSize: textSize,
-      marginLeft: icon
-        ? theme.buttons.secondary.marginLeftWithIcon
-        : theme.buttons.secondary.marginLeft,
     })
 
     return {

--- a/src/ui/components/buttons/ButtonSecondaryBlack.ts
+++ b/src/ui/components/buttons/ButtonSecondaryBlack.ts
@@ -26,9 +26,6 @@ export const ButtonSecondaryBlack = styledButton(AppButton).attrs<BaseButtonProp
         ? theme.buttons.disabled.secondaryBlack.textColor
         : theme.buttons.secondaryBlack.textColor,
       fontSize: textSize,
-      marginLeft: icon
-        ? theme.buttons.secondaryBlack.marginLeftWithIcon
-        : theme.buttons.secondaryBlack.marginLeft,
     })
 
     return {

--- a/src/ui/components/buttons/ButtonSecondaryWhite.ts
+++ b/src/ui/components/buttons/ButtonSecondaryWhite.ts
@@ -30,9 +30,6 @@ export const ButtonSecondaryWhite = styledButton(AppButton).attrs<BaseButtonProp
         ? theme.buttons.disabled.secondaryWhite.textColor
         : theme.buttons.secondaryWhite.textColor,
       fontSize: textSize,
-      marginLeft: icon
-        ? theme.buttons.secondaryWhite.marginLeftWithIcon
-        : theme.buttons.secondaryWhite.marginLeft,
     })
 
     return {

--- a/src/ui/components/buttons/ButtonTertiaryBlack.ts
+++ b/src/ui/components/buttons/ButtonTertiaryBlack.ts
@@ -28,9 +28,6 @@ export const ButtonTertiaryBlack = styledButton(AppButton).attrs<BaseButtonProps
         ? theme.buttons.disabled.tertiaryBlack.textColor
         : theme.buttons.tertiaryBlack.textColor,
       fontSize: textSize,
-      marginLeft: icon
-        ? theme.buttons.tertiaryBlack.marginLeftWithIcon
-        : theme.buttons.tertiaryBlack.marginLeft,
     })
     return {
       ...rest,

--- a/src/ui/components/buttons/ButtonTertiaryNeutralInfo.ts
+++ b/src/ui/components/buttons/ButtonTertiaryNeutralInfo.ts
@@ -25,9 +25,6 @@ export const ButtonTertiaryNeutralInfo = styledButton(AppButton).attrs<BaseButto
         ? theme.buttons.disabled.tertiaryNeutralInfo.textColor
         : theme.buttons.tertiaryNeutralInfo.textColor,
       fontSize: textSize,
-      marginLeft: icon
-        ? theme.buttons.tertiaryNeutralInfo.marginLeftWithIcon
-        : theme.buttons.tertiaryNeutralInfo.marginLeft,
     })
 
     return {

--- a/src/ui/components/buttons/ButtonTertiaryPrimary.ts
+++ b/src/ui/components/buttons/ButtonTertiaryPrimary.ts
@@ -30,9 +30,6 @@ export const ButtonTertiaryPrimary = styledButton(AppButton).attrs<BaseButtonPro
         ? theme.buttons.disabled.tertiary.textColor
         : theme.buttons.tertiary.textColor,
       fontSize: textSize,
-      marginLeft: icon
-        ? theme.buttons.tertiary.marginLeftWithIcon
-        : theme.buttons.tertiary.marginLeft,
     })
 
     return {

--- a/src/ui/components/buttons/ButtonTertiaryWhite.ts
+++ b/src/ui/components/buttons/ButtonTertiaryWhite.ts
@@ -31,9 +31,6 @@ export const ButtonTertiaryWhite = styledButton(AppButton).attrs<BaseButtonProps
         ? theme.buttons.disabled.tertiaryWhite.textColor
         : theme.buttons.tertiaryWhite.textColor,
       fontSize: textSize,
-      marginLeft: icon
-        ? theme.buttons.tertiaryWhite.marginLeftWithIcon
-        : theme.buttons.tertiaryWhite.marginLeft,
     })
 
     return {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28800

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
