### PR TITLE
(PC-30927) feat(search): empty map tab when selected location mode is everywhere

### DIFF
--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -21,6 +21,7 @@ import { PLACEHOLDER_DATA as mockSubcategoriesData } from 'libs/subcategories/pl
 import { mockedSuggestedVenue } from 'libs/venue/fixtures/mockedSuggestedVenues'
 import { Offer } from 'shared/offer/types'
 import { mockAuthContextWithoutUser, mockAuthContextWithUser } from 'tests/AuthContextUtils'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
 import { theme } from 'theme'
 
@@ -779,7 +780,7 @@ describe('SearchResultsContent component', () => {
     beforeEach(() => {
       mockHits = mockedAlgoliaResponse.hits
       mockNbHits = mockedAlgoliaResponse.nbHits
-      useFeatureFlagSpy.mockReturnValueOnce(true)
+      useFeatureFlagSpy.mockReturnValue(true)
     })
 
     afterEach(() => {
@@ -794,7 +795,7 @@ describe('SearchResultsContent component', () => {
     })
 
     it('should log consult venue map when pressing map tab', async () => {
-      renderSearchResultsContent()
+      render(reactQueryProviderHOC(<SearchResultsContent />))
 
       fireEvent.press(await screen.findByText('Carte'))
 
@@ -822,22 +823,28 @@ describe('SearchResultsContent component', () => {
     })
 
     it('should not open venue map location modal when pressing map tab and user location selected is not everywhere', async () => {
-      renderSearchResultsContent()
+      render(reactQueryProviderHOC(<SearchResultsContent />))
 
       fireEvent.press(await screen.findByText('Carte'))
 
       expect(screen.queryByText('Localisation')).not.toBeOnTheScreen()
     })
 
-    it('should redirect to search list results when pressing map tab and closing venue map location modal', async () => {
+    it('should display venue map when pressing map tab if user location selected is not everywhere', async () => {
+      render(reactQueryProviderHOC(<SearchResultsContent />))
+
+      fireEvent.press(await screen.findByText('Carte'))
+
+      expect(screen.getByTestId('venue-map-view')).toBeOnTheScreen()
+    })
+
+    it('should not display venue map when pressing map tab if user location selected is everywhere', async () => {
       mockSelectedLocationMode = LocationMode.EVERYWHERE
       renderSearchResultsContent()
 
       fireEvent.press(await screen.findByText('Carte'))
 
-      fireEvent.press(await screen.findByLabelText('Fermer la modale'))
-
-      expect(screen.getByText('Les offres')).toBeOnTheScreen()
+      expect(screen.queryByTestId('venue-map-view')).not.toBeOnTheScreen()
     })
   })
 })

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -289,7 +289,10 @@ export const SearchResultsContent: React.FC = () => {
         venuesUserData={venuesUserData}
       />
     ),
-    [Tab.MAP]: <VenueMapView height={venueMapHeight} from="searchResults" />,
+    [Tab.MAP]:
+      selectedLocationMode === LocationMode.EVERYWHERE ? null : (
+        <VenueMapView height={venueMapHeight} from="searchResults" />
+      ),
   }
 
   const shouldDisplayTabLayout = shouldDisplayVenueMapInSearch && !isWeb

--- a/src/features/venue/components/TabLayout/TabLayout.tsx
+++ b/src/features/venue/components/TabLayout/TabLayout.tsx
@@ -9,7 +9,7 @@ import { getSpacing, Spacer } from 'ui/theme'
 import { InfoTab } from './InfoTab'
 
 type TabLayoutProps<TabKeyType extends string> = {
-  tabPanels: Record<TabKeyType, JSX.Element>
+  tabPanels: Record<TabKeyType, JSX.Element | null>
   onTabChange?: Partial<Record<TabKeyType, () => void>>
   tabs: { key: TabKeyType; Icon?: React.FC<AccessibleIcon> }[]
   defaultTab: TabKeyType


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30927


## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

Avant Android :

https://github.com/user-attachments/assets/db79ed23-7b15-42c3-99cb-7f0887b76dbf


Après Android :

https://github.com/user-attachments/assets/23773658-5b98-4241-89c4-24b12823ab81


Avant iOS :


https://github.com/user-attachments/assets/27b6833a-2447-413a-bf9e-643f02bc1024




Après iOS :


https://github.com/user-attachments/assets/636830ae-2601-49bd-b077-ddb37b5863af




[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
