### PR TITLE
(PC-28774) feat(venue): Fix accessibility for opening hours

### DIFF
--- a/src/features/venue/components/OpeningHours/OpeningHours.native.test.tsx
+++ b/src/features/venue/components/OpeningHours/OpeningHours.native.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import { venueWithOpeningHours } from 'features/venue/fixtures/venueWithOpeningHours'
+import { render, screen } from 'tests/utils'
+
+import { OpeningHours } from './OpeningHours'
+
+describe('OpeningHours', () => {
+  it('should return opening hours accessibility label with one time slot', () => {
+    render(<OpeningHours openingHours={venueWithOpeningHours.openingHours} />)
+
+    const mondayOpeningHoursAccessibilityLabel = screen.getByLabelText('Lundi 09:00 - 19:00')
+
+    expect(mondayOpeningHoursAccessibilityLabel).toBeOnTheScreen()
+  })
+
+  it('should return opening hours accessibility label with two time slots', () => {
+    render(<OpeningHours openingHours={venueWithOpeningHours.openingHours} />)
+
+    const tuesdayOpeningHoursAccessibilityLabel = screen.getByLabelText(
+      'Mardi 09:00 - 12:00 puis 14:00 - 19:00'
+    )
+
+    expect(tuesdayOpeningHoursAccessibilityLabel).toBeOnTheScreen()
+  })
+})

--- a/src/features/venue/components/OpeningHours/OpeningHours.tsx
+++ b/src/features/venue/components/OpeningHours/OpeningHours.tsx
@@ -1,6 +1,8 @@
 import React, { FC } from 'react'
 import styled from 'styled-components/native'
 
+import { Li } from 'ui/components/Li'
+import { VerticalUl } from 'ui/components/Ul'
 import { Typo } from 'ui/theme'
 
 import { OpeningHours as OpeningHoursType, getOpeningHours } from './getOpeningHours'
@@ -10,23 +12,26 @@ type Props = { openingHours: OpeningHoursType }
 export const OpeningHours: FC<Props> = ({ openingHours }) => {
   const { days } = getOpeningHours(openingHours)
   return (
-    <Container>
+    <StyledVerticalUl>
       {days.map((day) => (
-        <DayWrapper key={day.label}>
-          <Typo.Body>{day.label}</Typo.Body>
-          <Typo.Body>{day.hours}</Typo.Body>
-        </DayWrapper>
+        <StyledLi
+          key={day.label}
+          accessibilityLabel={`${day.label} ${day.hours.replace('/', ' puis ')}`}>
+          <Typo.Body accessibilityHidden>{day.label}</Typo.Body>
+          <Typo.Body accessibilityHidden>{day.hours}</Typo.Body>
+        </StyledLi>
       ))}
-    </Container>
+    </StyledVerticalUl>
   )
 }
 
-const Container = styled.View({
+const StyledVerticalUl = styled(VerticalUl)({
   display: 'flex',
   flexDirection: 'column',
   gap: 8,
 })
 
-const DayWrapper = styled.View({
+const StyledLi = styled(Li)({
+  display: 'flex',
   gap: 4,
 })

--- a/src/features/venue/components/PracticalInformation/PracticalInformation.native.test.tsx
+++ b/src/features/venue/components/PracticalInformation/PracticalInformation.native.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { PracticalInformation } from 'features/venue/components/PracticalInformation/PracticalInformation'
 import { venueResponseSnap } from 'features/venue/fixtures/venueResponseSnap'
+import { venueWithOpeningHours } from 'features/venue/fixtures/venueWithOpeningHours'
 import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, screen } from 'tests/utils'
@@ -127,33 +128,7 @@ describe('PracticalInformation', () => {
   })
 
   it('should display opening hours section', async () => {
-    render(
-      reactQueryProviderHOC(
-        <PracticalInformation
-          venue={{
-            ...venueResponseSnap,
-            openingHours: {
-              MONDAY: [{ open: '10:00', close: '20:00' }],
-              TUESDAY: [
-                { open: '10:00', close: '12:00' },
-                { open: '14:00', close: '20:00' },
-              ],
-              WEDNESDAY: [
-                { open: '10:00', close: '12:00' },
-                { open: '14:00', close: '20:00' },
-              ],
-              THURSDAY: [
-                { open: '10:00', close: '12:00' },
-                { open: '14:00', close: '20:00' },
-              ],
-              FRIDAY: undefined,
-              SATURDAY: [{ open: '09:00', close: '20:00' }],
-              SUNDAY: undefined,
-            },
-          }}
-        />
-      )
-    )
+    render(reactQueryProviderHOC(<PracticalInformation venue={venueWithOpeningHours} />))
 
     expect(screen.getByText('Horaires d’ouverture')).toBeOnTheScreen()
   })

--- a/src/features/venue/components/VenueTopComponent/VenueTopComponent.native.test.tsx
+++ b/src/features/venue/components/VenueTopComponent/VenueTopComponent.native.test.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { VenueResponse, VenueTypeCodeKey } from 'api/gen'
 import { VenueTopComponent } from 'features/venue/components/VenueTopComponent/VenueTopComponent'
 import { venueResponseSnap } from 'features/venue/fixtures/venueResponseSnap'
+import { venueWithOpeningHours } from 'features/venue/fixtures/venueWithOpeningHours'
 import { analytics } from 'libs/analytics'
 import * as useFeatureFlag from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { ILocationContext, useLocation } from 'libs/location'
@@ -89,39 +90,13 @@ describe('<VenueTopComponent />', () => {
     mockdate.set(new Date('2024-05-31T08:31:00'))
     jest.spyOn(useFeatureFlag, 'useFeatureFlag').mockReturnValueOnce(true)
 
-    const venue = {
-      ...venueResponseSnap,
-      openingHours: {
-        MONDAY: [{ open: '09:00', close: '19:00' }],
-        TUESDAY: [{ open: '09:00', close: '19:00' }],
-        WEDNESDAY: [{ open: '09:00', close: '19:00' }],
-        THURSDAY: [{ open: '09:00', close: '19:00' }],
-        FRIDAY: [{ open: '09:00', close: '19:00' }],
-        SATURDAY: [],
-        SUNDAY: [],
-      },
-    }
-
-    render(reactQueryProviderHOC(<VenueTopComponent venue={venue} />))
+    render(reactQueryProviderHOC(<VenueTopComponent venue={venueWithOpeningHours} />))
 
     expect(screen.getByText('Ouvre bientôt - 9h')).toBeOnTheScreen()
   })
 
   it('should NOT render dynamics opening hours when feature flag is disabled', async () => {
-    const venue = {
-      ...venueResponseSnap,
-      openingHours: {
-        MONDAY: [{ open: '09:00', close: '19:00' }],
-        TUESDAY: [{ open: '09:00', close: '19:00' }],
-        WEDNESDAY: [{ open: '09:00', close: '19:00' }],
-        THURSDAY: [{ open: '09:00', close: '19:00' }],
-        FRIDAY: [{ open: '09:00', close: '19:00' }],
-        SATURDAY: [],
-        SUNDAY: [],
-      },
-    }
-
-    render(reactQueryProviderHOC(<VenueTopComponent venue={venue} />))
+    render(reactQueryProviderHOC(<VenueTopComponent venue={venueWithOpeningHours} />))
 
     expect(screen.queryByText('Fermé')).not.toBeOnTheScreen()
   })

--- a/src/features/venue/fixtures/venueWithOpeningHours.ts
+++ b/src/features/venue/fixtures/venueWithOpeningHours.ts
@@ -1,0 +1,24 @@
+import { VenueResponse } from 'api/gen'
+import { venueResponseSnap } from 'features/venue/fixtures/venueResponseSnap'
+
+export const venueWithOpeningHours: VenueResponse = {
+  ...venueResponseSnap,
+  openingHours: {
+    MONDAY: [{ open: '09:00', close: '19:00' }],
+    TUESDAY: [
+      { open: '09:00', close: '12:00' },
+      { open: '14:00', close: '19:00' },
+    ],
+    WEDNESDAY: [
+      { open: '09:00', close: '12:00' },
+      { open: '14:00', close: '19:00' },
+    ],
+    THURSDAY: [
+      { open: '09:00', close: '12:00' },
+      { open: '14:00', close: '19:00' },
+    ],
+    FRIDAY: [{ open: '09:00', close: '19:00' }],
+    SATURDAY: undefined,
+    SUNDAY: undefined,
+  },
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28774

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Sans Zoom 200% | Avec Zoom 200% |
| :--------------- | :-----------: | :---: |
| iOS              |  <img width="478" alt="Capture d’écran 2024-06-21 à 15 47 01" src="https://github.com/pass-culture/pass-culture-app-native/assets/62059034/1a2d0d00-760c-4ac1-a4b9-e3043b2da3b6"> <img width="474" alt="Capture d’écran 2024-06-21 à 14 17 04" src="https://github.com/pass-culture/pass-culture-app-native/assets/62059034/6e9bc2fe-f9ee-4630-9064-136fd78ad7b1">  |  <img width="477" alt="Capture d’écran 2024-06-21 à 14 26 04" src="https://github.com/pass-culture/pass-culture-app-native/assets/62059034/2da9f739-b4f2-400a-af7d-307717ead065"> <img width="472" alt="Capture d’écran 2024-06-21 à 14 25 20" src="https://github.com/pass-culture/pass-culture-app-native/assets/62059034/1ad23dda-8196-4c64-ace9-aab5fc885952"> |
| Desktop - Chrome | <img width="1728" alt="Capture d’écran 2024-06-21 à 14 41 26" src="https://github.com/pass-culture/pass-culture-app-native/assets/62059034/9435ebc5-3e88-40a8-accd-880b488a116f">  <img width="1678" alt="Capture d’écran 2024-06-21 à 14 17 46" src="https://github.com/pass-culture/pass-culture-app-native/assets/62059034/e27e7269-6f44-4903-aa0e-9f37e57f863c"> | <img width="1728" alt="Capture d’écran 2024-06-21 à 14 25 52" src="https://github.com/pass-culture/pass-culture-app-native/assets/62059034/f6f51fab-66ac-496c-995f-9637de4073d4"> <img width="1728" alt="Capture d’écran 2024-06-21 à 14 25 44" src="https://github.com/pass-culture/pass-culture-app-native/assets/62059034/2bd7a51d-5192-451c-b6c6-cd9c0a3b8f95"> |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
