### PR TITLE
(PC-30709) fix(home): add only call_id from api reco params for ModuleDisplayedOnHomepage log

### DIFF
--- a/src/features/home/components/modules/RecommendationModule.native.test.tsx
+++ b/src/features/home/components/modules/RecommendationModule.native.test.tsx
@@ -44,7 +44,7 @@ describe('RecommendationModule', () => {
 
     await waitFor(() => {
       expect(analytics.logModuleDisplayedOnHomepage).toHaveBeenNthCalledWith(1, {
-        ...defaultRecommendationApiParams,
+        call_id: '1',
         moduleId: 'abcd',
         moduleType: ContentTypes.RECOMMENDATION,
         index: 1,

--- a/src/features/home/components/modules/RecommendationModule.tsx
+++ b/src/features/home/components/modules/RecommendationModule.tsx
@@ -50,7 +50,7 @@ export const RecommendationModule = (props: RecommendationModuleProps) => {
   useEffect(() => {
     if (shouldModuleBeDisplayed) {
       analytics.logModuleDisplayedOnHomepage({
-        ...recommendationApiParams,
+        call_id: recommendationApiParams?.call_id,
         moduleId,
         moduleType: ContentTypes.RECOMMENDATION,
         index,

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -416,14 +416,14 @@ export const logEventAnalytics = {
     moduleType: ContentTypes
     index: number
     homeEntryId: string | undefined
-    apiRecoParams?: RecommendationApiParams
+    call_id?: string | null
     offers?: string[]
     venues?: string[]
   }) =>
     analytics.logEvent(
       { firebase: AnalyticsEvent.MODULE_DISPLAYED_ON_HOMEPAGE },
       {
-        ...params.apiRecoParams,
+        call_id: params.call_id,
         homeEntryId: params.homeEntryId,
         index: params.index,
         moduleId: params.moduleId,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30709

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
