### PR TITLE
(PC-29724) feat(VideoModuleMobile): Refonte UI bloc mono/multi offre

### DIFF
--- a/__snapshots__/features/home/components/AttachedOfferCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/AttachedOfferCard.native.test.tsx.native-snap
@@ -2,15 +2,9 @@
 
 exports[`<AttachedOfferCard> matches snapshot if all proprieties are defined 1`] = `
 <View
-  accessibilityLabel="Carte offre Soirée super trop drôle de fou malade !"
-  isFocus={false}
-  onBlur={[Function]}
-  onFocus={[Function]}
-  onMouseDown={[Function]}
   style={
     [
       {
-        "alignItems": "center",
         "backgroundColor": "#ffffff",
         "borderColor": "#CBCDD2",
         "borderRadius": 12,
@@ -43,6 +37,7 @@ exports[`<AttachedOfferCard> matches snapshot if all proprieties are defined 1`]
           "flexGrow": 1,
           "flexShrink": 1,
           "gap": 4,
+          "justifyContent": "center",
           "textAlign": "left",
           "wordWrap": "break-word",
         },
@@ -112,13 +107,22 @@ exports[`<AttachedOfferCard> matches snapshot if all proprieties are defined 1`]
       [
         {
           "alignItems": "flex-end",
-          "flexDirection": "column",
-          "height": "100%",
-          "justifyContent": "space-between",
+          "marginVertical": 1,
         },
       ]
     }
   >
+    <View
+      style={
+        [
+          {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+        ]
+      }
+    />
     <View
       numberOfSpaces={1}
       style={
@@ -131,11 +135,10 @@ exports[`<AttachedOfferCard> matches snapshot if all proprieties are defined 1`]
     />
     <View
       height={16}
-      testID="ArrowRighIcon"
       width={16}
     >
       <Text>
-        ArrowRighIcon-SVG-Mock
+        undefined-SVG-Mock
       </Text>
     </View>
   </View>
@@ -144,15 +147,9 @@ exports[`<AttachedOfferCard> matches snapshot if all proprieties are defined 1`]
 
 exports[`<AttachedOfferCard> matches snapshot if there is no distance and arrow 1`] = `
 <View
-  accessibilityLabel="Carte offre Soirée super trop drôle de fou malade !"
-  isFocus={false}
-  onBlur={[Function]}
-  onFocus={[Function]}
-  onMouseDown={[Function]}
   style={
     [
       {
-        "alignItems": "center",
         "backgroundColor": "#ffffff",
         "borderColor": "#CBCDD2",
         "borderRadius": 12,
@@ -185,6 +182,7 @@ exports[`<AttachedOfferCard> matches snapshot if there is no distance and arrow 
           "flexGrow": 1,
           "flexShrink": 1,
           "gap": 4,
+          "justifyContent": "center",
           "textAlign": "left",
           "wordWrap": "break-word",
         },
@@ -240,12 +238,22 @@ exports[`<AttachedOfferCard> matches snapshot if there is no distance and arrow 
       [
         {
           "alignItems": "flex-end",
-          "flexDirection": "column",
-          "height": "100%",
-          "justifyContent": "space-between",
+          "marginVertical": 1,
         },
       ]
     }
-  />
+  >
+    <View
+      style={
+        [
+          {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+          },
+        ]
+      }
+    />
+  </View>
 </View>
 `;

--- a/__snapshots__/features/home/components/AttachedOfferCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/AttachedOfferCard.native.test.tsx.native-snap
@@ -1,0 +1,251 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AttachedOfferCard> matches snapshot if all proprieties are defined 1`] = `
+<View
+  accessibilityLabel="Carte offre Soirée super trop drôle de fou malade !"
+  isFocus={false}
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  style={
+    [
+      {
+        "alignItems": "center",
+        "backgroundColor": "#ffffff",
+        "borderColor": "#CBCDD2",
+        "borderRadius": 12,
+        "borderWidth": 1,
+        "flexDirection": "row",
+        "flexWrap": "wrap",
+        "gap": 8,
+        "maxHeight": 132,
+        "paddingBottom": 16,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 16,
+        "shadowColor": "#161617",
+        "shadowOffset": {
+          "height": 12,
+          "width": 0,
+        },
+        "shadowOpacity": 0.15,
+        "shadowRadius": 48,
+      },
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "flexBasis": 0,
+          "flexDirection": "column",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "gap": 4,
+          "textAlign": "left",
+          "wordWrap": "break-word",
+        },
+      ]
+    }
+  >
+    <Text
+      style={
+        [
+          {
+            "color": "#161617",
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 12,
+            "lineHeight": 16,
+          },
+        ]
+      }
+    >
+      Concert
+    </Text>
+    <Text
+      numberOfLines={2}
+      style={
+        [
+          {
+            "color": "#161617",
+            "fontFamily": "Montserrat-Bold",
+            "fontSize": 15,
+            "lineHeight": 20,
+          },
+        ]
+      }
+    >
+      Soirée super trop drôle de fou malade !
+    </Text>
+    <Text
+      style={
+        [
+          {
+            "color": "#696A6F",
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 12,
+            "lineHeight": 16,
+          },
+        ]
+      }
+    >
+      Du 12/06 au 24/06
+    </Text>
+    <Text
+      style={
+        [
+          {
+            "color": "#696A6F",
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 12,
+            "lineHeight": 16,
+          },
+        ]
+      }
+    >
+      Gratuit
+    </Text>
+  </View>
+  <View
+    style={
+      [
+        {
+          "alignItems": "flex-end",
+          "flexDirection": "column",
+          "height": "100%",
+          "justifyContent": "space-between",
+        },
+      ]
+    }
+  >
+    <View
+      numberOfSpaces={1}
+      style={
+        [
+          {
+            "width": 4,
+          },
+        ]
+      }
+    />
+    <View
+      height={16}
+      testID="ArrowRighIcon"
+      width={16}
+    >
+      <Text>
+        ArrowRighIcon-SVG-Mock
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`<AttachedOfferCard> matches snapshot if there is no distance and arrow 1`] = `
+<View
+  accessibilityLabel="Carte offre Soirée super trop drôle de fou malade !"
+  isFocus={false}
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  style={
+    [
+      {
+        "alignItems": "center",
+        "backgroundColor": "#ffffff",
+        "borderColor": "#CBCDD2",
+        "borderRadius": 12,
+        "borderWidth": 1,
+        "flexDirection": "row",
+        "flexWrap": "wrap",
+        "gap": 8,
+        "maxHeight": 132,
+        "paddingBottom": 16,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 16,
+        "shadowColor": "#161617",
+        "shadowOffset": {
+          "height": 12,
+          "width": 0,
+        },
+        "shadowOpacity": 0.15,
+        "shadowRadius": 48,
+      },
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "flexBasis": 0,
+          "flexDirection": "column",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "gap": 4,
+          "textAlign": "left",
+          "wordWrap": "break-word",
+        },
+      ]
+    }
+  >
+    <Text
+      style={
+        [
+          {
+            "color": "#161617",
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 12,
+            "lineHeight": 16,
+          },
+        ]
+      }
+    >
+      Concert
+    </Text>
+    <Text
+      numberOfLines={2}
+      style={
+        [
+          {
+            "color": "#161617",
+            "fontFamily": "Montserrat-Bold",
+            "fontSize": 15,
+            "lineHeight": 20,
+          },
+        ]
+      }
+    >
+      Soirée super trop drôle de fou malade !
+    </Text>
+    <Text
+      style={
+        [
+          {
+            "color": "#696A6F",
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 12,
+            "lineHeight": 16,
+          },
+        ]
+      }
+    >
+      Gratuit
+    </Text>
+  </View>
+  <View
+    style={
+      [
+        {
+          "alignItems": "flex-end",
+          "flexDirection": "column",
+          "height": "100%",
+          "justifyContent": "space-between",
+        },
+      ]
+    }
+  />
+</View>
+`;

--- a/__snapshots__/features/home/components/AttachedOfferCard.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/AttachedOfferCard.native.test.tsx.native-snap
@@ -61,7 +61,7 @@ exports[`<AttachedOfferCard> matches snapshot if all proprieties are defined 1`]
         ]
       }
     >
-      Concert
+      concert
     </Text>
     <Text
       numberOfLines={2}
@@ -203,7 +203,7 @@ exports[`<AttachedOfferCard> matches snapshot if there is no distance and arrow 
         ]
       }
     >
-      Concert
+      concert
     </Text>
     <Text
       numberOfLines={2}

--- a/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
@@ -709,3 +709,713 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
   </View>
 </Modal>
 `;
+
+exports[`VideoModal should render properly with FF on 1`] = `
+<Modal
+  accessibilityLabelledBy="testUuidV4"
+  accessibilityModal={true}
+  accessibilityRole="none"
+  animationType="none"
+  deviceHeight={1334}
+  deviceWidth={750}
+  hardwareAccelerated={false}
+  hideModalContentWhileAnimating={false}
+  onBackdropPress={[Function]}
+  onModalHide={[Function]}
+  onModalWillHide={[Function]}
+  onModalWillShow={[Function]}
+  onRequestClose={[Function]}
+  onSwipeComplete={[Function]}
+  panResponderThreshold={4}
+  scrollHorizontal={false}
+  scrollOffset={0}
+  scrollOffsetMax={0}
+  scrollTo={null}
+  statusBarTranslucent={true}
+  supportedOrientations={
+    [
+      "portrait",
+      "landscape",
+    ]
+  }
+  swipeDirection="down"
+  swipeThreshold={100}
+  testID="modal"
+  transparent={true}
+  visible={true}
+>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    forwardedRef={[Function]}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "backgroundColor": "black",
+        "bottom": 0,
+        "height": 1334,
+        "left": 0,
+        "opacity": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+        "width": 750,
+      }
+    }
+  />
+  <View
+    accessibilityLabelledBy="testUuidV4"
+    accessibilityModal={true}
+    accessibilityRole="none"
+    collapsable={false}
+    deviceHeight={1334}
+    deviceWidth={750}
+    forwardedRef={[Function]}
+    hideModalContentWhileAnimating={false}
+    onBackdropPress={[Function]}
+    onModalHide={[Function]}
+    onModalWillHide={[Function]}
+    onModalWillShow={[Function]}
+    onMoveShouldSetResponder={[Function]}
+    onMoveShouldSetResponderCapture={[Function]}
+    onResponderEnd={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderReject={[Function]}
+    onResponderRelease={[Function]}
+    onResponderStart={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    onStartShouldSetResponderCapture={[Function]}
+    onSwipeComplete={[Function]}
+    panResponderThreshold={4}
+    pointerEvents="box-none"
+    scrollHorizontal={false}
+    scrollOffset={0}
+    scrollOffsetMax={0}
+    scrollTo={null}
+    statusBarTranslucent={true}
+    style={
+      {
+        "alignItems": "center",
+        "bottom": 0,
+        "flex": 1,
+        "justifyContent": "center",
+        "left": 0,
+        "margin": "auto",
+        "position": "absolute",
+        "right": 0,
+        "top": "auto",
+        "transform": [
+          {
+            "translateY": 1334,
+          },
+        ],
+      }
+    }
+    supportedOrientations={
+      [
+        "portrait",
+        "landscape",
+      ]
+    }
+    swipeDirection="down"
+    swipeThreshold={100}
+  >
+    <View
+      desktopMaxHeight={1000.5}
+      height={1318}
+      maxHeight={1334}
+      noPadding={true}
+      noPaddingBottom={true}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "backgroundColor": "#ffffff",
+            "borderBottomEndRadius": 0,
+            "borderBottomLeftRadius": 0,
+            "borderBottomRightRadius": 0,
+            "borderBottomStartRadius": 0,
+            "borderTopEndRadius": 16,
+            "borderTopLeftRadius": 20,
+            "borderTopRightRadius": 20,
+            "borderTopStartRadius": 16,
+            "flexDirection": "column",
+            "height": 1318,
+            "justifyContent": "center",
+            "maxHeight": 1334,
+            "maxWidth": 960,
+            "width": "100%",
+          },
+        ]
+      }
+      testID="modalContainer"
+    >
+      <View
+        nativeID="testUuidV4"
+        style={
+          [
+            {
+              "flexDirection": "row",
+              "width": "100%",
+            },
+          ]
+        }
+        testID="customModalHeader"
+      />
+      <View
+        style={
+          [
+            {
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "width": "100%",
+            },
+          ]
+        }
+        testID="fullscreenModalView"
+      >
+        <View
+          style={
+            [
+              {
+                "backgroundColor": "#161617",
+                "borderTopLeftRadius": 16,
+                "borderTopRightRadius": 16,
+                "overflow": "hidden",
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              {
+                "height": 421.875,
+                "width": 750,
+              }
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "flex": 1,
+                    "overflow": "hidden",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <RNCWebView
+                allowsFullscreenVideo={true}
+                allowsInlineMediaPlayback={true}
+                bounces={false}
+                cacheEnabled={true}
+                injectedJavaScriptBeforeContentLoadedForMainFrameOnly={true}
+                injectedJavaScriptForMainFrameOnly={true}
+                javaScriptEnabled={true}
+                mediaPlaybackRequiresUserAction={false}
+                messagingEnabled={true}
+                onContentProcessDidTerminate={[Function]}
+                onHttpError={[Function]}
+                onLoadingError={[Function]}
+                onLoadingFinish={[Function]}
+                onLoadingProgress={[Function]}
+                onLoadingStart={[Function]}
+                onMessage={[Function]}
+                onShouldStartLoadWithRequest={[Function]}
+                overScrollMode="never"
+                scrollEnabled={false}
+                source={
+                  {
+                    "uri": "https://lonelycpp.github.io/react-native-youtube-iframe/iframe.html?data=%7B%22rel_s%22:0,%22loop_s%22:0,%22videoId_s%22:%22qE7xwEZnFP0%22,%22controls_s%22:1,%22contentScale_s%22:1,%22cc_lang_pref_s%22:%22%22,%22allowWebViewZoom%22:false,%22modestbranding_s%22:1,%22preventFullScreen_s%22:1,%22showClosedCaptions_s%22:0%7D",
+                  }
+                }
+                style={
+                  [
+                    {
+                      "flex": 1,
+                      "overflow": "hidden",
+                    },
+                    {
+                      "backgroundColor": "#ffffff",
+                    },
+                    [
+                      {
+                        "backgroundColor": "transparent",
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+                textInteractionEnabled={true}
+                useSharedProcessPool={true}
+                userAgent=""
+              />
+            </View>
+          </View>
+        </View>
+        <RCTScrollView
+          style={
+            [
+              {
+                "paddingHorizontal": 24,
+              },
+            ]
+          }
+        >
+          <View>
+            <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "height": 16,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "flex-start",
+                  },
+                ]
+              }
+            >
+              <View
+                color="Aquamarine"
+                style={
+                  [
+                    {
+                      "backgroundColor": "#0E8474",
+                      "borderRadius": 4,
+                      "paddingBottom": 4,
+                      "paddingLeft": 4,
+                      "paddingRight": 4,
+                      "paddingTop": 4,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#ffffff",
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 12,
+                        "lineHeight": 16,
+                      },
+                    ]
+                  }
+                >
+                  FAQ
+                </Text>
+              </View>
+            </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "height": 8,
+                  },
+                ]
+              }
+            />
+            <Text
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Bold",
+                    "fontSize": 20,
+                    "lineHeight": 24,
+                  },
+                ]
+              }
+            >
+              Découvre Lujipeka
+            </Text>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "height": 8,
+                  },
+                ]
+              }
+            />
+            <Text
+              style={
+                [
+                  {
+                    "color": "#90949D",
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 12,
+                    "lineHeight": 16,
+                  },
+                ]
+              }
+            >
+              Publiée le 16 juin 2023
+            </Text>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "height": 8,
+                  },
+                ]
+              }
+            />
+            <Text
+              style={
+                [
+                  {
+                    "color": "#696A6F",
+                    "fontFamily": "Montserrat-Regular",
+                    "fontSize": 15,
+                    "lineHeight": 20,
+                  },
+                ]
+              }
+            >
+              Lujipeka répond à vos questions sur sa tournée, sa musique, ses inspirations et pleins d’autres questions&nbsp;!
+            </Text>
+            <View
+              numberOfSpaces={6}
+              style={
+                [
+                  {
+                    "height": 24,
+                  },
+                ]
+              }
+            />
+            <Text
+              style={
+                [
+                  {
+                    "color": "#161617",
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 18,
+                    "lineHeight": 22,
+                  },
+                ]
+              }
+            >
+              Pour aller plus loin…
+            </Text>
+            <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "height": 16,
+                  },
+                ]
+              }
+            />
+            <View
+              accessibilityRole="link"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={false}
+              collapsable={false}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                {
+                  "alignItems": "flex-start",
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#CBCDD2",
+                  "borderRadius": 8,
+                  "borderStyle": "solid",
+                  "borderWidth": 1,
+                  "height": 140,
+                  "opacity": 1,
+                  "overflow": "hidden",
+                  "userSelect": "auto",
+                }
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "marginBottom": 16,
+                        "marginLeft": 16,
+                        "marginRight": 16,
+                        "marginTop": 16,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    size="medium"
+                    style={
+                      [
+                        {
+                          "borderRadius": 4,
+                          "height": 112,
+                          "shadowColor": "#696A6F",
+                          "shadowOffset": {
+                            "height": 4,
+                            "width": 0,
+                          },
+                          "shadowOpacity": 0.2,
+                          "shadowRadius": 4,
+                          "width": 80,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "overflow": "hidden",
+                          },
+                          [
+                            {
+                              "backgroundColor": "#F1F1F4",
+                              "borderRadius": 4,
+                              "height": 112,
+                              "width": 80,
+                            },
+                          ],
+                        ]
+                      }
+                    >
+                      <FastImageView
+                        defaultSource={null}
+                        resizeMode="cover"
+                        size="medium"
+                        source={
+                          {
+                            "uri": "https://storage.gra.cloud.ovh.net/v1/AUTH_688df1e25bd84a48a3804e7fa8938085/storage-pc-dev/thumbs/mediations/CDNQ",
+                          }
+                        }
+                        style={
+                          {
+                            "bottom": 0,
+                            "left": 0,
+                            "position": "absolute",
+                            "right": 0,
+                            "top": 0,
+                          }
+                        }
+                      />
+                    </View>
+                  </View>
+                </View>
+                <View
+                  style={
+                    [
+                      {
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                        "marginRight": 16,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    color="Aquamarine"
+                    style={
+                      [
+                        {
+                          "color": "#0E8474",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 16,
+                          "marginBottom": 4,
+                        },
+                      ]
+                    }
+                  >
+                    Livre
+                  </Text>
+                  <Text
+                    numberOfLines={2}
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Bold",
+                          "fontSize": 15,
+                          "lineHeight": 20,
+                          "marginBottom": 4,
+                        },
+                      ]
+                    }
+                  >
+                    La nuit des temps
+                  </Text>
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#696A6F",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 16,
+                          "marginBottom": 4,
+                        },
+                      ]
+                    }
+                  >
+                    0,28 €
+                  </Text>
+                </View>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "bottom": 16,
+                      "position": "absolute",
+                      "right": 16,
+                    },
+                  ]
+                }
+              >
+                <View
+                  height={24}
+                  width={24}
+                >
+                  <Text>
+                    undefined-SVG-Mock
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              numberOfSpaces={8}
+              style={
+                [
+                  {
+                    "height": 32,
+                  },
+                ]
+              }
+            />
+          </View>
+        </RCTScrollView>
+        <View
+          accessibilityLabel="Fermer la modale vidéo"
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "backgroundColor": "#ffffff",
+              "borderRadius": 40,
+              "opacity": 1,
+              "paddingBottom": 10,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 10,
+              "position": "absolute",
+              "right": 16,
+              "top": 16,
+              "userSelect": "auto",
+            }
+          }
+          testID="Fermer la modale vidéo"
+        >
+          <View
+            height={20}
+            width={20}
+          >
+            <Text>
+              undefined-SVG-Mock
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</Modal>
+`;

--- a/__snapshots__/features/home/components/modules/video/VideoModule.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoModule.native.test.tsx.native-snap
@@ -1,0 +1,526 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VideoModule should render properly with FF on 1`] = `
+<View
+  style={
+    [
+      {
+        "paddingBottom": 24,
+      },
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "paddingBottom": 24,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "marginHorizontal": 24,
+          },
+        ]
+      }
+    >
+      <Text
+        numberOfLines={2}
+        style={
+          [
+            {
+              "color": "#161617",
+              "fontFamily": "Montserrat-Bold",
+              "fontSize": 20,
+              "lineHeight": 24,
+            },
+          ]
+        }
+      >
+        Découvre Lujipeka
+      </Text>
+    </View>
+    <View
+      numberOfSpaces={5}
+      style={
+        [
+          {
+            "height": 20,
+          },
+        ]
+      }
+    />
+    <View
+      testID="mobile-video-module"
+    >
+      <BVLinearGradient
+        colorCategoryBackgroundHeightUniqueOffer={163}
+        colors={
+          [
+            4292607978,
+            4292607978,
+          ]
+        }
+        enableMultiVideoModule={true}
+        endPoint={
+          {
+            "x": 0,
+            "y": 1,
+          }
+        }
+        isMultiOffer={false}
+        locations={null}
+        startPoint={
+          {
+            "x": 0,
+            "y": 0,
+          }
+        }
+        style={
+          [
+            {
+              "height": 163,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 79,
+            },
+          ]
+        }
+      />
+      <View
+        enableMultiVideoModule={true}
+        style={
+          [
+            {
+              "marginHorizontal": 0,
+            },
+          ]
+        }
+      >
+        <View
+          accessibilityRole="button"
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            [
+              {
+                "borderRadius": 8,
+              },
+            ]
+          }
+          testID="video-thumbnail"
+        >
+          <View
+            accessibilityIgnoresInvertColors={true}
+            style={
+              [
+                {
+                  "backgroundColor": "#F1F1F4",
+                  "borderColor": "#CBCDD2",
+                  "borderRadius": 8,
+                  "borderStyle": "solid",
+                  "borderWidth": 1,
+                  "height": 210,
+                  "overflow": "hidden",
+                  "width": "100%",
+                },
+              ]
+            }
+          >
+            <Image
+              enableMultiVideoModule={true}
+              source={
+                {
+                  "uri": "https://images.ctfassets.net/2bg01iqy0isv/326jseCDgaDNyOu4XAsBec/f338921eaae630381841d0eeeb84ce60/lujipeka",
+                }
+              }
+              style={
+                [
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                  {
+                    "height": 210,
+                    "width": "100%",
+                  },
+                  undefined,
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                  },
+                ]
+              }
+            >
+              <BVLinearGradient
+                colors={
+                  [
+                    1447447,
+                    2870351383,
+                  ]
+                }
+                endPoint={
+                  {
+                    "x": 0.5,
+                    "y": 1,
+                  }
+                }
+                locations={null}
+                startPoint={
+                  {
+                    "x": 0.5,
+                    "y": 0,
+                  }
+                }
+                style={
+                  [
+                    {
+                      "height": 32,
+                    },
+                  ]
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "backgroundColor": "rgba(22,22,23,0.67)",
+                      "paddingBottom": 16,
+                      "paddingLeft": 16,
+                      "paddingRight": 16,
+                      "paddingTop": 16,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  ellipsizeMode="tail"
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "color": "#ffffff",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 26,
+                        "lineHeight": 24,
+                        "textAlign": "center",
+                        "textTransform": "uppercase",
+                      },
+                    ]
+                  }
+                >
+                  Lujipeka répond à vos questions !
+                </Text>
+              </View>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 50,
+                  },
+                ]
+              }
+            >
+              <View
+                accessibilityLabel="Jouer"
+                height={96}
+                width={96}
+              >
+                <Text>
+                  undefined-SVG-Mock
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          numberOfSpaces={4}
+          style={
+            [
+              {
+                "height": 16,
+              },
+            ]
+          }
+        />
+        <View
+          onLayout={[Function]}
+        >
+          <View
+            accessibilityRole="link"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={false}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignItems": "flex-start",
+                "backgroundColor": "#ffffff",
+                "borderColor": "#CBCDD2",
+                "borderRadius": 8,
+                "borderStyle": "solid",
+                "borderWidth": 1,
+                "flexGrow": 1,
+                "height": 140,
+                "marginHorizontal": 24,
+                "opacity": 1,
+                "overflow": "hidden",
+                "userSelect": "auto",
+              }
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "marginBottom": 16,
+                      "marginLeft": 16,
+                      "marginRight": 16,
+                      "marginTop": 16,
+                    },
+                  ]
+                }
+              >
+                <View
+                  size="medium"
+                  style={
+                    [
+                      {
+                        "borderRadius": 4,
+                        "height": 112,
+                        "shadowColor": "#696A6F",
+                        "shadowOffset": {
+                          "height": 4,
+                          "width": 0,
+                        },
+                        "shadowOpacity": 0.2,
+                        "shadowRadius": 4,
+                        "width": 80,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      [
+                        {
+                          "overflow": "hidden",
+                        },
+                        [
+                          {
+                            "backgroundColor": "#F1F1F4",
+                            "borderRadius": 4,
+                            "height": 112,
+                            "width": 80,
+                          },
+                        ],
+                      ]
+                    }
+                  >
+                    <FastImageView
+                      defaultSource={null}
+                      resizeMode="cover"
+                      size="medium"
+                      source={
+                        {
+                          "uri": "http://thumbnail",
+                        }
+                      }
+                      style={
+                        {
+                          "bottom": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                        }
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "flexBasis": 0,
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                      "marginRight": 16,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  color="Aquamarine"
+                  style={
+                    [
+                      {
+                        "color": "#0E8474",
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 12,
+                        "lineHeight": 16,
+                        "marginBottom": 4,
+                      },
+                    ]
+                  }
+                >
+                  Concert
+                </Text>
+                <Text
+                  numberOfLines={2}
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-Bold",
+                        "fontSize": 15,
+                        "lineHeight": 20,
+                        "marginBottom": 4,
+                      },
+                    ]
+                  }
+                >
+                  La nuit des temps
+                </Text>
+              </View>
+            </View>
+            <View
+              style={
+                [
+                  {
+                    "bottom": 16,
+                    "position": "absolute",
+                    "right": 16,
+                  },
+                ]
+              }
+            >
+              <View
+                height={24}
+                width={24}
+              >
+                <Text>
+                  undefined-SVG-Mock
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      numberOfSpaces={4}
+      style={
+        [
+          {
+            "height": 16,
+          },
+        ]
+      }
+    />
+  </View>
+  <Modal
+    accessibilityLabelledBy="testUuidV4"
+    accessibilityModal={true}
+    accessibilityRole="none"
+    animationType="none"
+    deviceHeight={1334}
+    deviceWidth={750}
+    hardwareAccelerated={false}
+    hideModalContentWhileAnimating={false}
+    onBackdropPress={[Function]}
+    onModalHide={[Function]}
+    onModalWillHide={[Function]}
+    onModalWillShow={[Function]}
+    onRequestClose={[Function]}
+    onSwipeComplete={[Function]}
+    panResponderThreshold={4}
+    scrollHorizontal={false}
+    scrollOffset={0}
+    scrollOffsetMax={0}
+    scrollTo={null}
+    statusBarTranslucent={true}
+    supportedOrientations={
+      [
+        "portrait",
+        "landscape",
+      ]
+    }
+    swipeDirection="down"
+    swipeThreshold={100}
+    testID="modal"
+    transparent={true}
+    visible={false}
+  />
+</View>
+`;

--- a/__snapshots__/features/home/components/modules/video/VideoModule.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoModule.native.test.tsx.native-snap
@@ -137,7 +137,7 @@ exports[`VideoModule should render properly with FF on 1`] = `
                 {
                   "backgroundColor": "#F1F1F4",
                   "borderColor": "#CBCDD2",
-                  "borderRadius": 8,
+                  "borderRadius": "unset",
                   "borderStyle": "solid",
                   "borderWidth": 1,
                   "height": 210,

--- a/__snapshots__/features/home/components/modules/video/VideoMonoOfferTile.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoMonoOfferTile.native.test.tsx.native-snap
@@ -1,0 +1,210 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VideoMonoOfferTile should render properly with FF on 1`] = `
+<View
+  accessibilityRole="link"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={false}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "flex-start",
+      "backgroundColor": "#ffffff",
+      "borderColor": "#CBCDD2",
+      "borderRadius": 8,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "height": 140,
+      "opacity": 1,
+      "overflow": "hidden",
+      "userSelect": "auto",
+    }
+  }
+>
+  <View
+    style={
+      [
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "marginBottom": 16,
+            "marginLeft": 16,
+            "marginRight": 16,
+            "marginTop": 16,
+          },
+        ]
+      }
+    >
+      <View
+        size="medium"
+        style={
+          [
+            {
+              "borderRadius": 4,
+              "height": 112,
+              "shadowColor": "#696A6F",
+              "shadowOffset": {
+                "height": 4,
+                "width": 0,
+              },
+              "shadowOpacity": 0.2,
+              "shadowRadius": 4,
+              "width": 80,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "overflow": "hidden",
+              },
+              [
+                {
+                  "backgroundColor": "#F1F1F4",
+                  "borderRadius": 4,
+                  "height": 112,
+                  "width": 80,
+                },
+              ],
+            ]
+          }
+        >
+          <FastImageView
+            defaultSource={null}
+            resizeMode="cover"
+            size="medium"
+            source={
+              {
+                "uri": "https://storage.gra.cloud.ovh.net/v1/AUTH_688df1e25bd84a48a3804e7fa8938085/storage-pc-dev/thumbs/mediations/CDNQ",
+              }
+            }
+            style={
+              {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              }
+            }
+          />
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        [
+          {
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+            "marginRight": 16,
+          },
+        ]
+      }
+    >
+      <Text
+        color=""
+        style={
+          [
+            {
+              "color": "#161617",
+              "fontFamily": "Montserrat-SemiBold",
+              "fontSize": 12,
+              "lineHeight": 16,
+              "marginBottom": 4,
+            },
+          ]
+        }
+      >
+        Livre
+      </Text>
+      <Text
+        numberOfLines={2}
+        style={
+          [
+            {
+              "color": "#161617",
+              "fontFamily": "Montserrat-Bold",
+              "fontSize": 15,
+              "lineHeight": 20,
+              "marginBottom": 4,
+            },
+          ]
+        }
+      >
+        La nuit des temps
+      </Text>
+      <Text
+        style={
+          [
+            {
+              "color": "#696A6F",
+              "fontFamily": "Montserrat-SemiBold",
+              "fontSize": 12,
+              "lineHeight": 16,
+              "marginBottom": 4,
+            },
+          ]
+        }
+      >
+        0,28 €
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      [
+        {
+          "bottom": 16,
+          "position": "absolute",
+          "right": 16,
+        },
+      ]
+    }
+  >
+    <View
+      height={24}
+      width={24}
+    >
+      <Text>
+        undefined-SVG-Mock
+      </Text>
+    </View>
+  </View>
+</View>
+`;

--- a/__snapshots__/features/home/components/modules/video/VideoMultiOfferTile.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoMultiOfferTile.native.test.tsx.native-snap
@@ -1,0 +1,168 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VideoMultiOfferTile should render properly with FF on 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "#ffffff",
+        "borderRadius": 8,
+      },
+    ]
+  }
+>
+  <View
+    accessibilityRole="link"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={false}
+    collapsable={false}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "opacity": 1,
+        "userSelect": "auto",
+        "width": 96,
+      }
+    }
+  >
+    <View
+      borderRadius={8}
+      size="large"
+      style={
+        [
+          {
+            "borderRadius": 8,
+            "height": 144,
+            "shadowColor": "#696A6F",
+            "shadowOffset": {
+              "height": 4,
+              "width": 0,
+            },
+            "shadowOpacity": 0.2,
+            "shadowRadius": 4,
+            "width": 96,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "overflow": "hidden",
+            },
+            [
+              {
+                "backgroundColor": "#F1F1F4",
+                "borderColor": "#696A6F",
+                "borderRadius": 8,
+                "borderWidth": 1,
+                "height": 144,
+                "width": 96,
+              },
+            ],
+          ]
+        }
+      >
+        <FastImageView
+          borderRadius={8}
+          defaultSource={null}
+          resizeMode="cover"
+          size="large"
+          source={
+            {
+              "uri": "https://storage.gra.cloud.ovh.net/v1/AUTH_688df1e25bd84a48a3804e7fa8938085/storage-pc-dev/thumbs/mediations/CDNQ",
+            }
+          }
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+          withSroke={true}
+        />
+      </View>
+    </View>
+    <View
+      numberOfSpaces={2}
+      style={
+        [
+          {
+            "height": 8,
+          },
+        ]
+      }
+    />
+    <Text
+      numberOfLines={1}
+      style={
+        [
+          {
+            "color": "#161617",
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 12,
+            "lineHeight": 16,
+          },
+        ]
+      }
+    >
+      La nuit des temps
+    </Text>
+    <Text
+      style={
+        [
+          {
+            "color": "#696A6F",
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 12,
+            "lineHeight": 16,
+          },
+        ]
+      }
+    >
+      Livre
+    </Text>
+    <Text
+      style={
+        [
+          {
+            "color": "#696A6F",
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 12,
+            "lineHeight": 16,
+          },
+        ]
+      }
+    >
+      0,28 €
+    </Text>
+  </View>
+</View>
+`;

--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -45,7 +45,7 @@
 ./src/features/home/components/modules/OffersModule.tsx:71
 ./src/features/home/components/modules/video/VideoModal.tsx:109
 ./src/features/home/components/modules/video/VideoModuleDesktop.tsx:96
-./src/features/home/components/modules/video/VideoModuleMobile.tsx:70
+./src/features/home/components/modules/video/VideoModuleMobile.tsx:112
 ./src/features/identityCheck/api/useProfileInfo.ts:21
 ./src/features/identityCheck/pages/helpers/parseUrlParams.ts:8
 ./src/features/identityCheck/pages/helpers/useSetCurrentSubscriptionStep.ts:41

--- a/src/features/home/components/AttachedOfferCard.native.test.tsx
+++ b/src/features/home/components/AttachedOfferCard.native.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+
+import { CategoryIdEnum, SubcategoryIdEnum } from 'api/gen'
+import { AttachedOfferCard } from 'features/home/components/AttachedOfferCard'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { render, screen } from 'tests/utils'
+
+describe('<AttachedOfferCard>', () => {
+  it('matches snapshot if all proprieties are defined', () => {
+    render(
+      reactQueryProviderHOC(
+        <AttachedOfferCard
+          subcategoryId={SubcategoryIdEnum.CONCERT}
+          withRightArrow
+          imageUrl="https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/9MPGW"
+          price="Gratuit"
+          categoryId={CategoryIdEnum.MUSIQUE_LIVE}
+          title="Soirée super trop drôle de fou malade&nbsp;!"
+          date="Du 12/06 au 24/06"
+        />
+      )
+    )
+
+    expect(screen).toMatchSnapshot()
+  })
+
+  it('matches snapshot if there is no distance and arrow', () => {
+    render(
+      reactQueryProviderHOC(
+        <AttachedOfferCard
+          subcategoryId={SubcategoryIdEnum.CONCERT}
+          imageUrl="https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/9MPGW"
+          price="Gratuit"
+          categoryId={CategoryIdEnum.MUSIQUE_LIVE}
+          title="Soirée super trop drôle de fou malade&nbsp;!"
+        />
+      )
+    )
+
+    expect(screen).toMatchSnapshot()
+  })
+})

--- a/src/features/home/components/AttachedOfferCard.native.test.tsx
+++ b/src/features/home/components/AttachedOfferCard.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { CategoryIdEnum, SubcategoryIdEnum } from 'api/gen'
+import { CategoryIdEnum } from 'api/gen'
 import { AttachedOfferCard } from 'features/home/components/AttachedOfferCard'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen } from 'tests/utils'
@@ -10,7 +10,7 @@ describe('<AttachedOfferCard>', () => {
     render(
       reactQueryProviderHOC(
         <AttachedOfferCard
-          subcategoryId={SubcategoryIdEnum.CONCERT}
+          categoryText="concert"
           withRightArrow
           imageUrl="https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/9MPGW"
           price="Gratuit"
@@ -28,7 +28,7 @@ describe('<AttachedOfferCard>', () => {
     render(
       reactQueryProviderHOC(
         <AttachedOfferCard
-          subcategoryId={SubcategoryIdEnum.CONCERT}
+          categoryText="concert"
           imageUrl="https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/9MPGW"
           price="Gratuit"
           categoryId={CategoryIdEnum.MUSIQUE_LIVE}

--- a/src/features/home/components/AttachedOfferCard.stories.tsx
+++ b/src/features/home/components/AttachedOfferCard.stories.tsx
@@ -5,7 +5,6 @@ import { AttachedOfferCard } from './AttachedOfferCard'
 const meta: ComponentMeta<typeof AttachedOfferCard> = {
   title: 'ui/AttachedOfferCard',
   component: AttachedOfferCard,
-  decorators: [(Story) => <Story />],
 }
 export default meta
 
@@ -18,7 +17,7 @@ Default.args = {
   imageUrl:
     'https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/9MPGW',
   price: 'Gratuit',
-  categoryText: 'cinéma',
+  categoryText: 'Cinéma',
   title: 'La Joconde',
   date: 'Du 12/06 au 24/06',
 }

--- a/src/features/home/components/AttachedOfferCard.stories.tsx
+++ b/src/features/home/components/AttachedOfferCard.stories.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer } from '@react-navigation/native'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 import React from 'react'
 
@@ -6,13 +5,7 @@ import { AttachedOfferCard } from './AttachedOfferCard'
 const meta: ComponentMeta<typeof AttachedOfferCard> = {
   title: 'ui/AttachedOfferCard',
   component: AttachedOfferCard,
-  decorators: [
-    (Story) => (
-      <NavigationContainer>
-        <Story />
-      </NavigationContainer>
-    ),
-  ],
+  decorators: [(Story) => <Story />],
 }
 export default meta
 
@@ -25,7 +18,7 @@ Default.args = {
   imageUrl:
     'https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/9MPGW',
   price: 'Gratuit',
-  tag: 'Musée',
+  categoryText: 'cinéma',
   title: 'La Joconde',
   date: 'Du 12/06 au 24/06',
 }

--- a/src/features/home/components/AttachedOfferCard.tsx
+++ b/src/features/home/components/AttachedOfferCard.tsx
@@ -29,10 +29,10 @@ export type AttachedOfferCardProps = {
 export const AttachedOfferCard = ({
   title,
   categoryId,
-  categoryText,
   imageUrl,
   geoloc,
   price,
+  categoryText,
   date,
   withRightArrow,
   showImage,

--- a/src/features/home/components/AttachedOfferCard.tsx
+++ b/src/features/home/components/AttachedOfferCard.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { CategoryIdEnum } from 'api/gen'
+import { useDistance } from 'libs/location/hooks/useDistance'
+import { OfferLocation } from 'shared/offer/types'
 import { OfferImage } from 'ui/components/tiles/OfferImage'
 import { OfferName } from 'ui/components/tiles/OfferName'
 import { ArrowRight } from 'ui/svg/icons/ArrowRight'
@@ -14,13 +16,13 @@ const OFFER_CARD_PADDING = getSpacing(4)
 
 export type AttachedOfferCardProps = {
   title: string
-  categoryId?: CategoryIdEnum
+  categoryId: CategoryIdEnum
+  categoryText: string
+  geoloc?: OfferLocation
   imageUrl?: string
   showImage?: boolean
-  distanceToOffer?: string
   price?: string
   withRightArrow?: boolean
-  tag: string
   date?: string
 }
 
@@ -28,13 +30,15 @@ export const AttachedOfferCard = ({
   title,
   categoryId,
   imageUrl,
-  distanceToOffer,
+  geoloc,
   price,
-  tag,
+  categoryText,
   date,
   withRightArrow,
   showImage,
 }: AttachedOfferCardProps) => {
+  const distanceToOffer = useDistance(geoloc || { lat: 0, lng: 0 })
+
   return (
     <Container>
       {showImage ? (
@@ -48,15 +52,15 @@ export const AttachedOfferCard = ({
         </ImageContainer>
       ) : null}
       <CentralColumn>
-        <Typo.Caption>{tag}</Typo.Caption>
+        <Typo.Caption>{categoryText}</Typo.Caption>
         <OfferName title={title} />
         {date ? <CaptionNeutralInfo>{date}</CaptionNeutralInfo> : null}
         {price ? <CaptionNeutralInfo>{price}</CaptionNeutralInfo> : null}
       </CentralColumn>
       <RightColumn>
-        {distanceToOffer ? (
+        {geoloc ? (
           <DistanceWrapper label={`à ${distanceToOffer}`}>
-            <Typo.Hint>{distanceToOffer}</Typo.Hint>
+            <Typo.Hint>à {distanceToOffer}</Typo.Hint>
           </DistanceWrapper>
         ) : null}
         <Spacer.Flex />

--- a/src/features/home/components/AttachedOfferCard.tsx
+++ b/src/features/home/components/AttachedOfferCard.tsx
@@ -18,7 +18,7 @@ export type AttachedOfferCardProps = {
   title: string
   categoryId: CategoryIdEnum
   categoryText: string
-  geoloc?: OfferLocation
+  offerLocation?: OfferLocation
   imageUrl?: string
   showImage?: boolean
   price?: string
@@ -30,14 +30,14 @@ export const AttachedOfferCard = ({
   title,
   categoryId,
   imageUrl,
-  geoloc,
+  offerLocation,
   price,
   categoryText,
   date,
   withRightArrow,
   showImage,
 }: AttachedOfferCardProps) => {
-  const distanceToOffer = useDistance(geoloc || { lat: 0, lng: 0 })
+  const distanceToOffer = useDistance(offerLocation || { lat: 0, lng: 0 })
 
   return (
     <Container>
@@ -58,7 +58,7 @@ export const AttachedOfferCard = ({
         {price ? <CaptionNeutralInfo>{price}</CaptionNeutralInfo> : null}
       </CentralColumn>
       <RightColumn>
-        {geoloc ? (
+        {distanceToOffer ? (
           <DistanceWrapper label={`à ${distanceToOffer}`}>
             <Typo.Hint>à {distanceToOffer}</Typo.Hint>
           </DistanceWrapper>

--- a/src/features/home/components/AttachedOfferCard.tsx
+++ b/src/features/home/components/AttachedOfferCard.tsx
@@ -29,10 +29,10 @@ export type AttachedOfferCardProps = {
 export const AttachedOfferCard = ({
   title,
   categoryId,
+  categoryText,
   imageUrl,
   geoloc,
   price,
-  categoryText,
   date,
   withRightArrow,
   showImage,

--- a/src/features/home/components/AttachedOfferCardButton.native.test.tsx
+++ b/src/features/home/components/AttachedOfferCardButton.native.test.tsx
@@ -10,11 +10,14 @@ describe('<AttachedOfferCardButton>', () => {
   it('should call onPress when pressing the button', () => {
     render(
       <AttachedOfferCardButton
-        distanceToOffer="à 120 m"
+        geoloc={{
+          lat: 48.94476,
+          lng: 2.25055,
+        }}
         withRightArrow
         imageUrl="https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/9MPGW"
         price="Gratuit"
-        tag="Musée"
+        categoryText="Musée"
         categoryId={CategoryIdEnum.MUSIQUE_LIVE}
         title="Soirée super trop drôle de fou malade&nbsp;!"
         date="Du 12/06 au 24/06"

--- a/src/features/home/components/AttachedOfferCardButton.native.test.tsx
+++ b/src/features/home/components/AttachedOfferCardButton.native.test.tsx
@@ -10,7 +10,7 @@ describe('<AttachedOfferCardButton>', () => {
   it('should call onPress when pressing the button', () => {
     render(
       <AttachedOfferCardButton
-        geoloc={{
+        offerLocation={{
           lat: 48.94476,
           lng: 2.25055,
         }}

--- a/src/features/home/components/AttachedOfferCardButton.tsx
+++ b/src/features/home/components/AttachedOfferCardButton.tsx
@@ -20,7 +20,7 @@ export const AttachedOfferCardButton = ({
   title,
   categoryId,
   imageUrl,
-  offerLocation: geoloc,
+  offerLocation,
   price,
   categoryText,
   date,
@@ -42,7 +42,7 @@ export const AttachedOfferCardButton = ({
         title={title}
         categoryId={categoryId}
         imageUrl={imageUrl}
-        offerLocation={geoloc}
+        offerLocation={offerLocation}
         price={price}
         categoryText={categoryText}
         date={date}

--- a/src/features/home/components/AttachedOfferCardButton.tsx
+++ b/src/features/home/components/AttachedOfferCardButton.tsx
@@ -20,9 +20,9 @@ export const AttachedOfferCardButton = ({
   title,
   categoryId,
   imageUrl,
-  distanceToOffer,
+  geoloc,
   price,
-  tag,
+  categoryText,
   date,
   withRightArrow,
   onPress,
@@ -42,9 +42,9 @@ export const AttachedOfferCardButton = ({
         title={title}
         categoryId={categoryId}
         imageUrl={imageUrl}
-        distanceToOffer={distanceToOffer}
+        geoloc={geoloc}
         price={price}
-        tag={tag}
+        categoryText={categoryText}
         date={date}
         withRightArrow={withRightArrow}
         showImage={showImage}

--- a/src/features/home/components/AttachedOfferCardButton.tsx
+++ b/src/features/home/components/AttachedOfferCardButton.tsx
@@ -20,7 +20,7 @@ export const AttachedOfferCardButton = ({
   title,
   categoryId,
   imageUrl,
-  geoloc,
+  offerLocation: geoloc,
   price,
   categoryText,
   date,
@@ -42,7 +42,7 @@ export const AttachedOfferCardButton = ({
         title={title}
         categoryId={categoryId}
         imageUrl={imageUrl}
-        geoloc={geoloc}
+        offerLocation={geoloc}
         price={price}
         categoryText={categoryText}
         date={date}

--- a/src/features/home/components/modules/video/VideoModal.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoModal.native.test.tsx
@@ -5,11 +5,14 @@ import { VideoModal } from 'features/home/components/modules/video/VideoModal'
 import { videoModuleFixture } from 'features/home/fixtures/videoModule.fixture'
 import { mockedAlgoliaResponse } from 'libs/algolia/fixtures/algoliaFixtures'
 import { analytics } from 'libs/analytics'
+import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
 import { MODAL_TO_SHOW_TIME } from 'tests/constants'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, fireEvent, render, screen } from 'tests/utils'
+
+const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
 
 jest.useFakeTimers()
 
@@ -45,6 +48,16 @@ describe('VideoModal', () => {
       moduleId: 'abcd',
       modalType: 'video',
     })
+  })
+
+  it('should render properly with FF on', async () => {
+    useFeatureFlagSpy.mockReturnValueOnce(true)
+
+    renderVideoModal()
+
+    await screen.findByText('La nuit des temps')
+
+    expect(screen).toMatchSnapshot()
   })
 })
 

--- a/src/features/home/components/modules/video/VideoModule.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoModule.native.test.tsx
@@ -5,10 +5,13 @@ import { useVideoOffers } from 'features/home/api/useVideoOffers'
 import { VideoModule } from 'features/home/components/modules/video/VideoModule'
 import { videoModuleFixture } from 'features/home/fixtures/videoModule.fixture'
 import { analytics } from 'libs/analytics'
+import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+
+const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
 
 const mockShowModal = jest.fn()
 jest.mock('ui/components/modals/useModal', () => ({
@@ -95,12 +98,24 @@ describe('VideoModule', () => {
 
     expect(multiOfferList).toBeOnTheScreen()
   })
+
+  it('should render properly with FF on', async () => {
+    useFeatureFlagSpy.mockReturnValueOnce(true)
+
+    mockUseVideoOffers.mockReturnValueOnce({ offers: [offerFixture] })
+    renderVideoModule()
+
+    await screen.findByText('La nuit des temps')
+
+    expect(screen).toMatchSnapshot()
+  })
 })
 
 const offerFixture = {
   offer: {
     thumbUrl: 'http://thumbnail',
     subcategoryId: 'CONCERT',
+    name: 'La nuit des temps',
   },
   objectID: 1234,
   venue: {

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -12,19 +12,10 @@ import { VideoMultiOfferPlaylist } from 'features/home/components/modules/video/
 import { VideoModuleProps } from 'features/home/types'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import { theme } from 'theme'
 import { Play } from 'ui/svg/icons/Play'
 import { Spacer, Typo, getSpacing } from 'ui/theme'
 import { gradientColorsMapping } from 'ui/theme/gradientColorsMapping'
-
-const newGradientColorsMapping = {
-  Gold: [theme.colors.goldLight100, theme.colors.goldLight100],
-  Aquamarine: [theme.colors.aquamarineLight, theme.colors.aquamarineLight],
-  SkyBlue: [theme.colors.skyBlueLight, theme.colors.skyBlueLight],
-  DeepPink: [theme.colors.deepPinkLight, theme.colors.deepPinkLight],
-  Coral: [theme.colors.coralLight, theme.colors.coralLight],
-  Lilac: [theme.colors.lilacLight, theme.colors.lilacLight],
-}
+import { videoModuleMobileColorsMapping } from 'ui/theme/videoModuleMobileColorsMapping'
 
 const THUMBNAIL_HEIGHT = getSpacing(52.5)
 // We do not center the player icon, because when the title is 2-line long,
@@ -40,9 +31,6 @@ const COLOR_CATEGORY_BACKGROUND_HEIGHT_MULTI_OFFER =
 const NEW_PLAYER_SIZE = getSpacing(24)
 
 export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) => {
-  // PENSER A SUPPRIMER CETTE LIGNE
-  props = { ...props, isMultiOffer: false }
-
   const enableMultiVideoModule = useFeatureFlag(
     RemoteStoreFeatureFlags.WIP_APP_V2_MULTI_VIDEO_MODULE
   )
@@ -50,7 +38,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
   const videoDuration = `${props.durationInMinutes} min`
 
   const colorCategoryBackgroundHeightUniqueOffer =
-    THUMBNAIL_HEIGHT - GRADIENT_START_POSITION + getSpacing(43)
+    THUMBNAIL_HEIGHT - GRADIENT_START_POSITION + getSpacing(enableMultiVideoModule ? 40 : 43)
 
   return (
     <Container>
@@ -66,7 +54,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
           end={{ x: 0, y: 1 }}
           colors={
             enableMultiVideoModule
-              ? newGradientColorsMapping[props.color]
+              ? videoModuleMobileColorsMapping[props.color]
               : gradientColorsMapping[props.color]
           }
           isMultiOffer={props.isMultiOffer}
@@ -95,7 +83,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
               </PlayerContainer>
             </Thumbnail>
           </StyledTouchableHighlight>
-          <Spacer.Column numberOfSpaces={2} />
+          <Spacer.Column numberOfSpaces={enableMultiVideoModule ? 4 : 2} />
           {props.isMultiOffer ? null : (
             <StyledVideoMonoOfferTile
               // @ts-expect-error: because of noUncheckedIndexedAccess
@@ -117,7 +105,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
           />
         </React.Fragment>
       ) : null}
-      {props.isMultiOffer ? null : <Spacer.Column numberOfSpaces={6} />}
+      {props.isMultiOffer ? null : <Spacer.Column numberOfSpaces={4} />}
     </Container>
   )
 }
@@ -126,11 +114,9 @@ const Container = styled.View(({ theme }) => ({
   paddingBottom: theme.home.spaceBetweenModules,
 }))
 
-const VideoOfferContainer = styled.View<{ enableMultiVideoModule: boolean }>(
-  ({ theme, enableMultiVideoModule }) => ({
-    marginHorizontal: enableMultiVideoModule ? undefined : theme.contentPage.marginHorizontal,
-  })
-)
+const VideoOfferContainer = styled.View(({ theme }) => ({
+  marginHorizontal: theme.contentPage.marginHorizontal,
+}))
 
 const Thumbnail = styled.ImageBackground(({ theme }) => ({
   // the overflow: hidden allow to add border radius to the image
@@ -172,7 +158,6 @@ const ColorCategoryBackground = styled(LinearGradient)<{
 }))
 
 type EnableMultiVideoModuleFFProps = { enableMultiVideoModule: boolean }
-
 const Player = styled(Play).attrs<EnableMultiVideoModuleFFProps>(
   ({ theme, enableMultiVideoModule }) =>
     enableMultiVideoModule

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -14,7 +14,7 @@ import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureF
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { Play } from 'ui/svg/icons/Play'
 import { Spacer, Typo, getSpacing } from 'ui/theme'
-import { gradientColorsMapping } from 'ui/theme/gradientColorsMapping'
+import { gradientColorsMapping, newGradientColorsMapping } from 'ui/theme/gradientColorsMapping'
 
 const THUMBNAIL_HEIGHT = getSpacing(52.5)
 // We do not center the player icon, because when the title is 2-line long,
@@ -51,7 +51,11 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
           colorCategoryBackgroundHeightUniqueOffer={colorCategoryBackgroundHeightUniqueOffer}
           start={{ x: 0, y: 0 }}
           end={{ x: 0, y: 1 }}
-          colors={gradientColorsMapping[props.color]}
+          colors={
+            enableMultiVideoModule
+              ? newGradientColorsMapping[props.color]
+              : gradientColorsMapping[props.color]
+          }
           isMultiOffer={props.isMultiOffer}
         />
         <VideoOfferContainer enableMultiVideoModule={enableMultiVideoModule}>

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -24,9 +24,12 @@ const PLAYER_TOP_MARGIN = getSpacing(12.5)
 const PLAYER_SIZE = getSpacing(14.5)
 
 const GRADIENT_START_POSITION = PLAYER_TOP_MARGIN + PLAYER_SIZE / 2
+const COLOR_CATEGORY_BACKGROUND_HEIGHT = getSpacing(37.5)
 
-const COLOR_CATEGORY_BACKGROUND_HEIGHT_MULTI_OFFER =
-  THUMBNAIL_HEIGHT - GRADIENT_START_POSITION + getSpacing(16)
+const getColorCategoryBackgroundHeightMultiOffer = (enableMultiVideoModule: boolean) =>
+  enableMultiVideoModule
+    ? THUMBNAIL_HEIGHT - GRADIENT_START_POSITION + COLOR_CATEGORY_BACKGROUND_HEIGHT
+    : THUMBNAIL_HEIGHT - GRADIENT_START_POSITION + getSpacing(16)
 
 const NEW_PLAYER_SIZE = getSpacing(24)
 
@@ -49,6 +52,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
 
       <View testID="mobile-video-module">
         <ColorCategoryBackground
+          enableMultiVideoModule={enableMultiVideoModule}
           colorCategoryBackgroundHeightUniqueOffer={colorCategoryBackgroundHeightUniqueOffer}
           start={{ x: 0, y: 0 }}
           end={{ x: 0, y: 1 }}
@@ -91,13 +95,14 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
               color={props.color}
               hideModal={props.hideVideoModal}
               analyticsParams={props.analyticsParams}
+              enableMultiVideoModule={enableMultiVideoModule}
             />
           )}
         </VideoOfferContainer>
       </View>
       {props.isMultiOffer ? (
         <React.Fragment>
-          <Spacer.Column numberOfSpaces={2} />
+          {enableMultiVideoModule ? null : <Spacer.Column numberOfSpaces={2} />}
           <VideoMultiOfferPlaylist
             offers={props.offers}
             hideModal={props.hideVideoModal}
@@ -114,9 +119,11 @@ const Container = styled.View(({ theme }) => ({
   paddingBottom: theme.home.spaceBetweenModules,
 }))
 
-const VideoOfferContainer = styled.View(({ theme }) => ({
-  marginHorizontal: theme.contentPage.marginHorizontal,
-}))
+const VideoOfferContainer = styled.View<{ enableMultiVideoModule: boolean }>(
+  ({ theme, enableMultiVideoModule }) => ({
+    marginHorizontal: enableMultiVideoModule ? 0 : theme.contentPage.marginHorizontal,
+  })
+)
 
 const Thumbnail = styled.ImageBackground(({ theme }) => ({
   // the overflow: hidden allow to add border radius to the image
@@ -147,13 +154,14 @@ const PlayerContainer = styled.View({
 const ColorCategoryBackground = styled(LinearGradient)<{
   colorCategoryBackgroundHeightUniqueOffer: number
   isMultiOffer: boolean
-}>(({ colorCategoryBackgroundHeightUniqueOffer, isMultiOffer }) => ({
+  enableMultiVideoModule: boolean
+}>(({ colorCategoryBackgroundHeightUniqueOffer, isMultiOffer, enableMultiVideoModule }) => ({
   position: 'absolute',
   top: GRADIENT_START_POSITION,
   right: 0,
   left: 0,
   height: isMultiOffer
-    ? COLOR_CATEGORY_BACKGROUND_HEIGHT_MULTI_OFFER
+    ? getColorCategoryBackgroundHeightMultiOffer(enableMultiVideoModule)
     : colorCategoryBackgroundHeightUniqueOffer,
 }))
 
@@ -203,6 +211,9 @@ const StyledTitleComponent = styled(Typo.Title3).attrs({
   numberOfLines: 2,
 })({})
 
-const StyledVideoMonoOfferTile = styled(VideoMonoOfferTile)({
-  flexGrow: 1,
-})
+const StyledVideoMonoOfferTile = styled(VideoMonoOfferTile)<{ enableMultiVideoModule: boolean }>(
+  ({ enableMultiVideoModule, theme }) => ({
+    flexGrow: 1,
+    marginHorizontal: enableMultiVideoModule ? theme.contentPage.marginHorizontal : 0,
+  })
+)

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -4,7 +4,6 @@ import { View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import styled from 'styled-components/native'
 
-import { AttachedOfferCard } from 'features/home/components/AttachedOfferCard'
 import { BlackCaption } from 'features/home/components/BlackCaption'
 import { BlackGradient } from 'features/home/components/BlackGradient'
 import { TEXT_BACKGROUND_OPACITY } from 'features/home/components/constants'
@@ -13,7 +12,6 @@ import { VideoMultiOfferPlaylist } from 'features/home/components/modules/video/
 import { VideoModuleProps } from 'features/home/types'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import { useCategoryIdMapping } from 'libs/subcategories'
 import { theme } from 'theme'
 import { Play } from 'ui/svg/icons/Play'
 import { Spacer, Typo, getSpacing } from 'ui/theme'
@@ -42,6 +40,9 @@ const COLOR_CATEGORY_BACKGROUND_HEIGHT_MULTI_OFFER =
 const NEW_PLAYER_SIZE = getSpacing(24)
 
 export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) => {
+  // PENSER A SUPPRIMER CETTE LIGNE
+  props = { ...props, isMultiOffer: false }
+
   const enableMultiVideoModule = useFeatureFlag(
     RemoteStoreFeatureFlags.WIP_APP_V2_MULTI_VIDEO_MODULE
   )
@@ -51,11 +52,6 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
   const colorCategoryBackgroundHeightUniqueOffer =
     THUMBNAIL_HEIGHT - GRADIENT_START_POSITION + getSpacing(43)
 
-  const mapping = useCategoryIdMapping()
-  const categoryId = mapping[props.offers[0].offer.subcategoryId]
-
-  console.log({ offers: props.offers })
-  /// https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/thumbs/mediations/DU_1
   return (
     <Container>
       <StyledTitleContainer>
@@ -73,7 +69,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
               ? newGradientColorsMapping[props.color]
               : gradientColorsMapping[props.color]
           }
-          isMultiOffer={false}
+          isMultiOffer={props.isMultiOffer}
         />
         <VideoOfferContainer enableMultiVideoModule={enableMultiVideoModule}>
           <StyledTouchableHighlight
@@ -100,19 +96,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
             </Thumbnail>
           </StyledTouchableHighlight>
           <Spacer.Column numberOfSpaces={2} />
-          {false ? null : enableMultiVideoModule ? (
-            <AttachedOfferCard
-              title={props.offers[0]?.offer.name ?? ''}
-              categoryId={categoryId}
-              imageUrl={props.offers[0]?.offer.thumbUrl}
-              showImage
-              tag="string"
-              withRightArrow
-              geoloc={props.offers[0]?._geoloc}
-              date={props.offers[0]?.offer.dates}
-              price={props.offers[0]?.offer.prices[0]}
-            />
-          ) : (
+          {props.isMultiOffer ? null : (
             <StyledVideoMonoOfferTile
               // @ts-expect-error: because of noUncheckedIndexedAccess
               offer={props.offers[0]}
@@ -123,7 +107,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
           )}
         </VideoOfferContainer>
       </View>
-      {false ? (
+      {props.isMultiOffer ? (
         <React.Fragment>
           <Spacer.Column numberOfSpaces={2} />
           <VideoMultiOfferPlaylist
@@ -133,7 +117,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
           />
         </React.Fragment>
       ) : null}
-      {false ? null : <Spacer.Column numberOfSpaces={6} />}
+      {props.isMultiOffer ? null : <Spacer.Column numberOfSpaces={6} />}
     </Container>
   )
 }

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -150,7 +150,7 @@ const Thumbnail = styled.ImageBackground<{ enableMultiVideoModule: boolean }>(
     // the overflow: hidden allow to add border radius to the image
     // https://stackoverflow.com/questions/49442165/how-do-you-add-borderradius-to-imagebackground/57616397
     overflow: 'hidden',
-    borderRadius: theme.borderRadius.radius,
+    borderRadius: enableMultiVideoModule ? 'unset' : theme.borderRadius.radius,
     height: enableMultiVideoModule ? NEW_THUMBNAIL_HEIGHT : THUMBNAIL_HEIGHT,
     width: '100%',
     border: 1,

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -4,6 +4,7 @@ import { View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import styled from 'styled-components/native'
 
+import { AttachedOfferCard } from 'features/home/components/AttachedOfferCard'
 import { BlackCaption } from 'features/home/components/BlackCaption'
 import { BlackGradient } from 'features/home/components/BlackGradient'
 import { TEXT_BACKGROUND_OPACITY } from 'features/home/components/constants'
@@ -12,9 +13,20 @@ import { VideoMultiOfferPlaylist } from 'features/home/components/modules/video/
 import { VideoModuleProps } from 'features/home/types'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { useCategoryIdMapping } from 'libs/subcategories'
+import { theme } from 'theme'
 import { Play } from 'ui/svg/icons/Play'
 import { Spacer, Typo, getSpacing } from 'ui/theme'
-import { gradientColorsMapping, newGradientColorsMapping } from 'ui/theme/gradientColorsMapping'
+import { gradientColorsMapping } from 'ui/theme/gradientColorsMapping'
+
+const newGradientColorsMapping = {
+  Gold: [theme.colors.goldLight100, theme.colors.goldLight100],
+  Aquamarine: [theme.colors.aquamarineLight, theme.colors.aquamarineLight],
+  SkyBlue: [theme.colors.skyBlueLight, theme.colors.skyBlueLight],
+  DeepPink: [theme.colors.deepPinkLight, theme.colors.deepPinkLight],
+  Coral: [theme.colors.coralLight, theme.colors.coralLight],
+  Lilac: [theme.colors.lilacLight, theme.colors.lilacLight],
+}
 
 const THUMBNAIL_HEIGHT = getSpacing(52.5)
 // We do not center the player icon, because when the title is 2-line long,
@@ -27,7 +39,7 @@ const GRADIENT_START_POSITION = PLAYER_TOP_MARGIN + PLAYER_SIZE / 2
 const COLOR_CATEGORY_BACKGROUND_HEIGHT_MULTI_OFFER =
   THUMBNAIL_HEIGHT - GRADIENT_START_POSITION + getSpacing(16)
 
-const NEW_PLAYER_SIZE = getSpacing(21)
+const NEW_PLAYER_SIZE = getSpacing(24)
 
 export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) => {
   const enableMultiVideoModule = useFeatureFlag(
@@ -39,6 +51,11 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
   const colorCategoryBackgroundHeightUniqueOffer =
     THUMBNAIL_HEIGHT - GRADIENT_START_POSITION + getSpacing(43)
 
+  const mapping = useCategoryIdMapping()
+  const categoryId = mapping[props.offers[0].offer.subcategoryId]
+
+  console.log({ offers: props.offers })
+  /// https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/thumbs/mediations/DU_1
   return (
     <Container>
       <StyledTitleContainer>
@@ -56,7 +73,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
               ? newGradientColorsMapping[props.color]
               : gradientColorsMapping[props.color]
           }
-          isMultiOffer={props.isMultiOffer}
+          isMultiOffer={false}
         />
         <VideoOfferContainer enableMultiVideoModule={enableMultiVideoModule}>
           <StyledTouchableHighlight
@@ -83,7 +100,19 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
             </Thumbnail>
           </StyledTouchableHighlight>
           <Spacer.Column numberOfSpaces={2} />
-          {props.isMultiOffer ? null : (
+          {false ? null : enableMultiVideoModule ? (
+            <AttachedOfferCard
+              title={props.offers[0]?.offer.name ?? ''}
+              categoryId={categoryId}
+              imageUrl={props.offers[0]?.offer.thumbUrl}
+              showImage
+              tag="string"
+              withRightArrow
+              geoloc={props.offers[0]?._geoloc}
+              date={props.offers[0]?.offer.dates}
+              price={props.offers[0]?.offer.prices[0]}
+            />
+          ) : (
             <StyledVideoMonoOfferTile
               // @ts-expect-error: because of noUncheckedIndexedAccess
               offer={props.offers[0]}
@@ -94,7 +123,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
           )}
         </VideoOfferContainer>
       </View>
-      {props.isMultiOffer ? (
+      {false ? (
         <React.Fragment>
           <Spacer.Column numberOfSpaces={2} />
           <VideoMultiOfferPlaylist
@@ -104,7 +133,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
           />
         </React.Fragment>
       ) : null}
-      {props.isMultiOffer ? null : <Spacer.Column numberOfSpaces={6} />}
+      {false ? null : <Spacer.Column numberOfSpaces={6} />}
     </Container>
   )
 }

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -25,6 +25,9 @@ const GRADIENT_START_POSITION = PLAYER_TOP_MARGIN + PLAYER_SIZE / 2
 const COLOR_CATEGORY_BACKGROUND_HEIGHT_MULTI_OFFER =
   THUMBNAIL_HEIGHT - GRADIENT_START_POSITION + getSpacing(16)
 
+const wipAppV2MultiVideoModuleFF = true
+const NEW_PLAYER_SIZE = getSpacing(21)
+
 export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) => {
   const videoDuration = `${props.durationInMinutes} min`
 
@@ -138,7 +141,16 @@ const ColorCategoryBackground = styled(LinearGradient)<{
     : colorCategoryBackgroundHeightUniqueOffer,
 }))
 
-const Player = styled(Play).attrs({ size: PLAYER_SIZE })({})
+const Player = styled(Play).attrs(({ theme }) =>
+  wipAppV2MultiVideoModuleFF
+    ? {
+        size: NEW_PLAYER_SIZE,
+        color: theme.colors.brownLight,
+      }
+    : {
+        size: PLAYER_SIZE,
+      }
+)({})
 
 const TextContainer = styled.View({ position: 'absolute', bottom: 0, left: 0, right: 0 })
 

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -64,7 +64,13 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
               <TextContainer>
                 <BlackGradient />
                 <BlackBackground>
-                  <VideoTitle numberOfLines={2}>{props.videoTitle}</VideoTitle>
+                  {enableMultiVideoModule ? (
+                    <NewVideoTitle numberOfLines={1} ellipsizeMode="tail">
+                      {props.videoTitle}
+                    </NewVideoTitle>
+                  ) : (
+                    <VideoTitle numberOfLines={2}>{props.videoTitle}</VideoTitle>
+                  )}
                 </BlackBackground>
               </TextContainer>
               <PlayerContainer>
@@ -148,17 +154,19 @@ const ColorCategoryBackground = styled(LinearGradient)<{
     : colorCategoryBackgroundHeightUniqueOffer,
 }))
 
-type PlayerProps = { enableMultiVideoModule: boolean }
-const Player = styled(Play).attrs<PlayerProps>(({ theme, enableMultiVideoModule }) =>
-  enableMultiVideoModule
-    ? {
-        size: NEW_PLAYER_SIZE,
-        color: theme.colors.brownLight,
-      }
-    : {
-        size: PLAYER_SIZE,
-      }
-)<PlayerProps>({})
+type EnableMultiVideoModuleFFProps = { enableMultiVideoModule: boolean }
+
+const Player = styled(Play).attrs<EnableMultiVideoModuleFFProps>(
+  ({ theme, enableMultiVideoModule }) =>
+    enableMultiVideoModule
+      ? {
+          size: NEW_PLAYER_SIZE,
+          color: theme.colors.brownLight,
+        }
+      : {
+          size: PLAYER_SIZE,
+        }
+)<EnableMultiVideoModuleFFProps>({})
 
 const TextContainer = styled.View({ position: 'absolute', bottom: 0, left: 0, right: 0 })
 
@@ -170,6 +178,13 @@ const BlackBackground = styled.View(({ theme }) => ({
 const VideoTitle = styled(Typo.Title4)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'left',
+}))
+
+const NewVideoTitle = styled(Typo.Title3)(({ theme }) => ({
+  color: theme.colors.white,
+  textAlign: 'center',
+  textTransform: 'uppercase',
+  fontSize: getSpacing(6.5),
 }))
 
 const StyledTouchableHighlight = styled.TouchableHighlight.attrs(({ theme }) => ({

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -17,21 +17,29 @@ import { Spacer, Typo, getSpacing } from 'ui/theme'
 import { gradientColorsMapping } from 'ui/theme/gradientColorsMapping'
 import { videoModuleMobileColorsMapping } from 'ui/theme/videoModuleMobileColorsMapping'
 
-const THUMBNAIL_HEIGHT = getSpacing(52.5)
+const THUMBNAIL_HEIGHT = getSpacing(45)
+const NEW_THUMBNAIL_HEIGHT = getSpacing(52.5)
 // We do not center the player icon, because when the title is 2-line long,
 // the title is to close to the player. So the player is closer to the top.
 const PLAYER_TOP_MARGIN = getSpacing(12.5)
 const PLAYER_SIZE = getSpacing(14.5)
 const GRADIENT_START_POSITION = PLAYER_TOP_MARGIN + PLAYER_SIZE / 2
 const COLOR_CATEGORY_BACKGROUND_HEIGHT = getSpacing(37.5)
-const VIDEO_THUMBNAIL_HEIGHT = THUMBNAIL_HEIGHT - GRADIENT_START_POSITION
 const MONO_OFFER_CARD_VERTICAL_SPACING = getSpacing(8)
 const NEW_PLAYER_SIZE = getSpacing(24)
 
-const getColorCategoryBackgroundHeightMultiOffer = (enableMultiVideoModule: boolean) =>
+const getVideoThumbnailHeight = (enableMultiVideoModule: boolean) =>
   enableMultiVideoModule
+    ? NEW_THUMBNAIL_HEIGHT - GRADIENT_START_POSITION
+    : THUMBNAIL_HEIGHT - GRADIENT_START_POSITION
+
+const getColorCategoryBackgroundHeightMultiOffer = (enableMultiVideoModule: boolean) => {
+  const VIDEO_THUMBNAIL_HEIGHT = getVideoThumbnailHeight(enableMultiVideoModule)
+
+  return enableMultiVideoModule
     ? VIDEO_THUMBNAIL_HEIGHT + COLOR_CATEGORY_BACKGROUND_HEIGHT
     : VIDEO_THUMBNAIL_HEIGHT + getSpacing(16)
+}
 
 export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) => {
   const [monoOfferCardHeight, setMonoOfferCardHeight] = useState<number>(0)
@@ -41,7 +49,9 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
 
   const MONO_OFFER_CARD_HEIGHT = enableMultiVideoModule ? monoOfferCardHeight : getSpacing(43)
   const colorCategoryBackgroundHeightUniqueOffer =
-    VIDEO_THUMBNAIL_HEIGHT + MONO_OFFER_CARD_VERTICAL_SPACING + MONO_OFFER_CARD_HEIGHT
+    getVideoThumbnailHeight(enableMultiVideoModule) +
+    MONO_OFFER_CARD_VERTICAL_SPACING +
+    MONO_OFFER_CARD_HEIGHT
 
   const videoDuration = `${props.durationInMinutes} min`
 
@@ -70,7 +80,9 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
             onPress={props.showVideoModal}
             testID="video-thumbnail"
             accessibilityRole="button">
-            <Thumbnail source={{ uri: props.videoThumbnail }}>
+            <Thumbnail
+              source={{ uri: props.videoThumbnail }}
+              enableMultiVideoModule={enableMultiVideoModule}>
               {enableMultiVideoModule ? null : <DurationCaption label={videoDuration} />}
               <TextContainer>
                 <BlackGradient />
@@ -133,17 +145,19 @@ const VideoOfferContainer = styled.View<{ enableMultiVideoModule: boolean }>(
   })
 )
 
-const Thumbnail = styled.ImageBackground(({ theme }) => ({
-  // the overflow: hidden allow to add border radius to the image
-  // https://stackoverflow.com/questions/49442165/how-do-you-add-borderradius-to-imagebackground/57616397
-  overflow: 'hidden',
-  borderRadius: theme.borderRadius.radius,
-  height: THUMBNAIL_HEIGHT,
-  width: '100%',
-  border: 1,
-  borderColor: theme.colors.greyMedium,
-  backgroundColor: theme.colors.greyLight,
-}))
+const Thumbnail = styled.ImageBackground<{ enableMultiVideoModule: boolean }>(
+  ({ theme, enableMultiVideoModule }) => ({
+    // the overflow: hidden allow to add border radius to the image
+    // https://stackoverflow.com/questions/49442165/how-do-you-add-borderradius-to-imagebackground/57616397
+    overflow: 'hidden',
+    borderRadius: theme.borderRadius.radius,
+    height: enableMultiVideoModule ? NEW_THUMBNAIL_HEIGHT : THUMBNAIL_HEIGHT,
+    width: '100%',
+    border: 1,
+    borderColor: theme.colors.greyMedium,
+    backgroundColor: theme.colors.greyLight,
+  })
+)
 
 const DurationCaption = styled(BlackCaption)({
   position: 'absolute',

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -10,11 +10,13 @@ import { TEXT_BACKGROUND_OPACITY } from 'features/home/components/constants'
 import { VideoMonoOfferTile } from 'features/home/components/modules/video/VideoMonoOfferTile'
 import { VideoMultiOfferPlaylist } from 'features/home/components/modules/video/VideoMultiOfferPlaylist'
 import { VideoModuleProps } from 'features/home/types'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { Play } from 'ui/svg/icons/Play'
 import { Spacer, Typo, getSpacing } from 'ui/theme'
 import { gradientColorsMapping } from 'ui/theme/gradientColorsMapping'
 
-const THUMBNAIL_HEIGHT = getSpacing(45)
+const THUMBNAIL_HEIGHT = getSpacing(52.5)
 // We do not center the player icon, because when the title is 2-line long,
 // the title is to close to the player. So the player is closer to the top.
 const PLAYER_TOP_MARGIN = getSpacing(12.5)
@@ -25,10 +27,13 @@ const GRADIENT_START_POSITION = PLAYER_TOP_MARGIN + PLAYER_SIZE / 2
 const COLOR_CATEGORY_BACKGROUND_HEIGHT_MULTI_OFFER =
   THUMBNAIL_HEIGHT - GRADIENT_START_POSITION + getSpacing(16)
 
-const wipAppV2MultiVideoModuleFF = true
 const NEW_PLAYER_SIZE = getSpacing(21)
 
 export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) => {
+  const enableMultiVideoModule = useFeatureFlag(
+    RemoteStoreFeatureFlags.WIP_APP_V2_MULTI_VIDEO_MODULE
+  )
+
   const videoDuration = `${props.durationInMinutes} min`
 
   const colorCategoryBackgroundHeightUniqueOffer =
@@ -49,7 +54,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
           colors={gradientColorsMapping[props.color]}
           isMultiOffer={props.isMultiOffer}
         />
-        <VideoOfferContainer>
+        <VideoOfferContainer enableMultiVideoModule={enableMultiVideoModule}>
           <StyledTouchableHighlight
             onPress={props.showVideoModal}
             testID="video-thumbnail"
@@ -63,7 +68,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
                 </BlackBackground>
               </TextContainer>
               <PlayerContainer>
-                <Player />
+                <Player enableMultiVideoModule={!!enableMultiVideoModule} />
               </PlayerContainer>
             </Thumbnail>
           </StyledTouchableHighlight>
@@ -98,9 +103,11 @@ const Container = styled.View(({ theme }) => ({
   paddingBottom: theme.home.spaceBetweenModules,
 }))
 
-const VideoOfferContainer = styled.View(({ theme }) => ({
-  marginHorizontal: theme.contentPage.marginHorizontal,
-}))
+const VideoOfferContainer = styled.View<{ enableMultiVideoModule: boolean }>(
+  ({ theme, enableMultiVideoModule }) => ({
+    marginHorizontal: enableMultiVideoModule ? undefined : theme.contentPage.marginHorizontal,
+  })
+)
 
 const Thumbnail = styled.ImageBackground(({ theme }) => ({
   // the overflow: hidden allow to add border radius to the image
@@ -141,8 +148,9 @@ const ColorCategoryBackground = styled(LinearGradient)<{
     : colorCategoryBackgroundHeightUniqueOffer,
 }))
 
-const Player = styled(Play).attrs(({ theme }) =>
-  wipAppV2MultiVideoModuleFF
+type PlayerProps = { enableMultiVideoModule: boolean }
+const Player = styled(Play).attrs<PlayerProps>(({ theme, enableMultiVideoModule }) =>
+  enableMultiVideoModule
     ? {
         size: NEW_PLAYER_SIZE,
         color: theme.colors.brownLight,
@@ -150,7 +158,7 @@ const Player = styled(Play).attrs(({ theme }) =>
     : {
         size: PLAYER_SIZE,
       }
-)({})
+)<PlayerProps>({})
 
 const TextContainer = styled.View({ position: 'absolute', bottom: 0, left: 0, right: 0 })
 

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -60,7 +60,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
             testID="video-thumbnail"
             accessibilityRole="button">
             <Thumbnail source={{ uri: props.videoThumbnail }}>
-              <DurationCaption label={videoDuration} />
+              {enableMultiVideoModule ? null : <DurationCaption label={videoDuration} />}
               <TextContainer>
                 <BlackGradient />
                 <BlackBackground>

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -1,6 +1,6 @@
 import colorAlpha from 'color-alpha'
-import React, { FunctionComponent } from 'react'
-import { View } from 'react-native'
+import React, { FunctionComponent, useState } from 'react'
+import { LayoutChangeEvent, View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import styled from 'styled-components/native'
 
@@ -22,26 +22,28 @@ const THUMBNAIL_HEIGHT = getSpacing(52.5)
 // the title is to close to the player. So the player is closer to the top.
 const PLAYER_TOP_MARGIN = getSpacing(12.5)
 const PLAYER_SIZE = getSpacing(14.5)
-
 const GRADIENT_START_POSITION = PLAYER_TOP_MARGIN + PLAYER_SIZE / 2
 const COLOR_CATEGORY_BACKGROUND_HEIGHT = getSpacing(37.5)
+const VIDEO_THUMBNAIL_HEIGHT = THUMBNAIL_HEIGHT - GRADIENT_START_POSITION
+const MONO_OFFER_CARD_VERTICAL_SPACING = getSpacing(8)
+const NEW_PLAYER_SIZE = getSpacing(24)
 
 const getColorCategoryBackgroundHeightMultiOffer = (enableMultiVideoModule: boolean) =>
   enableMultiVideoModule
-    ? THUMBNAIL_HEIGHT - GRADIENT_START_POSITION + COLOR_CATEGORY_BACKGROUND_HEIGHT
-    : THUMBNAIL_HEIGHT - GRADIENT_START_POSITION + getSpacing(16)
-
-const NEW_PLAYER_SIZE = getSpacing(24)
+    ? VIDEO_THUMBNAIL_HEIGHT + COLOR_CATEGORY_BACKGROUND_HEIGHT
+    : VIDEO_THUMBNAIL_HEIGHT + getSpacing(16)
 
 export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) => {
+  const [monoOfferCardHeight, setMonoOfferCardHeight] = useState<number>(0)
   const enableMultiVideoModule = useFeatureFlag(
     RemoteStoreFeatureFlags.WIP_APP_V2_MULTI_VIDEO_MODULE
   )
 
-  const videoDuration = `${props.durationInMinutes} min`
-
+  const MONO_OFFER_CARD_HEIGHT = enableMultiVideoModule ? monoOfferCardHeight : getSpacing(43)
   const colorCategoryBackgroundHeightUniqueOffer =
-    THUMBNAIL_HEIGHT - GRADIENT_START_POSITION + getSpacing(enableMultiVideoModule ? 40 : 43)
+    VIDEO_THUMBNAIL_HEIGHT + MONO_OFFER_CARD_VERTICAL_SPACING + MONO_OFFER_CARD_HEIGHT
+
+  const videoDuration = `${props.durationInMinutes} min`
 
   return (
     <Container>
@@ -89,14 +91,20 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
           </StyledTouchableHighlight>
           <Spacer.Column numberOfSpaces={enableMultiVideoModule ? 4 : 2} />
           {props.isMultiOffer ? null : (
-            <StyledVideoMonoOfferTile
-              // @ts-expect-error: because of noUncheckedIndexedAccess
-              offer={props.offers[0]}
-              color={props.color}
-              hideModal={props.hideVideoModal}
-              analyticsParams={props.analyticsParams}
-              enableMultiVideoModule={enableMultiVideoModule}
-            />
+            <View
+              onLayout={(event: LayoutChangeEvent) => {
+                const { height } = event.nativeEvent.layout
+                setMonoOfferCardHeight(height)
+              }}>
+              <StyledVideoMonoOfferTile
+                // @ts-expect-error: because of noUncheckedIndexedAccess
+                offer={props.offers[0]}
+                color={props.color}
+                hideModal={props.hideVideoModal}
+                analyticsParams={props.analyticsParams}
+                enableMultiVideoModule={enableMultiVideoModule}
+              />
+            </View>
           )}
         </VideoOfferContainer>
       </View>

--- a/src/features/home/components/modules/video/VideoMonoOfferTile.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoMonoOfferTile.native.test.tsx
@@ -7,6 +7,7 @@ import { VideoMonoOfferTile } from 'features/home/components/modules/video/Video
 import { mockedAlgoliaResponse } from 'libs/algolia/fixtures/algoliaFixtures'
 import { analytics } from 'libs/analytics'
 import { OfferAnalyticsParams } from 'libs/analytics/types'
+import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
 import { Offer } from 'shared/offer/types'
 import { mockServer } from 'tests/mswServer'
@@ -14,6 +15,7 @@ import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, fireEvent, render, screen } from 'tests/utils'
 
 const mockOffer = mockedAlgoliaResponse.hits[0]
+const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
 
 const mockAnalyticsParams: OfferAnalyticsParams = {
   from: 'home',
@@ -57,6 +59,16 @@ describe('VideoMonoOfferTile', () => {
       offerId: +mockOffer.objectID,
       ...mockAnalyticsParams,
     })
+  })
+
+  it('should render properly with FF on', async () => {
+    useFeatureFlagSpy.mockReturnValueOnce(true)
+
+    renderOfferVideoModule()
+
+    await screen.findByText('La nuit des temps')
+
+    expect(screen).toMatchSnapshot()
   })
 })
 

--- a/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
@@ -87,19 +87,19 @@ export const VideoMonoOfferTile: FunctionComponent<Props> = ({
   )
 }
 
-const OfferInsert = styled(InternalTouchableLink)<{ offerHeight: number }>(
-  ({ theme, offerHeight }) => ({
-    // the overflow: hidden allow to add border radius to the image
-    // https://stackoverflow.com/questions/49442165/how-do-you-add-borderradius-to-imagebackground/57616397
-    overflow: 'hidden',
-    borderRadius: theme.borderRadius.radius,
-    backgroundColor: theme.colors.white,
-    height: offerHeight,
-    alignItems: 'flex-start',
-    border: 1,
-    borderColor: theme.colors.greyMedium,
-  })
-)
+const OfferInsert = styled(InternalTouchableLink)<{
+  offerHeight: number
+}>(({ theme, offerHeight }) => ({
+  // the overflow: hidden allow to add border radius to the image
+  // https://stackoverflow.com/questions/49442165/how-do-you-add-borderradius-to-imagebackground/57616397
+  overflow: 'hidden',
+  borderRadius: theme.borderRadius.radius,
+  backgroundColor: theme.colors.white,
+  height: offerHeight,
+  alignItems: 'flex-start',
+  border: 1,
+  borderColor: theme.colors.greyMedium,
+}))
 
 const Row = styled.View({
   flexDirection: 'row',

--- a/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
@@ -50,6 +50,7 @@ export const VideoMonoOfferTile: FunctionComponent<Props> = ({
   const offerHeight = theme.isDesktopViewport ? getSpacing(45) : getSpacing(35)
 
   const categoryId = mapping[offer.offer.subcategoryId]
+  const categoryText = labelMapping[offer.offer.subcategoryId]
 
   const containerProps = {
     offerHeight,
@@ -77,7 +78,7 @@ export const VideoMonoOfferTile: FunctionComponent<Props> = ({
       <AttachedOfferCard
         title={offer.offer.name ?? ''}
         categoryId={categoryId}
-        subcategoryId={offer.offer.subcategoryId}
+        categoryText={categoryText ?? ''}
         imageUrl={offer.offer.thumbUrl}
         showImage
         withRightArrow

--- a/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
@@ -83,7 +83,7 @@ export const VideoMonoOfferTile: FunctionComponent<Props> = ({
         imageUrl={offer.offer.thumbUrl}
         showImage
         withRightArrow
-        geoloc={offer._geoloc}
+        offerLocation={offer._geoloc}
         date={displayDate}
         price={displayPrice}
       />

--- a/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
@@ -37,19 +37,20 @@ export const VideoMonoOfferTile: FunctionComponent<Props> = ({
   const enableMultiVideoModule = useFeatureFlag(
     RemoteStoreFeatureFlags.WIP_APP_V2_MULTI_VIDEO_MODULE
   )
-  const timestampsInMillis = offer.offer.dates?.map((timestampInSec) => timestampInSec * 1000)
   const labelMapping = useCategoryHomeLabelMapping()
   const mapping = useCategoryIdMapping()
-  const displayDate = formatDates(timestampsInMillis)
-  const displayPrice = getDisplayPrice(offer?.offer?.prices)
-
   const prePopulateOffer = usePrePopulateOffer()
-
   const theme = useTheme()
+
+  const timestampsInMillis = offer.offer.dates?.map((timestampInSec) => timestampInSec * 1000)
+  const displayDate = formatDates(timestampsInMillis)
+
+  const displayPrice = getDisplayPrice(offer?.offer?.prices)
 
   const offerHeight = theme.isDesktopViewport ? getSpacing(45) : getSpacing(35)
 
   const categoryId = mapping[offer.offer.subcategoryId]
+
   const categoryText = labelMapping[offer.offer.subcategoryId]
 
   const containerProps = {

--- a/src/features/home/components/modules/video/VideoMultiOfferTile.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoMultiOfferTile.native.test.tsx
@@ -6,12 +6,14 @@ import { VideoMultiOfferTile } from 'features/home/components/modules/video/Vide
 import { mockedAlgoliaResponse } from 'libs/algolia/fixtures/algoliaFixtures'
 import { analytics } from 'libs/analytics'
 import { OfferAnalyticsParams } from 'libs/analytics/types'
+import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, fireEvent, render, screen } from 'tests/utils'
 
 const mockOffer = mockedAlgoliaResponse.hits[0]
+const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
 
 const mockAnalyticsParams: OfferAnalyticsParams = {
   from: 'home',
@@ -46,6 +48,16 @@ describe('VideoMultiOfferTile', () => {
       offerId: +mockOffer.objectID,
       ...mockAnalyticsParams,
     })
+  })
+
+  it('should render properly with FF on', async () => {
+    useFeatureFlagSpy.mockReturnValueOnce(true)
+
+    renderMultiOfferTile()
+
+    await screen.findByText('La nuit des temps')
+
+    expect(screen).toMatchSnapshot()
   })
 })
 

--- a/src/features/home/components/modules/video/VideoMultiOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMultiOfferTile.tsx
@@ -33,8 +33,8 @@ export const VideoMultiOfferTile: FunctionComponent<Props> = ({
   const enableMultiVideoModule = useFeatureFlag(
     RemoteStoreFeatureFlags.WIP_APP_V2_MULTI_VIDEO_MODULE
   )
-
   const labelMapping = useCategoryHomeLabelMapping()
+  const prePopulateOffer = usePrePopulateOffer()
   const mapping = useCategoryIdMapping()
   const { userLocation } = useLocation()
   const { user } = useAuthContext()
@@ -43,10 +43,11 @@ export const VideoMultiOfferTile: FunctionComponent<Props> = ({
 
   const timestampsInMillis = offer.offer.dates?.map((timestampInSec) => timestampInSec * 1000)
   const displayDate = formatDates(timestampsInMillis)
+
   const displayDistance = formatDistance(offer._geoloc, userLocation)
-  const prePopulateOffer = usePrePopulateOffer()
 
   const categoryId = mapping[offer.offer.subcategoryId]
+
   const categoryLabel = labelMapping[offer.offer.subcategoryId]
 
   return (

--- a/src/features/home/components/modules/video/VideoMultiOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMultiOfferTile.tsx
@@ -2,15 +2,22 @@ import React, { FunctionComponent } from 'react'
 import { View } from 'react-native'
 import styled from 'styled-components/native'
 
+import { useAuthContext } from 'features/auth/context/AuthContext'
+import { NewOfferTileContent } from 'features/offer/components/OfferTile/NewOfferTileContent'
 import { analytics } from 'libs/analytics'
 import { OfferAnalyticsParams } from 'libs/analytics/types'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { useLocation } from 'libs/location'
+import { formatDates } from 'libs/parsers/formatDates'
+import { formatDistance } from 'libs/parsers/formatDistance'
 import { getDisplayPrice } from 'libs/parsers/getDisplayPrice'
 import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
 import { Offer } from 'shared/offer/types'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
 import { OfferImage } from 'ui/components/tiles/OfferImage'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
-import { Spacer, Typo, getSpacing } from 'ui/theme'
+import { getSpacing, Spacer, Typo } from 'ui/theme'
 
 type Props = {
   offer: Offer
@@ -23,13 +30,24 @@ export const VideoMultiOfferTile: FunctionComponent<Props> = ({
   hideModal,
   analyticsParams,
 }) => {
+  const enableMultiVideoModule = useFeatureFlag(
+    RemoteStoreFeatureFlags.WIP_APP_V2_MULTI_VIDEO_MODULE
+  )
+
   const labelMapping = useCategoryHomeLabelMapping()
   const mapping = useCategoryIdMapping()
+  const { userLocation } = useLocation()
+  const { user } = useAuthContext()
+
   const displayPrice = getDisplayPrice(offer?.offer?.prices)
 
+  const timestampsInMillis = offer.offer.dates?.map((timestampInSec) => timestampInSec * 1000)
+  const displayDate = formatDates(timestampsInMillis)
+  const displayDistance = formatDistance(offer._geoloc, userLocation)
   const prePopulateOffer = usePrePopulateOffer()
 
   const categoryId = mapping[offer.offer.subcategoryId]
+  const categoryLabel = labelMapping[offer.offer.subcategoryId]
 
   return (
     <Container>
@@ -51,17 +69,35 @@ export const VideoMultiOfferTile: FunctionComponent<Props> = ({
           })
         }}
         testId="multi-offer-tile">
-        <OfferImage
-          imageUrl={offer.offer.thumbUrl}
-          categoryId={categoryId}
-          size="large"
-          borderRadius={getSpacing(2)}
-          withStroke
-        />
-        <Spacer.Column numberOfSpaces={2} />
-        <Typo.Caption numberOfLines={1}>{offer.offer.name}</Typo.Caption>
-        <AdditionalInfoText>{labelMapping[offer.offer.subcategoryId]}</AdditionalInfoText>
-        {displayPrice ? <AdditionalInfoText>{displayPrice}</AdditionalInfoText> : null}
+        {enableMultiVideoModule ? (
+          <NewOfferTileContent
+            categoryId={categoryId}
+            thumbnailUrl={offer.offer.thumbUrl}
+            distance={displayDistance}
+            name={offer.offer.name}
+            date={displayDate}
+            price={displayPrice}
+            categoryLabel={categoryLabel}
+            width={getSpacing(26)}
+            height={getSpacing(39)}
+            isBeneficiary={user?.isBeneficiary}
+            isDuo={offer.offer.isDuo}
+          />
+        ) : (
+          <React.Fragment>
+            <OfferImage
+              imageUrl={offer.offer.thumbUrl}
+              categoryId={categoryId}
+              size="large"
+              borderRadius={getSpacing(2)}
+              withStroke
+            />
+            <Spacer.Column numberOfSpaces={2} />
+            <Typo.Caption numberOfLines={1}>{offer.offer.name}</Typo.Caption>
+            <AdditionalInfoText>{labelMapping[offer.offer.subcategoryId]}</AdditionalInfoText>
+            {displayPrice ? <AdditionalInfoText>{displayPrice}</AdditionalInfoText> : null}
+          </React.Fragment>
+        )}
       </StyledTouchableLink>
     </Container>
   )

--- a/src/features/internal/cheatcodes/pages/CheatMenu/Video9:16/Video916.tsx
+++ b/src/features/internal/cheatcodes/pages/CheatMenu/Video9:16/Video916.tsx
@@ -10,7 +10,7 @@ export const Video916Cheatcodes = () => {
     <CheatcodeView>
       <Spacer.Column numberOfSpaces={10} />
       <AttachedOfferCardButton
-        geoloc={{
+        offerLocation={{
           lat: 48.94476,
           lng: 2.25055,
         }}
@@ -28,7 +28,7 @@ export const Video916Cheatcodes = () => {
       />
       <Spacer.Column numberOfSpaces={10} />
       <AttachedOfferCardButton
-        geoloc={{
+        offerLocation={{
           lat: 48.94476,
           lng: 2.25055,
         }}

--- a/src/features/internal/cheatcodes/pages/CheatMenu/Video9:16/Video916.tsx
+++ b/src/features/internal/cheatcodes/pages/CheatMenu/Video9:16/Video916.tsx
@@ -10,12 +10,15 @@ export const Video916Cheatcodes = () => {
     <CheatcodeView>
       <Spacer.Column numberOfSpaces={10} />
       <AttachedOfferCardButton
-        distanceToOffer="à 120 m"
+        geoloc={{
+          lat: 48.94476,
+          lng: 2.25055,
+        }}
         showImage
         withRightArrow
         imageUrl="https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/9MPGW"
         price="Gratuit"
-        tag="Musée"
+        categoryText="Musée"
         categoryId={CategoryIdEnum.MUSIQUE_LIVE}
         title="Soirée super trop drôle de fou malade&nbsp;!"
         date="Du 12/06 au 24/06"
@@ -25,11 +28,14 @@ export const Video916Cheatcodes = () => {
       />
       <Spacer.Column numberOfSpaces={10} />
       <AttachedOfferCardButton
-        distanceToOffer="à 120 m"
+        geoloc={{
+          lat: 48.94476,
+          lng: 2.25055,
+        }}
         withRightArrow
         price="Gratuit"
         showImage
-        tag="Musée"
+        categoryText="Musée"
         categoryId={CategoryIdEnum.MUSIQUE_LIVE}
         title="C’est une tuile sans datas image mais avec un super long titre!"
         date="Du 12/06 au 24/06"
@@ -41,7 +47,7 @@ export const Video916Cheatcodes = () => {
       <AttachedOfferCardButton
         withRightArrow
         price="Gratuit"
-        tag="Musée"
+        categoryText="Musée"
         categoryId={CategoryIdEnum.MUSIQUE_LIVE}
         title="C’est une tuile sans datas image mais avec un super long titre!"
         onPress={() => {
@@ -50,7 +56,7 @@ export const Video916Cheatcodes = () => {
       />
       <Spacer.Column numberOfSpaces={10} />
       <AttachedOfferCardButton
-        tag="Musée"
+        categoryText="Musée"
         categoryId={CategoryIdEnum.MUSIQUE_LIVE}
         title="C’est une tuile sans image mais avec un super long titre!"
         date="Du 12/06 au 24/06"

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -181,6 +181,7 @@ export const theme = {
     greySemiDark: ColorsEnum.GREY_SEMI_DARK,
     greyMedium: ColorsEnum.GREY_MEDIUM,
     greyLight: ColorsEnum.GREY_LIGHT,
+    brownLight: ColorsEnum.BROWN_LIGHT,
     primary: ColorsEnum.PRIMARY,
     primaryDisabled: ColorsEnum.PRIMARY_DISABLED,
     primaryDark: ColorsEnum.PRIMARY_DARK,

--- a/src/ui/svg/icons/Play.tsx
+++ b/src/ui/svg/icons/Play.tsx
@@ -30,8 +30,6 @@ const PlaySvg: React.FunctionComponent<AccessibleIcon> = ({
   )
 }
 
-// const Player = styled(Play).attrs({ size: PLAYER_SIZE })({})
-
 export const Play = styled(PlaySvg).attrs(({ color, size, theme }) => ({
   color: color ?? theme.colors.black,
   size: size ?? theme.icons.sizes.smaller,

--- a/src/ui/svg/icons/Play.tsx
+++ b/src/ui/svg/icons/Play.tsx
@@ -30,7 +30,9 @@ const PlaySvg: React.FunctionComponent<AccessibleIcon> = ({
   )
 }
 
+// const Player = styled(Play).attrs({ size: PLAYER_SIZE })({})
+
 export const Play = styled(PlaySvg).attrs(({ color, size, theme }) => ({
   color: color ?? theme.colors.black,
   size: size ?? theme.icons.sizes.smaller,
-}))``
+}))({})

--- a/src/ui/theme/colors.ts
+++ b/src/ui/theme/colors.ts
@@ -11,6 +11,7 @@ export enum ColorsEnum {
   GREY_SEMI_DARK = '#90949D',
   GREY_MEDIUM = '#CBCDD2',
   GREY_LIGHT = '#F1F1F4',
+  BROWN_LIGHT = '#8c7a74',
   PRIMARY = '#eb0055',
   PRIMARY_DISABLED = '#ff99be',
   PRIMARY_DARK = '#c10046',

--- a/src/ui/theme/gradientColorsMapping.ts
+++ b/src/ui/theme/gradientColorsMapping.ts
@@ -8,12 +8,3 @@ export const gradientColorsMapping = {
   Coral: [theme.colors.coral, theme.colors.coralDark],
   Lilac: [theme.colors.lilac, theme.colors.lilacDark],
 }
-
-export const newGradientColorsMapping = {
-  Gold: [theme.colors.goldLight100, theme.colors.goldDark],
-  Aquamarine: [theme.colors.aquamarineLight, theme.colors.aquamarineDark],
-  SkyBlue: [theme.colors.skyBlueLight, theme.colors.skyBlueDark],
-  DeepPink: [theme.colors.deepPinkLight, theme.colors.deepPinkLight],
-  Coral: [theme.colors.coralLight, theme.colors.coralDark],
-  Lilac: [theme.colors.lilacLight, theme.colors.lilacDark],
-}

--- a/src/ui/theme/gradientColorsMapping.ts
+++ b/src/ui/theme/gradientColorsMapping.ts
@@ -8,3 +8,12 @@ export const gradientColorsMapping = {
   Coral: [theme.colors.coral, theme.colors.coralDark],
   Lilac: [theme.colors.lilac, theme.colors.lilacDark],
 }
+
+export const newGradientColorsMapping = {
+  Gold: [theme.colors.goldLight100, theme.colors.goldDark],
+  Aquamarine: [theme.colors.aquamarineLight, theme.colors.aquamarineDark],
+  SkyBlue: [theme.colors.skyBlueLight, theme.colors.skyBlueDark],
+  DeepPink: [theme.colors.deepPinkLight, theme.colors.deepPinkLight],
+  Coral: [theme.colors.coralLight, theme.colors.coralDark],
+  Lilac: [theme.colors.lilacLight, theme.colors.lilacDark],
+}

--- a/src/ui/theme/videoModuleMobileColorsMapping.native.test.ts
+++ b/src/ui/theme/videoModuleMobileColorsMapping.native.test.ts
@@ -1,0 +1,58 @@
+import { theme } from 'theme'
+import { videoModuleMobileColorsMapping } from 'ui/theme/videoModuleMobileColorsMapping'
+
+describe('videoModuleMobileColorsMapping', () => {
+  it('should return gold color code', () => {
+    const input = 'Gold'
+
+    const color = videoModuleMobileColorsMapping[input]
+
+    expect(color[0]).toEqual(theme.colors.goldLight100)
+    expect(color[1]).toEqual(theme.colors.goldLight100)
+  })
+
+  it('should return aquamarine color code', () => {
+    const input = 'Aquamarine'
+
+    const color = videoModuleMobileColorsMapping[input]
+
+    expect(color[0]).toEqual(theme.colors.aquamarineLight)
+    expect(color[1]).toEqual(theme.colors.aquamarineLight)
+  })
+
+  it('should return skyBlue color code', () => {
+    const input = 'SkyBlue'
+
+    const color = videoModuleMobileColorsMapping[input]
+
+    expect(color[0]).toEqual(theme.colors.skyBlueLight)
+    expect(color[1]).toEqual(theme.colors.skyBlueLight)
+  })
+
+  it('should return deepPink color code', () => {
+    const input = 'DeepPink'
+
+    const color = videoModuleMobileColorsMapping[input]
+
+    expect(color[0]).toEqual(theme.colors.deepPinkLight)
+    expect(color[1]).toEqual(theme.colors.deepPinkLight)
+  })
+
+  it('should return coral color code', () => {
+    const input = 'Coral'
+
+    const color = videoModuleMobileColorsMapping[input]
+
+    expect(color[0]).toEqual(theme.colors.coralLight)
+    expect(color[1]).toEqual(theme.colors.coralLight)
+  })
+
+  it('should return lilac color code', () => {
+    const input = 'Lilac'
+
+    const color = videoModuleMobileColorsMapping[input]
+
+    expect(color[0]).toEqual(theme.colors.lilacLight)
+    expect(color[1]).toEqual(theme.colors.lilacLight)
+  })
+})

--- a/src/ui/theme/videoModuleMobileColorsMapping.ts
+++ b/src/ui/theme/videoModuleMobileColorsMapping.ts
@@ -1,0 +1,10 @@
+import { theme } from 'theme'
+
+export const videoModuleMobileColorsMapping = {
+  Gold: [theme.colors.goldLight100, theme.colors.goldLight100],
+  Aquamarine: [theme.colors.aquamarineLight, theme.colors.aquamarineLight],
+  SkyBlue: [theme.colors.skyBlueLight, theme.colors.skyBlueLight],
+  DeepPink: [theme.colors.deepPinkLight, theme.colors.deepPinkLight],
+  Coral: [theme.colors.coralLight, theme.colors.coralLight],
+  Lilac: [theme.colors.lilacLight, theme.colors.lilacLight],
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29724

## Checklist

I have:

- [X] Made sure my feature is working on web.
- [X] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome - MonoOffre | <img width="431" alt="PC-29724-monooffer-before" src="https://github.com/pass-culture/pass-culture-app-native/assets/158567429/687f8df0-923a-45fb-9e74-88ec66780863"> | <img width="433" alt="PC-29724-monooffer-after" src="https://github.com/pass-culture/pass-culture-app-native/assets/158567429/374726ed-1dfc-43ff-89a1-721a82f143e0"> |
| Desktop - Chrome - MultiOffre | <img width="434" alt="PC-29724-multioffer-before" src="https://github.com/pass-culture/pass-culture-app-native/assets/158567429/0c7431f8-71d8-4507-9910-6ea26551f477"> | <img width="431" alt="PC-29724-multioffer-after" src="https://github.com/pass-culture/pass-culture-app-native/assets/158567429/5a48757d-1c38-45b1-90fc-f6e519414e33"> |