### PR TITLE
(PC-28498) fix(CookiesModal): hide modal before state update attempting to fix "NSSetM was mutate…

### DIFF
--- a/src/features/cookies/pages/CookiesConsent.tsx
+++ b/src/features/cookies/pages/CookiesConsent.tsx
@@ -30,6 +30,7 @@ export const CookiesConsent = ({ visible, hideModal }: Props) => {
 
   const params = route?.params
   const acceptAll = useCallback(async () => {
+    hideModal()
     setCookiesConsent({
       mandatory: COOKIES_BY_CATEGORY.essential,
       accepted: ALL_OPTIONAL_COOKIES,
@@ -38,20 +39,20 @@ export const CookiesConsent = ({ visible, hideModal }: Props) => {
     startTracking(true)
     analytics.logHasAcceptedAllCookies()
     await setMarketingParams(params, ALL_OPTIONAL_COOKIES)
-    hideModal()
   }, [params, hideModal, setCookiesConsent])
 
   const declineAll = useCallback(() => {
+    hideModal()
     setCookiesConsent({
       mandatory: COOKIES_BY_CATEGORY.essential,
       accepted: [],
       refused: ALL_OPTIONAL_COOKIES,
     })
     startTracking(false)
-    hideModal()
   }, [hideModal, setCookiesConsent])
 
   const customChoice = useCallback(async () => {
+    hideModal()
     const { accepted, refused } = getCookiesChoiceFromCategories(settingsCookiesChoice)
     setCookiesConsent({
       mandatory: COOKIES_BY_CATEGORY.essential,
@@ -64,7 +65,6 @@ export const CookiesConsent = ({ visible, hideModal }: Props) => {
       type: settingsCookiesChoice,
     })
     await setMarketingParams(params, accepted)
-    hideModal()
   }, [params, settingsCookiesChoice, hideModal, setCookiesConsent])
 
   const { childrenProps } = useCookiesModalContent({


### PR DESCRIPTION
…d while being enumerated" on Sentry

Sentry showed us that this crash would appear when people would click on "accept all cookies".
There was no way to reproduce the crash, but some people on the github issues of reanimated pointed towards a fix where the action of closing the modal should be done before updating states. So that's what I did in this PR. I noticed the buttons on the cookies modal would first make state updates, then close the modal, and I inverted that. We will have to follow the issue on Sentry to see if it goes down once this PR is merged and hits production. 

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-28498

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
