### PR TITLE
(PC-31322) feat(verticalVideo): make sure we log videoPaused on player state change

### DIFF
--- a/src/features/home/components/modules/video/useVerticalVideoPlayer.ts
+++ b/src/features/home/components/modules/video/useVerticalVideoPlayer.ts
@@ -42,35 +42,7 @@ export const useVerticalVideoPlayer = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const onChangeState = useCallback(
-    (state: string) => {
-      setVideoState(state as PlayerState)
-      setShowErrorView(false)
-      if (state === PlayerState.ENDED) {
-        const analyticsAllVideo = { moduleId, youtubeId: currentVideoId }
-        analytics.logHasSeenAllVideo(analyticsAllVideo)
-        setHasFinishedPlaying(true)
-        setIsPlaying(false)
-      } else if (state === PlayerState.PAUSED) {
-        setIsPlaying(false)
-      } else if (state === PlayerState.PLAYING) {
-        setIsPlaying(true)
-      } else if (state === PlayerState.UNSTARTED) {
-        setIsPlaying(true)
-      }
-    },
-    [currentVideoId, moduleId, setHasFinishedPlaying, setIsPlaying]
-  )
-
-  const getVideoDuration = useCallback(async () => {
-    return verticalPlayerRef.current?.getDuration()
-  }, [])
-
-  const getCurrentTime = useCallback(async () => {
-    return verticalPlayerRef.current?.getCurrentTime()
-  }, [])
-
-  const logPausedVideo = async () => {
+  const logPausedVideo = useCallback(async () => {
     const [currentTime = 0, videoDuration = 0] = await Promise.all([
       verticalPlayerRef.current?.getCurrentTime(),
       verticalPlayerRef.current?.getDuration(),
@@ -83,7 +55,42 @@ export const useVerticalVideoPlayer = ({
       homeEntryId,
       moduleId,
     })
-  }
+  }, [currentVideoId, moduleId, homeEntryId])
+
+  const pauseVideo = useCallback(() => {
+    if (isPlaying) {
+      setIsPlaying(false)
+      logPausedVideo()
+    }
+  }, [isPlaying, logPausedVideo, setIsPlaying])
+
+  const onChangeState = useCallback(
+    (state: string) => {
+      setVideoState(state as PlayerState)
+      setShowErrorView(false)
+      if (state === PlayerState.ENDED) {
+        const analyticsAllVideo = { moduleId, youtubeId: currentVideoId }
+        analytics.logHasSeenAllVideo(analyticsAllVideo)
+        setHasFinishedPlaying(true)
+        setIsPlaying(false)
+      } else if (state === PlayerState.PAUSED) {
+        pauseVideo()
+      } else if (state === PlayerState.PLAYING) {
+        setIsPlaying(true)
+      } else if (state === PlayerState.UNSTARTED) {
+        setIsPlaying(true)
+      }
+    },
+    [currentVideoId, moduleId, setHasFinishedPlaying, setIsPlaying, pauseVideo]
+  )
+
+  const getVideoDuration = useCallback(async () => {
+    return verticalPlayerRef.current?.getDuration()
+  }, [])
+
+  const getCurrentTime = useCallback(async () => {
+    return verticalPlayerRef.current?.getCurrentTime()
+  }, [])
 
   const intersectionObserverListener = (isInView: boolean) => {
     if (!isInView) pauseVideo()
@@ -91,13 +98,6 @@ export const useVerticalVideoPlayer = ({
 
   const toggleMute = () => {
     setIsMuted(!isMuted)
-  }
-
-  const pauseVideo = () => {
-    if (isPlaying) {
-      setIsPlaying(false)
-      logPausedVideo()
-    }
   }
 
   const togglePlay = () => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-31322

Made sure the tracker is logged when navigating in the app

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

