### PR TITLE
(PC-29383) fix(firebase): Reset default event params when no campaign date in storage

### DIFF
--- a/src/libs/firebase/analytics/useInit.native.test.ts
+++ b/src/libs/firebase/analytics/useInit.native.test.ts
@@ -27,8 +27,28 @@ describe('useInit', () => {
     })
   })
 
+  it('should set default event parameters to null when there is no campaign date', async () => {
+    useUtmParamsSpy.mockReturnValueOnce({ campaignDate: null })
+    renderHook(useInit)
+
+    expect(firebaseAnalytics.setDefaultEventParameters).toHaveBeenCalledWith({
+      traffic_campaign: null,
+      traffic_content: null,
+      traffic_gen: null,
+      traffic_medium: null,
+      traffic_source: null,
+    })
+  })
+
   it('should not reset default event parameters if the campaign date started less than 24 hours ago', async () => {
     useUtmParamsSpy.mockReturnValueOnce({ campaignDate: TWENTY_THREE_HOURS_AGO })
+    renderHook(useInit)
+
+    expect(firebaseAnalytics.setDefaultEventParameters).not.toHaveBeenCalled()
+  })
+
+  it('should not reset default event parameters while reading campaign date', async () => {
+    useUtmParamsSpy.mockReturnValueOnce({ campaignDate: undefined })
     renderHook(useInit)
 
     expect(firebaseAnalytics.setDefaultEventParameters).not.toHaveBeenCalled()

--- a/src/libs/firebase/analytics/useInit.ts
+++ b/src/libs/firebase/analytics/useInit.ts
@@ -8,7 +8,7 @@ export const setFirebaseParams = (campaignDate?: Date | null) => {
   ago24Hours.setDate(ago24Hours.getDate() - 1)
 
   // If the user has clicked on marketing link 24h ago, we want to remove the marketing params
-  if (campaignDate && campaignDate < ago24Hours) {
+  if (campaignDate === null || (campaignDate && campaignDate < ago24Hours)) {
     const marketingParams = {
       traffic_campaign: null,
       traffic_content: null,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29383

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
