### PR TITLE
(BSR) fix(VideoModuleMobile): Set borderRadius to 0 instead of unset

### DIFF
--- a/__snapshots__/features/home/components/modules/video/VideoModule.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoModule.native.test.tsx.native-snap
@@ -137,7 +137,7 @@ exports[`VideoModule should render properly with FF on 1`] = `
                 {
                   "backgroundColor": "#F1F1F4",
                   "borderColor": "#CBCDD2",
-                  "borderRadius": "unset",
+                  "borderRadius": 0,
                   "borderStyle": "solid",
                   "borderWidth": 1,
                   "height": 210,

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -150,7 +150,7 @@ const Thumbnail = styled.ImageBackground<{ enableMultiVideoModule: boolean }>(
     // the overflow: hidden allow to add border radius to the image
     // https://stackoverflow.com/questions/49442165/how-do-you-add-borderradius-to-imagebackground/57616397
     overflow: 'hidden',
-    borderRadius: enableMultiVideoModule ? 'unset' : theme.borderRadius.radius,
+    borderRadius: enableMultiVideoModule ? 0 : theme.borderRadius.radius,
     height: enableMultiVideoModule ? NEW_THUMBNAIL_HEIGHT : THUMBNAIL_HEIGHT,
     width: '100%',
     border: 1,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29724

## Checklist

I have:

- [X] Made sure my feature is working on web.
- [X] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
