### PR TITLE
(PC-31553) feat(venueMap): use multiOffer request for venu offers in bottom sheet

### DIFF
--- a/src/features/venue/api/useVenueOffers.test.ts
+++ b/src/features/venue/api/useVenueOffers.test.ts
@@ -1,0 +1,138 @@
+import * as UnderageUserAPI from 'features/profile/helpers/useIsUserUnderage'
+import { SearchState } from 'features/search/types'
+import { useVenueOffers } from 'features/venue/api/useVenueOffers'
+import * as useVenueSearchParameters from 'features/venue/helpers/useVenueSearchParameters'
+import mockVenueResponse from 'fixtures/venueResponse'
+import { fetchMultipleOffers } from 'libs/algolia/fetchAlgolia/fetchMultipleOffers/fetchMultipleOffers'
+import { LocationMode, Position } from 'libs/location/types'
+import * as useNetInfoContextDefault from 'libs/network/NetInfoWrapper'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { renderHook, waitFor } from 'tests/utils'
+
+const mockLocationMode = LocationMode.AROUND_ME
+const mockUserLocation: Position = { latitude: 48.90374, longitude: 2.48171 }
+jest.mock('libs/location/LocationWrapper', () => ({
+  useLocation: () => ({
+    userLocation: mockUserLocation,
+    selectedLocationMode: mockLocationMode,
+  }),
+}))
+
+jest.mock('features/search/context/SearchWrapper', () => ({
+  useSearch: () => ({
+    resetSearch: jest.fn(),
+  }),
+}))
+
+const venueSearchParamsMock: SearchState = {
+  beginningDatetime: undefined,
+  endingDatetime: undefined,
+  hitsPerPage: 30,
+  locationFilter: {
+    locationType: LocationMode.EVERYWHERE,
+  },
+  venue: {
+    label: mockVenueResponse.publicName || '',
+    info: mockVenueResponse.city || '',
+    _geoloc: {
+      lat: mockVenueResponse.latitude,
+      lng: mockVenueResponse.longitude,
+    },
+    venueId: mockVenueResponse.id,
+  },
+  offerCategories: [],
+  offerSubcategories: [],
+  offerIsDuo: false,
+  offerIsFree: false,
+  isDigital: false,
+  priceRange: [0, 300],
+  tags: [],
+  date: null,
+  timeRange: null,
+  query: '',
+}
+
+jest
+  .spyOn(useVenueSearchParameters, 'useVenueSearchParameters')
+  .mockReturnValue(venueSearchParamsMock)
+
+jest.mock('features/profile/helpers/useIsUserUnderage')
+jest.spyOn(UnderageUserAPI, 'useIsUserUnderage').mockReturnValue(false)
+
+jest.mock('libs/algolia/fetchAlgolia/fetchMultipleOffers/fetchMultipleOffers')
+const mockFetchMultipleOffers = fetchMultipleOffers as jest.Mock
+
+const mockUseAuthContext = jest.fn().mockReturnValue({
+  user: undefined,
+  isLoggedIn: false,
+})
+jest.mock('features/auth/context/AuthContext', () => ({
+  useAuthContext: () => mockUseAuthContext(),
+}))
+
+jest.mock('libs/firebase/analytics/analytics')
+
+const mockUseNetInfoContext = jest.spyOn(useNetInfoContextDefault, 'useNetInfoContext') as jest.Mock
+mockUseNetInfoContext.mockReturnValue({ isConnected: true, isInternetReachable: true })
+
+const EXPECTED_CALL_PARAM = {
+  indexName: 'algoliaTopOffersIndexName',
+  isUserUnderage: false,
+  paramsList: [
+    {
+      locationParams: {
+        aroundMeRadius: 100,
+        aroundPlaceRadius: 100,
+        selectedLocationMode: 'AROUND_ME',
+        userLocation: { latitude: 48.90374, longitude: 2.48171 },
+      },
+      offerParams: {
+        venue: {
+          _geoloc: { lat: 48.8536, lng: 2.34199 },
+          info: 'PARIS 6',
+          label: 'Cinéma St André des Arts',
+          venueId: 26235,
+        },
+      },
+    },
+    {
+      locationParams: {
+        aroundMeRadius: 100,
+        aroundPlaceRadius: 100,
+        selectedLocationMode: 'AROUND_ME',
+        userLocation: { latitude: 48.90374, longitude: 2.48171 },
+      },
+      offerParams: {
+        beginningDatetime: undefined,
+        date: null,
+        endingDatetime: undefined,
+        hitsPerPage: 30,
+        isDigital: false,
+        locationFilter: { locationType: 'EVERYWHERE' },
+        offerCategories: [],
+        offerIsDuo: false,
+        offerIsFree: false,
+        offerSubcategories: [],
+        priceRange: [0, 300],
+        query: '',
+        tags: [],
+        timeRange: null,
+        venue: {
+          _geoloc: { lat: 48.8536, lng: 2.34199 },
+          info: 'PARIS 6',
+          label: 'Cinéma St André des Arts',
+          venueId: 26235,
+        },
+      },
+    },
+  ],
+}
+
+describe('useVenueOffers', () => {
+  it('should call multiple fetch offers algolia request', async () => {
+    renderHook(() => useVenueOffers(mockVenueResponse), {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    })
+    await waitFor(() => expect(mockFetchMultipleOffers).toHaveBeenCalledWith(EXPECTED_CALL_PARAM))
+  })
+})

--- a/src/features/venue/api/useVenueOffers.ts
+++ b/src/features/venue/api/useVenueOffers.ts
@@ -1,13 +1,15 @@
 import uniqBy from 'lodash/uniqBy'
+import { useCallback } from 'react'
 import { useQuery, UseQueryResult } from 'react-query'
 
 import { VenueResponse } from 'api/gen'
 import { useIsUserUnderage } from 'features/profile/helpers/useIsUserUnderage'
+import { useSearch } from 'features/search/context/SearchWrapper'
 import { MAX_RADIUS } from 'features/search/helpers/reducer.helpers'
 import { useVenueSearchParameters } from 'features/venue/helpers/useVenueSearchParameters'
-import { useSearchAnalyticsState } from 'libs/algolia/analytics/SearchAnalyticsWrapper'
-import { fetchOffers } from 'libs/algolia/fetchAlgolia/fetchOffers'
+import { fetchMultipleOffers } from 'libs/algolia/fetchAlgolia/fetchMultipleOffers/fetchMultipleOffers'
 import { filterOfferHit, useTransformOfferHits } from 'libs/algolia/fetchAlgolia/transformOfferHit'
+import { SearchQueryParameters } from 'libs/algolia/types'
 import { env } from 'libs/environment'
 import { useLocation } from 'libs/location'
 import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
@@ -19,26 +21,37 @@ export type VenueOffers = { hits: Offer[]; nbHits: number }
 export const useVenueOffers = (venue?: VenueResponse): UseQueryResult<VenueOffers> => {
   const { userLocation, selectedLocationMode } = useLocation()
   const transformHits = useTransformOfferHits()
-  const params = useVenueSearchParameters(venue)
+  const venueSearchParams = useVenueSearchParameters(venue)
+  const { searchState } = useSearch()
   const isUserUnderage = useIsUserUnderage()
   const netInfo = useNetInfoContext()
 
-  const { setCurrentQueryID } = useSearchAnalyticsState()
+  const buildPlaylistOfferParams = useCallback(
+    (offerParams: SearchQueryParameters) => ({
+      locationParams: {
+        userLocation,
+        selectedLocationMode,
+        aroundMeRadius: MAX_RADIUS,
+        aroundPlaceRadius: MAX_RADIUS,
+      },
+      offerParams,
+    }),
+    [userLocation, selectedLocationMode]
+  )
 
   return useQuery(
     [QueryKeys.VENUE_OFFERS, venue?.id, userLocation, selectedLocationMode],
     () =>
-      fetchOffers({
-        parameters: { ...params, page: 0 },
-        buildLocationParameterParams: {
-          userLocation,
-          selectedLocationMode,
-          aroundMeRadius: MAX_RADIUS,
-          aroundPlaceRadius: MAX_RADIUS,
-        },
+      fetchMultipleOffers({
+        paramsList: [
+          buildPlaylistOfferParams({
+            ...searchState,
+            venue: venueSearchParams.venue,
+          }),
+          buildPlaylistOfferParams(venueSearchParams),
+        ],
         isUserUnderage,
-        storeQueryID: setCurrentQueryID,
-        indexSearch: env.ALGOLIA_TOP_OFFERS_INDEX_NAME,
+        indexName: env.ALGOLIA_TOP_OFFERS_INDEX_NAME,
       }),
     {
       enabled: !!(netInfo.isConnected && venue),

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
@@ -38,7 +38,7 @@ describe('<VenueMapView />', () => {
   })
 
   it('should render map', async () => {
-    renderVenueMapView({})
+    render(getVenueMapViewComponent({}))
     const mapView = await screen.findByTestId('venue-map-view')
 
     expect(mapView).toBeOnTheScreen()
@@ -46,13 +46,13 @@ describe('<VenueMapView />', () => {
   })
 
   it('should not display search button after initializing the map', async () => {
-    renderVenueMapView({})
+    render(getVenueMapViewComponent({}))
 
     expect(screen.queryByText('Rechercher dans cette zone')).not.toBeOnTheScreen()
   })
 
   it('should display search button after region change', async () => {
-    renderVenueMapView({})
+    render(getVenueMapViewComponent({}))
     const mapView = await screen.findByTestId('venue-map-view')
 
     // Simulate region change
@@ -67,7 +67,7 @@ describe('<VenueMapView />', () => {
   })
 
   it('should not display search button after search press', async () => {
-    renderVenueMapView({})
+    render(getVenueMapViewComponent({}))
     const mapView = await screen.findByTestId('venue-map-view')
 
     // Simulate region change
@@ -83,7 +83,7 @@ describe('<VenueMapView />', () => {
   })
 
   it('should reset initial venues store when pressing search button', async () => {
-    renderVenueMapView({})
+    render(getVenueMapViewComponent({}))
     const mapView = screen.getByTestId('venue-map-view')
 
     // Simulate region change
@@ -100,7 +100,7 @@ describe('<VenueMapView />', () => {
   })
 
   it('should display venueMapPreview + venueMapList in bottom sheet when marker is pressed', async () => {
-    renderVenueMapView({ selectedVenue: venuesFixture[0] })
+    render(getVenueMapViewComponent({ selectedVenue: venuesFixture[0] }))
     await screen.findByTestId(`marker-${venuesFixture[0].venueId}`)
     fireEvent.press(screen.getByTestId(`marker-${venuesFixture[0].venueId}`), {
       stopPropagation: () => false,
@@ -121,7 +121,7 @@ describe('<VenueMapView />', () => {
   })
 
   it('should not display preview is marker id has not been found in venue list', async () => {
-    renderVenueMapView({})
+    render(getVenueMapViewComponent({}))
     await screen.findByTestId(`marker-${venuesFixture[0].venueId}`)
     fireEvent.press(screen.getByTestId(`marker-${venuesFixture[0].venueId}`), {
       stopPropagation: () => false,
@@ -140,7 +140,7 @@ describe('<VenueMapView />', () => {
   it('should not display preview is FF disabled', async () => {
     // eslint-disable-next-line local-rules/independent-mocks
     useFeatureFlagSpy.mockReturnValue(false)
-    renderVenueMapView({})
+    render(getVenueMapViewComponent({}))
     await screen.findByTestId(`marker-${venuesFixture[0].venueId}`)
     fireEvent.press(screen.getByTestId(`marker-${venuesFixture[0].venueId}`), {
       stopPropagation: () => false,
@@ -161,7 +161,7 @@ describe('<VenueMapView />', () => {
     useFeatureFlagSpy.mockImplementation((flagId: RemoteStoreFeatureFlags) =>
       flagId === RemoteStoreFeatureFlags.WIP_OFFERS_IN_BOTTOM_SHEET ? false : true
     )
-    renderVenueMapView({ selectedVenue: venuesFixture[0] })
+    render(getVenueMapViewComponent({ selectedVenue: venuesFixture[0] }))
     await screen.findByTestId(`marker-${venuesFixture[0].venueId}`)
     fireEvent.press(screen.getByTestId(`marker-${venuesFixture[0].venueId}`), {
       stopPropagation: () => false,
@@ -182,7 +182,7 @@ describe('<VenueMapView />', () => {
   })
 
   it('should hide bottom sheet when a marker is selected and map is pressed', async () => {
-    renderVenueMapView({})
+    const { rerender } = render(getVenueMapViewComponent({ selectedVenue: venuesFixture[0] }))
     await screen.findByTestId(`marker-${venuesFixture[0].venueId}`)
     fireEvent.press(screen.getByTestId(`marker-${venuesFixture[0].venueId}`), {
       stopPropagation: () => false,
@@ -197,11 +197,13 @@ describe('<VenueMapView />', () => {
 
     fireEvent.press(screen.getByTestId('venue-map-view'))
 
+    rerender(getVenueMapViewComponent({}))
+
     await waitFor(() => expect(screen.queryByTestId('venueMapPreview')).not.toBeOnTheScreen())
   })
 
   it('should center map on bottom sheet animation', async () => {
-    renderVenueMapView({})
+    render(getVenueMapViewComponent({}))
     await screen.findByTestId(`marker-${venuesFixture[0].venueId}`)
     fireEvent.press(screen.getByTestId('venue-map-view'))
 
@@ -229,26 +231,24 @@ const mockCurrentRegion = {
 
 type RenderVenueMapViewType = Partial<ComponentProps<typeof VenueMapView>>
 
-function renderVenueMapView({
+function getVenueMapViewComponent({
   selectedVenue = null,
   venues = venuesFixture,
   venueTypeCode = VenueTypeCodeKey.VISUAL_ARTS,
   currentRegion = mockCurrentRegion,
 }: RenderVenueMapViewType) {
-  return render(
-    reactQueryProviderHOC(
-      <VenueMapView
-        height={700}
-        from="venueMap"
-        venues={venues}
-        selectedVenue={selectedVenue}
-        venueTypeCode={venueTypeCode}
-        setSelectedVenue={jest.fn()}
-        removeSelectedVenue={jest.fn()}
-        currentRegion={currentRegion}
-        setCurrentRegion={jest.fn()}
-        setLastRegionSearched={jest.fn()}
-      />
-    )
+  return reactQueryProviderHOC(
+    <VenueMapView
+      height={700}
+      from="venueMap"
+      venues={venues}
+      selectedVenue={selectedVenue}
+      venueTypeCode={venueTypeCode}
+      setSelectedVenue={jest.fn()}
+      removeSelectedVenue={jest.fn()}
+      currentRegion={currentRegion}
+      setCurrentRegion={jest.fn()}
+      setLastRegionSearched={jest.fn()}
+    />
   )
 }

--- a/src/fixtures/venueResponse.ts
+++ b/src/fixtures/venueResponse.ts
@@ -1,0 +1,18 @@
+import { VenueResponse } from 'api/gen'
+
+export default {
+  address: '30 rue saint-andré des arts',
+  bannerUrl:
+    'https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/google_places/26235.jpeg',
+  city: 'PARIS 6',
+  latitude: 48.8536,
+  longitude: 2.34199,
+  id: 26235,
+  isPermanent: true,
+  name: 'SHELLAC EXPLOITATION',
+  postalCode: '75006',
+  publicName: 'Cinéma St André des Arts',
+  timezone: 'Europe/Paris',
+  accessibility: {},
+  isVirtual: false,
+} satisfies VenueResponse


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-31553

Branchement de la nouvelle multi-requete agolia pour la récupération des offres en fonction d'un lieu + attributs de recherche

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
