### PR TITLE
(PC-30944) fix(SearchBox): keep the location filter on go back in theSearch

### DIFF
--- a/src/features/search/components/SearchBox/SearchBox.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.tsx
@@ -173,9 +173,12 @@ export const SearchBox: React.FunctionComponent<Props> = ({
         setQuery('')
         dispatch({
           type: 'SET_STATE',
-          payload: initialSearchState,
+          payload: { ...initialSearchState, locationFilter: searchState.locationFilter },
         })
-        navigateToSearchLanding(initialSearchState, defaultDisabilitiesProperties)
+        navigateToSearchLanding(
+          { ...initialSearchState, locationFilter: searchState.locationFilter },
+          defaultDisabilitiesProperties
+        )
         break
       default:
         break


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30944

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

Avant : 

https://github.com/user-attachments/assets/37bb8ad2-bb49-40b0-a9b6-3d4492d640dc



Après: 

https://github.com/user-attachments/assets/685f1a10-02cc-4938-97de-49920932c466


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
