### PR TITLE
(PC-31001) fix(deps): downgrade react-native-launch-navigator in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -22539,10 +22539,10 @@ react-native-keychain@^8.0.0:
   resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-8.0.0.tgz#ff708e4dc2a5440df717179bf9b7cd50f78b61d7"
   integrity sha512-c7Cs+YQN26UaQsRG1dmlXL7VL2ctnXwH/dl0IOMEQ7ZaL2NdN313YSAI8ZEZZjrVhNmPsyWEuvTFqWrdpItqQg==
 
-react-native-launch-navigator@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/react-native-launch-navigator/-/react-native-launch-navigator-1.0.9.tgz#b37a77c9fe62564fb23be302cac86b212ce71638"
-  integrity sha512-YJIx8fX7Un5Hvaydwy1Qg96Zh98N9BtjOTlGPXC/7tPoB2UuLw6efYP3WdZqhMQgvBaz5yhVwI37++7MhThbWg==
+react-native-launch-navigator@1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/react-native-launch-navigator/-/react-native-launch-navigator-1.0.8.tgz#c86f45406d37c0942a9d1a3e54a6d4e28c91ee81"
+  integrity sha512-9/xsmcoXa02waKYX37Fx86U3e9FUDeNz0RmWiZ/JeBRAO1U0J2yK0xmTLiGyP4J9txZ9Qc9iZBJF+qMq8LXsEQ==
 
 react-native-linear-gradient@^2.8.3:
   version "2.8.3"


### PR DESCRIPTION
## Disclaimer

On se permet ici de merger avec les tests de performance rouge pour justement les rétablir.
En effet, lors du bump de TypeScript dans [cette PR](https://github.com/pass-culture/pass-culture-app-native/pull/6718), le `yarn.lock` a été modifié avec une mauvaise version (1.0.9) de la lib `react-native-launch-navigator`. On la remet ici à 1.0.8.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
