### PR TITLE
(PC-31018) feat(CI): trigger ios prod build at the same time as a staging build

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -182,7 +182,7 @@ jobs:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
   hard-deploy-ios-production:
     needs: yarn-tester
-    if: startsWith(github.ref, 'refs/tags/prod-hard-deploy')
+    if: startsWith(github.ref, 'refs/tags/patch') || startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/dev_on_workflow_environment_ios_deploy.yml
     with:
       CACHE_BUCKET_NAME: passculture-infra-prod-github-runner-cache


### PR DESCRIPTION
The idea is to trigger a production build for ios when we trigger a staging build as it will push a TestFlight version to AppStoreConnect

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-31018
