### PR TITLE
(PC-29395) fix(StickyBookingButton): fix the spacing between the bottom of the mobile and the blur

### DIFF
--- a/src/features/offer/components/StickyBookingButton/StickyBookingButton.tsx
+++ b/src/features/offer/components/StickyBookingButton/StickyBookingButton.tsx
@@ -7,6 +7,7 @@ import { ICTAWordingAndAction } from 'features/offer/helpers/useCtaWordingAndAct
 import { BlurryWrapper } from 'ui/components/BlurryWrapper/BlurryWrapper'
 import { StickyBottomWrapper } from 'ui/components/StickyBottomWrapper/StickyBottomWrapper'
 import { Spacer, getSpacing } from 'ui/theme'
+import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 type Props = {
   ctaWordingAndAction: ICTAWordingAndAction
@@ -19,6 +20,7 @@ export const StickyBookingButton: FunctionComponent<Props> = ({
   isFreeDigitalOffer,
   isLoggedIn,
 }) => {
+  const { bottom } = useCustomSafeInsets()
   const { wording, onPress, navigateTo, externalNav, isDisabled, bottomBannerText } =
     ctaWordingAndAction
 
@@ -27,7 +29,7 @@ export const StickyBookingButton: FunctionComponent<Props> = ({
   }
 
   return (
-    <StickyBottomWrapper>
+    <StyledStickyBottomWrapper bottom={-bottom}>
       {wording ? (
         <BlurryWrapper>
           <CallToActionContainer testID="sticky-booking-button">
@@ -45,9 +47,11 @@ export const StickyBookingButton: FunctionComponent<Props> = ({
       ) : null}
 
       {bottomBannerText ? <StyledBottomBanner text={bottomBannerText} /> : <Spacer.BottomScreen />}
-    </StickyBottomWrapper>
+    </StyledStickyBottomWrapper>
   )
 }
+
+const StyledStickyBottomWrapper = styled(StickyBottomWrapper)(({ bottom }) => ({ bottom }))
 
 const CallToActionContainer = styled.View({
   paddingHorizontal: getSpacing(4),

--- a/src/ui/components/BlurryWrapper/BlurryWrapper.tsx
+++ b/src/ui/components/BlurryWrapper/BlurryWrapper.tsx
@@ -13,7 +13,7 @@ export function BlurryWrapper({ children }: Props) {
   ) : (
     <StyledBlurry
       blurType="light"
-      blurAmount={1}
+      blurAmount={5}
       reducedTransparencyFallbackColor="white"
       testID="blurry-wrapper">
       {children}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29395

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="445" alt="Capture d’écran 2024-04-29 à 16 11 28" src="https://github.com/pass-culture/pass-culture-app-native/assets/62058919/7eeb41d2-7b15-4fc0-9672-7fe432b0650d">|<img width="447" alt="Capture d’écran 2024-04-29 à 16 10 51" src="https://github.com/pass-culture/pass-culture-app-native/assets/62058919/2b587e26-2c9e-4c6b-8ce0-44a16c2fb67a">|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
