### PR TITLE
(PC-30362) fix(offer): not display Oups page when similar offers API not respond on offer page

### DIFF
--- a/src/features/offer/api/useSimilarOffers.native.test.ts
+++ b/src/features/offer/api/useSimilarOffers.native.test.ts
@@ -34,110 +34,138 @@ const fetchApiRecoSpy = jest.spyOn(global, 'fetch')
 jest.spyOn(PackageJson, 'getAppVersion').mockReturnValue('1.10.5')
 
 describe('useSimilarOffers', () => {
-  beforeEach(() => {
-    mockServer.getApi<SimilarOffersResponse>(`/v1/recommendation/similar_offers/${mockOfferId}`, {
-      params: {},
-      results: [],
+  describe('When success API response', () => {
+    beforeEach(() => {
+      mockServer.getApi<SimilarOffersResponse>(`/v1/recommendation/similar_offers/${mockOfferId}`, {
+        params: {},
+        results: [],
+      })
     })
-  })
 
-  it('should call Algolia hook with category included', async () => {
-    renderHook(
-      () =>
-        useSimilarOffers({
-          offerId: mockOfferId,
-          position,
-          categoryIncluded: SearchGroupNameEnumv2.FILMS_SERIES_CINEMA,
-        }),
-      {
-        wrapper: ({ children }) => reactQueryProviderHOC(children),
-      }
-    )
-    await waitFor(() => {
-      expect(algoliaSpy).toHaveBeenCalledTimes(1)
-    })
-  })
-
-  it('should call Algolia hook with category excluded', async () => {
-    renderHook(
-      () =>
-        useSimilarOffers({
-          offerId: mockOfferId,
-          position,
-          categoryExcluded: SearchGroupNameEnumv2.FILMS_SERIES_CINEMA,
-        }),
-      {
-        wrapper: ({ children }) => reactQueryProviderHOC(children),
-      }
-    )
-    await waitFor(() => {
-      expect(algoliaSpy).toHaveBeenCalledTimes(1)
-    })
-  })
-
-  it('should call similar offers API when offer id provided and user share his position', async () => {
-    renderHook(
-      () =>
-        useSimilarOffers({
-          offerId: mockOfferId,
-          categoryIncluded: SearchGroupNameEnumv2.FILMS_SERIES_CINEMA,
-          position: { latitude: 10, longitude: 15 },
-        }),
-      {
-        wrapper: ({ children }) => reactQueryProviderHOC(children),
-      }
-    )
-
-    await waitFor(() => {
-      expect(fetchApiRecoSpy).toHaveBeenNthCalledWith(
-        1,
-        `${env.API_BASE_URL}/native/v1/recommendation/similar_offers/1?longitude=15&latitude=10&categories=FILMS_SERIES_CINEMA`,
+    it('should call Algolia hook with category included', async () => {
+      renderHook(
+        () =>
+          useSimilarOffers({
+            offerId: mockOfferId,
+            position,
+            categoryIncluded: SearchGroupNameEnumv2.FILMS_SERIES_CINEMA,
+          }),
         {
-          credentials: 'omit',
-          headers: {
-            'app-version': '1.10.5',
-            'code-push-id': 'abel',
-            'commit-hash': '13371337',
-            'device-id': 'ad7b7b5a169641e27cadbdb35adad9c4ca23099a',
-            platform: 'ios',
-            'request-id': 'testUuidV4',
-          },
-          method: 'GET',
+          wrapper: ({ children }) => reactQueryProviderHOC(children),
         }
       )
+      await waitFor(() => {
+        expect(algoliaSpy).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    it('should call Algolia hook with category excluded', async () => {
+      renderHook(
+        () =>
+          useSimilarOffers({
+            offerId: mockOfferId,
+            position,
+            categoryExcluded: SearchGroupNameEnumv2.FILMS_SERIES_CINEMA,
+          }),
+        {
+          wrapper: ({ children }) => reactQueryProviderHOC(children),
+        }
+      )
+      await waitFor(() => {
+        expect(algoliaSpy).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    it('should call similar offers API when offer id provided and user share his position', async () => {
+      renderHook(
+        () =>
+          useSimilarOffers({
+            offerId: mockOfferId,
+            categoryIncluded: SearchGroupNameEnumv2.FILMS_SERIES_CINEMA,
+            position: { latitude: 10, longitude: 15 },
+          }),
+        {
+          wrapper: ({ children }) => reactQueryProviderHOC(children),
+        }
+      )
+
+      await waitFor(() => {
+        expect(fetchApiRecoSpy).toHaveBeenNthCalledWith(
+          1,
+          `${env.API_BASE_URL}/native/v1/recommendation/similar_offers/1?longitude=15&latitude=10&categories=FILMS_SERIES_CINEMA`,
+          {
+            credentials: 'omit',
+            headers: {
+              'app-version': '1.10.5',
+              'code-push-id': 'abel',
+              'commit-hash': '13371337',
+              'device-id': 'ad7b7b5a169641e27cadbdb35adad9c4ca23099a',
+              platform: 'ios',
+              'request-id': 'testUuidV4',
+            },
+            method: 'GET',
+          }
+        )
+      })
+    })
+
+    it('should call similar offers API when offer id provided and user not share his position', async () => {
+      renderHook(
+        () =>
+          useSimilarOffers({
+            offerId: mockOfferId,
+            categoryIncluded: SearchGroupNameEnumv2.FILMS_SERIES_CINEMA,
+            position: null,
+          }),
+        {
+          wrapper: ({ children }) => reactQueryProviderHOC(children),
+        }
+      )
+
+      await waitFor(() => {
+        expect(fetchApiRecoSpy).toHaveBeenNthCalledWith(
+          1,
+          `${env.API_BASE_URL}/native/v1/recommendation/similar_offers/1?categories=FILMS_SERIES_CINEMA`,
+          {
+            credentials: 'omit',
+            headers: {
+              'app-version': '1.10.5',
+              'code-push-id': 'abel',
+              'commit-hash': '13371337',
+              'device-id': 'ad7b7b5a169641e27cadbdb35adad9c4ca23099a',
+              platform: 'ios',
+              'request-id': 'testUuidV4',
+            },
+            method: 'GET',
+          }
+        )
+      })
     })
   })
 
-  it('should call similar offers API when offer id provided and user not share his position', async () => {
-    renderHook(
-      () =>
-        useSimilarOffers({
-          offerId: mockOfferId,
-          categoryIncluded: SearchGroupNameEnumv2.FILMS_SERIES_CINEMA,
-          position: null,
-        }),
-      {
-        wrapper: ({ children }) => reactQueryProviderHOC(children),
-      }
-    )
+  describe('When error API response', () => {
+    beforeEach(() => {
+      mockServer.getApi<SimilarOffersResponse>(`/v1/recommendation/similar_offers/${mockOfferId}`, {
+        responseOptions: { statusCode: 503 },
+      })
+    })
 
-    await waitFor(() => {
-      expect(fetchApiRecoSpy).toHaveBeenNthCalledWith(
-        1,
-        `${env.API_BASE_URL}/native/v1/recommendation/similar_offers/1?categories=FILMS_SERIES_CINEMA`,
+    it('should return empty params and undefined similar offers when fetch similar offers call fails', async () => {
+      const { result } = renderHook(
+        () =>
+          useSimilarOffers({
+            offerId: mockOfferId,
+            categoryIncluded: SearchGroupNameEnumv2.FILMS_SERIES_CINEMA,
+            position: null,
+          }),
         {
-          credentials: 'omit',
-          headers: {
-            'app-version': '1.10.5',
-            'code-push-id': 'abel',
-            'commit-hash': '13371337',
-            'device-id': 'ad7b7b5a169641e27cadbdb35adad9c4ca23099a',
-            platform: 'ios',
-            'request-id': 'testUuidV4',
-          },
-          method: 'GET',
+          wrapper: ({ children }) => reactQueryProviderHOC(children),
         }
       )
+
+      await waitFor(() => {
+        expect(result.current).toEqual({ apiRecoParams: {}, similarOffers: undefined })
+      })
     })
   })
 })

--- a/src/features/offer/api/useSimilarOffers.ts
+++ b/src/features/offer/api/useSimilarOffers.ts
@@ -58,14 +58,21 @@ export const useSimilarOffers = ({
 
   const { data: apiRecoResponse } = useQuery(
     [QueryKeys.SIMILAR_OFFERS, offerId, position, categories],
-    () =>
-      api.getNativeV1RecommendationSimilarOffersofferId(
-        offerId,
-        position?.longitude,
-        position?.latitude,
-        categories
-      ),
-    { enabled: !!categories }
+    async () => {
+      try {
+        return await api.getNativeV1RecommendationSimilarOffersofferId(
+          offerId,
+          position?.longitude,
+          position?.latitude,
+          categories
+        )
+      } catch (err) {
+        return { params: {}, results: [] }
+      }
+    },
+    {
+      enabled: !!categories,
+    }
   )
 
   return {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30362

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
