### PR TITLE
(BSR) fix(firestore): feature flags for web

### DIFF
--- a/src/libs/firebase/firestore/getCookiesLastUpdate.native.test.ts
+++ b/src/libs/firebase/firestore/getCookiesLastUpdate.native.test.ts
@@ -1,7 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import { fetch } from '@react-native-community/netinfo'
 
-import { firestoreRemoteStore } from 'libs/firebase/firestore/client'
 import firestore from 'libs/firebase/shims/firestore'
 import { captureMonitoringError } from 'libs/monitoring'
 
@@ -18,7 +16,6 @@ const validFirebaseData = {
 }
 
 const mockGet = jest.fn()
-const mockFetch = fetch as jest.Mock
 const mockCaptureMonitoringError = captureMonitoringError as jest.Mock
 
 const mockFirestoreDocumentGet = collection('cookiesLastUpdate').doc('testing').get as jest.Mock
@@ -55,24 +52,6 @@ describe('[method] getCookiesLastUpdate', () => {
     const cookiesLastUpdate = await getCookiesLastUpdate()
 
     expect(cookiesLastUpdate).toBeUndefined()
-  })
-
-  it('should inform firestore to fetch data from its cache when internet is not reachable', async () => {
-    mockFetch.mockResolvedValueOnce({
-      isConnected: true,
-      isInternetReachable: false,
-      type: 'cellular',
-    })
-
-    await getCookiesLastUpdate()
-
-    expect(firestoreRemoteStore.disableNetwork).toHaveBeenCalledWith()
-  })
-
-  it('should inform firestore to fetch data from server when internet is reachable', async () => {
-    await getCookiesLastUpdate()
-
-    expect(firestoreRemoteStore.enableNetwork).toHaveBeenCalledWith()
   })
 
   it('should log error when firestore cannot retrieve collection', async () => {

--- a/src/libs/firebase/firestore/getCookiesLastUpdate.ts
+++ b/src/libs/firebase/firestore/getCookiesLastUpdate.ts
@@ -1,5 +1,4 @@
 // eslint-disable-next-line no-restricted-imports
-import { fetch } from '@react-native-community/netinfo'
 
 import { env } from 'libs/environment'
 import { firestoreRemoteStore } from 'libs/firebase/firestore/client'
@@ -14,18 +13,6 @@ export const getCookiesLastUpdate = async (): Promise<
     }
   | undefined
 > => {
-  const networkStatus = await fetch()
-  if (networkStatus.isInternetReachable) {
-    await firestoreRemoteStore.enableNetwork()
-  } else {
-    /**
-     * While the network is disabled, any snapshot listeners or get() calls
-     * will return results from cache, and any write operations will be queued
-     * until the network is restored.
-     */
-    await firestoreRemoteStore.disableNetwork()
-  }
-
   return firestoreRemoteStore
     .collection(RemoteStoreCollections.COOKIES_LAST_UPDATE)
     .doc(env.ENV)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

Fix sur les feature flags qui étaient inactifs côté web.
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
