### PR TITLE
(PC-29257) refactor(subscription): move animated components outside

### DIFF
--- a/src/features/home/components/headers/AnimatedCategoryThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/AnimatedCategoryThematicHomeHeader.tsx
@@ -18,10 +18,6 @@ export const AnimatedCategoryThematicHomeHeader: FunctionComponent<CategoryThema
   imageAnimatedHeight,
   gradientTranslation,
 }) => {
-  const AnimatedImage = Animated.createAnimatedComponent(StyledImage)
-  const AnimatedBlackBackground = Animated.createAnimatedComponent(BlackBackground)
-  const AnimatedBlackGradient = Animated.createAnimatedComponent(BlackGradient)
-
   return (
     <Container testID="animated-thematic-header">
       <AnimatedImage source={{ uri: imageUrl }} height={imageAnimatedHeight} />
@@ -71,3 +67,7 @@ const Subtitle = styled(Typo.Title4)(({ theme }) => ({
 const Title = styled(Typo.Title1)(({ theme }) => ({
   color: theme.colors.white,
 }))
+
+const AnimatedImage = Animated.createAnimatedComponent(StyledImage)
+const AnimatedBlackBackground = Animated.createAnimatedComponent(BlackBackground)
+const AnimatedBlackGradient = Animated.createAnimatedComponent(BlackGradient)

--- a/src/features/home/components/headers/AnimatedHighlightThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/AnimatedHighlightThematicHomeHeader.tsx
@@ -29,10 +29,6 @@ export const AnimatedHighlightThematicHomeHeader: FunctionComponent<
 
   const dateRange = computeDateRangeDisplay(beginningDate, endingDate)
 
-  const AnimatedImage = Animated.createAnimatedComponent(StyledImage)
-  const AnimatedBlackBackground = Animated.createAnimatedComponent(BlackBackground)
-  const AnimatedBlackGradient = Animated.createAnimatedComponent(BlackGradient)
-
   return (
     <Container testID="animated-thematic-header">
       <AnimatedImage source={{ uri: imageUrl }} height={imageAnimatedHeight} />
@@ -101,3 +97,7 @@ const Subtitle = styled(Typo.Title4)(({ theme }) => ({
 const Title = styled(Typo.Title1)(({ theme }) => ({
   color: theme.colors.white,
 }))
+
+const AnimatedImage = Animated.createAnimatedComponent(StyledImage)
+const AnimatedBlackBackground = Animated.createAnimatedComponent(BlackBackground)
+const AnimatedBlackGradient = Animated.createAnimatedComponent(BlackGradient)

--- a/src/features/home/pages/ThematicHome.tsx
+++ b/src/features/home/pages/ThematicHome.tsx
@@ -109,8 +109,6 @@ export const ThematicHome: FunctionComponent = () => {
   const { userLocation } = useLocation()
   const isLocated = !!userLocation
 
-  const AnimatedHeader = Animated.createAnimatedComponent(AnimatedHeaderContainer)
-
   const { onScroll, headerTransition, imageAnimatedHeight, gradientTranslation, viewTranslation } =
     useOpacityTransition({
       headerHeight:
@@ -183,6 +181,8 @@ const AnimatedHeaderContainer = styled.View({
   left: 0,
   right: 0,
 })
+
+const AnimatedHeader = Animated.createAnimatedComponent(AnimatedHeaderContainer)
 
 const Container = styled.View(({ theme }) => ({
   flex: 1,


### PR DESCRIPTION
redeclaring animated components create a new component, thus remounting all child components.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29257

## Checklist

I have:

- [X] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [X] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

https://github.com/pass-culture/pass-culture-app-native/assets/26348504/bd8ddcec-1135-424a-b55b-08d305bbc8fb


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
