### PR TITLE
(PC-31387) feat(navigation): bookings reaction counter

### DIFF
--- a/src/features/bookings/components/BicolorBookingsCountV2.native.test.tsx
+++ b/src/features/bookings/components/BicolorBookingsCountV2.native.test.tsx
@@ -7,7 +7,7 @@ jest.useFakeTimers()
 
 describe('<BicolorBookingsCountV2 />', () => {
   it('should display booking icon with count', async () => {
-    render(<BicolorBookingsCountV2 />)
+    render(<BicolorBookingsCountV2 badgeValue={1} />)
 
     expect(await screen.findByText('1')).toBeOnTheScreen()
   })

--- a/src/features/bookings/components/BicolorBookingsCountV2.tsx
+++ b/src/features/bookings/components/BicolorBookingsCountV2.tsx
@@ -13,19 +13,15 @@ export const BicolorBookingsCountV2: React.FC<AccessibleBicolorIcon> = ({
   color,
   color2,
   testID,
+  badgeValue,
 }) => {
-  //TODO(PC-29452): Update when got back info
-  let bookingsCount: number
-  // eslint-disable-next-line prefer-const
-  bookingsCount = 1
+  const scale = useScaleAnimation(badgeValue)
 
-  const scale = useScaleAnimation(bookingsCount)
-
-  if (bookingsCount === 0) {
+  if (!badgeValue || badgeValue === 0) {
     return <BicolorBookingsV2 size={size} color={color} color2={color2} testID={testID} />
   }
 
-  const { fullCountLabel, accessibilityLabel } = createLabels(bookingsCount, 'réservations')
+  const { fullCountLabel, accessibilityLabel } = createLabels(badgeValue, 'réservations')
 
   return (
     <Container>

--- a/src/features/bookings/helpers/useBookingsAwaitingReaction.test.tsx
+++ b/src/features/bookings/helpers/useBookingsAwaitingReaction.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+
+import { CategoryIdEnum, NativeCategoryIdEnumv2, SubcategoryIdEnum } from 'api/gen'
+import { useBookings } from 'features/bookings/api'
+import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
+import { useBookingsAwaitingReaction } from 'features/bookings/helpers/useBookingsAwaitingReaction'
+import { RemoteConfigProvider } from 'libs/firebase/remoteConfig/RemoteConfigProvider'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { renderHook, waitFor } from 'tests/utils'
+
+jest.mock('libs/firebase/analytics/analytics')
+
+const mockGetConfigValues = jest.fn()
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services', () => ({
+  remoteConfig: {
+    configure: () => Promise.resolve(true),
+    refresh: () => Promise.resolve(true),
+    getValues: () => mockGetConfigValues(),
+  },
+}))
+
+jest.mock('features/bookings/api')
+const mockUseBookings = useBookings as jest.Mock
+
+const mockUseSubcategoriesMapping = jest.fn()
+jest.mock('libs/subcategories/mappings', () => ({
+  useSubcategoriesMapping: jest.fn(() => mockUseSubcategoriesMapping()),
+}))
+mockUseSubcategoriesMapping.mockReturnValue({
+  [SubcategoryIdEnum.SEANCE_CINE]: {
+    isEvent: false,
+    categoryId: CategoryIdEnum.CINEMA,
+    nativeCategoryId: NativeCategoryIdEnumv2.SEANCES_DE_CINEMA,
+  },
+  [SubcategoryIdEnum.EVENEMENT_PATRIMOINE]: {
+    isEvent: false,
+    categoryId: CategoryIdEnum.CONFERENCE,
+    nativeCategoryId: NativeCategoryIdEnumv2.EVENEMENTS_PATRIMOINE,
+  },
+})
+
+const MOCK_BOOKINGS = {
+  ...bookingsSnap,
+  ended_bookings: bookingsSnap.ended_bookings.map((booking) => ({
+    ...booking,
+    userReaction: null,
+  })),
+}
+
+describe('useBookingsAwaitingReaction', () => {
+  beforeAll(() => {
+    mockGetConfigValues.mockReturnValue({
+      reactionCategories: { categories: ['SEANCES_DE_CINEMA'] },
+    })
+    mockUseBookings.mockReturnValue({ data: MOCK_BOOKINGS })
+  })
+
+  it('get bookings awaiting reactions count', async () => {
+    const { result } = renderHook(() => useBookingsAwaitingReaction(), {
+      wrapper: ({ children }) => (
+        <RemoteConfigProvider>{reactQueryProviderHOC(children)}</RemoteConfigProvider>
+      ),
+    })
+    await waitFor(() => expect(result.current).toBe(1))
+  })
+})

--- a/src/features/bookings/helpers/useBookingsAwaitingReaction.ts
+++ b/src/features/bookings/helpers/useBookingsAwaitingReaction.ts
@@ -1,0 +1,20 @@
+import { useBookings } from 'features/bookings/api'
+import { useRemoteConfigContext } from 'libs/firebase/remoteConfig/RemoteConfigProvider'
+import { useSubcategoriesMapping } from 'libs/subcategories'
+
+export function useBookingsAwaitingReaction() {
+  const { data: bookings } = useBookings()
+  const subcategoriesMapping = useSubcategoriesMapping()
+
+  const { reactionCategories } = useRemoteConfigContext()
+
+  const { ended_bookings: endedBookings = [] } = bookings ?? {}
+
+  return endedBookings.filter((data) => {
+    const subCategory = subcategoriesMapping[data.stock.offer.subcategoryId]
+    return (
+      reactionCategories.categories.includes(subCategory.nativeCategoryId) &&
+      data.userReaction === null
+    )
+  }).length
+}

--- a/src/features/navigation/RootNavigator/Header/AccessibleTabBar.web.test.tsx
+++ b/src/features/navigation/RootNavigator/Header/AccessibleTabBar.web.test.tsx
@@ -2,10 +2,12 @@ import { NavigationContainer } from '@react-navigation/native'
 import React from 'react'
 
 import { defaultDisabilitiesProperties } from 'features/accessibility/context/AccessibilityFiltersWrapper'
+import { useTabBarItemBadges } from 'features/navigation/helpers/useTabBarItemBadges'
 import * as navigationRefAPI from 'features/navigation/navigationRef'
 import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/helpers'
 import { initialSearchState } from 'features/search/context/reducer'
 import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { ThemeProvider } from 'libs/styled'
 import { computedTheme } from 'tests/computedTheme'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -30,12 +32,39 @@ jest.mock('features/search/context/SearchWrapper', () => ({
   useSearch: () => ({ searchState: mockSearchState, dispatch: jest.fn() }),
 }))
 
-jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
+const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
+
+const activateFeatureFlags = (activeFeatureFlags: RemoteStoreFeatureFlags[] = []) => {
+  useFeatureFlagSpy.mockImplementation((flag) => activeFeatureFlags.includes(flag))
+}
 
 jest.mock('libs/firebase/analytics/analytics')
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 
+jest.mock('features/navigation/helpers/useTabBarItemBadges')
+const mockUseTabBarItemBadges = useTabBarItemBadges as jest.Mock
+
 describe('AccessibleTabBar', () => {
+  beforeAll(() => {
+    mockUseTabBarItemBadges.mockReturnValue({
+      Bookings: 999,
+    })
+  })
+
+  beforeEach(() => {
+    activateFeatureFlags()
+  })
+
+  it('renders correclty when FF is enabled', async () => {
+    activateFeatureFlags([
+      RemoteStoreFeatureFlags.WIP_APP_V2_TAB_BAR,
+      RemoteStoreFeatureFlags.WIP_REACTION_FEATURE,
+    ])
+    renderTabBar()
+
+    expect(await screen.findByText('99+')).toBeInTheDocument()
+  })
+
   it('should display the 5 following tabs', () => {
     renderTabBar()
     const expectedTabsTestIds = [

--- a/src/features/navigation/RootNavigator/Header/AccessibleTabBar.web.tsx
+++ b/src/features/navigation/RootNavigator/Header/AccessibleTabBar.web.tsx
@@ -7,6 +7,7 @@ import {
   useAccessibilityFiltersContext,
 } from 'features/accessibility/context/AccessibilityFiltersWrapper'
 import { useCurrentRoute } from 'features/navigation/helpers/useCurrentRoute'
+import { useTabBarItemBadges } from 'features/navigation/helpers/useTabBarItemBadges'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { TabBarComponent } from 'features/navigation/TabBar/TabBarComponent'
 import { TabBarContainer } from 'features/navigation/TabBar/TabBarContainer'
@@ -24,6 +25,7 @@ export const AccessibleTabBar = ({ id }: { id: string }) => {
   const { searchState, hideSuggestions } = useSearch()
   const { disabilities } = useAccessibilityFiltersContext()
   const enableTabBarV2 = useFeatureFlag(RemoteStoreFeatureFlags.WIP_APP_V2_TAB_BAR)
+  const routeBadgeMap = useTabBarItemBadges()
 
   if (currentRoute && currentRoute.name !== 'TabNavigator') return null
 
@@ -53,6 +55,7 @@ export const AccessibleTabBar = ({ id }: { id: string }) => {
                   onPress={route.name === 'SearchStackNavigator' ? hideSuggestions : undefined}
                   tabName={route.name}
                   isSelected={route.isSelected}
+                  badgeValue={routeBadgeMap[route.name]}
                   v2={!!enableTabBarV2}
                 />
               </LinkContainer>

--- a/src/features/navigation/RootNavigator/Header/Header.web.test.tsx
+++ b/src/features/navigation/RootNavigator/Header/Header.web.test.tsx
@@ -5,9 +5,11 @@ import { ThemeProvider } from 'styled-components/native'
 
 import { FavoritesCountResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
+import { useTabBarItemBadges } from 'features/navigation/helpers/useTabBarItemBadges'
 import { TabNavigationStateProvider } from 'features/navigation/TabBar/TabNavigationStateContext'
 import { initialSearchState } from 'features/search/context/reducer'
 import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, screen } from 'tests/utils/web'
@@ -17,6 +19,9 @@ import { Header } from './Header'
 
 jest.mock('libs/jwt/jwt')
 jest.mock('features/favorites/context/FavoritesWrapper')
+
+jest.mock('features/navigation/helpers/useTabBarItemBadges')
+const mockUseTabBarItemBadges = useTabBarItemBadges as jest.Mock
 
 const mockedUseAuthContext = useAuthContext as jest.Mock
 jest.mock('features/auth/context/AuthContext')
@@ -37,6 +42,10 @@ jest.mock('features/navigation/RootNavigator/routes', () => ({
 }))
 
 const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
+const activateFeatureFlags = (activeFeatureFlags: RemoteStoreFeatureFlags[] = []) => {
+  useFeatureFlagSpy.mockImplementation((flag) => activeFeatureFlags.includes(flag))
+}
+
 const mockSearchState = initialSearchState
 jest.mock('features/search/context/SearchWrapper', () => ({
   useSearch: () => ({
@@ -49,6 +58,13 @@ jest.mock('libs/firebase/analytics/analytics')
 describe('Header', () => {
   beforeEach(() => {
     mockServer.getApi<FavoritesCountResponse>(`/v1/me/favorites/count`, { count: 2 })
+    activateFeatureFlags()
+  })
+
+  beforeAll(() => {
+    mockUseTabBarItemBadges.mockReturnValue({
+      Bookings: 999,
+    })
   })
 
   it('should render correctly', async () => {
@@ -58,11 +74,15 @@ describe('Header', () => {
   })
 
   it('should render correctly when FF is enabled', async () => {
-    useFeatureFlagSpy.mockReturnValueOnce(true)
+    activateFeatureFlags([
+      RemoteStoreFeatureFlags.WIP_APP_V2_TAB_BAR,
+      RemoteStoreFeatureFlags.WIP_REACTION_FEATURE,
+    ])
     renderHeader({ isLoggedIn: true, isBeneficiary: true })
 
     expect(await screen.findByText('Favoris')).toBeInTheDocument()
     expect(await screen.findByText('2')).toBeInTheDocument()
+    expect(await screen.findByText('99+')).toBeInTheDocument()
   })
 
   it('should render Header without Bookings item for non-beneficiary and logged out users', () => {

--- a/src/features/navigation/RootNavigator/Header/Header.web.tsx
+++ b/src/features/navigation/RootNavigator/Header/Header.web.tsx
@@ -3,6 +3,7 @@ import { Animated } from 'react-native'
 import webStyled from 'styled-components'
 import styled, { useTheme } from 'styled-components/native'
 
+import { useTabBarItemBadges } from 'features/navigation/helpers/useTabBarItemBadges'
 import { homeNavConfig } from 'features/navigation/TabBar/helpers'
 import { useMediaQuery } from 'libs/react-responsive/useMediaQuery'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
@@ -17,6 +18,7 @@ const MINIMUM_BRAND_SIZE = 140
 
 export const Header = memo(function Header({ mainId }: { mainId: string }) {
   const theme = useTheme()
+  const routeBadgeMap = useTabBarItemBadges()
 
   const fadeAnim = useRef({
     opacity: new Animated.Value(0),
@@ -110,6 +112,7 @@ export const Header = memo(function Header({ mainId }: { mainId: string }) {
           maxWidth={theme.appContentWidth}
           height={theme.navTopHeight}
           noShadow={theme.isDesktopViewport}
+          routeBadgeMap={routeBadgeMap}
         />
         <RightContainer
           margin={margin}

--- a/src/features/navigation/RootNavigator/Header/Nav.tsx
+++ b/src/features/navigation/RootNavigator/Header/Nav.tsx
@@ -6,6 +6,7 @@ import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/h
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { mapTabRouteToBicolorIcon } from 'features/navigation/TabBar/mapTabRouteToBicolorIcon'
 import { useTabNavigationContext } from 'features/navigation/TabBar/TabNavigationStateContext'
+import { TabParamList } from 'features/navigation/TabBar/types'
 import { initialSearchState } from 'features/search/context/reducer'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
@@ -22,9 +23,10 @@ type Props = {
   maxWidth?: number
   height?: number
   noShadow?: boolean
+  routeBadgeMap?: Partial<Record<keyof TabParamList, number>>
 }
 
-export const Nav: React.FC<Props> = ({ maxWidth, height, noShadow }) => {
+export const Nav: React.FC<Props> = ({ maxWidth, height, noShadow, routeBadgeMap }) => {
   const enableNavBarV2 = useFeatureFlag(RemoteStoreFeatureFlags.WIP_APP_V2_TAB_BAR)
   const enableReactionFeature = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
   const { tabRoutes } = useTabNavigationContext()
@@ -64,6 +66,7 @@ export const Nav: React.FC<Props> = ({ maxWidth, height, noShadow }) => {
                 onBeforeNavigate={
                   route.name === 'SearchStackNavigator' ? hideSuggestions : undefined
                 }
+                badgeValue={routeBadgeMap?.[route.name]}
                 navigateTo={{
                   screen: tabNavConfig[0],
                   params: tabNavConfig[1],

--- a/src/features/navigation/RootNavigator/Header/NavItem.tsx
+++ b/src/features/navigation/RootNavigator/Header/NavItem.tsx
@@ -14,6 +14,7 @@ interface NavItemInterface {
   BicolorIcon: React.FC<AccessibleBicolorIcon>
   navigateTo: InternalNavigationProps['navigateTo']
   tabName: TabRouteName
+  badgeValue?: number
   onBeforeNavigate?: () => void
 }
 
@@ -22,6 +23,7 @@ export const NavItem: React.FC<NavItemInterface> = ({
   navigateTo,
   tabName,
   isSelected,
+  badgeValue,
   onBeforeNavigate,
 }) => (
   <StyledTouchableLink
@@ -32,7 +34,7 @@ export const NavItem: React.FC<NavItemInterface> = ({
     testID={`${tabName} tab`}
     onBeforeNavigate={onBeforeNavigate}
     accessibilityCurrent={isSelected ? 'page' : undefined}>
-    <StyledIcon as={BicolorIcon} selected={isSelected} />
+    <StyledIcon as={BicolorIcon} selected={isSelected} badgeValue={badgeValue} />
     <Title isSelected={isSelected}>{menu[tabName].displayName}</Title>
   </StyledTouchableLink>
 )

--- a/src/features/navigation/RootNavigator/RootNavigator.web.test.tsx
+++ b/src/features/navigation/RootNavigator/RootNavigator.web.test.tsx
@@ -1,11 +1,12 @@
 import { NavigationContainer } from '@react-navigation/native'
 import React from 'react'
 
-import { FavoritesCountResponse } from 'api/gen'
+import { FavoritesCountResponse, SubcategoriesResponseModelv2 } from 'api/gen'
 import { useCurrentRoute } from 'features/navigation/helpers/useCurrentRoute'
 import { initialSearchState } from 'features/search/context/reducer'
 import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { useSplashScreenContext } from 'libs/splashscreen'
+import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, render, screen } from 'tests/utils/web'
@@ -49,6 +50,7 @@ describe('<RootNavigator />', () => {
   beforeEach(() => {
     mockUseCurrentRoute.mockReturnValue({ name: 'TabNavigator', key: 'key' })
     mockServer.getApi<FavoritesCountResponse>('/v1/me/favorites/count', { count: 2 })
+    mockServer.getApi<SubcategoriesResponseModelv2>('/v1/subcategories/v2', subcategoriesDataTest)
   })
 
   it('should NOT display PrivacyPolicy if splash screen is not yet hidden', async () => {

--- a/src/features/navigation/TabBar/TabBar.tsx
+++ b/src/features/navigation/TabBar/TabBar.tsx
@@ -5,6 +5,7 @@ import {
   defaultDisabilitiesProperties,
   useAccessibilityFiltersContext,
 } from 'features/accessibility/context/AccessibilityFiltersWrapper'
+import { useTabBarItemBadges } from 'features/navigation/helpers/useTabBarItemBadges'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { TabBarContainer } from 'features/navigation/TabBar/TabBarContainer'
 import { useTabNavigationContext } from 'features/navigation/TabBar/TabNavigationStateContext'
@@ -23,10 +24,10 @@ export const TabBar: React.FC<Props> = ({ navigation, state }) => {
   const { searchState, dispatch, hideSuggestions } = useSearch()
   const { setDisabilities, disabilities } = useAccessibilityFiltersContext()
   const enableTabBarV2 = useFeatureFlag(RemoteStoreFeatureFlags.WIP_APP_V2_TAB_BAR)
+  const routeBadgeMap = useTabBarItemBadges()
   const { locationFilter } = searchState
 
   useTabBar({ state })
-
   return (
     <TabBarContainer v2={!!enableTabBarV2}>
       {tabRoutes.map((route) => {
@@ -91,6 +92,7 @@ export const TabBar: React.FC<Props> = ({ navigation, state }) => {
             key={`key-tab-nav-${route.key}`}
             tabName={route.name}
             isSelected={route.isSelected}
+            badgeValue={routeBadgeMap[route.name]}
             onPress={onPress}
           />
         )

--- a/src/features/navigation/TabBar/TabBarComponent.tsx
+++ b/src/features/navigation/TabBar/TabBarComponent.tsx
@@ -15,6 +15,7 @@ import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 interface Props {
   v2: boolean
   isSelected?: boolean
+  badgeValue?: number
   navigateTo: InternalNavigationProps['navigateTo']
   enableNavigate?: boolean
   onPress?: () => void
@@ -30,6 +31,7 @@ export const TabBarComponent: React.FC<Props> = ({
   enableNavigate = true,
   onPress,
   tabName,
+  badgeValue,
 }) => {
   const enableReactionFeature = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
   const BicolorIcon = mapTabRouteToBicolorIcon({ route: tabName, v2, enableReactionFeature })
@@ -44,7 +46,12 @@ export const TabBarComponent: React.FC<Props> = ({
       accessibilityLabel={menu[tabName].accessibilityLabel}
       testID={menu[tabName].accessibilityLabel ?? menu[tabName].displayName}
       accessibilityCurrent={isSelected ? 'page' : undefined}>
-      <InnerComponent tabName={tabName} isSelected={isSelected} BicolorIcon={BicolorIcon} />
+      <InnerComponent
+        tabName={tabName}
+        isSelected={isSelected}
+        BicolorIcon={BicolorIcon}
+        badgeValue={badgeValue}
+      />
     </TabComponentContainer>
   )
 }

--- a/src/features/navigation/TabBar/TabBarInnerComponent.tsx
+++ b/src/features/navigation/TabBar/TabBarInnerComponent.tsx
@@ -3,22 +3,20 @@ import styled from 'styled-components/native'
 
 import { menu } from 'features/navigation/TabBar/menu'
 import { TabBarTitle as Title } from 'features/navigation/TabBar/TabBarTitle'
-import { TabRouteName } from 'features/navigation/TabBar/types'
+import { TabInnerComponentProps } from 'features/navigation/TabBar/types'
 import { BicolorLogo } from 'ui/svg/icons/BicolorLogo'
 import { BicolorSelector } from 'ui/svg/icons/BicolorSelector'
-import { AccessibleBicolorIcon } from 'ui/svg/icons/types'
 import { Spacer, getSpacing } from 'ui/theme'
 
 const SELECTOR_WIDTH = '80%'
 const SELECTOR_HEIGHT = getSpacing(1)
 
-interface Props {
-  isSelected?: boolean
-  BicolorIcon: React.FC<AccessibleBicolorIcon>
-  tabName: TabRouteName
-}
-
-export const TabBarInnerComponent: React.FC<Props> = ({ isSelected, BicolorIcon, tabName }) => {
+export const TabBarInnerComponent: React.FC<TabInnerComponentProps> = ({
+  isSelected,
+  BicolorIcon,
+  tabName,
+  badgeValue,
+}) => {
   const accessibilityLabel = menu[tabName].accessibilityLabel
   return (
     <React.Fragment>
@@ -30,7 +28,7 @@ export const TabBarInnerComponent: React.FC<Props> = ({ isSelected, BicolorIcon,
         />
       ) : null}
       <Spacer.Flex />
-      <StyledIcon as={BicolorIcon} selected={isSelected} />
+      <StyledIcon as={BicolorIcon} selected={isSelected} badgeValue={badgeValue} />
       <Title selected={isSelected} displayName={menu[tabName].displayName} />
       <Spacer.Flex />
       {isSelected ? <BicolorSelectorPlaceholder /> : null}

--- a/src/features/navigation/TabBar/TabBarInnerComponentV2.tsx
+++ b/src/features/navigation/TabBar/TabBarInnerComponentV2.tsx
@@ -5,22 +5,20 @@ import styled from 'styled-components/native'
 
 import { menu } from 'features/navigation/TabBar/menu'
 import { TabBarTitle } from 'features/navigation/TabBar/TabBarTitle'
-import { TabRouteName } from 'features/navigation/TabBar/types'
+import { TabInnerComponentProps } from 'features/navigation/TabBar/types'
 import { BicolorLogo } from 'ui/svg/icons/BicolorLogo'
-import { AccessibleBicolorIcon } from 'ui/svg/icons/types'
 import { getSpacing, Spacer } from 'ui/theme'
 
-interface Props {
-  tabName: TabRouteName
-  isSelected?: boolean
-  BicolorIcon: React.FC<AccessibleBicolorIcon>
-}
-
-export const TabBarInnerComponentV2: React.FC<Props> = ({ tabName, isSelected, BicolorIcon }) => (
+export const TabBarInnerComponentV2: React.FC<TabInnerComponentProps> = ({
+  tabName,
+  isSelected,
+  BicolorIcon,
+  badgeValue,
+}) => (
   <React.Fragment>
     {isSelected ? <Gradient /> : null}
     <Spacer.Flex />
-    <StyledIcon as={BicolorIcon} selected={isSelected} />
+    <StyledIcon as={BicolorIcon} selected={isSelected} badgeValue={badgeValue} />
     <Spacer.Column numberOfSpaces={2.5} />
     <TabBarTitle selected={isSelected} displayName={menu[tabName].displayName} />
     <Spacer.Flex />

--- a/src/features/navigation/TabBar/types.ts
+++ b/src/features/navigation/TabBar/types.ts
@@ -6,6 +6,7 @@ import {
   SearchStackParamList,
 } from 'features/navigation/SearchStackNavigator/types'
 import { ArrayElement } from 'libs/typesUtils/typeHelpers'
+import { AccessibleBicolorIcon } from 'ui/svg/icons/types'
 
 export type TabRouteName = keyof TabParamList
 
@@ -27,3 +28,10 @@ export type TabStateRoute = ArrayElement<TabNavigationStateType['routes']> & {
 }
 
 export type TabRoute = GenericRoute<TabParamList>
+
+export type TabInnerComponentProps = {
+  isSelected?: boolean
+  BicolorIcon: React.FC<AccessibleBicolorIcon>
+  tabName: TabRouteName
+  badgeValue?: number
+}

--- a/src/features/navigation/helpers/useTabBarItemBadges.test.ts
+++ b/src/features/navigation/helpers/useTabBarItemBadges.test.ts
@@ -1,0 +1,14 @@
+import { useTabBarItemBadges } from 'features/navigation/helpers/useTabBarItemBadges'
+import { renderHook } from 'tests/utils'
+
+jest.mock('features/bookings/helpers/useBookingsAwaitingReaction', () => ({
+  useBookingsAwaitingReaction: () => 10,
+}))
+
+describe('useTabBarItemBadges', () => {
+  it('should return badges by route', () => {
+    const { result } = renderHook(() => useTabBarItemBadges())
+
+    expect(result.current.Bookings).toBe(10)
+  })
+})

--- a/src/features/navigation/helpers/useTabBarItemBadges.ts
+++ b/src/features/navigation/helpers/useTabBarItemBadges.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react'
+
+import { useBookingsAwaitingReaction } from 'features/bookings/helpers/useBookingsAwaitingReaction'
+import { TabParamList } from 'features/navigation/TabBar/types'
+
+export const useTabBarItemBadges = (): Partial<Record<keyof TabParamList, number>> => {
+  const bookingsBadge = useBookingsAwaitingReaction()
+
+  const routeBadgeMap = useMemo(
+    () => ({
+      Bookings: bookingsBadge,
+    }),
+    [bookingsBadge]
+  )
+
+  return routeBadgeMap
+}

--- a/src/ui/svg/icons/types.ts
+++ b/src/ui/svg/icons/types.ts
@@ -20,6 +20,7 @@ export interface AccessibleIcon extends AccessibleIconSharedProperties {
 export interface AccessibleBicolorIcon extends AccessibleIcon {
   color2?: ColorsEnum | UniqueColors
   thin?: boolean
+  badgeValue?: number
 }
 
 export interface AccessibleRectangleIcon extends AccessibleIconSharedProperties {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-31387

Gestion du badge pour les réservations terminées dans la tabBar sur mobile et le Header pour le web.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots
<img width="1073" alt="image" src="https://github.com/user-attachments/assets/53a4fd38-06c9-4730-900e-14f160babfdf">
<img width="771" alt="image" src="https://github.com/user-attachments/assets/dbf3395b-087a-4099-b79a-d1bf76ac323b">
<img width="364" alt="image" src="https://github.com/user-attachments/assets/51d39f8e-ef1a-49e3-a0fa-d59b4b57e9f5">



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
