### PR TITLE
(PC-30345) fix(AttachedCardDisplay): android weird shape on press

### DIFF
--- a/src/features/home/components/AttachedModuleCard/AttachedCardDisplay.tsx
+++ b/src/features/home/components/AttachedModuleCard/AttachedCardDisplay.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { OfferName } from 'ui/components/tiles/OfferName'
-import { getShadow, getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, Typo } from 'ui/theme'
 
 interface AttachedCardDisplayProps {
   title: string
@@ -90,15 +90,6 @@ const ImageContainer = styled.View({
 })
 
 const Container = styled.View<{ shouldFixHeight: boolean }>(({ theme, shouldFixHeight }) => ({
-  ...getShadow({
-    shadowOffset: {
-      width: 0,
-      height: getSpacing(3),
-    },
-    shadowRadius: getSpacing(12),
-    shadowColor: theme.colors.black,
-    shadowOpacity: 0.15,
-  }),
   backgroundColor: theme.colors.white,
   borderRadius: getSpacing(3),
   borderWidth: BORDER_WIDTH,

--- a/src/features/home/components/modules/marketing/MarketingBlockExclusivity.tsx
+++ b/src/features/home/components/modules/marketing/MarketingBlockExclusivity.tsx
@@ -1,9 +1,11 @@
 import React, { memo } from 'react'
+import styled from 'styled-components/native'
 
 import { AttachedOfferCard } from 'features/home/components/AttachedModuleCard/AttachedOfferCard'
 import { MarketingBlock } from 'features/home/components/modules/marketing/MarketingBlock'
 import { analytics } from 'libs/analytics'
 import { Offer } from 'shared/offer/types'
+import { getShadow, getSpacing } from 'ui/theme'
 
 type AttachedOfferCardProps = {
   offer: Offer
@@ -33,10 +35,27 @@ const UnmemoizedMarketingBlockExclusivity = ({
       navigateTo={{ screen: 'Offer', params: { id: offer.objectID } }}
       onBeforeNavigate={logConsultOffer}
       backgroundImageUrl={backgroundImageUrl}
-      AttachedCardComponent={<AttachedOfferCard offer={offer} />}
+      AttachedCardComponent={
+        <ShadowWrapper>
+          <AttachedOfferCard offer={offer} />
+        </ShadowWrapper>
+      }
     />
   )
 }
 
 // Old version: HighlightOfferModule.tsx
 export const MarketingBlockExclusivity = memo(UnmemoizedMarketingBlockExclusivity)
+
+const ShadowWrapper = styled.View(({ theme }) => ({
+  ...getShadow({
+    shadowOffset: {
+      width: 0,
+      height: getSpacing(3),
+    },
+    shadowRadius: getSpacing(12),
+    shadowColor: theme.colors.black,
+    shadowOpacity: 0.15,
+  }),
+}))
+// expliquer bugg android en comm

--- a/src/features/home/components/modules/marketing/MarketingBlockExclusivity.tsx
+++ b/src/features/home/components/modules/marketing/MarketingBlockExclusivity.tsx
@@ -1,11 +1,10 @@
 import React, { memo } from 'react'
-import styled from 'styled-components/native'
 
 import { AttachedOfferCard } from 'features/home/components/AttachedModuleCard/AttachedOfferCard'
 import { MarketingBlock } from 'features/home/components/modules/marketing/MarketingBlock'
 import { analytics } from 'libs/analytics'
 import { Offer } from 'shared/offer/types'
-import { getShadow, getSpacing } from 'ui/theme'
+import { ShadowWrapper } from 'ui/components/ShadowWrapper'
 
 type AttachedOfferCardProps = {
   offer: Offer
@@ -46,16 +45,3 @@ const UnmemoizedMarketingBlockExclusivity = ({
 
 // Old version: HighlightOfferModule.tsx
 export const MarketingBlockExclusivity = memo(UnmemoizedMarketingBlockExclusivity)
-
-const ShadowWrapper = styled.View(({ theme }) => ({
-  ...getShadow({
-    shadowOffset: {
-      width: 0,
-      height: getSpacing(3),
-    },
-    shadowRadius: getSpacing(12),
-    shadowColor: theme.colors.black,
-    shadowOpacity: 0.15,
-  }),
-}))
-// expliquer bugg android en comm

--- a/src/features/home/components/modules/marketing/MarketingBlockHighlight.tsx
+++ b/src/features/home/components/modules/marketing/MarketingBlockHighlight.tsx
@@ -1,9 +1,8 @@
 import React, { memo } from 'react'
-import styled from 'styled-components/native'
 
 import { AttachedThematicCard } from 'features/home/components/AttachedModuleCard/AttachedThematicCard'
 import { MarketingBlock } from 'features/home/components/modules/marketing/MarketingBlock'
-import { getShadow, getSpacing } from 'ui/theme'
+import { ShadowWrapper } from 'ui/components/ShadowWrapper'
 
 export type MarketingBlockHighlightProps = {
   title: string
@@ -40,15 +39,3 @@ const UnmemoizedMarketingBlockHighlight = ({
 
 // Old version: ThematicHighlightModule.tsx
 export const MarketingBlockHighlight = memo(UnmemoizedMarketingBlockHighlight)
-
-const ShadowWrapper = styled.View(({ theme }) => ({
-  ...getShadow({
-    shadowOffset: {
-      width: 0,
-      height: getSpacing(3),
-    },
-    shadowRadius: getSpacing(12),
-    shadowColor: theme.colors.black,
-    shadowOpacity: 0.15,
-  }),
-}))

--- a/src/features/home/components/modules/marketing/MarketingBlockHighlight.tsx
+++ b/src/features/home/components/modules/marketing/MarketingBlockHighlight.tsx
@@ -1,7 +1,9 @@
 import React, { memo } from 'react'
+import styled from 'styled-components/native'
 
 import { AttachedThematicCard } from 'features/home/components/AttachedModuleCard/AttachedThematicCard'
 import { MarketingBlock } from 'features/home/components/modules/marketing/MarketingBlock'
+import { getShadow, getSpacing } from 'ui/theme'
 
 export type MarketingBlockHighlightProps = {
   title: string
@@ -28,7 +30,9 @@ const UnmemoizedMarketingBlockHighlight = ({
       }}
       backgroundImageUrl={backgroundImageUrl}
       AttachedCardComponent={
-        <AttachedThematicCard title={title} subtitle={subtitle} label={label} />
+        <ShadowWrapper>
+          <AttachedThematicCard title={title} subtitle={subtitle} label={label} />
+        </ShadowWrapper>
       }
     />
   )
@@ -36,3 +40,15 @@ const UnmemoizedMarketingBlockHighlight = ({
 
 // Old version: ThematicHighlightModule.tsx
 export const MarketingBlockHighlight = memo(UnmemoizedMarketingBlockHighlight)
+
+const ShadowWrapper = styled.View(({ theme }) => ({
+  ...getShadow({
+    shadowOffset: {
+      width: 0,
+      height: getSpacing(3),
+    },
+    shadowRadius: getSpacing(12),
+    shadowColor: theme.colors.black,
+    shadowOpacity: 0.15,
+  }),
+}))

--- a/src/features/home/components/modules/video/VideoCarouselModule.tsx
+++ b/src/features/home/components/modules/video/VideoCarouselModule.tsx
@@ -25,7 +25,7 @@ import { useCategoryIdMapping } from 'libs/subcategories'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
 import { CarouselBar } from 'ui/CarouselBar/CarouselBar'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
-import { getSpacing } from 'ui/theme'
+import { getShadow, getSpacing } from 'ui/theme'
 
 const CAROUSEL_HEIGHT = getSpacing(35)
 const CAROUSEL_ANIMATION_DURATION = 500
@@ -230,9 +230,18 @@ const ColoredAttachedTileContainer = styled.View<{
   backgroundColor: newColorMapping[color].fill,
 }))
 
-const StyledInternalTouchableLink = styled(InternalTouchableLink)({
+const StyledInternalTouchableLink = styled(InternalTouchableLink)(({ theme }) => ({
+  ...getShadow({
+    shadowOffset: {
+      width: 0,
+      height: getSpacing(3),
+    },
+    shadowRadius: getSpacing(12),
+    shadowColor: theme.colors.black,
+    shadowOpacity: 0.15,
+  }),
   paddingHorizontal: getSpacing(1),
-})
+}))
 
 const SingleItemContainer = styled.View({
   marginHorizontal: getSpacing(5),

--- a/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
@@ -18,7 +18,7 @@ import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
 import { OfferImage } from 'ui/components/tiles/OfferImage'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
-import { getSpacing, Typo } from 'ui/theme'
+import { getShadow, getSpacing, Typo } from 'ui/theme'
 
 type Props = {
   offer: Offer
@@ -80,9 +80,9 @@ export const VideoMonoOfferTile: FunctionComponent<Props> = ({
   }
 
   return hasGraphicRedesign ? (
-    <Container {...containerProps}>
+    <StyledInternalTouchableLink {...containerProps}>
       <AttachedOfferCard offer={offer} />
-    </Container>
+    </StyledInternalTouchableLink>
   ) : (
     <OfferInsert {...containerProps}>
       <Row>
@@ -107,7 +107,17 @@ export const VideoMonoOfferTile: FunctionComponent<Props> = ({
   )
 }
 
-const Container = styled(InternalTouchableLink)({})
+const StyledInternalTouchableLink = styled(InternalTouchableLink)(({ theme }) => ({
+  ...getShadow({
+    shadowOffset: {
+      width: 0,
+      height: getSpacing(3),
+    },
+    shadowRadius: getSpacing(12),
+    shadowColor: theme.colors.black,
+    shadowOpacity: 0.15,
+  }),
+}))
 
 const OfferInsert = styled(InternalTouchableLink)<{
   offerHeight: number

--- a/src/ui/components/ShadowWrapper.tsx
+++ b/src/ui/components/ShadowWrapper.tsx
@@ -1,0 +1,23 @@
+import React, { PropsWithChildren } from 'react'
+import styled from 'styled-components/native'
+
+import { getShadow, getSpacing } from 'ui/theme'
+
+/* On Android, Touchables react weirdly to children with shadow, we have some component that where used inside both Touchables 
+and nonTouchables that needed to get rid of this shadow so we have this wrapper for nonTouchable ones. */
+
+export const ShadowWrapper: React.FC<PropsWithChildren> = ({ children }) => {
+  return <Container>{children}</Container>
+}
+
+const Container = styled.View(({ theme }) => ({
+  ...getShadow({
+    shadowOffset: {
+      width: 0,
+      height: getSpacing(3),
+    },
+    shadowRadius: getSpacing(12),
+    shadowColor: theme.colors.black,
+    shadowOpacity: 0.15,
+  }),
+}))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30345

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Before | After |
| :--------------- | :-----------: | :---: |
| iOS              | (pareil qu'après)      |<img width="373" alt="Capture d’écran 2024-07-11 à 10 22 32" src="https://github.com/pass-culture/pass-culture-app-native/assets/144016890/47feec12-6867-4bf2-a20d-60b9cb081cd4">|
| Android          |<img width="341" alt="Capture d’écran 2024-07-11 à 10 35 01" src="https://github.com/pass-culture/pass-culture-app-native/assets/144016890/56a53c71-dcf2-4d48-943e-f63466bddf88">|<img width="386" alt="Capture d’écran 2024-07-11 à 10 20 53" src="https://github.com/pass-culture/pass-culture-app-native/assets/144016890/02e5d00e-2552-4bfa-8803-326a3106fc12">|
| Desktop - Chrome | <img width="1270" alt="Capture d’écran 2024-07-11 à 10 26 02" src="https://github.com/pass-culture/pass-culture-app-native/assets/144016890/21ae6f44-f626-438a-8c09-26e528d3ac84">|<img width="1265" alt="Capture d’écran 2024-07-11 à 10 21 46" src="https://github.com/pass-culture/pass-culture-app-native/assets/144016890/4f8cbec1-7509-49e3-a3d4-fb32b9f302b2">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
