### PR TITLE
(PC-31561) fix(offer): like counter visibility upon feature flag value

### DIFF
--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -76,6 +76,7 @@ export const OfferBody: FunctionComponent<Props> = ({
   const [surveyModalState, setSurveyModalState] = useState(DEFAULT_SURVEY_MODAL_DATA)
   const hasFakeDoorArtist = useFeatureFlag(RemoteStoreFeatureFlags.FAKE_DOOR_ARTIST)
   const hasAccessToArtistPage = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ARTIST_PAGE)
+  const isReactionFeatureActive = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
 
   const enableReactionFakeDoor = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FAKE_DOOR)
   const shouldDisplayFakeDoorArtist =
@@ -147,7 +148,9 @@ export const OfferBody: FunctionComponent<Props> = ({
 
           {prices ? <OfferPrice prices={prices} /> : null}
 
-          <OfferReactions user={user} isLoggedIn={isLoggedIn} offer={offer} />
+          {isReactionFeatureActive ? (
+            <OfferReactions user={user} isLoggedIn={isLoggedIn} offer={offer} />
+          ) : null}
 
           {shouldDisplayReactionButton ? (
             <ToggleButton


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-31561

Fix sur le compteur de like dans la page offre,  qui n'était pas conditionné par un feature flag.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
