### PR TITLE
(PC-30862) fix(useSignIn): better handling of accountState

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
     'local-rules/use-the-right-test-utils': ['error'],
     'local-rules/no-use-of-algolia-multiple-queries': ['error'],
     'no-negated-condition': 'warn',
+    '@typescript-eslint/switch-exhaustiveness-check': 'error',
     '@typescript-eslint/ban-ts-comment': [
       'error',
       {

--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -76,7 +76,7 @@
 ./src/features/offer/components/VenueSelectionListItem/VenueSelectionListItem.web.tsx:83
 ./src/features/offer/components/VenueSelectionListItem/VenueSelectionListItem.web.tsx:85
 ./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts:927
-./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts:228
+./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts:231
 ./src/features/profile/components/CreditInfo/CreditProgressBar.tsx:32
 ./src/features/search/api/useSearchResults/useSearchResults.ts:91
 ./src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx:127

--- a/src/api/apiHelpers.ts
+++ b/src/api/apiHelpers.ts
@@ -93,13 +93,14 @@ export const safeFetch = async (
           return createNeedsAuthenticationResponse(url)
         case UNKNOWN_ERROR_WHILE_REFRESHING_ACCESS_TOKEN:
           throw new Error(UNKNOWN_ERROR_WHILE_REFRESHING_ACCESS_TOKEN)
-      }
-      runtimeOptions = {
-        ...runtimeOptions,
-        headers: {
-          ...runtimeOptions.headers,
-          Authorization: `Bearer ${newAccessToken}`,
-        },
+        case undefined: // When no error
+          runtimeOptions = {
+            ...runtimeOptions,
+            headers: {
+              ...runtimeOptions.headers,
+              Authorization: `Bearer ${newAccessToken}`,
+            },
+          }
       }
     } catch (error) {
       const errorMessage = getErrorMessage(error)

--- a/src/features/auth/api/useSignIn.ts
+++ b/src/features/auth/api/useSignIn.ts
@@ -87,63 +87,58 @@ const useHandleSigninSuccess = (
 
   const offerId = params?.offerId
 
+  const navigateForActiveState = useCallback(async () => {
+    const user = await api.getNativeV1Me()
+    const hasSeenEligibleCard = !!(await storage.readObject('has_seen_eligible_card'))
+
+    if (user?.recreditAmountToShow) {
+      navigate('RecreditBirthdayNotification')
+    } else if (!hasSeenEligibleCard && user.showEligibleCard) {
+      navigate('EighteenBirthday')
+    } else if (shouldShowCulturalSurvey(user)) {
+      navigate('CulturalSurveyIntro')
+    } else if (offerId) {
+      switch (params.from) {
+        case StepperOrigin.BOOKING:
+          navigate('Offer', { id: offerId, openModalOnNavigation: true })
+          return
+
+        case StepperOrigin.FAVORITE:
+        case StepperOrigin.OFFER:
+          addFavorite({ offerId })
+          navigate('Offer', { id: offerId })
+          return
+        default:
+          navigateToHome()
+          return
+      }
+    } else {
+      navigateToHome()
+    }
+  }, [addFavorite, navigate, offerId, params?.from, shouldShowCulturalSurvey])
+
   return useCallback(
     async (accountState: AccountState) => {
       try {
         if (doNotNavigateOnSigninSuccess) {
           return
         }
-        const statesThatRedirectToSuspensionScreen = [
-          AccountState.INACTIVE,
-          AccountState.SUSPENDED,
-          AccountState.SUSPENDED_UPON_USER_REQUEST,
-          AccountState.SUSPICIOUS_LOGIN_REPORTED_BY_USER,
-        ]
-        if (statesThatRedirectToSuspensionScreen.includes(accountState)) {
-          return navigate('SuspensionScreen')
-        }
-        if (accountState !== AccountState.ACTIVE) {
-          throw new Error(`Unexpected account state: ${accountState}`)
-        }
-
-        const user = await api.getNativeV1Me()
-        const hasSeenEligibleCard = !!(await storage.readObject('has_seen_eligible_card'))
-
-        if (user?.recreditAmountToShow) {
-          navigate('RecreditBirthdayNotification')
-        } else if (!hasSeenEligibleCard && user.showEligibleCard) {
-          navigate('EighteenBirthday')
-        } else if (shouldShowCulturalSurvey(user)) {
-          navigate('CulturalSurveyIntro')
-        } else if (offerId) {
-          switch (params.from) {
-            case StepperOrigin.BOOKING:
-              navigate('Offer', { id: offerId, openModalOnNavigation: true })
-              return
-
-            case StepperOrigin.FAVORITE:
-            case StepperOrigin.OFFER:
-              addFavorite({ offerId })
-              navigate('Offer', { id: offerId })
-              return
-            default:
-              navigateToHome()
-          }
-        } else {
-          navigateToHome()
+        switch (accountState) {
+          case AccountState.INACTIVE:
+          case AccountState.SUSPENDED:
+          case AccountState.SUSPENDED_UPON_USER_REQUEST:
+          case AccountState.SUSPICIOUS_LOGIN_REPORTED_BY_USER:
+            return navigate('SuspensionScreen')
+          case AccountState.DELETED:
+            throw new Error(`Unexpected account state: ${accountState}`)
+          case AccountState.ACTIVE:
+            navigateForActiveState()
+            return
         }
       } catch {
         setErrorMessage?.('Il y a eu un problème. Tu peux réessayer plus tard')
       }
     },
-    [
-      offerId,
-      navigate,
-      doNotNavigateOnSigninSuccess,
-      setErrorMessage,
-      params?.from,
-      addFavorite,
-      shouldShowCulturalSurvey,
-    ]
+    [doNotNavigateOnSigninSuccess, navigate, navigateForActiveState, setErrorMessage]
   )
 }

--- a/src/features/auth/api/useSignIn.ts
+++ b/src/features/auth/api/useSignIn.ts
@@ -17,7 +17,6 @@ import {
 import { useDeviceInfo } from 'features/trustedDevice/helpers/useDeviceInfo'
 import { analytics } from 'libs/analytics'
 import { LoginRoutineMethod, SSOType } from 'libs/analytics/logEventAnalytics'
-import { eventMonitoring } from 'libs/monitoring'
 import { storage } from 'libs/storage'
 import { useShouldShowCulturalSurvey } from 'shared/culturalSurvey/useShouldShowCulturalSurvey'
 
@@ -104,7 +103,6 @@ const useHandleSigninSuccess = (
           return navigate('SuspensionScreen')
         }
         if (accountState !== AccountState.ACTIVE) {
-          eventMonitoring.captureException(`Unexpected account state: ${accountState}`)
           throw new Error(`Unexpected account state: ${accountState}`)
         }
 

--- a/src/features/auth/api/useSignIn.ts
+++ b/src/features/auth/api/useSignIn.ts
@@ -130,7 +130,7 @@ const useHandleSigninSuccess = (
           case AccountState.SUSPICIOUS_LOGIN_REPORTED_BY_USER:
             return navigate('SuspensionScreen')
           case AccountState.DELETED:
-            throw new Error(`Unexpected account state: ${accountState}`)
+            return setErrorMessage?.('Ton compte à été supprimé')
           case AccountState.ACTIVE:
             navigateForActiveState()
             return

--- a/src/features/auth/pages/login/Login.native.test.tsx
+++ b/src/features/auth/pages/login/Login.native.test.tsx
@@ -329,6 +329,18 @@ describe('<Login/>', () => {
     expect(navigate).toHaveBeenNthCalledWith(1, 'SuspensionScreen')
   })
 
+  it('should show appropriate message if account is deleted', async () => {
+    simulateSignin200(AccountState.DELETED)
+    renderLogin()
+
+    await fillInputs()
+    await act(() => fireEvent.press(screen.getByText('Se connecter')))
+
+    const errorMessage = screen.getByText('Ton compte à été supprimé')
+
+    expect(errorMessage).toBeTruthy()
+  })
+
   it('should show email error message WHEN invalid e-mail format', async () => {
     renderLogin()
 

--- a/src/features/auth/pages/login/Login.native.test.tsx
+++ b/src/features/auth/pages/login/Login.native.test.tsx
@@ -761,12 +761,8 @@ function mockMeApiCall(response: UserProfileResponse) {
   mockServer.getApi<UserProfileResponse>('/v1/me', response)
 }
 
-type SigninResponseWithOptionalAccountState = Omit<SigninResponse, 'accountState'> & {
-  accountState?: AccountState
-}
-
-function simulateSignin200(accountState: AccountState | undefined) {
-  mockServer.postApi<SigninResponseWithOptionalAccountState>('/v1/signin', {
+function simulateSignin200(accountState: AccountState) {
+  mockServer.postApi<SigninResponse>('/v1/signin', {
     accessToken: 'accessToken',
     refreshToken: 'refreshToken',
     accountState,

--- a/src/features/auth/pages/login/Login.native.test.tsx
+++ b/src/features/auth/pages/login/Login.native.test.tsx
@@ -26,7 +26,7 @@ import { analytics } from 'libs/analytics'
 // eslint-disable-next-line no-restricted-imports
 import { firebaseAnalytics } from 'libs/firebase/analytics'
 import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
-import { captureMonitoringError, eventMonitoring } from 'libs/monitoring'
+import { captureMonitoringError } from 'libs/monitoring'
 import { NetworkErrorFixture, UnknownErrorFixture } from 'libs/recaptcha/fixtures'
 import { storage } from 'libs/storage'
 import { mockServer } from 'tests/mswServer'
@@ -327,18 +327,6 @@ describe('<Login/>', () => {
     await act(() => fireEvent.press(screen.getByText('Se connecter')))
 
     expect(navigate).toHaveBeenNthCalledWith(1, 'SuspensionScreen')
-  })
-
-  it('should log WHEN signin is successful but no account status (shouldn’t happen)', async () => {
-    simulateSignin200(undefined)
-    renderLogin()
-
-    await fillInputs()
-    await act(() => fireEvent.press(screen.getByText('Se connecter')))
-
-    expect(eventMonitoring.captureException).toHaveBeenCalledWith(
-      'Unexpected account state: undefined'
-    )
   })
 
   it('should show email error message WHEN invalid e-mail format', async () => {

--- a/src/features/bookOffer/components/BookingOfferModalFooter.tsx
+++ b/src/features/bookOffer/components/BookingOfferModalFooter.tsx
@@ -74,6 +74,9 @@ const handleBookingSteps = (
 
     case Step.DUO:
       return dispatch({ type: 'VALIDATE_OPTIONS' })
+
+    case Step.CONFIRMATION:
+      return // handled above
   }
 }
 

--- a/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts
+++ b/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts
@@ -178,6 +178,9 @@ export const getCtaWordingAndAction = ({
           },
           movieScreeningUserData: { hasNotCompletedSubscriptionYet: true },
         }
+      case undefined:
+      case null:
+        return
     }
   }
 

--- a/src/features/tutorial/helpers/useUserRoleFromOnboarding.ts
+++ b/src/features/tutorial/helpers/useUserRoleFromOnboarding.ts
@@ -23,6 +23,8 @@ export const useUserRoleFromOnboarding = () => {
       case NonEligible.OVER_18:
         setOnboardingRole(UserOnboardingRole.NON_ELIGIBLE)
         break
+      default:
+        throw new Error(`Unexpected value for userOnboardingAge ${String(userOnboardingAge)}`)
     }
   })
 

--- a/src/features/tutorial/helpers/useUserRoleFromOnboarding.ts
+++ b/src/features/tutorial/helpers/useUserRoleFromOnboarding.ts
@@ -10,6 +10,7 @@ export const useUserRoleFromOnboarding = () => {
   )
 
   storage.readObject<number | string>('user_age').then((userOnboardingAge) => {
+    //eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
     switch (userOnboardingAge) {
       case 18:
         setOnboardingRole(UserOnboardingRole.EIGHTEEN)
@@ -23,8 +24,6 @@ export const useUserRoleFromOnboarding = () => {
       case NonEligible.OVER_18:
         setOnboardingRole(UserOnboardingRole.NON_ELIGIBLE)
         break
-      default:
-        throw new Error(`Unexpected value for userOnboardingAge ${String(userOnboardingAge)}`)
     }
   })
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30862

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

![image](https://github.com/user-attachments/assets/068c1c24-3208-4cba-ad68-245a2feaef09)
