### PR TITLE
(PC-29734) feat(HighlightOfferModule): display new MarketingBlockExclusivity component with FF in HighlightOfferModule

### DIFF
--- a/src/features/home/components/modules/HighlightOfferModule.native.test.tsx
+++ b/src/features/home/components/modules/HighlightOfferModule.native.test.tsx
@@ -46,6 +46,7 @@ describe('HighlightOfferModule', () => {
       favoritesResponseWithoutOfferIn
     )
     mockServer.postApi<FavoriteResponse>('/v1/me/favorites', favoriteResponseSnap)
+    mockFeatureFlag.mockReturnValue(false)
   })
 
   it('should navigate to offer page on press', async () => {

--- a/src/features/home/components/modules/HighlightOfferModule.native.test.tsx
+++ b/src/features/home/components/modules/HighlightOfferModule.native.test.tsx
@@ -184,6 +184,32 @@ describe('HighlightOfferModule', () => {
       expect(screen.getByText('name')).toBeOnTheScreen()
     })
   })
+
+  it('should render new design when feature flag is enabled', async () => {
+    mockUseHighlightOffer.mockReturnValueOnce({
+      ...offerFixture,
+    })
+    mockFeatureFlag.mockReturnValueOnce(true)
+
+    renderHighlightModule()
+
+    await act(async () => {
+      expect(screen.queryByTestId('highlight-offer-image')).not.toBeOnTheScreen()
+    })
+  })
+
+  it('should render old design when feature flag is disabled', async () => {
+    mockUseHighlightOffer.mockReturnValueOnce({
+      ...offerFixture,
+    })
+    mockFeatureFlag.mockReturnValueOnce(false)
+
+    renderHighlightModule()
+
+    await act(async () => {
+      expect(screen.getByTestId('highlight-offer-image')).toBeOnTheScreen()
+    })
+  })
 })
 
 const renderHighlightModule = () => {

--- a/src/features/home/components/modules/HighlightOfferModule.native.test.tsx
+++ b/src/features/home/components/modules/HighlightOfferModule.native.test.tsx
@@ -9,6 +9,7 @@ import { useHighlightOffer } from 'features/home/api/useHighlightOffer'
 import { HighlightOfferModule } from 'features/home/components/modules/HighlightOfferModule'
 import { highlightOfferModuleFixture } from 'features/home/fixtures/highlightOfferModule.fixture'
 import { analytics } from 'libs/analytics'
+import * as useFeatureFlag from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
 import { offersFixture } from 'shared/offer/offer.fixture'
 import { mockServer } from 'tests/mswServer'
@@ -29,6 +30,8 @@ mockUseAuthContext.mockReturnValue({
   refetchUser: jest.fn(),
   isUserLoading: false,
 })
+
+const mockFeatureFlag = jest.spyOn(useFeatureFlag, 'useFeatureFlag').mockReturnValue(false)
 
 describe('HighlightOfferModule', () => {
   beforeEach(() => {

--- a/src/features/home/components/modules/HighlightOfferModule.native.test.tsx
+++ b/src/features/home/components/modules/HighlightOfferModule.native.test.tsx
@@ -46,7 +46,6 @@ describe('HighlightOfferModule', () => {
       favoritesResponseWithoutOfferIn
     )
     mockServer.postApi<FavoriteResponse>('/v1/me/favorites', favoriteResponseSnap)
-    mockFeatureFlag.mockReturnValue(false)
   })
 
   it('should navigate to offer page on press', async () => {

--- a/src/features/home/components/modules/HighlightOfferModule.tsx
+++ b/src/features/home/components/modules/HighlightOfferModule.tsx
@@ -1,3 +1,4 @@
+import { parseInt } from 'lodash'
 import React, { memo, useEffect, useState } from 'react'
 import { LayoutChangeEvent, View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
@@ -87,7 +88,7 @@ const UnmemoizedHighlightOfferModule = (props: HighlightOfferModuleProps) => {
       <Spacer.Column numberOfSpaces={5} />
       {isNewExclusivityModule ? (
         <MarketingBlockExclusivity
-          offerId={Number(offerId)}
+          offerId={parseInt(highlightOfferId)}
           title={highlightOffer.offer.name || ''}
           categoryId={categoryId}
           backgroundImageUrl={props.image}

--- a/src/features/home/components/modules/HighlightOfferModule.tsx
+++ b/src/features/home/components/modules/HighlightOfferModule.tsx
@@ -81,10 +81,14 @@ const UnmemoizedHighlightOfferModule = (props: HighlightOfferModuleProps) => {
 
   return (
     <Container>
+      <StyledTitleContainer>
+        <StyledTitle>{props.highlightTitle}</StyledTitle>
+      </StyledTitleContainer>
+      <Spacer.Column numberOfSpaces={5} />
       {isNewExclusivityModule ? (
         <MarketingBlockExclusivity
           offerId={Number(offerId)}
-          title={props.highlightTitle}
+          title={highlightOffer.offer.name || ''}
           categoryId={categoryId}
           backgroundImageUrl={props.image}
           offerImageUrl={highlightOffer.offer.thumbUrl}
@@ -93,75 +97,69 @@ const UnmemoizedHighlightOfferModule = (props: HighlightOfferModuleProps) => {
           categoryText={categoryLabel || ''}
         />
       ) : (
-        <React.Fragment>
-          <StyledTitleContainer>
-            <StyledTitle>{props.highlightTitle}</StyledTitle>
-          </StyledTitleContainer>
-          <Spacer.Column numberOfSpaces={5} />
-          <View>
-            <ColorCategoryBackground
-              start={{ x: 0, y: 0 }}
-              end={{ x: 0, y: 1 }}
-              colors={gradientColorsMapping[props.color]}
-              height={
-                isDesktopViewport
-                  ? DESKTOP_COLOR_BACKGROUND_HEIGHT
-                  : getColorBackgroundHeight(offerDetailsHeight)
-              }
-            />
-            <StyledTouchableLink
-              testID="highlight-offer-image"
-              accessibilityRole="button"
-              highlight
-              navigateTo={{
-                screen: 'Offer',
-                params: { id: highlightOfferId },
+        <View>
+          <ColorCategoryBackground
+            start={{ x: 0, y: 0 }}
+            end={{ x: 0, y: 1 }}
+            colors={gradientColorsMapping[props.color]}
+            height={
+              isDesktopViewport
+                ? DESKTOP_COLOR_BACKGROUND_HEIGHT
+                : getColorBackgroundHeight(offerDetailsHeight)
+            }
+          />
+          <StyledTouchableLink
+            testID="highlight-offer-image"
+            accessibilityRole="button"
+            highlight
+            navigateTo={{
+              screen: 'Offer',
+              params: { id: highlightOfferId },
+            }}
+            onBeforeNavigate={() => {
+              prePopulateOffer({
+                ...offer,
+                offerId: +highlightOfferId,
+                categoryId,
+              })
+              analytics.logConsultOffer({
+                offerId: +highlightOfferId,
+                from: 'highlightOffer',
+                moduleId: props.id,
+                moduleName: props.highlightTitle,
+                homeEntryId: props.homeEntryId,
+              })
+            }}>
+            <TouchableContent>
+              <OfferImage source={{ uri: props.image }}>
+                {categoryLabel ? <CategoryCaption label={categoryLabel} /> : null}
+              </OfferImage>
+              <OfferDetails
+                onLayout={(event: LayoutChangeEvent) =>
+                  setOfferDetailsHeight(event.nativeEvent.layout.height)
+                }>
+                <StyledOfferTitle>{props.offerTitle}</StyledOfferTitle>
+                {formattedDate ? <AdditionalDetail>{formattedDate}</AdditionalDetail> : null}
+                {venueName ? <AdditionalDetail>{venueName}</AdditionalDetail> : null}
+                {formattedPrice ? <AdditionalDetail>{priceText}</AdditionalDetail> : null}
+              </OfferDetails>
+              <ArrowOffer>
+                <PlainArrowNext size={theme.icons.sizes.small} />
+              </ArrowOffer>
+            </TouchableContent>
+          </StyledTouchableLink>
+          <FavoriteButtonContainer>
+            <FavoriteButton
+              offerId={parseInt(highlightOfferId)}
+              analyticsParams={{
+                from: 'highlightOffer',
+                moduleId: props.id,
+                moduleName: props.highlightTitle,
               }}
-              onBeforeNavigate={() => {
-                prePopulateOffer({
-                  ...offer,
-                  offerId: +highlightOfferId,
-                  categoryId,
-                })
-                analytics.logConsultOffer({
-                  offerId: +highlightOfferId,
-                  from: 'highlightOffer',
-                  moduleId: props.id,
-                  moduleName: props.highlightTitle,
-                  homeEntryId: props.homeEntryId,
-                })
-              }}>
-              <TouchableContent>
-                <OfferImage source={{ uri: props.image }}>
-                  {categoryLabel ? <CategoryCaption label={categoryLabel} /> : null}
-                </OfferImage>
-                <OfferDetails
-                  onLayout={(event: LayoutChangeEvent) =>
-                    setOfferDetailsHeight(event.nativeEvent.layout.height)
-                  }>
-                  <StyledOfferTitle>{props.offerTitle}</StyledOfferTitle>
-                  {formattedDate ? <AdditionalDetail>{formattedDate}</AdditionalDetail> : null}
-                  {venueName ? <AdditionalDetail>{venueName}</AdditionalDetail> : null}
-                  {formattedPrice ? <AdditionalDetail>{priceText}</AdditionalDetail> : null}
-                </OfferDetails>
-                <ArrowOffer>
-                  <PlainArrowNext size={theme.icons.sizes.small} />
-                </ArrowOffer>
-              </TouchableContent>
-            </StyledTouchableLink>
-            <FavoriteButtonContainer>
-              <FavoriteButton
-                offerId={parseInt(highlightOfferId)}
-                analyticsParams={{
-                  from: 'highlightOffer',
-                  moduleId: props.id,
-                  moduleName: props.highlightTitle,
-                }}
-              />
-            </FavoriteButtonContainer>
-            <Spacer.Column numberOfSpaces={6} />
-          </View>
-        </React.Fragment>
+            />
+          </FavoriteButtonContainer>
+          <Spacer.Column numberOfSpaces={6} />
+        </View>
       )}
     </Container>
   )

--- a/src/features/home/components/modules/marketing/MarketingBlockContent.tsx
+++ b/src/features/home/components/modules/marketing/MarketingBlockContent.tsx
@@ -54,20 +54,20 @@ export const MarketingBlockContent = ({
             <StyledIcon />
           </ImagePlaceholder>
         )}
+        <AttachedOfferCardContainer>
+          <AttachedOfferCard
+            title={title}
+            categoryId={categoryId}
+            imageUrl={imageUrl}
+            offerLocation={offerLocation}
+            price={price}
+            categoryText={categoryText}
+            date={date}
+            withRightArrow={withRightArrow}
+            showImage={showImage}
+          />
+        </AttachedOfferCardContainer>
       </BackgroundImageContainer>
-      <AttachedOfferCardContainer>
-        <AttachedOfferCard
-          title={title}
-          categoryId={categoryId}
-          imageUrl={imageUrl}
-          offerLocation={offerLocation}
-          price={price}
-          categoryText={categoryText}
-          date={date}
-          withRightArrow={withRightArrow}
-          showImage={showImage}
-        />
-      </AttachedOfferCardContainer>
     </InternalTouchableLink>
   )
 }

--- a/src/libs/firebase/firestore/types.ts
+++ b/src/libs/firebase/firestore/types.ts
@@ -57,4 +57,5 @@ export enum RemoteStoreFeatureFlags {
   WIP_VENUE_MAP_WITHOUT_POSITION = 'wipVenueMapWithoutPosition',
   WIP_VENUE_MAP_WITHOUT_PREVIEW = 'wipVenueMapWithoutPreview',
   WIP_ENABLE_DYNAMIC_OPENING_HOURS = 'wipEnableDynamicOpeningHours',
+  WIP_NEW_EXCLUSIVITY_MODULE = 'wipNewExclusivityModule',
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29741

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |        <img width="285" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/169038942/b14b3ad3-3e18-4ca0-bd17-9e69225568e7">       |   ![image](https://github.com/pass-culture/pass-culture-app-native/assets/169038942/0d89736b-3dd9-4e24-a358-33c12f92eb57)    |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |       <img width="533" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/169038942/c5b20cee-7574-40ea-ac95-865ffcbe3022">        |    <img width="1512" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/169038942/3a52d7eb-6262-4a57-9dd9-003813967e0a">   |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
