### PR TITLE
(PC-31308) chore(deps): upgrade target SDK 33 -> 34

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,13 +2,12 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "33.0.0"
-        minSdkVersion = 21
-        compileSdkVersion = 33
-        targetSdkVersion = 33
+        buildToolsVersion = "34.0.0"
+        minSdkVersion = 24
+        compileSdkVersion = 34
+        targetSdkVersion = 34
 
-        // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
-        ndkVersion = "23.1.7779620"
+        ndkVersion = "25.1.8937393"
 
         firebaseIidVersion = "19.0.1"
         supportLibVersion = "28.0.0"
@@ -29,3 +28,5 @@ buildscript {
         classpath("com.google.firebase:perf-plugin:1.4.1")
     }
 }
+
+

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -39,3 +39,4 @@ newArchEnabled=false
 # If set to false, you will be using JSC instead.
 hermesEnabled=true
 android.disableAutomaticComponentCreation=true
+android.suppressUnsupportedCompileSdk=34


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-31308

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)

The minSdkVersion has been upgraded to 24 according to [this](https://stackoverflow.com/questions/77910478/flutter-android-unable-to-build-failed-to-transform-kotlin-stdlib-1-9-10-jar)
