### PR TITLE
(BSR) fix(analytics): make sure ConsultVideo is logged on first video autoplay

### DIFF
--- a/src/features/home/components/modules/video/VideoCarouselModule.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoCarouselModule.native.test.tsx
@@ -33,11 +33,6 @@ const DEFAULT_ITEM_WITH_HOME_ENTRY_ID = videoCarouselModuleFixture.items[2]
 const MOCKED_ALGOLIA_RESPONSE_OFFER = mockedAlgoliaResponse.hits[0]
 
 describe('<VideoCarouselModule />', () => {
-  beforeEach(() => {
-    MockedYouTubePlayer.setPlayerState(PlayerState.UNSTARTED)
-    MockedYouTubePlayer.setError(false)
-  })
-
   it('should call fetchCarouselVideoOffers with properly formatted data', async () => {
     renderVideoCarouselModule(videoCarouselModuleFixture)
 
@@ -158,6 +153,19 @@ describe('<VideoCarouselModule />', () => {
   })
 
   describe('tracking', () => {
+    it('should send logConsultVideo when video starts autoplay', async () => {
+      renderVideoCarouselModule(videoCarouselModuleFixture)
+
+      await screen.findByText(MOCKED_ALGOLIA_RESPONSE_OFFER.offer.name)
+
+      expect(analytics.logConsultVideo).toHaveBeenNthCalledWith(1, {
+        from: 'video_carousel_block',
+        moduleId: videoCarouselModuleFixture.id,
+        homeEntryId: videoCarouselModuleFixture.homeEntryId,
+        youtubeId: videoCarouselModuleFixture.items[2].youtubeVideoId,
+      })
+    })
+
     it('should send logConsultVideo event when user presses `next video button`', async () => {
       MockedYouTubePlayer.setPlayerState(PlayerState.ENDED)
 
@@ -176,7 +184,7 @@ describe('<VideoCarouselModule />', () => {
       })
     })
 
-    it('should send logConsultVideo event when user presses on offer', async () => {
+    it('should send logConsultOffer event when user presses on offer', async () => {
       const OFFER_NAME = MOCKED_ALGOLIA_RESPONSE_OFFER.offer.name
       const OFFER_ID = MOCKED_ALGOLIA_RESPONSE_OFFER.objectID
 

--- a/src/features/home/components/modules/video/VideoCarouselModule.tsx
+++ b/src/features/home/components/modules/video/VideoCarouselModule.tsx
@@ -85,7 +85,7 @@ export const VideoCarouselModule: FunctionComponent<VideoCarouselModuleBaseProps
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentIndex])
+  }, [currentIndex, shouldModuleBeDisplayed])
 
   const playNextVideo = () => {
     let nextIndex


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Result |
| :--------------- | :-----------: |
| iOS              |<img width="639" alt="Capture d’écran 2024-07-04 à 17 16 49" src="https://github.com/pass-culture/pass-culture-app-native/assets/47600889/81cf3889-63e5-4f84-bee5-e46b1a2d7701">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
