### PR TITLE
(PC-30929) feat(venueMap): handle bottom sheet when center on location

### DIFF
--- a/__mocks__/react-native-map-clustering.ts
+++ b/__mocks__/react-native-map-clustering.ts
@@ -1,0 +1,18 @@
+import React from 'react'
+import MapView from 'react-native-map-clustering'
+
+const MapViewMock = React.forwardRef(function Component(
+  props: {
+    onMapReady?: () => void
+  },
+  ref: unknown
+) {
+  React.useEffect(() => {
+    props.onMapReady?.()
+  }, [props])
+
+  // @ts-ignore avoid internal typing complexity
+  return React.createElement(MapView, { ref, ...props })
+})
+
+export default MapViewMock

--- a/jest/jest.setup.ts
+++ b/jest/jest.setup.ts
@@ -77,3 +77,24 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+jest.mock('@gorhom/bottom-sheet', () => {
+  const ActualBottomSheet = jest.requireActual('@gorhom/bottom-sheet/mock').default
+
+  class MockBottomSheet extends ActualBottomSheet {
+    close() {
+      this.props.onAnimate(0, -1)
+    }
+    expand() {
+      this.props.onAnimate(0, 2)
+    }
+    collapse() {
+      this.props.onAnimate(-1, 0)
+    }
+  }
+  return {
+    __esModule: true,
+    ...require('@gorhom/bottom-sheet/mock'),
+    default: MockBottomSheet,
+  }
+})

--- a/src/features/venueMap/components/VenueMapBottomSheet/VenueMapBottomSheet.tsx
+++ b/src/features/venueMap/components/VenueMapBottomSheet/VenueMapBottomSheet.tsx
@@ -91,9 +91,9 @@ export const VenueMapBottomSheet = forwardRef<BottomSheetMethods, VenueMapBottom
     return (
       <StyledBottomSheet
         ref={ref}
-        index={venue ? 0 : -1}
-        handleComponent={HandleComponent}
-        {...bottomSheetProps}>
+        index={-1}
+        {...bottomSheetProps}
+        handleComponent={HandleComponent}>
         <StyledBottomSheetView>
           {venueMapPreview}
           {offersPlaylist}

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
@@ -27,10 +27,13 @@ jest.mock('features/venue/api/useVenueOffers')
 jest.mock('features/venueMap/helpers/zoomOutIfMapEmpty')
 
 describe('<VenueMapView />', () => {
+  beforeEach(() => {
+    useFeatureFlagSpy.mockReturnValue(true)
+  })
+
   beforeAll(() => {
     mockUseGetAllVenues.mockReturnValue({ venues: venuesFixture })
     mockUseCenterOnLocation.mockReturnValue(jest.fn())
-    useFeatureFlagSpy.mockReturnValue(true)
   })
 
   it('should render map', async () => {
@@ -134,7 +137,8 @@ describe('<VenueMapView />', () => {
   })
 
   it('should not display preview is FF disabled', async () => {
-    useFeatureFlagSpy.mockReturnValueOnce(false)
+    // eslint-disable-next-line local-rules/independent-mocks
+    useFeatureFlagSpy.mockReturnValue(false)
     renderVenueMapView()
     await screen.findByTestId(`marker-${venuesFixture[0].venueId}`)
     fireEvent.press(screen.getByTestId(`marker-${venuesFixture[0].venueId}`), {
@@ -193,6 +197,25 @@ describe('<VenueMapView />', () => {
     fireEvent.press(screen.getByTestId('venue-map-view'))
 
     await waitFor(() => expect(screen.queryByTestId('venueMapPreview')).not.toBeOnTheScreen())
+  })
+
+  it('should center map on bottom sheet animation', async () => {
+    renderVenueMapView()
+    await screen.findByTestId(`marker-${venuesFixture[0].venueId}`)
+    fireEvent.press(screen.getByTestId('venue-map-view'))
+
+    fireEvent.press(screen.getByTestId(`marker-${venuesFixture[0].venueId}`), {
+      stopPropagation: () => false,
+      nativeEvent: {
+        id: venuesFixture[0].venueId.toString(),
+        coordinate: {
+          latitude: venuesFixture[0]._geoloc.lat,
+          longitude: venuesFixture[0]._geoloc.lng,
+        },
+      },
+    })
+
+    expect(mockUseCenterOnLocation).toHaveBeenCalledWith(expect.any(Object))
   })
 })
 

--- a/src/features/venueMap/components/VenueMapView/constant.ts
+++ b/src/features/venueMap/components/VenueMapView/constant.ts
@@ -1,4 +1,3 @@
 import { getSpacing } from 'ui/theme'
 
-export const PREVIEW_BOTTOM_MARGIN = getSpacing(10)
 export const FILTER_BANNER_HEIGHT = getSpacing(12)

--- a/src/features/venueMap/hook/useCenterOnLocation.native.test.ts
+++ b/src/features/venueMap/hook/useCenterOnLocation.native.test.ts
@@ -24,11 +24,24 @@ const pointForCoordinate = jest.fn()
 const animateToRegion = jest.fn()
 
 describe('useCenterOnLocation', () => {
+  it('should not center if MapRef is not defined', async () => {
+    const {
+      result: { current: centerOnLocation },
+    } = renderHook(() =>
+      useCenterOnLocation({ currentRegion, mapViewRef: { current: null }, mapHeight })
+    )
+
+    centerOnLocation(48.8566, 2, previewHeight)
+    await waitFor(() => {
+      expect(animateToRegion).not.toHaveBeenCalled()
+    })
+  })
+
   it('should center on location if the pin is too far on the left', async () => {
     pointForCoordinate.mockResolvedValueOnce({ x: 0, y: 200 })
     const centerOnLocation = renderUseCenterOnLocation()
 
-    centerOnLocation(48.8566, 2)
+    centerOnLocation(48.8566, 2, previewHeight)
 
     await waitFor(() => {
       expect(animateToRegion).toHaveBeenCalledWith({
@@ -43,7 +56,7 @@ describe('useCenterOnLocation', () => {
     pointForCoordinate.mockResolvedValueOnce({ x: WIDTH_MOCK, y: 200 })
     const centerOnLocation = renderUseCenterOnLocation()
 
-    centerOnLocation(48.8566, 3)
+    centerOnLocation(48.8566, 3, previewHeight)
 
     await waitFor(() => {
       expect(animateToRegion).toHaveBeenCalledWith({
@@ -58,7 +71,7 @@ describe('useCenterOnLocation', () => {
     pointForCoordinate.mockResolvedValueOnce({ x: 200, y: 0 })
     const centerOnLocation = renderUseCenterOnLocation()
 
-    centerOnLocation(49, 2.3522)
+    centerOnLocation(49, 2.3522, previewHeight)
 
     await waitFor(() => {
       expect(animateToRegion).toHaveBeenCalledWith({
@@ -73,7 +86,7 @@ describe('useCenterOnLocation', () => {
     pointForCoordinate.mockResolvedValueOnce({ x: 200, y: mapHeight - previewHeight })
     const centerOnLocation = renderUseCenterOnLocation()
 
-    centerOnLocation(48, 2.3522)
+    centerOnLocation(48, 2.3522, previewHeight)
 
     await waitFor(() => {
       expect(animateToRegion).toHaveBeenCalledWith({
@@ -81,6 +94,17 @@ describe('useCenterOnLocation', () => {
         latitude: 48,
         longitude: 2.3522,
       })
+    })
+  })
+
+  it('should not center if previewHeight is not given', async () => {
+    pointForCoordinate.mockResolvedValueOnce({ x: 200, y: mapHeight - previewHeight })
+    const centerOnLocation = renderUseCenterOnLocation()
+
+    centerOnLocation(48, 2.3522)
+
+    await waitFor(() => {
+      expect(animateToRegion).not.toHaveBeenCalledWith()
     })
   })
 })
@@ -91,13 +115,6 @@ const renderUseCenterOnLocation = () => {
   >[0]['mapViewRef']
   const {
     result: { current: centerOnLocation },
-  } = renderHook(() =>
-    useCenterOnLocation({
-      currentRegion,
-      previewHeight,
-      mapViewRef,
-      mapHeight,
-    })
-  )
+  } = renderHook(() => useCenterOnLocation({ currentRegion, mapViewRef, mapHeight }))
   return centerOnLocation
 }

--- a/src/features/venueMap/hook/useCenterOnLocation.ts
+++ b/src/features/venueMap/hook/useCenterOnLocation.ts
@@ -1,7 +1,6 @@
-import { RefObject } from 'react'
+import { RefObject, useCallback } from 'react'
 import { useWindowDimensions } from 'react-native'
 
-import { PREVIEW_BOTTOM_MARGIN } from 'features/venueMap/components/VenueMapView/constant'
 import type { Region, Map } from 'libs/maps/maps'
 import { getSpacing } from 'ui/theme'
 
@@ -9,33 +8,29 @@ const CENTER_PIN_THRESHOLD = getSpacing(4)
 
 type Params = {
   currentRegion: Region
-  previewHeight: number
   mapViewRef: RefObject<Map>
   mapHeight: number
 }
 
-export const useCenterOnLocation = ({
-  currentRegion,
-  previewHeight,
-  mapViewRef,
-  mapHeight,
-}: Params) => {
+export const useCenterOnLocation = ({ currentRegion, mapViewRef, mapHeight }: Params) => {
   const { width } = useWindowDimensions()
 
-  return async (latitude: number, longitude: number) => {
-    if (!mapViewRef?.current) return
+  return useCallback(
+    async (latitude: number, longitude: number, previewHeight = 0) => {
+      if (!mapViewRef?.current) return
 
-    const region = { ...currentRegion, latitude, longitude }
-    const point = await mapViewRef.current.pointForCoordinate({ latitude, longitude })
+      const region = { ...currentRegion, latitude, longitude }
+      const point = await mapViewRef.current.pointForCoordinate({ latitude, longitude })
 
-    const isBehindPreview =
-      point.y > mapHeight - (PREVIEW_BOTTOM_MARGIN + previewHeight + CENTER_PIN_THRESHOLD)
-    const isBehindHeader = point.y < CENTER_PIN_THRESHOLD
-    const isBehindRightBorder = point.x > width - CENTER_PIN_THRESHOLD
-    const isBehindLeftBorder = point.x < CENTER_PIN_THRESHOLD
+      const isBehindPreview = point.y > mapHeight - (previewHeight + CENTER_PIN_THRESHOLD)
+      const isBehindHeader = point.y < CENTER_PIN_THRESHOLD
+      const isBehindRightBorder = point.x > width - CENTER_PIN_THRESHOLD
+      const isBehindLeftBorder = point.x < CENTER_PIN_THRESHOLD
 
-    if (isBehindHeader || isBehindRightBorder || isBehindPreview || isBehindLeftBorder) {
-      mapViewRef.current.animateToRegion(region)
-    }
-  }
+      if (isBehindHeader || isBehindRightBorder || isBehindPreview || isBehindLeftBorder) {
+        mapViewRef.current.animateToRegion(region)
+      }
+    },
+    [currentRegion, mapViewRef, mapHeight, width]
+  )
 }

--- a/src/tests/setupTests.js
+++ b/src/tests/setupTests.js
@@ -11,11 +11,6 @@ import { queryCache } from './reactQueryProviderHOC'
 // Configuration for performance tests
 configure({ testingLibrary: 'react-native' })
 
-jest.mock('@gorhom/bottom-sheet', () => ({
-  __esModule: true,
-  ...require('@gorhom/bottom-sheet/mock'),
-}))
-
 global.expect.extend(toHaveNoViolations)
 global.TextEncoder = TextEncoder
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30929

Prise en compte de l'occupation de la bottom sheet lors du recentrage d'un marker sur la carte.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

https://github.com/user-attachments/assets/836d1d8e-74c5-40ca-acc8-615ec85f76c2


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
