### PR TITLE
(PC-28937) feat(GetOpeningHoursStatus): Add timezone to dynamic open status

### DIFF
--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -5767,6 +5767,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                             },
                             "postalCode": "75000",
                             "publicName": "Le Petit Rintintin 1",
+                            "timezone": "UTC",
                             "venueTypeCode": "BOOKSTORE",
                             "withdrawalDetails": "How to withdraw, https://test.com",
                           }
@@ -6538,6 +6539,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                                 },
                                 "postalCode": "75000",
                                 "publicName": "Le Petit Rintintin 1",
+                                "timezone": "UTC",
                                 "venueTypeCode": "BOOKSTORE",
                                 "withdrawalDetails": "How to withdraw, https://test.com",
                               }

--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -99,7 +99,7 @@
 ./src/features/search/helpers/useSortedSearchCategories/useSortedSearchCategories.native.test.ts:37
 ./src/features/search/pages/SuggestedPlacesOrVenues/SuggestedVenues.native.test.tsx:37
 ./src/features/search/pages/modals/CategoriesModal/CategoriesModal.tsx:121
-./src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.native.test.tsx:48
+./src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.native.test.tsx:68
 ./src/features/venue/components/TabLayout/useTabArrowNavigation.web.ts:24
 ./src/features/venueMap/store/selectedVenueStore.native.test.ts:20
 ./src/features/venueMap/store/selectedVenueStore.native.test.ts:31

--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -4026,6 +4026,11 @@ export interface VenueResponse {
    */
   publicName?: string | null
   /**
+   * @type {string}
+   * @memberof VenueResponse
+   */
+  timezone: string
+  /**
    * @type {VenueTypeCodeKey}
    * @memberof VenueResponse
    */

--- a/src/features/gtlPlaylist/hooks/useGTLPlaylists.native.test.ts
+++ b/src/features/gtlPlaylist/hooks/useGTLPlaylists.native.test.ts
@@ -18,6 +18,7 @@ const venue: VenueResponse = {
   id: 123,
   isVirtual: false,
   accessibility: {},
+  timezone: 'Europe/Paris',
 }
 const mockLocationMode = LocationMode.AROUND_ME
 const mockUserLocation: Position = { latitude: 2, longitude: 2 }

--- a/src/features/home/components/modules/venues/VenueTile.tsx
+++ b/src/features/home/components/modules/venues/VenueTile.tsx
@@ -35,6 +35,7 @@ const mergeVenueData =
   (prevData: VenueResponse | undefined): VenueResponse => ({
     ...venueHit,
     isVirtual: false,
+    timezone: '',
     ...(prevData ?? {}),
   })
 

--- a/src/features/offer/components/OfferPlace/OfferPlace.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.tsx
@@ -48,6 +48,7 @@ const mergeVenueData =
     description: venue.description,
     accessibility: {},
     contact: {},
+    timezone: '',
     ...(prevData ?? {}),
   })
 

--- a/src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.native.test.tsx
+++ b/src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.native.test.tsx
@@ -8,6 +8,8 @@ jest.unmock('libs/appState')
 const appStateSpy = jest.spyOn(AppState, 'addEventListener')
 
 const CURRENT_DATE = new Date('2024-05-31T08:30:00')
+const TIMEZONE = 'UTC'
+
 jest.useFakeTimers().setSystemTime(CURRENT_DATE)
 
 describe('<OpeningHoursStatus />', () => {
@@ -15,7 +17,13 @@ describe('<OpeningHoursStatus />', () => {
     const openingHours = {
       FRIDAY: [{ open: '09:00', close: '19:00' }],
     }
-    render(<OpeningHoursStatus openingHours={openingHours} currentDate={CURRENT_DATE} />)
+    render(
+      <OpeningHoursStatus
+        openingHours={openingHours}
+        currentDate={CURRENT_DATE}
+        timezone={TIMEZONE}
+      />
+    )
 
     expect(screen.getByText('Ouvre bientôt - 9h')).toBeOnTheScreen()
 
@@ -28,22 +36,34 @@ describe('<OpeningHoursStatus />', () => {
     const openingHours = {
       FRIDAY: [{ open: '09:01', close: '19:00' }],
     }
-    render(<OpeningHoursStatus openingHours={openingHours} currentDate={CURRENT_DATE} />)
+    render(
+      <OpeningHoursStatus
+        openingHours={openingHours}
+        currentDate={CURRENT_DATE}
+        timezone={TIMEZONE}
+      />
+    )
 
-    expect(screen.getByText('Ouvre bientôt - 9h1')).toBeOnTheScreen()
+    expect(screen.getByText('Ouvre bientôt - 9h01')).toBeOnTheScreen()
 
     await act(async () => jest.advanceTimersByTime(31 * 60 * 1000))
 
-    expect(await screen.findByText('Ouvre bientôt - 9h1')).toBeOnTheScreen()
+    expect(await screen.findByText('Ouvre bientôt - 9h01')).toBeOnTheScreen()
   })
 
   it('should set timer to 0 when app is in background for longer than remaining time', async () => {
     const openingHours = {
       FRIDAY: [{ open: '09:01', close: '19:00' }],
     }
-    render(<OpeningHoursStatus openingHours={openingHours} currentDate={CURRENT_DATE} />)
+    render(
+      <OpeningHoursStatus
+        openingHours={openingHours}
+        currentDate={CURRENT_DATE}
+        timezone={TIMEZONE}
+      />
+    )
 
-    expect(screen.getByText('Ouvre bientôt - 9h1')).toBeOnTheScreen()
+    expect(screen.getByText('Ouvre bientôt - 9h01')).toBeOnTheScreen()
 
     // @ts-expect-error: because of noUncheckedIndexedAccess
     const mockCurrentAppState = appStateSpy.mock.calls[0][1]

--- a/src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.stories.tsx
+++ b/src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.stories.tsx
@@ -12,6 +12,9 @@ export default meta
 const Template: ComponentStory<typeof OpeningHoursStatus> = (props) => (
   <OpeningHoursStatus {...props} currentDate={new Date(props.currentDate)} />
 )
+
+const TIMEZONE = 'UTC'
+
 const openingHours = {
   MONDAY: [{ open: '09:00', close: '19:00' }],
   TUESDAY: [{ open: '09:00', close: '19:00' }],
@@ -21,21 +24,26 @@ export const Close = Template.bind({})
 Close.args = {
   openingHours,
   currentDate: new Date('2024-05-13T20:00:00Z'),
+  timezone: TIMEZONE,
 }
 
 export const Open = Template.bind({})
 Open.args = {
   openingHours,
   currentDate: new Date('2024-05-13T12:00:00Z'),
+  timezone: TIMEZONE,
 }
+
 export const OpenSoon = Template.bind({})
 OpenSoon.args = {
   openingHours,
   currentDate: new Date('2024-05-13T06:00:00Z'),
+  timezone: TIMEZONE,
 }
 
 export const CloseSoon = Template.bind({})
 CloseSoon.args = {
   openingHours,
   currentDate: new Date('2024-05-13T16:00:00Z'),
+  timezone: TIMEZONE,
 }

--- a/src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.tsx
+++ b/src/features/venue/components/OpeningHoursStatus/OpeningHoursStatus.tsx
@@ -14,10 +14,11 @@ import {
 
 type Props = {
   openingHours: OpeningHours
+  timezone: string
   currentDate: Date
 }
 
-export const OpeningHoursStatus: FC<Props> = ({ openingHours, currentDate }) => {
+export const OpeningHoursStatus: FC<Props> = ({ openingHours, currentDate, timezone }) => {
   const [date, setDate] = useState(currentDate)
   const {
     openingState: state,
@@ -26,6 +27,7 @@ export const OpeningHoursStatus: FC<Props> = ({ openingHours, currentDate }) => 
   } = getOpeningHoursStatus({
     openingHours,
     currentDate: date,
+    timezone,
   })
 
   useEffect(() => {

--- a/src/features/venue/components/VenueTopComponent/VenueTopComponent.tsx
+++ b/src/features/venue/components/VenueTopComponent/VenueTopComponent.tsx
@@ -56,7 +56,11 @@ export const VenueTopComponent: React.FunctionComponent<Props> = ({ venue }) => 
             {venueName}
           </VenueTitle>
           {isDynamicOpeningHoursDisplayed ? (
-            <OpeningHoursStatus currentDate={currentDate} openingHours={venue.openingHours} />
+            <OpeningHoursStatus
+              currentDate={currentDate}
+              openingHours={venue.openingHours}
+              timezone={venue.timezone}
+            />
           ) : null}
           <ViewGap gap={3}>
             <ViewGap gap={1}>

--- a/src/features/venue/fixtures/venueDataTest.ts
+++ b/src/features/venue/fixtures/venueDataTest.ts
@@ -71,4 +71,5 @@ export const venueDataTest: VenueResponse = {
   publicName: 'Le Petit Rintintin 1',
   venueTypeCode: VenueTypeCodeKey.BOOKSTORE,
   withdrawalDetails: 'How to withdraw, https://test.com',
+  timezone: 'UTC',
 }

--- a/src/libs/location/components/WhereSection.tsx
+++ b/src/libs/location/components/WhereSection.tsx
@@ -39,6 +39,7 @@ const mergeVenueData =
     description: venue.description,
     accessibility: {},
     contact: {},
+    timezone: '',
     ...(prevData || {}),
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12471,9 +12471,9 @@ data-urls@^3.0.2:
     whatwg-url "^11.0.0"
 
 date-fns-tz@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-2.0.0.tgz#1b14c386cb8bc16fc56fe333d4fc34ae1d1099d5"
-  integrity sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-2.0.1.tgz#0a9b2099031c0d74120b45de9fd23192e48ea495"
+  integrity sha512-fJCG3Pwx8HUoLhkepdsP7Z5RsucUi+ZBOxyM5d0ZZ6c4SdYustq0VMmOu6Wf7bli+yS/Jwp91TOCqn9jMcVrUA==
 
 date-fns@2.29.3:
   version "2.29.3"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28937

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
