### PR TITLE
(BSR) chore(deps): fix android apk generation

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,8 +1,6 @@
 rootProject.name = 'PassCulture'
 include ':react-native-device-info'
 project(':react-native-device-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-device-info/android')
-include ':@react-native-community_netinfo'
-project(':@react-native-community_netinfo').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/netinfo/android')
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app', ':react-native-code-push'
 project(':react-native-code-push').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-code-push/android/app')


### PR DESCRIPTION
After RN upgrade to RN 0.72 we had an issue building the APK :
https://github.com/react-native-netinfo/react-native-netinfo/issues/679#issuecomment-1786822460