### PR TITLE
(PC-30769) feat(venueMap): bottom-sheet integration into venueMap

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@babel/runtime": "^7.24.4",
     "@bam.tech/react-native-config": "^1.4.5",
     "@batch.com/react-native-plugin": "^8.1.2",
+    "@gorhom/bottom-sheet": "^4",
     "@hookform/resolvers": "^2.9.11",
     "@openspacelabs/react-native-zoomable-view": "^2.1.5",
     "@ptomasroos/react-native-multi-slider": "^2.2.2",

--- a/src/features/venueMap/components/VenueMapBottomSheet/VenueMapBottomSheet.tsx
+++ b/src/features/venueMap/components/VenueMapBottomSheet/VenueMapBottomSheet.tsx
@@ -1,0 +1,24 @@
+import BottomSheet, { BottomSheetProps, BottomSheetView } from '@gorhom/bottom-sheet'
+import { BottomSheetMethods } from '@gorhom/bottom-sheet/lib/typescript/types'
+import React, { forwardRef } from 'react'
+import styled from 'styled-components/native'
+
+import { Typo } from 'ui/theme'
+
+export type VenueMapBottomSheetProps = Omit<BottomSheetProps, 'children'>
+
+export const VenueMapBottomSheet = forwardRef<BottomSheetMethods, VenueMapBottomSheetProps>(
+  function VenueMapBottomSheet(props, ref) {
+    return (
+      <StyledBottomSheet ref={ref} {...props}>
+        <BottomSheetView>
+          <Typo.Body>COUCOU</Typo.Body>
+        </BottomSheetView>
+      </StyledBottomSheet>
+    )
+  }
+)
+
+const StyledBottomSheet = styled(BottomSheet).attrs<VenueMapBottomSheetProps>({
+  containerStyle: { zIndex: 99 },
+})``

--- a/src/features/venueMap/components/VenueMapBottomSheet/VenueMapBottomSheet.tsx
+++ b/src/features/venueMap/components/VenueMapBottomSheet/VenueMapBottomSheet.tsx
@@ -69,6 +69,7 @@ export const VenueMapBottomSheet = forwardRef<BottomSheetMethods, VenueMapBottom
             tags={venueTags}
             navigateTo={{ screen: 'Venue', params: { id: venue.venueId } }}
             noBorder
+            testID="venueMapPreview"
           />
         )
       }

--- a/src/features/venueMap/components/VenueMapBottomSheet/VenueMapBottomSheet.tsx
+++ b/src/features/venueMap/components/VenueMapBottomSheet/VenueMapBottomSheet.tsx
@@ -41,7 +41,7 @@ export const VenueMapBottomSheet = forwardRef<BottomSheetMethods, VenueMapBottom
     }, [venue, distanceToVenue])
 
     const offersPlaylist = useMemo(() => {
-      if (Array.isArray(venueOffers) && venueOffers.length > 0) {
+      if (venueOffers?.length) {
         const handlePressMore = venue ? () => navigate('Venue', { id: venue.venueId }) : undefined
         return (
           <Fragment>
@@ -88,15 +88,14 @@ export const VenueMapBottomSheet = forwardRef<BottomSheetMethods, VenueMapBottom
 )
 
 const StyledBottomSheetView = styled(BottomSheetView)({
-  paddingRight: getSpacing(4),
-  paddingLeft: getSpacing(4),
   paddingTop: getSpacing(2),
+  paddingHorizontal: getSpacing(4),
   flex: 1,
 })
 
-const StyledBottomSheet = styled(BottomSheet).attrs<VenueMapBottomSheetProps>({
-  containerStyle: { zIndex: 99 },
-})``
+const StyledBottomSheet = styled(BottomSheet).attrs<VenueMapBottomSheetProps>(({ theme }) => ({
+  containerStyle: { zIndex: theme.zIndex.bottomSheet },
+}))``
 
 const StyledSeparator = styled(Separator.Horizontal)({
   marginTop: getSpacing(4),

--- a/src/features/venueMap/components/VenueMapBottomSheet/VenueMapBottomSheet.tsx
+++ b/src/features/venueMap/components/VenueMapBottomSheet/VenueMapBottomSheet.tsx
@@ -1,66 +1,85 @@
 import BottomSheet, { BottomSheetProps, BottomSheetView } from '@gorhom/bottom-sheet'
 import { BottomSheetMethods } from '@gorhom/bottom-sheet/lib/typescript/types'
-import React, { forwardRef, useImperativeHandle, useMemo, useRef } from 'react'
+import { useNavigation } from '@react-navigation/native'
+import React, { forwardRef, Fragment, useMemo } from 'react'
+import { ScrollView } from 'react-native-gesture-handler'
 import styled from 'styled-components/native'
 
+import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { VenueOfferPlaylist } from 'features/venueMap/components/VenueMapBottomSheet/VenueOfferPlaylist'
 import { VenueMapPreview } from 'features/venueMap/components/VenueMapPreview/VenueMapPreview'
 import { GeolocatedVenue } from 'features/venueMap/components/VenueMapView/types'
 import { getVenueTags } from 'features/venueMap/helpers/getVenueTags/getVenueTags'
 import { useDistance } from 'libs/location/hooks/useDistance'
 import { parseType } from 'libs/parsers/venueType'
+import { Offer } from 'shared/offer/types'
+import { Separator } from 'ui/components/Separator'
 import { getSpacing } from 'ui/theme'
 
 const VENUE_THUMBNAIL_SIZE = getSpacing(12)
 
-export interface VenueMapBottomSheetProps extends Omit<BottomSheetProps, 'children'> {
+interface VenueMapBottomSheetProps extends Omit<BottomSheetProps, 'children'> {
   onClose?: () => void
   venue?: GeolocatedVenue | null
+  venueOffers?: Offer[] | null
 }
 
 export const VenueMapBottomSheet = forwardRef<BottomSheetMethods, VenueMapBottomSheetProps>(
-  function VenueMapBottomSheet({ onClose, venue, ...bottomSheetProps }, ref) {
-    const bottomSheetRef = useRef<BottomSheet>(null)
-    const handleClose = () => {
-      bottomSheetRef.current?.close()
-      onClose?.()
-    }
-
-    // Plug internal Ref to an external Ref
-    useImperativeHandle<Partial<BottomSheetMethods>, Partial<BottomSheetMethods>>(ref, () => ({
-      close: bottomSheetRef.current?.close,
-      snapToIndex: bottomSheetRef.current?.snapToIndex,
-    }))
-
+  function VenueMapBottomSheet({ onClose, venue, venueOffers, ...bottomSheetProps }, ref) {
     const distanceToVenue = useDistance({
       lat: venue?._geoloc.lat,
       lng: venue?._geoloc.lng,
     })
+    const { navigate } = useNavigation<UseNavigationType>()
 
     const venueTags = useMemo(() => {
       if (!venue) {
         return []
       }
-
       const venueTypeLabel = parseType(venue?.venue_type)
       return getVenueTags({ distance: distanceToVenue, venue_type: venueTypeLabel })
     }, [venue, distanceToVenue])
 
+    const offersPlaylist = useMemo(() => {
+      if (Array.isArray(venueOffers) && venueOffers.length > 0) {
+        const handlePressMore = venue ? () => navigate('Venue', { id: venue.venueId }) : undefined
+        return (
+          <Fragment>
+            <StyledSeparator />
+            <ScrollView>
+              <VenueOfferPlaylist offers={venueOffers} onPressMore={handlePressMore} />
+            </ScrollView>
+          </Fragment>
+        )
+      }
+      return null
+    }, [venueOffers, navigate, venue])
+
+    const venueMapPreview = useMemo(() => {
+      if (venue) {
+        return (
+          <VenueMapPreview
+            venueName={venue.label}
+            onClose={onClose}
+            iconSize={20}
+            address={`${venue?.info}, ${venue?.postalCode}`}
+            bannerUrl={venue.banner_url ?? ''}
+            imageWidth={VENUE_THUMBNAIL_SIZE}
+            imageHeight={VENUE_THUMBNAIL_SIZE}
+            tags={venueTags}
+            navigateTo={{ screen: 'Venue', params: { id: venue.venueId } }}
+            noBorder
+          />
+        )
+      }
+      return null
+    }, [venue, onClose, venueTags])
+
     return (
-      <StyledBottomSheet ref={bottomSheetRef} {...bottomSheetProps}>
+      <StyledBottomSheet ref={ref} index={venue ? 0 : -1} {...bottomSheetProps}>
         <StyledBottomSheetView>
-          {venue ? (
-            <VenueMapPreview
-              venueName={venue.label}
-              onClose={handleClose}
-              address={`${venue?.info}, ${venue?.postalCode}`}
-              bannerUrl={venue.banner_url ?? ''}
-              imageWidth={VENUE_THUMBNAIL_SIZE}
-              imageHeight={VENUE_THUMBNAIL_SIZE}
-              tags={venueTags}
-              navigateTo={{ screen: 'Venue', params: { id: venue.venueId } }}
-              noBorder
-            />
-          ) : null}
+          {venueMapPreview}
+          {offersPlaylist}
         </StyledBottomSheetView>
       </StyledBottomSheet>
     )
@@ -71,8 +90,14 @@ const StyledBottomSheetView = styled(BottomSheetView)({
   paddingRight: getSpacing(4),
   paddingLeft: getSpacing(4),
   paddingTop: getSpacing(2),
+  flex: 1,
 })
 
 const StyledBottomSheet = styled(BottomSheet).attrs<VenueMapBottomSheetProps>({
   containerStyle: { zIndex: 99 },
 })``
+
+const StyledSeparator = styled(Separator.Horizontal)({
+  marginTop: getSpacing(4),
+  marginBottom: getSpacing(3),
+})

--- a/src/features/venueMap/components/VenueMapBottomSheet/VenueMapBottomSheet.tsx
+++ b/src/features/venueMap/components/VenueMapBottomSheet/VenueMapBottomSheet.tsx
@@ -1,23 +1,77 @@
 import BottomSheet, { BottomSheetProps, BottomSheetView } from '@gorhom/bottom-sheet'
 import { BottomSheetMethods } from '@gorhom/bottom-sheet/lib/typescript/types'
-import React, { forwardRef } from 'react'
+import React, { forwardRef, useImperativeHandle, useMemo, useRef } from 'react'
 import styled from 'styled-components/native'
 
-import { Typo } from 'ui/theme'
+import { VenueMapPreview } from 'features/venueMap/components/VenueMapPreview/VenueMapPreview'
+import { GeolocatedVenue } from 'features/venueMap/components/VenueMapView/types'
+import { getVenueTags } from 'features/venueMap/helpers/getVenueTags/getVenueTags'
+import { useDistance } from 'libs/location/hooks/useDistance'
+import { parseType } from 'libs/parsers/venueType'
+import { getSpacing } from 'ui/theme'
 
-export type VenueMapBottomSheetProps = Omit<BottomSheetProps, 'children'>
+const VENUE_THUMBNAIL_SIZE = getSpacing(12)
+
+export interface VenueMapBottomSheetProps extends Omit<BottomSheetProps, 'children'> {
+  onClose?: () => void
+  venue?: GeolocatedVenue | null
+}
 
 export const VenueMapBottomSheet = forwardRef<BottomSheetMethods, VenueMapBottomSheetProps>(
-  function VenueMapBottomSheet(props, ref) {
+  function VenueMapBottomSheet({ onClose, venue, ...bottomSheetProps }, ref) {
+    const bottomSheetRef = useRef<BottomSheet>(null)
+    const handleClose = () => {
+      bottomSheetRef.current?.close()
+      onClose?.()
+    }
+
+    // Plug internal Ref to an external Ref
+    useImperativeHandle<Partial<BottomSheetMethods>, Partial<BottomSheetMethods>>(ref, () => ({
+      close: bottomSheetRef.current?.close,
+      snapToIndex: bottomSheetRef.current?.snapToIndex,
+    }))
+
+    const distanceToVenue = useDistance({
+      lat: venue?._geoloc.lat,
+      lng: venue?._geoloc.lng,
+    })
+
+    const venueTags = useMemo(() => {
+      if (!venue) {
+        return []
+      }
+
+      const venueTypeLabel = parseType(venue?.venue_type)
+      return getVenueTags({ distance: distanceToVenue, venue_type: venueTypeLabel })
+    }, [venue, distanceToVenue])
+
     return (
-      <StyledBottomSheet ref={ref} {...props}>
-        <BottomSheetView>
-          <Typo.Body>COUCOU</Typo.Body>
-        </BottomSheetView>
+      <StyledBottomSheet ref={bottomSheetRef} {...bottomSheetProps}>
+        <StyledBottomSheetView>
+          {venue ? (
+            <VenueMapPreview
+              venueName={venue.label}
+              onClose={handleClose}
+              address={`${venue?.info}, ${venue?.postalCode}`}
+              bannerUrl={venue.banner_url ?? ''}
+              imageWidth={VENUE_THUMBNAIL_SIZE}
+              imageHeight={VENUE_THUMBNAIL_SIZE}
+              tags={venueTags}
+              navigateTo={{ screen: 'Venue', params: { id: venue.venueId } }}
+              noBorder
+            />
+          ) : null}
+        </StyledBottomSheetView>
       </StyledBottomSheet>
     )
   }
 )
+
+const StyledBottomSheetView = styled(BottomSheetView)({
+  paddingRight: getSpacing(4),
+  paddingLeft: getSpacing(4),
+  paddingTop: getSpacing(2),
+})
 
 const StyledBottomSheet = styled(BottomSheet).attrs<VenueMapBottomSheetProps>({
   containerStyle: { zIndex: 99 },

--- a/src/features/venueMap/components/VenueMapBottomSheet/VenueOfferPlaylist.tsx
+++ b/src/features/venueMap/components/VenueMapBottomSheet/VenueOfferPlaylist.tsx
@@ -55,6 +55,7 @@ export const VenueOfferPlaylist = ({ offers, onPressMore }: VenueOfferPlaylistPr
         renderItem={renderItem}
         keyExtractor={keyExtractor}
         FlatListComponent={FlatList}
+        testID="venueOfferPlaylist"
       />
       <StyleButtonTertiaryBlack
         inline

--- a/src/features/venueMap/components/VenueMapBottomSheet/VenueOfferPlaylist.tsx
+++ b/src/features/venueMap/components/VenueMapBottomSheet/VenueOfferPlaylist.tsx
@@ -7,7 +7,7 @@ import { getDisplayPrice } from 'libs/parsers/getDisplayPrice'
 import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
 import { Offer } from 'shared/offer/types'
 import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
-import { Playlist } from 'ui/components/Playlist'
+import { CustomListRenderItem, Playlist } from 'ui/components/Playlist'
 import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
 import { getSpacing, LENGTH_S, RATIO_HOME_IMAGE } from 'ui/theme'
 
@@ -25,8 +25,8 @@ export const VenueOfferPlaylist = ({ offers, onPressMore }: VenueOfferPlaylistPr
   const mapping = useCategoryIdMapping()
   const labelMapping = useCategoryHomeLabelMapping()
 
-  const renderItem = useCallback(
-    ({ item }: { item: Offer }) => (
+  const renderItem: CustomListRenderItem<Offer> = useCallback(
+    ({ item }) => (
       <OfferTile
         offerId={Number(item.objectID)}
         categoryLabel={labelMapping[item.offer.subcategoryId]}

--- a/src/features/venueMap/components/VenueMapBottomSheet/VenueOfferPlaylist.tsx
+++ b/src/features/venueMap/components/VenueMapBottomSheet/VenueOfferPlaylist.tsx
@@ -1,0 +1,72 @@
+import React, { Fragment, useCallback } from 'react'
+import { FlatList } from 'react-native-gesture-handler'
+import styled from 'styled-components/native'
+
+import { OfferTile } from 'features/offer/components/OfferTile/OfferTile'
+import { getDisplayPrice } from 'libs/parsers/getDisplayPrice'
+import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
+import { Offer } from 'shared/offer/types'
+import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
+import { Playlist } from 'ui/components/Playlist'
+import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
+import { getSpacing, LENGTH_S, RATIO_HOME_IMAGE } from 'ui/theme'
+
+type VenueOfferPlaylistProps = {
+  offers: Offer[]
+  onPressMore?: () => void
+}
+
+const PLAYLIST_ITEM_HEIGHT = LENGTH_S
+const PLAYLIST_ITEM_WIDTH = PLAYLIST_ITEM_HEIGHT * RATIO_HOME_IMAGE
+
+const keyExtractor = (item: Offer) => item.objectID
+
+export const VenueOfferPlaylist = ({ offers, onPressMore }: VenueOfferPlaylistProps) => {
+  const mapping = useCategoryIdMapping()
+  const labelMapping = useCategoryHomeLabelMapping()
+
+  const renderItem = useCallback(
+    ({ item }: { item: Offer }) => (
+      <OfferTile
+        offerId={Number(item.objectID)}
+        categoryLabel={labelMapping[item.offer.subcategoryId]}
+        categoryId={mapping[item.offer.subcategoryId]}
+        subcategoryId={item.offer.subcategoryId}
+        name={item.offer.name}
+        offerLocation={item._geoloc}
+        analyticsFrom="venuemap"
+        thumbUrl={item.offer.thumbUrl}
+        price={getDisplayPrice(item.offer.prices)}
+        width={PLAYLIST_ITEM_WIDTH}
+        height={PLAYLIST_ITEM_HEIGHT}
+        variant="new"
+        isDuo={false}
+      />
+    ),
+    [labelMapping, mapping]
+  )
+
+  return (
+    <Fragment>
+      <Playlist
+        data={offers}
+        itemHeight={PLAYLIST_ITEM_HEIGHT}
+        itemWidth={PLAYLIST_ITEM_WIDTH}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        FlatListComponent={FlatList}
+      />
+      <StyleButtonTertiaryBlack
+        inline
+        wording="Voir les offres du lieu"
+        onPress={onPressMore}
+        icon={PlainArrowNext}
+      />
+    </Fragment>
+  )
+}
+
+const StyleButtonTertiaryBlack = styled(ButtonTertiaryBlack)({
+  transform: 'translateY(-10px)',
+  paddingBottom: getSpacing(2),
+})

--- a/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.native.test.tsx
@@ -6,7 +6,7 @@ import { VenueMapPreview } from 'features/venueMap/components/VenueMapPreview/Ve
 import { fireEvent, render, screen } from 'tests/utils'
 
 describe('<VenueMapPreview />', () => {
-  it('should render correctly by default', () => {
+  it('should render correctly with border by default', () => {
     renderVenueMapPreview({})
 
     expect(screen.getByTestId('venueMapPreview')).toHaveStyle({ borderWidth: 1 })

--- a/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.native.test.tsx
@@ -6,6 +6,18 @@ import { VenueMapPreview } from 'features/venueMap/components/VenueMapPreview/Ve
 import { fireEvent, render, screen } from 'tests/utils'
 
 describe('<VenueMapPreview />', () => {
+  it('should render correctly by default', () => {
+    renderVenueMapPreview({})
+
+    expect(screen.getByTestId('venueMapPreview')).toHaveStyle({ borderWidth: 1 })
+  })
+
+  it('should render correctly with no border', () => {
+    renderVenueMapPreview({ noBorder: true })
+
+    expect(screen.getByTestId('venueMapPreview')).not.toHaveStyle({ borderWidth: 1 })
+  })
+
   it('should display venue name', () => {
     renderVenueMapPreview({})
 
@@ -48,15 +60,18 @@ function renderVenueMapPreview({
   address = offerResponseSnap.venue.address ?? '',
   bannerUrl = offerResponseSnap.venue.bannerUrl ?? '',
   tags = [],
+  noBorder = false,
   navigateTo = { screen: 'Venue' },
 }: RenderVenueMapPreviewType) {
-  render(
+  return render(
     <VenueMapPreview
       venueName={venueName}
       address={address}
       bannerUrl={bannerUrl}
       tags={tags}
+      noBorder={noBorder}
       navigateTo={navigateTo}
+      testID="venueMapPreview"
     />
   )
 }

--- a/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.tsx
+++ b/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.tsx
@@ -14,6 +14,7 @@ type Props = {
   bannerUrl: string
   tags: string[]
   onClose?: VoidFunction
+  noBorder?: boolean
 } & ComponentProps<typeof InternalTouchableLink>
 
 const VENUE_THUMBNAIL_SIZE = getSpacing(12)
@@ -24,10 +25,12 @@ export const VenueMapPreview: FunctionComponent<Props> = ({
   bannerUrl,
   tags,
   onClose,
+  noBorder,
   ...touchableProps
 }) => {
+  const Wrapper = noBorder ? InternalTouchableLink : Container
   return (
-    <Container {...touchableProps}>
+    <Wrapper {...touchableProps}>
       <Row>
         <StyledInformationTags tags={tags} />
         <StyledCloseButton onClose={onClose} />
@@ -40,7 +43,7 @@ export const VenueMapPreview: FunctionComponent<Props> = ({
         imageWidth={VENUE_THUMBNAIL_SIZE}
         imageHeight={VENUE_THUMBNAIL_SIZE}
       />
-    </Container>
+    </Wrapper>
   )
 }
 

--- a/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.tsx
+++ b/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.tsx
@@ -15,6 +15,7 @@ type Props = {
   tags: string[]
   onClose?: VoidFunction
   noBorder?: boolean
+  iconSize?: number
 } & ComponentProps<typeof InternalTouchableLink>
 
 const VENUE_THUMBNAIL_SIZE = getSpacing(12)
@@ -25,6 +26,7 @@ export const VenueMapPreview: FunctionComponent<Props> = ({
   bannerUrl,
   tags,
   onClose,
+  iconSize,
   noBorder,
   ...touchableProps
 }) => {
@@ -33,7 +35,7 @@ export const VenueMapPreview: FunctionComponent<Props> = ({
     <Wrapper {...touchableProps}>
       <Row>
         <StyledInformationTags tags={tags} />
-        <StyledCloseButton onClose={onClose} />
+        <StyledCloseButton onClose={onClose} size={iconSize} />
       </Row>
       <Spacer.Column numberOfSpaces={2} />
       <VenuePreview

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
@@ -26,9 +26,11 @@ jest.mock('features/venue/api/useVenueOffers')
 jest.mock('features/venueMap/helpers/zoomOutIfMapEmpty')
 
 describe('<VenueMapView />', () => {
-  mockUseGetAllVenues.mockReturnValue({ venues: venuesFixture })
-  mockUseCenterOnLocation.mockReturnValue(jest.fn())
-  useFeatureFlagSpy.mockReturnValue(true)
+  beforeAll(() => {
+    mockUseGetAllVenues.mockReturnValue({ venues: venuesFixture })
+    mockUseCenterOnLocation.mockReturnValue(jest.fn())
+    useFeatureFlagSpy.mockReturnValue(true)
+  })
 
   it('should render map', async () => {
     renderVenueMapView()

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
 
 import { VenueMapView } from 'features/venueMap/components/VenueMapView/VenueMapView'
+import { useCenterOnLocation } from 'features/venueMap/hook/useCenterOnLocation'
+import { useGetAllVenues } from 'features/venueMap/useGetAllVenues'
+import { venuesFixture } from 'libs/algolia/fetchAlgolia/fetchVenues/fixtures/venuesFixture'
 import * as useFeatureFlag from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen } from 'tests/utils'
+import { fireEvent, render, screen, waitFor } from 'tests/utils'
 
 const mockSetInitialVenues = jest.fn()
 jest.mock('features/venueMap/store/initialVenuesStore', () => ({
@@ -11,14 +14,28 @@ jest.mock('features/venueMap/store/initialVenuesStore', () => ({
   useInitialVenues: jest.fn(),
 }))
 
-jest.spyOn(useFeatureFlag, 'useFeatureFlag').mockReturnValue(true)
+const useFeatureFlagSpy = jest.spyOn(useFeatureFlag, 'useFeatureFlag')
+
+jest.mock('features/venueMap/useGetAllVenues')
+const mockUseGetAllVenues = useGetAllVenues as jest.Mock
+
+jest.mock('features/venueMap/hook/useCenterOnLocation')
+const mockUseCenterOnLocation = useCenterOnLocation as jest.Mock
+
+jest.mock('features/venue/api/useVenueOffers')
+jest.mock('features/venueMap/helpers/zoomOutIfMapEmpty')
 
 describe('<VenueMapView />', () => {
+  mockUseGetAllVenues.mockReturnValue({ venues: venuesFixture })
+  mockUseCenterOnLocation.mockReturnValue(jest.fn())
+  useFeatureFlagSpy.mockReturnValue(true)
+
   it('should render map', async () => {
     renderVenueMapView()
     const mapView = await screen.findByTestId('venue-map-view')
 
     expect(mapView).toBeOnTheScreen()
+    expect(screen.getAllByTestId(/marker-/)).toHaveLength(venuesFixture.length)
   })
 
   it('should not display search button after initializing the map', async () => {
@@ -74,8 +91,83 @@ describe('<VenueMapView />', () => {
 
     expect(mockSetInitialVenues).toHaveBeenNthCalledWith(1, [])
   })
+
+  it('should display venueMapPreview + venueMapList in bottom sheet when marker is pressed', async () => {
+    renderVenueMapView()
+    await screen.findByTestId(`marker-${venuesFixture[0].venueId}`)
+    fireEvent.press(screen.getByTestId(`marker-${venuesFixture[0].venueId}`), {
+      stopPropagation: () => false,
+      nativeEvent: {
+        id: venuesFixture[0].venueId.toString(),
+        coordinate: {
+          latitude: venuesFixture[0]._geoloc.lat,
+          longitude: venuesFixture[0]._geoloc.lng,
+        },
+      },
+    })
+
+    await screen.findByTestId('venueMapPreview')
+
+    expect(screen.getByTestId('venueMapPreview')).toBeOnTheScreen()
+    expect(screen.getByTestId('venueOfferPlaylist')).toBeOnTheScreen()
+    expect(screen.getByText('Voir les offres du lieu')).toBeOnTheScreen()
+  })
+
+  it('should not display preview is marker id has not been found in venue list', async () => {
+    renderVenueMapView()
+    await screen.findByTestId(`marker-${venuesFixture[0].venueId}`)
+    fireEvent.press(screen.getByTestId(`marker-${venuesFixture[0].venueId}`), {
+      stopPropagation: () => false,
+      nativeEvent: {
+        id: '0',
+        coordinate: {
+          latitude: venuesFixture[0]._geoloc.lat,
+          longitude: venuesFixture[0]._geoloc.lng,
+        },
+      },
+    })
+
+    await waitFor(() => expect(screen.queryByTestId('venueMapPreview')).not.toBeOnTheScreen())
+  })
+
+  it('should not display preview is FF disabled', async () => {
+    useFeatureFlagSpy.mockReturnValueOnce(false)
+    renderVenueMapView()
+    await screen.findByTestId(`marker-${venuesFixture[0].venueId}`)
+    fireEvent.press(screen.getByTestId(`marker-${venuesFixture[0].venueId}`), {
+      stopPropagation: () => false,
+      nativeEvent: {
+        id: venuesFixture[0].venueId.toString(),
+        coordinate: {
+          latitude: venuesFixture[0]._geoloc.lat,
+          longitude: venuesFixture[0]._geoloc.lng,
+        },
+      },
+    })
+
+    await waitFor(() => expect(screen.queryByTestId('venueMapPreview')).not.toBeOnTheScreen())
+  })
+
+  it('should hide bottom sheet when a marker is selected and map is pressed', async () => {
+    renderVenueMapView()
+    await screen.findByTestId(`marker-${venuesFixture[0].venueId}`)
+    fireEvent.press(screen.getByTestId(`marker-${venuesFixture[0].venueId}`), {
+      stopPropagation: () => false,
+      nativeEvent: {
+        id: venuesFixture[0].venueId.toString(),
+        coordinate: {
+          latitude: venuesFixture[0]._geoloc.lat,
+          longitude: venuesFixture[0]._geoloc.lng,
+        },
+      },
+    })
+
+    fireEvent.press(screen.getByTestId('venue-map-view'))
+
+    await waitFor(() => expect(screen.queryByTestId('venueMapPreview')).not.toBeOnTheScreen())
+  })
 })
 
 function renderVenueMapView() {
-  render(reactQueryProviderHOC(<VenueMapView height={700} from="venueMap" />))
+  return render(reactQueryProviderHOC(<VenueMapView height={700} from="venueMap" />))
 }

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
@@ -128,7 +128,7 @@ export const VenueMapView: FunctionComponent<Props> = ({ height, from }) => {
   const snapPoints = useMemo(
     () =>
       from === 'searchResults'
-        ? [windowHeight / 3 - tabBarHeight, windowHeight / 2 - tabBarHeight]
+        ? [tabBarHeight + 140, windowHeight / 2 - tabBarHeight]
         : ['25%', '50%'],
     [from, tabBarHeight, windowHeight]
   )
@@ -143,7 +143,13 @@ export const VenueMapView: FunctionComponent<Props> = ({ height, from }) => {
 
   return (
     <React.Fragment>
-      <VenueMapBottomSheet snapPoints={snapPoints} index={-1} ref={bottomSheetRef} />
+      <VenueMapBottomSheet
+        snapPoints={snapPoints}
+        index={-1}
+        ref={bottomSheetRef}
+        onClose={removeSelectedVenue}
+        venue={selectedVenue}
+      />
       <StyledMapView
         ref={mapViewRef}
         showsUserLocation

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
@@ -126,6 +126,7 @@ export const VenueMapView: FunctionComponent<Props> = ({ height, from }) => {
     const foundVenue = filteredVenues.find(
       (venue) => venue.venueId.toString() === event.nativeEvent.id
     )
+
     if (!foundVenue) {
       return
     }
@@ -194,7 +195,7 @@ export const VenueMapView: FunctionComponent<Props> = ({ height, from }) => {
         pitchEnabled={false}
         moveOnMarkerPress={false}
         onRegionChangeComplete={handleRegionChangeComplete}
-        renderCluster={(props) => <VenueMapCluster {...props} />}
+        renderCluster={VenueMapCluster}
         onPress={isPreviewEnabled ? handlePressOutOfVenuePin : undefined}
         onClusterPress={isPreviewEnabled ? handlePressOutOfVenuePin : undefined}
         radius={50}
@@ -213,6 +214,7 @@ export const VenueMapView: FunctionComponent<Props> = ({ height, from }) => {
               uri: getVenueTypeIconName(venue.venueId === selectedVenue?.venueId, venue.venue_type),
             }}
             identifier={venue.venueId.toString()}
+            testID={`marker-${venue.venueId}`}
             zIndex={venue.venueId === selectedVenue?.venueId ? PIN_MAX_Z_INDEX : undefined}
           />
         ))}

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.web.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.web.tsx
@@ -1,0 +1,1 @@
+export const VenueMapView = () => null

--- a/src/features/venueMap/helpers/geoLocatedVenueToVenueResponse/geoLocatedVenueToVenueResponse.test.ts
+++ b/src/features/venueMap/helpers/geoLocatedVenueToVenueResponse/geoLocatedVenueToVenueResponse.test.ts
@@ -1,0 +1,35 @@
+import { VenueResponse } from 'api/gen'
+import { GeolocatedVenue } from 'features/venueMap/components/VenueMapView/types'
+import { transformGeoLocatedVenueToVenueResponse } from 'features/venueMap/helpers/geoLocatedVenueToVenueResponse/geoLocatedVenueToVenueResponse'
+
+describe('transformGeoLocatedVenueToVenueResponse', () => {
+  it('should tranform GeolocatedVenue to VenueResponse', () => {
+    const geolocatedData = {
+      label: 'VENUE',
+      _geoloc: {
+        lat: 1.1,
+        lng: 2.2,
+      },
+      info: 'INFO',
+      venueId: 123,
+    } satisfies GeolocatedVenue
+
+    const expectedVenueResponse = {
+      id: geolocatedData.venueId,
+      name: geolocatedData.label,
+      longitude: geolocatedData._geoloc.lng,
+      latitude: geolocatedData._geoloc.lat,
+      accessibility: {},
+      timezone: '',
+      isVirtual: false,
+    } satisfies VenueResponse
+
+    expect(transformGeoLocatedVenueToVenueResponse(geolocatedData)).toMatchObject(
+      expectedVenueResponse
+    )
+  })
+
+  it('should return undefined if no data', () => {
+    expect(transformGeoLocatedVenueToVenueResponse(undefined)).toBeUndefined()
+  })
+})

--- a/src/features/venueMap/helpers/geoLocatedVenueToVenueResponse/geoLocatedVenueToVenueResponse.ts
+++ b/src/features/venueMap/helpers/geoLocatedVenueToVenueResponse/geoLocatedVenueToVenueResponse.ts
@@ -1,0 +1,20 @@
+import { VenueResponse } from 'api/gen'
+import { GeolocatedVenue } from 'features/venueMap/components/VenueMapView/types'
+
+export const transformGeoLocatedVenueToVenueResponse = (
+  data?: GeolocatedVenue | null
+): VenueResponse | undefined => {
+  if (data && data !== null) {
+    const { venueId, label, _geoloc } = data
+    return {
+      id: venueId,
+      name: label,
+      longitude: _geoloc.lng,
+      latitude: _geoloc.lat,
+      accessibility: {},
+      timezone: '',
+      isVirtual: false,
+    }
+  }
+  return undefined
+}

--- a/src/features/venueMap/pages/VenueMap/VenueMap.native.test.tsx
+++ b/src/features/venueMap/pages/VenueMap/VenueMap.native.test.tsx
@@ -7,6 +7,7 @@ import * as useFeatureFlag from 'libs/firebase/firestore/featureFlags/useFeature
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { fireEvent, render, screen, waitFor } from 'tests/utils'
 
+jest.mock('features/venue/api/useVenueOffers')
 jest.spyOn(useFeatureFlag, 'useFeatureFlag').mockReturnValue(true)
 
 const mockGoBack = jest.fn()

--- a/src/features/venueMap/pages/VenueMap/VenueMap.tsx
+++ b/src/features/venueMap/pages/VenueMap/VenueMap.tsx
@@ -2,113 +2,24 @@ import React, { FunctionComponent } from 'react'
 import { useWindowDimensions } from 'react-native'
 import styled from 'styled-components/native'
 
-import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/helpers'
-import { useGoBack } from 'features/navigation/useGoBack'
-import { SingleFilterButton } from 'features/search/components/Buttons/SingleFilterButton/SingleFilterButton'
 import { FILTER_BANNER_HEIGHT } from 'features/venueMap/components/VenueMapView/constant'
 import { VenueMapView } from 'features/venueMap/components/VenueMapView/VenueMapView'
-import { getVenueTypeLabel } from 'features/venueMap/helpers/getVenueTypeLabel/getVenueTypeLabel'
-import { VenueTypeModal } from 'features/venueMap/pages/modals/VenueTypeModal/VenueTypeModal'
-import {
-  useVenueTypeCode,
-  useVenueTypeCodeActions,
-} from 'features/venueMap/store/venueTypeCodeStore'
-import { ellipseString } from 'shared/string/ellipseString'
-import {
-  PageHeaderWithoutPlaceholder,
-  useGetHeaderHeight,
-} from 'ui/components/headers/PageHeaderWithoutPlaceholder'
-import { Li } from 'ui/components/Li'
-import { useModal } from 'ui/components/modals/useModal'
-import { Ul } from 'ui/components/Ul'
-import { getSpacing } from 'ui/theme'
-
-const MAX_VENUE_CHARACTERS = 20
+import { VenueMapBase } from 'features/venueMap/pages/VenueMap/VenueMapBase'
+import { useGetHeaderHeight } from 'ui/components/headers/PageHeaderWithoutPlaceholder'
 
 export const VenueMap: FunctionComponent = () => {
-  const { goBack } = useGoBack(...getSearchStackConfig('SearchLanding'))
-
-  const venueTypeCode = useVenueTypeCode()
-  const { setVenueTypeCode } = useVenueTypeCodeActions()
-
   const headerHeight = useGetHeaderHeight()
   const { height } = useWindowDimensions()
-
-  const {
-    visible: venueTypeModalVisible,
-    showModal: showVenueTypeModal,
-    hideModal: hideVenueTypeModal,
-  } = useModal(false)
-
   const venueMapHeight = height - (headerHeight + FILTER_BANNER_HEIGHT)
-
-  const venueTypeLabel = getVenueTypeLabel(venueTypeCode) ?? 'Tous les lieux'
-
-  const handleGoBack = () => {
-    setVenueTypeCode(null)
-    goBack()
-  }
-
   return (
-    <React.Fragment>
-      <Container>
-        <StyledHeader title="Carte des lieux" onGoBack={handleGoBack} />
-        <PlaceHolder headerHeight={headerHeight + FILTER_BANNER_HEIGHT} />
-
-        <FilterBannerContainer headerHeight={headerHeight}>
-          <StyledUl>
-            <StyledLi>
-              <SingleFilterButton
-                label={ellipseString(venueTypeLabel, MAX_VENUE_CHARACTERS)}
-                isSelected={venueTypeCode !== null}
-                onPress={showVenueTypeModal}
-              />
-            </StyledLi>
-          </StyledUl>
-        </FilterBannerContainer>
-
-        <MapContainer>
-          <VenueMapView height={venueMapHeight} from="venueMap" />
-        </MapContainer>
-      </Container>
-      <VenueTypeModal hideModal={hideVenueTypeModal} isVisible={venueTypeModalVisible} />
-    </React.Fragment>
+    <VenueMapBase>
+      <MapContainer>
+        <VenueMapView height={venueMapHeight} from="venueMap" />
+      </MapContainer>
+    </VenueMapBase>
   )
 }
 
-const Container = styled.View({
-  flex: 1,
-})
-
-const StyledHeader = styled(PageHeaderWithoutPlaceholder)(({ theme }) => ({
-  backgroundColor: theme.colors.white,
-}))
-
-const PlaceHolder = styled.View<{ headerHeight: number }>(({ headerHeight }) => ({
-  height: headerHeight,
-}))
-
-const FilterBannerContainer = styled.View<{ headerHeight: number }>(({ headerHeight }) => ({
-  height: FILTER_BANNER_HEIGHT,
-  position: 'absolute',
-  zIndex: 1,
-  top: headerHeight,
-  left: 0,
-  right: 0,
-  paddingHorizontal: getSpacing(6),
-  paddingVertical: getSpacing(1),
-}))
-
 const MapContainer = styled.View({
   flex: 1,
-})
-
-const StyledUl = styled(Ul)({
-  alignItems: 'center',
-})
-
-const StyledLi = styled(Li)({
-  marginLeft: getSpacing(1),
-  marginTop: getSpacing(1),
-  marginBottom: getSpacing(1),
 })

--- a/src/features/venueMap/pages/VenueMap/VenueMap.web.tsx
+++ b/src/features/venueMap/pages/VenueMap/VenueMap.web.tsx
@@ -1,0 +1,3 @@
+import { VenueMapBase } from 'features/venueMap/pages/VenueMap/VenueMapBase'
+
+export const VenueMap = VenueMapBase

--- a/src/features/venueMap/pages/VenueMap/VenueMapBase.tsx
+++ b/src/features/venueMap/pages/VenueMap/VenueMapBase.tsx
@@ -1,0 +1,102 @@
+import React, { FunctionComponent, ReactNode } from 'react'
+import styled from 'styled-components/native'
+
+import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/helpers'
+import { useGoBack } from 'features/navigation/useGoBack'
+import { SingleFilterButton } from 'features/search/components/Buttons/SingleFilterButton/SingleFilterButton'
+import { FILTER_BANNER_HEIGHT } from 'features/venueMap/components/VenueMapView/constant'
+import { getVenueTypeLabel } from 'features/venueMap/helpers/getVenueTypeLabel/getVenueTypeLabel'
+import { VenueTypeModal } from 'features/venueMap/pages/modals/VenueTypeModal/VenueTypeModal'
+import {
+  useVenueTypeCode,
+  useVenueTypeCodeActions,
+} from 'features/venueMap/store/venueTypeCodeStore'
+import { ellipseString } from 'shared/string/ellipseString'
+import {
+  PageHeaderWithoutPlaceholder,
+  useGetHeaderHeight,
+} from 'ui/components/headers/PageHeaderWithoutPlaceholder'
+import { Li } from 'ui/components/Li'
+import { useModal } from 'ui/components/modals/useModal'
+import { Ul } from 'ui/components/Ul'
+import { getSpacing } from 'ui/theme'
+
+const MAX_VENUE_CHARACTERS = 20
+
+export const VenueMapBase: FunctionComponent<{ children?: ReactNode }> = ({ children }) => {
+  const { goBack } = useGoBack(...getSearchStackConfig('SearchLanding'))
+
+  const venueTypeCode = useVenueTypeCode()
+  const { setVenueTypeCode } = useVenueTypeCodeActions()
+
+  const headerHeight = useGetHeaderHeight()
+
+  const {
+    visible: venueTypeModalVisible,
+    showModal: showVenueTypeModal,
+    hideModal: hideVenueTypeModal,
+  } = useModal(false)
+
+  const venueTypeLabel = getVenueTypeLabel(venueTypeCode) ?? 'Tous les lieux'
+
+  const handleGoBack = () => {
+    setVenueTypeCode(null)
+    goBack()
+  }
+
+  return (
+    <React.Fragment>
+      <Container>
+        <StyledHeader title="Carte des lieux" onGoBack={handleGoBack} />
+        <PlaceHolder headerHeight={headerHeight + FILTER_BANNER_HEIGHT} />
+
+        <FilterBannerContainer headerHeight={headerHeight}>
+          <StyledUl>
+            <StyledLi>
+              <SingleFilterButton
+                label={ellipseString(venueTypeLabel, MAX_VENUE_CHARACTERS)}
+                isSelected={venueTypeCode !== null}
+                onPress={showVenueTypeModal}
+              />
+            </StyledLi>
+          </StyledUl>
+        </FilterBannerContainer>
+        {children}
+      </Container>
+      <VenueTypeModal hideModal={hideVenueTypeModal} isVisible={venueTypeModalVisible} />
+    </React.Fragment>
+  )
+}
+
+const Container = styled.View({
+  flex: 1,
+})
+
+const StyledHeader = styled(PageHeaderWithoutPlaceholder)(({ theme }) => ({
+  backgroundColor: theme.colors.white,
+}))
+
+const PlaceHolder = styled.View<{ headerHeight: number }>(({ headerHeight }) => ({
+  height: headerHeight,
+}))
+
+const FilterBannerContainer = styled.View<{ headerHeight: number }>(({ headerHeight }) => ({
+  height: FILTER_BANNER_HEIGHT,
+  position: 'absolute',
+  zIndex: 1,
+  top: headerHeight,
+  left: 0,
+  right: 0,
+  paddingHorizontal: getSpacing(6),
+  paddingVertical: getSpacing(1),
+}))
+
+const StyledUl = styled(Ul)({
+  alignItems: 'center',
+})
+
+const StyledLi = styled(Li)({
+  marginLeft: getSpacing(1),
+  marginTop: getSpacing(1),
+  marginBottom: getSpacing(1),
+})

--- a/src/features/venueMap/pages/VenueMap/VenueMapBase.tsx
+++ b/src/features/venueMap/pages/VenueMap/VenueMapBase.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode } from 'react'
+import React, { FunctionComponent, PropsWithChildren } from 'react'
 import styled from 'styled-components/native'
 
 import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/helpers'
@@ -23,7 +23,7 @@ import { getSpacing } from 'ui/theme'
 
 const MAX_VENUE_CHARACTERS = 20
 
-export const VenueMapBase: FunctionComponent<{ children?: ReactNode }> = ({ children }) => {
+export const VenueMapBase: FunctionComponent<PropsWithChildren> = ({ children }) => {
   const { goBack } = useGoBack(...getSearchStackConfig('SearchLanding'))
 
   const venueTypeCode = useVenueTypeCode()
@@ -97,6 +97,5 @@ const StyledUl = styled(Ul)({
 
 const StyledLi = styled(Li)({
   marginLeft: getSpacing(1),
-  marginTop: getSpacing(1),
-  marginBottom: getSpacing(1),
+  marginVertical: getSpacing(1),
 })

--- a/src/libs/algolia/fetchAlgolia/fetchVenues/fixtures/AlgoliaVenuesFixture.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchVenues/fixtures/AlgoliaVenuesFixture.ts
@@ -28,7 +28,7 @@ export const algoliaVenuesFixture: AlgoliaVenue[] = [
     _geoloc: { lat: 48.871728, lng: 2.308157 },
   },
   {
-    _geoloc: { lat: 48.871728, lng: 2.308157 },
+    _geoloc: { lat: 48.84751, lng: 2.34231 },
     audio_disability: false,
     banner_url:
       'https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/thumbs/venues/CBQA_1678748459',

--- a/src/libs/algolia/fetchAlgolia/fetchVenues/fixtures/venuesFixture.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchVenues/fixtures/venuesFixture.ts
@@ -14,7 +14,7 @@ export const venuesFixture = [
     label: 'La librairie quantique',
     info: 'Syndicat des librairies physiques',
     venueId: 4192,
-    _geoloc: { lat: 48.871728, lng: 2.308157 },
+    _geoloc: { lat: 48.84751, lng: 2.34231 },
     banner_url:
       'https://storage.googleapis.com/passculture-metier-ehp-testing-assets-fine-grained/thumbs/venues/CBQA_1678748459',
     postalCode: '',

--- a/src/tests/setupTests.js
+++ b/src/tests/setupTests.js
@@ -9,6 +9,11 @@ import { queryCache } from './reactQueryProviderHOC'
 // Configuration for performance tests
 configure({ testingLibrary: 'react-native' })
 
+jest.mock('@gorhom/bottom-sheet', () => ({
+  __esModule: true,
+  ...require('@gorhom/bottom-sheet/mock'),
+}))
+
 global.expect.extend(toHaveNoViolations)
 
 consoleFailTestModule.cft({

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -256,6 +256,7 @@ export const theme = {
     tabBar: zIndex.tabBar,
     headerNav: zIndex.headerNav,
     snackbar: zIndex.snackbar,
+    bottomSheet: zIndex.bottomSheet,
   },
   offlineMode: {
     banner: {

--- a/src/ui/components/Playlist.tsx
+++ b/src/ui/components/Playlist.tsx
@@ -1,8 +1,9 @@
 /* We use many `any` on purpose in this module, so we deactivate the following rule : */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { FlashList, ListRenderItemInfo, ListRenderItem } from '@shopify/flash-list'
+import { ListRenderItemInfo, FlashList } from '@shopify/flash-list'
 import React, { FunctionComponent, useCallback, useMemo, useRef } from 'react'
 import { Platform, useWindowDimensions } from 'react-native'
+import { FlatList as RNGHFlatList } from 'react-native-gesture-handler'
 import styled, { useTheme } from 'styled-components/native'
 
 import { PlaylistType } from 'features/offer/enums'
@@ -39,6 +40,7 @@ type Props = {
   children?: never
   tileType?: 'offer' | 'venue' | 'video-module-offer'
   playlistType?: PlaylistType
+  FlatListComponent?: typeof FlashList | typeof RNGHFlatList
 }
 
 function defaultKeyExtractor(item: any, index: number): string {
@@ -63,6 +65,7 @@ export const Playlist: FunctionComponent<Props> = ({
   renderHeader,
   renderFooter,
   onEndReached,
+  FlatListComponent = FlashList,
   tileType = 'offer',
 }) => {
   const { isTouch, tiles } = useTheme()
@@ -100,8 +103,8 @@ export const Playlist: FunctionComponent<Props> = ({
     [renderHeader, renderFooter, keyExtractor, nbOfItems]
   )
 
-  const renderItemWithHeaderAndFooter: ListRenderItem<any> = useCallback(
-    function ({ item, index }) {
+  const renderItemWithHeaderAndFooter = useCallback(
+    function ({ item, index = -1 }: { item: object; index: number }) {
       if (renderHeader && index === 0) {
         return renderHeader({ height: itemHeight, width: itemWidth })
       }
@@ -144,7 +147,7 @@ export const Playlist: FunctionComponent<Props> = ({
           top={scrollButtonOffsetY}
         />
       ) : null}
-      <FlashList
+      <FlatListComponent
         onScroll={onScroll}
         onContentSizeChange={onContentSizeChange}
         testID={testID}

--- a/src/ui/components/headers/CloseButton.tsx
+++ b/src/ui/components/headers/CloseButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useTheme } from 'styled-components'
+import { useTheme } from 'styled-components/native'
 
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { HiddenAccessibleText } from 'ui/components/HiddenAccessibleText'

--- a/src/ui/components/headers/CloseButton.tsx
+++ b/src/ui/components/headers/CloseButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components/native'
+import { useTheme } from 'styled-components'
 
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { HiddenAccessibleText } from 'ui/components/HiddenAccessibleText'
@@ -12,17 +12,20 @@ interface HeaderIconProps {
   hitSlop?: number
   onClose?: () => void
   color?: ColorsEnum
+  size?: number | string
 }
 
 export const CloseButton: React.FC<HeaderIconProps> = ({
   color,
   onClose,
   hitSlop = 8,
+  size,
   ...props
 }) => {
+  const theme = useTheme()
   return (
     <StyledTouchable onPress={onClose} accessibilityLabel="Fermer" hitSlop={hitSlop} {...props}>
-      <Close testID="icon-close" color={color} />
+      <DefaultClose testID="icon-close" color={color} size={size ?? theme.icons.sizes.small} />
       <HiddenAccessibleText>Retour</HiddenAccessibleText>
     </StyledTouchable>
   )
@@ -32,8 +35,3 @@ const StyledTouchable = styledButton(Touchable)({
   justifyContent: 'center',
   alignItems: 'center',
 })
-
-const Close = styled(DefaultClose).attrs<{ color: ColorsEnum }>(({ theme, color }) => ({
-  color: color ?? theme.colors.white,
-  size: theme.icons.sizes.small,
-}))``

--- a/src/ui/theme/layers.ts
+++ b/src/ui/theme/layers.ts
@@ -13,5 +13,6 @@ export const zIndex = {
   tabBar: 2,
   cheatCodeButton: 50,
   snackbar: 50,
+  bottomSheet: 60,
   // !!! Important !!! Whatever you do, you will never get something above a react-native modal
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5084,6 +5084,21 @@
     open "^7.0.3"
     server-destroy "^1.0.1"
 
+"@gorhom/bottom-sheet@^4":
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-4.6.3.tgz#0e16999de7468efc6b730f680692f6d53f0abd8e"
+  integrity sha512-fSuSfbtoKsjmSeyz+tG2C0GtcEL7PS63iEXI23c9M+HeCT1IFK6ffmIa2pqyqB43L1jtkR+BWkpZwqXnN4H8xA==
+  dependencies:
+    "@gorhom/portal" "1.0.14"
+    invariant "^2.2.4"
+
+"@gorhom/portal@1.0.14":
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@gorhom/portal/-/portal-1.0.14.tgz#1953edb76aaba80fb24021dc774550194a18e111"
+  integrity sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==
+  dependencies:
+    nanoid "^3.3.1"
+
 "@grpc/grpc-js@^1.3.2":
   version "1.8.22"
   resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.8.22.tgz#847930c9af46e14df05b57fc12325db140ceff1d"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30769

Intégration d'un composant BottomSheet, comprenant les informations sur le lieu ainsi que la playlist des offres liées à ce lieu, dans la carte.

La gestion du recentrage auto de la carte sera gérée dans une autre PR.

⚠️ ~En attente de confirmation pour placer cette feature sous FF~
Validé avec @henrigarnier  : On prévoit la feature flag dans une autre PR

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots


https://github.com/user-attachments/assets/e6ff0c38-0ad5-4f43-89d7-daee1340c3eb



https://github.com/user-attachments/assets/6488a520-03d4-4f36-913c-658f24cac994



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
