### PR TITLE
(PC-31349) feat(DeleteProfileAccountNotDeletable): can not delete account screen

### DIFF
--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
@@ -42,8 +42,8 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
     }
   >
     <View
-      height={156}
-      width={200}
+      height={109.2}
+      width={140}
     >
       <Text>
         undefined-SVG-Mock
@@ -237,24 +237,7 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
           ]
         }
       >
-        Pour ne plus recevoir de communications du pass Culture, tu peux
-         
-        <Text
-          style={
-            [
-              {
-                "color": "#161617",
-                "fontFamily": "Montserrat-Medium",
-                "fontSize": 14,
-                "fontWeight": "bold",
-                "lineHeight": 22.4,
-              },
-            ]
-          }
-        >
-          désactiver tes notifications
-        </Text>
-        .
+        Pour ne plus recevoir de communications du pass Culture, tu peux désactiver tes notifications
       </Text>
     </View>
     <View

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
@@ -125,6 +125,7 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
         }
       >
         À tes 21 ans, ton compte pourra être supprimé et tu pourras faire une demande pour anonymiser tes données. Tu peux en savoir plus en
+         
         <View>
           <View
             accessibilityLabel="consultant cette page"

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
@@ -1,0 +1,488 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
+<View
+  style={
+    [
+      {
+        "alignSelf": "center",
+        "flexBasis": 0,
+        "flexGrow": 1,
+        "flexShrink": 1,
+        "maxWidth": 500,
+        "overflow": "scroll",
+        "paddingHorizontal": 24,
+        "width": "100%",
+      },
+    ]
+  }
+>
+  <View
+    flex={2}
+    style={
+      [
+        {
+          "flexBasis": 0,
+          "flexGrow": 2,
+          "flexShrink": 1,
+        },
+      ]
+    }
+  />
+  <View
+    hasHeight={false}
+    style={
+      [
+        {
+          "alignItems": "center",
+          "flexGrow": 1,
+          "justifyContent": "center",
+        },
+      ]
+    }
+  >
+    <View
+      height={156}
+      width={200}
+    >
+      <Text>
+        undefined-SVG-Mock
+      </Text>
+    </View>
+  </View>
+  <Text
+    style={
+      [
+        {
+          "color": "#161617",
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 22,
+          "lineHeight": 26,
+          "textAlign": "center",
+        },
+      ]
+    }
+  >
+    Nous ne pouvons pas encore supprimer ton compte
+  </Text>
+  <View
+    flex={0.5}
+    style={
+      [
+        {
+          "flexBasis": 0,
+          "flexGrow": 0.5,
+          "flexShrink": 1,
+        },
+      ]
+    }
+  />
+  <View
+    gap={6}
+    style={
+      [
+        {
+          "gap": 24,
+          "marginTop": 16,
+        },
+      ]
+    }
+  >
+    <View
+      gap={6}
+      style={
+        [
+          {
+            "gap": 24,
+          },
+        ]
+      }
+    >
+      <Text
+        style={
+          [
+            {
+              "color": "#161617",
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 14,
+              "lineHeight": 22.4,
+            },
+          ]
+        }
+      >
+        Pour éviter les cas de fraude et te permettre d’accéder à ton crédit, il est nécessaire de garder ton compte pour l’instant.
+      </Text>
+      <Text
+        style={
+          [
+            {
+              "color": "#161617",
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 14,
+              "lineHeight": 22.4,
+            },
+          ]
+        }
+      >
+        À tes 21 ans, ton compte pourra être supprimé et tu pourras faire une demande pour anonymiser tes données. Tu peux en savoir plus en
+        <View>
+          <View
+            accessibilityLabel="consultant cette page"
+            accessibilityRole="link"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                [
+                  {
+                    "userSelect": "auto",
+                  },
+                  {
+                    "top": 3,
+                  },
+                ],
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            testID="consultant cette page"
+          >
+            <View
+              paddingForIcon={0}
+              style={
+                [
+                  {
+                    "flexDirection": "row",
+                    "top": 0,
+                  },
+                ]
+              }
+            >
+              <View
+                accessibilityLabel="Nouvelle fenêtre"
+                height={20}
+                testID="button-icon"
+                width={20}
+              >
+                <Text>
+                  button-icon-SVG-Mock
+                </Text>
+              </View>
+              <View
+                numberOfSpaces={1}
+                style={
+                  [
+                    {
+                      "width": 4,
+                    },
+                  ]
+                }
+              />
+              <Text
+                color="#161617"
+                style={
+                  [
+                    {
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 15,
+                      "lineHeight": 20,
+                    },
+                  ]
+                }
+                typography="ButtonText"
+              >
+                consultant cette page
+              </Text>
+            </View>
+          </View>
+        </View>
+        .
+      </Text>
+      <Text
+        style={
+          [
+            {
+              "color": "#161617",
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 14,
+              "lineHeight": 22.4,
+            },
+          ]
+        }
+      >
+        Pour ne plus recevoir de communications du pass Culture, tu peux
+         
+        <Text
+          style={
+            [
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 14,
+                "fontWeight": "bold",
+                "lineHeight": 22.4,
+              },
+            ]
+          }
+        >
+          désactiver tes notifications
+        </Text>
+        .
+      </Text>
+    </View>
+    <View
+      gap={6}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "gap": 24,
+          },
+        ]
+      }
+    >
+      <View
+        accessibilityLabel="Retourner sur mon profil"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            [
+              {
+                "userSelect": "auto",
+              },
+              {
+                "alignItems": "center",
+                "backgroundColor": "#eb0055",
+                "borderRadius": 24,
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": 500,
+                "minHeight": 40,
+                "paddingBottom": 2,
+                "paddingLeft": 20,
+                "paddingRight": 20,
+                "paddingTop": 2,
+                "width": "100%",
+              },
+              {},
+            ],
+            {
+              "opacity": 1,
+            },
+          ]
+        }
+        testID="Retourner sur mon profil"
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+            ]
+          }
+        >
+          <Text
+            adjustsFontSizeToFit={false}
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "color": "#ffffff",
+                  "fontFamily": "Montserrat-Bold",
+                  "fontSize": 15,
+                  "lineHeight": 20,
+                  "maxWidth": "100%",
+                },
+              ]
+            }
+          >
+            Retourner sur mon profil
+          </Text>
+        </View>
+      </View>
+      <View
+        accessibilityLabel="Désactiver mes notifications"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            [
+              {
+                "userSelect": "auto",
+              },
+              {
+                "alignItems": "center",
+                "borderRadius": 24,
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "maxWidth": 500,
+                "minHeight": 40,
+                "paddingBottom": 2,
+                "paddingLeft": 2,
+                "paddingRight": 2,
+                "paddingTop": 2,
+                "width": "100%",
+              },
+              {
+                "backgroundColor": "transparent",
+              },
+            ],
+            {
+              "opacity": 1,
+            },
+          ]
+        }
+        testID="Désactiver mes notifications"
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "flexDirection": "row",
+                  "flexShrink": 0,
+                },
+              ]
+            }
+          >
+            <View
+              height={20}
+              testID="button-icon-left"
+              width={20}
+            >
+              <Text>
+                button-icon-left-SVG-Mock
+              </Text>
+            </View>
+            <View
+              numberOfSpaces={2}
+              style={
+                [
+                  {
+                    "width": 8,
+                  },
+                ]
+              }
+            />
+          </View>
+          <Text
+            adjustsFontSizeToFit={false}
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Bold",
+                  "fontSize": 15,
+                  "lineHeight": 20,
+                  "maxWidth": "100%",
+                },
+              ]
+            }
+          >
+            Désactiver mes notifications
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    flex={1.5}
+    style={
+      [
+        {
+          "flexBasis": 0,
+          "flexGrow": 1.5,
+          "flexShrink": 1,
+        },
+      ]
+    }
+  />
+</View>
+`;

--- a/src/features/internal/cheatcodes/pages/Navigation/Navigation.tsx
+++ b/src/features/internal/cheatcodes/pages/Navigation/Navigation.tsx
@@ -214,6 +214,12 @@ export function Navigation(): React.JSX.Element {
           <Row half>
             <ButtonPrimary wording="MarketingBlocks" onPress={() => navigate('MarketingBlocks')} />
           </Row>
+          <Row half>
+            <ButtonPrimary
+              wording="DeleteProfileAccountNotDeletble"
+              onPress={() => navigate('DeleteProfileAccountNotDeletable')}
+            />
+          </Row>
         </StyledContainer>
         <Spacer.BottomScreen />
       </ScrollView>

--- a/src/features/navigation/RootNavigator/routes.ts
+++ b/src/features/navigation/RootNavigator/routes.ts
@@ -63,6 +63,7 @@ import { ConsentSettings } from 'features/profile/pages/ConsentSettings/ConsentS
 import { ConfirmDeleteProfile } from 'features/profile/pages/DeleteProfile/ConfirmDeleteProfile'
 import { DeactivateProfileSuccess } from 'features/profile/pages/DeleteProfile/DeactivateProfileSuccess'
 import { DeleteProfileAccountHacked } from 'features/profile/pages/DeleteProfile/DeleteProfileAccountHacked'
+import { DeleteProfileAccountNotDeletable } from 'features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable'
 import { DeleteProfileConfirmation } from 'features/profile/pages/DeleteProfile/DeleteProfileConfirmation'
 import { DeleteProfileContactSupport } from 'features/profile/pages/DeleteProfile/DeleteProfileContactSupport'
 import { DeleteProfileEmailHacked } from 'features/profile/pages/DeleteProfile/DeleteProfileEmailHacked'
@@ -284,6 +285,13 @@ export const routes: RootRoute[] = [
     component: DeleteProfileAccountHacked,
     path: 'profil/suppression/compte-pirate',
     options: { title: 'Sécurise ton compte' },
+    secure: true,
+  },
+  {
+    name: 'DeleteProfileAccountNotDeletable',
+    component: DeleteProfileAccountNotDeletable,
+    path: 'profil/suppression/information',
+    options: { title: 'Compte non supprimable' },
     secure: true,
   },
   {

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -214,6 +214,7 @@ export type RootStackParamList = {
   DeleteProfileContactSupport: undefined
   DeleteProfileEmailHacked: undefined
   DeleteProfileAccountHacked: undefined
+  DeleteProfileAccountNotDeletable: undefined
   ConfirmDeleteProfile: undefined
   BookingConfirmation: { offerId: number; bookingId: number; apiRecoParams?: string }
   BookingDetails: { id: number }

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import { render, screen } from 'tests/utils'
+
+import { DeleteProfileAccountNotDeletable } from './DeleteProfileAccountNotDeletable'
+
+jest.mock('libs/firebase/analytics/analytics')
+
+describe('DeleteProfileAccountNotDeletable', () => {
+  it('should render correctly', () => {
+    render(<DeleteProfileAccountNotDeletable />)
+
+    expect(screen).toMatchSnapshot()
+  })
+})

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import { render, screen } from 'tests/utils'
+import { navigate } from '__mocks__/@react-navigation/native'
+import { fireEvent, render, screen } from 'tests/utils'
 
 import { DeleteProfileAccountNotDeletable } from './DeleteProfileAccountNotDeletable'
 
@@ -11,5 +12,23 @@ describe('DeleteProfileAccountNotDeletable', () => {
     render(<DeleteProfileAccountNotDeletable />)
 
     expect(screen).toMatchSnapshot()
+  })
+
+  it('should navigate to profile on press Retourner sur mon profil', async () => {
+    render(<DeleteProfileAccountNotDeletable />)
+    const button = screen.getByText('Retourner sur mon profil')
+
+    fireEvent.press(button)
+
+    expect(navigate).toHaveBeenCalledWith('TabNavigator', { params: undefined, screen: 'Profile' })
+  })
+
+  it('should navigate to notifications settings on press Désactiver mes notifications', async () => {
+    render(<DeleteProfileAccountNotDeletable />)
+    const button = screen.getByText('Désactiver mes notifications')
+
+    fireEvent.press(button)
+
+    expect(navigate).toHaveBeenCalledWith('NotificationsSettings')
   })
 })

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
@@ -52,8 +52,8 @@ export const DeleteProfileAccountNotDeletable: FC = () => {
             .
           </TypoDS.BodyS>
           <TypoDS.BodyS>
-            Pour ne plus recevoir de communications du pass Culture, tu peux{SPACE}
-            <StyledBoldText>désactiver tes notifications</StyledBoldText>.
+            Pour ne plus recevoir de communications du pass Culture, tu peux désactiver tes
+            notifications
           </TypoDS.BodyS>
         </ViewGap>
 
@@ -80,10 +80,6 @@ const ContentBottom = styled(ViewGap).attrs({
   gap: 6,
 })({
   alignItems: 'center',
-})
-
-const StyledBoldText = styled(TypoDS.BodyS)({
-  fontWeight: 'bold',
 })
 
 const StyledButtonInsideText = styled(ButtonInsideText).attrs(({ theme }) => ({

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
@@ -1,5 +1,6 @@
 import { useNavigation } from '@react-navigation/native'
 import React, { FC } from 'react'
+import { useTheme } from 'styled-components'
 import styled from 'styled-components/native'
 
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
@@ -23,12 +24,14 @@ export const DeleteProfileAccountNotDeletable: FC = () => {
   const navigateToProfile = () => navigate(...getTabNavConfig('Profile'))
 
   const navigateToNotifications = () => navigate('NotificationsSettings')
+  const { illustrations } = useTheme()
 
   return (
     <GenericInfoPageWhite
       headerGoBack
       separateIconFromTitle={false}
       icon={BicolorError}
+      iconSize={illustrations.sizes.medium}
       titleComponent={Typo.Title2}
       title="Nous ne pouvons pas encore supprimer ton compte">
       <Content>

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
@@ -1,0 +1,87 @@
+import { useNavigation } from '@react-navigation/native'
+import React, { FC } from 'react'
+import styled from 'styled-components/native'
+
+import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { env } from 'libs/environment'
+import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
+import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
+import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
+import { BellFilled } from 'ui/svg/icons/BellFilled'
+import { BicolorError } from 'ui/svg/icons/BicolorError'
+import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
+import { getSpacing, Typo, TypoDS } from 'ui/theme'
+
+export const DeleteProfileAccountNotDeletable: FC = () => {
+  const { navigate } = useNavigation<UseNavigationType>()
+
+  const navigateToProfile = () => navigate(...getTabNavConfig('Profile'))
+
+  const navigateToNotifications = () => navigate('NotificationsSettings')
+
+  return (
+    <GenericInfoPageWhite
+      headerGoBack
+      separateIconFromTitle={false}
+      icon={BicolorError}
+      titleComponent={Typo.Title2}
+      title="Nous ne pouvons pas encore supprimer ton compte">
+      <Content>
+        <ViewGap gap={6}>
+          <TypoDS.BodyS>
+            Pour éviter les cas de fraude et te permettre d’accéder à ton crédit, il est nécessaire
+            de garder ton compte pour l’instant.
+          </TypoDS.BodyS>
+          <TypoDS.BodyS>
+            À tes 21 ans, ton compte pourra être supprimé et tu pourras faire une demande pour
+            anonymiser tes données. Tu peux en savoir plus en
+            <ExternalTouchableLink
+              as={StyledButtonInsideText}
+              wording="consultant cette page"
+              icon={ExternalSiteFilled}
+              externalNav={{ url: env.FAQ_LINK_PERSONAL_DATA }}
+            />
+            .
+          </TypoDS.BodyS>
+          <TypoDS.BodyS>
+            Pour ne plus recevoir de communications du pass Culture, tu peux{' '}
+            <StyledBoldText>désactiver tes notifications</StyledBoldText>.
+          </TypoDS.BodyS>
+        </ViewGap>
+
+        <ContentBottom>
+          <ButtonPrimary wording="Retourner sur mon profil" onPress={navigateToProfile} />
+          <ButtonTertiaryBlack
+            wording="Désactiver mes notifications"
+            onPress={navigateToNotifications}
+            icon={BellFilled}
+          />
+        </ContentBottom>
+      </Content>
+    </GenericInfoPageWhite>
+  )
+}
+
+const Content = styled(ViewGap).attrs({
+  gap: 6,
+})({
+  marginTop: getSpacing(4),
+})
+
+const ContentBottom = styled(ViewGap).attrs({
+  gap: 6,
+})({
+  alignItems: 'center',
+})
+
+const StyledBoldText = styled(TypoDS.BodyS)({
+  fontWeight: 'bold',
+})
+
+const StyledButtonInsideText = styled(ButtonInsideText).attrs(({ theme }) => ({
+  buttonColor: theme.colors.black,
+}))``

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
@@ -38,7 +38,7 @@ export const DeleteProfileAccountNotDeletable: FC = () => {
           </TypoDS.BodyS>
           <TypoDS.BodyS>
             À tes 21 ans, ton compte pourra être supprimé et tu pourras faire une demande pour
-            anonymiser tes données. Tu peux en savoir plus en
+            anonymiser tes données. Tu peux en savoir plus en{' '}
             <ExternalTouchableLink
               as={StyledButtonInsideText}
               wording="consultant cette page"

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.tsx
@@ -15,6 +15,7 @@ import { BellFilled } from 'ui/svg/icons/BellFilled'
 import { BicolorError } from 'ui/svg/icons/BicolorError'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { getSpacing, Typo, TypoDS } from 'ui/theme'
+import { SPACE } from 'ui/theme/constants'
 
 export const DeleteProfileAccountNotDeletable: FC = () => {
   const { navigate } = useNavigation<UseNavigationType>()
@@ -38,7 +39,7 @@ export const DeleteProfileAccountNotDeletable: FC = () => {
           </TypoDS.BodyS>
           <TypoDS.BodyS>
             À tes 21 ans, ton compte pourra être supprimé et tu pourras faire une demande pour
-            anonymiser tes données. Tu peux en savoir plus en{' '}
+            anonymiser tes données. Tu peux en savoir plus en{SPACE}
             <ExternalTouchableLink
               as={StyledButtonInsideText}
               wording="consultant cette page"
@@ -48,7 +49,7 @@ export const DeleteProfileAccountNotDeletable: FC = () => {
             .
           </TypoDS.BodyS>
           <TypoDS.BodyS>
-            Pour ne plus recevoir de communications du pass Culture, tu peux{' '}
+            Pour ne plus recevoir de communications du pass Culture, tu peux{SPACE}
             <StyledBoldText>désactiver tes notifications</StyledBoldText>.
           </TypoDS.BodyS>
         </ViewGap>

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.web.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.web.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+import { checkAccessibilityFor, render } from 'tests/utils/web'
+
+import { DeleteProfileAccountNotDeletable } from './DeleteProfileAccountNotDeletable'
+
+jest.mock('libs/firebase/analytics/analytics')
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
+
+describe('DeleteProfileAccountNotDeletable', () => {
+  describe('Accessibility', () => {
+    it('should not have basic accessibility issues', async () => {
+      const { container } = render(<DeleteProfileAccountNotDeletable />)
+      const results = await checkAccessibilityFor(container)
+
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/src/ui/pages/GenericInfoPageWhite.tsx
+++ b/src/ui/pages/GenericInfoPageWhite.tsx
@@ -26,6 +26,7 @@ type PropsWithAnimation = {
 
 type PropsWithIcon = {
   icon: React.FC<AccessibleIcon>
+  iconSize?: number
 }
 
 type Props = {
@@ -52,7 +53,7 @@ export const GenericInfoPageWhite: React.FC<Props> = ({
   const grid = useGrid()
 
   const { animation } = props as PropsWithAnimation
-  const { icon: Icon } = props as PropsWithIcon
+  const { icon: Icon, iconSize } = props as PropsWithIcon
   const titleComponent = props.titleComponent ?? Typo.Title1
   const subtitleComponent = props.subtitleComponent ?? Typo.Title4
   const { isDesktopViewport } = useTheme()
@@ -66,7 +67,7 @@ export const GenericInfoPageWhite: React.FC<Props> = ({
   const StyledIcon =
     Icon &&
     styled(Icon).attrs(({ theme }) => ({
-      size: theme.illustrations.sizes.fullPage,
+      size: iconSize || theme.illustrations.sizes.fullPage,
     }))({ width: '100%' })
 
   const StyledSubtitle = useMemo(() => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-31349

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |    ![image](https://github.com/user-attachments/assets/f8cfecb0-39b4-4097-bc62-8e6024ad3493)   |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |    <img width="1512" alt="image" src="https://github.com/user-attachments/assets/4144c646-5c60-443a-94c0-c9e5d2ffd603">   |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
