### PR TITLE
(PC-22093) fix(firestore): handle offline persistence + network

### DIFF
--- a/.storybook/mocks/firebase.js
+++ b/.storybook/mocks/firebase.js
@@ -11,6 +11,7 @@ const firebase = {
   }),
   firestore: () => ({
     settings: () => {},
+    enablePersistence: () => true
   }),
 }
 

--- a/__mocks__/@react-native-community/netinfo.ts
+++ b/__mocks__/@react-native-community/netinfo.ts
@@ -1,10 +1,15 @@
 // eslint-disable-next-line no-restricted-imports
 import { useNetInfo as actualUseNetInfo } from '@react-native-community/netinfo'
 
-export const useNetInfo: typeof actualUseNetInfo = jest.fn().mockReturnValue({
+const STATUS = {
   isConnected: true,
+  isInternetReachable: true,
   type: 'cellular',
-})
+}
+
+export const fetch = jest.fn().mockResolvedValue(STATUS)
+
+export const useNetInfo: typeof actualUseNetInfo = jest.fn().mockReturnValue(STATUS)
 
 // We copy this type from the real NetInfoStateType
 export enum NetInfoStateType {

--- a/__mocks__/@react-native-firebase/firestore.ts
+++ b/__mocks__/@react-native-firebase/firestore.ts
@@ -10,4 +10,6 @@ const collection = jest.fn().mockReturnValue({ doc })
 
 export default () => ({
   collection,
+  disableNetwork: jest.fn(),
+  enableNetwork: jest.fn(),
 })

--- a/jest/jest.web.setup.ts
+++ b/jest/jest.web.setup.ts
@@ -1,6 +1,15 @@
 import 'jest-canvas-mock'
+import mockFirestore from 'libs/firebase/shims/firestore/index.web'
 
 jest.unmock('react-native-modal')
+jest.mock('libs/firebase/firestore/client.web', () => {
+  const firestoreRemoteStore = mockFirestore()
+  firestoreRemoteStore.settings({ experimentalAutoDetectLongPolling: true, merge: true })
+  return {
+    __esModule: true,
+    default: firestoreRemoteStore,
+  }
+})
 
 window.open = jest.fn()
 

--- a/src/libs/firebase/firestore/client.web.ts
+++ b/src/libs/firebase/firestore/client.web.ts
@@ -2,3 +2,4 @@ import firestore from 'libs/firebase/shims/firestore/index.web'
 
 export const firestoreRemoteStore = firestore()
 firestoreRemoteStore.settings({ experimentalAutoDetectLongPolling: true, merge: true })
+firestoreRemoteStore.enablePersistence()


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-22093

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
