### PR TITLE
(PC-30773) feat(search): reset tab to search results list when filter applied and filter is not location

### DIFF
--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -95,8 +95,8 @@
 ./src/features/search/components/Highlight/Highlight.native.test.tsx:74
 ./src/features/search/components/Highlight/Highlight.native.test.tsx:79
 ./src/features/search/components/Highlight/Highlight.native.test.tsx:86
-./src/features/search/components/SearchResultsContent/SearchResultsContent.tsx:196
-./src/features/search/components/SearchResultsContent/SearchResultsContent.tsx:198
+./src/features/search/components/SearchResultsContent/SearchResultsContent.tsx:216
+./src/features/search/components/SearchResultsContent/SearchResultsContent.tsx:218
 ./src/features/search/components/sections/Accessibility/Accessibility.tsx:33
 ./src/features/search/helpers/useSortedSearchCategories/useSortedSearchCategories.native.test.ts:30
 ./src/features/search/helpers/useSortedSearchCategories/useSortedSearchCategories.native.test.ts:37

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -18,6 +18,7 @@ import { SearchList } from 'features/search/components/SearchList/SearchList'
 import { HEADER_SEARCH_VENUE_MAP } from 'features/search/constants'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { FilterBehaviour } from 'features/search/enums'
+import { getStringifySearchStateWithoutLocation } from 'features/search/helpers/getStringifySearchStateWithoutLocation/getStringifySearchStateWithoutLocation'
 import {
   FILTER_TYPES,
   useAppliedFilters,
@@ -99,6 +100,11 @@ export const SearchResultsContent: React.FC = () => {
   const [tempLocationMode, setTempLocationMode] = useState<LocationMode>(selectedLocationMode)
 
   const isVenue = !!searchState.venue
+
+  // Initial copy of location filters
+  const stringifySearchStateWithoutLocation = useRef(
+    getStringifySearchStateWithoutLocation(searchState)
+  )
 
   // Execute log only on initial search fetch
   const previousIsLoading = usePrevious(isLoading)
@@ -188,6 +194,20 @@ export const SearchResultsContent: React.FC = () => {
       setDefaultTab(Tab.SEARCHLIST)
     }
   }, [selectedLocationMode, venueMapLocationModalVisible])
+
+  // This useEffect monitors changes to `searchState`. When `searchState` is updated, it
+  // generates a string representation of the filters excluding location data. If the new
+  // filter string differs from the previously stored value, it resets the default tab to
+  // `Tab.SEARCHLIST` and updates the stored filter string. This ensures that the UI
+  // responds correctly to filter changes while ignoring location information.
+  useEffect(() => {
+    const currentFiltersWithoutLocation = getStringifySearchStateWithoutLocation(searchState)
+
+    if (currentFiltersWithoutLocation !== stringifySearchStateWithoutLocation.current) {
+      setDefaultTab(Tab.SEARCHLIST)
+      stringifySearchStateWithoutLocation.current = currentFiltersWithoutLocation
+    }
+  }, [searchState])
 
   const onEndReached = useCallback(() => {
     if (data && hasNextPage) {

--- a/src/features/search/helpers/getStringifySearchStateWithoutLocation/getStringifySearchStateWithoutLocation.test.ts
+++ b/src/features/search/helpers/getStringifySearchStateWithoutLocation/getStringifySearchStateWithoutLocation.test.ts
@@ -1,0 +1,13 @@
+import { initialSearchState } from 'features/search/context/reducer'
+import { getStringifySearchStateWithoutLocation } from 'features/search/helpers/getStringifySearchStateWithoutLocation/getStringifySearchStateWithoutLocation'
+
+describe('getStringifySearchStateWithoutLocation', () => {
+  it('should return search state without location', () => {
+    const stringifySearchStateWithoutLocation =
+      getStringifySearchStateWithoutLocation(initialSearchState)
+
+    expect(stringifySearchStateWithoutLocation).toEqual(
+      '{"date":null,"hitsPerPage":20,"offerCategories":[],"offerSubcategories":[],"offerIsDuo":false,"offerIsFree":false,"isDigital":false,"priceRange":null,"query":"","tags":[],"timeRange":null,"gtls":[]}'
+    )
+  })
+})

--- a/src/features/search/helpers/getStringifySearchStateWithoutLocation/getStringifySearchStateWithoutLocation.ts
+++ b/src/features/search/helpers/getStringifySearchStateWithoutLocation/getStringifySearchStateWithoutLocation.ts
@@ -1,0 +1,6 @@
+import { SearchState } from 'features/search/types'
+
+export function getStringifySearchStateWithoutLocation(searchState: SearchState) {
+  const { locationFilter: _, ...rest } = searchState
+  return JSON.stringify(rest)
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30773

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
