### PR TITLE
(PC-30763) feat(search): display search results venues playlist in the map

### DIFF
--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -79,7 +79,7 @@
 ./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts:936
 ./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts:233
 ./src/features/profile/components/CreditInfo/CreditProgressBar.tsx:32
-./src/features/search/api/useSearchResults/useSearchResults.ts:83
+./src/features/search/api/useSearchResults/useSearchResults.ts:91
 ./src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx:130
 ./src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx:133
 ./src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx:140
@@ -95,8 +95,8 @@
 ./src/features/search/components/Highlight/Highlight.native.test.tsx:74
 ./src/features/search/components/Highlight/Highlight.native.test.tsx:79
 ./src/features/search/components/Highlight/Highlight.native.test.tsx:86
-./src/features/search/components/SearchResultsContent/SearchResultsContent.tsx:168
-./src/features/search/components/SearchResultsContent/SearchResultsContent.tsx:170
+./src/features/search/components/SearchResultsContent/SearchResultsContent.tsx:173
+./src/features/search/components/SearchResultsContent/SearchResultsContent.tsx:175
 ./src/features/search/components/sections/Accessibility/Accessibility.tsx:33
 ./src/features/search/helpers/useSortedSearchCategories/useSortedSearchCategories.native.test.ts:30
 ./src/features/search/helpers/useSortedSearchCategories/useSortedSearchCategories.native.test.ts:37

--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -95,8 +95,8 @@
 ./src/features/search/components/Highlight/Highlight.native.test.tsx:74
 ./src/features/search/components/Highlight/Highlight.native.test.tsx:79
 ./src/features/search/components/Highlight/Highlight.native.test.tsx:86
-./src/features/search/components/SearchResultsContent/SearchResultsContent.tsx:173
-./src/features/search/components/SearchResultsContent/SearchResultsContent.tsx:175
+./src/features/search/components/SearchResultsContent/SearchResultsContent.tsx:174
+./src/features/search/components/SearchResultsContent/SearchResultsContent.tsx:176
 ./src/features/search/components/sections/Accessibility/Accessibility.tsx:33
 ./src/features/search/helpers/useSortedSearchCategories/useSortedSearchCategories.native.test.ts:30
 ./src/features/search/helpers/useSortedSearchCategories/useSortedSearchCategories.native.test.ts:37

--- a/src/features/location/components/VenueMapLocationModal.native.test.tsx
+++ b/src/features/location/components/VenueMapLocationModal.native.test.tsx
@@ -154,7 +154,7 @@ describe('VenueMapLocationModal', () => {
     const validateButon = screen.getByText('Valider et voir sur la carte')
     fireEvent.press(validateButon)
 
-    expect(navigate).toHaveBeenNthCalledWith(1, 'VenueMap', {})
+    expect(navigate).toHaveBeenNthCalledWith(1, 'VenueMap')
   })
 
   it('should request geolocation if geolocation is denied and the geolocation button pressed', async () => {

--- a/src/features/location/components/VenueMapLocationModal.tsx
+++ b/src/features/location/components/VenueMapLocationModal.tsx
@@ -77,7 +77,7 @@ export const VenueMapLocationModal = ({ visible, dismissModal }: LocationModalPr
 
   const handleSubmit = () => {
     onSubmit()
-    navigate('VenueMap', {})
+    navigate('VenueMap')
   }
 
   return (

--- a/src/features/navigation/RootNavigator/routes.ts
+++ b/src/features/navigation/RootNavigator/routes.ts
@@ -436,11 +436,7 @@ export const routes: RootRoute[] = [
   {
     name: 'VenueMap',
     component: VenueMap,
-    pathConfig: {
-      path: 'carte-des-lieux',
-      parse: screenParamsParser['VenueMap'],
-      stringify: screenParamsStringifier['VenueMap'],
-    },
+    path: 'carte-des-lieux',
     options: { title: 'Carte des lieux' },
   },
   {

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -278,9 +278,7 @@ export type RootStackParamList = {
     from?: Referrals
     searchId?: string
   }
-  VenueMap: {
-    initialVenues?: Venue[]
-  }
+  VenueMap: undefined
   DeeplinksGenerator: undefined
   UTMParameters: undefined
   ThematicHome: ThematicHomeParams

--- a/src/features/navigation/screenParamsUtils.ts
+++ b/src/features/navigation/screenParamsUtils.ts
@@ -14,7 +14,6 @@ type ScreensRequiringParsing = Extract<
   | 'ReinitializePassword'
   | 'ResetPasswordExpiredLink'
   | 'Venue'
-  | 'VenueMap'
   | 'SearchFilter'
   | 'SuspensionChoice'
   | 'LocationFilter'
@@ -132,9 +131,6 @@ export const screenParamsParser: ParamsParsers = {
     from: identityFn,
     searchId: identityFn,
   },
-  VenueMap: {
-    initialVenues: JSON.parse,
-  },
   SearchResults: searchParamsParser,
   SearchLanding: searchParamsParser,
   SearchN1: searchParamsParser,
@@ -185,7 +181,7 @@ function parseDataWithISODates(data: any) {
 
 type ScreensRequiringStringifying = Extract<
   ScreenNames,
-  'SearchFilter' | 'LocationFilter' | 'SearchLanding' | 'SearchResults' | 'SearchN1' | 'VenueMap'
+  'SearchFilter' | 'LocationFilter' | 'SearchLanding' | 'SearchResults' | 'SearchN1'
 >
 type ParamsStringifiers = {
   [Screen in ScreensRequiringStringifying]: {
@@ -235,8 +231,5 @@ export const screenParamsStringifier: ParamsStringifiers = {
   LocationFilter: {
     selectedVenue: JSON.stringify,
     selectedPlace: JSON.stringify,
-  },
-  VenueMap: {
-    initialVenues: JSON.stringify,
   },
 }

--- a/src/features/search/components/SearchListHeader/SearchListHeader.native.test.tsx
+++ b/src/features/search/components/SearchListHeader/SearchListHeader.native.test.tsx
@@ -75,6 +75,12 @@ jest.mock('features/search/context/SearchWrapper', () => ({
   useSearch: () => mockUseSearch(),
 }))
 
+const mockSetInitialVenues = jest.fn()
+jest.mock('features/venueMap/store/initialVenuesStore', () => ({
+  useInitialVenuesActions: () => ({ setInitialVenues: mockSetInitialVenues }),
+  useInitialVenues: jest.fn(),
+}))
+
 describe('<SearchListHeader />', () => {
   beforeEach(() => {
     mockUseAccessibilityFiltersContext.mockReturnValue(defaultValuesAccessibilityContext)
@@ -524,9 +530,37 @@ describe('<SearchListHeader />', () => {
 
       fireEvent.press(screen.getByText(`Voir sur la carte (${mockAlgoliaVenues.length})`))
 
-      expect(navigate).toHaveBeenNthCalledWith(1, 'VenueMap', {
-        initialVenues: adaptAlgoliaVenues(mockAlgoliaVenues),
+      expect(navigate).toHaveBeenNthCalledWith(1, 'VenueMap')
+    })
+
+    it('should update initial venues store when pressing see map button with playlist venues content', () => {
+      mockUseSearch.mockReturnValueOnce({
+        searchState: {
+          ...mockSearchState,
+          searchId,
+          locationFilter: { locationType: LocationMode.AROUND_ME, aroundRadius: MAX_RADIUS },
+        },
       })
+      const location = {
+        geolocPosition: mockPosition,
+        selectedLocationMode: LocationMode.AROUND_ME,
+        hasGeolocPosition: true,
+      }
+      mockUseLocation.mockReturnValueOnce(location)
+      mockUseLocation.mockReturnValueOnce(location)
+
+      render(
+        <SearchListHeader
+          nbHits={10}
+          userData={[]}
+          venuesUserData={[]}
+          venues={mockAlgoliaVenues}
+        />
+      )
+
+      fireEvent.press(screen.getByText(`Voir sur la carte (${mockAlgoliaVenues.length})`))
+
+      expect(mockSetInitialVenues).toHaveBeenNthCalledWith(1, adaptAlgoliaVenues(mockAlgoliaVenues))
     })
 
     it('should log consult venue map from search playlist when pressing see map button', () => {

--- a/src/features/search/components/SearchListHeader/SearchListHeader.tsx
+++ b/src/features/search/components/SearchListHeader/SearchListHeader.tsx
@@ -15,6 +15,7 @@ import { useSearch } from 'features/search/context/SearchWrapper'
 import { getSearchVenuePlaylistTitle } from 'features/search/helpers/getSearchVenuePlaylistTitle/getSearchVenuePlaylistTitle'
 import { VenuesUserData } from 'features/search/types'
 import { useShouldDisplayVenueMap } from 'features/venueMap/hook/useShouldDisplayVenueMap'
+import { useInitialVenuesActions } from 'features/venueMap/store/initialVenuesStore'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { adaptAlgoliaVenues } from 'libs/algolia/fetchAlgolia/fetchVenues/adaptAlgoliaVenues'
 import { AlgoliaVenue } from 'libs/algolia/types'
@@ -69,6 +70,7 @@ export const SearchListHeader: React.FC<SearchListHeaderProps> = ({
     searchState: { searchId, venue, offerCategories },
   } = useSearch()
   const { navigate } = useNavigation<UseNavigationType>()
+  const { setInitialVenues } = useInitialVenuesActions()
 
   const isLocated = useMemo(
     () => selectedLocationMode !== LocationMode.EVERYWHERE,
@@ -122,8 +124,9 @@ export const SearchListHeader: React.FC<SearchListHeaderProps> = ({
   )
 
   const handleSeeMapPress = () => {
+    setInitialVenues(venues?.length ? adaptAlgoliaVenues(venues) : [])
     analytics.logConsultVenueMap({ from: 'searchPlaylist' })
-    navigate('VenueMap', venues?.length ? { initialVenues: adaptAlgoliaVenues(venues) } : {})
+    navigate('VenueMap')
   }
 
   return (

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -237,7 +237,7 @@ export const SearchResultsContent: React.FC = () => {
         venuesUserData={venuesUserData}
       />
     ),
-    [Tab.MAP]: <VenueMapView height={venueMapHeight} shouldDisplaySearchButton={false} />,
+    [Tab.MAP]: <VenueMapView height={venueMapHeight} from="searchResults" />,
   }
   return (
     <React.Fragment>

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -91,6 +91,7 @@ export const SearchResultsContent: React.FC = () => {
   const { height } = useWindowDimensions()
   const { top, tabBarHeight } = useCustomSafeInsets()
   const venueMapHeight = height - top - tabBarHeight - HEADER_SEARCH_VENUE_MAP
+  const [isSearchListTab, setIsSearchListTab] = useState(true)
 
   const isVenue = !!searchState.venue
 
@@ -218,7 +219,10 @@ export const SearchResultsContent: React.FC = () => {
 
   // We don't want to render it on the web, even if it's not plugged in, since it avoids the user
   // to press on a working button
-  const shouldRenderScrollToTopButton = nbHits > 0 && Platform.OS !== 'web'
+  const shouldRenderScrollToTopButton =
+    nbHits > 0 &&
+    Platform.OS !== 'web' &&
+    (!shouldDisplayVenueMapInSearch || (shouldDisplayVenueMapInSearch && isSearchListTab))
   const tabPanels = {
     [Tab.SEARCHLIST]: (
       <SearchList
@@ -326,11 +330,14 @@ export const SearchResultsContent: React.FC = () => {
               { key: Tab.MAP, Icon: Map },
             ]}
             onTabChange={{
-              Carte: () =>
+              Carte: () => {
                 analytics.logConsultVenueMap({
                   from: 'search',
                   searchId: searchState.searchId,
-                }),
+                })
+                setIsSearchListTab(false)
+              },
+              Liste: () => setIsSearchListTab(true),
             }}
           />
         ) : (

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -233,7 +233,7 @@ export const SearchResultsContent: React.FC = () => {
       />
     ),
     // TODO(PC-30764) Calcul de la height dynamique
-    [Tab.MAP]: <VenueMapView height={600} />,
+    [Tab.MAP]: <VenueMapView height={600} shouldDisplaySearchButton={false} />,
   }
   return (
     <React.Fragment>

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -2,7 +2,7 @@ import { useIsFocused } from '@react-navigation/native'
 import { FlashList } from '@shopify/flash-list'
 import debounce from 'lodash/debounce'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { FlatList, Platform, ScrollView, View } from 'react-native'
+import { FlatList, Platform, ScrollView, useWindowDimensions, View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { AccessibilityFiltersModal } from 'features/accessibility/components/AccessibilityFiltersModal'
@@ -13,6 +13,7 @@ import { AutoScrollSwitch } from 'features/search/components/AutoScrollSwitch/Au
 import { FilterButton } from 'features/search/components/Buttons/FilterButton/FilterButton'
 import { SingleFilterButton } from 'features/search/components/Buttons/SingleFilterButton/SingleFilterButton'
 import { SearchList } from 'features/search/components/SearchList/SearchList'
+import { HEADER_SEARCH_VENUE_MAP } from 'features/search/constants'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { FilterBehaviour } from 'features/search/enums'
 import {
@@ -46,6 +47,7 @@ import { Ul } from 'ui/components/Ul'
 import { Map } from 'ui/svg/icons/Map'
 import { Sort } from 'ui/svg/icons/Sort'
 import { getSpacing, Spacer } from 'ui/theme'
+import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 import { Helmet } from 'ui/web/global/Helmet'
 
 const ANIMATION_DURATION = 700
@@ -86,6 +88,9 @@ export const SearchResultsContent: React.FC = () => {
   const shouldDisplayVenueMapInSearch = useFeatureFlag(
     RemoteStoreFeatureFlags.WIP_VENUE_MAP_IN_SEARCH
   )
+  const { height } = useWindowDimensions()
+  const { top, tabBarHeight } = useCustomSafeInsets()
+  const venueMapHeight = height - top - tabBarHeight - HEADER_SEARCH_VENUE_MAP
 
   const isVenue = !!searchState.venue
 
@@ -232,8 +237,7 @@ export const SearchResultsContent: React.FC = () => {
         venuesUserData={venuesUserData}
       />
     ),
-    // TODO(PC-30764) Calcul de la height dynamique
-    [Tab.MAP]: <VenueMapView height={600} shouldDisplaySearchButton={false} />,
+    [Tab.MAP]: <VenueMapView height={venueMapHeight} shouldDisplaySearchButton={false} />,
   }
   return (
     <React.Fragment>

--- a/src/features/search/constants.ts
+++ b/src/features/search/constants.ts
@@ -5,3 +5,4 @@ export const LIST_ITEM_HEIGHT = 130
 export const SCROLL_TO_TOP_BUTTON_LINEAR_GRADIENT_START = { x: 0, y: 0 }
 export const SCROLL_TO_TOP_BUTTON_LINEAR_GRADIENT_END = { x: 0, y: 1 }
 export const DEFAULT_RADIUS = 50
+export const HEADER_SEARCH_VENUE_MAP = 212

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
@@ -79,5 +79,5 @@ describe('<VenueMapView />', () => {
 })
 
 function renderVenueMapView() {
-  render(reactQueryProviderHOC(<VenueMapView height={700} />))
+  render(reactQueryProviderHOC(<VenueMapView height={700} from="venueMap" />))
 }

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
@@ -5,6 +5,12 @@ import * as useFeatureFlag from 'libs/firebase/firestore/featureFlags/useFeature
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { fireEvent, render, screen } from 'tests/utils'
 
+const mockSetInitialVenues = jest.fn()
+jest.mock('features/venueMap/store/initialVenuesStore', () => ({
+  useInitialVenuesActions: () => ({ setInitialVenues: mockSetInitialVenues }),
+  useInitialVenues: jest.fn(),
+}))
+
 jest.spyOn(useFeatureFlag, 'useFeatureFlag').mockReturnValue(true)
 
 describe('<VenueMapView />', () => {
@@ -50,6 +56,25 @@ describe('<VenueMapView />', () => {
     fireEvent.press(await screen.findByText('Rechercher dans cette zone'))
 
     expect(screen.queryByText('Rechercher dans cette zone')).not.toBeOnTheScreen()
+  })
+
+  it('should reset initial venues store when pressing search button', async () => {
+    renderVenueMapView()
+    const mapView = screen.getByTestId('venue-map-view')
+
+    await act(() => {})
+
+    // Simulate region change
+    fireEvent(mapView, 'onRegionChangeComplete', {
+      latitude: 1,
+      longitude: 1,
+      latitudeDelta: 1,
+      longitudeDelta: 1,
+    })
+
+    await act(async () => fireEvent.press(await screen.findByText('Rechercher dans cette zone')))
+
+    expect(mockSetInitialVenues).toHaveBeenNthCalledWith(1, [])
   })
 })
 

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
@@ -62,8 +62,6 @@ describe('<VenueMapView />', () => {
     renderVenueMapView()
     const mapView = screen.getByTestId('venue-map-view')
 
-    await act(() => {})
-
     // Simulate region change
     fireEvent(mapView, 'onRegionChangeComplete', {
       latitude: 1,
@@ -72,7 +70,7 @@ describe('<VenueMapView />', () => {
       longitudeDelta: 1,
     })
 
-    await act(async () => fireEvent.press(await screen.findByText('Rechercher dans cette zone')))
+    fireEvent.press(await screen.findByText('Rechercher dans cette zone'))
 
     expect(mockSetInitialVenues).toHaveBeenNthCalledWith(1, [])
   })

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
@@ -32,13 +32,14 @@ import { getSpacing } from 'ui/theme'
 
 type Props = {
   height: number
+  shouldDisplaySearchButton?: boolean
 }
 
 const PREVIEW_HEIGHT_ESTIMATION = 114
 
 const PIN_MAX_Z_INDEX = 10_000
 
-export const VenueMapView: FunctionComponent<Props> = ({ height }) => {
+export const VenueMapView: FunctionComponent<Props> = ({ height, shouldDisplaySearchButton }) => {
   const { navigate } = useNavigation<UseNavigationType>()
   const { params } = useRoute<UseRouteType<'VenueMap'>>()
   const [initialVenues, setInitialVenues] = useState(params?.initialVenues)
@@ -50,6 +51,7 @@ export const VenueMapView: FunctionComponent<Props> = ({ height }) => {
   const [currentRegion, setCurrentRegion] = useState<Region>(defaultRegion)
   const [lastRegionSearched, setLastRegionSearched] = useState<Region>(defaultRegion)
   const [showSearchButton, setShowSearchButton] = useState<boolean>(false)
+  const hasSearchButton = shouldDisplaySearchButton ?? showSearchButton
 
   const selectedVenue = useSelectedVenue()
   const venueTypeCode = useVenueTypeCode()
@@ -163,7 +165,7 @@ export const VenueMapView: FunctionComponent<Props> = ({ height }) => {
           />
         ))}
       </StyledMapView>
-      {showSearchButton ? (
+      {hasSearchButton ? (
         <ButtonContainer>
           <ButtonPrimary wording="Rechercher dans cette zone" onPress={handleSearchPress} />
         </ButtonContainer>

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
@@ -1,9 +1,9 @@
-import { useNavigation, useRoute } from '@react-navigation/native'
+import { useNavigation } from '@react-navigation/native'
 import React, { FunctionComponent, useEffect, useRef, useState } from 'react'
 import { LayoutChangeEvent } from 'react-native'
 import styled from 'styled-components/native'
 
-import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
+import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { VenueMapCluster } from 'features/venueMap/components/VenueMapCluster/VenueMapCluster'
 import { VenueMapPreview } from 'features/venueMap/components/VenueMapPreview/VenueMapPreview'
 import { PREVIEW_BOTTOM_MARGIN } from 'features/venueMap/components/VenueMapView/constant'
@@ -16,6 +16,10 @@ import { useGetDefaultRegion } from 'features/venueMap/hook/useGetDefaultRegion'
 import { useGetVenuesInRegion } from 'features/venueMap/hook/useGetVenuesInRegion'
 import { useTrackMapSeenDuration } from 'features/venueMap/hook/useTrackMapSeenDuration'
 import { useTrackMapSessionDuration } from 'features/venueMap/hook/useTrackSessionDuration'
+import {
+  useInitialVenues,
+  useInitialVenuesActions,
+} from 'features/venueMap/store/initialVenuesStore'
 import {
   useSelectedVenue,
   useSelectedVenueActions,
@@ -41,8 +45,8 @@ const PIN_MAX_Z_INDEX = 10_000
 
 export const VenueMapView: FunctionComponent<Props> = ({ height, shouldDisplaySearchButton }) => {
   const { navigate } = useNavigation<UseNavigationType>()
-  const { params } = useRoute<UseRouteType<'VenueMap'>>()
-  const [initialVenues, setInitialVenues] = useState(params?.initialVenues)
+  const initialVenues = useInitialVenues()
+  const { setInitialVenues } = useInitialVenuesActions()
   const isPreviewEnabled = useFeatureFlag(RemoteStoreFeatureFlags.WIP_VENUE_MAP)
   const mapViewRef = useRef<Map>(null)
   const previewHeight = useRef<number>(PREVIEW_HEIGHT_ESTIMATION)
@@ -91,7 +95,7 @@ export const VenueMapView: FunctionComponent<Props> = ({ height, shouldDisplaySe
   }
 
   const handleSearchPress = () => {
-    setInitialVenues(undefined)
+    setInitialVenues([])
     setLastRegionSearched(currentRegion)
     setShowSearchButton(false)
   }

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
@@ -36,14 +36,14 @@ import { getSpacing } from 'ui/theme'
 
 type Props = {
   height: number
-  shouldDisplaySearchButton?: boolean
+  from: 'venueMap' | 'searchResults'
 }
 
 const PREVIEW_HEIGHT_ESTIMATION = 114
 
 const PIN_MAX_Z_INDEX = 10_000
 
-export const VenueMapView: FunctionComponent<Props> = ({ height, shouldDisplaySearchButton }) => {
+export const VenueMapView: FunctionComponent<Props> = ({ height, from }) => {
   const { navigate } = useNavigation<UseNavigationType>()
   const initialVenues = useInitialVenues()
   const { setInitialVenues } = useInitialVenuesActions()
@@ -55,7 +55,7 @@ export const VenueMapView: FunctionComponent<Props> = ({ height, shouldDisplaySe
   const [currentRegion, setCurrentRegion] = useState<Region>(defaultRegion)
   const [lastRegionSearched, setLastRegionSearched] = useState<Region>(defaultRegion)
   const [showSearchButton, setShowSearchButton] = useState<boolean>(false)
-  const hasSearchButton = shouldDisplaySearchButton ?? showSearchButton
+  const hasSearchButton = from === 'venueMap' ? showSearchButton : false
 
   const selectedVenue = useSelectedVenue()
   const venueTypeCode = useVenueTypeCode()

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
@@ -153,6 +153,7 @@ export const VenueMapView: FunctionComponent<Props> = ({ height, shouldDisplaySe
         onClusterPress={isPreviewEnabled ? handlePressOutOfVenuePin : undefined}
         radius={50}
         animationEnabled={false}
+        height={height}
         testID="venue-map-view">
         {filteredVenues.map((venue) => (
           <Marker
@@ -192,7 +193,10 @@ export const VenueMapView: FunctionComponent<Props> = ({ height, shouldDisplaySe
   )
 }
 
-const StyledMapView = styled(MapView)({ height: '100%', width: '100%' })
+const StyledMapView = styled(MapView)<{ height?: number }>(({ height }) => ({
+  height: height ?? '100%',
+  width: '100%',
+}))
 
 const ButtonContainer = styled.View({
   position: 'absolute',

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
@@ -33,6 +33,7 @@ import MapView, { Map, Marker, MarkerPressEvent, Region } from 'libs/maps/maps'
 import { parseType } from 'libs/parsers/venueType'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { getSpacing } from 'ui/theme'
+import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 type Props = {
   height: number
@@ -45,6 +46,7 @@ const PIN_MAX_Z_INDEX = 10_000
 
 export const VenueMapView: FunctionComponent<Props> = ({ height, from }) => {
   const { navigate } = useNavigation<UseNavigationType>()
+  const { tabBarHeight } = useCustomSafeInsets()
   const initialVenues = useInitialVenues()
   const { setInitialVenues } = useInitialVenuesActions()
   const isPreviewEnabled = useFeatureFlag(RemoteStoreFeatureFlags.WIP_VENUE_MAP)
@@ -187,6 +189,8 @@ export const VenueMapView: FunctionComponent<Props> = ({ height, from }) => {
           onLayout={({ nativeEvent }: LayoutChangeEvent) => {
             previewHeight.current = nativeEvent.layout.height
           }}
+          from={from}
+          tabBarHeight={tabBarHeight}
         />
       ) : null}
     </React.Fragment>
@@ -206,9 +210,12 @@ const ButtonContainer = styled.View({
   alignItems: 'center',
 })
 
-const StyledVenueMapPreview = styled(VenueMapPreview)(({ theme }) => ({
+const StyledVenueMapPreview = styled(VenueMapPreview)<{
+  from: 'venueMap' | 'searchResults'
+  tabBarHeight: number
+}>(({ theme, from, tabBarHeight }) => ({
   position: 'absolute',
-  bottom: PREVIEW_BOTTOM_MARGIN,
+  bottom: from === 'venueMap' ? PREVIEW_BOTTOM_MARGIN : PREVIEW_BOTTOM_MARGIN + tabBarHeight,
   left: getSpacing(4),
   right: getSpacing(4),
   backgroundColor: theme.colors.white,

--- a/src/features/venueMap/pages/VenueMap/VenueMap.tsx
+++ b/src/features/venueMap/pages/VenueMap/VenueMap.tsx
@@ -68,7 +68,7 @@ export const VenueMap: FunctionComponent = () => {
         </FilterBannerContainer>
 
         <MapContainer>
-          <VenueMapView height={venueMapHeight} />
+          <VenueMapView height={venueMapHeight} from="venueMap" />
         </MapContainer>
       </Container>
       <VenueTypeModal hideModal={hideVenueTypeModal} isVisible={venueTypeModalVisible} />

--- a/src/features/venueMap/store/initialVenuesStore.native.test.ts
+++ b/src/features/venueMap/store/initialVenuesStore.native.test.ts
@@ -1,0 +1,25 @@
+import {
+  useInitialVenues,
+  useInitialVenuesActions,
+} from 'features/venueMap/store/initialVenuesStore'
+import { geolocatedVenuesFixture } from 'fixtures/geolocatedVenues'
+import { act, renderHook } from 'tests/utils'
+
+describe('initialVenuesStore', () => {
+  it('should venues be empty on init', async () => {
+    const { result: venues } = renderHook(useInitialVenues)
+
+    expect(venues.current).toEqual([])
+  })
+
+  it('should handle setInitialVenues', async () => {
+    const { result: venues } = renderHook(useInitialVenues)
+    const { result: actions } = renderHook(useInitialVenuesActions)
+
+    await act(async () => {
+      actions.current.setInitialVenues(geolocatedVenuesFixture)
+    })
+
+    expect(venues.current).toEqual(geolocatedVenuesFixture)
+  })
+})

--- a/src/features/venueMap/store/initialVenuesStore.ts
+++ b/src/features/venueMap/store/initialVenuesStore.ts
@@ -1,0 +1,22 @@
+import { Venue } from 'features/venue/types'
+import { createStore } from 'libs/store/createStore'
+
+type State = {
+  initialVenues: Venue[]
+}
+
+const defaultState: State = { initialVenues: [] }
+
+const setActions = (set: (payload: State) => void) => ({
+  setInitialVenues: (payload: Venue[]) => set({ initialVenues: payload }),
+})
+
+const useInitialVenuesStore = createStore<State, ReturnType<typeof setActions>>(
+  'venue-map-store',
+  defaultState,
+  setActions,
+  { persist: true }
+)
+
+export const useInitialVenues = () => useInitialVenuesStore((state) => state.initialVenues)
+export const useInitialVenuesActions = () => useInitialVenuesStore((state) => state.actions)


### PR DESCRIPTION
management of the height of the map in the tab

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30763

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |![Capture d’écran 2024-07-15 à 15 49 42](https://github.com/user-attachments/assets/73e784de-c66d-4e01-a42e-d7b2a67bde1a) ![Capture d’écran 2024-07-15 à 16 34 21](https://github.com/user-attachments/assets/86086151-b2a2-4a37-a999-45f8d2187970)|![Capture d’écran 2024-07-15 à 15 49 19](https://github.com/user-attachments/assets/114abbe0-0697-40a0-a291-359741947bf7) ![Capture d’écran 2024-07-15 à 16 34 01](https://github.com/user-attachments/assets/f5dd15da-1023-41b0-88d6-a9b0ebf19085)|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
