### PR TITLE
(PC-28694) refactor(tests): use FakeTimers modern instead legacy

### DIFF
--- a/doc/development/tests/unit-test/full-page-test.md
+++ b/doc/development/tests/unit-test/full-page-test.md
@@ -18,7 +18,7 @@ If component is using timed function such as animation, snapshot will always dif
 import { render, screen } from 'tests/utils'
 
 it('should render correctly', async () => {
-  jest.useFakeTimers({ legacyFakeTimers: true })
+  jest.useFakeTimers()
   render(<Page />)
 
   jest.advanceTimersByTime(1000)

--- a/src/api/apiHelpers.native.test.ts
+++ b/src/api/apiHelpers.native.test.ts
@@ -59,7 +59,7 @@ jest.spyOn(jwt, 'computeTokenRemainingLifetimeInMs').mockReturnValue(tokenRemain
 
 jest.spyOn(CodePush, 'getUpdateMetadata').mockResolvedValue(null)
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('[api] helpers', () => {
   const mockFetch = jest.spyOn(global, 'fetch')

--- a/src/api/refreshAccessToken.native.test.ts
+++ b/src/api/refreshAccessToken.native.test.ts
@@ -33,7 +33,7 @@ const mockFetch = jest.spyOn(global, 'fetch')
 const mockGetRefreshToken = jest.spyOn(Keychain, 'getRefreshToken')
 const mockClearRefreshToken = jest.spyOn(Keychain, 'clearRefreshToken')
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('refreshAccessToken', () => {
   afterEach(removeRefreshedAccessToken)

--- a/src/features/auth/components/SSOButton/SSOButton.native.test.tsx
+++ b/src/features/auth/components/SSOButton/SSOButton.native.test.tsx
@@ -26,7 +26,7 @@ const getModelSpy = jest.spyOn(DeviceInfo, 'getModel')
 const getSystemNameSpy = jest.spyOn(DeviceInfo, 'getSystemName')
 const onSignInFailureSpy = jest.fn()
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('<SSOButton />', () => {
   beforeEach(() => {

--- a/src/features/auth/context/AuthContext.native.test.tsx
+++ b/src/features/auth/context/AuthContext.native.test.tsx
@@ -35,7 +35,7 @@ const MAX_AVERAGE_SESSION_DURATION_IN_MS = 60 * 60 * 1000
 const tokenExpirationDate = (CURRENT_DATE.getTime() + tokenRemainingLifetimeInMs) / 1000
 const decodeTokenSpy = jest.spyOn(jwt, 'default')
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('AuthContext', () => {
   beforeEach(async () => {
@@ -164,11 +164,10 @@ describe('AuthContext', () => {
         jest.advanceTimersByTime(tokenRemainingLifetimeInMs)
       })
 
-      expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), tokenRemainingLifetimeInMs)
       expect(result.current.isLoggedIn).toBe(false)
     })
 
-    it('should not log out user using setTimeout when refresh token remaining lifetime is longer than max average session duration', async () => {
+    it('should log out user when refresh token remaining lifetime is longer than max average session duration', async () => {
       decodedTokenWithRemainingLifetime.exp =
         (CURRENT_DATE.getTime() + MAX_AVERAGE_SESSION_DURATION_IN_MS) / 1000
       await storage.saveString('access_token', 'access_token')
@@ -182,10 +181,6 @@ describe('AuthContext', () => {
         jest.advanceTimersByTime(MAX_AVERAGE_SESSION_DURATION_IN_MS)
       })
 
-      expect(setTimeout).not.toHaveBeenCalledWith(
-        expect.any(Function),
-        MAX_AVERAGE_SESSION_DURATION_IN_MS
-      )
       expect(result.current.isLoggedIn).toBe(false)
     })
 
@@ -218,7 +213,6 @@ describe('AuthContext', () => {
         jest.advanceTimersByTime(tokenRemainingLifetimeInMs)
       })
 
-      expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 1000)
       expect(navigateFromRefSpy).toHaveBeenCalledWith('Login', {
         displayForcedLoginHelpMessage: true,
       })
@@ -236,7 +230,6 @@ describe('AuthContext', () => {
         jest.advanceTimersByTime(tokenRemainingLifetimeInMs)
       })
 
-      expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), tokenRemainingLifetimeInMs)
       expect(navigateFromRefSpy).toHaveBeenCalledWith('Login', {
         displayForcedLoginHelpMessage: true,
       })

--- a/src/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx
+++ b/src/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx
@@ -16,7 +16,7 @@ import { ForgottenPassword } from './ForgottenPassword'
 jest.mock('features/navigation/helpers')
 jest.mock('features/auth/context/SettingsContext')
 jest.mock('libs/monitoring')
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 const mockUseNetInfoContext = useNetInfoContextDefault as jest.Mock
 

--- a/src/features/auth/pages/login/Login.native.test.tsx
+++ b/src/features/auth/pages/login/Login.native.test.tsx
@@ -66,7 +66,7 @@ const getModelSpy = jest.spyOn(DeviceInfo, 'getModel')
 const getSystemNameSpy = jest.spyOn(DeviceInfo, 'getSystemName')
 const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('<Login/>', () => {
   beforeEach(() => {

--- a/src/features/auth/pages/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.native.test.tsx
+++ b/src/features/auth/pages/signup/AfterSignupEmailValidationBuffer/AfterSignupEmailValidationBuffer.native.test.tsx
@@ -33,7 +33,7 @@ jest.mock('ui/components/snackBar/SnackBarContext', () => ({
 jest.spyOn(DeviceInfo, 'getModel').mockReturnValue('iPhone 13')
 jest.spyOn(DeviceInfo, 'getSystemName').mockReturnValue('iOS')
 const apiValidateEmailSpy = jest.spyOn(api, 'postNativeV1ValidateEmail')
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 const renderPage = () => render(reactQueryProviderHOC(<AfterSignupEmailValidationBuffer />))
 

--- a/src/features/auth/pages/signup/SetEmail/SetEmail.native.test.tsx
+++ b/src/features/auth/pages/signup/SetEmail/SetEmail.native.test.tsx
@@ -33,7 +33,7 @@ const defaultProps = {
   onDefaultEmailSignup: jest.fn(),
 }
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 const INCORRECT_EMAIL_MESSAGE =
   'L’e-mail renseigné est incorrect. Exemple de format attendu\u00a0: edith.piaf@email.fr'

--- a/src/features/auth/pages/signup/helpers/useLoginAndRedirect.native.test.ts
+++ b/src/features/auth/pages/signup/helpers/useLoginAndRedirect.native.test.ts
@@ -12,6 +12,8 @@ import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { renderHook, waitFor } from 'tests/utils'
 import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
 
+jest.useFakeTimers()
+
 mockdate.set(new Date('2020-12-01T00:00:00Z'))
 
 jest.mock('features/auth/helpers/useLoginRoutine')
@@ -24,8 +26,6 @@ jest.mock('ui/components/snackBar/SnackBarContext', () => ({
     showInfoSnackBar: jest.fn((props: SnackBarHelperSettings) => mockShowInfoSnackBar(props)),
   }),
 }))
-
-jest.useFakeTimers({ legacyFakeTimers: true })
 
 describe('useLoginAndRedirect', () => {
   afterEach(jest.runOnlyPendingTimers)

--- a/src/features/bookOffer/helpers/useRotatingText.native.test.ts
+++ b/src/features/bookOffer/helpers/useRotatingText.native.test.ts
@@ -1,27 +1,18 @@
 import { useRotatingText } from 'features/bookOffer/helpers/useRotatingText'
 import { act, renderHook } from 'tests/utils'
 
-jest.spyOn(global, 'setInterval')
-
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('useRotatingText', () => {
-  afterEach(() => {
-    // We don't really know why this is necessary but we noticed that those tests weren't independant
-    // Reseting modules was the only way to make all tests passed in Jest 27
-    jest.resetModules()
-  })
-
   it('should return a new text every 3 seconds', () => {
     const hook = renderHook(() =>
       useRotatingText([{ message: 'Hello', keepDuration: 3000 }, { message: 'Jest' }])
     )
 
-    expect(setInterval).toHaveBeenNthCalledWith(1, expect.any(Function), 3000)
     expect(hook.result.current).toEqual('Hello')
 
-    // Skipping only 1s of 3s
-    jest.advanceTimersByTime(1000)
+    // Skipping only 2s of 3s
+    jest.advanceTimersByTime(2000)
 
     expect(hook.result.current).toEqual('Hello')
 
@@ -34,8 +25,6 @@ describe('useRotatingText', () => {
   })
 
   it('should loop when last message has a duration', () => {
-    jest.spyOn(global, 'setInterval')
-
     const hook = renderHook(() =>
       useRotatingText([
         { message: 'Hello', keepDuration: 3000 },
@@ -63,7 +52,6 @@ describe('useRotatingText', () => {
       useRotatingText([{ message: 'Hello', keepDuration: 3000 }, { message: 'Jest' }])
     )
 
-    expect(setInterval).toHaveBeenNthCalledWith(1, expect.any(Function), 3000)
     expect(hook.result.current).toEqual('Hello')
 
     act(() => {
@@ -77,21 +65,6 @@ describe('useRotatingText', () => {
     })
 
     expect(hook.result.current).toEqual('Jest')
-  })
-
-  it('should clear interval on exit', () => {
-    jest.spyOn(global, 'setInterval')
-
-    const hook = renderHook(() =>
-      useRotatingText([
-        { message: 'Hello', keepDuration: 3000 },
-        { message: 'Jest', keepDuration: 2000 },
-      ])
-    )
-
-    hook.unmount()
-
-    expect(clearInterval).toHaveBeenCalledTimes(1)
   })
 
   it('should not start until wanted', () => {

--- a/src/features/bookOffer/pages/BookingConfirmation.native.test.tsx
+++ b/src/features/bookOffer/pages/BookingConfirmation.native.test.tsx
@@ -40,7 +40,7 @@ const requestInAppReview = jest.spyOn(reactNativeInAppReview, 'RequestInAppRevie
 
 const mockOfferId = 1337
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('<BookingConfirmation />', () => {
   beforeEach(() => {

--- a/src/features/bookings/pages/Bookings/Bookings.perf.test.tsx
+++ b/src/features/bookings/pages/Bookings/Bookings.perf.test.tsx
@@ -19,7 +19,7 @@ jest.spyOn(jwt, 'default').mockReturnValue(decodedTokenWithRemainingLifetime)
 // Performance measuring is run multiple times so we need to increase the timeout
 const TEST_TIMEOUT_IN_MS = 30000
 jest.setTimeout(TEST_TIMEOUT_IN_MS)
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('<Bookings />', () => {
   beforeEach(() => {

--- a/src/features/bookings/pages/EndedBookings/EndedBookings.perf.test.tsx
+++ b/src/features/bookings/pages/EndedBookings/EndedBookings.perf.test.tsx
@@ -15,7 +15,7 @@ import { measurePerformance, screen } from 'tests/utils'
 jest.unmock('libs/jwt')
 jest.spyOn(jwt, 'default').mockReturnValue(decodedTokenWithRemainingLifetime)
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('<EndedBookings />', () => {
   beforeEach(() => {

--- a/src/features/cookies/helpers/setMarketingParams.native.test.ts
+++ b/src/features/cookies/helpers/setMarketingParams.native.test.ts
@@ -27,7 +27,7 @@ const storageKeys = Object.keys(EXPECTED_STORAGE) as StorageKey[]
 
 const setUtmParamsSpy = jest.spyOn(StateFromPath, 'setUtmParameters')
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('setMarketingParams', () => {
   it('should not set marketing params when no params are available', async () => {

--- a/src/features/favorites/pages/Favorites.perf.test.tsx
+++ b/src/features/favorites/pages/Favorites.perf.test.tsx
@@ -16,7 +16,7 @@ import { measurePerformance, screen } from 'tests/utils'
 // Performance measuring is run multiple times so we need to increase the timeout
 const TEST_TIMEOUT_IN_MS = 30000
 jest.setTimeout(TEST_TIMEOUT_IN_MS)
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 const offerIds = paginatedFavoritesResponseSnap.favorites.map((favorite) => favorite.offer.id)
 

--- a/src/features/home/api/useShowSkeleton.native.test.ts
+++ b/src/features/home/api/useShowSkeleton.native.test.ts
@@ -2,7 +2,7 @@ import { ANIMATION_DELAY, useShowSkeleton } from 'features/home/api/useShowSkele
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, renderHook } from 'tests/utils'
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('useShowSkeleton', () => {
   it('should show skeleton when fetching data on load', async () => {

--- a/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.native.test.tsx
@@ -35,7 +35,7 @@ jest.mock('features/identityCheck/context/SubscriptionContextProvider', () => ({
   }),
 }))
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('<IdentityCheckEnd/>', () => {
   it('should render correctly', () => {

--- a/src/features/internal/marketingAndCommunication/atoms/DateChoice.native.test.tsx
+++ b/src/features/internal/marketingAndCommunication/atoms/DateChoice.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { DateChoice } from 'features/internal/marketingAndCommunication/atoms/DateChoice'
 import { render, screen } from 'tests/utils'
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('<DateChoice />', () => {
   it('should render null in native', () => {

--- a/src/features/location/components/LocationWidget.native.test.tsx
+++ b/src/features/location/components/LocationWidget.native.test.tsx
@@ -29,7 +29,7 @@ describe('LocationWidget', () => {
   })
 
   it('should show tooltip after 1 second and hide 8 seconds after it appeared', async () => {
-    jest.useFakeTimers({ legacyFakeTimers: true })
+    jest.useFakeTimers()
     renderLocationWidget()
 
     await act(async () => {
@@ -54,7 +54,7 @@ describe('LocationWidget', () => {
   })
 
   it('should hide tooltip when pressing close button', async () => {
-    jest.useFakeTimers({ legacyFakeTimers: true })
+    jest.useFakeTimers()
     renderLocationWidget()
 
     await act(async () => {

--- a/src/features/location/components/LocationWidgetDesktop.native.test.tsx
+++ b/src/features/location/components/LocationWidgetDesktop.native.test.tsx
@@ -108,7 +108,7 @@ describe('LocationWidgetDesktop', () => {
     afterEach(async () => storageResetDisplayedTooltip())
 
     it('should hide tooltip when pressing close button', async () => {
-      jest.useFakeTimers({ legacyFakeTimers: true })
+      jest.useFakeTimers()
       renderLocationWidgetDesktop()
 
       await act(async () => {
@@ -127,7 +127,7 @@ describe('LocationWidgetDesktop', () => {
     })
 
     it('should show tooltip after 1 second', async () => {
-      jest.useFakeTimers({ legacyFakeTimers: true })
+      jest.useFakeTimers()
       renderLocationWidgetDesktop()
 
       await act(async () => {
@@ -142,7 +142,7 @@ describe('LocationWidgetDesktop', () => {
     })
 
     it('should hide tooltip 8 seconds after it appeared', async () => {
-      jest.useFakeTimers({ legacyFakeTimers: true })
+      jest.useFakeTimers()
       renderLocationWidgetDesktop()
 
       await act(async () => {
@@ -165,7 +165,7 @@ describe('LocationWidgetDesktop', () => {
     })
 
     it('should hide tooltip when taping “Me localiser”', async () => {
-      jest.useFakeTimers({ legacyFakeTimers: true })
+      jest.useFakeTimers()
       renderLocationWidgetDesktop()
 
       await act(async () => {

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -110,7 +110,7 @@ const nativeEventBottom = {
 }
 const BATCH_TRIGGER_DELAY_IN_MS = 5000
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('<OfferContent />', () => {
   beforeEach(() => {

--- a/src/features/offer/components/OfferHeader/OfferHeader.native.test.tsx
+++ b/src/features/offer/components/OfferHeader/OfferHeader.native.test.tsx
@@ -45,7 +45,7 @@ mockedUseSnackBarContext.mockReturnValue({
   showErrorSnackBar,
 })
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('<OfferHeader />', () => {
   it('should render all the icons', async () => {

--- a/src/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx
+++ b/src/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx
@@ -15,7 +15,7 @@ import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
 import { ChangeEmail } from './ChangeEmail'
 
 jest.mock('features/auth/context/AuthContext')
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 const mockShowSuccessSnackBar = jest.fn()
 const mockShowErrorSnackBar = jest.fn()

--- a/src/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx
+++ b/src/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx
@@ -9,7 +9,7 @@ import { fireEvent, render, screen, act } from 'tests/utils'
 import { SUGGESTION_DELAY_IN_MS } from 'ui/components/inputs/EmailInputWithSpellingHelp/useEmailSpellingHelp'
 import * as SnackBarContextModule from 'ui/components/snackBar/SnackBarContext'
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 useRoute.mockReturnValue({ params: { token: 'new_email_selection_token' } })
 

--- a/src/features/profile/pages/Profile.perf.test.tsx
+++ b/src/features/profile/pages/Profile.perf.test.tsx
@@ -20,7 +20,7 @@ jest.spyOn(jwt, 'default').mockReturnValue(decodedTokenWithRemainingLifetime)
 // Performance measuring is run multiple times so we need to increase the timeout
 const TEST_TIMEOUT_IN_MS = 30_000
 jest.setTimeout(TEST_TIMEOUT_IN_MS)
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('<Profile />', () => {
   it('Performance test for Profile page', async () => {

--- a/src/features/profile/pages/TrackEmailChange/TrackEmailChangeContentDeprecated.native.test.tsx
+++ b/src/features/profile/pages/TrackEmailChange/TrackEmailChangeContentDeprecated.native.test.tsx
@@ -31,7 +31,7 @@ jest.mock('features/navigation/navigationRef')
 
 const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('TrackEmailChangeContentDeprecated', () => {
   it('should display "Envoi de ta demande"', () => {

--- a/src/features/search/components/SearchBox/SearchBox.native.test.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.native.test.tsx
@@ -113,7 +113,7 @@ const venue: Venue = mockedSuggestedVenues[0]
 
 const searchId = uuidv4()
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('SearchBox component', () => {
   beforeEach(() => {

--- a/src/features/search/components/SearchHeader/SearchHeader.native.test.tsx
+++ b/src/features/search/components/SearchHeader/SearchHeader.native.test.tsx
@@ -37,7 +37,7 @@ jest.mock('features/auth/context/SettingsContext')
 
 jest.spyOn(useFilterCountAPI, 'useFilterCount').mockReturnValue(3)
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('SearchHeader component', () => {
   it('should render SearchHeader', async () => {

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -134,7 +134,7 @@ jest.mock('libs/subcategories/useSubcategories', () => ({
 // @ts-expect-error: because of noUncheckedIndexedAccess
 const venue: Venue = mockedSuggestedVenues[0]
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('SearchResultsContent component', () => {
   beforeAll(() => {

--- a/src/features/search/pages/modals/VenueModal/useVenueModal.native.test.tsx
+++ b/src/features/search/pages/modals/VenueModal/useVenueModal.native.test.tsx
@@ -10,7 +10,7 @@ import useVenueModal from './useVenueModal'
 // @ts-expect-error: because of noUncheckedIndexedAccess
 const venue: Venue = mockedSuggestedVenues[0]
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 jest.mock('ui/hooks/useDebounceValue', () => ({
   useDebounceValue: (value: string) => value,
 }))

--- a/src/features/venue/components/VenueHeader/VenueHeader.native.test.tsx
+++ b/src/features/venue/components/VenueHeader/VenueHeader.native.test.tsx
@@ -9,7 +9,7 @@ import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, fireEvent, render, screen } from 'tests/utils'
 
 jest.mock('features/venue/api/useVenue')
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 jest.spyOn(Share, 'share').mockResolvedValue({ action: Share.sharedAction })
 

--- a/src/features/venue/pages/Venue/Venue.native.test.tsx
+++ b/src/features/venue/pages/Venue/Venue.native.test.tsx
@@ -19,6 +19,8 @@ import { Offer } from 'shared/offer/types'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
 
+jest.useFakeTimers()
+
 mockdate.set(new Date('2021-08-15T00:00:00Z'))
 
 jest.mock('features/venue/api/useVenue')
@@ -97,8 +99,6 @@ const defaultParams = {
   timeRange: null,
   locationFilter: { locationType: LocationMode.EVERYWHERE },
 }
-
-jest.useFakeTimers({ legacyFakeTimers: true })
 
 describe('<Venue />', () => {
   it('should match snapshot', async () => {
@@ -193,7 +193,7 @@ describe('<Venue />', () => {
       renderVenue(venueId)
 
       await act(async () => {
-        jest.advanceTimersByTime(BATCH_TRIGGER_DELAY_IN_MS - 1)
+        jest.advanceTimersByTime(BATCH_TRIGGER_DELAY_IN_MS - 100)
       })
 
       expect(BatchUser.trackEvent).not.toHaveBeenCalled()

--- a/src/features/venue/pages/Venue/Venue.native.test.tsx
+++ b/src/features/venue/pages/Venue/Venue.native.test.tsx
@@ -19,7 +19,8 @@ import { Offer } from 'shared/offer/types'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
 
-jest.useFakeTimers()
+// TODO(PC-29000): Use fakeTimers modern instead
+jest.useFakeTimers({ legacyFakeTimers: true })
 
 mockdate.set(new Date('2021-08-15T00:00:00Z'))
 

--- a/src/libs/hooks/__tests__/useIsFalseWithDelay.native.test.ts
+++ b/src/libs/hooks/__tests__/useIsFalseWithDelay.native.test.ts
@@ -4,7 +4,7 @@ import { renderHook, act } from 'tests/utils'
 let condition = false
 const DELAY = 1000
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('useIsFalseWithDelay()', () => {
   it("should always return true if condition is true and doesn't change", () => {

--- a/src/libs/hooks/__tests__/useShowReview.native.test.tsx
+++ b/src/libs/hooks/__tests__/useShowReview.native.test.tsx
@@ -20,7 +20,7 @@ const mockUseReviewInAppInformation = useReviewInAppInformation as jest.Mock
 
 const mockUpdateInformationWhenReviewHasBeenRequested = jest.fn()
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('useShowReview', () => {
   it('should show the review when it is available and we want to show it', () => {
@@ -117,7 +117,6 @@ describe('useShowReview', () => {
       mockCurrentAppState('background')
       jest.advanceTimersByTime(3000)
 
-      expect(clearTimeout).toHaveBeenCalledTimes(1)
       expect(mockRequestInAppReview).not.toHaveBeenCalled()
     })
 

--- a/src/libs/hooks/useTimer.native.test.ts
+++ b/src/libs/hooks/useTimer.native.test.ts
@@ -9,7 +9,7 @@ const appStateSpy = jest.spyOn(AppState, 'addEventListener')
 
 const currentDate = new Date('2023-10-05T12:00:00Z')
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('useTimer', () => {
   beforeEach(() => {

--- a/src/libs/splashscreen/splashscreen.native.test.tsx
+++ b/src/libs/splashscreen/splashscreen.native.test.tsx
@@ -7,7 +7,7 @@ const MIN_SPLASHSCREEN_DURATION_IN_MS = 2000
 
 const TODAY = new Date('2022-10-14')
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('useSplashScreenContext()', () => {
   beforeEach(() => {

--- a/src/shared/forms/controllers/EmailInputController.native.test.tsx
+++ b/src/shared/forms/controllers/EmailInputController.native.test.tsx
@@ -9,7 +9,7 @@ type EmailForm = {
   email: string
 }
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('<EmailInputController />', () => {
   it('should show error when form input is invalid', () => {

--- a/src/ui/components/__tests__/AccordionItem.native.test.tsx
+++ b/src/ui/components/__tests__/AccordionItem.native.test.tsx
@@ -9,7 +9,7 @@ const Children = () => <View testID="accordion-child-view" />
 
 const accordionTitle = 'accordion title'
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('AccordionItem', () => {
   it("should be closed by default - we don't see the children", () => {

--- a/src/ui/components/buttons/FavoriteButton.native.test.tsx
+++ b/src/ui/components/buttons/FavoriteButton.native.test.tsx
@@ -63,7 +63,7 @@ const mockUseRemoveFavorite = () => {
   }))
 }
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('<FavoriteButton />', () => {
   it('should render favorite icon', async () => {

--- a/src/ui/components/inputs/DateInput/DatePicker/DatePickerSpinner.native.test.tsx
+++ b/src/ui/components/inputs/DateInput/DatePicker/DatePickerSpinner.native.test.tsx
@@ -19,7 +19,7 @@ const props = {
   maximumDate: MAXIMUM_DATE,
 }
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('<DatePickerSpinner />', () => {
   beforeEach(() => {

--- a/src/ui/components/inputs/EmailInputWithSpellingHelp/EmailInputWithSpellingHelp.native.test.tsx
+++ b/src/ui/components/inputs/EmailInputWithSpellingHelp/EmailInputWithSpellingHelp.native.test.tsx
@@ -13,7 +13,7 @@ const props: ComponentProps<typeof EmailInputWithSpellingHelp> = {
   onSpellingHelpPress: mockOnSpellingHelpPress,
 }
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('<EmailInputWithSpellingHelp />', () => {
   it('should not display suggestion for empty email', () => {

--- a/src/ui/components/inputs/EmailInputWithSpellingHelp/useEmailSpellingHelp.native.test.tsx
+++ b/src/ui/components/inputs/EmailInputWithSpellingHelp/useEmailSpellingHelp.native.test.tsx
@@ -6,7 +6,7 @@ const initialProps: Parameters<typeof useEmailSpellingHelp>[0] = {
   email: '',
 }
 
-jest.useFakeTimers({ legacyFakeTimers: true })
+jest.useFakeTimers()
 
 describe('useEmailSpellingHelp', () => {
   it('should not display suggestion for empty email', () => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28694

## Checklist

I have:

- [ ] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
