### PR TITLE
(PC-29992) fix(auth): fix refresh token read on iOS

### DIFF
--- a/src/libs/keychain/keychain.native.test.ts
+++ b/src/libs/keychain/keychain.native.test.ts
@@ -1,4 +1,5 @@
 import * as Keychain from '__mocks__/react-native-keychain'
+import { env } from 'libs/environment/fixtures'
 
 import { getRefreshToken, saveRefreshToken } from './keychain'
 
@@ -11,7 +12,8 @@ describe('saveRefreshToken()', () => {
     expect(Keychain.setGenericPassword).toHaveBeenCalledTimes(1)
     expect(Keychain.setGenericPassword).toHaveBeenCalledWith(
       'PASSCULTURE_REFRESH_TOKEN',
-      'fake_access_token'
+      'fake_access_token',
+      { service: env.IOS_APP_ID }
     )
   })
 

--- a/src/libs/keychain/keychain.ts
+++ b/src/libs/keychain/keychain.ts
@@ -1,13 +1,19 @@
+import { Platform } from 'react-native'
 import * as Keychain from 'react-native-keychain'
 
+import { env } from 'libs/environment'
+
 const REFRESH_TOKEN_KEY = 'PASSCULTURE_REFRESH_TOKEN'
+
+// firebase sometimes overrides the default keychain credentials on ios, see oblador/react-native-keychain/issues/363
+const keychainOptions = Platform.OS === 'ios' ? { service: env.IOS_APP_ID } : {}
 
 export async function saveRefreshToken(refreshToken: string | undefined): Promise<void> {
   if (!refreshToken) {
     throw Error('Aucun refresh token à sauvegarder')
   }
   try {
-    await Keychain.setGenericPassword(REFRESH_TOKEN_KEY, refreshToken)
+    await Keychain.setGenericPassword(REFRESH_TOKEN_KEY, refreshToken, keychainOptions)
   } catch {
     throw Error('Keychain non accessible')
   }
@@ -15,7 +21,7 @@ export async function saveRefreshToken(refreshToken: string | undefined): Promis
 
 export async function clearRefreshToken(): Promise<void> {
   try {
-    await Keychain.resetGenericPassword()
+    await Keychain.resetGenericPassword(keychainOptions)
   } catch {
     throw Error('Keychain non accessible')
   }
@@ -23,7 +29,7 @@ export async function clearRefreshToken(): Promise<void> {
 
 export async function getRefreshToken(): Promise<string | null> {
   try {
-    const credentials = await Keychain.getGenericPassword()
+    const credentials = await Keychain.getGenericPassword(keychainOptions)
     if (credentials) {
       return credentials.password
     }

--- a/src/libs/keychain/keychain.ts
+++ b/src/libs/keychain/keychain.ts
@@ -5,7 +5,7 @@ import { env } from 'libs/environment'
 
 const REFRESH_TOKEN_KEY = 'PASSCULTURE_REFRESH_TOKEN'
 
-// firebase sometimes overrides the default keychain credentials on ios, see oblador/react-native-keychain/issues/363
+// firebase sometimes overrides the default keychain credentials on iOS, see https://github.com/oblador/react-native-keychain/issues/363
 const keychainOptions = Platform.OS === 'ios' ? { service: env.IOS_APP_ID } : {}
 
 export async function saveRefreshToken(refreshToken: string | undefined): Promise<void> {


### PR DESCRIPTION
Firebase sometimes overrides the credentials returned by Keychain.getGenericPassword. Since we store the refresh token there, the backend sometimes rightfully returns a 422 error because the refresh token is not one issued by the backend.

This bug only occurs on iOS, see oblador/react-native-keychain/issues/363.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29992