### PR TITLE
(PC-30586) fix(location): keep locationFilter on "Recherche" press in the tabBar

### DIFF
--- a/src/features/navigation/TabBar/TabBar.tsx
+++ b/src/features/navigation/TabBar/TabBar.tsx
@@ -64,6 +64,7 @@ export const TabBar: React.FC<Props> = ({ navigation, state }) => {
                   params: {
                     ...initialSearchState,
                     accessibilityFilter: defaultDisabilitiesProperties,
+                    locationFilter,
                   },
                 }
               } else {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30586

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<video src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/29a4d094-8047-4811-9d45-2e768a41de23"/>|<video src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/c579eae8-d5eb-47f7-a746-76d19d1cb3ff"/>|
