### PR TITLE
(PC-29257) refactor(subscription): group modals and button to prevent rerender

### DIFF
--- a/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
@@ -47,8 +47,10 @@ exports[`ThematicHome should render correctly 1`] = `
               isLocated={true}
               thematicHeader={
                 {
+                  "imageUrl": "url.com/image",
                   "subtitle": "HeaderSubtitle",
                   "title": "HeaderTitle",
+                  "type": "Category",
                 }
               }
             />
@@ -128,99 +130,15 @@ exports[`ThematicHome should render correctly 1`] = `
             }
           >
             <View
+              numberOfSpaces={58}
               style={
                 [
                   {
-                    "flexGrow": 1,
-                    "flexShrink": 0,
+                    "height": 232,
                   },
                 ]
               }
-            >
-              <View
-                style={
-                  [
-                    {
-                      "marginBottom": 8,
-                      "marginHorizontal": 24,
-                      "marginTop": 8,
-                    },
-                  ]
-                }
-              >
-                <View
-                  headerHeight={80}
-                  style={
-                    [
-                      {
-                        "height": 80,
-                      },
-                    ]
-                  }
-                />
-                <View
-                  style={
-                    [
-                      {
-                        "maxHeight": 96,
-                        "overflow": "hidden",
-                      },
-                    ]
-                  }
-                >
-                  <Text
-                    numberOfLines={2}
-                    style={
-                      [
-                        {
-                          "color": "#161617",
-                          "fontFamily": "Montserrat-Black",
-                          "fontSize": 26,
-                          "lineHeight": 34,
-                        },
-                      ]
-                    }
-                  >
-                    HeaderTitle
-                  </Text>
-                  <View
-                    numberOfSpaces={2}
-                    style={
-                      [
-                        {
-                          "height": 8,
-                        },
-                      ]
-                    }
-                  />
-                  <Text
-                    numberOfLines={2}
-                    style={
-                      [
-                        {
-                          "color": "#161617",
-                          "fontFamily": "Montserrat-Regular",
-                          "fontSize": 15,
-                          "lineHeight": 20,
-                        },
-                      ]
-                    }
-                  >
-                    HeaderSubtitle
-                  </Text>
-                </View>
-                <View
-                  numberOfSpaces={6}
-                  style={
-                    [
-                      {
-                        "height": 24,
-                      },
-                    ]
-                  }
-                />
-              </View>
-            </View>
+            />
           </View>
           <View
             onFocusCapture={[Function]}
@@ -653,129 +571,388 @@ exports[`ThematicHome should render correctly 1`] = `
       }
     />
   </View>
-  <Modal
-    accessibilityLabelledBy="testUuidV4"
-    accessibilityModal={true}
-    accessibilityRole="none"
-    animationType="none"
-    deviceHeight={1334}
-    deviceWidth={750}
-    hardwareAccelerated={false}
-    hideModalContentWhileAnimating={false}
-    onBackdropPress={[Function]}
-    onModalHide={[Function]}
-    onModalWillHide={[Function]}
-    onModalWillShow={[Function]}
-    onRequestClose={[Function]}
-    panResponderThreshold={4}
-    scrollHorizontal={false}
-    scrollOffset={0}
-    scrollOffsetMax={0}
-    scrollTo={null}
-    statusBarTranslucent={true}
-    supportedOrientations={
+  <View
+    collapsable={false}
+    style={
       [
-        "portrait",
-        "landscape",
+        {
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "transform": [
+            {
+              "translateY": 0,
+            },
+          ],
+        },
       ]
     }
-    swipeThreshold={100}
-    testID="modal"
-    transparent={true}
-    visible={false}
-  />
-  <Modal
-    accessibilityLabelledBy="testUuidV4"
-    accessibilityModal={true}
-    accessibilityRole="none"
-    animationType="none"
-    deviceHeight={1334}
-    deviceWidth={750}
-    hardwareAccelerated={false}
-    hideModalContentWhileAnimating={false}
-    onBackdropPress={[Function]}
-    onModalHide={[Function]}
-    onModalWillHide={[Function]}
-    onModalWillShow={[Function]}
-    onRequestClose={[Function]}
-    panResponderThreshold={4}
-    scrollHorizontal={false}
-    scrollOffset={0}
-    scrollOffsetMax={0}
-    scrollTo={null}
-    statusBarTranslucent={true}
-    supportedOrientations={
-      [
-        "portrait",
-        "landscape",
-      ]
-    }
-    swipeThreshold={100}
-    testID="modal"
-    transparent={true}
-    visible={false}
-  />
-  <Modal
-    accessibilityLabelledBy="testUuidV4"
-    accessibilityModal={true}
-    accessibilityRole="none"
-    animationType="none"
-    deviceHeight={1334}
-    deviceWidth={750}
-    hardwareAccelerated={false}
-    hideModalContentWhileAnimating={false}
-    onBackdropPress={[Function]}
-    onModalHide={[Function]}
-    onModalWillHide={[Function]}
-    onModalWillShow={[Function]}
-    onRequestClose={[Function]}
-    panResponderThreshold={4}
-    scrollHorizontal={false}
-    scrollOffset={0}
-    scrollOffsetMax={0}
-    scrollTo={null}
-    statusBarTranslucent={true}
-    supportedOrientations={
-      [
-        "portrait",
-        "landscape",
-      ]
-    }
-    swipeThreshold={100}
-    testID="modal"
-    transparent={true}
-    visible={false}
-  />
-  <Modal
-    accessibilityLabelledBy="testUuidV4"
-    accessibilityModal={true}
-    accessibilityRole="none"
-    animationType="none"
-    deviceHeight={1334}
-    deviceWidth={750}
-    hardwareAccelerated={false}
-    hideModalContentWhileAnimating={false}
-    onBackdropPress={[Function]}
-    onModalHide={[Function]}
-    onModalWillHide={[Function]}
-    onModalWillShow={[Function]}
-    onRequestClose={[Function]}
-    panResponderThreshold={4}
-    scrollHorizontal={false}
-    scrollOffset={0}
-    scrollOffsetMax={0}
-    scrollTo={null}
-    statusBarTranslucent={true}
-    supportedOrientations={
-      [
-        "portrait",
-        "landscape",
-      ]
-    }
-    swipeThreshold={100}
-    testID="modal"
-    transparent={true}
-    visible={false}
-  />
+  >
+    <View
+      style={
+        [
+          {
+            "height": 208,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+      testID="animated-thematic-header"
+    >
+      <Image
+        collapsable={false}
+        height={208}
+        source={
+          {
+            "uri": "url.com/image",
+          }
+        }
+        style={
+          [
+            {
+              "height": 208,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {},
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+            },
+          ]
+        }
+      >
+        <BVLinearGradient
+          collapsable={false}
+          colors={
+            [
+              1447447,
+              2870351383,
+            ]
+          }
+          endPoint={
+            {
+              "x": 0.5,
+              "y": 1,
+            }
+          }
+          height={208}
+          locations={null}
+          startPoint={
+            {
+              "x": 0.5,
+              "y": 0,
+            }
+          }
+          style={
+            [
+              {
+                "height": 208,
+              },
+              {
+                "transform": [
+                  {
+                    "translateY": 0,
+                  },
+                ],
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "backgroundColor": "rgba(22,22,23,0.67)",
+                "paddingBottom": 16,
+                "paddingHorizontal": 24,
+                "paddingTop": 8,
+              },
+              {
+                "transform": [
+                  {
+                    "translateY": 0,
+                  },
+                ],
+              },
+            ]
+          }
+        >
+          <Text
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "color": "#ffffff",
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 18,
+                  "lineHeight": 22,
+                },
+              ]
+            }
+          >
+            HeaderSubtitle
+          </Text>
+          <View
+            numberOfSpaces={1}
+            style={
+              [
+                {
+                  "height": 4,
+                },
+              ]
+            }
+          />
+          <Text
+            numberOfLines={2}
+            style={
+              [
+                {
+                  "color": "#ffffff",
+                  "fontFamily": "Montserrat-Black",
+                  "fontSize": 26,
+                  "lineHeight": 34,
+                },
+              ]
+            }
+          >
+            HeaderTitle
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        [
+          {
+            "position": "absolute",
+            "right": 16,
+            "top": 160,
+          },
+        ]
+      }
+    >
+      <View
+        accessibilityLabel="Suivre ce thème"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#ffffff",
+            "borderColor": "#90949D",
+            "borderRadius": 24,
+            "borderWidth": 1,
+            "flexDirection": "row",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 4,
+            "userSelect": "auto",
+          }
+        }
+        testID="Suivre ce thème"
+      >
+        <View
+          height={24}
+          width={24}
+        >
+          <Text>
+            undefined-SVG-Mock
+          </Text>
+        </View>
+        <View
+          numberOfSpaces={2}
+          style={
+            [
+              {
+                "width": 8,
+              },
+            ]
+          }
+        />
+        <Text
+          style={
+            [
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-SemiBold",
+                "fontSize": 12,
+                "lineHeight": 16,
+              },
+            ]
+          }
+        >
+          Suivre
+        </Text>
+      </View>
+    </View>
+    <Modal
+      accessibilityLabelledBy="testUuidV4"
+      accessibilityModal={true}
+      accessibilityRole="none"
+      animationType="none"
+      deviceHeight={1334}
+      deviceWidth={750}
+      hardwareAccelerated={false}
+      hideModalContentWhileAnimating={false}
+      onBackdropPress={[Function]}
+      onModalHide={[Function]}
+      onModalWillHide={[Function]}
+      onModalWillShow={[Function]}
+      onRequestClose={[Function]}
+      panResponderThreshold={4}
+      scrollHorizontal={false}
+      scrollOffset={0}
+      scrollOffsetMax={0}
+      scrollTo={null}
+      statusBarTranslucent={true}
+      supportedOrientations={
+        [
+          "portrait",
+          "landscape",
+        ]
+      }
+      swipeThreshold={100}
+      testID="modal"
+      transparent={true}
+      visible={false}
+    />
+    <Modal
+      accessibilityLabelledBy="testUuidV4"
+      accessibilityModal={true}
+      accessibilityRole="none"
+      animationType="none"
+      deviceHeight={1334}
+      deviceWidth={750}
+      hardwareAccelerated={false}
+      hideModalContentWhileAnimating={false}
+      onBackdropPress={[Function]}
+      onModalHide={[Function]}
+      onModalWillHide={[Function]}
+      onModalWillShow={[Function]}
+      onRequestClose={[Function]}
+      panResponderThreshold={4}
+      scrollHorizontal={false}
+      scrollOffset={0}
+      scrollOffsetMax={0}
+      scrollTo={null}
+      statusBarTranslucent={true}
+      supportedOrientations={
+        [
+          "portrait",
+          "landscape",
+        ]
+      }
+      swipeThreshold={100}
+      testID="modal"
+      transparent={true}
+      visible={false}
+    />
+    <Modal
+      accessibilityLabelledBy="testUuidV4"
+      accessibilityModal={true}
+      accessibilityRole="none"
+      animationType="none"
+      deviceHeight={1334}
+      deviceWidth={750}
+      hardwareAccelerated={false}
+      hideModalContentWhileAnimating={false}
+      onBackdropPress={[Function]}
+      onModalHide={[Function]}
+      onModalWillHide={[Function]}
+      onModalWillShow={[Function]}
+      onRequestClose={[Function]}
+      panResponderThreshold={4}
+      scrollHorizontal={false}
+      scrollOffset={0}
+      scrollOffsetMax={0}
+      scrollTo={null}
+      statusBarTranslucent={true}
+      supportedOrientations={
+        [
+          "portrait",
+          "landscape",
+        ]
+      }
+      swipeThreshold={100}
+      testID="modal"
+      transparent={true}
+      visible={false}
+    />
+    <Modal
+      accessibilityLabelledBy="testUuidV4"
+      accessibilityModal={true}
+      accessibilityRole="none"
+      animationType="none"
+      deviceHeight={1334}
+      deviceWidth={750}
+      hardwareAccelerated={false}
+      hideModalContentWhileAnimating={false}
+      onBackdropPress={[Function]}
+      onModalHide={[Function]}
+      onModalWillHide={[Function]}
+      onModalWillShow={[Function]}
+      onRequestClose={[Function]}
+      panResponderThreshold={4}
+      scrollHorizontal={false}
+      scrollOffset={0}
+      scrollOffsetMax={0}
+      scrollTo={null}
+      statusBarTranslucent={true}
+      supportedOrientations={
+        [
+          "portrait",
+          "landscape",
+        ]
+      }
+      swipeThreshold={100}
+      testID="modal"
+      transparent={true}
+      visible={false}
+    />
+  </View>
 </View>
 `;

--- a/scripts/dead_code_snapshot.txt
+++ b/scripts/dead_code_snapshot.txt
@@ -1,2 +1,4 @@
 src/features/auth/helpers/contactSupport.ts:38 - satisfies
 src/features/auth/helpers/contactSupport.ts:38 - ContactSupport (used in module)
+src/features/home/fixtures/homepage.fixture.ts:206 - satisfies
+src/features/home/fixtures/homepage.fixture.ts:206 - Homepage (used in module)

--- a/src/features/home/components/SubscribeButtonWithModals.native.test.tsx
+++ b/src/features/home/components/SubscribeButtonWithModals.native.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react'
+
+import { useAuthContext } from 'features/auth/context/AuthContext'
+import * as useMapSubscriptionHomeIdsToThematic from 'features/subscription/helpers/useMapSubscriptionHomeIdsToThematic'
+import { SubscriptionTheme } from 'features/subscription/types'
+import { beneficiaryUser } from 'fixtures/user'
+import { storage } from 'libs/storage'
+import { mockServer } from 'tests/mswServer'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { act, fireEvent, render, screen } from 'tests/utils'
+import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
+
+import { SubscribeButtonWithModals } from './SubscribeButtonWithModals'
+
+const baseAuthContext = {
+  isLoggedIn: true,
+  setIsLoggedIn: jest.fn(),
+  user: beneficiaryUser,
+  refetchUser: jest.fn(),
+  isUserLoading: false,
+}
+jest.mock('features/auth/context/AuthContext')
+const mockUseAuthContext = useAuthContext as jest.MockedFunction<typeof useAuthContext>
+mockUseAuthContext.mockReturnValue(baseAuthContext)
+
+const mockShowSuccessSnackBar = jest.fn()
+jest.mock('ui/components/snackBar/SnackBarContext', () => ({
+  useSnackBarContext: () => ({
+    showSuccessSnackBar: mockShowSuccessSnackBar,
+  }),
+}))
+
+jest
+  .spyOn(useMapSubscriptionHomeIdsToThematic, 'useMapSubscriptionHomeIdsToThematic')
+  .mockReturnValue(SubscriptionTheme.CINEMA)
+
+describe('SubscribeButtonWithModals', () => {
+  beforeEach(() => {
+    storage.clear('times_user_subscribed_to_a_theme')
+  })
+
+  it('should open logged out modal when user is not logged in', async () => {
+    mockUseAuthContext.mockReturnValueOnce({
+      ...baseAuthContext,
+      isLoggedIn: false,
+      user: undefined,
+    })
+
+    render(reactQueryProviderHOC(<SubscribeButtonWithModals homeId="fakeEntryId" />))
+
+    await act(async () => fireEvent.press(screen.getByText('Suivre')))
+
+    expect(screen.getByText('Identifie-toi pour t’abonner à un thème')).toBeOnTheScreen()
+  })
+
+  it('should show inactive SubscribeButton when user is logged in and not subscribed yet', async () => {
+    render(reactQueryProviderHOC(<SubscribeButtonWithModals homeId="fakeEntryId" />))
+
+    expect(await screen.findByText('Suivre')).toBeOnTheScreen()
+  })
+
+  it('should show active SubscribeButton when user is logged in and already subscribed', async () => {
+    mockUseAuthContext.mockReturnValueOnce({
+      ...baseAuthContext,
+      isLoggedIn: true,
+      user: {
+        ...beneficiaryUser,
+        subscriptions: {
+          marketingEmail: true,
+          marketingPush: true,
+          subscribedThemes: [SubscriptionTheme.CINEMA],
+        },
+      },
+    })
+
+    render(reactQueryProviderHOC(<SubscribeButtonWithModals homeId="fakeEntryId" />))
+
+    expect(await screen.findByText('Déjà suivi')).toBeOnTheScreen()
+  })
+
+  it('should show notifications settings modal when user has no notifications activated and click on subscribe button', async () => {
+    mockUseAuthContext.mockReturnValueOnce({
+      ...baseAuthContext,
+      isLoggedIn: true,
+      user: {
+        ...beneficiaryUser,
+        subscriptions: {
+          marketingEmail: false,
+          marketingPush: false,
+          subscribedThemes: [],
+        },
+      },
+    })
+
+    render(reactQueryProviderHOC(<SubscribeButtonWithModals homeId="fakeEntryId" />))
+
+    await act(async () => fireEvent.press(screen.getByText('Suivre')))
+
+    expect(screen.getByText('Autoriser l’envoi d’e-mails')).toBeOnTheScreen()
+  })
+
+  it('should show unsubscribe modal when user is already subscribed and click on subscribe button', async () => {
+    mockUseAuthContext.mockReturnValueOnce({
+      ...baseAuthContext,
+      isLoggedIn: true,
+      user: {
+        ...beneficiaryUser,
+        subscriptions: {
+          marketingEmail: true,
+          marketingPush: true,
+          subscribedThemes: [SubscriptionTheme.CINEMA],
+        },
+      },
+    })
+
+    render(reactQueryProviderHOC(<SubscribeButtonWithModals homeId="fakeEntryId" />))
+
+    await act(async () => fireEvent.press(screen.getByText('Déjà suivi')))
+
+    expect(
+      screen.getByText('Es-tu sûr de ne plus vouloir suivre ce thème\u00a0?')
+    ).toBeOnTheScreen()
+  })
+
+  it('should show subscription success modal when user subscribe to a thematic for the second time', async () => {
+    mockServer.postApi('/v1/profile', {})
+
+    await storage.saveObject('times_user_subscribed_to_a_theme', 1)
+    render(reactQueryProviderHOC(<SubscribeButtonWithModals homeId="fakeEntryId" />))
+
+    await act(async () => fireEvent.press(screen.getByText('Suivre')))
+
+    expect(screen.getByText('Tu suis le thème "Cinéma"')).toBeOnTheScreen()
+    expect(screen.getByText('Voir mes préférences')).toBeOnTheScreen()
+  })
+
+  it('should show snackbar when user subscribe to a thematic home for more than 3 times', async () => {
+    mockServer.postApi('/v1/profile', {})
+
+    await storage.saveObject('times_user_subscribed_to_a_theme', 3)
+    render(reactQueryProviderHOC(<SubscribeButtonWithModals homeId="fakeEntryId" />))
+
+    await act(async () => fireEvent.press(screen.getByText('Suivre')))
+
+    expect(mockShowSuccessSnackBar).toHaveBeenCalledWith({
+      message: 'Tu suis le thème “Cinéma”\u00a0! Tu peux gérer tes alertes depuis ton profil.',
+      timeout: SNACK_BAR_TIME_OUT,
+    })
+  })
+})

--- a/src/features/home/components/SubscribeButtonWithModals.tsx
+++ b/src/features/home/components/SubscribeButtonWithModals.tsx
@@ -1,0 +1,132 @@
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { useAuthContext } from 'features/auth/context/AuthContext'
+import { SubscriptionSuccessModal } from 'features/subscription/components/modals/SubscriptionSuccessModal'
+import { UnsubscribingConfirmationModal } from 'features/subscription/components/modals/UnsubscribingConfirmationModal'
+import { mapSubscriptionThemeToName } from 'features/subscription/helpers/mapSubscriptionThemeToName'
+import { useThematicSubscription } from 'features/subscription/helpers/useThematicSubscription'
+import { NotificationsLoggedOutModal } from 'features/subscription/NotificationsLoggedOutModal'
+import { NotificationsSettingsModal } from 'features/subscription/NotificationsSettingsModal'
+import { SubscriptionTheme } from 'features/subscription/types'
+import { storage } from 'libs/storage'
+import { useModal } from 'ui/components/modals/useModal'
+import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
+import { getSpacing } from 'ui/theme'
+
+import { SubscribeButtonWithTooltip } from './SubscribeButtonWithTooltip'
+
+interface Props {
+  homeId: string
+}
+
+export const SubscribeButtonWithModals = ({ homeId }: Props) => {
+  const { showSuccessSnackBar } = useSnackBarContext()
+  const { user, isLoggedIn } = useAuthContext()
+
+  const {
+    visible: isNotificationsModalVisible,
+    showModal: showNotificationsModal,
+    hideModal: hideNotificationsModal,
+  } = useModal(false)
+  const {
+    visible: isUnsubscribingModalVisible,
+    showModal: showUnsubscribingModal,
+    hideModal: hideUnsubscribingModal,
+  } = useModal(false)
+  const {
+    visible: isSubscriptionSuccessModalVisible,
+    showModal: showSubscriptionSuccessModal,
+    hideModal: hideSubscriptionSuccessModal,
+  } = useModal(false)
+  const {
+    visible: visibleLoggedOutModal,
+    showModal: showLoggedOutModal,
+    hideModal: hideLoggedOutModal,
+  } = useModal(false)
+
+  const onUpdateSubscriptionSuccess = async (thematic: SubscriptionTheme) => {
+    if (!thematic) return
+    const hasSubscribedTimes =
+      (await storage.readObject<number>('times_user_subscribed_to_a_theme')) ?? 0
+    if (hasSubscribedTimes < 3) {
+      showSubscriptionSuccessModal()
+      await storage.saveObject('times_user_subscribed_to_a_theme', hasSubscribedTimes + 1)
+    } else {
+      showSuccessSnackBar({
+        message: `Tu suis le thème “${mapSubscriptionThemeToName[thematic]}”\u00a0! Tu peux gérer tes alertes depuis ton profil.`,
+        timeout: SNACK_BAR_TIME_OUT,
+      })
+    }
+  }
+
+  const {
+    isSubscribeButtonActive,
+    isAtLeastOneNotificationTypeActivated,
+    updateSubscription,
+    updateSettings,
+    thematic,
+  } = useThematicSubscription({
+    user,
+    homeId,
+    onUpdateSubscriptionSuccess,
+  })
+
+  const onUnsubscribeConfirmationPress = () => {
+    updateSubscription()
+    hideUnsubscribingModal()
+  }
+
+  const onSubscribeButtonPress = () => {
+    if (!isLoggedIn) {
+      showLoggedOutModal()
+    } else if (!isAtLeastOneNotificationTypeActivated) {
+      showNotificationsModal()
+    } else if (isSubscribeButtonActive) {
+      showUnsubscribingModal()
+    } else {
+      updateSubscription()
+    }
+  }
+
+  if (!thematic) return null
+
+  return (
+    <React.Fragment>
+      <SubscribeButtonContainer>
+        <SubscribeButtonWithTooltip
+          active={isSubscribeButtonActive}
+          onPress={onSubscribeButtonPress}
+        />
+      </SubscribeButtonContainer>
+
+      <NotificationsSettingsModal
+        visible={isNotificationsModalVisible}
+        dismissModal={hideNotificationsModal}
+        theme={thematic}
+        onPressSaveChanges={updateSettings}
+      />
+      <UnsubscribingConfirmationModal
+        visible={isUnsubscribingModalVisible}
+        dismissModal={hideUnsubscribingModal}
+        theme={thematic}
+        onUnsubscribePress={onUnsubscribeConfirmationPress}
+      />
+      <SubscriptionSuccessModal
+        visible={isSubscriptionSuccessModalVisible}
+        dismissModal={hideSubscriptionSuccessModal}
+        theme={thematic}
+      />
+      <NotificationsLoggedOutModal
+        visible={visibleLoggedOutModal}
+        dismissModal={hideLoggedOutModal}
+      />
+    </React.Fragment>
+  )
+}
+
+const SubscribeButtonContainer = styled.View({
+  position: 'absolute',
+  right: getSpacing(4),
+  top: getSpacing(40),
+})

--- a/src/features/home/fixtures/homepage.fixture.ts
+++ b/src/features/home/fixtures/homepage.fixture.ts
@@ -11,6 +11,7 @@ import {
   CategoryListModule,
   ThematicHeaderType,
   Color,
+  HomepageTag,
 } from 'features/home/types'
 
 export const formattedBusinessModule: BusinessModule = {
@@ -167,6 +168,9 @@ export const formattedCategoryListModule: CategoryListModule = {
   ],
 }
 
+const venueModules: VenuesModule[] = [formattedVenuesModule]
+const emptyTags: HomepageTag[] = []
+
 export const adaptedHomepage: Homepage = {
   tags: [],
   id: '6DCThxvbPFKAo04SVRZtwY',
@@ -187,7 +191,7 @@ export const adaptedHomepage: Homepage = {
   ],
 }
 export const highlightHeaderFixture = {
-  modules: [formattedVenuesModule],
+  modules: venueModules,
   id: 'fakeEntryId',
   thematicHeader: {
     type: ThematicHeaderType.Highlight,
@@ -198,5 +202,5 @@ export const highlightHeaderFixture = {
     beginningDate: new Date('2022-12-21T23:00:00.000Z'),
     endingDate: new Date('2023-01-14T23:00:00.000Z'),
   },
-  tags: [],
-} as const
+  tags: emptyTags,
+} as const satisfies Homepage

--- a/src/features/home/pages/ThematicHome.native.test.tsx
+++ b/src/features/home/pages/ThematicHome.native.test.tsx
@@ -3,7 +3,6 @@ import { Platform } from 'react-native'
 
 import { useRoute } from '__mocks__/@react-navigation/native'
 import { SubcategoriesResponseModelv2 } from 'api/gen'
-import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useHomepageData } from 'features/home/api/useHomepageData'
 import {
   formattedVenuesModule,
@@ -13,22 +12,19 @@ import { ThematicHome } from 'features/home/pages/ThematicHome'
 import { ThematicHeaderType } from 'features/home/types'
 import * as useMapSubscriptionHomeIdsToThematic from 'features/subscription/helpers/useMapSubscriptionHomeIdsToThematic'
 import { SubscriptionTheme } from 'features/subscription/types'
-import { beneficiaryUser } from 'fixtures/user'
 import { analytics } from 'libs/analytics'
 import { useLocation } from 'libs/location'
-import { storage } from 'libs/storage'
 import { placeholderData } from 'libs/subcategories/placeholderData'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen } from 'tests/utils'
-import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
+import { act, render, screen, waitFor } from 'tests/utils'
 
 jest.mock('features/home/api/useShowSkeleton', () => ({
   useShowSkeleton: jest.fn(() => false),
 }))
 
 jest.mock('features/home/api/useHomepageData')
-const mockUseHomepageData = useHomepageData as jest.Mock
+const mockUseHomepageData = useHomepageData as jest.MockedFunction<typeof useHomepageData>
 
 jest.mock('libs/location/LocationWrapper')
 const mockUserLocation = useLocation as jest.Mock
@@ -38,17 +34,6 @@ mockUserLocation.mockReturnValue({
     longitude: 2,
   },
 })
-
-const baseAuthContext = {
-  isLoggedIn: true,
-  setIsLoggedIn: jest.fn(),
-  user: beneficiaryUser,
-  refetchUser: jest.fn(),
-  isUserLoading: false,
-}
-jest.mock('features/auth/context/AuthContext')
-const mockUseAuthContext = useAuthContext as jest.MockedFunction<typeof useAuthContext>
-mockUseAuthContext.mockReturnValue(baseAuthContext)
 
 jest
   .spyOn(useMapSubscriptionHomeIdsToThematic, 'useMapSubscriptionHomeIdsToThematic')
@@ -75,7 +60,13 @@ describe('ThematicHome', () => {
   mockUseHomepageData.mockReturnValue({
     modules,
     id: 'fakeEntryId',
-    thematicHeader: { title: 'HeaderTitle', subtitle: 'HeaderSubtitle' },
+    thematicHeader: {
+      title: 'HeaderTitle',
+      subtitle: 'HeaderSubtitle',
+      type: ThematicHeaderType.Category,
+      imageUrl: 'url.com/image',
+    },
+    tags: [],
   })
 
   beforeEach(() => {
@@ -84,7 +75,8 @@ describe('ThematicHome', () => {
 
   it('should render correctly', async () => {
     renderThematicHome()
-    await act(async () => {})
+
+    await screen.findByText('Suivre')
 
     expect(screen).toMatchSnapshot()
   })
@@ -94,10 +86,9 @@ describe('ThematicHome', () => {
       mockUseHomepageData.mockReturnValueOnce(highlightHeaderFixture)
 
       renderThematicHome()
-      await act(async () => {})
 
+      expect(await screen.findByText('Un sous-titre')).toBeOnTheScreen()
       expect(screen.getAllByText('Bloc temps fort')).not.toHaveLength(0)
-      expect(screen.getByText('Un sous-titre')).toBeOnTheScreen()
     })
 
     it('should show highlight animated header when provided and platform is iOS', async () => {
@@ -106,7 +97,6 @@ describe('ThematicHome', () => {
       mockUseHomepageData.mockReturnValueOnce(highlightHeaderFixture)
 
       renderThematicHome()
-      await act(async () => {})
 
       expect(await screen.findAllByText('Bloc temps fort')).not.toHaveLength(0)
       expect(screen.getByTestId('animated-thematic-header')).toBeOnTheScreen()
@@ -126,9 +116,8 @@ describe('ThematicHome', () => {
       mockUseHomepageData.mockReturnValueOnce(mockedHighlightHeaderDataWithIntroduction)
 
       renderThematicHome()
-      await act(async () => {})
 
-      expect(screen.getByText('IntroductionTitle')).toBeOnTheScreen()
+      expect(await screen.findByText('IntroductionTitle')).toBeOnTheScreen()
       expect(screen.getByText('IntroductionParagraph')).toBeOnTheScreen()
     })
 
@@ -138,7 +127,6 @@ describe('ThematicHome', () => {
       mockUseHomepageData.mockReturnValueOnce(highlightHeaderFixture)
 
       renderThematicHome()
-      await act(async () => {})
 
       expect(await screen.findAllByText('Bloc temps fort')).not.toHaveLength(0)
       expect(screen.queryByTestId('animated-thematic-header')).not.toBeOnTheScreen()
@@ -147,6 +135,7 @@ describe('ThematicHome', () => {
     it('should show category header when provided', async () => {
       mockUseHomepageData.mockReturnValueOnce({
         modules,
+        tags: [],
         id: 'fakeEntryId',
         thematicHeader: {
           type: ThematicHeaderType.Category,
@@ -158,132 +147,19 @@ describe('ThematicHome', () => {
       })
 
       renderThematicHome()
-      await act(async () => {})
 
       expect(await screen.findAllByText('Catégorie cinéma')).not.toHaveLength(0)
       expect(screen.getByText('Un sous-titre')).toBeOnTheScreen()
     })
   })
 
-  describe('SubscribeButton', () => {
-    it('should open logged out modal when user is not logged in', async () => {
-      mockUseAuthContext.mockReturnValueOnce({
-        ...baseAuthContext,
-        isLoggedIn: false,
-        user: undefined,
-      })
-
-      renderThematicHome()
-
-      await act(async () => fireEvent.press(screen.getByText('Suivre')))
-
-      expect(screen.getByText('Identifie-toi pour t’abonner à un thème')).toBeOnTheScreen()
-    })
-
-    it('should show inactive SubscribeButton when user is logged in and not subscribed yet', async () => {
-      renderThematicHome()
-      await act(async () => {})
-
-      expect(screen.getByText('Suivre')).toBeOnTheScreen()
-    })
-
-    it('should show active SubscribeButton when user is logged in and already subscribed', async () => {
-      mockUseAuthContext.mockReturnValueOnce({
-        ...baseAuthContext,
-        isLoggedIn: true,
-        user: {
-          ...beneficiaryUser,
-          subscriptions: {
-            marketingEmail: true,
-            marketingPush: true,
-            subscribedThemes: [SubscriptionTheme.CINEMA],
-          },
-        },
-      })
-
-      renderThematicHome()
-      await act(async () => {})
-
-      expect(screen.getByText('Déjà suivi')).toBeOnTheScreen()
-    })
-
-    it('should show notifications settings modal when user has no notifications activated and click on subscribe button', async () => {
-      mockUseAuthContext.mockReturnValueOnce({
-        ...baseAuthContext,
-        isLoggedIn: true,
-        user: {
-          ...beneficiaryUser,
-          subscriptions: {
-            marketingEmail: false,
-            marketingPush: false,
-            subscribedThemes: [],
-          },
-        },
-      })
-
-      renderThematicHome()
-
-      await act(async () => fireEvent.press(screen.getByText('Suivre')))
-
-      expect(screen.getByText('Autoriser l’envoi d’e-mails')).toBeOnTheScreen()
-    })
-
-    it('should show unsubscribe modal when user is already subscribed and click on subscribe button', async () => {
-      mockUseAuthContext.mockReturnValueOnce({
-        ...baseAuthContext,
-        isLoggedIn: true,
-        user: {
-          ...beneficiaryUser,
-          subscriptions: {
-            marketingEmail: true,
-            marketingPush: true,
-            subscribedThemes: [SubscriptionTheme.CINEMA],
-          },
-        },
-      })
-
-      renderThematicHome()
-
-      await act(async () => fireEvent.press(screen.getByText('Déjà suivi')))
-
-      expect(
-        screen.getByText('Es-tu sûr de ne plus vouloir suivre ce thème\u00a0?')
-      ).toBeOnTheScreen()
-    })
-
-    it('should show subscription success modal when user subscribe to a thematic for the second time', async () => {
-      mockServer.postApi('/v1/profile', {})
-
-      await storage.saveObject('times_user_subscribed_to_a_theme', 1)
-      renderThematicHome()
-
-      await act(async () => fireEvent.press(screen.getByText('Suivre')))
-
-      expect(screen.getByText('Tu suis le thème "Cinéma"')).toBeOnTheScreen()
-      expect(screen.getByText('Voir mes préférences')).toBeOnTheScreen()
-    })
-
-    it('should show snackbar when user subscribe to a thematic home for more than 3 times', async () => {
-      mockServer.postApi('/v1/profile', {})
-
-      await storage.saveObject('times_user_subscribed_to_a_theme', 3)
-      renderThematicHome()
-
-      await act(async () => fireEvent.press(screen.getByText('Suivre')))
-
-      expect(mockShowSuccessSnackBar).toHaveBeenCalledWith({
-        message: 'Tu suis le thème “Cinéma”\u00a0! Tu peux gérer tes alertes depuis ton profil.',
-        timeout: SNACK_BAR_TIME_OUT,
-      })
-    })
-  })
-
   describe('analytics', () => {
     it('should log ConsultHome', async () => {
       renderThematicHome()
-      await act(async () => {})
 
-      expect(analytics.logConsultHome).toHaveBeenNthCalledWith(1, { homeEntryId: 'fakeEntryId' })
+      await waitFor(() => {
+        expect(analytics.logConsultHome).toHaveBeenNthCalledWith(1, { homeEntryId: 'fakeEntryId' })
+      })
     })
 
     it('should log ConsultHome when coming from category block', async () => {
@@ -296,13 +172,14 @@ describe('ThematicHome', () => {
         },
       })
       renderThematicHome()
-      await act(async () => {})
 
-      expect(analytics.logConsultHome).toHaveBeenNthCalledWith(1, {
-        homeEntryId: 'fakeEntryId',
-        from: 'category_block',
-        moduleId: 'moduleId',
-        moduleListId: 'moduleListId',
+      await waitFor(() => {
+        expect(analytics.logConsultHome).toHaveBeenNthCalledWith(1, {
+          homeEntryId: 'fakeEntryId',
+          from: 'category_block',
+          moduleId: 'moduleId',
+          moduleListId: 'moduleListId',
+        })
       })
     })
 
@@ -317,10 +194,12 @@ describe('ThematicHome', () => {
       renderThematicHome()
       await act(async () => {})
 
-      expect(analytics.logConsultHome).toHaveBeenNthCalledWith(1, {
-        homeEntryId: 'fakeEntryId',
-        from: 'highlight_thematic_block',
-        moduleId: 'moduleId',
+      await waitFor(() => {
+        expect(analytics.logConsultHome).toHaveBeenNthCalledWith(1, {
+          homeEntryId: 'fakeEntryId',
+          from: 'highlight_thematic_block',
+          moduleId: 'moduleId',
+        })
       })
     })
   })
@@ -332,9 +211,9 @@ describe('ThematicHome', () => {
       })
       renderThematicHome()
 
-      await act(async () => {})
-
-      expect(screen.getByText('Géolocalise-toi')).toBeOnTheScreen()
+      await waitFor(() => {
+        expect(screen.getByText('Géolocalise-toi')).toBeOnTheScreen()
+      })
     })
 
     it('should not show geolocation banner when user is geolocated or located', async () => {
@@ -346,7 +225,7 @@ describe('ThematicHome', () => {
       })
       renderThematicHome()
 
-      await act(async () => {})
+      await screen.findByText('Suivre')
 
       expect(screen.queryByText('Géolocalise-toi')).not.toBeOnTheScreen()
     })
@@ -354,7 +233,5 @@ describe('ThematicHome', () => {
 })
 
 const renderThematicHome = () => {
-  render(<ThematicHome />, {
-    wrapper: ({ children }) => reactQueryProviderHOC(children),
-  })
+  render(reactQueryProviderHOC(<ThematicHome />))
 }

--- a/src/features/subscription/helpers/useThematicSubscription.native.test.tsx
+++ b/src/features/subscription/helpers/useThematicSubscription.native.test.tsx
@@ -1,5 +1,6 @@
 import * as API from 'api/api'
 import { UserProfileResponse } from 'api/gen'
+import * as useMapSubscriptionHomeIdsToThematic from 'features/subscription/helpers/useMapSubscriptionHomeIdsToThematic'
 import {
   useThematicSubscription,
   Props as useThematicSubscriptionProps,
@@ -24,6 +25,10 @@ jest.mock('ui/components/snackBar/SnackBarContext', () => ({
     showErrorSnackBar: mockShowErrorSnackBar,
   }),
 }))
+
+jest
+  .spyOn(useMapSubscriptionHomeIdsToThematic, 'useMapSubscriptionHomeIdsToThematic')
+  .mockReturnValue(SubscriptionTheme.CINEMA)
 
 const postProfileSpy = jest.spyOn(API.api, 'postNativeV1Profile')
 
@@ -66,7 +71,6 @@ describe('useThematicSubscription', () => {
     it('should give us the information that at least one notification is active', async () => {
       const { result } = renderUseThematicSubscription({
         user: userWithNotificationsButNoSubscriptions,
-        thematic: SubscriptionTheme.ACTIVITES,
         homeId,
         onUpdateSubscriptionSuccess: jest.fn(),
       })
@@ -80,7 +84,6 @@ describe('useThematicSubscription', () => {
       it('should consider subscribe button active', async () => {
         const { result } = renderUseThematicSubscription({
           user: userWithNotificationsAndSubscribed,
-          thematic: SubscriptionTheme.ACTIVITES,
           homeId,
           onUpdateSubscriptionSuccess: jest.fn(),
         })
@@ -94,7 +97,6 @@ describe('useThematicSubscription', () => {
         mockServer.postApi('/v1/profile', {})
         const { result } = renderUseThematicSubscription({
           user: userWithNotificationsAndSubscribed,
-          thematic: SubscriptionTheme.CINEMA,
           homeId,
           onUpdateSubscriptionSuccess: jest.fn(),
         })
@@ -117,7 +119,6 @@ describe('useThematicSubscription', () => {
       it('should consider subscribe button inactive', async () => {
         const { result } = renderUseThematicSubscription({
           user: userWithNotificationsButNoSubscriptions,
-          thematic: SubscriptionTheme.ACTIVITES,
           homeId,
           onUpdateSubscriptionSuccess: jest.fn(),
         })
@@ -131,7 +132,6 @@ describe('useThematicSubscription', () => {
         mockServer.postApi('/v1/profile', {})
         const { result } = renderUseThematicSubscription({
           user: userWithNotificationsButNoSubscriptions,
-          thematic: SubscriptionTheme.MUSIQUE,
           homeId,
           onUpdateSubscriptionSuccess: jest.fn(),
         })
@@ -143,7 +143,7 @@ describe('useThematicSubscription', () => {
             subscriptions: {
               marketingEmail: true,
               marketingPush: true,
-              subscribedThemes: [SubscriptionTheme.MUSIQUE],
+              subscribedThemes: [SubscriptionTheme.CINEMA],
             },
           })
         })
@@ -155,7 +155,6 @@ describe('useThematicSubscription', () => {
     it('should give us the information that notifications are inactive', async () => {
       const { result } = renderUseThematicSubscription({
         user: userWithoutNotificationsAndWithoutSubscriptions,
-        thematic: SubscriptionTheme.ACTIVITES,
         homeId,
         onUpdateSubscriptionSuccess: jest.fn(),
       })
@@ -169,7 +168,6 @@ describe('useThematicSubscription', () => {
       it('should consider subscribe button inactive', async () => {
         const { result } = renderUseThematicSubscription({
           user: userWithoutNotificationsButWithSubscriptions,
-          thematic: SubscriptionTheme.CINEMA,
           homeId,
           onUpdateSubscriptionSuccess: jest.fn(),
         })
@@ -183,7 +181,6 @@ describe('useThematicSubscription', () => {
         mockServer.postApi('/v1/profile', {})
         const { result } = renderUseThematicSubscription({
           user: userWithoutNotificationsButWithSubscriptions,
-          thematic: SubscriptionTheme.CINEMA,
           homeId,
           onUpdateSubscriptionSuccess: jest.fn(),
         })
@@ -209,7 +206,6 @@ describe('useThematicSubscription', () => {
       it('should consider subscribe button inactive', async () => {
         const { result } = renderUseThematicSubscription({
           user: userWithoutNotificationsAndWithoutSubscriptions,
-          thematic: SubscriptionTheme.CINEMA,
           homeId,
           onUpdateSubscriptionSuccess: jest.fn(),
         })
@@ -223,7 +219,6 @@ describe('useThematicSubscription', () => {
         mockServer.postApi('/v1/profile', {})
         const { result } = renderUseThematicSubscription({
           user: userWithoutNotificationsAndWithoutSubscriptions,
-          thematic: SubscriptionTheme.CINEMA,
           homeId,
           onUpdateSubscriptionSuccess: jest.fn(),
         })
@@ -250,7 +245,6 @@ describe('useThematicSubscription', () => {
         mockServer.postApi('/v1/profile', {})
         const { result } = renderUseThematicSubscription({
           user: undefined,
-          thematic: SubscriptionTheme.CINEMA,
           homeId,
           onUpdateSubscriptionSuccess: jest.fn(),
         })
@@ -281,7 +275,6 @@ describe('useThematicSubscription', () => {
 
       const { result } = renderUseThematicSubscription({
         user: userWithNotificationsButNoSubscriptions,
-        thematic: SubscriptionTheme.ACTIVITES,
         homeId,
         onUpdateSubscriptionSuccess: jest.fn(),
       })
@@ -305,7 +298,6 @@ describe('useThematicSubscription', () => {
 
       const { result } = renderUseThematicSubscription({
         user: userWithNotificationsButNoSubscriptions,
-        thematic: SubscriptionTheme.ACTIVITES,
         homeId,
         onUpdateSubscriptionSuccess: onUpdateSubscriptionSuccessMock,
       })
@@ -323,7 +315,6 @@ describe('useThematicSubscription', () => {
       mockServer.postApi('/v1/profile', {})
       const { result } = renderUseThematicSubscription({
         user: userWithNotificationsButNoSubscriptions,
-        thematic: SubscriptionTheme.ACTIVITES,
         homeId,
         onUpdateSubscriptionSuccess: jest.fn(),
       })
@@ -343,7 +334,6 @@ describe('useThematicSubscription', () => {
       mockServer.postApi('/v1/profile', {})
       const { result } = renderUseThematicSubscription({
         user: userWithNotificationsAndSubscribed,
-        thematic: SubscriptionTheme.ACTIVITES,
         homeId,
         onUpdateSubscriptionSuccess: jest.fn(),
       })

--- a/src/features/subscription/helpers/useThematicSubscription.web.test.tsx
+++ b/src/features/subscription/helpers/useThematicSubscription.web.test.tsx
@@ -1,3 +1,4 @@
+import * as useMapSubscriptionHomeIdsToThematic from 'features/subscription/helpers/useMapSubscriptionHomeIdsToThematic'
 import {
   useThematicSubscription,
   Props as useThematicSubscriptionProps,
@@ -15,6 +16,10 @@ jest.mock('features/profile/pages/NotificationSettings/usePushPermission', () =>
 
 const homeId = 'homeId'
 
+jest
+  .spyOn(useMapSubscriptionHomeIdsToThematic, 'useMapSubscriptionHomeIdsToThematic')
+  .mockReturnValue(SubscriptionTheme.CINEMA)
+
 describe('useThematicSubscription', () => {
   describe('when the user has email notifications off and push notifications on', () => {
     it('should give the information that there is not at least one notification type active', async () => {
@@ -27,7 +32,6 @@ describe('useThematicSubscription', () => {
             subscribedThemes: [],
           },
         },
-        thematic: SubscriptionTheme.CINEMA,
         homeId,
         onUpdateSubscriptionSuccess: jest.fn(),
       })
@@ -47,7 +51,6 @@ describe('useThematicSubscription', () => {
             subscribedThemes: [],
           },
         },
-        thematic: SubscriptionTheme.CINEMA,
         homeId,
         onUpdateSubscriptionSuccess: jest.fn(),
       })
@@ -69,7 +72,6 @@ describe('useThematicSubscription', () => {
             subscribedThemes: [],
           },
         },
-        thematic: SubscriptionTheme.CINEMA,
         homeId,
         onUpdateSubscriptionSuccess: jest.fn(),
       })
@@ -89,7 +91,6 @@ describe('useThematicSubscription', () => {
             subscribedThemes: [SubscriptionTheme.CINEMA],
           },
         },
-        thematic: SubscriptionTheme.CINEMA,
         homeId,
         onUpdateSubscriptionSuccess: jest.fn(),
       })


### PR DESCRIPTION
moving the modals state down the tree prevent flashes when a user subscribes to a home thematic.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29257

## Checklist

I have:

- [X] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [X] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screencast

https://github.com/pass-culture/pass-culture-app-native/assets/26348504/d72bfb29-e807-4d83-bd18-92e69fca805b


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
