### PR TITLE
(PC-29290) fix(ui): remove spacing when button not display for survey modal

### DIFF
--- a/src/ui/components/modals/SurveyModal.tsx
+++ b/src/ui/components/modals/SurveyModal.tsx
@@ -34,17 +34,20 @@ export const SurveyModal = ({
           <Typo.Body>{surveyDescription}</Typo.Body>
         </Container>
       )}
-      <Spacer.Column numberOfSpaces={8} />
+
       {surveyUrl ? (
-        <ExternalTouchableLink
-          onBeforeNavigate={hideModal}
-          as={ButtonPrimary}
-          icon={ExternalSite}
-          wording="Répondre au questionnaire"
-          externalNav={{
-            url: surveyUrl,
-          }}
-        />
+        <React.Fragment>
+          <Spacer.Column numberOfSpaces={8} />
+          <ExternalTouchableLink
+            onBeforeNavigate={hideModal}
+            as={ButtonPrimary}
+            icon={ExternalSite}
+            wording="Répondre au questionnaire"
+            externalNav={{
+              url: surveyUrl,
+            }}
+          />
+        </React.Fragment>
       ) : null}
     </AppInformationModal>
   )


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29290

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |![Capture d’écran 2024-04-30 à 09 48 17](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/2df8fcc4-65ea-4a4c-ba86-714fbacc0cf0)|![Capture d’écran 2024-04-30 à 09 48 04](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/5d06f48c-4840-442d-88ac-d5eb8c9e96ad)|
| Android          |![Capture d’écran 2024-04-30 à 09 48 21](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/d84eada8-2018-419d-905e-443e03a1c8f9)|![Capture d’écran 2024-04-30 à 09 47 36](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/241fac68-8319-4cd5-8350-ed1f2cb79652)|
| Phone - Chrome   |               |       |
| Desktop - Chrome |<img width="1727" alt="Capture d’écran 2024-04-30 à 09 49 12" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/b6c3a664-177e-4b2a-9f96-fdae19696fa2">|<img width="1728" alt="Capture d’écran 2024-04-30 à 09 39 12" src="https://github.com/pass-culture/pass-culture-app-native/assets/78556024/558c168a-62a4-4343-a46b-156e848c141b">|


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
