### PR TITLE
(BSR) fix(home): fix warning

### DIFF
--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -264,6 +264,7 @@ export enum Color {
 
 export type VenueMapModule = {
   type: HomepageModuleType.VenueMapModule
+  id: string
 }
 
 export type VideoModule = {

--- a/src/libs/contentful/adapters/modules/adaptVenueMapModule.native.test.ts
+++ b/src/libs/contentful/adapters/modules/adaptVenueMapModule.native.test.ts
@@ -5,6 +5,7 @@ import { venueMapBlockContentModelFixture } from 'libs/contentful/fixtures/venue
 describe('adaptVenueMapModule', () => {
   it('should adapt from Contentful VenueMapBlock data', () => {
     expect(adaptVenueMapModule(venueMapBlockContentModelFixture)).toEqual({
+      id: '5Tzq8bP20RkPQexo7qNb9i',
       type: HomepageModuleType.VenueMapModule,
     })
   })

--- a/src/libs/contentful/adapters/modules/adaptVenueMapModule.ts
+++ b/src/libs/contentful/adapters/modules/adaptVenueMapModule.ts
@@ -5,6 +5,7 @@ export const adaptVenueMapModule = (module: VenueMapBlockContentModel): VenueMap
   if (module.fields === undefined) return null
 
   return {
+    id: module.sys.id,
     type: HomepageModuleType.VenueMapModule,
   }
 }


### PR DESCRIPTION
On utilise l'id du module Contentful comme key sur la Home. Pour le module de carte des lieux, on ne gardait pas cet id : on avait donc `undefined` comme key -> warning sur la home en local