### PR TITLE
(PC-30515) feat(analytics): add video paused analytics params and round durations

### DIFF
--- a/src/features/home/components/modules/video/VerticalVideoPlayer.tsx
+++ b/src/features/home/components/modules/video/VerticalVideoPlayer.tsx
@@ -43,6 +43,7 @@ export interface VideoPlayerProps {
   hasFinishedPlaying: boolean
   setHasFinishedPlaying: React.Dispatch<React.SetStateAction<boolean>>
   moduleId: string
+  homeEntryId: string
 }
 
 export const VerticalVideoPlayer: React.FC<VideoPlayerProps> = ({
@@ -54,6 +55,7 @@ export const VerticalVideoPlayer: React.FC<VideoPlayerProps> = ({
   hasFinishedPlaying,
   setHasFinishedPlaying,
   moduleId,
+  homeEntryId,
 }) => {
   const {
     isMuted,
@@ -75,6 +77,7 @@ export const VerticalVideoPlayer: React.FC<VideoPlayerProps> = ({
     setHasFinishedPlaying,
     moduleId,
     currentVideoId: videoSources[currentIndex],
+    homeEntryId,
   })
 
   const { isDesktopViewport } = useTheme()

--- a/src/features/home/components/modules/video/VideoCarouselModule.tsx
+++ b/src/features/home/components/modules/video/VideoCarouselModule.tsx
@@ -184,6 +184,7 @@ export const VideoCarouselModule: FunctionComponent<VideoCarouselModuleBaseProps
         hasFinishedPlaying={hasFinishedPlaying}
         setHasFinishedPlaying={setHasFinishedPlaying}
         moduleId={id}
+        homeEntryId={homeEntryId}
       />
       <ColoredAttachedTileContainer color={color}>
         {itemsWithRelatedData.length > 1 ? (

--- a/src/features/home/components/modules/video/useVerticalVideoPlayer.native.test.ts
+++ b/src/features/home/components/modules/video/useVerticalVideoPlayer.native.test.ts
@@ -1,0 +1,30 @@
+import { useVerticalVideoPlayer } from 'features/home/components/modules/video/useVerticalVideoPlayer'
+import { analytics } from 'libs/analytics'
+import { renderHook, waitFor } from 'tests/utils'
+
+const mockProps = {
+  isPlaying: true,
+  setIsPlaying: jest.fn(),
+  setHasFinishedPlaying: jest.fn(),
+  moduleId: '123456',
+  currentVideoId: 'TEST_ID_VIDEO',
+  homeEntryId: '123456',
+}
+
+describe('useVerticalVideoPlayer', () => {
+  it('should log videoPaused when video was playing and togglePlay is called', async () => {
+    const { result } = renderHook(() => useVerticalVideoPlayer(mockProps))
+
+    result.current.togglePlay()
+
+    await waitFor(() => {
+      expect(analytics.logVideoPaused).toHaveBeenNthCalledWith(1, {
+        videoDuration: 0,
+        seenDuration: 0,
+        youtubeId: mockProps.currentVideoId,
+        homeEntryId: mockProps.homeEntryId,
+        moduleId: mockProps.moduleId,
+      })
+    })
+  })
+})

--- a/src/features/home/components/modules/video/useVerticalVideoPlayer.ts
+++ b/src/features/home/components/modules/video/useVerticalVideoPlayer.ts
@@ -88,8 +88,8 @@ export const useVerticalVideoPlayer = ({
   const logPausedVideo = async () => {
     const videoDuration = await getVideoDuration()
     analytics.logVideoPaused({
-      videoDuration,
-      seenDuration: videoDuration ? elapsed * videoDuration : 0,
+      videoDuration: videoDuration ? Math.round(videoDuration) : 0,
+      seenDuration: videoDuration ? Math.round(elapsed * videoDuration) : 0,
       youtubeId: currentVideoId,
       homeEntryId,
       moduleId,

--- a/src/features/home/components/modules/video/useVerticalVideoPlayer.ts
+++ b/src/features/home/components/modules/video/useVerticalVideoPlayer.ts
@@ -18,6 +18,7 @@ type Props = {
   setHasFinishedPlaying: React.Dispatch<React.SetStateAction<boolean>>
   moduleId: string
   currentVideoId?: string
+  homeEntryId: string
 }
 
 export const useVerticalVideoPlayer = ({
@@ -26,6 +27,7 @@ export const useVerticalVideoPlayer = ({
   setHasFinishedPlaying,
   moduleId,
   currentVideoId,
+  homeEntryId,
 }: Props) => {
   const [isMuted, setIsMuted] = useState(true)
   const [elapsed, setElapsed] = useState(0)
@@ -89,6 +91,8 @@ export const useVerticalVideoPlayer = ({
       videoDuration,
       seenDuration: videoDuration ? elapsed * videoDuration : 0,
       youtubeId: currentVideoId,
+      homeEntryId,
+      moduleId,
     })
   }
 

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -697,6 +697,11 @@ export const logEventAnalytics = {
     analytics.logEvent({ firebase: AnalyticsEvent.VENUE_SEE_ALL_OFFERS_CLICKED }, { venueId }),
   logVenueSeeMoreClicked: (venueId: number) =>
     analytics.logEvent({ firebase: AnalyticsEvent.VENUE_SEE_MORE_CLICKED }, { venueId }),
-  logVideoPaused: (params: { videoDuration?: number; seenDuration: number; youtubeId?: string }) =>
-    analytics.logEvent({ firebase: AnalyticsEvent.VIDEO_PAUSED }, params),
+  logVideoPaused: (params: {
+    videoDuration?: number
+    seenDuration: number
+    youtubeId?: string
+    homeEntryId: string
+    moduleId: string
+  }) => analytics.logEvent({ firebase: AnalyticsEvent.VIDEO_PAUSED }, params),
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30515

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Result |
| :--------------- | :-----------: |
| iOS              |<img width="635" alt="Capture d’écran 2024-07-01 à 11 21 08" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/5856d2b6-1e71-4917-94e6-3d6771055148">|
