### PR TITLE
(PC-31162) feat(jwt): add 1 minute buffer to verify token expiration

### DIFF
--- a/src/libs/jwt/jwt.test.ts
+++ b/src/libs/jwt/jwt.test.ts
@@ -39,14 +39,34 @@ describe('getTokenStatus', () => {
     expect(accessTokenStatus).toBe('expired')
   })
 
-  it('valid status given access token that expires in the future', () => {
+  it('valid status given access token that expires in the future and expiration is more than 2 minutes away', () => {
     mockJwtDecode.mockReturnValueOnce({
-      exp: new Date().getTime() / 1000 + 1,
+      exp: new Date().getTime() / 1000 + 2 * 60 + 1,
     } as jwtDecode.JwtPayload)
 
     const accessTokenStatus = getTokenStatus(fakeAccessToken)
 
     expect(accessTokenStatus).toBe('valid')
+  })
+
+  it('expired status given access token that expires in the future and expiration is exactly 2 minutes', () => {
+    mockJwtDecode.mockReturnValueOnce({
+      exp: new Date().getTime() / 1000 + 2 * 60,
+    } as jwtDecode.JwtPayload)
+
+    const accessTokenStatus = getTokenStatus(fakeAccessToken)
+
+    expect(accessTokenStatus).toBe('expired')
+  })
+
+  it('expired status given access token that expires in the future and expiration is less than 2 minutes away', () => {
+    mockJwtDecode.mockReturnValueOnce({
+      exp: new Date().getTime() / 1000 + 2 * 60 - 1,
+    } as jwtDecode.JwtPayload)
+
+    const accessTokenStatus = getTokenStatus(fakeAccessToken)
+
+    expect(accessTokenStatus).toBe('expired')
   })
 })
 

--- a/src/libs/jwt/jwt.test.ts
+++ b/src/libs/jwt/jwt.test.ts
@@ -39,9 +39,9 @@ describe('getTokenStatus', () => {
     expect(accessTokenStatus).toBe('expired')
   })
 
-  it('valid status given access token that expires in the future and expiration is more than 2 minutes away', () => {
+  it('valid status given access token that expires in the future and expiration is more than 1 minute away', () => {
     mockJwtDecode.mockReturnValueOnce({
-      exp: new Date().getTime() / 1000 + 2 * 60 + 1,
+      exp: new Date().getTime() / 1000 + 1 * 60 + 1,
     } as jwtDecode.JwtPayload)
 
     const accessTokenStatus = getTokenStatus(fakeAccessToken)
@@ -49,9 +49,9 @@ describe('getTokenStatus', () => {
     expect(accessTokenStatus).toBe('valid')
   })
 
-  it('expired status given access token that expires in the future and expiration is exactly 2 minutes', () => {
+  it('expired status given access token that expires in the future and expiration is exactly 1 minute', () => {
     mockJwtDecode.mockReturnValueOnce({
-      exp: new Date().getTime() / 1000 + 2 * 60,
+      exp: new Date().getTime() / 1000 + 1 * 60,
     } as jwtDecode.JwtPayload)
 
     const accessTokenStatus = getTokenStatus(fakeAccessToken)
@@ -59,9 +59,9 @@ describe('getTokenStatus', () => {
     expect(accessTokenStatus).toBe('expired')
   })
 
-  it('expired status given access token that expires in the future and expiration is less than 2 minutes away', () => {
+  it('expired status given access token that expires in the future and expiration is less than 1 minute away', () => {
     mockJwtDecode.mockReturnValueOnce({
-      exp: new Date().getTime() / 1000 + 2 * 60 - 1,
+      exp: new Date().getTime() / 1000 + 1 * 60 - 1,
     } as jwtDecode.JwtPayload)
 
     const accessTokenStatus = getTokenStatus(fakeAccessToken)

--- a/src/libs/jwt/jwt.ts
+++ b/src/libs/jwt/jwt.ts
@@ -29,7 +29,7 @@ export const getUserIdFromAccessToken = (accessToken: string) => {
 
 type TokenStatus = 'valid' | 'expired' | 'unknown'
 
-const TOKEN_EXPIRATION_BUFFER_MS = 2 * 60 * 1000 // 2 minutes buffer in milliseconds
+const TOKEN_EXPIRATION_BUFFER_MS = 1 * 60 * 1000 // 1 minute buffer in milliseconds
 
 export const getTokenStatus = (token: string | null): TokenStatus => {
   if (!token) return 'unknown'

--- a/src/libs/jwt/jwt.ts
+++ b/src/libs/jwt/jwt.ts
@@ -29,11 +29,14 @@ export const getUserIdFromAccessToken = (accessToken: string) => {
 
 type TokenStatus = 'valid' | 'expired' | 'unknown'
 
+const TOKEN_EXPIRATION_BUFFER_MS = 2 * 60 * 1000 // 2 minutes buffer in milliseconds
+
 export const getTokenStatus = (token: string | null): TokenStatus => {
   if (!token) return 'unknown'
   const tokenContent = decodeToken(token)
   if (!tokenContent?.exp) return 'unknown'
-  return tokenContent.exp * 1000 > Date.now() ? 'valid' : 'expired'
+  const currentTimeWithBuffer = Date.now() + TOKEN_EXPIRATION_BUFFER_MS
+  return tokenContent.exp * 1000 > currentTimeWithBuffer ? 'valid' : 'expired'
 }
 
 export const computeTokenRemainingLifetimeInMs = (encodedToken: string): number | undefined => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-31162

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
