### PR TITLE
(PC-28943) feat(OfferBody): don't display offer venue button and summary info dates when this is a cinema offer

### DIFF
--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -127,8 +127,12 @@ describe('<OfferBody />', () => {
   })
 
   describe('Venue button section & Summary info section', () => {
-    it('should display both section', async () => {
-      renderOfferBody({})
+    it('should display both section when this is not a cinema offer', async () => {
+      const subcategory: Subcategory = {
+        ...mockSubcategory,
+        categoryId: CategoryIdEnum.LIVRE,
+      }
+      renderOfferBody({ subcategory })
 
       expect(
         await screen.findByTestId('Accéder à la page du lieu PATHE BEAUGRENELLE')
@@ -194,20 +198,41 @@ describe('<OfferBody />', () => {
     })
 
     describe('Venue button section', () => {
-      it('should display venue button', async () => {
-        renderOfferBody({})
+      it('should display venue button when this is not a cinema offer', async () => {
+        const subcategory: Subcategory = {
+          ...mockSubcategory,
+          categoryId: CategoryIdEnum.LIVRE,
+        }
+        renderOfferBody({ subcategory })
 
         expect(
           await screen.findByTestId('Accéder à la page du lieu PATHE BEAUGRENELLE')
         ).toBeOnTheScreen()
       })
 
-      it('should not display venue button', async () => {
+      it('should not display venue button when venue is not permanent', async () => {
         const offer: OfferResponse = {
           ...offerResponseSnap,
           venue: {
             ...offerResponseSnap.venue,
             isPermanent: false,
+          },
+        }
+        renderOfferBody({ offer })
+
+        await screen.findByText(offer.name)
+
+        expect(
+          screen.queryByTestId('Accéder à la page du lieu PATHE BEAUGRENELLE')
+        ).not.toBeOnTheScreen()
+      })
+
+      it('should not display venue button when this is a cinema offer', async () => {
+        const offer: OfferResponse = {
+          ...offerResponseSnap,
+          venue: {
+            ...offerResponseSnap.venue,
+            isPermanent: true,
           },
         }
         renderOfferBody({ offer })
@@ -267,6 +292,43 @@ describe('<OfferBody />', () => {
 
         expect(screen.queryByText('à 900+ km')).not.toBeOnTheScreen()
       })
+    })
+  })
+
+  describe('About section', () => {
+    it('should display about section', async () => {
+      const offer: OfferResponse = {
+        ...offerResponseSnap,
+        description: 'Cette offre est super cool cool cool cool cool cool',
+        extraData: {
+          speaker: 'Toto',
+        },
+        accessibility: {
+          audioDisability: true,
+          mentalDisability: true,
+          motorDisability: false,
+          visualDisability: false,
+        },
+      }
+      renderOfferBody({ offer })
+
+      await screen.findByText(offerResponseSnap.name)
+
+      expect(screen.getByText('À propos')).toBeOnTheScreen()
+    })
+
+    it('should not display about section', async () => {
+      const offer: OfferResponse = {
+        ...offerResponseSnap,
+        description: undefined,
+        extraData: {},
+        accessibility: {},
+      }
+      renderOfferBody({ offer })
+
+      await screen.findByText(offerResponseSnap.name)
+
+      expect(screen.queryByText('À propos')).not.toBeOnTheScreen()
     })
   })
 

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -61,7 +61,7 @@ export const OfferBody: FunctionComponent<Props> = ({
 
   const { summaryInfoItems } = useOfferSummaryInfoList({
     offer,
-    isCinemaXpAvailable: isCinemaOffer,
+    isCinemaOffer,
   })
 
   const metadata = getOfferMetadata(extraData)

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react'
 import { View } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
-import { OfferResponse, SearchGroupNameEnumv2 } from 'api/gen'
+import { CategoryIdEnum, OfferResponse, SearchGroupNameEnumv2 } from 'api/gen'
 import { OfferAbout } from 'features/offer/components/OfferAbout/OfferAbout'
 import { OfferArtists } from 'features/offer/components/OfferArtists/OfferArtists'
 import { OfferCTAButton } from 'features/offer/components/OfferCTAButton/OfferCTAButton'
@@ -46,6 +46,9 @@ export const OfferBody: FunctionComponent<Props> = ({
 }) => {
   const { isDesktopViewport } = useTheme()
   const hasFakeDoorArtist = useFeatureFlag(RemoteStoreFeatureFlags.FAKE_DOOR_ARTIST)
+  const enableNewXpCineFromOffer = useFeatureFlag(
+    RemoteStoreFeatureFlags.WIP_ENABLE_NEW_XP_CINE_FROM_OFFER
+  )
   const shouldDisplayFakeDoorArtist =
     hasFakeDoorArtist && FAKE_DOOR_ARTIST_SEARCH_GROUPS.includes(subcategory.searchGroupName)
 
@@ -54,7 +57,12 @@ export const OfferBody: FunctionComponent<Props> = ({
   const artists = getOfferArtists(subcategory.categoryId, offer)
   const prices = getOfferPrices(offer.stocks)
 
-  const { summaryInfoItems } = useOfferSummaryInfoList({ offer })
+  const isCinemaOffer = enableNewXpCineFromOffer && subcategory.categoryId === CategoryIdEnum.CINEMA
+
+  const { summaryInfoItems } = useOfferSummaryInfoList({
+    offer,
+    isCinemaXpAvailable: isCinemaOffer,
+  })
 
   const metadata = getOfferMetadata(extraData)
   const hasMetadata = metadata.length > 0
@@ -90,7 +98,7 @@ export const OfferBody: FunctionComponent<Props> = ({
 
         <GroupWithSeparator
           showTopComponent={offer.venue.isPermanent}
-          TopComponent={<OfferVenueButton venue={offer.venue} />}
+          TopComponent={isCinemaOffer ? null : <OfferVenueButton venue={offer.venue} />}
           showBottomComponent={summaryInfoItems.length > 0}
           BottomComponent={<OfferSummaryInfoList summaryInfoItems={summaryInfoItems} />}
         />

--- a/src/features/offer/helpers/useOfferSummaryInfoList/useOfferSummaryInfoList.native.test.tsx
+++ b/src/features/offer/helpers/useOfferSummaryInfoList/useOfferSummaryInfoList.native.test.tsx
@@ -9,7 +9,7 @@ import { computedTheme } from 'tests/computedTheme'
 import { renderHook } from 'tests/utils'
 
 describe('useOfferSummaryInfoList', () => {
-  it('should return summaryInfoItems when offer has atleast one in stock', async () => {
+  it('should return summaryInfoItems when offer has at least one in stock', async () => {
     const { result } = renderHook(
       () =>
         useOfferSummaryInfoList({
@@ -30,7 +30,7 @@ describe('useOfferSummaryInfoList', () => {
     ])
   })
 
-  it('should return summaryInfoItems dates when offer stock has date in future', async () => {
+  it('should return summaryInfoItems dates when offer stock has date in future and cinema experience is not available', async () => {
     mockdate.set('2021-01-02T18:00:00')
     const offer: OfferResponse = {
       ...offerResponseSnap,
@@ -40,6 +40,7 @@ describe('useOfferSummaryInfoList', () => {
       () =>
         useOfferSummaryInfoList({
           offer,
+          isCinemaXpAvailable: false,
         }),
       {
         wrapper: ({ children }) => <ThemeProvider theme={computedTheme}>{children}</ThemeProvider>,
@@ -54,6 +55,28 @@ describe('useOfferSummaryInfoList', () => {
         title: 'Dates',
       },
     ])
+
+    mockdate.reset()
+  })
+
+  it('should not return summaryInfoItems dates when offer stock has date in future and is cinema experience is available', async () => {
+    mockdate.set('2021-01-02T18:00:00')
+    const offer: OfferResponse = {
+      ...offerResponseSnap,
+      isDuo: false,
+    }
+    const { result } = renderHook(
+      () =>
+        useOfferSummaryInfoList({
+          offer,
+          isCinemaXpAvailable: true,
+        }),
+      {
+        wrapper: ({ children }) => <ThemeProvider theme={computedTheme}>{children}</ThemeProvider>,
+      }
+    )
+
+    expect(result.current.summaryInfoItems).toEqual([])
 
     mockdate.reset()
   })

--- a/src/features/offer/helpers/useOfferSummaryInfoList/useOfferSummaryInfoList.native.test.tsx
+++ b/src/features/offer/helpers/useOfferSummaryInfoList/useOfferSummaryInfoList.native.test.tsx
@@ -30,7 +30,7 @@ describe('useOfferSummaryInfoList', () => {
     ])
   })
 
-  it('should return summaryInfoItems dates when offer stock has date in future and cinema experience is not available', async () => {
+  it('should return summaryInfoItems dates when offer stock has date in future and is not a cinema offer', async () => {
     mockdate.set('2021-01-02T18:00:00')
     const offer: OfferResponse = {
       ...offerResponseSnap,
@@ -40,7 +40,7 @@ describe('useOfferSummaryInfoList', () => {
       () =>
         useOfferSummaryInfoList({
           offer,
-          isCinemaXpAvailable: false,
+          isCinemaOffer: false,
         }),
       {
         wrapper: ({ children }) => <ThemeProvider theme={computedTheme}>{children}</ThemeProvider>,
@@ -59,7 +59,7 @@ describe('useOfferSummaryInfoList', () => {
     mockdate.reset()
   })
 
-  it('should not return summaryInfoItems dates when offer stock has date in future and is cinema experience is available', async () => {
+  it('should not return summaryInfoItems dates when offer stock has date in future and is a cinema offer', async () => {
     mockdate.set('2021-01-02T18:00:00')
     const offer: OfferResponse = {
       ...offerResponseSnap,
@@ -69,7 +69,7 @@ describe('useOfferSummaryInfoList', () => {
       () =>
         useOfferSummaryInfoList({
           offer,
-          isCinemaXpAvailable: true,
+          isCinemaOffer: true,
         }),
       {
         wrapper: ({ children }) => <ThemeProvider theme={computedTheme}>{children}</ThemeProvider>,

--- a/src/features/offer/helpers/useOfferSummaryInfoList/useOfferSummaryInfoList.tsx
+++ b/src/features/offer/helpers/useOfferSummaryInfoList/useOfferSummaryInfoList.tsx
@@ -14,14 +14,14 @@ import { Stock } from 'ui/svg/icons/Stock'
 
 type Props = {
   offer: OfferResponse
-  isCinemaXpAvailable?: boolean
+  isCinemaOffer?: boolean
 }
 
 export type SummaryInfoItem = SummaryInfoProps & {
   isDisplayed?: boolean
 }
 
-export const useOfferSummaryInfoList = ({ offer, isCinemaXpAvailable }: Props) => {
+export const useOfferSummaryInfoList = ({ offer, isCinemaOffer }: Props) => {
   const theme = useTheme()
   const { venue, isDigital, isDuo, extraData } = offer
   const dates = extractStockDates(offer)
@@ -33,7 +33,7 @@ export const useOfferSummaryInfoList = ({ offer, isCinemaXpAvailable }: Props) =
 
   const summaryInfoItems: SummaryInfoItem[] = [
     {
-      isDisplayed: !!formattedDate && !isCinemaXpAvailable,
+      isDisplayed: !!formattedDate && !isCinemaOffer,
       Icon: <CalendarS size={theme.icons.sizes.small} />,
       title: 'Dates',
       subtitle: formattedDate,

--- a/src/features/offer/helpers/useOfferSummaryInfoList/useOfferSummaryInfoList.tsx
+++ b/src/features/offer/helpers/useOfferSummaryInfoList/useOfferSummaryInfoList.tsx
@@ -14,13 +14,14 @@ import { Stock } from 'ui/svg/icons/Stock'
 
 type Props = {
   offer: OfferResponse
+  isCinemaXpAvailable?: boolean
 }
 
 export type SummaryInfoItem = SummaryInfoProps & {
-  isDisplayed: boolean
+  isDisplayed?: boolean
 }
 
-export const useOfferSummaryInfoList = ({ offer }: Props) => {
+export const useOfferSummaryInfoList = ({ offer, isCinemaXpAvailable }: Props) => {
   const theme = useTheme()
   const { venue, isDigital, isDuo, extraData } = offer
   const dates = extractStockDates(offer)
@@ -32,7 +33,7 @@ export const useOfferSummaryInfoList = ({ offer }: Props) => {
 
   const summaryInfoItems: SummaryInfoItem[] = [
     {
-      isDisplayed: !!formattedDate,
+      isDisplayed: !!formattedDate && !isCinemaXpAvailable,
       Icon: <CalendarS size={theme.icons.sizes.small} />,
       title: 'Dates',
       subtitle: formattedDate,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28943

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |![Capture d’écran 2024-04-08 à 16 08 28](https://github.com/pass-culture/pass-culture-app-native/assets/62058919/15a2edaa-d9c6-450c-a8d5-c1c1f038ce67)|![Capture d’écran 2024-04-08 à 16 08 08](https://github.com/pass-culture/pass-culture-app-native/assets/62058919/c6271d67-4094-41a3-b335-d592953f1b21)|
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
