### PR TITLE
(PC-30656) feat(venueMap): larger cluster and no animation in iOS

### DIFF
--- a/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
@@ -23,7 +23,7 @@ import { analytics } from 'libs/analytics'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { useDistance } from 'libs/location/hooks/useDistance'
-import MapView, { Marker, Region, MarkerPressEvent, Map } from 'libs/maps/maps'
+import MapView, { Map, Marker, MarkerPressEvent, Region } from 'libs/maps/maps'
 import { parseType } from 'libs/parsers/venueType'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { getSpacing } from 'ui/theme'
@@ -139,6 +139,8 @@ export const VenueMapView: FunctionComponent<Props> = ({ height }) => {
         renderCluster={(props) => <VenueMapCluster {...props} />}
         onPress={isPreviewEnabled ? handlePressOutOfVenuePin : undefined}
         onClusterPress={isPreviewEnabled ? handlePressOutOfVenuePin : undefined}
+        radius={50}
+        animationEnabled={false}
         testID="venue-map-view">
         {filteredVenues.map((venue) => (
           <Marker


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30656

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |![Capture d’écran 2024-07-11 à 09 17 52](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/fb7f3120-113c-4e53-ad97-44297531f6c2)|![Capture d’écran 2024-07-11 à 09 16 39](https://github.com/pass-culture/pass-culture-app-native/assets/78556024/bb809cdb-34c0-4fad-9cbc-882d08edd053)|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
