### PR TITLE
(PC-30156) fix(NotConnectedFavorites): connect button is now responsive

### DIFF
--- a/__snapshots__/features/favorites/pages/NotConnectedFavorites.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/NotConnectedFavorites.native.test.tsx.native-snap
@@ -100,6 +100,7 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
           "flexBasis": 0,
           "flexGrow": 1,
           "flexShrink": 1,
+          "minHeight": 124,
           "paddingBottom": 40,
         },
       ]

--- a/src/features/favorites/pages/NotConnectedFavorites.tsx
+++ b/src/features/favorites/pages/NotConnectedFavorites.tsx
@@ -51,6 +51,7 @@ const StyledTitle4 = styled(Typo.Title4)({
 const ButtonContainer = styled.View({
   flex: 1,
   paddingBottom: getSpacing(10),
+  minHeight: getSpacing(31), // To avoid button getting smashed on "square" screens
 })
 
 const CenteredText = styled(Typo.Body)({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30156

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome | <img width="635" alt="Screenshot 2024-06-14 at 11 21 22" src="https://github.com/pass-culture/pass-culture-app-native/assets/75068235/97eb07d7-5af4-42fc-b387-db47b2a6620d"> |  <img width="626" alt="Screenshot 2024-06-14 at 11 21 05" src="https://github.com/pass-culture/pass-culture-app-native/assets/75068235/eb81b5af-b00e-4fe2-b48d-233f7ff71149"> |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
