### PR TITLE
(PC-30074) feat(VideoModuleDesktop): refonte ui de VideoModuleDesktop

### DIFF
--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -43,9 +43,10 @@
 ./src/features/home/components/modules/OffersModule.tsx:54
 ./src/features/home/components/modules/OffersModule.tsx:62
 ./src/features/home/components/modules/OffersModule.tsx:71
+./src/features/home/components/modules/video/OldVideoModuleDesktop.tsx:96
 ./src/features/home/components/modules/video/OldVideoModuleMobile.tsx:70
 ./src/features/home/components/modules/video/VideoModal.tsx:109
-./src/features/home/components/modules/video/VideoModuleDesktop.tsx:96
+./src/features/home/components/modules/video/VideoModuleDesktop.tsx:86
 ./src/features/home/components/modules/video/VideoModuleMobile.tsx:71
 ./src/features/identityCheck/api/useProfileInfo.ts:21
 ./src/features/identityCheck/pages/helpers/parseUrlParams.ts:8

--- a/src/features/home/components/modules/video/OldVideoModuleDesktop.tsx
+++ b/src/features/home/components/modules/video/OldVideoModuleDesktop.tsx
@@ -1,0 +1,225 @@
+import colorAlpha from 'color-alpha'
+import React, { FunctionComponent } from 'react'
+// eslint-disable-next-line no-restricted-imports
+import { ImageBackground, View } from 'react-native'
+import LinearGradient from 'react-native-linear-gradient'
+import styled from 'styled-components/native'
+
+import { BlackCaption } from 'features/home/components/BlackCaption'
+import { BlackGradient } from 'features/home/components/BlackGradient'
+import { TEXT_BACKGROUND_OPACITY } from 'features/home/components/constants'
+import { VideoMonoOfferTile } from 'features/home/components/modules/video/VideoMonoOfferTile'
+import { VideoModuleProps } from 'features/home/types'
+import { Offer } from 'shared/offer/types'
+import { SeeMoreWithEye } from 'ui/components/SeeMoreWithEye'
+import { Separator } from 'ui/components/Separator'
+import { HorizontalOfferTile } from 'ui/components/tiles/HorizontalOfferTile'
+import { Play } from 'ui/svg/icons/Play'
+import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { gradientColorsMapping } from 'ui/theme/gradientColorsMapping'
+
+const THUMBNAIL_HEIGHT_MULTI_OFFER = getSpacing(90)
+const THUMBNAIL_HEIGHT_MONO_OFFER = getSpacing(45)
+const THUMBNAIL_WIDTH_MULTI_OFFER = getSpacing(132)
+const THUMBNAIL_WIDTH_MONO_OFFER = getSpacing(82)
+// We do not center the player icon for mono offer, because when the title is 2-line long,
+// the title is to close to the player. So the player is closer to the top.
+const PLAYER_TOP_MARGIN = getSpacing(12.5)
+const PLAYER_SIZE = getSpacing(14.5)
+
+const GRADIENT_HEIGHT = getSpacing(33)
+
+export const OldVideoModuleDesktop: FunctionComponent<VideoModuleProps> = (props) => {
+  const videoDuration = `${props.durationInMinutes} min`
+
+  const showSeeMore = props.offers.length > 3
+  const hasOnlyTwoOffers = props.offers.length === 2
+  const nbOfSeparators = hasOnlyTwoOffers ? 1 : 2
+
+  function renderTitleSeeMore() {
+    return <SeeMoreWithEye title={props.videoTitle} onPressSeeMore={props.showVideoModal} />
+  }
+
+  return (
+    <React.Fragment>
+      <StyledTitleContainer>
+        <StyledTitleComponent>{props.title}</StyledTitleComponent>
+        {showSeeMore && props.isMultiOffer && renderTitleSeeMore()}
+      </StyledTitleContainer>
+      <Spacer.Column numberOfSpaces={5} />
+
+      <StyledWrapper isMultiOffer={props.isMultiOffer} testID="desktop-video-module">
+        <ColorCategoryBackground
+          start={{ x: 0, y: 0 }}
+          end={{ x: 0, y: 1 }}
+          colors={gradientColorsMapping[props.color]}
+          isMultiOffer={props.isMultiOffer}
+        />
+        <VideoOfferContainer>
+          <StyledTouchableHighlight
+            onPress={props.showVideoModal}
+            testID="video-thumbnail"
+            accessibilityRole="button"
+            isMultiOffer={props.isMultiOffer}>
+            <Thumbnail source={{ uri: props.videoThumbnail }}>
+              <DurationCaption label={videoDuration} />
+              <TextContainer>
+                <BlackGradient />
+                <BlackBackground>
+                  <VideoTitle numberOfLines={2}>{props.videoTitle}</VideoTitle>
+                </BlackBackground>
+              </TextContainer>
+              <PlayerContainer isMultiOffer={props.isMultiOffer}>
+                <Player />
+              </PlayerContainer>
+            </Thumbnail>
+          </StyledTouchableHighlight>
+
+          <Spacer.Row numberOfSpaces={4} />
+          {props.isMultiOffer ? (
+            <StyledMultiOfferList hasOnlyTwoOffers={hasOnlyTwoOffers}>
+              {props.offers.slice(0, 3).map((offer: Offer, index) => (
+                <React.Fragment key={offer.objectID}>
+                  <StyledHorizontalOfferTile
+                    offer={offer}
+                    onPress={props.hideVideoModal}
+                    analyticsParams={props.analyticsParams}
+                  />
+                  {index < nbOfSeparators ? (
+                    <StyledSeparator hasOnlyTwoOffers={hasOnlyTwoOffers} />
+                  ) : null}
+                </React.Fragment>
+              ))}
+            </StyledMultiOfferList>
+          ) : (
+            <StyledVideoMonoOfferTile
+              // @ts-expect-error: because of noUncheckedIndexedAccess
+              offer={props.offers[0]}
+              color={props.color}
+              hideModal={props.hideVideoModal}
+              analyticsParams={props.analyticsParams}
+              homeEntryId={props.homeEntryId}
+            />
+          )}
+        </VideoOfferContainer>
+      </StyledWrapper>
+    </React.Fragment>
+  )
+}
+
+const StyledWrapper = styled(View)<{
+  isMultiOffer: boolean
+}>(({ isMultiOffer }) => ({
+  height:
+    (isMultiOffer ? THUMBNAIL_HEIGHT_MULTI_OFFER : THUMBNAIL_HEIGHT_MONO_OFFER) + getSpacing(6),
+}))
+
+const VideoOfferContainer = styled.View(({ theme }) => ({
+  marginHorizontal: theme.contentPage.marginHorizontal,
+  flexDirection: 'row',
+  height: '100%',
+}))
+
+const Thumbnail = styled(ImageBackground)(({ theme }) => ({
+  // the overflow: hidden allow to add border radius to the image
+  // https://stackoverflow.com/questions/49442165/how-do-you-add-borderradius-to-imagebackground/57616397
+  overflow: 'hidden',
+  borderRadius: theme.borderRadius.radius,
+  flex: 1,
+  border: 1,
+  borderColor: theme.colors.greyMedium,
+  backgroundColor: theme.colors.greyLight,
+}))
+
+const DurationCaption = styled(BlackCaption)({
+  position: 'absolute',
+  top: getSpacing(2),
+  right: getSpacing(2),
+})
+
+const PlayerContainer = styled(View)<{
+  isMultiOffer: boolean
+}>(({ isMultiOffer }) => ({
+  ...(isMultiOffer
+    ? {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+      }
+    : { position: 'absolute', top: PLAYER_TOP_MARGIN, left: 0, right: 0, alignItems: 'center' }),
+}))
+
+const ColorCategoryBackground = styled(LinearGradient)<{
+  isMultiOffer: boolean
+}>(({ isMultiOffer }) => ({
+  position: 'absolute',
+  bottom: 0,
+  left: 0,
+  height: GRADIENT_HEIGHT,
+  ...(isMultiOffer
+    ? {
+        width: getSpacing(144),
+        borderTopRightRadius: getSpacing(4),
+        borderBottomRightRadius: getSpacing(4),
+      }
+    : {
+        right: 0,
+      }),
+}))
+
+const Player = styled(Play).attrs({ size: PLAYER_SIZE })({})
+
+const TextContainer = styled.View({ position: 'absolute', bottom: 0, left: 0, right: 0 })
+
+const BlackBackground = styled.View(({ theme }) => ({
+  padding: getSpacing(4),
+  backgroundColor: colorAlpha(theme.colors.black, TEXT_BACKGROUND_OPACITY),
+}))
+
+const VideoTitle = styled(Typo.Title4)(({ theme }) => ({
+  color: theme.colors.white,
+  textAlign: 'left',
+}))
+
+const StyledTouchableHighlight = styled.TouchableHighlight.attrs(({ theme }) => ({
+  underlayColor: theme.colors.white,
+}))<{ isMultiOffer: boolean }>(({ theme, isMultiOffer }) => ({
+  borderRadius: theme.borderRadius.radius,
+  height: isMultiOffer ? THUMBNAIL_HEIGHT_MULTI_OFFER : THUMBNAIL_HEIGHT_MONO_OFFER,
+  width: isMultiOffer ? THUMBNAIL_WIDTH_MULTI_OFFER : THUMBNAIL_WIDTH_MONO_OFFER,
+}))
+
+const StyledTitleContainer = styled.View(({ theme }) => ({
+  marginHorizontal: theme.contentPage.marginHorizontal,
+  flexDirection: 'row',
+  alignItems: 'center',
+}))
+
+const StyledTitleComponent = styled(Typo.Title3).attrs({
+  numberOfLines: 2,
+})({})
+
+const StyledVideoMonoOfferTile = styled(VideoMonoOfferTile)({
+  flex: 1,
+  flexGrow: 1,
+})
+
+const StyledMultiOfferList = styled(View)<{
+  hasOnlyTwoOffers: boolean
+}>(({ hasOnlyTwoOffers }) => ({
+  flex: 1,
+  marginLeft: getSpacing(10),
+  justifyContent: hasOnlyTwoOffers ? 'flex-start' : 'space-between',
+  height: '100%',
+}))
+
+const StyledSeparator = styled(Separator.Horizontal)<{
+  hasOnlyTwoOffers: boolean
+}>(({ hasOnlyTwoOffers }) => ({
+  height: 2,
+  marginVertical: hasOnlyTwoOffers ? getSpacing(6) : 0,
+}))
+
+const StyledHorizontalOfferTile = styled(HorizontalOfferTile)({
+  marginVertical: 0,
+})

--- a/src/features/home/components/modules/video/OldVideoModuleDesktop.tsx
+++ b/src/features/home/components/modules/video/OldVideoModuleDesktop.tsx
@@ -1,5 +1,5 @@
 import colorAlpha from 'color-alpha'
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useMemo } from 'react'
 // eslint-disable-next-line no-restricted-imports
 import { ImageBackground, View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
@@ -30,7 +30,7 @@ const PLAYER_SIZE = getSpacing(14.5)
 const GRADIENT_HEIGHT = getSpacing(33)
 
 export const OldVideoModuleDesktop: FunctionComponent<VideoModuleProps> = (props) => {
-  const videoDuration = `${props.durationInMinutes} min`
+  const videoDuration = useMemo(() => `${props.durationInMinutes} min`, [props.durationInMinutes])
 
   const showSeeMore = props.offers.length > 3
   const hasOnlyTwoOffers = props.offers.length === 2

--- a/src/features/home/components/modules/video/OldVideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/OldVideoModuleMobile.tsx
@@ -1,5 +1,5 @@
 import colorAlpha from 'color-alpha'
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useMemo } from 'react'
 import { View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import styled from 'styled-components/native'
@@ -26,7 +26,7 @@ const COLOR_CATEGORY_BACKGROUND_HEIGHT_MULTI_OFFER =
   THUMBNAIL_HEIGHT - GRADIENT_START_POSITION + getSpacing(16)
 
 export const OldVideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) => {
-  const videoDuration = `${props.durationInMinutes} min`
+  const videoDuration = useMemo(() => `${props.durationInMinutes} min`, [props.durationInMinutes])
 
   const colorCategoryBackgroundHeightUniqueOffer =
     THUMBNAIL_HEIGHT - GRADIENT_START_POSITION + getSpacing(43)

--- a/src/features/home/components/modules/video/VideoModule.tsx
+++ b/src/features/home/components/modules/video/VideoModule.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent, useEffect } from 'react'
 import styled, { useTheme } from 'styled-components/native'
 
 import { useVideoOffers } from 'features/home/api/useVideoOffers'
+import { OldVideoModuleDesktop } from 'features/home/components/modules/video/OldVideoModuleDesktop'
 import { OldVideoModuleMobile } from 'features/home/components/modules/video/OldVideoModuleMobile'
 import { VideoModal } from 'features/home/components/modules/video/VideoModal'
 import { VideoModuleDesktop } from 'features/home/components/modules/video/VideoModuleDesktop'
@@ -21,16 +22,32 @@ interface VideoModuleBaseProps extends VideoModuleType {
   shouldShowModal: boolean
 }
 
-const VideoModuleMobileFF: FunctionComponent<VideoModuleProps> = (props) => {
+const VideoModuleFF: FunctionComponent<VideoModuleProps> = (props) => {
+  const theme = useTheme()
+
   const enableMultiVideoModule = useFeatureFlag(
     RemoteStoreFeatureFlags.WIP_APP_V2_MULTI_VIDEO_MODULE
   )
+
   const hasGraphicRedesign = useHasGraphicRedesign({
     isFeatureFlagActive: enableMultiVideoModule,
     homeId: props.homeEntryId,
   })
 
-  return hasGraphicRedesign ? <VideoModuleMobile {...props} /> : <OldVideoModuleMobile {...props} />
+  const videoModule = {
+    DESKTOP: hasGraphicRedesign ? (
+      <VideoModuleDesktop {...props} />
+    ) : (
+      <OldVideoModuleDesktop {...props} />
+    ),
+    MOBILE: hasGraphicRedesign ? (
+      <VideoModuleMobile {...props} />
+    ) : (
+      <OldVideoModuleMobile {...props} />
+    ),
+  }
+
+  return theme.isDesktopViewport ? videoModule.DESKTOP : videoModule.MOBILE
 }
 
 export const VideoModule: FunctionComponent<VideoModuleBaseProps> = (props) => {
@@ -39,8 +56,6 @@ export const VideoModule: FunctionComponent<VideoModuleBaseProps> = (props) => {
     showModal: showVideoModal,
     hideModal: hideVideoModal,
   } = useModal(props.shouldShowModal)
-
-  const theme = useTheme()
 
   const { offers } = useVideoOffers(
     props.offersModuleParameters,
@@ -84,11 +99,8 @@ export const VideoModule: FunctionComponent<VideoModuleBaseProps> = (props) => {
 
   return (
     <Container>
-      {theme.isDesktopViewport ? (
-        <VideoModuleDesktop {...props} {...videoModuleParams} />
-      ) : (
-        <VideoModuleMobileFF {...props} {...videoModuleParams} />
-      )}
+      <VideoModuleFF {...props} {...videoModuleParams} />
+
       <VideoModal
         visible={videoModalVisible}
         hideModal={hideVideoModal}

--- a/src/features/home/components/modules/video/VideoModuleDesktop.tsx
+++ b/src/features/home/components/modules/video/VideoModuleDesktop.tsx
@@ -2,12 +2,8 @@ import colorAlpha from 'color-alpha'
 import React, { FunctionComponent } from 'react'
 // eslint-disable-next-line no-restricted-imports
 import { ImageBackground, View } from 'react-native'
-import LinearGradient from 'react-native-linear-gradient'
 import styled from 'styled-components/native'
 
-import { BlackCaption } from 'features/home/components/BlackCaption'
-import { BlackGradient } from 'features/home/components/BlackGradient'
-import { TEXT_BACKGROUND_OPACITY } from 'features/home/components/constants'
 import { VideoMonoOfferTile } from 'features/home/components/modules/video/VideoMonoOfferTile'
 import { VideoModuleProps } from 'features/home/types'
 import { Offer } from 'shared/offer/types'
@@ -16,22 +12,17 @@ import { Separator } from 'ui/components/Separator'
 import { HorizontalOfferTile } from 'ui/components/tiles/HorizontalOfferTile'
 import { Play } from 'ui/svg/icons/Play'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
-import { gradientColorsMapping } from 'ui/theme/gradientColorsMapping'
+// eslint-disable-next-line no-restricted-imports
+import { ColorsEnum } from 'ui/theme/colors'
+import { videoModuleColorsMapping } from 'ui/theme/videoModuleColorsMapping'
 
-const THUMBNAIL_HEIGHT_MULTI_OFFER = getSpacing(90)
-const THUMBNAIL_HEIGHT_MONO_OFFER = getSpacing(45)
-const THUMBNAIL_WIDTH_MULTI_OFFER = getSpacing(132)
-const THUMBNAIL_WIDTH_MONO_OFFER = getSpacing(82)
-// We do not center the player icon for mono offer, because when the title is 2-line long,
-// the title is to close to the player. So the player is closer to the top.
-const PLAYER_TOP_MARGIN = getSpacing(12.5)
-const PLAYER_SIZE = getSpacing(14.5)
-
-const GRADIENT_HEIGHT = getSpacing(33)
+const PLAYER_SIZE = getSpacing(24)
+const THUMBNAIL_HEIGHT = getSpacing(93.5)
+const THUMBNAIL_WIDTH = getSpacing(150)
+const COLOR_CATEGORY_BACKGROUND_HEIGHT = getSpacing(55.5)
+const COLOR_CATEGORY_BACKGROUND_WIDTH = getSpacing(160)
 
 export const VideoModuleDesktop: FunctionComponent<VideoModuleProps> = (props) => {
-  const videoDuration = `${props.durationInMinutes} min`
-
   const showSeeMore = props.offers.length > 3
   const hasOnlyTwoOffers = props.offers.length === 2
   const nbOfSeparators = hasOnlyTwoOffers ? 1 : 2
@@ -43,79 +34,86 @@ export const VideoModuleDesktop: FunctionComponent<VideoModuleProps> = (props) =
   return (
     <React.Fragment>
       <StyledTitleContainer>
-        <StyledTitleComponent>{props.title}</StyledTitleComponent>
+        <Typo.Title3 numberOfLines={2}>{props.title}</Typo.Title3>
         {showSeeMore && props.isMultiOffer && renderTitleSeeMore()}
       </StyledTitleContainer>
       <Spacer.Column numberOfSpaces={5} />
 
-      <StyledWrapper isMultiOffer={props.isMultiOffer} testID="desktop-video-module">
-        <ColorCategoryBackground
-          start={{ x: 0, y: 0 }}
-          end={{ x: 0, y: 1 }}
-          colors={gradientColorsMapping[props.color]}
-          isMultiOffer={props.isMultiOffer}
-        />
-        <VideoOfferContainer>
+      <View>
+        <ColorCategoryBackgroundWrapper>
+          <ColorCategoryBackground
+            backgroundColor={videoModuleColorsMapping[props.color]}
+            isMultiOffer={props.isMultiOffer}
+          />
+        </ColorCategoryBackgroundWrapper>
+        <VideoOfferContainer isMultiOffer={props.isMultiOffer}>
           <StyledTouchableHighlight
             onPress={props.showVideoModal}
             testID="video-thumbnail"
             accessibilityRole="button"
             isMultiOffer={props.isMultiOffer}>
             <Thumbnail source={{ uri: props.videoThumbnail }}>
-              <DurationCaption label={videoDuration} />
+              <BlackView />
               <TextContainer>
-                <BlackGradient />
-                <BlackBackground>
-                  <VideoTitle numberOfLines={2}>{props.videoTitle}</VideoTitle>
-                </BlackBackground>
+                <VideoTitle numberOfLines={1} ellipsizeMode="tail">
+                  {props.videoTitle}
+                </VideoTitle>
               </TextContainer>
-              <PlayerContainer isMultiOffer={props.isMultiOffer}>
+              <PlayerContainer>
                 <Player />
               </PlayerContainer>
             </Thumbnail>
           </StyledTouchableHighlight>
-
-          <Spacer.Row numberOfSpaces={4} />
-          {props.isMultiOffer ? (
-            <StyledMultiOfferList hasOnlyTwoOffers={hasOnlyTwoOffers}>
-              {props.offers.slice(0, 3).map((offer: Offer, index) => (
-                <React.Fragment key={offer.objectID}>
-                  <StyledHorizontalOfferTile
-                    offer={offer}
-                    onPress={props.hideVideoModal}
-                    analyticsParams={props.analyticsParams}
-                  />
-                  {index < nbOfSeparators ? (
-                    <StyledSeparator hasOnlyTwoOffers={hasOnlyTwoOffers} />
-                  ) : null}
-                </React.Fragment>
-              ))}
-            </StyledMultiOfferList>
-          ) : (
-            <StyledVideoMonoOfferTile
-              // @ts-expect-error: because of noUncheckedIndexedAccess
-              offer={props.offers[0]}
-              color={props.color}
-              hideModal={props.hideVideoModal}
-              analyticsParams={props.analyticsParams}
-              homeEntryId={props.homeEntryId}
-            />
-          )}
+          <StyledView>
+            <Spacer.Row numberOfSpaces={4} />
+            {props.isMultiOffer ? (
+              <StyledMultiOfferList hasOnlyTwoOffers={hasOnlyTwoOffers}>
+                {props.offers.slice(0, 3).map((offer: Offer, index) => (
+                  <React.Fragment key={offer.objectID}>
+                    <StyledHorizontalOfferTile
+                      offer={offer}
+                      onPress={props.hideVideoModal}
+                      analyticsParams={props.analyticsParams}
+                    />
+                    {index < nbOfSeparators ? (
+                      <StyledSeparator hasOnlyTwoOffers={hasOnlyTwoOffers} />
+                    ) : null}
+                  </React.Fragment>
+                ))}
+              </StyledMultiOfferList>
+            ) : (
+              <StyledVideoMonoOfferTile
+                // @ts-expect-error: because of noUncheckedIndexedAccess
+                offer={props.offers[0]}
+                color={props.color}
+                hideModal={props.hideVideoModal}
+                analyticsParams={props.analyticsParams}
+                homeEntryId={props.homeEntryId}
+              />
+            )}
+          </StyledView>
         </VideoOfferContainer>
-      </StyledWrapper>
+      </View>
     </React.Fragment>
   )
 }
 
-const StyledWrapper = styled(View)<{
-  isMultiOffer: boolean
-}>(({ isMultiOffer }) => ({
-  height:
-    (isMultiOffer ? THUMBNAIL_HEIGHT_MULTI_OFFER : THUMBNAIL_HEIGHT_MONO_OFFER) + getSpacing(6),
+const StyledView = styled.View({
+  flex: 1,
+})
+
+const BlackView = styled.View(({ theme }) => ({
+  backgroundColor: colorAlpha(theme.colors.black, 0.6),
+  height: THUMBNAIL_HEIGHT,
+  justifyContent: 'center',
 }))
 
-const VideoOfferContainer = styled.View(({ theme }) => ({
-  marginHorizontal: theme.contentPage.marginHorizontal,
+const VideoOfferContainer = styled.View<{
+  isMultiOffer: boolean
+}>(({ theme, isMultiOffer }) => ({
+  ...(isMultiOffer
+    ? { marginHorizontal: theme.contentPage.marginHorizontal }
+    : { marginLeft: theme.contentPage.marginHorizontal }),
   flexDirection: 'row',
   height: '100%',
 }))
@@ -126,68 +124,59 @@ const Thumbnail = styled(ImageBackground)(({ theme }) => ({
   overflow: 'hidden',
   borderRadius: theme.borderRadius.radius,
   flex: 1,
-  border: 1,
-  borderColor: theme.colors.greyMedium,
-  backgroundColor: theme.colors.greyLight,
 }))
 
-const DurationCaption = styled(BlackCaption)({
+const PlayerContainer = styled(View)({
   position: 'absolute',
-  top: getSpacing(2),
-  right: getSpacing(2),
+  width: '100%',
+  height: '100%',
+  justifyContent: 'center',
+  alignItems: 'center',
 })
 
-const PlayerContainer = styled(View)<{
+const ColorCategoryBackgroundWrapper = styled.View({
+  position: 'absolute',
+  left: 0,
+  height: '100%',
+  width: '100%',
+  justifyContent: 'center',
+})
+
+const ColorCategoryBackground = styled.View<{
   isMultiOffer: boolean
-}>(({ isMultiOffer }) => ({
-  ...(isMultiOffer
-    ? {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-      }
-    : { position: 'absolute', top: PLAYER_TOP_MARGIN, left: 0, right: 0, alignItems: 'center' }),
+  backgroundColor: ColorsEnum
+}>(({ isMultiOffer, backgroundColor }) => ({
+  height: COLOR_CATEGORY_BACKGROUND_HEIGHT,
+  width: isMultiOffer ? COLOR_CATEGORY_BACKGROUND_WIDTH : '100%',
+  backgroundColor,
 }))
 
-const ColorCategoryBackground = styled(LinearGradient)<{
-  isMultiOffer: boolean
-}>(({ isMultiOffer }) => ({
+const Player = styled(Play).attrs(({ theme }) => ({
+  size: PLAYER_SIZE,
+  color: theme.colors.brownLight,
+}))({})
+
+const TextContainer = styled.View({
   position: 'absolute',
   bottom: 0,
   left: 0,
-  height: GRADIENT_HEIGHT,
-  ...(isMultiOffer
-    ? {
-        width: getSpacing(144),
-        borderTopRightRadius: getSpacing(4),
-        borderBottomRightRadius: getSpacing(4),
-      }
-    : {
-        right: 0,
-      }),
-}))
+  right: 0,
+})
 
-const Player = styled(Play).attrs({ size: PLAYER_SIZE })({})
-
-const TextContainer = styled.View({ position: 'absolute', bottom: 0, left: 0, right: 0 })
-
-const BlackBackground = styled.View(({ theme }) => ({
-  padding: getSpacing(4),
-  backgroundColor: colorAlpha(theme.colors.black, TEXT_BACKGROUND_OPACITY),
-}))
-
-const VideoTitle = styled(Typo.Title4)(({ theme }) => ({
+const VideoTitle = styled(Typo.Title3)(({ theme }) => ({
   color: theme.colors.white,
-  textAlign: 'left',
+  textAlign: 'center',
+  textTransform: 'uppercase',
+  fontSize: getSpacing(6.5),
+  padding: getSpacing(4),
 }))
 
 const StyledTouchableHighlight = styled.TouchableHighlight.attrs(({ theme }) => ({
   underlayColor: theme.colors.white,
-}))<{ isMultiOffer: boolean }>(({ theme, isMultiOffer }) => ({
-  borderRadius: theme.borderRadius.radius,
-  height: isMultiOffer ? THUMBNAIL_HEIGHT_MULTI_OFFER : THUMBNAIL_HEIGHT_MONO_OFFER,
-  width: isMultiOffer ? THUMBNAIL_WIDTH_MULTI_OFFER : THUMBNAIL_WIDTH_MONO_OFFER,
-}))
+}))({
+  height: THUMBNAIL_HEIGHT,
+  width: THUMBNAIL_WIDTH,
+})
 
 const StyledTitleContainer = styled.View(({ theme }) => ({
   marginHorizontal: theme.contentPage.marginHorizontal,
@@ -195,19 +184,15 @@ const StyledTitleContainer = styled.View(({ theme }) => ({
   alignItems: 'center',
 }))
 
-const StyledTitleComponent = styled(Typo.Title3).attrs({
-  numberOfLines: 2,
-})({})
-
 const StyledVideoMonoOfferTile = styled(VideoMonoOfferTile)({
-  flex: 1,
   flexGrow: 1,
+  justifyContent: 'center',
+  marginHorizontal: getSpacing(8),
 })
 
 const StyledMultiOfferList = styled(View)<{
   hasOnlyTwoOffers: boolean
 }>(({ hasOnlyTwoOffers }) => ({
-  flex: 1,
   marginLeft: getSpacing(10),
   justifyContent: hasOnlyTwoOffers ? 'flex-start' : 'space-between',
   height: '100%',

--- a/src/features/home/components/modules/video/VideoModuleMobile.tsx
+++ b/src/features/home/components/modules/video/VideoModuleMobile.tsx
@@ -10,7 +10,7 @@ import { Play } from 'ui/svg/icons/Play'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 // eslint-disable-next-line no-restricted-imports
 import { ColorsEnum } from 'ui/theme/colors'
-import { videoModuleMobileColorsMapping } from 'ui/theme/videoModuleMobileColorsMapping'
+import { videoModuleColorsMapping } from 'ui/theme/videoModuleColorsMapping'
 
 const THUMBNAIL_HEIGHT = getSpacing(52.5)
 // We do not center the player icon, because when the title is 2-line long,
@@ -78,7 +78,7 @@ export const VideoModuleMobile: FunctionComponent<VideoModuleProps> = (props) =>
           )}
           <ColorCategoryBackground
             colorCategoryBackgroundHeightUniqueOffer={COLOR_CATEGORY_BACKGROUND_HEIGHT_MONO_OFFER}
-            backgroundColor={videoModuleMobileColorsMapping[props.color]}
+            backgroundColor={videoModuleColorsMapping[props.color]}
             isMultiOffer={props.isMultiOffer}
           />
         </View>

--- a/src/ui/theme/videoModuleColorsMapping.ts
+++ b/src/ui/theme/videoModuleColorsMapping.ts
@@ -1,7 +1,9 @@
 import { Color } from 'features/home/types'
 import { theme } from 'theme'
+// eslint-disable-next-line no-restricted-imports
+import { ColorsEnum } from 'ui/theme/colors'
 
-export const videoModuleMobileColorsMapping: Record<keyof typeof Color, string> = {
+export const videoModuleColorsMapping: Record<keyof typeof Color, ColorsEnum> = {
   Gold: theme.colors.goldLight100,
   Aquamarine: theme.colors.aquamarineLight,
   SkyBlue: theme.colors.skyBlueLight,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30074

## Checklist

I have:

- [X] Made sure my feature is working on web.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change

## Screenshots

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome | <img width="1029" alt="Capture d’écran 2024-06-14 à 11 35 15" src="https://github.com/pass-culture/pass-culture-app-native/assets/158567429/26fac027-bb96-420e-803f-c28a88d02b18"> | <img width="1026" alt="PC-30004-desktop3" src="https://github.com/pass-culture/pass-culture-app-native/assets/158567429/a904fa52-6a0d-4f09-9439-707372dd2b97"> |
| Desktop - Chrome | <img width="1028" alt="Capture d’écran 2024-06-14 à 11 36 12" src="https://github.com/pass-culture/pass-culture-app-native/assets/158567429/042bf68f-dfb1-4fd8-bc9b-35de450a9a48"> | <img width="1030" alt="PC-30004-desktop2" src="https://github.com/pass-culture/pass-culture-app-native/assets/158567429/b662142f-d8a5-408c-8116-e86495d9d879"> |
| Desktop - Chrome | <img width="1027" alt="Capture d’écran 2024-06-14 à 11 33 44" src="https://github.com/pass-culture/pass-culture-app-native/assets/158567429/b2698451-c45c-4556-98e9-9f6ac06c940c"> | <img width="1030" alt="PC-30004-desktop" src="https://github.com/pass-culture/pass-culture-app-native/assets/158567429/a6581027-8ab5-4d4a-b334-5ed441561169"> |
