### PR TITLE
(PC-30725) fix(offer): adapt modal size in desktop

### DIFF
--- a/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
@@ -208,7 +208,6 @@ exports[`<AccessibilityFiltersModal /> should not reset filter when reset button
       swipeThreshold={100}
     >
       <View
-        desktopMaxHeight={1000.5}
         height={1318}
         maxHeight={1334}
         noPadding={true}
@@ -1333,7 +1332,6 @@ exports[`<AccessibilityFiltersModal /> should not save modified disabilities whe
       swipeThreshold={100}
     >
       <View
-        desktopMaxHeight={1000.5}
         height={1318}
         maxHeight={1334}
         noPadding={true}
@@ -2458,7 +2456,6 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
       swipeThreshold={100}
     >
       <View
-        desktopMaxHeight={1000.5}
         height={1318}
         maxHeight={1334}
         noPadding={true}
@@ -3583,7 +3580,6 @@ exports[`<AccessibilityFiltersModal /> should reset filter when reset button and
       swipeThreshold={100}
     >
       <View
-        desktopMaxHeight={1000.5}
         height={1318}
         maxHeight={1334}
         noPadding={true}
@@ -4708,7 +4704,6 @@ exports[`<AccessibilityFiltersModal /> should save selected disabilities when se
       swipeThreshold={100}
     >
       <View
-        desktopMaxHeight={1000.5}
         height={1318}
         maxHeight={1334}
         noPadding={true}

--- a/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
@@ -147,7 +147,6 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
     swipeThreshold={100}
   >
     <View
-      desktopMaxHeight={988.5}
       maxHeight={1318}
       noPadding={true}
       style={

--- a/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
@@ -166,7 +166,6 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
     swipeThreshold={100}
   >
     <View
-      desktopMaxHeight={1000.5}
       height={1318}
       maxHeight={1334}
       noPadding={true}
@@ -928,7 +927,6 @@ exports[`VideoModal should render properly with FF on 1`] = `
     swipeThreshold={100}
   >
     <View
-      desktopMaxHeight={1000.5}
       height={1318}
       maxHeight={1334}
       noPadding={true}

--- a/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
@@ -147,7 +147,6 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
     swipeThreshold={100}
   >
     <View
-      desktopMaxHeight={1000.5}
       height={1318}
       maxHeight={1334}
       noPadding={true}

--- a/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
@@ -171,7 +171,6 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
       swipeThreshold={100}
     >
       <View
-        desktopMaxHeight={1000.5}
         height={1318}
         maxHeight={1334}
         noPadding={true}

--- a/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
@@ -208,7 +208,6 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
       swipeThreshold={100}
     >
       <View
-        desktopMaxHeight={1000.5}
         height={1318}
         maxHeight={1334}
         noPadding={true}

--- a/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
@@ -147,7 +147,6 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
     swipeThreshold={100}
   >
     <View
-      desktopMaxHeight={1000.5}
       height={1318}
       maxHeight={1334}
       noPadding={true}
@@ -2857,7 +2856,6 @@ exports[`<CategoriesModal/> new book native categories section should display th
     swipeThreshold={100}
   >
     <View
-      desktopMaxHeight={1000.5}
       height={1318}
       maxHeight={1334}
       noPadding={true}

--- a/__snapshots__/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx.native-snap
@@ -147,7 +147,6 @@ exports[`<DatesHoursModal/> should render modal correctly after animation and wi
     swipeThreshold={100}
   >
     <View
-      desktopMaxHeight={1000.5}
       height={1318}
       maxHeight={1334}
       noPadding={true}

--- a/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
@@ -147,7 +147,6 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
     swipeThreshold={100}
   >
     <View
-      desktopMaxHeight={1000.5}
       height={1318}
       maxHeight={1334}
       noPadding={true}

--- a/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
@@ -147,7 +147,6 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
     swipeThreshold={100}
   >
     <View
-      desktopMaxHeight={1000.5}
       height={1318}
       maxHeight={1334}
       noPadding={true}

--- a/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
@@ -147,7 +147,6 @@ exports[`VenueModal should render correctly 1`] = `
     swipeThreshold={100}
   >
     <View
-      desktopMaxHeight={1000.5}
       height={1318}
       maxHeight={1334}
       noPadding={true}

--- a/__snapshots__/features/venueMap/pages/modals/VenueTypeModal/VenueTypeModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/venueMap/pages/modals/VenueTypeModal/VenueTypeModal.native.test.tsx.native-snap
@@ -147,7 +147,6 @@ exports[`<VenueTypeModal /> When venue type is null should render modal correctl
     swipeThreshold={100}
   >
     <View
-      desktopMaxHeight={1000.5}
       height={1318}
       maxHeight={1334}
       noPadding={true}

--- a/__snapshots__/ui/components/modals/AppModal.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/modals/AppModal.native.test.tsx.native-snap
@@ -147,6 +147,12 @@ exports[`<AppModal /> on big screen 1`] = `
     swipeThreshold={100}
   >
     <View
+      desktopConstraints={
+        {
+          "maxHeight": undefined,
+          "maxWidth": 520,
+        }
+      }
       height={428}
       style={
         [

--- a/src/features/offer/components/OfferImageCarouselPagination/OfferImageCarouselPagination.web.tsx
+++ b/src/features/offer/components/OfferImageCarouselPagination/OfferImageCarouselPagination.web.tsx
@@ -6,6 +6,7 @@ import { OfferImageCarouselPaginationProps } from 'features/offer/types'
 import { CarouselDot } from 'ui/CarouselDot/CarouselDot'
 import { RoundedButton } from 'ui/components/buttons/RoundedButton'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { getSpacing } from 'ui/theme'
 
 export const OfferImageCarouselPagination: FunctionComponent<OfferImageCarouselPaginationProps> = ({
   progressValue,
@@ -17,16 +18,18 @@ export const OfferImageCarouselPagination: FunctionComponent<OfferImageCarouselP
   if (!progressValue) return null
 
   return (
-    <Container gap={4} testID="buttonsAndDotsContainer">
+    <Container testID="buttonsAndDotsContainer">
       <RoundedButton
         iconName="previous"
         onPress={() => handlePressButton(-1)}
         accessibilityLabel="Image précédente"
       />
 
-      {offerImages.map((_, index) => (
-        <CarouselDot animValue={progressValue} index={index} key={index + carouselDotId} />
-      ))}
+      <DotContainer gap={1.3}>
+        {offerImages.map((_, index) => (
+          <CarouselDot animValue={progressValue} index={index} key={index + carouselDotId} />
+        ))}
+      </DotContainer>
 
       <RoundedButton
         iconName="next"
@@ -37,7 +40,13 @@ export const OfferImageCarouselPagination: FunctionComponent<OfferImageCarouselP
   )
 }
 
-const Container = styled(ViewGap)({
+const DotContainer = styled(ViewGap)({
+  flexDirection: 'row',
+  alignItems: 'center',
+  marginLeft: getSpacing(6),
+  marginRight: getSpacing(6),
+})
+const Container = styled.View({
   flexDirection: 'row',
   alignSelf: 'center',
   alignItems: 'center',

--- a/src/features/offer/components/OfferPreviewModal/OfferPreviewModal.tsx
+++ b/src/features/offer/components/OfferPreviewModal/OfferPreviewModal.tsx
@@ -1,17 +1,22 @@
-import React, { useRef, useState } from 'react'
+import React, { useMemo, useRef, useState } from 'react'
 // eslint-disable-next-line no-restricted-imports
-import { Image } from 'react-native'
+import { Image, useWindowDimensions } from 'react-native'
 import { useSharedValue } from 'react-native-reanimated'
 import Carousel, { ICarouselInstance } from 'react-native-reanimated-carousel'
-import styled from 'styled-components/native'
+import styled, { useTheme } from 'styled-components/native'
 
 import { calculateCarouselIndex } from 'features/offer/helpers/calculateCarouselIndex/calculateCarouselIndex'
 import { RoundedButton } from 'ui/components/buttons/RoundedButton'
 import { AppModal } from 'ui/components/modals/AppModal'
+// eslint-disable-next-line no-restricted-imports
+import { ModalSpacing } from 'ui/components/modals/enum'
 import { Close } from 'ui/svg/icons/Close'
 import { getSpacing } from 'ui/theme'
+import { Breakpoints } from 'ui/theme/grid'
 
-const CAROUSEL_ITEM_PADDING = getSpacing(12)
+const MODAL_MAX_WIDTH = Breakpoints.LG
+const MODAL_PADDING = { x: getSpacing(10), y: getSpacing(10) }
+const MODAL_HEADER_HEIGHT = getSpacing(7)
 
 type OfferPreviewModalProps = {
   offerImages: string[]
@@ -31,11 +36,15 @@ export const OfferPreviewModal = ({
   const [carouselSize, setCarouselSize] = useState({ width: 100, height: 100 })
   const carouselRef = useRef<ICarouselInstance>(null)
   const progressValue = useSharedValue<number>(0)
+  const { width: windowWidth, height: windowHeight } = useWindowDimensions()
+  const { isDesktopViewport } = useTheme()
 
   const getTitleLabel = (progressValue: number) =>
     `${Math.round(progressValue) + 1}/${offerImages.length}`
 
   const [title, setTitle] = useState(getTitleLabel(progressValue.value))
+
+  const CAROUSEL_ITEM_PADDING = isDesktopViewport ? getSpacing(20) : getSpacing(12)
 
   const handleCloseModal = () => {
     hideModal()
@@ -99,16 +108,26 @@ export const OfferPreviewModal = ({
     return <CarouselImage source={{ uri: String(offerImages[0]) }} accessibilityLabel="Image 1" />
   }
 
+  const desktopConstraints = useMemo(
+    () => ({
+      maxWidth: Math.min(windowWidth, MODAL_MAX_WIDTH) - 2 * MODAL_PADDING.x,
+      maxHeight: windowHeight - 2 * MODAL_PADDING.y,
+    }),
+    [windowWidth, windowHeight]
+  )
+
   return (
     <AppModal
       title={offerImages.length > 1 ? title : ''}
       visible={isVisible}
       isFullscreen
       rightIcon={Close}
+      desktopConstraints={desktopConstraints}
       onLayout={({ nativeEvent }) => {
         setCarouselSize({
           width: nativeEvent.layout.width - CAROUSEL_ITEM_PADDING * 2,
-          height: nativeEvent.layout.height - CAROUSEL_ITEM_PADDING * 2,
+          height:
+            nativeEvent.layout.height - ModalSpacing.MD - ModalSpacing.LG - MODAL_HEADER_HEIGHT,
         })
       }}
       rightIconAccessibilityLabel="Fermer la fenêtre"

--- a/src/ui/CarouselDot/CarouselDot.tsx
+++ b/src/ui/CarouselDot/CarouselDot.tsx
@@ -13,7 +13,7 @@ type Props = {
 }
 
 const SMALL_DOT_SIZE = 6
-const BIG_DOT_SIZE = SMALL_DOT_SIZE + 4
+const BIG_DOT_SIZE = SMALL_DOT_SIZE + 2
 
 export const CarouselDot: React.FunctionComponent<Props> = ({ animValue, index }) => {
   const theme = useTheme()

--- a/src/ui/components/modals/appModalContainerStyle.ts
+++ b/src/ui/components/modals/appModalContainerStyle.ts
@@ -8,20 +8,20 @@ const BORDER_VERTICAL_RADIUS = getSpacing(4)
 
 type Props = {
   theme: DefaultTheme
-  desktopMaxHeight?: number
   height?: number
   maxHeight: number
   noPadding?: boolean
   noPaddingBottom?: boolean
+  desktopConstraints?: Pick<CSSObject, 'maxWidth' | 'maxHeight'>
 }
 
 export const appModalContainerStyle = ({
   theme,
   height,
-  desktopMaxHeight,
   maxHeight,
   noPadding,
   noPaddingBottom,
+  desktopConstraints,
 }: Props): CSSObject => ({
   alignItems: 'center',
   backgroundColor: theme.colors.white,
@@ -41,8 +41,8 @@ export const appModalContainerStyle = ({
         borderBottomEndRadius: BORDER_VERTICAL_RADIUS,
         borderBottomRightRadius: BORDER_HORIZTONAL_RADIUS,
         borderBottomLeftRadius: BORDER_HORIZTONAL_RADIUS,
-        maxHeight: desktopMaxHeight,
-        maxWidth: theme.modal.desktopMaxWidth,
+        maxHeight: desktopConstraints?.maxHeight,
+        maxWidth: desktopConstraints?.maxWidth,
       }
     : {
         borderBottomStartRadius: 0,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30725

- Ajout d'une prop `desktopConstraints` dans `AppModal` permettant de gérer la taille de la modal en desktop
- Update visuel de la pagination en mode desktop

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

<img width="1507" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/173043140/21c78783-8529-41a1-ab5c-9e6d1ee936f5">

<img width="333" alt="image" src="https://github.com/pass-culture/pass-culture-app-native/assets/173043140/a072de7a-dfca-454f-b8e5-89635236accc">




[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
