### PR TITLE
(PC-29591) fix(SearchFilters): Fix reset press by resetting gtls array on dispatch

### DIFF
--- a/src/features/search/pages/SearchFilter/SearchFilter.native.test.tsx
+++ b/src/features/search/pages/SearchFilter/SearchFilter.native.test.tsx
@@ -147,6 +147,7 @@ describe('<SearchFilter/>', () => {
           maxPrice: undefined,
           offerGenreTypes: undefined,
           offerNativeCategories: undefined,
+          gtls: [],
         },
       })
     })

--- a/src/features/search/pages/SearchFilter/SearchFilter.tsx
+++ b/src/features/search/pages/SearchFilter/SearchFilter.tsx
@@ -101,6 +101,7 @@ export const SearchFilter: React.FC = () => {
         priceRange: null,
         tags: [],
         timeRange: null,
+        gtls: [],
       },
     })
     setDisabilities(defaultDisabilitiesProperties)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29591

## Checklist

I have:

- [X] Made sure my feature is working on the relevant real / virtual devices (native and web).
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [X] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| AVANT |
| :------------------: |

https://github.com/pass-culture/pass-culture-app-native/assets/158567429/b435fe2c-9e99-4e59-a2a3-141ccbdc205a

| APRES |
| :------------------: |

https://github.com/pass-culture/pass-culture-app-native/assets/158567429/b4f2b6e5-e90f-4c03-91e7-9d11003e5bec


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
