### PR TITLE
(BSR) fix(script): fix script on deployment

### DIFF
--- a/scripts/create_and_push_tag_from_package_json_version.sh
+++ b/scripts/create_and_push_tag_from_package_json_version.sh
@@ -8,7 +8,7 @@ create_and_push_tag_from_package_json_version() {
   TAG_PREFIX="$1"
   source ./scripts/get_version.sh
   git tag --annotate "${TAG_PREFIX}${VERSION}" --message "v${VERSION}"
-  git push origin "${TAG_PREFIX}${VERSION}"
+  git push origin "${TAG_PREFIX}${VERSION}" --no-verify
 }
 
 # $1 is the tag used to trigger the ci deployment (see .circleci/config.yml)

--- a/scripts/deploy_new_production_version.sh
+++ b/scripts/deploy_new_production_version.sh
@@ -14,4 +14,4 @@ error() {
 git checkout "$1"
 
 git tag "prod-hard-deploy-$1"
-git push origin "prod-hard-deploy-$1"
+git push origin "prod-hard-deploy-$1" --no-verify


### PR DESCRIPTION
There was an issue with the deployment scripts due to the pre-push hook. When we were performing a hotfix with the script, it retained the master version of the JSON packages, triggering a rebase or requiring conflict resolution. Consequently, the patch deployment resulted in an error.