### PR TITLE
(PC-28849) fix(OpeningHours): Update status when app is reopened

### DIFF
--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -97,6 +97,7 @@
 ./src/features/search/helpers/useSortedSearchCategories/useSortedSearchCategories.native.test.ts:37
 ./src/features/search/pages/SuggestedPlacesOrVenues/SuggestedVenues.native.test.tsx:37
 ./src/features/search/pages/modals/CategoriesModal/CategoriesModal.tsx:121
+./src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.native.test.tsx:48
 ./src/features/venue/components/TabLayout/useTabArrowNavigation.web.ts:24
 ./src/features/venueMap/store/selectedVenueStore.native.test.ts:20
 ./src/features/venueMap/store/selectedVenueStore.native.test.ts:31

--- a/src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.native.test.tsx
+++ b/src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.native.test.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
+import { AppState } from 'react-native'
 
 import { OpeningHoursStatus } from 'features/venue/components/OpeningHoursStatus/OpeningHoursStatus'
 import { act, render, screen } from 'tests/utils'
 
-const CURRENT_DATE = new Date('2024-05-31T08:30:00')
+jest.unmock('libs/appState')
+const appStateSpy = jest.spyOn(AppState, 'addEventListener')
 
+const CURRENT_DATE = new Date('2024-05-31T08:30:00')
 jest.useFakeTimers().setSystemTime(CURRENT_DATE)
 
 describe('<OpeningHoursStatus />', () => {
@@ -32,5 +35,26 @@ describe('<OpeningHoursStatus />', () => {
     await act(async () => jest.advanceTimersByTime(31 * 60 * 1000))
 
     expect(await screen.findByText('Ouvre bientôt - 9h1')).toBeOnTheScreen()
+  })
+
+  it('should set timer to 0 when app is in background for longer than remaining time', async () => {
+    const openingHours = {
+      FRIDAY: [{ open: '09:01', close: '19:00' }],
+    }
+    render(<OpeningHoursStatus openingHours={openingHours} currentDate={CURRENT_DATE} />)
+
+    expect(screen.getByText('Ouvre bientôt - 9h1')).toBeOnTheScreen()
+
+    // @ts-expect-error: because of noUncheckedIndexedAccess
+    const mockCurrentAppState = appStateSpy.mock.calls[0][1]
+    mockCurrentAppState('active')
+
+    await act(async () => {
+      mockCurrentAppState('background')
+      jest.advanceTimersByTime(31 * 60 * 1000)
+      mockCurrentAppState('active')
+    })
+
+    expect(await screen.findByText('Ouvert jusqu’à 19h')).toBeOnTheScreen()
   })
 })

--- a/src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.tsx
+++ b/src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.tsx
@@ -2,6 +2,7 @@ import React, { FC, useEffect, useState } from 'react'
 import styled, { DefaultTheme } from 'styled-components/native'
 
 import { OpeningHours, OpeningHoursStatusState } from 'features/venue/types'
+import { useAppStateChange } from 'libs/appState'
 import { ClockFilled } from 'ui/svg/icons/ClockFilled'
 import { getSpacing, Typo } from 'ui/theme'
 
@@ -35,6 +36,8 @@ export const OpeningHoursStatus: FC<Props> = ({ openingHours, currentDate }) => 
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  useAppStateChange(() => setDate(new Date()), undefined)
 
   return (
     <Container>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28849

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
