### PR TITLE
(PC-29078) fix(EventCard): Give user credit priority over screening status on movie screening event card

### DIFF
--- a/src/features/offer/components/MovieScreeningCalendar/MovieScreeningCalendar.native.test.tsx
+++ b/src/features/offer/components/MovieScreeningCalendar/MovieScreeningCalendar.native.test.tsx
@@ -331,6 +331,36 @@ describe('Movie screening calendar', () => {
       expect(await screen.findByText('Crédit insuffisant')).toBeOnTheScreen()
     })
 
+    it('should show "Crédit insuffisant" instead of "Complet" when user does not have enough credit and screening is sold out', async () => {
+      mockAuthContext = {
+        ...defaultLoggedInUser,
+        user: {
+          ...beneficiaryUser,
+          domainsCredit: {
+            all: { initial: 0, remaining: 0 },
+            physical: { initial: 0, remaining: 0 },
+            digital: { initial: 0, remaining: 0 },
+          },
+        },
+      }
+
+      renderMovieScreeningCalendar({
+        offer: {
+          ...defaultOfferResponse,
+          stocks: [
+            {
+              ...defaultOfferStockResponse,
+              isSoldOut: true,
+            },
+          ],
+        },
+      })
+
+      await screen.findByLabelText('Mardi 27 Février')
+
+      expect(await screen.findByText('Crédit insuffisant')).toBeOnTheScreen()
+    })
+
     it('should log event ClickBookOffer when user is logged in and a cliquable eventcard is pressed', async () => {
       mockServer.getApi<OfferResponse>(`/v1/offer/${offerResponseSnap.id}`, offerResponseSnap)
 

--- a/src/features/offer/components/MovieScreeningCalendar/useSelectedDateScreenings.ts
+++ b/src/features/offer/components/MovieScreeningCalendar/useSelectedDateScreenings.ts
@@ -42,7 +42,7 @@ export const useSelectedDateScreening = (
         let subtitleLeft: EventCardSubtitleEnum | string
 
         switch (true) {
-          case isScreeningSoldOut:
+          case isScreeningSoldOut && (!isUserLoggedIn || hasEnoughCredit):
             subtitleLeft = EventCardSubtitleEnum.FULLY_BOOKED
             isDisabled = true
             break


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29078

## Checklist

I have:

- [X] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change

## Screenshots

**delete** _if no UI change_

| Platform| Default(non connecté/assez crédit)| Before | After |
| :--------------- | :-----------: | :---: | :---: |
| iOS |  ![PC-29078_enough-credit](https://github.com/pass-culture/pass-culture-app-native/assets/158567429/86540a40-387b-4136-9054-d3bf8dee0b04)| ![PC-29078_before](https://github.com/pass-culture/pass-culture-app-native/assets/158567429/a8142801-a732-4a85-9b58-aa06fdee00cb)| ![PC-29078_after](https://github.com/pass-culture/pass-culture-app-native/assets/158567429/183bccab-1459-48d9-b6a7-1ce4fa77f9b5)      | 


