### PR TITLE
(PC-30445) fix(MarketingBlockExclusivity): add homeEntryId to tracking

### DIFF
--- a/src/features/home/components/modules/HighlightOfferModule.tsx
+++ b/src/features/home/components/modules/HighlightOfferModule.tsx
@@ -96,6 +96,7 @@ const UnmemoizedHighlightOfferModule = (props: HighlightOfferModuleProps) => {
       {hasGraphicRedesign ? (
         <MarketingBlockExclusivity
           offerId={parseInt(highlightOfferId)}
+          homeEntryId={homeEntryId}
           moduleId={props.id}
           title={highlightOffer.offer.name || ''}
           categoryId={categoryId}

--- a/src/features/home/components/modules/marketing/MarketingBlockExclusivity.native.test.tsx
+++ b/src/features/home/components/modules/marketing/MarketingBlockExclusivity.native.test.tsx
@@ -47,7 +47,7 @@ describe('MarketingBlockExclusivity', () => {
   })
 
   it('should log consult offer when pressed', () => {
-    render(<MarketingBlockExclusivity {...props} />)
+    render(<MarketingBlockExclusivity {...props} homeEntryId="fakeEntryId" />)
 
     const titlelink = screen.getByText('Harry Potter et l’Ordre du Phénix')
     fireEvent.press(titlelink)
@@ -55,6 +55,7 @@ describe('MarketingBlockExclusivity', () => {
     expect(analytics.logConsultOffer).toHaveBeenCalledWith({
       from: 'home',
       moduleId: '1',
+      homeEntryId: 'fakeEntryId',
       moduleName: 'Harry Potter et l’Ordre du Phénix',
       offerId: 123,
     })

--- a/src/features/home/components/modules/marketing/MarketingBlockExclusivity.tsx
+++ b/src/features/home/components/modules/marketing/MarketingBlockExclusivity.tsx
@@ -9,6 +9,7 @@ import { OfferLocation } from 'shared/offer/types'
 type AttachedOfferCardProps = {
   title: string
   moduleId: string
+  homeEntryId?: string
   categoryId: CategoryIdEnum
   offerId: number
   backgroundImageUrl: string
@@ -21,6 +22,7 @@ type AttachedOfferCardProps = {
 const UnmemoizedMarketingBlockExclusivity = ({
   title,
   moduleId,
+  homeEntryId,
   categoryId,
   offerId,
   backgroundImageUrl,
@@ -33,7 +35,7 @@ const UnmemoizedMarketingBlockExclusivity = ({
   const accessibilityLabel = `Découvre l’offre exclusive "${title}" de la catégorie "${categoryText}" au prix de ${price}. L’offre se trouve à ${distanceToOffer}`
 
   const logConsultOffer = () => {
-    analytics.logConsultOffer({ offerId, from: 'home', moduleName: title, moduleId })
+    analytics.logConsultOffer({ offerId, from: 'home', moduleName: title, moduleId, homeEntryId })
   }
 
   return (


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30445

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
