### PR TITLE
(PC-29925) feat(log): improve sentry logs for reco endpoint

### DIFF
--- a/src/libs/recommendation/useHomeRecommendedIdsQuery.native.test.ts
+++ b/src/libs/recommendation/useHomeRecommendedIdsQuery.native.test.ts
@@ -34,30 +34,6 @@ describe('useHomeRecommendedIdsQuery', () => {
     })
   })
 
-  it('should capture an exception when recommendation playlist is empty', async () => {
-    mockServer.postApi<PlaylistResponse>('/v1/recommendation/playlist', {
-      responseOptions: { statusCode: 200, data: { params: {}, playlistRecommendedOffers: [] } },
-    })
-    renderHook(
-      () =>
-        useHomeRecommendedIdsQuery({
-          playlistRequestBody: {},
-          playlistRequestQuery: {},
-          userId: 1,
-        }),
-      {
-        wrapper: ({ children }) => reactQueryProviderHOC(children),
-      }
-    )
-
-    await waitFor(() => {
-      expect(eventMonitoring.captureException).toHaveBeenCalledWith(
-        'Recommended offers playlist is empty',
-        { extra: { playlistRequestBody: '{}', playlistRequestQuery: '{}' }, level: 'info' }
-      )
-    })
-  })
-
   it('should return playlist offer ids', async () => {
     mockServer.postApi<PlaylistResponse>('/v1/recommendation/playlist', {
       responseOptions: {

--- a/src/libs/recommendation/useHomeRecommendedIdsQuery.native.test.ts
+++ b/src/libs/recommendation/useHomeRecommendedIdsQuery.native.test.ts
@@ -1,4 +1,5 @@
 import { PlaylistResponse } from 'api/gen'
+import { EmptyResponse } from 'libs/fetch'
 import { eventMonitoring } from 'libs/monitoring'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -10,8 +11,8 @@ jest.mock('libs/monitoring')
 
 describe('useHomeRecommendedIdsQuery', () => {
   it('should capture an exception when fetch call fails', async () => {
-    mockServer.postApi<PlaylistResponse>('/v1/recommendation/playlist', {
-      responseOptions: { statusCode: 400 },
+    mockServer.postApi<EmptyResponse>('/v1/recommendation/playlist', {
+      responseOptions: { statusCode: 502, data: {} },
     })
 
     renderHook(
@@ -28,8 +29,8 @@ describe('useHomeRecommendedIdsQuery', () => {
 
     await waitFor(() => {
       expect(eventMonitoring.captureException).toHaveBeenCalledWith(
-        'Error with recommendation endpoint',
-        { extra: { playlistRequestBody: '{}', playlistRequestQuery: '{}' } }
+        'Error 502 with recommendation endpoint',
+        { extra: { playlistRequestBody: '{}', playlistRequestQuery: '{}', statusCode: 502 } }
       )
     })
   })

--- a/src/libs/recommendation/useHomeRecommendedIdsQuery.ts
+++ b/src/libs/recommendation/useHomeRecommendedIdsQuery.ts
@@ -1,4 +1,3 @@
-import { ScopeContext } from '@sentry/types'
 import { useQuery } from 'react-query'
 
 import { api } from 'api/api'
@@ -28,18 +27,6 @@ export const useHomeRecommendedIdsQuery = (parameters: Parameters) => {
           longitude ?? undefined,
           latitude ?? undefined
         )
-
-        const captureContext: Partial<ScopeContext> = {
-          level: 'info',
-          extra: {
-            playlistRequestBody: stringifyPlaylistRequestBody,
-            playlistRequestQuery: stringifyPlaylistRequestQuery,
-          },
-        }
-
-        if (response.playlistRecommendedOffers?.length === 0) {
-          eventMonitoring.captureException('Recommended offers playlist is empty', captureContext)
-        }
 
         return response
       } catch (err) {

--- a/src/libs/recommendation/useHomeRecommendedIdsQuery.ts
+++ b/src/libs/recommendation/useHomeRecommendedIdsQuery.ts
@@ -1,6 +1,7 @@
 import { useQuery } from 'react-query'
 
 import { api } from 'api/api'
+import { ApiError } from 'api/ApiError'
 import { PlaylistRequestBody, PlaylistRequestQuery } from 'api/gen'
 import { eventMonitoring } from 'libs/monitoring'
 import { QueryKeys } from 'libs/queryKeys'
@@ -30,10 +31,12 @@ export const useHomeRecommendedIdsQuery = (parameters: Parameters) => {
 
         return response
       } catch (err) {
-        eventMonitoring.captureException('Error with recommendation endpoint', {
+        const statusCode = (err as ApiError).statusCode
+        eventMonitoring.captureException(`Error ${statusCode} with recommendation endpoint`, {
           extra: {
             playlistRequestBody: stringifyPlaylistRequestBody,
             playlistRequestQuery: stringifyPlaylistRequestQuery,
+            statusCode: statusCode,
           },
         })
 

--- a/src/tests/mswServer.ts
+++ b/src/tests/mswServer.ts
@@ -234,12 +234,8 @@ class MswMockServer
   isMockOptions<TResponse extends DefaultBodyType>(
     options: TResponse | MockOptions<string, TResponse, string | RegExp | Buffer>
   ): options is MockOptions<string, TResponse, string | RegExp | Buffer> {
-    return (
-      (options as MockOptions<string, TResponse, string | RegExp | Buffer>).responseOptions !==
-        undefined ||
-      (options as MockOptions<string, TResponse, string | RegExp | Buffer>).requestOptions !==
-        undefined
-    )
+    const optionsCasted = options as MockOptions<string, TResponse, string | RegExp | Buffer>
+    return optionsCasted.responseOptions !== undefined || optionsCasted.requestOptions !== undefined
   }
 
   universalGet<TResponse extends DefaultBodyType>(


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29925

Après discussion avec l'équipe data: 

1. Pas besoin de logguer une erreur si la liste des recos est vide:

- Retourner une liste de recos vide, c'est un comportement voulu dans quelques cas (Si on ne trouve pas de reco suffisamment pertinente, on préfère ne pas en retourner)
- Les cas où c'est non-optimal, c'est plutôt du côté de l'API reco que l'investigation aura lieu.

2. C'est mieux si on sépare les logs des erreurs par code d'erreur http, ça aidera à naviguer les erreurs sur Sentry pour tout le monde

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
