### PR TITLE
(PC-28917) fix(VenueMapPreview): correct ui when tags are in two lines

### DIFF
--- a/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
@@ -316,6 +316,7 @@ exports[`<AccessibilityFiltersModal /> should not reset filter when reset button
                   accessible={true}
                   collapsable={false}
                   focusable={true}
+                  hitSlop={8}
                   onClick={[Function]}
                   onResponderGrant={[Function]}
                   onResponderMove={[Function]}
@@ -1348,6 +1349,7 @@ exports[`<AccessibilityFiltersModal /> should not save modified disabilities whe
                   accessible={true}
                   collapsable={false}
                   focusable={true}
+                  hitSlop={8}
                   onClick={[Function]}
                   onResponderGrant={[Function]}
                   onResponderMove={[Function]}
@@ -2380,6 +2382,7 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                   accessible={true}
                   collapsable={false}
                   focusable={true}
+                  hitSlop={8}
                   onClick={[Function]}
                   onResponderGrant={[Function]}
                   onResponderMove={[Function]}
@@ -3412,6 +3415,7 @@ exports[`<AccessibilityFiltersModal /> should reset filter when reset button and
                   accessible={true}
                   collapsable={false}
                   focusable={true}
+                  hitSlop={8}
                   onClick={[Function]}
                   onResponderGrant={[Function]}
                   onResponderMove={[Function]}
@@ -4444,6 +4448,7 @@ exports[`<AccessibilityFiltersModal /> should save selected disabilities when se
                   accessible={true}
                   collapsable={false}
                   focusable={true}
+                  hitSlop={8}
                   onClick={[Function]}
                   onResponderGrant={[Function]}
                   onResponderMove={[Function]}

--- a/__snapshots__/features/search/components/SearchResultsContent/SearchResultsContent.web.test.tsx.web-snap
+++ b/__snapshots__/features/search/components/SearchResultsContent/SearchResultsContent.web.test.tsx.web-snap
@@ -292,7 +292,7 @@ exports[`SearchResultsContent component should render correctly 1`] = `
               >
                 <button
                   aria-label="Lieu culturel"
-                  class="c3 c4 sc-jlZhew c4"
+                  class="c3 c4 sc-cwHptR c4"
                   data-testid="Lieu culturel"
                   tabindex="0"
                   title="Lieu culturel"
@@ -313,7 +313,7 @@ exports[`SearchResultsContent component should render correctly 1`] = `
               >
                 <button
                   aria-label="Catégories"
-                  class="c3 c4 sc-jlZhew c4"
+                  class="c3 c4 sc-cwHptR c4"
                   data-testid="Catégories"
                   tabindex="0"
                   title="Catégories"
@@ -334,7 +334,7 @@ exports[`SearchResultsContent component should render correctly 1`] = `
               >
                 <button
                   aria-label="Prix"
-                  class="c3 c4 sc-jlZhew c4"
+                  class="c3 c4 sc-cwHptR c4"
                   data-testid="Prix"
                   tabindex="0"
                   title="Prix"
@@ -355,7 +355,7 @@ exports[`SearchResultsContent component should render correctly 1`] = `
               >
                 <button
                   aria-label="Dates & heures"
-                  class="c3 c4 sc-jlZhew c4"
+                  class="c3 c4 sc-cwHptR c4"
                   data-testid="Dates & heures"
                   tabindex="0"
                   title="Dates & heures"
@@ -753,7 +753,7 @@ exports[`SearchResultsContent component should render correctly 1`] = `
             >
               <button
                 aria-label="Lieu culturel"
-                class="c3 c4 sc-jlZhew c4"
+                class="c3 c4 sc-cwHptR c4"
                 data-testid="Lieu culturel"
                 tabindex="0"
                 title="Lieu culturel"
@@ -774,7 +774,7 @@ exports[`SearchResultsContent component should render correctly 1`] = `
             >
               <button
                 aria-label="Catégories"
-                class="c3 c4 sc-jlZhew c4"
+                class="c3 c4 sc-cwHptR c4"
                 data-testid="Catégories"
                 tabindex="0"
                 title="Catégories"
@@ -795,7 +795,7 @@ exports[`SearchResultsContent component should render correctly 1`] = `
             >
               <button
                 aria-label="Prix"
-                class="c3 c4 sc-jlZhew c4"
+                class="c3 c4 sc-cwHptR c4"
                 data-testid="Prix"
                 tabindex="0"
                 title="Prix"
@@ -816,7 +816,7 @@ exports[`SearchResultsContent component should render correctly 1`] = `
             >
               <button
                 aria-label="Dates & heures"
-                class="c3 c4 sc-jlZhew c4"
+                class="c3 c4 sc-cwHptR c4"
                 data-testid="Dates & heures"
                 tabindex="0"
                 title="Dates & heures"

--- a/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
@@ -257,6 +257,7 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
                 accessible={true}
                 collapsable={false}
                 focusable={true}
+                hitSlop={8}
                 onClick={[Function]}
                 onResponderGrant={[Function]}
                 onResponderMove={[Function]}
@@ -2891,6 +2892,7 @@ exports[`<CategoriesModal/> new book native categories section should display th
                 accessible={true}
                 collapsable={false}
                 focusable={true}
+                hitSlop={8}
                 onClick={[Function]}
                 onResponderGrant={[Function]}
                 onResponderMove={[Function]}

--- a/__snapshots__/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx.native-snap
@@ -257,6 +257,7 @@ exports[`<DatesHoursModal/> should render modal correctly after animation and wi
                 accessible={true}
                 collapsable={false}
                 focusable={true}
+                hitSlop={8}
                 onClick={[Function]}
                 onResponderGrant={[Function]}
                 onResponderMove={[Function]}

--- a/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
@@ -257,6 +257,7 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
                 accessible={true}
                 collapsable={false}
                 focusable={true}
+                hitSlop={8}
                 onClick={[Function]}
                 onResponderGrant={[Function]}
                 onResponderMove={[Function]}

--- a/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
@@ -257,6 +257,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                 accessible={true}
                 collapsable={false}
                 focusable={true}
+                hitSlop={8}
                 onClick={[Function]}
                 onResponderGrant={[Function]}
                 onResponderMove={[Function]}

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -117,12 +117,23 @@ exports[`<Venue /> should match snapshot 1`] = `
                 {
                   "flexDirection": "row",
                   "flexWrap": "wrap",
+                  "gap": 8,
                   "maxHeight": 56,
                   "overflow": "hidden",
                 },
               ]
             }
             testID="tagsContainer"
+          />
+          <View
+            numberOfSpaces={4}
+            style={
+              [
+                {
+                  "height": 16,
+                },
+              ]
+            }
           />
           <Text
             accessibilityLabel="Nom du lieu : Le Petit Rintintin 1"

--- a/src/features/search/components/SearchCustomModalHeader.tsx
+++ b/src/features/search/components/SearchCustomModalHeader.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native'
 
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { useWhiteStatusBar } from 'libs/hooks/useWhiteStatusBar'
+import { styledButton } from 'ui/components/buttons/styledButton'
 import { BackButton } from 'ui/components/headers/BackButton'
 import { CloseButton } from 'ui/components/headers/CloseButton'
 import { getSpacing } from 'ui/theme'
@@ -42,7 +43,9 @@ export const SearchCustomModalHeader: React.FC<Props> = ({
         </ButtonContainer>
         <Title nativeID={titleId}>{title}</Title>
         <ButtonContainer positionInHeader="right" testID="close-button-container">
-          {!!shouldDisplayCloseButton && <CloseButton onClose={onClose} color={ColorsEnum.BLACK} />}
+          {!!shouldDisplayCloseButton && (
+            <StyledCloseButton onClose={onClose} color={ColorsEnum.BLACK} />
+          )}
         </ButtonContainer>
       </HeaderContent>
     </Header>
@@ -83,3 +86,8 @@ const Title = styled.Text.attrs(() => ({
   textAlign: 'center',
   color: theme.colors.black,
 }))
+
+const StyledCloseButton = styledButton(CloseButton)({
+  width: getSpacing(10),
+  height: getSpacing(10),
+})

--- a/src/features/venue/components/VenueBody/VenueBody.tsx
+++ b/src/features/venue/components/VenueBody/VenueBody.tsx
@@ -66,6 +66,7 @@ export const VenueBody: FunctionComponent<Props> = ({
         <Spacer.Column numberOfSpaces={6} />
         <MarginContainer>
           <InformationTags tags={venueTags} />
+          <Spacer.Column numberOfSpaces={4} />
           <VenueTitle
             accessibilityLabel={`Nom du lieu\u00a0: ${venueName}`}
             adjustsFontSizeToFit

--- a/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.tsx
+++ b/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.tsx
@@ -17,7 +17,6 @@ type Props = {
 } & ComponentProps<typeof InternalTouchableLink>
 
 const VENUE_THUMBNAIL_SIZE = getSpacing(12)
-const CLOSE_BUTTON_HIT_SLOP = getSpacing(2)
 
 export const VenueMapPreview: FunctionComponent<Props> = ({
   venueName,
@@ -34,7 +33,6 @@ export const VenueMapPreview: FunctionComponent<Props> = ({
         <StyledCloseButton onClose={onClose} />
       </Row>
       <Spacer.Column numberOfSpaces={2} />
-
       <VenuePreview
         venueName={venueName}
         address={address}
@@ -68,7 +66,7 @@ const Row = styled.View({
 })
 
 const StyledCloseButton = styledButton(CloseButton)({
-  top: -CLOSE_BUTTON_HIT_SLOP,
+  justifyContent: 'flex-start',
 })
 
 const StyledInformationTags = styled(InformationTags)({

--- a/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.tsx
+++ b/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.tsx
@@ -6,7 +6,7 @@ import { CloseButton } from 'ui/components/headers/CloseButton'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { VenuePreview } from 'ui/components/VenuePreview/VenuePreview'
 import { InformationTags } from 'ui/InformationTags/InformationTags'
-import { getShadow, getSpacing } from 'ui/theme'
+import { getShadow, getSpacing, Spacer } from 'ui/theme'
 
 type Props = {
   venueName: string
@@ -30,9 +30,11 @@ export const VenueMapPreview: FunctionComponent<Props> = ({
   return (
     <Container {...touchableProps}>
       <Row>
-        <InformationTags tags={tags} />
+        <StyledInformationTags tags={tags} />
         <StyledCloseButton onClose={onClose} />
       </Row>
+      <Spacer.Column numberOfSpaces={2} />
+
       <VenuePreview
         venueName={venueName}
         address={address}
@@ -66,7 +68,9 @@ const Row = styled.View({
 })
 
 const StyledCloseButton = styledButton(CloseButton)({
-  position: 'absolute',
   top: -CLOSE_BUTTON_HIT_SLOP,
-  right: -CLOSE_BUTTON_HIT_SLOP,
+})
+
+const StyledInformationTags = styled(InformationTags)({
+  flexShrink: 1,
 })

--- a/src/ui/InformationTags/InformationTags.tsx
+++ b/src/ui/InformationTags/InformationTags.tsx
@@ -9,17 +9,17 @@ interface Props {
   tagsLines?: number
 }
 
-const MARGIN_BOTTOM_TAGS = getSpacing(2)
+const TAG_GAP = getSpacing(2)
 
 // This component is used to display tags on a number of lines defined as a parameter.
 // If the number of tags to display exceeds this limit, it will not be visible
-export function InformationTags({ tags, tagsLines = 2 }: Readonly<Props>) {
-  const maxContainerHeight = TAG_HEIGHT * tagsLines + MARGIN_BOTTOM_TAGS * (tagsLines - 1)
+export function InformationTags({ tags, tagsLines = 2, ...props }: Readonly<Props>) {
+  const maxContainerHeight = TAG_HEIGHT * tagsLines + TAG_GAP * (tagsLines - 1)
 
   return (
-    <Container maxHeight={maxContainerHeight} testID="tagsContainer">
+    <Container maxHeight={maxContainerHeight} testID="tagsContainer" {...props}>
       {tags.map((tag) => (
-        <StyledTag label={tag} key={tag} />
+        <Tag label={tag} key={tag} />
       ))}
     </Container>
   )
@@ -30,9 +30,5 @@ const Container = styled.View<{ maxHeight: number }>(({ maxHeight }) => ({
   flexWrap: 'wrap',
   overflow: 'hidden',
   maxHeight,
+  gap: TAG_GAP,
 }))
-
-const StyledTag = styled(Tag)({
-  marginRight: getSpacing(2),
-  marginBottom: MARGIN_BOTTOM_TAGS,
-})

--- a/src/ui/components/headers/CloseButton.tsx
+++ b/src/ui/components/headers/CloseButton.tsx
@@ -5,18 +5,23 @@ import { styledButton } from 'ui/components/buttons/styledButton'
 import { HiddenAccessibleText } from 'ui/components/HiddenAccessibleText'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { Close as DefaultClose } from 'ui/svg/icons/Close'
-import { getSpacing } from 'ui/theme'
 // eslint-disable-next-line no-restricted-imports
 import { ColorsEnum } from 'ui/theme/colors'
 
 interface HeaderIconProps {
+  hitSlop?: number
   onClose?: () => void
   color?: ColorsEnum
 }
 
-export const CloseButton: React.FC<HeaderIconProps> = ({ color, onClose, ...props }) => {
+export const CloseButton: React.FC<HeaderIconProps> = ({
+  color,
+  onClose,
+  hitSlop = 8,
+  ...props
+}) => {
   return (
-    <StyledTouchable onPress={onClose} accessibilityLabel="Fermer" {...props}>
+    <StyledTouchable onPress={onClose} accessibilityLabel="Fermer" hitSlop={hitSlop} {...props}>
       <Close testID="icon-close" color={color} />
       <HiddenAccessibleText>Retour</HiddenAccessibleText>
     </StyledTouchable>
@@ -24,8 +29,6 @@ export const CloseButton: React.FC<HeaderIconProps> = ({ color, onClose, ...prop
 }
 
 const StyledTouchable = styledButton(Touchable)({
-  width: getSpacing(10),
-  height: getSpacing(10),
   justifyContent: 'center',
   alignItems: 'center',
 })

--- a/src/ui/components/headers/PageHeaderSecondary.tsx
+++ b/src/ui/components/headers/PageHeaderSecondary.tsx
@@ -52,7 +52,7 @@ export const PageHeaderSecondary: React.FC<Props> = ({
             <Title nativeID={titleID}>{title}</Title>
             <ButtonContainer positionInHeader="right" testID="close-button-container">
               {!!shouldDisplayCloseButton && (
-                <CloseButton onClose={onClose} color={ColorsEnum.WHITE} />
+                <StyledCloseButton onClose={onClose} color={ColorsEnum.WHITE} />
               )}
             </ButtonContainer>
           </Row>
@@ -107,4 +107,9 @@ const Header = styled.View.attrs<{ children: React.ReactNode }>({
   accessibilityRole: AccessibilityRole.HEADER,
 })({
   width: '100%',
+})
+
+const StyledCloseButton = styled(CloseButton)({
+  width: getSpacing(10),
+  height: getSpacing(10),
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28917

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |<img width="428" alt="Capture d’écran 2024-03-29 à 14 11 00" src="https://github.com/pass-culture/pass-culture-app-native/assets/62058919/128cdbf6-9a65-4863-8fee-743d69fbc364">![Capture d’écran 2024-03-29 à 16 46 30](https://github.com/pass-culture/pass-culture-app-native/assets/62058919/8c2c8010-a2fa-4f51-be72-a94f16a98c76)|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
