### PR TITLE
(PC-28822) fix(tracking): add api reco params to trackers when offers comes from a reco playlist

### DIFF
--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -396,11 +396,11 @@
 ./src/features/offer/helpers/getIsFreeDigitalOffer/getIsFreeDigitalOffer.test.ts:26
 ./src/features/offer/helpers/getIsFreeDigitalOffer/getIsFreeDigitalOffer.test.ts:37
 ./src/features/offer/helpers/getIsFreeDigitalOffer/getIsFreeDigitalOffer.test.ts:48
-./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts:123
-./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts:372
-./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts:383
-./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts:847
-./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts:196
+./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts:124
+./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts:373
+./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts:384
+./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts:868
+./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts:201
 ./src/features/profile/components/Buttons/ContactSupportButton/ContactSupportButton.native.test.tsx:18
 ./src/features/profile/components/Buttons/ContactSupportButton/ContactSupportButton.native.test.tsx:20
 ./src/features/profile/components/Buttons/ContactSupportButton/ContactSupportButton.tsx:14

--- a/src/features/home/components/modules/RecommendationModule.native.test.tsx
+++ b/src/features/home/components/modules/RecommendationModule.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { mockedAlgoliaResponse } from 'libs/algolia/__mocks__/mockedAlgoliaResponse'
 import { analytics } from 'libs/analytics'
 import { ContentTypes, DisplayParametersFields } from 'libs/contentful/types'
+import { RecommendationApiParams } from 'shared/offer/types'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render } from 'tests/utils'
 
@@ -14,9 +15,15 @@ const displayParameters: DisplayParametersFields = {
   layout: 'one-item-medium',
 }
 
+const defaultRecommendationApiParams: RecommendationApiParams = {
+  call_id: '1',
+  reco_origin: 'unknown',
+}
+
 jest.mock('features/home/api/useHomeRecommendedOffers', () => ({
   useHomeRecommendedOffers: jest.fn(() => ({
     offers: mockedAlgoliaResponse.hits,
+    recommendationApiParams: defaultRecommendationApiParams,
   })),
 }))
 
@@ -29,7 +36,8 @@ describe('RecommendationModule', () => {
       'abcd',
       ContentTypes.RECOMMENDATION,
       1,
-      'xyz'
+      'xyz',
+      defaultRecommendationApiParams
     )
   })
 

--- a/src/features/home/components/modules/RecommendationModule.tsx
+++ b/src/features/home/components/modules/RecommendationModule.tsx
@@ -54,7 +54,8 @@ export const RecommendationModule = (props: RecommendationModuleProps) => {
         moduleId,
         ContentTypes.RECOMMENDATION,
         index,
-        homeEntryId
+        homeEntryId,
+        recommendationApiParams
       )
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/features/home/components/modules/RecommendationModule.tsx
+++ b/src/features/home/components/modules/RecommendationModule.tsx
@@ -45,7 +45,7 @@ export const RecommendationModule = (props: RecommendationModuleProps) => {
 
   const moduleName = displayParameters.title
   const logHasSeenAllTilesOnce = useFunctionOnce(() =>
-    analytics.logAllTilesSeen({ moduleName, numberOfTiles: nbOffers })
+    analytics.logAllTilesSeen({ moduleName, numberOfTiles: nbOffers, ...recommendationApiParams })
   )
 
   useEffect(() => {

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -201,7 +201,7 @@ export type RootStackParamList = {
   CheatMenu: undefined
   ConfirmChangeEmail: { token: string; expiration_timestamp: number }
   ConfirmDeleteProfile: undefined
-  BookingConfirmation: { offerId: number; bookingId: number }
+  BookingConfirmation: { offerId: number; bookingId: number; apiRecoParams?: string }
   BookingDetails: { id: number }
   ConsentSettings: { onGoBack?: () => void } | undefined
   CulturalSurvey: undefined

--- a/src/features/navigation/screenParamsUtils.ts
+++ b/src/features/navigation/screenParamsUtils.ts
@@ -86,6 +86,7 @@ export const screenParamsParser: ParamsParsers = {
   BookingConfirmation: {
     offerId: Number,
     bookingId: Number,
+    apiRecoParams: identityFn,
   },
 
   Login: {

--- a/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.tsx
+++ b/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.tsx
@@ -131,8 +131,11 @@ export function OfferPlaylistList({
   const shouldDisplaySameArtistPlaylist =
     !!isArrayNotEmpty(sameArtistPlaylist) && enableSameArtistPlaylist
 
-  const trackingOnHorizontalScroll = () => {
-    analytics.logPlaylistHorizontalScroll(fromOfferId)
+  const trackingOnHorizontalScroll = (
+    playlistType: PlaylistType,
+    apiRecoParams?: RecommendationApiParams
+  ) => {
+    analytics.logPlaylistHorizontalScroll(fromOfferId, playlistType, apiRecoParams)
   }
 
   const { itemWidth, itemHeight } = getPlaylistItemDimensionsFromLayout('two-items')
@@ -201,7 +204,7 @@ export function OfferPlaylistList({
                 apiRecoParams: playlist.apiRecoParams,
               })}
               title={playlist.title}
-              onEndReached={trackingOnHorizontalScroll}
+              onEndReached={() => trackingOnHorizontalScroll(playlist.type, playlist.apiRecoParams)}
               playlistType={playlist.type}
             />
           </IntersectionObserver>

--- a/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts
+++ b/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts
@@ -7,6 +7,7 @@ import {
   SearchGroupNameEnumv2,
   SubcategoryIdEnum,
 } from 'api/gen'
+import { PlaylistType } from 'features/offer/enums'
 import { offerResponseSnap as baseOffer } from 'features/offer/fixtures/offerResponse'
 import { analytics } from 'libs/analytics'
 import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
@@ -545,6 +546,14 @@ describe('getCtaWordingAndAction', () => {
   })
 
   describe('CTA - Analytics', () => {
+    const defaultApiRecoParams = {
+      call_id: '1',
+      reco_origin: 'unknown',
+      model_origin: 'default',
+    }
+
+    const defaultPlaylistType = PlaylistType.OTHER_CATEGORIES_SIMILAR_OFFERS
+
     it('logs event ClickBookOffer when we click CTA "Réserver l’offre" (beneficiary user)', () => {
       const offer = buildOffer({ externalTicketOfficeUrl: 'https://www.google.com' })
       const subcategory = buildSubcategory({ isEvent: false })
@@ -562,11 +571,17 @@ describe('getCtaWordingAndAction', () => {
           bookOffer: () => {},
           isBookingLoading: false,
           booking: undefined,
+          apiRecoParams: defaultApiRecoParams,
+          playlistType: defaultPlaylistType,
         }) || {}
 
       onPress?.()
 
-      expect(analytics.logClickBookOffer).toHaveBeenNthCalledWith(1, { offerId: baseOffer.id })
+      expect(analytics.logClickBookOffer).toHaveBeenNthCalledWith(1, {
+        offerId: baseOffer.id,
+        ...defaultApiRecoParams,
+        playlistType: defaultPlaylistType,
+      })
     })
 
     it('logs event ClickBookOffer when CTA "Voir les disponibilités" is clicked', () => {
@@ -586,11 +601,17 @@ describe('getCtaWordingAndAction', () => {
           bookOffer: () => {},
           isBookingLoading: false,
           booking: undefined,
+          apiRecoParams: defaultApiRecoParams,
+          playlistType: defaultPlaylistType,
         }) || {}
 
       onPress?.()
 
-      expect(analytics.logClickBookOffer).toHaveBeenNthCalledWith(1, { offerId: baseOffer.id })
+      expect(analytics.logClickBookOffer).toHaveBeenNthCalledWith(1, {
+        offerId: baseOffer.id,
+        ...defaultApiRecoParams,
+        playlistType: defaultPlaylistType,
+      })
     })
 
     it('logs event ConsultAvailableDates when we click CTA "Voir les disponibilités" (beneficiary user)', () => {

--- a/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts
+++ b/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts
@@ -25,6 +25,7 @@ import { openUrl } from 'features/navigation/helpers'
 import { Referrals, UseRouteType } from 'features/navigation/RootNavigator/types'
 import { BottomBannerTextEnum } from 'features/offer/components/MovieScreeningCalendar/enums'
 import { MovieScreeningUserData } from 'features/offer/components/MovieScreeningCalendar/types'
+import { PlaylistType } from 'features/offer/enums'
 import { getBookingOfferId } from 'features/offer/helpers/getBookingOfferId/getBookingOfferId'
 import { getIsFreeDigitalOffer } from 'features/offer/helpers/getIsFreeDigitalOffer/getIsFreeDigitalOffer'
 import { isUserUnderageBeneficiary } from 'features/profile/helpers/isUserUnderageBeneficiary'
@@ -71,6 +72,8 @@ type Props = {
   searchId?: string
   enableNewXpCine?: boolean
   isDepositExpired?: boolean
+  apiRecoParams?: RecommendationApiParams
+  playlistType?: PlaylistType
 }
 
 export type ICTAWordingAndAction = {
@@ -103,6 +106,8 @@ export const getCtaWordingAndAction = ({
   searchId,
   enableNewXpCine,
   isDepositExpired,
+  apiRecoParams,
+  playlistType,
 }: Props): ICTAWordingAndAction | undefined => {
   const { externalTicketOfficeUrl, subcategoryId } = offer
 
@@ -252,7 +257,13 @@ export const getCtaWordingAndAction = ({
       wording: 'Réserver l’offre',
       isDisabled: false,
       onPress: () => {
-        analytics.logClickBookOffer({ offerId: offer.id, from, searchId })
+        analytics.logClickBookOffer({
+          offerId: offer.id,
+          from,
+          searchId,
+          ...apiRecoParams,
+          playlistType,
+        })
       },
     }
   }
@@ -272,7 +283,13 @@ export const getCtaWordingAndAction = ({
       isDisabled: false,
       onPress: () => {
         analytics.logConsultAvailableDates(offer.id)
-        analytics.logClickBookOffer({ offerId: offer.id, from, searchId })
+        analytics.logClickBookOffer({
+          offerId: offer.id,
+          from,
+          searchId,
+          ...apiRecoParams,
+          playlistType,
+        })
       },
       movieScreeningUserData: { hasEnoughCredit },
     }
@@ -360,5 +377,7 @@ export const useCtaWordingAndAction = (props: UseGetCtaWordingAndActionProps) =>
     searchId,
     enableNewXpCine,
     isDepositExpired,
+    apiRecoParams,
+    playlistType,
   })
 }

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -20,6 +20,7 @@ import { analytics, buildPerformSearchState, urlWithValueMaxLength } from 'libs/
 import { buildAccessibilityFilterParam } from 'libs/analytics/utils'
 import { ContentTypes } from 'libs/contentful/types'
 import { AnalyticsEvent } from 'libs/firebase/analytics/events'
+import { RecommendationApiParams } from 'shared/offer/types'
 
 type BaseThematicHome = {
   homeEntryId: string
@@ -154,8 +155,13 @@ export const logEventAnalytics = {
       amplitude: AmplitudeEvent.CHOOSE_METHOD_UBBLE,
       firebase: AnalyticsEvent.CHOOSE_UBBLE_METHOD,
     }),
-  logClickBookOffer: (params: { offerId: number; from?: Referrals; searchId?: string }) =>
-    analytics.logEvent({ firebase: AnalyticsEvent.CLICK_BOOK_OFFER }, params),
+  logClickBookOffer: (params: {
+    offerId: number
+    from?: Referrals
+    searchId?: string
+    apiRecoParams?: RecommendationApiParams
+    playlistType?: PlaylistType
+  }) => analytics.logEvent({ firebase: AnalyticsEvent.CLICK_BOOK_OFFER }, params),
   logClickForceUpdate: (appVersionId: number) =>
     analytics.logEvent({ firebase: AnalyticsEvent.CLICK_FORCE_UPDATE }, { appVersionId }),
   logClickSeeMore: (params: { moduleName: string; moduleId: string }) =>
@@ -297,6 +303,8 @@ export const logEventAnalytics = {
     moduleName?: string
     moduleId?: string
     searchId?: string
+    apiRecoParams?: RecommendationApiParams
+    playlistType?: string
   }) => analytics.logEvent({ firebase: AnalyticsEvent.HAS_ADDED_OFFER_TO_FAVORITES }, params),
   logHasAppliedFavoritesSorting: ({ sortBy }: { sortBy: FavoriteSortBy }) =>
     analytics.logEvent(
@@ -381,11 +389,13 @@ export const logEventAnalytics = {
     moduleId: string,
     moduleType: ContentTypes,
     index: number,
-    homeEntryId: string | undefined
+    homeEntryId: string | undefined,
+    apiRecoParams?: RecommendationApiParams
   ) =>
     analytics.logEvent(
       { firebase: AnalyticsEvent.MODULE_DISPLAYED_ON_HOMEPAGE },
       {
+        ...apiRecoParams,
         homeEntryId,
         index,
         moduleId,
@@ -465,11 +475,17 @@ export const logEventAnalytics = {
     analytics.logEvent({ amplitude: AmplitudeEvent.PHONE_NUMBER_CLICKED }),
   logPhoneValidationCodeClicked: () =>
     analytics.logEvent({ amplitude: AmplitudeEvent.PHONE_VALIDATION_CODE_CLICKED }),
-  logPlaylistHorizontalScroll: (fromOfferId?: number) =>
+  logPlaylistHorizontalScroll: (
+    fromOfferId?: number,
+    playlistType?: PlaylistType,
+    apiRecoParams?: RecommendationApiParams
+  ) =>
     analytics.logEvent(
       { firebase: AnalyticsEvent.PLAYLIST_HORIZONTAL_SCROLL },
       {
+        ...apiRecoParams,
         fromOfferId,
+        playlistType,
       }
     ),
   logPlaylistVerticalScroll: (params: {

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -93,6 +93,7 @@ export const logEventAnalytics = {
     searchId?: string
     moduleId?: string
     venueId?: number
+    apiRecoParams?: RecommendationApiParams
   }) => analytics.logEvent({ firebase: AnalyticsEvent.ALL_TILES_SEEN }, params),
   logBackToHomeFromEduconnectError: (params: { fromError: string }) =>
     analytics.logEvent({ firebase: AnalyticsEvent.BACK_TO_HOME_FROM_EDUCONNECT_ERROR }, params),

--- a/src/libs/analytics/types.ts
+++ b/src/libs/analytics/types.ts
@@ -1,4 +1,5 @@
 import { Referrals, ScreenNames } from 'features/navigation/RootNavigator/types'
+import { PlaylistType } from 'features/offer/enums'
 import { AmplitudeEvent } from 'libs/amplitude/events'
 import { logEventAnalytics } from 'libs/analytics/logEventAnalytics'
 import { AnalyticsEvent } from 'libs/firebase/analytics/events'
@@ -23,4 +24,6 @@ export type OfferAnalyticsParams = {
   moduleName?: string
   moduleId?: string
   homeEntryId?: string
+  apiRecoParams?: string
+  playlistType?: PlaylistType
 }

--- a/src/ui/components/buttons/FavoriteButton.tsx
+++ b/src/ui/components/buttons/FavoriteButton.tsx
@@ -9,6 +9,7 @@ import { SignUpSignInChoiceOfferModal } from 'features/offer/components/SignUpSi
 import { analytics } from 'libs/analytics'
 import { OfferAnalyticsParams } from 'libs/analytics/types'
 import { accessibleCheckboxProps } from 'shared/accessibilityProps/accessibleCheckboxProps'
+import { RecommendationApiParams } from 'shared/offer/types'
 import { theme } from 'theme'
 import { RoundedButton } from 'ui/components/buttons/RoundedButton'
 import { useModal } from 'ui/components/modals/useModal'
@@ -38,13 +39,26 @@ export const FavoriteButton: React.FC<Props> = (props) => {
   const { showErrorSnackBar } = useSnackBarContext()
   const { params } = useRoute<UseRouteType<'Offer'>>()
 
+  const apiRecoParams: RecommendationApiParams = params?.apiRecoParams
+    ? JSON.parse(params?.apiRecoParams)
+    : undefined
+
   const scaleFavoriteIconAnimatedValueRef = useRef(new Animated.Value(1))
 
   const { mutate: addFavorite, isLoading: addFavoriteIsLoading } = useAddFavorite({
     onSuccess: () => {
       if (typeof offerId === 'number' && (props.analyticsParams ?? params)) {
-        const { from, moduleName, moduleId, searchId } = props.analyticsParams ?? params
-        analytics.logHasAddedOfferToFavorites({ from, offerId, moduleName, moduleId, searchId })
+        const { from, moduleName, moduleId, searchId, playlistType } =
+          props.analyticsParams ?? params
+        analytics.logHasAddedOfferToFavorites({
+          from,
+          offerId,
+          moduleName,
+          moduleId,
+          searchId,
+          ...apiRecoParams,
+          playlistType,
+        })
       }
     },
   })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28822

## Checklist

I have:

- [X] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [X] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Mockup/Before | After |
| :-----------: | :---: |
| <img width="364" alt="ClickBookOffer_before" src="https://github.com/pass-culture/pass-culture-app-native/assets/158567429/51cea35f-5797-4932-bdbc-e76737a4618a"> | <img width="466" alt="ClickBookOffer_after" src="https://github.com/pass-culture/pass-culture-app-native/assets/158567429/ac70d26e-3267-46a3-9ece-51f76ac7610b"> |
| <img width="377" alt="hasAddedToFavorites_before" src="https://github.com/pass-culture/pass-culture-app-native/assets/158567429/5236ef5e-8482-452c-badd-8e8dc8cb2fd4"> | <img width="466" alt="hasAddedToFavorites_after" src="https://github.com/pass-culture/pass-culture-app-native/assets/158567429/a27c4b27-1178-49d8-bb8d-69087409d538">  |
| <img width="360" alt="PlaylistHorizontalScroll_before" src="https://github.com/pass-culture/pass-culture-app-native/assets/158567429/b6273c53-4e2b-47a5-ba97-74b0e621d8d6"> | <img width="466" alt="PlaylistHorizontalScroll_after" src="https://github.com/pass-culture/pass-culture-app-native/assets/158567429/34b28db7-a405-4300-ad00-70f59b945e25">     |




[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
