### PR TITLE
(PC-28852) feat(search): reset searchState on goBack to search landing

### DIFF
--- a/src/features/search/components/SearchBox/SearchBox.native.test.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.native.test.tsx
@@ -352,7 +352,7 @@ describe('SearchBox component', () => {
     })
   })
 
-  it('should reset query when user go goBack to Landing', async () => {
+  it('should reset searchState when user go goBack to Landing', async () => {
     mockSearchState = {
       ...mockSearchState,
       view: SearchView.Results,
@@ -368,11 +368,7 @@ describe('SearchBox component', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith({
       type: 'SET_STATE',
-      payload: {
-        ...mockSearchState,
-        query: '',
-        view: SearchView.Landing,
-      },
+      payload: initialSearchState,
     })
   })
 

--- a/src/features/search/components/SearchBox/SearchBox.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.tsx
@@ -153,7 +153,7 @@ export const SearchBox: React.FunctionComponent<Props> = ({
         setQuery('')
         dispatch({
           type: 'SET_STATE',
-          payload: { ...searchState, view: SearchView.Landing, query: '' },
+          payload: initialSearchState,
         })
         break
       default:


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28852

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome |<video src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/a882f7e8-a558-46ee-945d-1854ae0b7dae" controls="controls"></video>|<video src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/b0b89494-26a0-4281-8a63-c90c54acd2c9" controls="controls">
</video>|



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
