### PR TITLE
(PC-31654) feat(offer): disable artist page link if artist has less than 2 offers

### DIFF
--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -28,6 +28,7 @@ import { getOfferMetadata } from 'features/offer/helpers/getOfferMetadata/getOff
 import { getOfferPrices } from 'features/offer/helpers/getOfferPrice/getOfferPrice'
 import { getOfferTags } from 'features/offer/helpers/getOfferTags/getOfferTags'
 import { useOfferSummaryInfoList } from 'features/offer/helpers/useOfferSummaryInfoList/useOfferSummaryInfoList'
+import { useSameArtistPlaylist } from 'features/offer/helpers/useSameArtistPlaylist/useSameArtistPlaylist'
 import { analytics } from 'libs/analytics'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
@@ -78,10 +79,16 @@ export const OfferBody: FunctionComponent<Props> = ({
   const tags = getOfferTags(subcategory.appLabel, extraData)
   const artists = getOfferArtists(subcategory.categoryId, offer)
   const prices = getOfferPrices(offer.stocks)
+  const { sameArtistPlaylist: artistOffers } = useSameArtistPlaylist({
+    artists,
+    searchGroupName: subcategory.searchGroupName,
+    venueLocation: {},
+  })
 
   const hasAccessToArtistPage =
     hasArtistPage &&
     artists &&
+    artistOffers?.length > 1 &&
     !COMMA_OR_SEMICOLON_REGEX.test(artists) &&
     !EXCLUDED_ARTISTS.includes(artists.toLowerCase())
   const isCinemaOffer = subcategory.categoryId === CategoryIdEnum.CINEMA

--- a/src/features/offer/pages/Offer/Offer.perf.test.tsx
+++ b/src/features/offer/pages/Offer/Offer.perf.test.tsx
@@ -4,8 +4,12 @@ import { useRoute } from '__mocks__/@react-navigation/native'
 import { OfferResponseV2, SimilarOffersResponse, SubcategoriesResponseModelv2 } from 'api/gen'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import * as GetInstalledAppsAPI from 'features/offer/helpers/getInstalledApps/getInstalledApps'
+import * as useSameArtistPlaylist from 'features/offer/helpers/useSameArtistPlaylist/useSameArtistPlaylist'
 import { Offer } from 'features/offer/pages/Offer/Offer'
-import { mockedAlgoliaResponse } from 'libs/algolia/fixtures/algoliaFixtures'
+import {
+  mockedAlgoliaOffersWithSameArtistResponse,
+  mockedAlgoliaResponse,
+} from 'libs/algolia/fixtures/algoliaFixtures'
 import * as useFeatureFlag from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { Network } from 'libs/share/types'
 import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
@@ -27,6 +31,10 @@ jest.mock('react-native-safe-area-context', () => ({
   ...(jest.requireActual('react-native-safe-area-context') as Record<string, unknown>),
   useSafeAreaInsets: () => ({ bottom: 16, right: 16, left: 16, top: 16 }),
 }))
+
+jest.spyOn(useSameArtistPlaylist, 'useSameArtistPlaylist').mockImplementation().mockReturnValue({
+  sameArtistPlaylist: mockedAlgoliaOffersWithSameArtistResponse,
+})
 
 jest.mock('@batch.com/react-native-plugin', () =>
   jest.requireActual('__mocks__/libs/react-native-batch')


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-31654

Désactivation du lien vers la page artiste si l'artiste à moins de 2 offres

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
