### PR TITLE
(PC-28570) feat(SubscribeButton): Handle tooltip display

### DIFF
--- a/scripts/dead_code_snapshot.txt
+++ b/scripts/dead_code_snapshot.txt
@@ -1,2 +1,1 @@
 src/ui/hooks/useElementWidth.ts:4 - useElementWidth
-src/features/home/components/SubscribeButton.tsx:9 - SubscribeButton

--- a/src/features/home/components/SubscribeButtonWithTooltip.native.test.tsx
+++ b/src/features/home/components/SubscribeButtonWithTooltip.native.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+import { SubscribeButtonWithTooltip } from 'features/home/components/SubscribeButtonWithTooltip'
+import { render, screen } from 'tests/utils'
+
+describe('<SubscribeButtonWithTooltip />', () => {
+  it('should render tooltip when user is not subscribed', () => {
+    render(<SubscribeButtonWithTooltip active={false} onPress={jest.fn()} />)
+
+    expect(
+      screen.getByText('Suis ce thème pour recevoir de l’actualité sur ce sujet !')
+    ).toBeOnTheScreen()
+  })
+
+  it('should not render tooltip when user is already subscribed', () => {
+    render(<SubscribeButtonWithTooltip active onPress={jest.fn()} />)
+
+    expect(
+      screen.queryByText('Suis ce thème pour recevoir de l’actualité sur ce sujet !')
+    ).not.toBeOnTheScreen()
+  })
+})

--- a/src/features/home/components/SubscribeButtonWithTooltip.native.test.tsx
+++ b/src/features/home/components/SubscribeButtonWithTooltip.native.test.tsx
@@ -1,22 +1,44 @@
 import React from 'react'
 
 import { SubscribeButtonWithTooltip } from 'features/home/components/SubscribeButtonWithTooltip'
-import { render, screen } from 'tests/utils'
+import { act, render, screen } from 'tests/utils'
+
+const DISPLAY_START_OFFSET_IN_MS = 1000
+const TOOLTIP_TEXT = 'Suis ce thème pour recevoir de l’actualité sur ce sujet !'
+
+jest.useFakeTimers({ legacyFakeTimers: true })
 
 describe('<SubscribeButtonWithTooltip />', () => {
-  it('should render tooltip when user is not subscribed', () => {
+  it('should not show tooltip before 1 second has elapsed', () => {
     render(<SubscribeButtonWithTooltip active={false} onPress={jest.fn()} />)
 
-    expect(
-      screen.getByText('Suis ce thème pour recevoir de l’actualité sur ce sujet !')
-    ).toBeOnTheScreen()
+    jest.advanceTimersByTime(DISPLAY_START_OFFSET_IN_MS - 1)
+
+    expect(screen.queryByText(TOOLTIP_TEXT)).not.toBeOnTheScreen()
   })
 
-  it('should not render tooltip when user is already subscribed', () => {
+  it('should show tooltip after 1 second when user is not subscribed', async () => {
+    render(<SubscribeButtonWithTooltip active={false} onPress={jest.fn()} />)
+
+    await act(() => jest.advanceTimersByTime(DISPLAY_START_OFFSET_IN_MS))
+
+    expect(screen.getByText(TOOLTIP_TEXT)).toBeOnTheScreen()
+  })
+
+  it('should not show tooltip when user is already subscribed', () => {
     render(<SubscribeButtonWithTooltip active onPress={jest.fn()} />)
 
-    expect(
-      screen.queryByText('Suis ce thème pour recevoir de l’actualité sur ce sujet !')
-    ).not.toBeOnTheScreen()
+    act(() => jest.advanceTimersByTime(DISPLAY_START_OFFSET_IN_MS))
+
+    expect(screen.queryByText(TOOLTIP_TEXT)).not.toBeOnTheScreen()
+  })
+
+  it('should hide tooltip 8 seconds after display', async () => {
+    render(<SubscribeButtonWithTooltip active={false} onPress={jest.fn()} />)
+
+    await act(() => jest.advanceTimersByTime(DISPLAY_START_OFFSET_IN_MS))
+    await act(() => jest.advanceTimersByTime(8000))
+
+    expect(screen.queryByText(TOOLTIP_TEXT)).not.toBeOnTheScreen()
   })
 })

--- a/src/features/home/components/SubscribeButtonWithTooltip.native.test.tsx
+++ b/src/features/home/components/SubscribeButtonWithTooltip.native.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { SubscribeButtonWithTooltip } from 'features/home/components/SubscribeButtonWithTooltip'
+import { storage } from 'libs/storage'
 import { act, render, screen } from 'tests/utils'
 
 const DISPLAY_START_OFFSET_IN_MS = 1000
@@ -9,6 +10,8 @@ const TOOLTIP_TEXT = 'Suis ce thème pour recevoir de l’actualité sur ce suje
 jest.useFakeTimers({ legacyFakeTimers: true })
 
 describe('<SubscribeButtonWithTooltip />', () => {
+  beforeEach(() => storage.clear('times_subscription_tooltip_has_been_displayed'))
+
   it('should not show tooltip before 1 second has elapsed', () => {
     render(<SubscribeButtonWithTooltip active={false} onPress={jest.fn()} />)
 
@@ -38,6 +41,28 @@ describe('<SubscribeButtonWithTooltip />', () => {
 
     await act(() => jest.advanceTimersByTime(DISPLAY_START_OFFSET_IN_MS))
     await act(() => jest.advanceTimersByTime(8000))
+
+    expect(screen.queryByText(TOOLTIP_TEXT)).not.toBeOnTheScreen()
+  })
+
+  it('should not show tooltip more than 3 times', async () => {
+    render(<SubscribeButtonWithTooltip active={false} onPress={jest.fn()} />)
+    await act(() => jest.advanceTimersByTime(DISPLAY_START_OFFSET_IN_MS))
+
+    expect(screen.getByText(TOOLTIP_TEXT)).toBeOnTheScreen()
+
+    render(<SubscribeButtonWithTooltip active={false} onPress={jest.fn()} />)
+    await act(() => jest.advanceTimersByTime(DISPLAY_START_OFFSET_IN_MS))
+
+    expect(screen.getByText(TOOLTIP_TEXT)).toBeOnTheScreen()
+
+    render(<SubscribeButtonWithTooltip active={false} onPress={jest.fn()} />)
+    await act(() => jest.advanceTimersByTime(DISPLAY_START_OFFSET_IN_MS))
+
+    expect(screen.getByText(TOOLTIP_TEXT)).toBeOnTheScreen()
+
+    render(<SubscribeButtonWithTooltip active={false} onPress={jest.fn()} />)
+    await act(() => jest.advanceTimersByTime(DISPLAY_START_OFFSET_IN_MS))
 
     expect(screen.queryByText(TOOLTIP_TEXT)).not.toBeOnTheScreen()
   })

--- a/src/features/home/components/SubscribeButtonWithTooltip.tsx
+++ b/src/features/home/components/SubscribeButtonWithTooltip.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback, useEffect } from 'react'
 import styled from 'styled-components/native'
 
 import { SubscribeButton } from 'features/home/components/SubscribeButton'
@@ -7,15 +7,35 @@ import { getSpacing } from 'ui/theme'
 
 const WIDGET_HEIGHT = getSpacing(10 + 1 + 4) // roundedButton + padding + caption
 const TOOLTIP_WIDTH = getSpacing(65)
+const DISPLAY_START_OFFSET_IN_MS = 1000
+const DISPLAY_DURATION_IN_MS = 8000
 
 export const SubscribeButtonWithTooltip = (props: { active: boolean; onPress: () => void }) => {
+  const [isTooltipVisible, setIsTooltipVisible] = React.useState(false)
+
+  const displayTooltip = useCallback(() => setIsTooltipVisible(true), [setIsTooltipVisible])
+  const hideTooltip = useCallback(() => setIsTooltipVisible(false), [setIsTooltipVisible])
+
+  useEffect(() => {
+    if (props.active) return
+
+    const timeoutOn = setTimeout(displayTooltip, DISPLAY_START_OFFSET_IN_MS)
+    const timeoutOff = setTimeout(hideTooltip, DISPLAY_START_OFFSET_IN_MS + DISPLAY_DURATION_IN_MS)
+
+    return () => {
+      clearTimeout(timeoutOn)
+      clearTimeout(timeoutOff)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [displayTooltip, hideTooltip])
+
   return (
     <React.Fragment>
       <SubscribeButton {...props} />
       <StyledTooltip
         label="Suis ce thème pour recevoir de l’actualité sur ce sujet&nbsp;!"
         pointerDirection="bottom"
-        isVisible={!props.active}
+        isVisible={isTooltipVisible}
       />
     </React.Fragment>
   )

--- a/src/features/home/components/SubscribeButtonWithTooltip.tsx
+++ b/src/features/home/components/SubscribeButtonWithTooltip.tsx
@@ -50,6 +50,7 @@ export const SubscribeButtonWithTooltip = (props: { active: boolean; onPress: ()
         label="Suis ce thème pour recevoir de l’actualité sur ce sujet&nbsp;!"
         pointerDirection="bottom"
         isVisible={isTooltipVisible}
+        onHide={hideTooltip}
       />
     </React.Fragment>
   )

--- a/src/features/home/components/SubscribeButtonWithTooltip.tsx
+++ b/src/features/home/components/SubscribeButtonWithTooltip.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { SubscribeButton } from 'features/home/components/SubscribeButton'
+import { Tooltip } from 'ui/components/Tooltip'
+import { getSpacing } from 'ui/theme'
+
+const WIDGET_HEIGHT = getSpacing(10 + 1 + 4) // roundedButton + padding + caption
+const TOOLTIP_WIDTH = getSpacing(65)
+
+export const SubscribeButtonWithTooltip = (props: { active: boolean; onPress: () => void }) => {
+  return (
+    <React.Fragment>
+      <SubscribeButton {...props} />
+      <StyledTooltip
+        label="Suis ce thème pour recevoir de l’actualité sur ce sujet&nbsp;!"
+        pointerDirection="bottom"
+        isVisible={!props.active}
+      />
+    </React.Fragment>
+  )
+}
+
+const StyledTooltip = styled(Tooltip)(({ theme }) => ({
+  position: 'absolute',
+  top: -WIDGET_HEIGHT - getSpacing(0.5),
+  right: -getSpacing(1),
+  zIndex: theme.zIndex.header,
+  width: TOOLTIP_WIDTH,
+}))

--- a/src/features/internal/cheatcodes/pages/ThematicHomeHeaderCheatcode/ThematicHomeWithSubscribeCheatcode.tsx
+++ b/src/features/internal/cheatcodes/pages/ThematicHomeHeaderCheatcode/ThematicHomeWithSubscribeCheatcode.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/native'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { CategoryThematicHomeHeader } from 'features/home/components/headers/CategoryThematicHomeHeader'
 import { ThematicHomeHeader } from 'features/home/components/headers/ThematicHomeHeader'
-import { SubscribeButton } from 'features/home/components/SubscribeButton'
+import { SubscribeButtonWithTooltip } from 'features/home/components/SubscribeButtonWithTooltip'
 import { mapSubscriptionThemeToName } from 'features/subscription/helpers/mapSubscriptionThemeToName'
 import { useThematicSubscription } from 'features/subscription/helpers/useThematicSubscription'
 import { NotificationsSettingsModal } from 'features/subscription/NotificationsSettingsModal'
@@ -54,7 +54,10 @@ export const ThematicHomeWithSubscribeCheatcode: FunctionComponent = () => {
         />
         {isLoggedIn ? (
           <SubscribeButtonContainer>
-            <SubscribeButton active={isSubscribeButtonActive} onPress={subscribeButtonOnPress} />
+            <SubscribeButtonWithTooltip
+              active={isSubscribeButtonActive}
+              onPress={subscribeButtonOnPress}
+            />
           </SubscribeButtonContainer>
         ) : null}
         <BodyPlaceholder />

--- a/src/libs/storage.ts
+++ b/src/libs/storage.ts
@@ -15,6 +15,7 @@ export type StorageKey =
   | 'phone_validation_code_asked_at'
   | 'react_navigation_persistence'
   | 'times_location_tooltip_has_been_displayed'
+  | 'times_subscription_tooltip_has_been_displayed'
   | 'times_review_has_been_requested'
   | 'traffic_campaign'
   | 'traffic_content'

--- a/src/ui/components/Tooltip.tsx
+++ b/src/ui/components/Tooltip.tsx
@@ -16,11 +16,18 @@ const FADE_IN_DURATION = 300
 type Props = {
   label: string
   isVisible?: boolean
+  pointerDirection?: 'top' | 'bottom'
   onHide?: () => void
   style?: ComponentProps<typeof AnimatedView>['style']
 }
 
-export const Tooltip: FunctionComponent<Props> = ({ label, isVisible, onHide, style }) => {
+export const Tooltip: FunctionComponent<Props> = ({
+  label,
+  isVisible,
+  pointerDirection = 'top',
+  onHide,
+  style,
+}) => {
   const containerRef: AnimatedRef = useRef(null)
   useEffect(() => {
     if (isVisible) {
@@ -41,19 +48,20 @@ export const Tooltip: FunctionComponent<Props> = ({ label, isVisible, onHide, st
   if (!isVisible) return null
 
   return (
-    <AnimatedView
+    <StyledAnimatedView
       duration={FADE_IN_DURATION}
       style={style}
       ref={containerRef}
-      accessibilityRole={AccessibilityRole.TOOLTIP}>
-      <StyledPointer />
+      accessibilityRole={AccessibilityRole.TOOLTIP}
+      pointerDirection={pointerDirection}>
+      <StyledPointer pointerDirection={pointerDirection} />
       <Background>
         <StyledText>{label}</StyledText>
         <StyledClearContainer onPress={onHide} accessibilityLabel="Fermer le tooltip">
           <StyledClearIcon />
         </StyledClearContainer>
       </Background>
-    </AnimatedView>
+    </StyledAnimatedView>
   )
 }
 
@@ -68,11 +76,19 @@ const Pointer = ({ style }: { style?: ComponentProps<typeof Svg>['style'] }) => 
     </Svg>
   )
 }
-const StyledPointer = styled(Pointer)({
+
+const StyledPointer = styled(Pointer)<Pick<Props, 'pointerDirection'>>(({ pointerDirection }) => ({
   position: 'relative',
   alignSelf: 'flex-end',
   right: getSpacing(3.5),
-})
+  transform: pointerDirection === 'bottom' ? 'rotate(180deg)' : undefined,
+}))
+
+const StyledAnimatedView = styled(AnimatedView)<Pick<Props, 'pointerDirection'>>(
+  ({ pointerDirection }) => ({
+    flexDirection: pointerDirection === 'bottom' ? 'column-reverse' : 'column',
+  })
+)
 
 const Background = styled.View(({ theme }) => ({
   flexDirection: 'row',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28570

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots
| Platform         | Mockup| After |
| :--------------- | :-----------: | :---: |
| iOS              |    ![image](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/404ff298-2f14-4fdf-90ee-cde79d0cf7cc)           |    ![Simulator Screenshot - iPhone 5 - 2024-04-04 at 17 36 46](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/03007daf-0b91-48ea-80b3-810f2ea9f6a1)   |
| Android          |      ![image](https://github.com/pass-culture/pass-culture-app-native/assets/46637324/5960b28f-ef33-44df-8ea9-b1dd8645e29b)         |  <img width="287" alt="Capture d’écran 2024-04-06 à 15 13 36" src="https://github.com/pass-culture/pass-culture-app-native/assets/46637324/eb5d5621-a2b2-4d6a-945a-ca7277031f3c">  |
| Desktop - Chrome |               |   <img width="1010" alt="Capture d’écran 2024-04-04 à 17 38 58" src="https://github.com/pass-culture/pass-culture-app-native/assets/46637324/b16ec4e0-e0fb-4b88-8f05-5847c4f140b4">    |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
