### PR TITLE
(PC-28825) feat(maestro): add test for info section while not logged

### DIFF
--- a/.maestro/testsV2/InfoSectionNotShown.yml
+++ b/.maestro/testsV2/InfoSectionNotShown.yml
@@ -1,0 +1,8 @@
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow: reusableFlows/LaunchApp.yml
+- runFlow: reusableFlows/features/cookies/AcceptCookies.yml
+- runFlow: reusableFlows/features/tutorial/onboarding/Onboard18.yml
+- tapOn: "Mon profil"
+- assertNotVisible: "Informations personnelles"
+- runFlow: reusableFlows/StopApp.yml 

--- a/.maestro/testsV2/reusableFlows/features/search/SearchBookableCinemaOffer.yml
+++ b/.maestro/testsV2/reusableFlows/features/search/SearchBookableCinemaOffer.yml
@@ -12,8 +12,8 @@ appId: ${MAESTRO_APP_ID}
 - assertVisible: 'Séances de cinéma'
 - tapOn: 'Rechercher'
 
-- tapOn:
-    id: '.*Voir tous les filtres.*'
+- tapOn:  
+    id: '.*Voir tous les filtres.*' # Sélection de l'icone filtre pour ouvrir la modale
 - tapOn: "Dates & heures"
 
 - assertVisible: "Dates & heures"

--- a/.maestro/testsV2/reusableFlows/features/search/SearchBookableDuoOffer.yml
+++ b/.maestro/testsV2/reusableFlows/features/search/SearchBookableDuoOffer.yml
@@ -14,7 +14,7 @@ appId: ${MAESTRO_APP_ID}
 - tapOn:
     id: '.*Voir tous les filtres.*'
 - tapOn:
-    id: "FilterRow"
+    id: "FilterRow" # Sélectionne le filtre Duo dans la modale Filtres
     index: 1
 - tapOn:
     id: "Interrupteur limitDuoOfferSearch"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28825

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots


https://github.com/pass-culture/pass-culture-app-native/assets/153505101/d69bec9c-4562-497d-8b78-382426d52003

