### PR TITLE
(BSR) fix(buildWeb): remove opera mobile from browserslist

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
       "not dead",
       "not op_mini all",
       "ie 11",
-      "ie 9"
+      "ie 9",
+      "not op_mob >=1"
     ],
     "development": [
       "last 1 chrome version",


### PR DESCRIPTION
The web build was failing due to browser list error after updating caniuse : 

```
$ NODE_OPTIONS=--openssl-legacy-provider SHOW_DUPLICATES_PLUGIN=${SHOW_DUPLICATES_PLUGIN:-true} node web/scripts/build.js
Creating an optimized production build...
Failed to compile.

./node_modules/@egjs/hammerjs/dist/hammer.esm.js
Error: [BABEL] /home/runner/work/pass-culture-app-native/pass-culture-app-native/node_modules/@egjs/hammerjs/dist/hammer.esm.js: @babel/helper-compilation-targets: 'opera_mobile' is not a valid target
- Did you mean 'opera'? (While processing: "/home/runner/work/pass-culture-app-native/pass-culture-app-native/node_modules/babel-preset-react-app/dependencies.js$0$43")
```