### PR TITLE
(BSR) chore(sentry): use error in capture exception for better formating

### DIFF
--- a/src/features/offer/api/useSimilarOffers.native.test.ts
+++ b/src/features/offer/api/useSimilarOffers.native.test.ts
@@ -179,7 +179,7 @@ describe('useSimilarOffers', () => {
 
     await waitFor(() => {
       expect(eventMonitoring.captureException).toHaveBeenCalledWith(
-        'Error 503 with recommendation endpoint to get similar offers',
+        new Error('Error 503 with recommendation endpoint to get similar offers'),
         {
           extra: {
             categories: '["FILMS_SERIES_CINEMA"]',

--- a/src/features/offer/api/useSimilarOffers.ts
+++ b/src/features/offer/api/useSimilarOffers.ts
@@ -73,7 +73,7 @@ export const useSimilarOffers = ({
         const errorMessage = err instanceof Error ? err.message : JSON.stringify(err)
 
         eventMonitoring.captureException(
-          `Error ${statusCode} with recommendation endpoint to get similar offers`,
+          new Error(`Error ${statusCode} with recommendation endpoint to get similar offers`),
           {
             extra: {
               offerId,


### PR DESCRIPTION
# POC

I tried locally to send 2 events to Sentry: 
```javascript
  eventMonitoring.captureException(new Error(`Error test`))
  eventMonitoring.captureException(`Error test badly formatted`)
```
Here are the resulting events in Sentry:
<img width="457" alt="Capture d’écran 2024-08-22 à 13 36 35" src="https://github.com/user-attachments/assets/5b1c8448-55ec-4773-9c57-332fbd31136b">

So it is better to use a real error object.
This should help with these particular issues

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |
