### PR TITLE
(PC-31711) feat(home): display reaction modal for bookings used for more than 24 hours

### DIFF
--- a/src/features/bookings/components/EndedBookingItem.tsx
+++ b/src/features/bookings/components/EndedBookingItem.tsx
@@ -7,6 +7,7 @@ import { BookingItemTitle } from 'features/bookings/components/BookingItemTitle'
 import { isEligibleBookingsForArchive } from 'features/bookings/helpers/expirationDateUtils'
 import { BookingItemProps } from 'features/bookings/types'
 import { ReactionChoiceModal } from 'features/reactions/components/ReactionChoiceModal/ReactionChoiceModal'
+import { ReactionFromEnum } from 'features/reactions/enum'
 import { getShareOffer } from 'features/share/helpers/getShareOffer'
 import { WebShareModal } from 'features/share/pages/WebShareModal'
 import { analytics } from 'libs/analytics'
@@ -237,6 +238,7 @@ export const EndedBookingItem = ({ booking, onSaveReaction }: BookingItemProps) 
           visible={reactionModalVisible}
           defaultReaction={userReaction}
           onSave={handleSaveReaction}
+          from={ReactionFromEnum.ENDED_BOOKING}
         />
       ) : null}
     </Container>

--- a/src/features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer.native.test.tsx
+++ b/src/features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer.native.test.tsx
@@ -141,7 +141,65 @@ describe('IncomingReactionModalContainer', () => {
     fireEvent.press(screen.getByText('Valider la réaction'))
 
     await waitFor(() => {
-      expect(mockMutate).toHaveBeenCalledTimes(1)
+      expect(mockMutate).toHaveBeenNthCalledWith(1, {
+        offerId: bookingsSnap.ended_bookings[0].stock.offer.id,
+        reactionType: ReactionTypeEnum.LIKE,
+      })
+    })
+  })
+
+  it('should send reaction with NO_REACTION when closing modalfrom offer has subcategory in reactionCategories remote config', async () => {
+    const dateUsed = new Date(CURRENT_DATE.getTime() - TWENTY_FOUR_HOURS - 1000).toISOString()
+    mockUseBookings.mockReturnValueOnce({
+      data: {
+        ended_bookings: [
+          {
+            ...bookingsSnap.ended_bookings[0],
+            userReaction: null,
+            dateUsed,
+            stock: {
+              ...bookingsSnap.ended_bookings[0].stock,
+              offer: {
+                ...bookingsSnap.ended_bookings[0].stock.offer,
+                subcategoryId: SubcategoryIdEnum.SEANCE_CINE,
+              },
+            },
+          },
+        ],
+      },
+    })
+    mockUseBookings.mockReturnValueOnce({
+      data: {
+        ended_bookings: [
+          {
+            ...bookingsSnap.ended_bookings[0],
+            userReaction: null,
+            dateUsed,
+            stock: {
+              ...bookingsSnap.ended_bookings[0].stock,
+              offer: {
+                ...bookingsSnap.ended_bookings[0].stock.offer,
+                subcategoryId: SubcategoryIdEnum.SEANCE_CINE,
+              },
+            },
+          },
+        ],
+      },
+    })
+
+    render(reactQueryProviderHOC(<IncomingReactionModalContainer />))
+
+    await act(async () => {
+      jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
+    })
+
+    fireEvent.press(screen.getByTestId('Fermer la modale'))
+
+    await waitFor(() => {
+      expect(mockMutate).toHaveBeenNthCalledWith(1, {
+        offerId: bookingsSnap.ended_bookings[0].stock.offer.id,
+        reactionType: ReactionTypeEnum.NO_REACTION,
+      })
     })
   })
 

--- a/src/features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer.native.test.tsx
+++ b/src/features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer.native.test.tsx
@@ -1,0 +1,223 @@
+import mockdate from 'mockdate'
+import React from 'react'
+
+import {
+  NativeCategoryIdEnumv2,
+  ReactionTypeEnum,
+  SubcategoriesResponseModelv2,
+  SubcategoryIdEnum,
+} from 'api/gen'
+import { CURRENT_DATE } from 'features/auth/fixtures/fixtures'
+import { useBookings } from 'features/bookings/api'
+import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
+import { IncomingReactionModalContainer } from 'features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer'
+import { TWENTY_FOUR_HOURS } from 'features/home/constants'
+import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
+import * as useRemoteConfigContext from 'libs/firebase/remoteConfig/RemoteConfigProvider'
+import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
+import { MODAL_TO_SHOW_TIME } from 'tests/constants'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
+jest.mock('libs/firebase/analytics/analytics')
+
+jest.mock('features/bookings/api')
+const mockUseBookings = useBookings as jest.Mock
+
+const mockMutate = jest.fn()
+jest.mock('features/reactions/api/useReactionMutation', () => ({
+  useReactionMutation: () => ({ mutate: mockMutate }),
+}))
+
+const useRemoteConfigContextSpy = jest.spyOn(useRemoteConfigContext, 'useRemoteConfigContext')
+
+jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
+
+jest.mock('@batch.com/react-native-plugin', () =>
+  jest.requireActual('__mocks__/libs/react-native-batch')
+)
+
+jest.mock('react-native-safe-area-context', () => ({
+  ...(jest.requireActual('react-native-safe-area-context') as Record<string, unknown>),
+  useSafeAreaInsets: () => ({ bottom: 16, right: 16, left: 16, top: 16 }),
+}))
+
+const mockData: SubcategoriesResponseModelv2 | undefined = PLACEHOLDER_DATA
+jest.mock('libs/subcategories/useSubcategories', () => ({
+  useSubcategories: () => ({
+    data: mockData,
+  }),
+}))
+
+jest.useFakeTimers()
+
+describe('IncomingReactionModalContainer', () => {
+  beforeAll(() => {
+    useRemoteConfigContextSpy.mockReturnValue({
+      ...DEFAULT_REMOTE_CONFIG,
+      reactionCategories: {
+        categories: [NativeCategoryIdEnumv2.SEANCES_DE_CINEMA],
+      },
+    })
+  })
+
+  beforeEach(() => {
+    mockdate.set(CURRENT_DATE)
+  })
+
+  it('should not render the modal if no bookings without reactions', () => {
+    mockUseBookings.mockReturnValueOnce({
+      data: {
+        ended_bookings: [
+          { ...bookingsSnap.ended_bookings[0], userReaction: ReactionTypeEnum.LIKE },
+        ],
+      },
+    })
+
+    render(<IncomingReactionModalContainer />)
+
+    expect(screen.queryByText('Choix de réaction')).not.toBeOnTheScreen()
+  })
+
+  it('should render the modal if there is a booking without reaction after 24 hours and subcategory is in reactionCategories remote config', async () => {
+    const dateUsed = new Date(CURRENT_DATE.getTime() - TWENTY_FOUR_HOURS - 1000).toISOString()
+    mockUseBookings.mockReturnValueOnce({
+      data: {
+        ended_bookings: [
+          {
+            ...bookingsSnap.ended_bookings[0],
+            userReaction: null,
+            dateUsed,
+            stock: {
+              ...bookingsSnap.ended_bookings[0].stock,
+              offer: {
+                ...bookingsSnap.ended_bookings[0].stock.offer,
+                subcategoryId: SubcategoryIdEnum.SEANCE_CINE,
+              },
+            },
+          },
+        ],
+      },
+    })
+
+    render(reactQueryProviderHOC(<IncomingReactionModalContainer />))
+
+    await act(async () => {
+      jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
+    })
+
+    expect(screen.getByText('Choix de réaction')).toBeOnTheScreen()
+  })
+
+  it('should send reaction from offer has subcategory in reactionCategories remote config', async () => {
+    const dateUsed = new Date(CURRENT_DATE.getTime() - TWENTY_FOUR_HOURS - 1000).toISOString()
+    mockUseBookings.mockReturnValueOnce({
+      data: {
+        ended_bookings: [
+          {
+            ...bookingsSnap.ended_bookings[0],
+            userReaction: null,
+            dateUsed,
+            stock: {
+              ...bookingsSnap.ended_bookings[0].stock,
+              offer: {
+                ...bookingsSnap.ended_bookings[0].stock.offer,
+                subcategoryId: SubcategoryIdEnum.SEANCE_CINE,
+              },
+            },
+          },
+        ],
+      },
+    })
+
+    render(reactQueryProviderHOC(<IncomingReactionModalContainer />))
+
+    await act(async () => {
+      jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
+    })
+
+    fireEvent.press(await screen.findByText('J’aime'))
+    fireEvent.press(screen.getByText('Valider la réaction'))
+
+    await waitFor(() => {
+      expect(mockMutate).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('should not render the modal if there is a booking without reaction after 24 hours and subcategory is not in reactionCategories remote config', async () => {
+    const now = new Date()
+    const dateUsed = new Date(now.getTime() - TWENTY_FOUR_HOURS - 1000).toISOString()
+    mockUseBookings.mockReturnValueOnce({
+      data: {
+        ended_bookings: [
+          {
+            ...bookingsSnap.ended_bookings[0],
+            userReaction: null,
+            dateUsed,
+          },
+        ],
+      },
+    })
+
+    render(reactQueryProviderHOC(<IncomingReactionModalContainer />))
+
+    await act(async () => {
+      jest.advanceTimersByTime(MODAL_TO_SHOW_TIME)
+    })
+
+    expect(screen.queryByText('Choix de réaction')).not.toBeOnTheScreen()
+  })
+
+  it('should not render the modal if booking has userReaction', () => {
+    const dateUsed = new Date(CURRENT_DATE.getTime() - TWENTY_FOUR_HOURS - 1000).toISOString()
+
+    mockUseBookings.mockReturnValueOnce({
+      data: {
+        ended_bookings: [
+          {
+            ...bookingsSnap.ended_bookings[0],
+            userReaction: ReactionTypeEnum.LIKE,
+            dateUsed,
+            stock: {
+              ...bookingsSnap.ended_bookings[0].stock,
+              offer: {
+                ...bookingsSnap.ended_bookings[0].stock.offer,
+                subcategoryId: SubcategoryIdEnum.SEANCE_CINE,
+              },
+            },
+          },
+        ],
+      },
+    })
+
+    render(<IncomingReactionModalContainer />)
+
+    expect(screen.queryByText('Choix de réaction')).not.toBeOnTheScreen()
+  })
+
+  it('should not render the modal if less than 24 hours have passed', () => {
+    const dateUsed = new Date(CURRENT_DATE.getTime() - TWENTY_FOUR_HOURS + 1000).toISOString()
+    mockUseBookings.mockReturnValueOnce({
+      data: {
+        ended_bookings: [
+          {
+            ...bookingsSnap.ended_bookings[0],
+            userReaction: null,
+            dateUsed,
+            stock: {
+              ...bookingsSnap.ended_bookings[0].stock,
+              offer: {
+                ...bookingsSnap.ended_bookings[0].stock.offer,
+                subcategoryId: SubcategoryIdEnum.SEANCE_CINE,
+              },
+            },
+          },
+        ],
+      },
+    })
+    render(<IncomingReactionModalContainer />)
+
+    expect(screen.queryByText('Choix de réaction')).not.toBeOnTheScreen()
+  })
+})

--- a/src/features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer.tsx
+++ b/src/features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer.tsx
@@ -1,0 +1,61 @@
+import React, { useCallback } from 'react'
+
+import { PostReactionRequest } from 'api/gen'
+import { useBookings } from 'features/bookings/api'
+import { TWENTY_FOUR_HOURS } from 'features/home/constants'
+import { useReactionMutation } from 'features/reactions/api/useReactionMutation'
+import { ReactionChoiceModal } from 'features/reactions/components/ReactionChoiceModal/ReactionChoiceModal'
+import { ReactionFromEnum } from 'features/reactions/enum'
+import { formatToSlashedFrenchDate } from 'libs/dates'
+import { useRemoteConfigContext } from 'libs/firebase/remoteConfig/RemoteConfigProvider'
+import { useSubcategoriesMapping } from 'libs/subcategories'
+import { useModal } from 'ui/components/modals/useModal'
+
+export const IncomingReactionModalContainer = () => {
+  const { reactionCategories } = useRemoteConfigContext()
+  const { data: bookings } = useBookings()
+  const { mutate: addReaction } = useReactionMutation()
+  const { visible: reactionModalVisible, hideModal: hideReactionModal } = useModal(true)
+  const subcategoriesMapping = useSubcategoriesMapping()
+  const now = new Date()
+
+  const bookingsWithoutReaction =
+    bookings?.ended_bookings.filter(({ dateUsed, userReaction }) => {
+      if (!dateUsed || userReaction !== null) return false
+
+      const elapsedTime = now.getTime() - new Date(dateUsed).getTime()
+      return elapsedTime > TWENTY_FOUR_HOURS
+    }) ?? []
+
+  const firstBooking = bookingsWithoutReaction[0]
+
+  const handleSaveReaction = useCallback(
+    ({ offerId, reactionType }: PostReactionRequest) => {
+      addReaction({ offerId, reactionType })
+      return Promise.resolve(true)
+    },
+    [addReaction]
+  )
+
+  if (!firstBooking) return null
+
+  const { stock, dateUsed } = firstBooking
+  const { offer } = stock
+  const subcategory = subcategoriesMapping[offer.subcategoryId]
+
+  const isEligibleCategory = reactionCategories.categories.includes(subcategory.nativeCategoryId)
+
+  if (!isEligibleCategory) return null
+
+  return (
+    <ReactionChoiceModal
+      offer={offer}
+      dateUsed={dateUsed ? `le ${formatToSlashedFrenchDate(dateUsed)}` : ''}
+      closeModal={hideReactionModal}
+      visible={reactionModalVisible}
+      defaultReaction={null}
+      onSave={handleSaveReaction}
+      from={ReactionFromEnum.HOME}
+    />
+  )
+}

--- a/src/features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer.tsx
+++ b/src/features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 
-import { PostReactionRequest } from 'api/gen'
+import { PostReactionRequest, ReactionTypeEnum } from 'api/gen'
 import { useBookings } from 'features/bookings/api'
 import { TWENTY_FOUR_HOURS } from 'features/home/constants'
 import { useReactionMutation } from 'features/reactions/api/useReactionMutation'
@@ -37,6 +37,17 @@ export const IncomingReactionModalContainer = () => {
     [addReaction]
   )
 
+  const handleCloseModal = useCallback(() => {
+    if (!firstBooking) return
+
+    addReaction({
+      offerId: firstBooking.stock.offer.id,
+      reactionType: ReactionTypeEnum.NO_REACTION,
+    })
+
+    hideReactionModal()
+  }, [addReaction, firstBooking, hideReactionModal])
+
   if (!firstBooking) return null
 
   const { stock, dateUsed } = firstBooking
@@ -51,7 +62,7 @@ export const IncomingReactionModalContainer = () => {
     <ReactionChoiceModal
       offer={offer}
       dateUsed={dateUsed ? `le ${formatToSlashedFrenchDate(dateUsed)}` : ''}
-      closeModal={hideReactionModal}
+      closeModal={handleCloseModal}
       visible={reactionModalVisible}
       defaultReaction={null}
       onSave={handleSaveReaction}

--- a/src/features/home/constants.ts
+++ b/src/features/home/constants.ts
@@ -1,2 +1,3 @@
 export const PERFORMANCE_HOME_CREATION = 'HOME:CREATION'
 export const PERFORMANCE_HOME_LOADING = 'HOME:LOADING'
+export const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000 // 24 hours in milliseconds

--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -7,6 +7,7 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useBookings } from 'features/bookings/api'
 import { useHomepageData } from 'features/home/api/useHomepageData'
 import { HomeHeader } from 'features/home/components/headers/HomeHeader'
+import { IncomingReactionModalContainer } from 'features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer'
 import { HomeBanner } from 'features/home/components/modules/banners/HomeBanner'
 import { PERFORMANCE_HOME_CREATION, PERFORMANCE_HOME_LOADING } from 'features/home/constants'
 import { GenericHome } from 'features/home/pages/GenericHome'
@@ -20,6 +21,8 @@ import {
   useShareAppModaleTrigger,
 } from 'features/subscription/helpers/useShareAppModaleTrigger'
 import { analytics } from 'libs/analytics'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { useRemoteConfigContext } from 'libs/firebase/remoteConfig/RemoteConfigProvider'
 import { useFunctionOnce } from 'libs/hooks'
 import { useLocation } from 'libs/location'
@@ -60,6 +63,7 @@ export const Home: FunctionComponent = () => {
     showOnboardingSubscriptionModal,
   })
   const { shouldApplyGraphicRedesign, shareAppTrigger } = useRemoteConfigContext()
+  const isReactionFeatureActive = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
   const { data: bookings } = useBookings()
 
   const getShareAppTrigger = () => {
@@ -148,6 +152,7 @@ export const Home: FunctionComponent = () => {
         visible={onboardingSubscriptionModalVisible}
         dismissModal={hideOnboardingSubscriptionModal}
       />
+      {isReactionFeatureActive ? <IncomingReactionModalContainer /> : null}
     </React.Fragment>
   )
 }

--- a/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.native.test.tsx
+++ b/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.native.test.tsx
@@ -147,25 +147,4 @@ describe('ReactionChoiceModal', () => {
       reactionType: ReactionTypeEnum.LIKE,
     })
   })
-
-  it('should save reaction with NO_REACTION when closing modal and modal openning from home', () => {
-    const mockHandleSave = jest.fn()
-    render(
-      <ReactionChoiceModal
-        offer={mockOffer}
-        dateUsed="2023-05-30"
-        visible
-        closeModal={mockCloseModal}
-        onSave={mockHandleSave}
-        from={ReactionFromEnum.HOME}
-      />
-    )
-
-    fireEvent.press(screen.getByTestId('Fermer la modale'))
-
-    expect(mockHandleSave).toHaveBeenCalledWith({
-      offerId: mockOffer.id,
-      reactionType: ReactionTypeEnum.NO_REACTION,
-    })
-  })
 })

--- a/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.native.test.tsx
+++ b/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { ReactionTypeEnum } from 'api/gen'
 import { mockOffer } from 'features/bookOffer/fixtures/offer'
 import { ReactionChoiceModal } from 'features/reactions/components/ReactionChoiceModal/ReactionChoiceModal'
+import { ReactionFromEnum } from 'features/reactions/enum'
 import { fireEvent, render, screen } from 'tests/utils'
 
 const mockCloseModal = jest.fn()
@@ -28,6 +29,7 @@ describe('ReactionChoiceModal', () => {
         dateUsed="2023-05-30"
         visible
         closeModal={mockCloseModal}
+        from={ReactionFromEnum.ENDED_BOOKING}
       />
     )
 
@@ -44,6 +46,7 @@ describe('ReactionChoiceModal', () => {
         dateUsed="2023-05-30"
         visible
         closeModal={mockCloseModal}
+        from={ReactionFromEnum.ENDED_BOOKING}
       />
     )
 
@@ -61,6 +64,7 @@ describe('ReactionChoiceModal', () => {
         dateUsed="2023-05-30"
         visible
         closeModal={mockCloseModal}
+        from={ReactionFromEnum.ENDED_BOOKING}
       />
     )
 
@@ -77,6 +81,7 @@ describe('ReactionChoiceModal', () => {
         dateUsed="2023-05-30"
         visible
         closeModal={mockCloseModal}
+        from={ReactionFromEnum.ENDED_BOOKING}
       />
     )
 
@@ -94,6 +99,7 @@ describe('ReactionChoiceModal', () => {
         dateUsed="2023-05-30"
         visible
         closeModal={mockCloseModal}
+        from={ReactionFromEnum.ENDED_BOOKING}
       />
     )
 
@@ -111,6 +117,7 @@ describe('ReactionChoiceModal', () => {
         dateUsed="2023-05-30"
         visible
         closeModal={mockCloseModal}
+        from={ReactionFromEnum.ENDED_BOOKING}
       />
     )
 
@@ -128,6 +135,7 @@ describe('ReactionChoiceModal', () => {
         visible
         closeModal={mockCloseModal}
         onSave={mockHandleSave}
+        from={ReactionFromEnum.ENDED_BOOKING}
       />
     )
 
@@ -137,6 +145,27 @@ describe('ReactionChoiceModal', () => {
     expect(mockHandleSave).toHaveBeenCalledWith({
       offerId: mockOffer.id,
       reactionType: ReactionTypeEnum.LIKE,
+    })
+  })
+
+  it('should save reaction with NO_REACTION when closing modal and modal openning from home', () => {
+    const mockHandleSave = jest.fn()
+    render(
+      <ReactionChoiceModal
+        offer={mockOffer}
+        dateUsed="2023-05-30"
+        visible
+        closeModal={mockCloseModal}
+        onSave={mockHandleSave}
+        from={ReactionFromEnum.HOME}
+      />
+    )
+
+    fireEvent.press(screen.getByTestId('Fermer la modale'))
+
+    expect(mockHandleSave).toHaveBeenCalledWith({
+      offerId: mockOffer.id,
+      reactionType: ReactionTypeEnum.NO_REACTION,
     })
   })
 })

--- a/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.tsx
+++ b/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.tsx
@@ -4,6 +4,7 @@ import styled, { useTheme } from 'styled-components/native'
 
 import { BookingOfferResponse, OfferResponse, PostReactionRequest, ReactionTypeEnum } from 'api/gen'
 import { ReactionToggleButton } from 'features/reactions/components/ReactionToggleButton/ReactionToggleButton'
+import { ReactionFromEnum } from 'features/reactions/enum'
 import { useSubcategory } from 'libs/subcategories'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { IconNames } from 'ui/components/icons/iconFactory'
@@ -24,6 +25,7 @@ type Props = {
   defaultReaction?: ReactionTypeEnum | null
   closeModal: () => void
   onSave?: ({ offerId, reactionType }: PostReactionRequest) => void
+  from: ReactionFromEnum
 }
 
 export const ReactionChoiceModal: FunctionComponent<Props> = ({
@@ -33,6 +35,7 @@ export const ReactionChoiceModal: FunctionComponent<Props> = ({
   defaultReaction,
   closeModal,
   onSave,
+  from,
 }) => {
   const { height } = useWindowDimensions()
   const { top } = useCustomSafeInsets()
@@ -50,11 +53,19 @@ export const ReactionChoiceModal: FunctionComponent<Props> = ({
     setIsButtonDisabled(false)
     setButtonWording('Valider la réaction')
     setReactionStatus((previousValue) => {
+      if (reactionType === previousValue && from === ReactionFromEnum.HOME)
+        setIsButtonDisabled(true)
       return reactionType === previousValue ? ReactionTypeEnum.NO_REACTION : reactionType
     })
   }
 
   const handleCloseModal = () => {
+    if (from === ReactionFromEnum.HOME) {
+      onSave?.({
+        offerId: offer.id,
+        reactionType: ReactionTypeEnum.NO_REACTION,
+      })
+    }
     closeModal()
   }
 
@@ -67,10 +78,14 @@ export const ReactionChoiceModal: FunctionComponent<Props> = ({
   }, [visible, defaultReaction])
 
   useEffect(() => {
-    if (!isButtonDisabled && reactionStatus === ReactionTypeEnum.NO_REACTION) {
+    if (
+      !isButtonDisabled &&
+      reactionStatus === ReactionTypeEnum.NO_REACTION &&
+      from === ReactionFromEnum.ENDED_BOOKING
+    ) {
       setButtonWording('Confirmer')
     }
-  }, [reactionStatus, isButtonDisabled])
+  }, [reactionStatus, isButtonDisabled, from])
 
   const getStyledIcon = useCallback(
     (name: IconNames, props?: object) =>

--- a/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.tsx
+++ b/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.tsx
@@ -59,16 +59,6 @@ export const ReactionChoiceModal: FunctionComponent<Props> = ({
     })
   }
 
-  const handleCloseModal = () => {
-    if (from === ReactionFromEnum.HOME) {
-      onSave?.({
-        offerId: offer.id,
-        reactionType: ReactionTypeEnum.NO_REACTION,
-      })
-    }
-    closeModal()
-  }
-
   useEffect(() => {
     if (visible && defaultReaction !== undefined && defaultReaction !== null) {
       setReactionStatus(defaultReaction)
@@ -124,7 +114,7 @@ export const ReactionChoiceModal: FunctionComponent<Props> = ({
       title="Choix de réaction"
       maxHeight={height - top}
       rightIcon={Close}
-      onRightIconPress={handleCloseModal}
+      onRightIconPress={closeModal}
       rightIconAccessibilityLabel="Fermer la modale"
       fixedModalBottom={
         <ButtonPrimary

--- a/src/features/reactions/enum.ts
+++ b/src/features/reactions/enum.ts
@@ -1,0 +1,4 @@
+export enum ReactionFromEnum {
+  HOME = 'home',
+  ENDED_BOOKING = 'ended_booking',
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-31711

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
