### PR TITLE
(PC-29251) fix(Search): Remove temporary fix

### DIFF
--- a/src/features/search/context/SearchWrapper.tsx
+++ b/src/features/search/context/SearchWrapper.tsx
@@ -65,11 +65,6 @@ export const SearchWrapper = memo(function SearchWrapper({
     }
   }, [selectedLocationMode, place, aroundMeRadius, aroundPlaceRadius, dispatch])
 
-  // Temporary fix: this useEffect reduces the amount of re-renders and fixes Search.web.perf test ==> PC-29251
-  useEffect(() => {
-    dispatch({ type: 'SET_STATE', payload: initialSearchState })
-  }, [])
-
   const resetSearch = useCallback(() => {
     dispatch({ type: 'SET_STATE', payload: initialSearchState })
   }, [])


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29251

## Context

Ce ticket fait suite à cette PR : https://github.com/pass-culture/pass-culture-app-native/pull/6283

J'ai supprimé le price range qui à priori n'est plus utilisé, donc j'ai également supprimé le useEffect qui mettait à jour le searchState avec le priceRange par défaut et à la suite de cela, la CI a remonté une augmentation de 5 re-renders sur la page Search Results. Suite à cela, j'ai remis le useEffect inutile (à priori) pour faire passer la CI (ce qui d'ailleurs faisait baisser le nombre de re-renders de 8 à 7), mais en gardant un ticket pour investiguer cette augmentation de re-renders.

Après investigation avec @aliraiki, on a remarqué qu'en fait, avec le useEffect, le test de perf de la page SearchResults testait en fait la page SearchLanding puisque le useEffect fait un dispatch de l'initialSearchState qui lui même set la view par défaut à Landing et donc en retirant le useEffect, on teste bien la page Results. Donc cette PR sert à retirer ce useEffect inutile et donc mettre à jour le nombre de renders de base de la page Results (dans le test de perf) qui serait en fait de 12-13 et non de 8.