### PR TITLE
(PC-29024) fix(subscription): hide deposit reset mention for most users

### DIFF
--- a/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
@@ -390,30 +390,6 @@ pour réserver cette offre
                   ]
                 }
               />
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#696A6F",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 12,
-                      "lineHeight": 16,
-                    },
-                  ]
-                }
-              >
-                Ton crédit précédent a été remis à 0 €.
-              </Text>
-              <View
-                numberOfSpaces={6}
-                style={
-                  [
-                    {
-                      "height": 24,
-                    },
-                  ]
-                }
-              />
               <View
                 accessibilityLabel="Aller vers la section profil"
                 accessibilityState={
@@ -501,7 +477,7 @@ pour réserver cette offre
 </Modal>
 `;
 
-exports[`<FinishSubscriptionModal /> should render correctly with eighteen years old deposit amount 1`] = `
+exports[`<FinishSubscriptionModal /> should display correct body when user turned eighteen and their previous deposit has been reset 1`] = `
 <Modal
   accessibilityLabelledBy="testUuidV4"
   accessibilityModal={true}
@@ -1002,6 +978,483 @@ pour réserver cette offre
 </Modal>
 `;
 
+exports[`<FinishSubscriptionModal /> should render correctly with eighteen years old deposit amount 1`] = `
+<Modal
+  accessibilityLabelledBy="testUuidV4"
+  accessibilityModal={true}
+  accessibilityRole="none"
+  animationType="none"
+  deviceHeight={1334}
+  deviceWidth={750}
+  hardwareAccelerated={false}
+  hideModalContentWhileAnimating={false}
+  onBackdropPress={[MockFunction]}
+  onModalHide={[Function]}
+  onModalWillHide={[Function]}
+  onModalWillShow={[Function]}
+  onRequestClose={[Function]}
+  panResponderThreshold={4}
+  scrollHorizontal={false}
+  scrollOffset={0}
+  scrollOffsetMax={0}
+  scrollTo={null}
+  statusBarTranslucent={true}
+  supportedOrientations={
+    [
+      "portrait",
+      "landscape",
+    ]
+  }
+  swipeThreshold={100}
+  testID="modal"
+  transparent={true}
+  visible={true}
+>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    forwardedRef={[Function]}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "backgroundColor": "black",
+        "bottom": 0,
+        "height": 1334,
+        "left": 0,
+        "opacity": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+        "width": 750,
+      }
+    }
+  />
+  <View
+    accessibilityLabelledBy="testUuidV4"
+    accessibilityModal={true}
+    accessibilityRole="none"
+    collapsable={false}
+    deviceHeight={1334}
+    deviceWidth={750}
+    forwardedRef={[Function]}
+    hideModalContentWhileAnimating={false}
+    onBackdropPress={[MockFunction]}
+    onModalHide={[Function]}
+    onModalWillHide={[Function]}
+    onModalWillShow={[Function]}
+    panResponderThreshold={4}
+    pointerEvents="box-none"
+    scrollHorizontal={false}
+    scrollOffset={0}
+    scrollOffsetMax={0}
+    scrollTo={null}
+    statusBarTranslucent={true}
+    style={
+      {
+        "alignItems": "center",
+        "bottom": 0,
+        "flex": 1,
+        "justifyContent": "center",
+        "left": 0,
+        "margin": "auto",
+        "position": "absolute",
+        "right": 0,
+        "top": "auto",
+        "transform": [
+          {
+            "translateY": 1334,
+          },
+        ],
+      }
+    }
+    supportedOrientations={
+      [
+        "portrait",
+        "landscape",
+      ]
+    }
+    swipeThreshold={100}
+  >
+    <View
+      height={428}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "backgroundColor": "#ffffff",
+            "borderBottomEndRadius": 0,
+            "borderBottomLeftRadius": 0,
+            "borderBottomRightRadius": 0,
+            "borderBottomStartRadius": 0,
+            "borderTopEndRadius": 16,
+            "borderTopLeftRadius": 20,
+            "borderTopRightRadius": 20,
+            "borderTopStartRadius": 16,
+            "flexDirection": "column",
+            "height": 428,
+            "justifyContent": "center",
+            "maxHeight": 650,
+            "maxWidth": 960,
+            "paddingBottom": 32,
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "paddingTop": 24,
+            "width": "100%",
+          },
+        ]
+      }
+      testID="modalContainer"
+    >
+      <View
+        onLayout={[Function]}
+        style={
+          [
+            {
+              "display": "flex",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "width": "100%",
+            },
+          ]
+        }
+        testID="modalHeader"
+      >
+        <View
+          justifyContent="left"
+          style={
+            [
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "height": 28,
+                "justifyContent": "flex-start",
+                "width": 28,
+              },
+            ]
+          }
+        />
+        <View
+          style={
+            [
+              {
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "center",
+                "paddingHorizontal": 12,
+                "zIndex": 1,
+              },
+            ]
+          }
+        >
+          <Text
+            nativeID="testUuidV4"
+            numberOfLines={2}
+            style={
+              [
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 18,
+                  "lineHeight": 22,
+                  "textAlign": "center",
+                },
+              ]
+            }
+            testID="modalHeaderTitle"
+          >
+            Débloque ton crédit
+pour réserver cette offre
+          </Text>
+        </View>
+        <View
+          justifyContent="right"
+          style={
+            [
+              {
+                "alignItems": "flex-start",
+                "flexDirection": "row",
+                "height": 28,
+                "justifyContent": "flex-end",
+                "width": 28,
+              },
+            ]
+          }
+        >
+          <View
+            accessibilityLabel="Fermer la modale"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "opacity": 1,
+                "paddingBottom": 4,
+                "paddingLeft": 4,
+                "paddingRight": 4,
+                "paddingTop": 4,
+                "userSelect": "auto",
+              }
+            }
+            testID="Fermer la modale"
+          >
+            <View
+              height={20}
+              testID="rightIcon"
+              width={20}
+            >
+              <Text>
+                rightIcon-SVG-Mock
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          [
+            {
+              "height": 20,
+            },
+          ]
+        }
+        testID="spacerBetweenHeaderAndContent"
+      />
+      <View
+        backdropColor="#00000080"
+        paddingBottom={8}
+        style={
+          [
+            {
+              "maxHeight": "100%",
+              "maxWidth": 480,
+              "paddingBottom": 8,
+              "width": "100%",
+            },
+          ]
+        }
+      >
+        <RCTScrollView
+          contentContainerStyle={{}}
+          onContentSizeChange={[Function]}
+          scrollEnabled={true}
+          testID="modalScrollView"
+        >
+          <View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "width": "100%",
+                  },
+                ]
+              }
+            >
+              <View
+                fill="none"
+                height={109.2}
+                width={140}
+              >
+                <Text>
+                  undefined-SVG-Mock
+                </Text>
+              </View>
+              <View
+                numberOfSpaces={6}
+                style={
+                  [
+                    {
+                      "height": 24,
+                    },
+                  ]
+                }
+              />
+              <Text
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Regular",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                      "textAlign": "center",
+                    },
+                  ]
+                }
+              >
+                Confirme tes informations personnelles pour débloquer
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Regular",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                        "textAlign": "center",
+                      },
+                    ]
+                  }
+                >
+                   
+                  tes 
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Bold",
+                          "fontSize": 15,
+                          "lineHeight": 20,
+                        },
+                      ]
+                    }
+                  >
+                    300 €
+                  </Text>
+                   
+                </Text>
+                et réserver cette offre.
+              </Text>
+              <View
+                numberOfSpaces={6}
+                style={
+                  [
+                    {
+                      "height": 24,
+                    },
+                  ]
+                }
+              />
+              <View
+                accessibilityLabel="Aller vers la section profil"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#eb0055",
+                    "borderRadius": 24,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "maxWidth": 500,
+                    "minHeight": 40,
+                    "opacity": 1,
+                    "paddingBottom": 2,
+                    "paddingLeft": 20,
+                    "paddingRight": 20,
+                    "paddingTop": 2,
+                    "userSelect": "auto",
+                    "width": "100%",
+                  }
+                }
+                testID="Aller vers la section profil"
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    adjustsFontSizeToFit={false}
+                    numberOfLines={1}
+                    style={
+                      [
+                        {
+                          "color": "#ffffff",
+                          "fontFamily": "Montserrat-Bold",
+                          "fontSize": 15,
+                          "lineHeight": 20,
+                          "maxWidth": "100%",
+                        },
+                      ]
+                    }
+                  >
+                    Confirmer mes informations
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RCTScrollView>
+      </View>
+    </View>
+  </View>
+</Modal>
+`;
+
 exports[`<FinishSubscriptionModal /> should render correctly with undefined deposit amount 1`] = `
 <Modal
   accessibilityLabelledBy="testUuidV4"
@@ -1351,30 +1804,6 @@ pour réserver cette offre
                 Confirme tes informations personnelles pour débloquer
                  ton crédit 
                 et réserver cette offre.
-              </Text>
-              <View
-                numberOfSpaces={6}
-                style={
-                  [
-                    {
-                      "height": 24,
-                    },
-                  ]
-                }
-              />
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#696A6F",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 12,
-                      "lineHeight": 16,
-                    },
-                  ]
-                }
-              >
-                Ton crédit précédent a été remis à 0 €.
               </Text>
               <View
                 numberOfSpaces={6}

--- a/src/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx
+++ b/src/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx
@@ -1,6 +1,8 @@
+import mockdate from 'mockdate'
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
+import { DepositType } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
 import { beneficiaryUser } from 'fixtures/user'
@@ -26,6 +28,9 @@ const modalProps = {
   from: StepperOrigin.FAVORITE,
 }
 
+const TODAY = '2021-10-24'
+mockdate.set(new Date(TODAY))
+
 describe('<FinishSubscriptionModal />', () => {
   it('should render correctly with undefined deposit amount', () => {
     mockDepositAmounts.mockReturnValueOnce(undefined)
@@ -43,6 +48,16 @@ describe('<FinishSubscriptionModal />', () => {
 
   it('should display correct body when user needs to verify his identity to activate his eighteen year old credit', async () => {
     mockUseAuthContext.mockReturnValueOnce({ user: { ...beneficiaryUser, requiresIdCheck: true } })
+
+    render(<FinishSubscriptionModal {...modalProps} />)
+
+    expect(screen).toMatchSnapshot()
+  })
+
+  it('should display correct body when user turned eighteen and their previous deposit has been reset', async () => {
+    mockUseAuthContext.mockReturnValueOnce({
+      user: { ...beneficiaryUser, depositType: DepositType.GRANT_15_17 },
+    })
 
     render(<FinishSubscriptionModal {...modalProps} />)
 

--- a/src/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.tsx
+++ b/src/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.tsx
@@ -2,8 +2,10 @@ import { useNavigation } from '@react-navigation/native'
 import React, { FunctionComponent, useCallback } from 'react'
 import styled from 'styled-components/native'
 
+import { DepositType } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { StepperOrigin, UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { getAge } from 'shared/user/getAge'
 import { useGetDepositAmountsByAge } from 'shared/user/useGetDepositAmountsByAge'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { AppModalWithIllustration } from 'ui/components/modals/AppModalWithIllustration'
@@ -38,6 +40,9 @@ export const FinishSubscriptionModal: FunctionComponent<Props> = ({ visible, hid
 
   const buttonLabel = user?.requiresIdCheck ? 'Vérifier mon identité' : 'Confirmer mes informations'
 
+  const userAge = getAge(user?.birthDate)
+  const isUserTransitioningTo18 = userAge === 18 && user?.depositType === DepositType.GRANT_15_17
+
   return (
     <AppModalWithIllustration
       visible={visible}
@@ -55,10 +60,14 @@ export const FinishSubscriptionModal: FunctionComponent<Props> = ({ visible, hid
         </StyledBody>
       )}
       <Spacer.Column numberOfSpaces={6} />
-      <Typo.CaptionNeutralInfo>
-        Ton crédit précédent a été remis à 0&nbsp;€.
-      </Typo.CaptionNeutralInfo>
-      <Spacer.Column numberOfSpaces={6} />
+      {!!isUserTransitioningTo18 && (
+        <React.Fragment>
+          <Typo.CaptionNeutralInfo>
+            Ton crédit précédent a été remis à 0&nbsp;€.
+          </Typo.CaptionNeutralInfo>
+          <Spacer.Column numberOfSpaces={6} />
+        </React.Fragment>
+      )}
       <ButtonPrimary
         wording={buttonLabel}
         accessibilityLabel="Aller vers la section profil"


### PR DESCRIPTION
The deposit reset mention is only relevant when the user turns 18.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29024

## Screenshots

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change


| Platform         | Mockup| After |
| :--------------- | :-----------: | :---: |
| iOS              |               |   <img width="367" alt="Capture d’écran 2024-04-17 à 12 00 29" src="https://github.com/pass-culture/pass-culture-app-native/assets/26348504/01d143f7-81bb-4de5-b63a-ce28f3fb414b">    |
| Android          |     |   <img width="425" alt="Capture d’écran 2024-04-16 à 18 39 46" src="https://github.com/pass-culture/pass-culture-app-native/assets/26348504/1ed6a94c-7f8a-40bf-8ac6-fdf03aa9d9ca">       |   
| Desktop - Chrome |               |   <img width="532" alt="Capture d’écran 2024-04-16 à 18 40 27" src="https://github.com/pass-culture/pass-culture-app-native/assets/26348504/61ed3646-76a1-46da-a71a-8aac3ae2c550">  |
