### PR TITLE
(PC-31361) fix(shared): Reset refs to initial values after duration calculation in useTrackDuration hook

### DIFF
--- a/src/shared/hook/useTrackDuration.ts
+++ b/src/shared/hook/useTrackDuration.ts
@@ -8,6 +8,7 @@ import { useAppStateChange } from 'libs/appState'
 export const useTrackDuration = (callback: (durationInSeconds: number) => void) => {
   const timeInBackground = useRef(0)
   const startTimeBackground = useRef<Date | null>(null)
+
   const onAppBecomeActive = () => {
     const endTimeBackground = new Date()
     if (startTimeBackground.current)
@@ -20,14 +21,19 @@ export const useTrackDuration = (callback: (durationInSeconds: number) => void) 
 
   useAppStateChange(onAppBecomeActive, onAppBecomeInactive)
 
-  const getMappSeenDuration = useCallback(() => {
+  const getMapSeenDuration = useCallback(() => {
     const startTime = new Date()
     return () => {
       const endTime = new Date()
       const totalDurationOnPage = (endTime.getTime() - startTime.getTime()) / 1000
       const durationWithoutBackgroundTime = totalDurationOnPage - timeInBackground.current
       callback(Number(durationWithoutBackgroundTime.toFixed(3)))
+
+      // Resetting the refs to initial values
+      timeInBackground.current = 0
+      startTimeBackground.current = null
     }
   }, [callback])
-  return getMappSeenDuration
+
+  return getMapSeenDuration
 }

--- a/src/shared/hook/useTrackDuration.ts
+++ b/src/shared/hook/useTrackDuration.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from 'react'
 
 import { useAppStateChange } from 'libs/appState'
+import { eventMonitoring } from 'libs/monitoring'
 
 /**
  * Use it in a useEffect or useFocusEffect, The passed callback should be wrapped in React.useCallback to avoid running the effect too often.
@@ -27,6 +28,18 @@ export const useTrackDuration = (callback: (durationInSeconds: number) => void) 
       const endTime = new Date()
       const totalDurationOnPage = (endTime.getTime() - startTime.getTime()) / 1000
       const durationWithoutBackgroundTime = totalDurationOnPage - timeInBackground.current
+      if (durationWithoutBackgroundTime <= 0) {
+        eventMonitoring.captureException(
+          `Error with useTrackDuration hook, duration calculated <= 0`,
+          {
+            extra: {
+              timeInBackground: timeInBackground.current,
+              startTimeBackground: startTimeBackground.current,
+              totalDurationOnPage,
+            },
+          }
+        )
+      }
       callback(Number(durationWithoutBackgroundTime.toFixed(3)))
 
       // Resetting the refs to initial values


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-31361

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
