### PR TITLE
(PC-29565) feat(offer): use image urls from images object of OfferResponseV2 + use OfferResponseV2 everywhere

### DIFF
--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -2086,6 +2086,117 @@ export interface OfferResponse {
 }
 /**
  * @export
+ * @interface OfferResponseV2
+ */
+export interface OfferResponseV2 {
+  /**
+   * @type {OfferAccessibilityResponse}
+   * @memberof OfferResponseV2
+   */
+  accessibility: OfferAccessibilityResponse
+  /**
+   * @type {string}
+   * @memberof OfferResponseV2
+   */
+  description?: string | null
+  /**
+   * @type {Array<ExpenseDomain>}
+   * @memberof OfferResponseV2
+   */
+  expenseDomains: Array<ExpenseDomain>
+  /**
+   * @type {string}
+   * @memberof OfferResponseV2
+   */
+  externalTicketOfficeUrl?: string | null
+  /**
+   * @type {OfferExtraData}
+   * @memberof OfferResponseV2
+   */
+  extraData?: OfferExtraData | null
+  /**
+   * @type {number}
+   * @memberof OfferResponseV2
+   */
+  id: number
+  /**
+   * @type {{ [key: string]: OfferImageResponse; }}
+   * @memberof OfferResponseV2
+   */
+  images?: { [key: string]: OfferImageResponse; } | null
+  /**
+   * @type {boolean}
+   * @memberof OfferResponseV2
+   */
+  isDigital: boolean
+  /**
+   * @type {boolean}
+   * @memberof OfferResponseV2
+   */
+  isDuo: boolean
+  /**
+   * @type {boolean}
+   * @memberof OfferResponseV2
+   */
+  isEducational: boolean
+  /**
+   * @type {boolean}
+   * @memberof OfferResponseV2
+   */
+  isExpired: boolean
+  /**
+   * @type {boolean}
+   * @memberof OfferResponseV2
+   */
+  isExternalBookingsDisabled: boolean
+  /**
+   * @type {boolean}
+   * @memberof OfferResponseV2
+   */
+  isForbiddenToUnderage: boolean
+  /**
+   * @type {boolean}
+   * @memberof OfferResponseV2
+   */
+  isReleased: boolean
+  /**
+   * @type {boolean}
+   * @memberof OfferResponseV2
+   */
+  isSoldOut: boolean
+  /**
+   * @type {any}
+   * @memberof OfferResponseV2
+   */
+  metadata: any
+  /**
+   * @type {string}
+   * @memberof OfferResponseV2
+   */
+  name: string
+  /**
+   * @type {Array<OfferStockResponse>}
+   * @memberof OfferResponseV2
+   */
+  stocks: Array<OfferStockResponse>
+  /**
+   * @type {SubcategoryIdEnum}
+   * @memberof OfferResponseV2
+   */
+  subcategoryId: SubcategoryIdEnum
+  /**
+   * @type {OfferVenueResponse}
+   * @memberof OfferResponseV2
+   */
+  venue: OfferVenueResponse
+  /**
+   * @type {string}
+   * @memberof OfferResponseV2
+   */
+  withdrawalDetails?: string | null
+}
+/**
+ * @export
  * @interface OfferStockActivationCodeResponse
  */
 export interface OfferStockActivationCodeResponse {
@@ -3940,6 +4051,7 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
     },
     /**
      * @summary get_offer <GET>
+     * @deprecated
      * @param {number} offer_id 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -4161,6 +4273,33 @@ export const DefaultApiFetchParamCreator = function (configuration?: Configurati
       const pathname = `/native/v1/venue/{venue_id}`.replace(
         `{${'venue_id'}}`,
         encodeURIComponent(String(venue_id))
+      )
+      let secureOptions = Object.assign(options, { credentials: 'omit' })
+      const localVarRequestOptions = Object.assign({ method: 'GET' }, secureOptions)
+      const localVarHeaderParameter = await getAuthenticationHeaders(secureOptions)
+      localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers)
+      return {
+        url: pathname,
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     * @summary get_offer_v2 <GET>
+     * @param {number} offer_id 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getNativeV2OfferofferId(offer_id: number, options: any = {}): Promise<FetchArgs> {
+      // verify required parameter 'offer_id' is not null or undefined
+      if (offer_id === null || offer_id === undefined) {
+        throw new RequiredError(
+          'offer_id',
+          'Required parameter offer_id was null or undefined when calling getNativeV2OfferofferId.'
+        )
+      }
+      const pathname = `/native/v2/offer/{offer_id}`.replace(
+        `{${'offer_id'}}`,
+        encodeURIComponent(String(offer_id))
       )
       let secureOptions = Object.assign(options, { credentials: 'omit' })
       const localVarRequestOptions = Object.assign({ method: 'GET' }, secureOptions)
@@ -5187,6 +5326,7 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
     /**
      * 
      * @summary get_offer <GET>
+     * @deprecated
      * @param {number} offer_id 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -5318,6 +5458,18 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: Configurat
      */
     async getNativeV1VenuevenueId(venue_id: number, options?: any): Promise<VenueResponse> {
       const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV1VenuevenueId(venue_id, options)
+      const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
+      return handleGeneratedApiResponse(response)
+    },
+    /**
+     * 
+     * @summary get_offer_v2 <GET>
+     * @param {number} offer_id 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getNativeV2OfferofferId(offer_id: number, options?: any): Promise<OfferResponseV2> {
+      const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getNativeV2OfferofferId(offer_id, options)
       const response = await safeFetch(configuration?.basePath + localVarFetchArgs.url, localVarFetchArgs.options, api)
       return handleGeneratedApiResponse(response)
     },
@@ -5956,6 +6108,7 @@ export class DefaultApi extends BaseAPI {
   /**
     * 
     * @summary get_offer <GET>
+    * @deprecated
     * @param {number} offer_id 
     * @param {*} [options] Override http request option.
     * @throws {RequiredError}
@@ -6089,6 +6242,18 @@ export class DefaultApi extends BaseAPI {
   public async getNativeV1VenuevenueId(venue_id: number, options?: any) {
     const configuration = this.getConfiguration()
     return DefaultApiFp(this, configuration).getNativeV1VenuevenueId(venue_id, options)
+  }
+  /**
+    * 
+    * @summary get_offer_v2 <GET>
+    * @param {number} offer_id 
+    * @param {*} [options] Override http request option.
+    * @throws {RequiredError}
+    * @memberof DefaultApi
+    */
+  public async getNativeV2OfferofferId(offer_id: number, options?: any) {
+    const configuration = this.getConfiguration()
+    return DefaultApiFp(this, configuration).getNativeV2OfferofferId(offer_id, options)
   }
   /**
     * 

--- a/src/features/bookOffer/components/AlreadyBooked.native.test.tsx
+++ b/src/features/bookOffer/components/AlreadyBooked.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { initialBookingState, Step } from 'features/bookOffer/context/reducer'
 import { fireEvent, render, screen } from 'tests/utils'
 
@@ -20,14 +20,14 @@ jest.mock('features/bookOffer/context/useBookingContext', () => ({
 
 describe('<AlreadyBooked />', () => {
   it('should dismiss modal when clicking on cta', () => {
-    render(<AlreadyBooked offer={{ name: 'hello' } as OfferResponse} />)
+    render(<AlreadyBooked offer={{ name: 'hello' } as OfferResponseV2} />)
     fireEvent.press(screen.getByText('Mes réservations terminées'))
 
     expect(mockDismissModal).toHaveBeenCalledTimes(1)
   })
 
   it('should change booking step from date to confirmation', () => {
-    render(<AlreadyBooked offer={{ name: 'hello' } as OfferResponse} />)
+    render(<AlreadyBooked offer={{ name: 'hello' } as OfferResponseV2} />)
 
     expect(mockDispatch).toHaveBeenNthCalledWith(1, {
       type: 'CHANGE_STEP',

--- a/src/features/bookOffer/components/AlreadyBooked.tsx
+++ b/src/features/bookOffer/components/AlreadyBooked.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import styled from 'styled-components/native'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { Step } from 'features/bookOffer/context/reducer'
 import { useBookingContext } from 'features/bookOffer/context/useBookingContext'
 import { env } from 'libs/environment'
@@ -11,7 +11,7 @@ import { Spacer } from 'ui/components/spacer/Spacer'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { getSpacing, Typo } from 'ui/theme'
 
-export function AlreadyBooked({ offer }: { offer: OfferResponse }) {
+export function AlreadyBooked({ offer }: { offer: OfferResponseV2 }) {
   const { bookingState, dismissModal, dispatch } = useBookingContext()
 
   // Change step to confirmation

--- a/src/features/bookOffer/components/BookHourChoice.native.test.tsx
+++ b/src/features/bookOffer/components/BookHourChoice.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { BookingState, Step } from 'features/bookOffer/context/reducer'
 import { mockOffer as mockBaseOffer } from 'features/bookOffer/fixtures/offer'
 import { stock1, stock2, stock3, stock4 } from 'features/bookOffer/fixtures/stocks'
@@ -36,7 +36,7 @@ jest.mock('features/bookOffer/helpers/useBookingStock', () => ({
   })),
 }))
 
-let mockOffer: OfferResponse = mockBaseOffer
+let mockOffer: OfferResponseV2 = mockBaseOffer
 jest.mock('features/bookOffer/helpers/useBookingOffer', () => ({
   useBookingOffer: jest.fn(() => mockOffer),
 }))

--- a/src/features/bookOffer/components/BookingDetails.native.test.tsx
+++ b/src/features/bookOffer/components/BookingDetails.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { OfferResponse, SubcategoryIdEnum } from 'api/gen'
+import { OfferResponseV2, SubcategoryIdEnum } from 'api/gen'
 import { BookingState, initialBookingState, Step } from 'features/bookOffer/context/reducer'
 import { mockDigitalOffer, mockOffer } from 'features/bookOffer/fixtures/offer'
 import * as BookingOfferAPI from 'features/bookOffer/helpers/useBookingOffer'
@@ -145,7 +145,7 @@ describe('<BookingDetails />', () => {
   })
 
   beforeEach(() => {
-    mockServer.getApi<OfferResponse>(`/v1/offer/${mockOfferId}`, offerResponseSnap)
+    mockServer.getApi<OfferResponseV2>(`/v2/offer/${mockOfferId}`, offerResponseSnap)
   })
 
   afterEach(() => {

--- a/src/features/bookOffer/components/BookingEventChoices.native.test.tsx
+++ b/src/features/bookOffer/components/BookingEventChoices.native.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { Step } from 'features/bookOffer/context/reducer'
 import { useBookingContext } from 'features/bookOffer/context/useBookingContext'
@@ -30,7 +30,7 @@ jest.mock('features/bookOffer/context/useBookingContext', () => ({
 
 describe('<BookingEventChoices />', () => {
   beforeEach(() => {
-    mockServer.getApi<OfferResponse>(`/v1/offer/116656`, offerResponseSnap)
+    mockServer.getApi<OfferResponseV2>(`/v2/offer/116656`, offerResponseSnap)
   })
 
   beforeAll(() => {

--- a/src/features/bookOffer/components/BookingInformations.native.test.tsx
+++ b/src/features/bookOffer/components/BookingInformations.native.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { OfferResponse, SubcategoryIdEnum } from 'api/gen'
+import { OfferResponseV2, SubcategoryIdEnum } from 'api/gen'
 import { initialBookingState } from 'features/bookOffer/context/reducer'
 import { useBookingContext } from 'features/bookOffer/context/useBookingContext'
 import { mockOffer as baseOffer } from 'features/bookOffer/fixtures/offer'
@@ -41,7 +41,7 @@ const carteCineOfferDigital = {
   isDigital: true,
 }
 
-const mockUseBookingOffer = jest.fn((): OfferResponse | undefined => cinePleinAirOffer)
+const mockUseBookingOffer = jest.fn((): OfferResponseV2 | undefined => cinePleinAirOffer)
 jest.mock('features/bookOffer/helpers/useBookingOffer', () => ({
   useBookingOffer: () => mockUseBookingOffer(),
 }))

--- a/src/features/bookOffer/components/CancellationDetails.native.test.tsx
+++ b/src/features/bookOffer/components/CancellationDetails.native.test.tsx
@@ -1,7 +1,7 @@
 import mockdate from 'mockdate'
 import React from 'react'
 
-import { OfferResponse, OfferStockResponse } from 'api/gen'
+import { OfferResponseV2, OfferStockResponse } from 'api/gen'
 import { offerStockResponseSnap } from 'features/offer/fixtures/offerStockResponse'
 import { formatDateTimezone } from 'libs/parsers/formatDates'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -35,7 +35,7 @@ jest.mock('features/bookOffer/helpers/useBookingStock', () => ({
   useBookingStock: jest.fn(() => mockStock),
 }))
 
-let mockOffer = { id: 1, isDuo: true } as unknown as OfferResponse
+let mockOffer = { id: 1, isDuo: true } as unknown as OfferResponseV2
 jest.mock('features/bookOffer/helpers/useBookingOffer', () => ({
   useBookingOffer: jest.fn(() => mockOffer),
 }))
@@ -51,7 +51,7 @@ describe('<CancellationDetails /> when isDigital = true', () => {
           cancellationLimitDatetime,
           activationCode: { expirationDate: '2030-02-05T00:00:00Z' },
         }
-        mockOffer = { ...mockOffer, isDigital: true } as unknown as OfferResponse
+        mockOffer = { ...mockOffer, isDigital: true } as unknown as OfferResponseV2
         render(reactQueryProviderHOC(<CancellationDetails />))
 
         expectNotCancellable()
@@ -69,7 +69,7 @@ describe('<CancellationDetails /> when isDigital = true', () => {
           cancellationLimitDatetime,
           activationCode: { expirationDate: null },
         }
-        mockOffer = { ...mockOffer, isDigital: true } as unknown as OfferResponse
+        mockOffer = { ...mockOffer, isDigital: true } as unknown as OfferResponseV2
         render(reactQueryProviderHOC(<CancellationDetails />))
 
         expectNotCancellable()
@@ -85,7 +85,7 @@ describe('<CancellationDetails /> when isDigital = true', () => {
         cancellationLimitDatetime: null,
         activationCode: null,
       }
-      mockOffer = { ...mockOffer, isDigital: true } as unknown as OfferResponse
+      mockOffer = { ...mockOffer, isDigital: true } as unknown as OfferResponseV2
       render(reactQueryProviderHOC(<CancellationDetails />))
 
       expectCancellable()
@@ -98,7 +98,7 @@ describe('<CancellationDetails /> when isDigital = true', () => {
         cancellationLimitDatetime: pastDate,
         activationCode: null,
       }
-      mockOffer = { ...mockOffer, isDigital: true } as unknown as OfferResponse
+      mockOffer = { ...mockOffer, isDigital: true } as unknown as OfferResponseV2
       render(reactQueryProviderHOC(<CancellationDetails />))
 
       expectNotCancellable()
@@ -111,7 +111,7 @@ describe('<CancellationDetails /> when isDigital = true', () => {
         cancellationLimitDatetime: futureDate,
         activationCode: null,
       }
-      mockOffer = { ...mockOffer, isDigital: true } as unknown as OfferResponse
+      mockOffer = { ...mockOffer, isDigital: true } as unknown as OfferResponseV2
       render(reactQueryProviderHOC(<CancellationDetails />))
 
       expectCancellableBefore()

--- a/src/features/bookOffer/fixtures/offer.ts
+++ b/src/features/bookOffer/fixtures/offer.ts
@@ -1,6 +1,6 @@
 import type { ReadonlyDeep } from 'type-fest'
 
-import { ExpenseDomain, OfferResponse, SubcategoryIdEnum } from 'api/gen'
+import { ExpenseDomain, OfferResponseV2, SubcategoryIdEnum } from 'api/gen'
 import { toMutable } from 'shared/types/toMutable'
 
 export const mockOffer = toMutable({
@@ -74,9 +74,11 @@ export const mockOffer = toMutable({
       features: [],
     },
   ],
-  image: {
-    url: 'https://storage.gra.cloud.ovh.net/v1/AUTH_688df1e25bd84a48a3804e7fa8938085/storage-pc-dev/thumbs/mediations/CW8Q',
-    credit: null,
+  images: {
+    image1: {
+      url: 'https://storage.gra.cloud.ovh.net/v1/AUTH_688df1e25bd84a48a3804e7fa8938085/storage-pc-dev/thumbs/mediations/CW8Q',
+      credit: null,
+    },
   },
   venue: {
     id: 2090,
@@ -115,7 +117,7 @@ export const mockOffer = toMutable({
     },
   },
   isExternalBookingsDisabled: false,
-} as const satisfies ReadonlyDeep<OfferResponse>)
+} as const satisfies ReadonlyDeep<OfferResponseV2>)
 
 export const mockDigitalOffer = toMutable({
   id: 146113,
@@ -164,9 +166,11 @@ export const mockDigitalOffer = toMutable({
       features: [],
     },
   ],
-  image: {
-    url: 'https://storage.gra.cloud.ovh.net/v1/AUTH_688df1e25bd84a48a3804e7fa8938085/storage-pc-dev/thumbs/mediations/CW8Q',
-    credit: null,
+  images: {
+    image1: {
+      url: 'https://storage.gra.cloud.ovh.net/v1/AUTH_688df1e25bd84a48a3804e7fa8938085/storage-pc-dev/thumbs/mediations/CW8Q',
+      credit: null,
+    },
   },
   venue: {
     id: 2090,
@@ -205,4 +209,4 @@ export const mockDigitalOffer = toMutable({
     },
   },
   isExternalBookingsDisabled: false,
-} as const satisfies ReadonlyDeep<OfferResponse>)
+} as const satisfies ReadonlyDeep<OfferResponseV2>)

--- a/src/features/bookOffer/helpers/useModalContent.native.test.tsx
+++ b/src/features/bookOffer/helpers/useModalContent.native.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Platform } from 'react-native'
 
-import { OfferResponse, SubcategoryIdEnum } from 'api/gen'
+import { OfferResponseV2, SubcategoryIdEnum } from 'api/gen'
 import { Step } from 'features/bookOffer/context/reducer'
 import { mockOffer as baseOffer } from 'features/bookOffer/fixtures/offer'
 import { offerStockResponseSnap } from 'features/offer/fixtures/offerStockResponse'
@@ -10,7 +10,7 @@ import { renderHook } from 'tests/utils'
 
 import { useModalContent } from './useModalContent'
 
-let mockOffer: OfferResponse | undefined = baseOffer
+let mockOffer: OfferResponseV2 | undefined = baseOffer
 
 const mockDismissModal = jest.fn()
 const mockDispatch = jest.fn()

--- a/src/features/bookOffer/helpers/useModalContent.tsx
+++ b/src/features/bookOffer/helpers/useModalContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Platform } from 'react-native'
 
-import { CategoryIdEnum, OfferResponse, OfferStockResponse } from 'api/gen'
+import { CategoryIdEnum, OfferResponseV2, OfferStockResponse } from 'api/gen'
 import { AlreadyBooked } from 'features/bookOffer/components/AlreadyBooked'
 import { BookingDetails } from 'features/bookOffer/components/BookingDetails'
 import { BookingEventChoices } from 'features/bookOffer/components/BookingEventChoices'
@@ -32,7 +32,7 @@ const getDefaultModalContent = (): ModalContent => {
   }
 }
 
-const getEndedUseBookingModalContent = (offer: OfferResponse): ModalContent => {
+const getEndedUseBookingModalContent = (offer: OfferResponseV2): ModalContent => {
   return {
     children: <AlreadyBooked offer={offer} />,
     title: 'Réservation impossible',

--- a/src/features/bookOffer/pages/BookingOfferModal.web.test.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.web.test.tsx
@@ -68,7 +68,7 @@ jest.mock('api/useSearchVenuesOffer/useSearchVenueOffers', () => ({
 describe('<BookingOfferModal/>', () => {
   describe('Accessibility', () => {
     beforeEach(() => {
-      mockServer.getApi(`/v1/offer/${mockOffer.id}`, mockOffer)
+      mockServer.getApi(`/v2/offer/${mockOffer.id}`, mockOffer)
     })
 
     it('should not have basic accessibility issues for step "date"', async () => {

--- a/src/features/favorites/helpers/simulateBackend.ts
+++ b/src/features/favorites/helpers/simulateBackend.ts
@@ -2,7 +2,7 @@
 
 import {
   FavoriteResponse,
-  OfferResponse,
+  OfferResponseV2,
   PaginatedFavoritesResponse,
   UserProfileResponse,
   SubcategoriesResponseModelv2,
@@ -37,7 +37,7 @@ export function simulateBackend(options: Options = defaultOptions) {
     ...options,
   }
 
-  mockServer.getApi<OfferResponse>(`/v1/offer/${id}`, offerResponseSnap)
+  mockServer.getApi<OfferResponseV2>(`/v2/offer/${id}`, offerResponseSnap)
   mockServer.getApi<UserProfileResponse>(`/v1/me`, beneficiaryUser)
   mockServer.getApi<PaginatedFavoritesResponse>(`/v1/me/favorites`, paginatedFavoritesResponseSnap)
   mockServer.getApi<SubcategoriesResponseModelv2>(`/v1/subcategories/v2`, { ...placeholderData })

--- a/src/features/home/components/modules/exclusivity/ExclusivityModule.native.test.tsx
+++ b/src/features/home/components/modules/exclusivity/ExclusivityModule.native.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { UseQueryResult } from 'react-query'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import * as excluOfferAPI from 'features/home/api/useExcluOffer'
 import { offerResponseSnap as mockOffer } from 'features/offer/fixtures/offerResponse'
 import { render, screen } from 'tests/utils'
@@ -17,7 +17,7 @@ excluOfferAPISpy.mockImplementation(() => {
   return {
     isLoading: false,
     data: mockOffer,
-  } as unknown as UseQueryResult<OfferResponse>
+  } as unknown as UseQueryResult<OfferResponseV2>
 })
 
 const props: ExclusivityModuleProps = {

--- a/src/features/home/components/modules/exclusivity/ExclusivityOffer.native.test.tsx
+++ b/src/features/home/components/modules/exclusivity/ExclusivityOffer.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { UseQueryResult } from 'react-query'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import * as excluOfferAPI from 'features/home/api/useExcluOffer'
 import { ExclusivityOffer } from 'features/home/components/modules/exclusivity/ExclusivityOffer'
 import { offerResponseSnap as mockOffer } from 'features/offer/fixtures/offerResponse'
@@ -33,7 +33,7 @@ describe('ExclusivityModule component', () => {
       return {
         isLoading: false,
         data: mockOffer,
-      } as unknown as UseQueryResult<OfferResponse>
+      } as unknown as UseQueryResult<OfferResponseV2>
     })
   })
 
@@ -84,7 +84,7 @@ describe('ExclusivityModule component', () => {
       return {
         isLoading: false,
         data: undefined,
-      } as UseQueryResult<OfferResponse>
+      } as UseQueryResult<OfferResponseV2>
     })
     render(<ExclusivityOffer {...props} />)
 

--- a/src/features/home/components/modules/exclusivity/helpers/useShouldDisplayExcluOffer.native.test.ts
+++ b/src/features/home/components/modules/exclusivity/helpers/useShouldDisplayExcluOffer.native.test.ts
@@ -1,6 +1,6 @@
 import { UseQueryResult } from 'react-query'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import * as excluOfferAPI from 'features/home/api/useExcluOffer'
 import { useShouldDisplayExcluOffer } from 'features/home/components/modules/exclusivity/helpers/useShouldDisplayExcluOffer'
 import { ExclusivityModule } from 'features/home/types'
@@ -30,7 +30,7 @@ const excluOfferAPISpy = jest.spyOn(excluOfferAPI, 'useExcluOffer')
 excluOfferAPISpy.mockReturnValue({
   isLoading: false,
   data: mockOffer,
-} as unknown as UseQueryResult<OfferResponse>)
+} as unknown as UseQueryResult<OfferResponseV2>)
 
 describe('useShouldDisplayExcluOffer', () => {
   it('should display offer if no display parameters available', () => {
@@ -68,7 +68,7 @@ describe('useShouldDisplayExcluOffer', () => {
       excluOfferAPISpy.mockReturnValueOnce({
         isLoading: false,
         data: offerWithoutCoordinates,
-      } as unknown as UseQueryResult<OfferResponse>)
+      } as unknown as UseQueryResult<OfferResponseV2>)
 
       const { result } = renderHook(() => useShouldDisplayExcluOffer(display, offerId))
 

--- a/src/features/offer/api/useOffer.native.test.ts
+++ b/src/features/offer/api/useOffer.native.test.ts
@@ -1,4 +1,4 @@
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -8,7 +8,7 @@ import { useOffer } from './useOffer'
 
 describe('useOffer', () => {
   beforeEach(() =>
-    mockServer.getApi<OfferResponse>(`/v1/offer/${offerResponseSnap.id}`, offerResponseSnap)
+    mockServer.getApi<OfferResponseV2>(`/v2/offer/${offerResponseSnap.id}`, offerResponseSnap)
   )
 
   it('should call API otherwise', async () => {

--- a/src/features/offer/api/useOffer.ts
+++ b/src/features/offer/api/useOffer.ts
@@ -2,7 +2,7 @@ import { useQuery } from 'react-query'
 
 import { api } from 'api/api'
 import { ApiError } from 'api/ApiError'
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { OfferNotFound } from 'features/offer/pages/OfferNotFound/OfferNotFound'
 import { OfferNotFoundError } from 'libs/monitoring'
 import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
@@ -13,7 +13,7 @@ async function getOfferById(offerId: number) {
     throw new OfferNotFoundError(offerId, { Screen: OfferNotFound })
   }
   try {
-    return await api.getNativeV1OfferofferId(offerId)
+    return await api.getNativeV2OfferofferId(offerId)
   } catch (error) {
     if (error instanceof ApiError && error.statusCode === 404) {
       // This happens when the offer has been rejected but it is still indexed on Algolia
@@ -27,7 +27,7 @@ async function getOfferById(offerId: number) {
 export const useOffer = ({ offerId }: { offerId: number }) => {
   const netInfo = useNetInfoContext()
 
-  return useQuery<OfferResponse | undefined>(
+  return useQuery<OfferResponseV2 | undefined>(
     [QueryKeys.OFFER, offerId],
     () => (offerId ? getOfferById(offerId) : undefined),
     { enabled: !!netInfo.isConnected }

--- a/src/features/offer/components/MovieScreeningCalendar/MovieScreeningCalendar.native.test.tsx
+++ b/src/features/offer/components/MovieScreeningCalendar/MovieScreeningCalendar.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import {
   BookingsResponse,
-  OfferResponse,
+  OfferResponseV2,
   OfferStockResponse,
   SubcategoriesResponseModelv2,
   SubcategoryIdEnum,
@@ -67,7 +67,7 @@ const defaultOfferStockResponse: OfferStockResponse = {
   price: 570,
 }
 
-const defaultOfferResponse: OfferResponse = {
+const defaultOfferResponse: OfferResponseV2 = {
   ...offerResponseSnap,
   subcategoryId: SubcategoryIdEnum.SEANCE_CINE,
   stocks: [defaultOfferStockResponse],
@@ -172,7 +172,7 @@ describe('Movie screening calendar', () => {
     beforeEach(() => {
       mockServer.getApi<BookingsResponse>('/v1/bookings', bookingsSnap)
       mockServer.getApi<SubcategoriesResponseModelv2>('/v1/subcategories/v2', placeholderData)
-      mockServer.getApi<OfferResponse>(`/v1/offer/${offerResponseSnap.id}`, offerResponseSnap)
+      mockServer.getApi<OfferResponseV2>(`/v2/offer/${offerResponseSnap.id}`, offerResponseSnap)
       mockAuthContext = defaultAuthContext
     })
 
@@ -188,7 +188,7 @@ describe('Movie screening calendar', () => {
     })
 
     it('should open isDuo modal when user is loggedIn and clicks on a bookable eventCard', async () => {
-      mockServer.getApi<OfferResponse>(`/v1/offer/${offerResponseSnap.id}`, offerResponseSnap)
+      mockServer.getApi<OfferResponseV2>(`/v2/offer/${offerResponseSnap.id}`, offerResponseSnap)
 
       mockAuthContext = defaultLoggedInUser
 
@@ -372,7 +372,7 @@ describe('Movie screening calendar', () => {
     })
 
     it('should log event ClickBookOffer when user is logged in and a cliquable eventcard is pressed', async () => {
-      mockServer.getApi<OfferResponse>(`/v1/offer/${offerResponseSnap.id}`, offerResponseSnap)
+      mockServer.getApi<OfferResponseV2>(`/v2/offer/${offerResponseSnap.id}`, offerResponseSnap)
 
       mockAuthContext = defaultLoggedInUser
 
@@ -422,7 +422,7 @@ const renderMovieScreeningCalendar = ({
   subcategory = mockSubcategory,
   isDesktopViewport = false,
 }: {
-  offer: OfferResponse
+  offer: OfferResponseV2
   subcategory?: Subcategory
   isDesktopViewport?: boolean
 }) => {

--- a/src/features/offer/components/MovieScreeningCalendar/MovieScreeningCalendar.tsx
+++ b/src/features/offer/components/MovieScreeningCalendar/MovieScreeningCalendar.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, useEffect, useMemo, useRef } from 'react'
 import { FlatList, View } from 'react-native'
 import styled from 'styled-components/native'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { MovieCalendar } from 'features/offer/components/MovieCalendar/MovieCalendar'
 import { useMovieScreeningCalendar } from 'features/offer/components/MovieScreeningCalendar/useMovieScreeningCalendar'
 import { useSelectedDateScreening } from 'features/offer/components/MovieScreeningCalendar/useSelectedDateScreenings'
@@ -12,7 +12,7 @@ import { EventCardList } from 'ui/components/eventCard/EventCardList'
 import { getSpacing, Spacer } from 'ui/theme'
 
 type Props = {
-  offer: OfferResponse
+  offer: OfferResponseV2
   subcategory: Subcategory
 }
 export const MovieScreeningCalendar: FunctionComponent<Props> = ({ offer, subcategory }) => {

--- a/src/features/offer/components/OfferAbout/OfferAbout.native.test.tsx
+++ b/src/features/offer/components/OfferAbout/OfferAbout.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { OfferAbout } from 'features/offer/components/OfferAbout/OfferAbout'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { render, screen } from 'tests/utils'
@@ -54,7 +54,7 @@ describe('<OfferAbout />', () => {
 
   describe('Description', () => {
     it('should display description', () => {
-      const offer: OfferResponse = {
+      const offer: OfferResponseV2 = {
         ...offerResponseSnap,
         description: 'Cette offre est super cool cool cool cool cool cool',
       }
@@ -74,7 +74,7 @@ describe('<OfferAbout />', () => {
     })
 
     it('should not display description when no description', () => {
-      const offer: OfferResponse = {
+      const offer: OfferResponseV2 = {
         ...offerResponseSnap,
         description: null,
       }
@@ -106,7 +106,7 @@ describe('<OfferAbout />', () => {
     })
 
     it('should not display accessibility when disabilities are not defined', () => {
-      const offer: OfferResponse = {
+      const offer: OfferResponseV2 = {
         ...offerResponseSnap,
         accessibility: {},
       }

--- a/src/features/offer/components/OfferAbout/OfferAbout.tsx
+++ b/src/features/offer/components/OfferAbout/OfferAbout.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import { View } from 'react-native'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { OfferAccessibility } from 'features/offer/components/OfferAccessibility/OfferAccessibility'
 import { OfferMetadataItemProps } from 'features/offer/components/OfferMetadataItem/OfferMetadataItem'
 import { OfferMetadataList } from 'features/offer/components/OfferMetadataList/OfferMetadataList'
@@ -11,7 +11,7 @@ import { Typo } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type Props = {
-  offer: OfferResponse
+  offer: OfferResponseV2
   metadata: OfferMetadataItemProps[]
   hasMetadata: boolean
   shouldDisplayAccessibilitySection: boolean

--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentProps } from 'react'
 
 import {
-  OfferResponse,
+  OfferResponseV2,
   SubcategoryIdEnum,
   CategoryIdEnum,
   SearchGroupNameEnumv2,
@@ -51,7 +51,7 @@ describe('<OfferBody />', () => {
     })
 
     it('should display vinyl tag', async () => {
-      const offer: OfferResponse = {
+      const offer: OfferResponseV2 = {
         ...offerResponseSnap,
         subcategoryId: SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE,
         extraData: { musicType: 'Metal', musicSubType: 'Industrial' },
@@ -86,7 +86,7 @@ describe('<OfferBody />', () => {
   })
 
   it('should display artists', async () => {
-    const offer: OfferResponse = {
+    const offer: OfferResponseV2 = {
       ...offerResponseSnap,
       subcategoryId: SubcategoryIdEnum.CINE_PLEIN_AIR,
       extraData: { stageDirector: 'Marion Cotillard, Leonardo DiCaprio' },
@@ -156,7 +156,7 @@ describe('<OfferBody />', () => {
   })
 
   it('should not display prices when the offer is free', async () => {
-    const offerFree: OfferResponse = {
+    const offerFree: OfferResponseV2 = {
       ...offerResponseSnap,
       stocks: [
         {
@@ -194,7 +194,7 @@ describe('<OfferBody />', () => {
     })
 
     it('should not display both section', async () => {
-      const offer: OfferResponse = {
+      const offer: OfferResponseV2 = {
         ...offerResponseSnap,
         isDuo: false,
         venue: {
@@ -214,7 +214,7 @@ describe('<OfferBody />', () => {
     })
 
     it('should not display top separator between this two section', async () => {
-      const offer: OfferResponse = {
+      const offer: OfferResponseV2 = {
         ...offerResponseSnap,
         isDuo: false,
         venue: {
@@ -230,7 +230,7 @@ describe('<OfferBody />', () => {
     })
 
     it('should display top separator above summary info list when venue button is not displayed', async () => {
-      const offerWithoutPermanentVenue: OfferResponse = {
+      const offerWithoutPermanentVenue: OfferResponseV2 = {
         ...offerResponseSnap,
         venue: {
           ...offerResponseSnap.venue,
@@ -264,7 +264,7 @@ describe('<OfferBody />', () => {
       })
 
       it('should not display venue button when venue is not permanent', async () => {
-        const offer: OfferResponse = {
+        const offer: OfferResponseV2 = {
           ...offerResponseSnap,
           venue: {
             ...offerResponseSnap.venue,
@@ -281,7 +281,7 @@ describe('<OfferBody />', () => {
       })
 
       it('should not display venue button when this is a cinema offer', async () => {
-        const offer: OfferResponse = {
+        const offer: OfferResponseV2 = {
           ...offerResponseSnap,
           venue: {
             ...offerResponseSnap.venue,
@@ -300,7 +300,7 @@ describe('<OfferBody />', () => {
 
     describe('Summary info section', () => {
       it('should display duo info', async () => {
-        const offer: OfferResponse = {
+        const offer: OfferResponseV2 = {
           ...offerResponseSnap,
           isDuo: true,
         }
@@ -310,7 +310,7 @@ describe('<OfferBody />', () => {
       })
 
       it('should not display duo info', async () => {
-        const offer: OfferResponse = {
+        const offer: OfferResponseV2 = {
           ...offerResponseSnap,
           isDuo: false,
         }
@@ -350,7 +350,7 @@ describe('<OfferBody />', () => {
 
   describe('About section', () => {
     it('should display about section', async () => {
-      const offer: OfferResponse = {
+      const offer: OfferResponseV2 = {
         ...offerResponseSnap,
         description: 'Cette offre est super cool cool cool cool cool cool',
         extraData: {
@@ -371,7 +371,7 @@ describe('<OfferBody />', () => {
     })
 
     it('should not display about section', async () => {
-      const offer: OfferResponse = {
+      const offer: OfferResponseV2 = {
         ...offerResponseSnap,
         description: undefined,
         extraData: {},
@@ -386,7 +386,7 @@ describe('<OfferBody />', () => {
   })
 
   describe('MovieScreeningCalendar', () => {
-    const offer: OfferResponse = {
+    const offer: OfferResponseV2 = {
       ...offerResponseSnap,
       subcategoryId: SubcategoryIdEnum.SEANCE_CINE,
       stocks: [

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -5,7 +5,7 @@ import styled, { useTheme } from 'styled-components/native'
 import {
   CategoryIdEnum,
   NativeCategoryIdEnumv2,
-  OfferResponse,
+  OfferResponseV2,
   SearchGroupNameEnumv2,
 } from 'api/gen'
 import { OfferAbout } from 'features/offer/components/OfferAbout/OfferAbout'
@@ -39,7 +39,7 @@ import { ThumbUp } from 'ui/svg/icons/ThumbUp'
 import { getSpacing, Spacer } from 'ui/theme'
 
 type Props = {
-  offer: OfferResponse
+  offer: OfferResponseV2
   subcategory: Subcategory
   trackEventHasSeenOfferOnce: VoidFunction
 }

--- a/src/features/offer/components/OfferCTAButton/OfferCTAButton.native.test.tsx
+++ b/src/features/offer/components/OfferCTAButton/OfferCTAButton.native.test.tsx
@@ -2,7 +2,7 @@ import React, { ComponentProps } from 'react'
 
 import { useRoute } from '__mocks__/@react-navigation/native'
 import { mockedBookingApi } from '__mocks__/fixtures/booking'
-import { BookingsResponse, BookOfferResponse, OfferResponse } from 'api/gen'
+import { BookingsResponse, BookOfferResponse, OfferResponseV2 } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { openUrl } from 'features/navigation/helpers/openUrl'
 import { OfferCTAButton } from 'features/offer/components/OfferCTAButton/OfferCTAButton'
@@ -80,7 +80,7 @@ describe('<OfferCTAButton />', () => {
 
   it('should open booking modal when login after booking attempt', async () => {
     mockServer.getApi<BookingsResponse>(`/v1/bookings`, {})
-    mockServer.getApi<OfferResponse>(`/v1/offer/${offerResponseSnap.id}`, {
+    mockServer.getApi<OfferResponseV2>(`/v2/offer/${offerResponseSnap.id}`, {
       requestOptions: { persist: true },
       responseOptions: { data: offerResponseSnap },
     })
@@ -170,7 +170,7 @@ describe('<OfferCTAButton />', () => {
     }
 
     mockServer.getApi<BookingsResponse>(`/v1/bookings`, expectedResponse)
-    mockServer.getApi<OfferResponse>(`/v1/offer/${offerResponseSnap.id}`, offerResponseSnap)
+    mockServer.getApi<OfferResponseV2>(`/v2/offer/${offerResponseSnap.id}`, offerResponseSnap)
 
     const fromOfferId = 1
     useRoute.mockReturnValueOnce({ params: { fromOfferId } })
@@ -203,7 +203,7 @@ describe('<OfferCTAButton />', () => {
 
     describe('When booking API response is success', () => {
       beforeEach(() => {
-        mockServer.getApi<OfferResponse>(`/v1/offer/${offerResponseSnap.id}`, offerResponseSnap)
+        mockServer.getApi<OfferResponseV2>(`/v2/offer/${offerResponseSnap.id}`, offerResponseSnap)
         mockServer.getApi<BookingsResponse>('/v1/bookings', {
           requestOptions: { persist: true },
           responseOptions: { data: expectedResponse },
@@ -295,7 +295,7 @@ describe('<OfferCTAButton />', () => {
 
     describe('When booking API response is error', () => {
       beforeEach(() => {
-        mockServer.getApi<OfferResponse>(`/v1/offer/${offerResponseSnap.id}`, offerResponseSnap)
+        mockServer.getApi<OfferResponseV2>(`/v2/offer/${offerResponseSnap.id}`, offerResponseSnap)
         mockServer.getApi<BookingsResponse>('/v1/bookings', {
           requestOptions: { persist: true },
           responseOptions: { data: expectedResponse },
@@ -361,7 +361,7 @@ describe('<OfferCTAButton />', () => {
     })
 
     it('should display an error message when pressing button to book the offer', async () => {
-      mockServer.getApi<OfferResponse>(`/v1/offer/${offerResponseSnap.id}`, offerResponseSnap)
+      mockServer.getApi<OfferResponseV2>(`/v2/offer/${offerResponseSnap.id}`, offerResponseSnap)
       mockServer.getApi<BookingsResponse>('/v1/bookings', {
         requestOptions: { persist: true },
         responseOptions: { data: expectedResponse },
@@ -420,7 +420,7 @@ describe('<OfferCTAButton />', () => {
 
     it('should directly redirect to the offer when pressing offer access button', async () => {
       mockServer.getApi<BookingsResponse>(`/v1/bookings`, expectedResponse)
-      mockServer.getApi<OfferResponse>(`/v1/offer/${offerResponseSnap.id}`, offerResponseSnap)
+      mockServer.getApi<OfferResponseV2>(`/v2/offer/${offerResponseSnap.id}`, offerResponseSnap)
 
       // Multiple renders force us to mock auth context as loggedIn user in this test
       // eslint-disable-next-line local-rules/independent-mocks

--- a/src/features/offer/components/OfferCTAButton/OfferCTAButton.tsx
+++ b/src/features/offer/components/OfferCTAButton/OfferCTAButton.tsx
@@ -2,7 +2,7 @@ import { useFocusEffect } from '@react-navigation/native'
 import React, { FunctionComponent, useCallback } from 'react'
 import { useTheme } from 'styled-components/native'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { BookingButton } from 'features/offer/components/BookingButton/BookingButton'
 import { useOfferCTAButton } from 'features/offer/components/OfferCTAButton/useOfferCTAButton'
@@ -11,7 +11,7 @@ import { getIsFreeDigitalOffer } from 'features/offer/helpers/getIsFreeDigitalOf
 import { Subcategory } from 'libs/subcategories/types'
 
 type Props = {
-  offer: OfferResponse
+  offer: OfferResponseV2
   subcategory: Subcategory
   trackEventHasSeenOfferOnce: VoidFunction
 }

--- a/src/features/offer/components/OfferCTAButton/useOfferCTAButton.ts
+++ b/src/features/offer/components/OfferCTAButton/useOfferCTAButton.ts
@@ -1,6 +1,6 @@
 import { useRoute } from '@react-navigation/native'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { UseRouteType, StepperOrigin } from 'features/navigation/RootNavigator/types'
 import { MovieScreeningBookingData } from 'features/offer/components/MovieScreeningCalendar/types'
 import { useCtaWordingAndAction } from 'features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction'
@@ -8,7 +8,7 @@ import { Subcategory } from 'libs/subcategories/types'
 import { useBookOfferModal } from 'shared/offer/helpers/useBookOfferModal'
 
 export const useOfferCTAButton = (
-  offer: OfferResponse,
+  offer: OfferResponseV2,
   subcategory: Subcategory,
   bookingData?: MovieScreeningBookingData
 ) => {

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -2,7 +2,7 @@ import React, { ComponentProps } from 'react'
 import { InViewProps } from 'react-native-intersection-observer'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import { NativeCategoryIdEnumv2, OfferResponse, SubcategoriesResponseModelv2 } from 'api/gen'
+import { NativeCategoryIdEnumv2, OfferResponseV2, SubcategoriesResponseModelv2 } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import * as useSimilarOffers from 'features/offer/api/useSimilarOffers'
 import { PlaylistType } from 'features/offer/enums'
@@ -143,15 +143,15 @@ describe('<OfferContent />', () => {
     it('should navigate to offer preview screen when clicking on image offer', async () => {
       renderOfferContent({})
 
-      fireEvent.press(await screen.findByTestId('offerImageContainerCarousel'))
+      fireEvent.press(await screen.findByTestId('offerImageWithoutCarousel'))
 
       expect(navigate).toHaveBeenCalledWith('OfferPreview', { id: 116656 })
     })
 
     it('should not navigate to offer preview screen when clicking on image offer and there is not an image', async () => {
-      const offer: OfferResponse = {
+      const offer: OfferResponseV2 = {
         ...offerResponseSnap,
-        image: null,
+        images: null,
       }
       renderOfferContent({ offer })
 

--- a/src/features/offer/components/OfferContent/OfferContent.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.tsx
@@ -6,7 +6,7 @@ import { NativeScrollEvent, NativeSyntheticEvent, Platform } from 'react-native'
 import { IOScrollView as IntersectionObserverScrollView } from 'react-native-intersection-observer'
 import styled, { useTheme } from 'styled-components/native'
 
-import { OfferResponse, SearchGroupResponseModelv2 } from 'api/gen'
+import { OfferResponseV2, SearchGroupResponseModelv2 } from 'api/gen'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { OfferBody } from 'features/offer/components/OfferBody/OfferBody'
 import { OfferBodyImage } from 'features/offer/components/OfferBodyImage'
@@ -17,6 +17,7 @@ import { OfferImageContainer } from 'features/offer/components/OfferImageContain
 import { OfferImageWrapper } from 'features/offer/components/OfferImageWrapper/OfferImageWrapper'
 import { OfferPlaylistList } from 'features/offer/components/OfferPlaylistList/OfferPlaylistList'
 import { OfferWebMetaHeader } from 'features/offer/components/OfferWebMetaHeader'
+import { getOfferImageUrls } from 'features/offer/helpers/getOfferImageUrls/getOfferImageUrls'
 import { useOfferBatchTracking } from 'features/offer/helpers/useOfferBatchTracking/useOfferBatchTracking'
 import { useOfferPlaylist } from 'features/offer/helpers/useOfferPlaylist/useOfferPlaylist'
 import { analytics, isCloseToBottom } from 'libs/analytics'
@@ -31,7 +32,7 @@ import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { getSpacing, Spacer } from 'ui/theme'
 
 type Props = {
-  offer: OfferResponse
+  offer: OfferResponseV2
   searchGroupList: SearchGroupResponseModelv2[]
   subcategory: Subcategory
 }
@@ -54,6 +55,9 @@ export const OfferContent: FunctionComponent<Props> = ({ offer, searchGroupList,
     otherCategoriesSimilarOffers,
     apiRecoParamsOtherCategories,
   } = useOfferPlaylist({ offer, offerSearchGroup: subcategory.searchGroupName, searchGroupList })
+
+  const offerImages = offer.images ? getOfferImageUrls(offer.images) : []
+  const imageUrl = offerImages.length ? offerImages[0] : ''
 
   const logConsultWholeOffer = useFunctionOnce(() => {
     analytics.logConsultWholeOffer(offer.id)
@@ -94,11 +98,10 @@ export const OfferContent: FunctionComponent<Props> = ({ offer, searchGroupList,
   const shouldDisplayOfferPreview = enableOfferPreview && !isWeb
 
   const onPress = () => {
-    if (shouldDisplayOfferPreview && offer.image) {
+    if (shouldDisplayOfferPreview && offerImages.length) {
       navigate('OfferPreview', { id: offer.id })
     }
   }
-  const imageUrl = offer.image?.url
 
   return (
     <Container>
@@ -134,7 +137,7 @@ export const OfferContent: FunctionComponent<Props> = ({ offer, searchGroupList,
         ) : (
           <ViewGap gap={8} testID="offer-body-mobile">
             <OfferImageContainer
-              imageUrl={imageUrl}
+              imageUrls={offerImages}
               categoryId={subcategory.categoryId}
               shouldDisplayOfferPreview={shouldDisplayOfferPreview}
               onPress={onPress}

--- a/src/features/offer/components/OfferHeader/OfferHeader.native.test.tsx
+++ b/src/features/offer/components/OfferHeader/OfferHeader.native.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Animated, Share } from 'react-native'
 
-import { OfferResponse, PaginatedFavoritesResponse } from 'api/gen'
+import { OfferResponseV2, PaginatedFavoritesResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { paginatedFavoritesResponseSnap } from 'features/favorites/fixtures/paginatedFavoritesResponseSnap'
 import { mockGoBack } from 'features/navigation/__mocks__/useGoBack'
@@ -121,7 +121,7 @@ const mockOffer = offerResponseSnap
 
 function renderOfferHeader() {
   mockServer.getApi<PaginatedFavoritesResponse>('/v1/me/favorites', paginatedFavoritesResponseSnap)
-  mockServer.getApi<OfferResponse>(`/v1/offer/${mockOffer.id}`, offerResponseSnap)
+  mockServer.getApi<OfferResponseV2>(`/v1/offer/${mockOffer.id}`, offerResponseSnap)
 
   const animatedValue = new Animated.Value(0)
   render(

--- a/src/features/offer/components/OfferHeader/OfferHeader.tsx
+++ b/src/features/offer/components/OfferHeader/OfferHeader.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react'
 import { Animated } from 'react-native'
 import { useTheme } from 'styled-components/native'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { getShareOffer } from 'features/share/helpers/getShareOffer'
@@ -18,7 +18,7 @@ import { Spacer } from 'ui/theme'
 interface Props {
   headerTransition: Animated.AnimatedInterpolation<string | number>
   title: string
-  offer: OfferResponse
+  offer: OfferResponseV2
 }
 
 /**

--- a/src/features/offer/components/OfferImageContainer/OfferImageContainer.native.test.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageContainer.native.test.tsx
@@ -11,7 +11,7 @@ describe('<OfferImageContainer />', () => {
   it('should display camera tag when offer preview feature flag activated and image url defined', () => {
     render(
       <OfferImageContainer
-        imageUrl="some_url_to_some_resource"
+        imageUrls={['some_url_to_some_resource']}
         categoryId={CategoryIdEnum.CINEMA}
         shouldDisplayOfferPreview
       />
@@ -23,7 +23,7 @@ describe('<OfferImageContainer />', () => {
   it('should not display camera tag when offer preview feature flag deactivated and image url defined', () => {
     render(
       <OfferImageContainer
-        imageUrl="some_url_to_some_resource"
+        imageUrls={['some_url_to_some_resource']}
         categoryId={CategoryIdEnum.CINEMA}
       />
     )
@@ -45,7 +45,7 @@ describe('<OfferImageContainer />', () => {
     it('should display image outside carousel when image url defined', () => {
       render(
         <OfferImageContainer
-          imageUrl="some_url_to_some_resource"
+          imageUrls={['some_url_to_some_resource']}
           categoryId={CategoryIdEnum.CINEMA}
         />
       )
@@ -67,10 +67,32 @@ describe('<OfferImageContainer />', () => {
       useFeatureFlagSpy.mockReturnValueOnce(true)
     })
 
-    it('should display image inside carousel when image url defined', async () => {
+    it('should not display image inside carousel when offer has only one image', () => {
       render(
         <OfferImageContainer
-          imageUrl="some_url_to_some_resource"
+          imageUrls={['some_url_to_some_resource']}
+          categoryId={CategoryIdEnum.CINEMA}
+        />
+      )
+
+      expect(screen.queryByTestId('offerImageContainerCarousel')).not.toBeOnTheScreen()
+    })
+
+    it('should not display carousel dots when offer has only one', () => {
+      render(
+        <OfferImageContainer
+          imageUrls={['some_url_to_some_resource']}
+          categoryId={CategoryIdEnum.CINEMA}
+        />
+      )
+
+      expect(screen.queryByTestId('offerImageContainerDots')).not.toBeOnTheScreen()
+    })
+
+    it('should display image inside carousel when offer has several images', async () => {
+      render(
+        <OfferImageContainer
+          imageUrls={['some_url_to_some_resource', 'some_url2_to_some_resource']}
           categoryId={CategoryIdEnum.CINEMA}
         />
       )
@@ -80,10 +102,10 @@ describe('<OfferImageContainer />', () => {
       })
     })
 
-    it('should display carousel dots when image url defined', async () => {
+    it('should display carousel dots when offer has several images', async () => {
       render(
         <OfferImageContainer
-          imageUrl="some_url_to_some_resource"
+          imageUrls={['some_url_to_some_resource', 'some_url2_to_some_resource']}
           categoryId={CategoryIdEnum.CINEMA}
         />
       )

--- a/src/features/offer/components/OfferImageContainer/OfferImageContainer.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageContainer.tsx
@@ -24,7 +24,7 @@ import { getSpacing, Spacer } from 'ui/theme'
 
 type Props = {
   categoryId: CategoryIdEnum | null
-  imageUrl?: string
+  imageUrls?: string[]
   shouldDisplayOfferPreview?: boolean
   onPress?: VoidFunction
 }
@@ -33,7 +33,7 @@ const isWeb = Platform.OS === 'web'
 
 export const OfferImageContainer: FunctionComponent<Props> = ({
   categoryId,
-  imageUrl,
+  imageUrls,
   shouldDisplayOfferPreview,
   onPress,
 }) => {
@@ -43,12 +43,13 @@ export const OfferImageContainer: FunctionComponent<Props> = ({
   )
   const theme = useTheme()
 
-  const images = imageUrl ? [imageUrl, imageUrl, imageUrl] : []
-  const hasCarousel = !!(shouldDisplayCarousel && images.length && !isWeb)
+  const offerImages = imageUrls ?? []
+
+  const hasCarousel = !!(shouldDisplayCarousel && offerImages.length > 1 && !isWeb)
   const progressValue = useSharedValue<number>(0)
-  const offerBodyImage = imageUrl ? (
+  const offerBodyImage = offerImages[0] ? (
     <React.Fragment>
-      <OfferBodyImage imageUrl={imageUrl} />
+      <OfferBodyImage imageUrl={offerImages[0]} />
       {shouldDisplayOfferPreview ? (
         <StyledTag label="1" Icon={StyledCamera} testID="imageTag" />
       ) : null}
@@ -62,7 +63,7 @@ export const OfferImageContainer: FunctionComponent<Props> = ({
   }
 
   return (
-    <HeaderWithImage imageHeight={backgroundHeight} imageUrl={imageUrl} onPress={onPress}>
+    <HeaderWithImage imageHeight={backgroundHeight} imageUrl={offerImages[0]} onPress={onPress}>
       <Spacer.Column numberOfSpaces={offerImageContainerMarginTop} />
 
       {hasCarousel ? (
@@ -78,10 +79,10 @@ export const OfferImageContainer: FunctionComponent<Props> = ({
               onProgressChange={(_, absoluteProgress) => {
                 progressValue.value = absoluteProgress
               }}
-              data={images}
+              data={offerImages}
               renderItem={({ item: image }) => (
                 <OfferImageWrapper
-                  imageUrl={imageUrl}
+                  imageUrl={offerImages[0]}
                   shouldDisplayOfferPreview={shouldDisplayOfferPreview}
                   isInCarousel>
                   <OfferBodyImage imageUrl={image} isInCarousel />
@@ -90,7 +91,7 @@ export const OfferImageContainer: FunctionComponent<Props> = ({
               style={carouselStyle}
             />
             {shouldDisplayOfferPreview ? (
-              <StyledTag label={String(images.length)} Icon={StyledCamera} testID="imageTag" />
+              <StyledTag label={String(offerImages.length)} Icon={StyledCamera} testID="imageTag" />
             ) : null}
           </View>
 
@@ -98,7 +99,7 @@ export const OfferImageContainer: FunctionComponent<Props> = ({
             <React.Fragment>
               <Spacer.Column numberOfSpaces={4} />
               <PaginationContainer gap={2} testID="offerImageContainerDots">
-                {images.map((_, index) => (
+                {offerImages.map((_, index) => (
                   <CarouselDot
                     animValue={progressValue}
                     index={index}
@@ -111,7 +112,7 @@ export const OfferImageContainer: FunctionComponent<Props> = ({
         </React.Fragment>
       ) : (
         <OfferImageWrapper
-          imageUrl={imageUrl}
+          imageUrl={offerImages[0]}
           shouldDisplayOfferPreview={shouldDisplayOfferPreview}
           testID="offerImageWithoutCarousel">
           {offerBodyImage}

--- a/src/features/offer/components/OfferMessagingApps/OfferMessagingApps.tsx
+++ b/src/features/offer/components/OfferMessagingApps/OfferMessagingApps.tsx
@@ -1,13 +1,13 @@
 import React, { useCallback } from 'react'
 import { Social } from 'react-native-share'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { MessagingApps } from 'features/share/components/MessagingApps/MessagingApps'
 import { getShareOffer } from 'features/share/helpers/getShareOffer'
 import { analytics } from 'libs/analytics'
 
 type MessagingAppsProps = {
-  offer: OfferResponse
+  offer: OfferResponseV2
 }
 
 export const OfferMessagingApps = ({ offer }: MessagingAppsProps) => {

--- a/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
@@ -2,7 +2,7 @@ import mockdate from 'mockdate'
 import React, { ComponentProps } from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import { OfferResponse, SubcategoryIdEnum } from 'api/gen'
+import { OfferResponseV2, SubcategoryIdEnum } from 'api/gen'
 import { mockOffer } from 'features/bookOffer/fixtures/offer'
 import { OfferPlace, OfferPlaceProps } from 'features/offer/components/OfferPlace/OfferPlace'
 import { mockSubcategory } from 'features/offer/fixtures/mockSubcategory'
@@ -333,7 +333,7 @@ describe('<OfferPlace />', () => {
 
   it('should not display "Voir la page du lieu" button when venue is not permanent', () => {
     mockUseSearchVenueOffers.mockReturnValueOnce(searchVenueOfferEmpty)
-    const offer: OfferResponse = {
+    const offer: OfferResponseV2 = {
       ...mockOffer,
       venue: {
         ...mockOffer.venue,
@@ -346,7 +346,7 @@ describe('<OfferPlace />', () => {
   })
 
   describe('When venue is permanent', () => {
-    const offer: OfferResponse = {
+    const offer: OfferResponseV2 = {
       ...mockOffer,
       venue: {
         ...mockOffer.venue,
@@ -378,7 +378,7 @@ describe('<OfferPlace />', () => {
 
   it('should display "Voir l’itinéraire" button when complete venue address specified', () => {
     mockUseSearchVenueOffers.mockReturnValueOnce(searchVenueOfferEmpty)
-    const offer: OfferResponse = {
+    const offer: OfferResponseV2 = {
       ...mockOffer,
       venue: {
         ...mockOffer.venue,
@@ -396,7 +396,7 @@ describe('<OfferPlace />', () => {
   describe('should not display "Voir l’itinéraire" button', () => {
     it('When address, city and postal code not provided', () => {
       mockUseSearchVenueOffers.mockReturnValueOnce(searchVenueOfferEmpty)
-      const offer: OfferResponse = {
+      const offer: OfferResponseV2 = {
         ...mockOffer,
         venue: {
           ...mockOffer.venue,
@@ -413,7 +413,7 @@ describe('<OfferPlace />', () => {
 
     it('When only address provided', () => {
       mockUseSearchVenueOffers.mockReturnValueOnce(searchVenueOfferEmpty)
-      const offer: OfferResponse = {
+      const offer: OfferResponseV2 = {
         ...mockOffer,
         venue: {
           ...mockOffer.venue,
@@ -430,7 +430,7 @@ describe('<OfferPlace />', () => {
 
     it('When only city provided', () => {
       mockUseSearchVenueOffers.mockReturnValueOnce(searchVenueOfferEmpty)
-      const offer: OfferResponse = {
+      const offer: OfferResponseV2 = {
         ...mockOffer,
         venue: {
           ...mockOffer.venue,
@@ -447,7 +447,7 @@ describe('<OfferPlace />', () => {
 
     it('When only city postalCode', () => {
       mockUseSearchVenueOffers.mockReturnValueOnce(searchVenueOfferEmpty)
-      const offer: OfferResponse = {
+      const offer: OfferResponseV2 = {
         ...mockOffer,
         venue: {
           ...mockOffer.venue,
@@ -465,7 +465,7 @@ describe('<OfferPlace />', () => {
 
   it('should log consult itinerary when pressing "Voir l’itinéraire" button', () => {
     mockUseSearchVenueOffers.mockReturnValueOnce(searchVenueOfferEmpty)
-    const offer: OfferResponse = {
+    const offer: OfferResponseV2 = {
       ...mockOffer,
       id: 146112,
     }

--- a/src/features/offer/components/OfferPlace/OfferPlace.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.tsx
@@ -4,7 +4,7 @@ import { View } from 'react-native'
 import { useQueryClient } from 'react-query'
 import { useTheme } from 'styled-components/native'
 
-import { OfferResponse, SubcategoryIdEnum, VenueResponse } from 'api/gen'
+import { OfferResponseV2, SubcategoryIdEnum, VenueResponse } from 'api/gen'
 import { useSearchVenueOffers } from 'api/useSearchVenuesOffer/useSearchVenueOffers'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { MovieScreeningCalendar } from 'features/offer/components/MovieScreeningCalendar/MovieScreeningCalendar'
@@ -29,7 +29,7 @@ import { SectionWithDivider } from 'ui/components/SectionWithDivider'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 
 export type OfferPlaceProps = {
-  offer: OfferResponse
+  offer: OfferResponseV2
   subcategory: Subcategory
 }
 

--- a/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.tsx
+++ b/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.tsx
@@ -1,7 +1,7 @@
 import { useRoute } from '@react-navigation/native'
 import React from 'react'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { HitOfferWithArtistAndEan } from 'features/offer/api/fetchOffersByArtist/fetchOffersByArtist'
 import { OfferPlaylist } from 'features/offer/components/OfferPlaylist/OfferPlaylist'
@@ -25,7 +25,7 @@ import { Offer, RecommendationApiParams, SimilarOfferPlaylist } from 'shared/off
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
 
 export type OfferPlaylistListProps = {
-  offer: OfferResponse
+  offer: OfferResponseV2
   position: Position
   sameCategorySimilarOffers?: Offer[]
   apiRecoParamsSameCategory?: RecommendationApiParams
@@ -39,7 +39,7 @@ function isArrayNotEmpty<T>(data: T[] | undefined): data is T[] {
 }
 
 type PlaylistItemProps = {
-  offer: OfferResponse
+  offer: OfferResponseV2
   position: Position
   categoryMapping: CategoryIdMapping
   labelMapping: CategoryHomeLabelMapping

--- a/src/features/offer/components/OfferTile/OfferTile.native.test.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.native.test.tsx
@@ -170,7 +170,7 @@ describe('OfferTile component', () => {
       description: '',
       expenseDomains: [],
       id: offerId,
-      image: { url: props.thumbUrl },
+      images: { recto: { url: props.thumbUrl } },
       isDigital: false,
       isDuo: false,
       isReleased: true,

--- a/src/features/offer/components/OfferVenueBlock/OfferVenueBlock.tsx
+++ b/src/features/offer/components/OfferVenueBlock/OfferVenueBlock.tsx
@@ -2,7 +2,7 @@ import React, { ComponentProps, Fragment, FunctionComponent, useMemo } from 'rea
 import { View } from 'react-native'
 import styled from 'styled-components/native'
 
-import { OfferResponse, SubcategoryIdEnum } from 'api/gen'
+import { OfferResponseV2, SubcategoryIdEnum } from 'api/gen'
 import { useVenueBlock } from 'features/offer/components/OfferVenueBlock/useVenueBlock'
 import { formatFullAddressStartsWithPostalCode } from 'libs/address/useFormatFullAddress'
 import { SeeItineraryButton } from 'libs/itinerary/components/SeeItineraryButton'
@@ -23,7 +23,7 @@ const VENUE_THUMBNAIL_SIZE = getSpacing(14)
 type Props = {
   distance?: string
   title: string
-  offer: OfferResponse
+  offer: OfferResponseV2
   onChangeVenuePress?: VoidFunction
   onSeeVenuePress?: VoidFunction
   onSeeItineraryPress?: VoidFunction

--- a/src/features/offer/components/OfferWebMetaHeader.tsx
+++ b/src/features/offer/components/OfferWebMetaHeader.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { Helmet } from 'libs/react-helmet/Helmet'
 
 import { description } from '../../../../package.json'
 
 interface Props {
-  offer: OfferResponse
+  offer: OfferResponseV2
 }
 
 export const OfferWebMetaHeader = ({ offer }: Props) => (

--- a/src/features/offer/fixtures/offerResponse.ts
+++ b/src/features/offer/fixtures/offerResponse.ts
@@ -1,6 +1,6 @@
 import type { ReadonlyDeep } from 'type-fest'
 
-import { ExpenseDomain, OfferResponse, SubcategoryIdEnum } from 'api/gen'
+import { ExpenseDomain, OfferResponseV2, SubcategoryIdEnum } from 'api/gen'
 import { toMutable } from 'shared/types/toMutable'
 
 // humanizedId AHD3A
@@ -46,9 +46,11 @@ export const offerResponseSnap = toMutable({
       features: [],
     },
   ],
-  image: {
-    url: 'https://storage.gra.cloud.ovh.net/v1/AUTH_688df1e25bd84a48a3804e7fa8938085/storage-pc-dev/thumbs/products/CHSYS',
-    credit: 'Author: photo credit author',
+  images: {
+    image1: {
+      url: 'https://storage.gra.cloud.ovh.net/v1/AUTH_688df1e25bd84a48a3804e7fa8938085/storage-pc-dev/thumbs/products/CHSYS',
+      credit: 'Author: photo credit author',
+    },
   },
   venue: {
     id: 1664,
@@ -86,4 +88,4 @@ export const offerResponseSnap = toMutable({
     },
   },
   isExternalBookingsDisabled: false,
-} as const satisfies ReadonlyDeep<OfferResponse>)
+} as const satisfies ReadonlyDeep<OfferResponseV2>)

--- a/src/features/offer/helpers/extractStockDates/extractStockDates.ts
+++ b/src/features/offer/helpers/extractStockDates/extractStockDates.ts
@@ -1,6 +1,6 @@
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 
-export function extractStockDates(offer: OfferResponse): string[] {
+export function extractStockDates(offer: OfferResponseV2): string[] {
   return offer.stocks
     .map((stock) => stock.beginningDatetime)
     .filter((date): date is string => date !== null && date !== undefined)

--- a/src/features/offer/helpers/getIsFreeDigitalOffer/getIsFreeDigitalOffer.ts
+++ b/src/features/offer/helpers/getIsFreeDigitalOffer/getIsFreeDigitalOffer.ts
@@ -1,5 +1,5 @@
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 
-export function getIsFreeDigitalOffer(offer?: OfferResponse) {
+export function getIsFreeDigitalOffer(offer?: OfferResponseV2) {
   return (offer?.isDigital && offer?.stocks[0]?.price === 0) ?? false
 }

--- a/src/features/offer/helpers/getOfferArtists/getOfferArtists.ts
+++ b/src/features/offer/helpers/getOfferArtists/getOfferArtists.ts
@@ -1,8 +1,8 @@
-import { CategoryIdEnum, OfferResponse } from 'api/gen'
+import { CategoryIdEnum, OfferResponseV2 } from 'api/gen'
 
 export function getOfferArtists(
   categoryId: CategoryIdEnum,
-  offer: OfferResponse
+  offer: OfferResponseV2
 ): string | undefined {
   const { extraData } = offer
 

--- a/src/features/offer/helpers/getOfferImageUrls/getOfferImageUrls.test.ts
+++ b/src/features/offer/helpers/getOfferImageUrls/getOfferImageUrls.test.ts
@@ -1,0 +1,21 @@
+import { getOfferImageUrls } from 'features/offer/helpers/getOfferImageUrls/getOfferImageUrls'
+
+describe('getOfferImageUrls', () => {
+  it('should return an empty array when images object is empty', () => {
+    const images = {}
+    const result = getOfferImageUrls(images)
+
+    expect(result).toEqual([])
+  })
+
+  it('should return an array of image URLs', () => {
+    const images = {
+      image1: { url: 'url1' },
+      image2: { url: 'url2' },
+      image3: { url: 'url3' },
+    }
+    const result = getOfferImageUrls(images)
+
+    expect(result).toEqual(['url1', 'url2', 'url3'])
+  })
+})

--- a/src/features/offer/helpers/getOfferImageUrls/getOfferImageUrls.ts
+++ b/src/features/offer/helpers/getOfferImageUrls/getOfferImageUrls.ts
@@ -1,0 +1,5 @@
+import { OfferImageResponse } from 'api/gen'
+
+export function getOfferImageUrls(images: { [key: string]: OfferImageResponse }) {
+  return Object.values(images).map((image) => image.url)
+}

--- a/src/features/offer/helpers/getOfferPrice/getOfferPrice.ts
+++ b/src/features/offer/helpers/getOfferPrice/getOfferPrice.ts
@@ -1,10 +1,10 @@
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 
-export const getOfferPrices = (offerStocks: OfferResponse['stocks']): number[] => {
+export const getOfferPrices = (offerStocks: OfferResponseV2['stocks']): number[] => {
   const bookableStocks = offerStocks.filter(({ isBookable }) => isBookable)
   const stocks = bookableStocks.length > 0 ? bookableStocks : offerStocks
   return stocks.map(({ price }) => price)
 }
 
-export const getOfferPrice = (stocks: OfferResponse['stocks']): number =>
+export const getOfferPrice = (stocks: OfferResponseV2['stocks']): number =>
   Math.min(...getOfferPrices(stocks))

--- a/src/features/offer/helpers/renderOfferPageTestUtil.tsx
+++ b/src/features/offer/helpers/renderOfferPageTestUtil.tsx
@@ -1,7 +1,7 @@
 import { NavigationContainer } from '@react-navigation/native'
 import React from 'react'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { RootStack } from 'features/navigation/RootNavigator/Stack'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { Offer } from 'features/offer/pages/Offer/Offer'
@@ -20,7 +20,7 @@ jest.mock('libs/itinerary/useItinerary', () => ({
   useItinerary: jest.fn(() => ({ availableApps: ['waze'], navigateTo: jest.fn() })),
 }))
 
-let mockedOffer: Partial<OfferResponse> | undefined | null = undefined
+let mockedOffer: Partial<OfferResponseV2> | undefined | null = undefined
 let mockedIsLoading = false
 jest.mock('features/offer/api/useOffer', () => ({
   useOffer: () => ({
@@ -32,14 +32,14 @@ jest.mock('features/offer/api/useOffer', () => ({
 const offerId = 116656
 
 type MockOffer =
-  | (OfferResponse & {
-      extraOffer?: Partial<Omit<OfferResponse, 'id'>>
+  | (OfferResponseV2 & {
+      extraOffer?: Partial<Omit<OfferResponseV2, 'id'>>
     })
   | null
 
 type RenderOfferPage = {
   fromOfferId?: number
-  extraOffer?: Partial<Omit<OfferResponse, 'id'>>
+  extraOffer?: Partial<Omit<OfferResponseV2, 'id'>>
   openModalOnNavigation?: boolean
   mockOffer?: MockOffer
   mockIsLoading?: boolean

--- a/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts
+++ b/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts
@@ -1,7 +1,7 @@
 import mockdate from 'mockdate'
 
 import {
-  OfferResponse,
+  OfferResponseV2,
   YoungStatusType,
   SubscriptionStatus,
   SearchGroupNameEnumv2,
@@ -301,7 +301,7 @@ describe('getCtaWordingAndAction', () => {
 
   describe('Beneficiary', () => {
     const getCta = (
-      partialOffer: Partial<OfferResponse>,
+      partialOffer: Partial<OfferResponseV2>,
       parameters?: Partial<Parameters<typeof getCtaWordingAndAction>[0]>,
       partialSubcategory?: Partial<Subcategory>
     ) =>
@@ -856,7 +856,7 @@ describe('getCtaWordingAndAction', () => {
   })
 })
 
-const buildOffer = (partialOffer: Partial<OfferResponse>): OfferResponse => ({
+const buildOffer = (partialOffer: Partial<OfferResponseV2>): OfferResponseV2 => ({
   ...baseOffer,
   ...partialOffer,
 })

--- a/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts
+++ b/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts
@@ -3,7 +3,7 @@ import { UseMutateFunction } from 'react-query'
 
 import { ApiError } from 'api/ApiError'
 import {
-  OfferResponse,
+  OfferResponseV2,
   FavoriteOfferResponse,
   UserProfileResponse,
   YoungStatusType,
@@ -42,7 +42,7 @@ import { ExternalNavigationProps, InternalNavigationProps } from 'ui/components/
 import { useHasEnoughCredit } from '../useHasEnoughCredit/useHasEnoughCredit'
 
 type UseGetCtaWordingAndActionProps = {
-  offer: OfferResponse
+  offer: OfferResponseV2
   subcategory: Subcategory
   from?: Referrals
   searchId?: string
@@ -57,7 +57,7 @@ type Props = {
   isLoggedIn: boolean
   userStatus: YoungStatusResponse
   isBeneficiary: boolean
-  offer: OfferResponse
+  offer: OfferResponseV2
   subcategory: Subcategory
   hasEnoughCredit: boolean
   bookedOffers: UserProfileResponse['bookedOffers']

--- a/src/features/offer/helpers/useHasEnoughCredit/useHasEnoughCredit.ts
+++ b/src/features/offer/helpers/useHasEnoughCredit/useHasEnoughCredit.ts
@@ -1,11 +1,11 @@
-import { FavoriteOfferResponse, OfferResponse, UserProfileResponse } from 'api/gen'
+import { FavoriteOfferResponse, OfferResponseV2, UserProfileResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useOffer } from 'features/offer/api/useOffer'
 
 import { getOfferPrice } from '../getOfferPrice/getOfferPrice'
 
 export const hasEnoughCredit = (
-  domains: OfferResponse['expenseDomains'] | FavoriteOfferResponse['expenseDomains'],
+  domains: OfferResponseV2['expenseDomains'] | FavoriteOfferResponse['expenseDomains'],
   price: number | FavoriteOfferResponse['price'] | FavoriteOfferResponse['startPrice'],
   domainsCredit: UserProfileResponse['domainsCredit']
 ): boolean => {
@@ -24,7 +24,7 @@ export const hasEnoughCredit = (
   })
 }
 
-export const useHasEnoughCredit = (offer?: OfferResponse): boolean => {
+export const useHasEnoughCredit = (offer?: OfferResponseV2): boolean => {
   const { user } = useAuthContext()
   if (!offer || !user) return false
 

--- a/src/features/offer/helpers/useOfferPlaylist/useOfferPlaylist.ts
+++ b/src/features/offer/helpers/useOfferPlaylist/useOfferPlaylist.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 
-import { OfferResponse, SearchGroupNameEnumv2, SearchGroupResponseModelv2 } from 'api/gen'
+import { OfferResponseV2, SearchGroupNameEnumv2, SearchGroupResponseModelv2 } from 'api/gen'
 import { HitOfferWithArtistAndEan } from 'features/offer/api/fetchOffersByArtist/fetchOffersByArtist'
 import { useSimilarOffers } from 'features/offer/api/useSimilarOffers'
 import { useSameArtistPlaylist } from 'features/offer/helpers/useSameArtistPlaylist/useSameArtistPlaylist'
@@ -8,7 +8,7 @@ import { useLocation, Position } from 'libs/location'
 import { Offer, RecommendationApiParams } from 'shared/offer/types'
 
 type Props = {
-  offer: OfferResponse
+  offer: OfferResponseV2
   offerSearchGroup: SearchGroupNameEnumv2
   searchGroupList: SearchGroupResponseModelv2[]
 }

--- a/src/features/offer/helpers/useOfferSummaryInfoList/useOfferSummaryInfoList.native.test.tsx
+++ b/src/features/offer/helpers/useOfferSummaryInfoList/useOfferSummaryInfoList.native.test.tsx
@@ -2,7 +2,7 @@ import mockdate from 'mockdate'
 import React from 'react'
 import { ThemeProvider } from 'styled-components/native'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { useOfferSummaryInfoList } from 'features/offer/helpers/useOfferSummaryInfoList/useOfferSummaryInfoList'
 import { computedTheme } from 'tests/computedTheme'
@@ -32,7 +32,7 @@ describe('useOfferSummaryInfoList', () => {
 
   it('should return summaryInfoItems dates when offer stock has date in future and is not a cinema offer', async () => {
     mockdate.set('2021-01-02T18:00:00')
-    const offer: OfferResponse = {
+    const offer: OfferResponseV2 = {
       ...offerResponseSnap,
       isDuo: false,
     }
@@ -61,7 +61,7 @@ describe('useOfferSummaryInfoList', () => {
 
   it('should not return summaryInfoItems dates when offer stock has date in future and is a cinema offer', async () => {
     mockdate.set('2021-01-02T18:00:00')
-    const offer: OfferResponse = {
+    const offer: OfferResponseV2 = {
       ...offerResponseSnap,
       isDuo: false,
     }
@@ -82,7 +82,7 @@ describe('useOfferSummaryInfoList', () => {
   })
 
   it('should return summaryInfoItems online when offer is digital', async () => {
-    const offer: OfferResponse = {
+    const offer: OfferResponseV2 = {
       ...offerResponseSnap,
       isDuo: false,
       isDigital: true,
@@ -108,7 +108,7 @@ describe('useOfferSummaryInfoList', () => {
   })
 
   it('should return summaryInfoItems duration when offer has duration', async () => {
-    const offer: OfferResponse = {
+    const offer: OfferResponseV2 = {
       ...offerResponseSnap,
       isDuo: false,
       extraData: { durationMinutes: 180 },
@@ -134,7 +134,7 @@ describe('useOfferSummaryInfoList', () => {
   })
 
   it('should return many summaryInfoItems when offer has various details like duration, duo offer, digital offer', async () => {
-    const offer: OfferResponse = {
+    const offer: OfferResponseV2 = {
       ...offerResponseSnap,
       isDuo: true,
       isDigital: true,
@@ -173,7 +173,7 @@ describe('useOfferSummaryInfoList', () => {
   })
 
   it('should not return summaryInfoItems when none are in offer stock', () => {
-    const offer: OfferResponse = {
+    const offer: OfferResponseV2 = {
       ...offerResponseSnap,
       isDuo: false,
     }

--- a/src/features/offer/helpers/useOfferSummaryInfoList/useOfferSummaryInfoList.tsx
+++ b/src/features/offer/helpers/useOfferSummaryInfoList/useOfferSummaryInfoList.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useTheme } from 'styled-components/native'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { extractStockDates } from 'features/offer/helpers/extractStockDates/extractStockDates'
 import { formatDuration } from 'features/offer/helpers/formatDuration/formatDuration'
 import { capitalizeFirstLetter, getFormattedDates } from 'libs/parsers/formatDates'
@@ -13,7 +13,7 @@ import { Digital } from 'ui/svg/icons/Digital'
 import { Stock } from 'ui/svg/icons/Stock'
 
 type Props = {
-  offer: OfferResponse
+  offer: OfferResponseV2
   isCinemaOffer?: boolean
 }
 

--- a/src/features/offer/pages/Offer/Offer.perf.test.tsx
+++ b/src/features/offer/pages/Offer/Offer.perf.test.tsx
@@ -2,7 +2,7 @@ import { Hit } from '@algolia/client-search'
 import React from 'react'
 
 import { useRoute } from '__mocks__/@react-navigation/native'
-import { OfferResponse, SubcategoriesResponseModelv2 } from 'api/gen'
+import { OfferResponseV2, SubcategoriesResponseModelv2 } from 'api/gen'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import * as GetInstalledAppsAPI from 'features/offer/helpers/getInstalledApps/getInstalledApps'
 import { Offer } from 'features/offer/pages/Offer/Offer'
@@ -32,7 +32,7 @@ jest.setTimeout(TEST_TIMEOUT_IN_MS)
 describe('<Offer />', () => {
   beforeEach(() => {
     // We mock server instead of hooks to test the real behavior of the component.
-    mockServer.getApi<OfferResponse>(`/v1/offer/${offerResponseSnap.id}`, {
+    mockServer.getApi<OfferResponseV2>(`/v1/offer/${offerResponseSnap.id}`, {
       requestOptions: { persist: true },
       responseOptions: { data: offerResponseSnap },
     })

--- a/src/features/offer/pages/Offer/Offer.perf.test.tsx
+++ b/src/features/offer/pages/Offer/Offer.perf.test.tsx
@@ -32,7 +32,7 @@ jest.setTimeout(TEST_TIMEOUT_IN_MS)
 describe('<Offer />', () => {
   beforeEach(() => {
     // We mock server instead of hooks to test the real behavior of the component.
-    mockServer.getApi<OfferResponseV2>(`/v1/offer/${offerResponseSnap.id}`, {
+    mockServer.getApi<OfferResponseV2>(`/v2/offer/${offerResponseSnap.id}`, {
       requestOptions: { persist: true },
       responseOptions: { data: offerResponseSnap },
     })

--- a/src/features/offer/pages/Offer/Offer.web.test.tsx
+++ b/src/features/offer/pages/Offer/Offer.web.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { VenueListItem } from 'features/offer/components/VenueSelectionList/VenueSelectionList'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { Offer } from 'features/offer/pages/Offer/Offer'
@@ -12,7 +12,7 @@ import { act, checkAccessibilityFor, render } from 'tests/utils/web'
 
 jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true)
 
-const mockedOffer: Partial<OfferResponse> | undefined = offerResponseSnap
+const mockedOffer: Partial<OfferResponseV2> | undefined = offerResponseSnap
 jest.mock('features/offer/api/useOffer', () => ({
   useOffer: () => ({
     data: mockedOffer,

--- a/src/features/offer/pages/OfferPreview/OfferPreview.native.test.tsx
+++ b/src/features/offer/pages/OfferPreview/OfferPreview.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { OfferResponse } from 'api/gen'
+import { OfferResponseV2 } from 'api/gen'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { OfferPreview } from 'features/offer/pages/OfferPreview/OfferPreview'
 import * as useFeatureFlag from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
@@ -8,8 +8,17 @@ import { render, screen } from 'tests/utils'
 
 const mockFeatureFlag = jest.spyOn(useFeatureFlag, 'useFeatureFlag').mockReturnValue(true)
 
-const mockOffer = jest.fn((): { data: OfferResponse } => ({
-  data: offerResponseSnap,
+const mockOffer = jest.fn((): { data: OfferResponseV2 } => ({
+  data: {
+    ...offerResponseSnap,
+    images: {
+      ...offerResponseSnap.images,
+      image2: {
+        url: 'https://storage.gra.cloud.ovh.net/v1/AUTH_688df1e25bd84a48a3804e7fa8938085/storage-pc-dev/thumbs/products/CHSYS',
+        credit: 'Author: photo credit author',
+      },
+    },
+  },
 }))
 
 jest.mock('features/offer/api/useOffer', () => ({
@@ -27,7 +36,7 @@ describe('<OfferPreview />', () => {
     it('should display offer preview page', () => {
       render(<OfferPreview />)
 
-      expect(screen.getByText('1/3')).toBeOnTheScreen()
+      expect(screen.getByText('1/2')).toBeOnTheScreen()
     })
   })
 
@@ -44,7 +53,7 @@ describe('<OfferPreview />', () => {
 
     it('should not display offer preview page when there is not an image', () => {
       mockOffer.mockReturnValueOnce({
-        data: { ...offerResponseSnap, image: null },
+        data: { ...offerResponseSnap, images: null },
       })
       render(<OfferPreview />)
 

--- a/src/features/offer/pages/OfferPreview/OfferPreview.tsx
+++ b/src/features/offer/pages/OfferPreview/OfferPreview.tsx
@@ -11,6 +11,7 @@ import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { useOffer } from 'features/offer/api/useOffer'
 import { PinchableBox } from 'features/offer/components/PinchableBox/PinchableBox'
+import { getOfferImageUrls } from 'features/offer/helpers/getOfferImageUrls/getOfferImageUrls'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { CarouselDot } from 'ui/CarouselDot/CarouselDot'
@@ -40,9 +41,9 @@ export const OfferPreview: FunctionComponent = () => {
   const [index, setIndex] = React.useState(0)
   const { height: screenHeight, width: screenWidth } = useWindowDimensions()
 
-  if (!offer?.image) return null
+  if (!offer?.images) return null
 
-  const images = [offer.image.url, offer.image.url, offer.image.url]
+  const images = getOfferImageUrls(offer.images)
   const carouselDotId = uuidv4()
 
   return (
@@ -87,7 +88,7 @@ export const OfferPreview: FunctionComponent = () => {
           ) : null}
         </React.Fragment>
       ) : (
-        <PinchableBox imageUrl={offer.image.url} />
+        <PinchableBox imageUrl={images[0] ?? ''} />
       )}
 
       <BlurHeader height={headerHeight} />

--- a/src/features/share/helpers/getShareOffer.tsx
+++ b/src/features/share/helpers/getShareOffer.tsx
@@ -1,10 +1,10 @@
-import { BookingOfferResponse, FavoriteOfferResponse, OfferResponse } from 'api/gen'
+import { BookingOfferResponse, FavoriteOfferResponse, OfferResponseV2 } from 'api/gen'
 import { formatShareOfferMessage } from 'features/share/helpers/formatShareOfferMessage'
 import { getOfferUrl } from 'features/share/helpers/getOfferUrl'
 import { share } from 'libs/share/share'
 import { ShareContent } from 'libs/share/types'
 
-type Offer = OfferResponse | BookingOfferResponse | FavoriteOfferResponse
+type Offer = OfferResponseV2 | BookingOfferResponse | FavoriteOfferResponse
 type Parameters = {
   offer?: Offer
   utmMedium: string

--- a/src/features/venue/components/VenueOfferTile/VenueOfferTile.native.test.tsx
+++ b/src/features/venue/components/VenueOfferTile/VenueOfferTile.native.test.tsx
@@ -69,7 +69,7 @@ describe('VenueOfferTile component', () => {
       description: '',
       expenseDomains: [],
       id: offerId,
-      image: { url: props.thumbUrl },
+      images: { recto: { url: props.thumbUrl } },
       isDigital: false,
       isDuo: false,
       isReleased: true,

--- a/src/libs/algolia/fetchAlgolia/transformOfferHit.ts
+++ b/src/libs/algolia/fetchAlgolia/transformOfferHit.ts
@@ -9,7 +9,7 @@ import { convertEuroToCents } from 'libs/parsers/pricesConversion'
 
 type Offer = AlgoliaHit['offer']
 
-// Prices are stored in euros in Algolia, but retrieved as cents in OfferResponse
+// Prices are stored in euros in Algolia, but retrieved as cents in OfferResponseV2
 // To follow good frontend practices (see https://frontstuff.io/how-to-handle-monetary-values-in-javascript)
 // we convert all prices in Algolia to cents, use cents in the frontend code,
 // and when we display the prices to the user, we format the price knowing that there are cents.

--- a/src/shared/multiVenueOffer/isMultiVenueCompatibleOffer.ts
+++ b/src/shared/multiVenueOffer/isMultiVenueCompatibleOffer.ts
@@ -1,16 +1,19 @@
-import { OfferResponse, SubcategoryIdEnum } from 'api/gen'
+import { OfferResponseV2, SubcategoryIdEnum } from 'api/gen'
 
 const MULTI_VENUE_COMPATIBLE_OFFER = [
   SubcategoryIdEnum.LIVRE_PAPIER,
   SubcategoryIdEnum.LIVRE_AUDIO_PHYSIQUE,
 ]
 
-const isBookMultiVenueCompatibleOffer = (offer: OfferResponse): boolean =>
+const isBookMultiVenueCompatibleOffer = (offer: OfferResponseV2): boolean =>
   Boolean(MULTI_VENUE_COMPATIBLE_OFFER.includes(offer.subcategoryId) && offer.extraData?.ean)
 
-const isMovieMultiVenueCompatibleOffer = (offer: OfferResponse): boolean =>
+const isMovieMultiVenueCompatibleOffer = (offer: OfferResponseV2): boolean =>
   Boolean(SubcategoryIdEnum.SEANCE_CINE === offer.subcategoryId && offer.extraData?.allocineId)
 
-export const isMultiVenueCompatibleOffer = (offer: OfferResponse, hasNewOfferVenueBlock = false) =>
+export const isMultiVenueCompatibleOffer = (
+  offer: OfferResponseV2,
+  hasNewOfferVenueBlock = false
+) =>
   isBookMultiVenueCompatibleOffer(offer) ||
   (isMovieMultiVenueCompatibleOffer(offer) && hasNewOfferVenueBlock)

--- a/src/shared/offer/usePrePopulateOffer.ts
+++ b/src/shared/offer/usePrePopulateOffer.ts
@@ -1,6 +1,6 @@
 import { useQueryClient } from 'react-query'
 
-import { ExpenseDomain, OfferResponse, OfferStockResponse, OfferVenueResponse } from 'api/gen'
+import { ExpenseDomain, OfferResponseV2, OfferStockResponse, OfferVenueResponse } from 'api/gen'
 import { OfferTileProps } from 'features/offer/types'
 import { QueryKeys } from 'libs/queryKeys'
 
@@ -14,9 +14,9 @@ type PartialOffer = Pick<
 // available, released, not sold out...
 const mergeOfferData =
   (offer: PartialOffer) =>
-  (prevData: OfferResponse | undefined): OfferResponse => ({
+  (prevData: OfferResponseV2 | undefined): OfferResponseV2 => ({
     description: '',
-    image: offer.thumbUrl ? { url: offer.thumbUrl } : undefined,
+    images: offer.thumbUrl ? { recto: { url: offer.thumbUrl } } : undefined,
     isDuo: offer.isDuo ?? false,
     name: offer.name ?? '',
     isDigital: false,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29565

## Checklist

I have:

- [x] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

Avant :

https://github.com/pass-culture/pass-culture-app-native/assets/78556024/e7f18330-8314-4220-9458-1a332b141a50


https://github.com/pass-culture/pass-culture-app-native/assets/78556024/4121d3fa-fc40-4039-bdd3-0c92db5ea732

Après :

https://github.com/pass-culture/pass-culture-app-native/assets/78556024/fc77e413-c62c-4a2a-b4eb-3418adbab2ff

![Capture d’écran 2024-05-06 à 16 44 45](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/44dabf12-70a7-4ab4-8790-66ba46456a2e)

![Capture d’écran 2024-05-06 à 16 45 53](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/fbf185c4-34b7-4351-9ad8-dd4e35ed354f)


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
