### PR TITLE
(PC-31503) fix(movieScreening): get movie duration from extra data

### DIFF
--- a/src/features/offer/components/MoviesScreeningCalendar/MovieOfferTile.tsx
+++ b/src/features/offer/components/MoviesScreeningCalendar/MovieOfferTile.tsx
@@ -123,7 +123,7 @@ export const MovieOfferTile: FC<MovieOfferTileProps> = ({
 
 const getSubtitles = (offer: OfferPreviewResponse): string[] => {
   const genre = offer.extraData?.genres?.length ? offer.extraData?.genres?.join(' / ') : ''
-  const duration = formatDuration(offer.durationMinutes)
+  const duration = formatDuration(offer.extraData?.durationMinutes)
 
   return [genre, duration]
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-31503

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
