### PR TITLE
(BSR) feat(ABtesting): limit AB testing for beneficiary user

### DIFF
--- a/src/features/home/components/modules/HighlightOfferModule.native.test.tsx
+++ b/src/features/home/components/modules/HighlightOfferModule.native.test.tsx
@@ -8,6 +8,7 @@ import { simulateBackend } from 'features/favorites/helpers/simulateBackend'
 import { useHighlightOffer } from 'features/home/api/useHighlightOffer'
 import { HighlightOfferModule } from 'features/home/components/modules/HighlightOfferModule'
 import { highlightOfferModuleFixture } from 'features/home/fixtures/highlightOfferModule.fixture'
+import { beneficiaryUser } from 'fixtures/user'
 import { analytics } from 'libs/analytics'
 import { REDESIGN_AB_TESTING_HOME_MODULES } from 'libs/contentful/constants'
 import * as useFeatureFlag from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
@@ -33,6 +34,7 @@ mockUseAuthContext.mockReturnValue({
   setIsLoggedIn: jest.fn(),
   refetchUser: jest.fn(),
   isUserLoading: false,
+  user: beneficiaryUser,
 })
 
 const mockFeatureFlag = jest.spyOn(useFeatureFlag, 'useFeatureFlag').mockReturnValue(false)

--- a/src/libs/contentful/useHasGraphicRedesign.native.test.ts
+++ b/src/libs/contentful/useHasGraphicRedesign.native.test.ts
@@ -1,9 +1,35 @@
+import { UserProfileResponse } from 'api/gen'
+import { IAuthContext } from 'features/auth/context/AuthContext'
+import { beneficiaryUser } from 'fixtures/user'
 import { useHasGraphicRedesign } from 'libs/contentful/useHasGraphicRedesign'
 import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
 import * as useRemoteConfigContext from 'libs/firebase/remoteConfig/RemoteConfigProvider'
 import { renderHook } from 'tests/utils'
 
 const useRemoteConfigContextSpy = jest.spyOn(useRemoteConfigContext, 'useRemoteConfigContext')
+
+const defaultAuthContext: IAuthContext = {
+  isLoggedIn: false,
+  setIsLoggedIn: jest.fn(),
+  refetchUser: jest.fn(),
+  isUserLoading: false,
+}
+
+const defaultLoggedInUser: UserProfileResponse | IAuthContext = {
+  isLoggedIn: true,
+  setIsLoggedIn: jest.fn(),
+  isUserLoading: false,
+  refetchUser: jest.fn(),
+  user: {
+    ...beneficiaryUser,
+    depositExpirationDate: `${new Date()}`,
+  },
+}
+
+let mockAuthContext = defaultAuthContext
+jest.mock('features/auth/context/AuthContext', () => ({
+  useAuthContext: jest.fn(() => mockAuthContext),
+}))
 
 describe('useHasGraphicRedesign', () => {
   describe('When shouldApplyGraphicRedesign remote config is false', () => {
@@ -12,6 +38,10 @@ describe('useHasGraphicRedesign', () => {
         ...DEFAULT_REMOTE_CONFIG,
         shouldApplyGraphicRedesign: false,
       })
+    })
+
+    beforeEach(() => {
+      mockAuthContext = defaultLoggedInUser
     })
 
     it('should return false when homeId is in REDESIGN_AB_TESTING_HOME_MODULES and isFeatureFlagActive is true', () => {
@@ -37,6 +67,16 @@ describe('useHasGraphicRedesign', () => {
 
       expect(result.current).toEqual(true)
     })
+
+    it('should return true when homeId is in REDESIGN_AB_TESTING_HOME_MODULES and isFeatureFlagActive is true and user is not beneficiary', () => {
+      mockAuthContext = defaultAuthContext
+
+      const { result } = renderHook(() =>
+        useHasGraphicRedesign({ isFeatureFlagActive: true, homeId: '4XbgmX7fVVgBMoCJiLiY9n' })
+      )
+
+      expect(result.current).toEqual(true)
+    })
   })
 
   describe('When shouldApplyGraphicRedesign remote config is true', () => {
@@ -45,6 +85,10 @@ describe('useHasGraphicRedesign', () => {
         ...DEFAULT_REMOTE_CONFIG,
         shouldApplyGraphicRedesign: true,
       })
+    })
+
+    beforeEach(() => {
+      mockAuthContext = defaultLoggedInUser
     })
 
     it('should return true when homeId is in REDESIGN_AB_TESTING_HOME_MODULES and isFeatureFlagActive is true', () => {

--- a/src/libs/contentful/useHasGraphicRedesign.ts
+++ b/src/libs/contentful/useHasGraphicRedesign.ts
@@ -11,10 +11,11 @@ export const useHasGraphicRedesign = ({ isFeatureFlagActive, homeId }: Props) =>
   const { user } = useAuthContext()
 
   const { shouldApplyGraphicRedesign } = useRemoteConfigContext()
-  const hasGraphicRedesign =
+
+  const userShouldSeeGraphicRedesign =
     REDESIGN_AB_TESTING_HOME_MODULES.includes(homeId) && user?.isBeneficiary
       ? isFeatureFlagActive && shouldApplyGraphicRedesign
       : isFeatureFlagActive
 
-  return hasGraphicRedesign
+  return userShouldSeeGraphicRedesign
 }

--- a/src/libs/contentful/useHasGraphicRedesign.ts
+++ b/src/libs/contentful/useHasGraphicRedesign.ts
@@ -1,3 +1,4 @@
+import { useAuthContext } from 'features/auth/context/AuthContext'
 import { REDESIGN_AB_TESTING_HOME_MODULES } from 'libs/contentful/constants'
 import { useRemoteConfigContext } from 'libs/firebase/remoteConfig'
 
@@ -7,10 +8,13 @@ type Props = {
 }
 
 export const useHasGraphicRedesign = ({ isFeatureFlagActive, homeId }: Props) => {
+  const { user } = useAuthContext()
+
   const { shouldApplyGraphicRedesign } = useRemoteConfigContext()
-  const hasGraphicRedesign = REDESIGN_AB_TESTING_HOME_MODULES.includes(homeId)
-    ? isFeatureFlagActive && shouldApplyGraphicRedesign
-    : isFeatureFlagActive
+  const hasGraphicRedesign =
+    REDESIGN_AB_TESTING_HOME_MODULES.includes(homeId) && user?.isBeneficiary
+      ? isFeatureFlagActive && shouldApplyGraphicRedesign
+      : isFeatureFlagActive
 
   return hasGraphicRedesign
 }


### PR DESCRIPTION
The 18 post first booking home is the same as the public one, we add a check to limit the AB testing to beneficiary user

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
