### PR TITLE
(PC-31778) feat(Bookings): post reaction on tab change or on change screen

### DIFF
--- a/__snapshots__/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx.native-snap
@@ -253,6 +253,7 @@ exports[`EndedBookings should render correctly 1`] = `
           },
           "token": "352UW5",
           "totalAmount": 1900,
+          "userReaction": null,
         },
         {
           "confirmationDate": "2021-02-15T23:01:37.925926",
@@ -297,6 +298,7 @@ exports[`EndedBookings should render correctly 1`] = `
           },
           "token": "352UW5",
           "totalAmount": 1900,
+          "userReaction": null,
         },
       ]
     }
@@ -787,6 +789,7 @@ exports[`EndedBookings should render correctly 1`] = `
               },
               "token": "352UW5",
               "totalAmount": 1900,
+              "userReaction": null,
             }
           }
           style={

--- a/src/api/gen/api.ts
+++ b/src/api/gen/api.ts
@@ -2710,19 +2710,30 @@ export interface PostFeedbackBody {
 }
 /**
  * @export
- * @interface PostReactionRequest
+ * @interface PostOneReactionRequest
  */
-export interface PostReactionRequest {
+export interface PostOneReactionRequest {
   /**
    * @type {number}
-   * @memberof PostReactionRequest
+   * @memberof PostOneReactionRequest
    */
   offerId: number
   /**
    * @type {ReactionTypeEnum}
-   * @memberof PostReactionRequest
+   * @memberof PostOneReactionRequest
    */
   reactionType: ReactionTypeEnum
+}
+/**
+ * @export
+ * @interface PostReactionRequest
+ */
+export interface PostReactionRequest {
+  /**
+   * @type {Array<PostOneReactionRequest>}
+   * @memberof PostReactionRequest
+   */
+  reactions: Array<PostOneReactionRequest>
 }
 /**
  * @export

--- a/src/features/bookings/components/EndedBookingItem.tsx
+++ b/src/features/bookings/components/EndedBookingItem.tsx
@@ -2,7 +2,7 @@ import React, { ComponentProps, FunctionComponent, useCallback, useMemo, useStat
 import { View } from 'react-native'
 import styled from 'styled-components/native'
 
-import { BookingCancellationReasons, PostReactionRequest, ReactionTypeEnum } from 'api/gen'
+import { BookingCancellationReasons, PostOneReactionRequest, ReactionTypeEnum } from 'api/gen'
 import { BookingItemTitle } from 'features/bookings/components/BookingItemTitle'
 import { isEligibleBookingsForArchive } from 'features/bookings/helpers/expirationDateUtils'
 import { BookingItemProps } from 'features/bookings/types'
@@ -50,7 +50,6 @@ export const EndedBookingItem = ({ booking, onSaveReaction }: BookingItemProps) 
   const { cancellationDate, cancellationReason, dateUsed, stock } = booking
   const subcategoriesMapping = useSubcategoriesMapping()
   const subCategory = subcategoriesMapping[stock.offer.subcategoryId]
-
   const prePopulateOffer = usePrePopulateOffer()
   const netInfo = useNetInfoContext()
   const { showErrorSnackBar } = useSnackBarContext()
@@ -150,7 +149,7 @@ export const EndedBookingItem = ({ booking, onSaveReaction }: BookingItemProps) 
     utmMedium: 'ended_booking',
   })
 
-  const handleSaveReaction = async ({ offerId, reactionType }: PostReactionRequest) => {
+  const handleSaveReaction = async ({ offerId, reactionType }: PostOneReactionRequest) => {
     await onSaveReaction?.({ offerId, reactionType })
     setUserReaction(reactionType)
     hideReactionModal()

--- a/src/features/bookings/fixtures/bookingsSnap.ts
+++ b/src/features/bookings/fixtures/bookingsSnap.ts
@@ -3,7 +3,6 @@ import type { ReadonlyDeep } from 'type-fest'
 import {
   BookingCancellationReasons,
   BookingsResponse,
-  ReactionTypeEnum,
   SubcategoryIdEnum,
   WithdrawalTypeEnum,
 } from 'api/gen'
@@ -108,7 +107,7 @@ export const bookingsSnap = toMutable({
       totalAmount: 1900,
       token: '352UW5',
       quantity: 10,
-      userReaction: ReactionTypeEnum.LIKE,
+      userReaction: null,
       stock: {
         id: 150230,
         price: 400,

--- a/src/features/bookings/fixtures/bookingsSnap.ts
+++ b/src/features/bookings/fixtures/bookingsSnap.ts
@@ -3,6 +3,7 @@ import type { ReadonlyDeep } from 'type-fest'
 import {
   BookingCancellationReasons,
   BookingsResponse,
+  ReactionTypeEnum,
   SubcategoryIdEnum,
   WithdrawalTypeEnum,
 } from 'api/gen'
@@ -66,6 +67,7 @@ export const bookingsSnap = toMutable({
       totalAmount: 1900,
       token: '352UW5',
       quantity: 10,
+      userReaction: null,
       stock: {
         id: 150230,
         price: 400,
@@ -106,6 +108,7 @@ export const bookingsSnap = toMutable({
       totalAmount: 1900,
       token: '352UW5',
       quantity: 10,
+      userReaction: ReactionTypeEnum.LIKE,
       stock: {
         id: 150230,
         price: 400,

--- a/src/features/bookings/pages/Bookings/Bookings.native.test.tsx
+++ b/src/features/bookings/pages/Bookings/Bookings.native.test.tsx
@@ -163,7 +163,10 @@ describe('Bookings', () => {
       fireEvent.press(await screen.findByText('En cours'))
 
       expect(mockMutate).toHaveBeenCalledWith({
-        reactions: [{ offerId: 147874, reactionType: ReactionTypeEnum.NO_REACTION }],
+        reactions: [
+          { offerId: 147874, reactionType: ReactionTypeEnum.NO_REACTION },
+          { offerId: 147874, reactionType: ReactionTypeEnum.NO_REACTION },
+        ],
       })
     })
   })

--- a/src/features/bookings/pages/Bookings/Bookings.tsx
+++ b/src/features/bookings/pages/Bookings/Bookings.tsx
@@ -31,12 +31,12 @@ export function Bookings() {
         .filter((ended_booking) => ended_booking.userReaction === null)
         .map((booking) => booking.stock.offer.id) ?? []
 
-    const bookingsTest = bookingsToUpdate.map((bookingId) => ({
+    const mutationPayload = bookingsToUpdate.map((bookingId) => ({
       offerId: bookingId,
       reactionType: ReactionTypeEnum.NO_REACTION,
     }))
-    if (bookingsTest.length > 0) {
-      addReaction({ reactions: bookingsTest })
+    if (mutationPayload.length > 0) {
+      addReaction({ reactions: mutationPayload })
     }
   }, [addReaction, bookings?.ended_bookings])
 

--- a/src/features/bookings/pages/Bookings/Bookings.web.test.tsx
+++ b/src/features/bookings/pages/Bookings/Bookings.web.test.tsx
@@ -52,7 +52,7 @@ describe('Bookings', () => {
     renderBookings(bookingsSnap)
 
     await waitFor(() => {
-      expect(useBookings).toHaveBeenCalledTimes(1)
+      expect(useBookings).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/src/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx
+++ b/src/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx
@@ -1,8 +1,6 @@
 import React, { Fragment, FunctionComponent } from 'react'
-import { QueryObserverResult } from 'react-query'
 
 import { BookingsResponse } from 'api/gen'
-import * as bookingsAPI from 'features/bookings/api/useBookings'
 import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import * as useGoBack from 'features/navigation/useGoBack'
 import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
@@ -62,13 +60,6 @@ describe('EndedBookings', () => {
     expect(screen).toMatchSnapshot()
   })
 
-  it('should always execute the query (in cache or in network)', () => {
-    const useBookings = jest.spyOn(bookingsAPI, 'useBookings')
-    renderEndedBookings(bookingsSnap)
-
-    expect(useBookings).toHaveBeenCalledTimes(1)
-  })
-
   it('should display the right number of ended bookings', () => {
     renderEndedBookings(bookingsSnap)
 
@@ -107,11 +98,9 @@ const renderEndedBookings = (
   bookings: BookingsResponse,
   Wrapper: FunctionComponent<{ children: JSX.Element }> = Fragment
 ) => {
-  jest
-    .spyOn(bookingsAPI, 'useBookings')
-    .mockReturnValue({ data: bookings } as QueryObserverResult<BookingsResponse, unknown>)
-
   return render(
-    <Wrapper>{reactQueryProviderHOC(<EndedBookings enableBookingImprove={false} />)}</Wrapper>
+    <Wrapper>
+      {reactQueryProviderHOC(<EndedBookings enableBookingImprove={false} bookings={bookings} />)}
+    </Wrapper>
   )
 }

--- a/src/features/bookings/pages/EndedBookings/EndedBookings.perf.test.tsx
+++ b/src/features/bookings/pages/EndedBookings/EndedBookings.perf.test.tsx
@@ -50,7 +50,7 @@ describe('<EndedBookings />', () => {
     await measurePerformance(
       reactQueryProviderHOC(
         <AuthWrapper>
-          <EndedBookings enableBookingImprove={false} />
+          <EndedBookings enableBookingImprove={false} bookings={bookingsSnap} />
         </AuthWrapper>
       ),
       {

--- a/src/features/bookings/pages/EndedBookings/EndedBookings.tsx
+++ b/src/features/bookings/pages/EndedBookings/EndedBookings.tsx
@@ -2,8 +2,7 @@ import React, { FunctionComponent, useCallback } from 'react'
 import { FlatList, ListRenderItem } from 'react-native'
 import styled from 'styled-components/native'
 
-import { PostReactionRequest } from 'api/gen'
-import { useBookings } from 'features/bookings/api'
+import { BookingsResponse, PostOneReactionRequest, PostReactionRequest } from 'api/gen'
 import { EndedBookingItem } from 'features/bookings/components/EndedBookingItem'
 import { NoBookingsView } from 'features/bookings/components/NoBookingsView'
 import { Booking } from 'features/bookings/types'
@@ -25,10 +24,10 @@ const keyExtractor: (item: Booking) => string = (item) => item.id.toString()
 
 type Props = {
   enableBookingImprove: boolean
+  bookings: BookingsResponse | undefined
 }
 
-export const EndedBookings: FunctionComponent<Props> = ({ enableBookingImprove }) => {
-  const { data: bookings } = useBookings()
+export const EndedBookings: FunctionComponent<Props> = ({ enableBookingImprove, bookings }) => {
   const { goBack } = useGoBack(...getTabNavConfig('Bookings'))
   const headerHeight = useGetHeaderHeight()
   const { mutate: addReaction } = useReactionMutation()
@@ -40,8 +39,11 @@ export const EndedBookings: FunctionComponent<Props> = ({ enableBookingImprove }
   })
 
   const handleSaveReaction = useCallback(
-    ({ offerId, reactionType }: PostReactionRequest) => {
-      addReaction({ offerId, reactionType })
+    ({ offerId, reactionType }: PostOneReactionRequest) => {
+      const reactionRequest: PostReactionRequest = {
+        reactions: [{ offerId, reactionType }],
+      }
+      addReaction(reactionRequest)
       return Promise.resolve(true)
     },
     [addReaction]

--- a/src/features/bookings/pages/EndedBookings/EndedBookings.web.test.tsx
+++ b/src/features/bookings/pages/EndedBookings/EndedBookings.web.test.tsx
@@ -45,5 +45,7 @@ const renderEndedBookings = (bookings: BookingsResponse) => {
     .spyOn(bookingsAPI, 'useBookings')
     .mockReturnValue({ data: bookings } as QueryObserverResult<BookingsResponse, unknown>)
 
-  return render(reactQueryProviderHOC(<EndedBookings enableBookingImprove={false} />))
+  return render(
+    reactQueryProviderHOC(<EndedBookings enableBookingImprove={false} bookings={bookingsSnap} />)
+  )
 }

--- a/src/features/bookings/types.ts
+++ b/src/features/bookings/types.ts
@@ -1,4 +1,4 @@
-import { BookingReponse, PostReactionRequest } from 'api/gen'
+import { BookingReponse, PostOneReactionRequest } from 'api/gen'
 
 export type BookingProperties = {
   isDuo?: boolean
@@ -14,5 +14,5 @@ export type Booking = BookingReponse
 export interface BookingItemProps {
   booking: Booking
   eligibleBookingsForArchive?: Booking[]
-  onSaveReaction?: (reactionParams: PostReactionRequest) => Promise<boolean>
+  onSaveReaction?: (reactionParams: PostOneReactionRequest) => Promise<boolean>
 }

--- a/src/features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer.native.test.tsx
+++ b/src/features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer.native.test.tsx
@@ -142,8 +142,12 @@ describe('IncomingReactionModalContainer', () => {
 
     await waitFor(() => {
       expect(mockMutate).toHaveBeenNthCalledWith(1, {
-        offerId: bookingsSnap.ended_bookings[0].stock.offer.id,
-        reactionType: ReactionTypeEnum.LIKE,
+        reactions: [
+          {
+            offerId: bookingsSnap.ended_bookings[0].stock.offer.id,
+            reactionType: ReactionTypeEnum.LIKE,
+          },
+        ],
       })
     })
   })
@@ -197,8 +201,12 @@ describe('IncomingReactionModalContainer', () => {
 
     await waitFor(() => {
       expect(mockMutate).toHaveBeenNthCalledWith(1, {
-        offerId: bookingsSnap.ended_bookings[0].stock.offer.id,
-        reactionType: ReactionTypeEnum.NO_REACTION,
+        reactions: [
+          {
+            offerId: bookingsSnap.ended_bookings[0].stock.offer.id,
+            reactionType: ReactionTypeEnum.NO_REACTION,
+          },
+        ],
       })
     })
   })

--- a/src/features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer.tsx
+++ b/src/features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 
-import { PostReactionRequest, ReactionTypeEnum } from 'api/gen'
+import { PostOneReactionRequest, PostReactionRequest, ReactionTypeEnum } from 'api/gen'
 import { useBookings } from 'features/bookings/api'
 import { TWENTY_FOUR_HOURS } from 'features/home/constants'
 import { useReactionMutation } from 'features/reactions/api/useReactionMutation'
@@ -30,8 +30,11 @@ export const IncomingReactionModalContainer = () => {
   const firstBooking = bookingsWithoutReaction[0]
 
   const handleSaveReaction = useCallback(
-    ({ offerId, reactionType }: PostReactionRequest) => {
-      addReaction({ offerId, reactionType })
+    ({ offerId, reactionType }: PostOneReactionRequest) => {
+      const reactionRequest: PostReactionRequest = {
+        reactions: [{ offerId, reactionType }],
+      }
+      addReaction(reactionRequest)
       return Promise.resolve(true)
     },
     [addReaction]
@@ -41,8 +44,12 @@ export const IncomingReactionModalContainer = () => {
     if (!firstBooking) return
 
     addReaction({
-      offerId: firstBooking.stock.offer.id,
-      reactionType: ReactionTypeEnum.NO_REACTION,
+      reactions: [
+        {
+          offerId: firstBooking.stock.offer.id,
+          reactionType: ReactionTypeEnum.NO_REACTION,
+        },
+      ],
     })
 
     hideReactionModal()

--- a/src/features/reactions/api/useReactionMutation.test.ts
+++ b/src/features/reactions/api/useReactionMutation.test.ts
@@ -21,7 +21,7 @@ describe('useReactionMutation', () => {
 
     const { result } = renderUseReactionMutation()
 
-    result.current.mutate({ offerId: 12, reactionType: ReactionTypeEnum.LIKE })
+    result.current.mutate({ reactions: [{ offerId: 12, reactionType: ReactionTypeEnum.LIKE }] })
 
     await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
   })
@@ -31,7 +31,7 @@ describe('useReactionMutation', () => {
 
     const { result } = renderUseReactionMutation()
 
-    result.current.mutate({ offerId: 12, reactionType: ReactionTypeEnum.LIKE })
+    result.current.mutate({ reactions: [{ offerId: 12, reactionType: ReactionTypeEnum.LIKE }] })
 
     await waitFor(() => {
       expect(result.current.isError).toBeTruthy()

--- a/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.tsx
+++ b/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.tsx
@@ -2,7 +2,12 @@ import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } f
 import { useWindowDimensions } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
-import { BookingOfferResponse, OfferResponse, PostReactionRequest, ReactionTypeEnum } from 'api/gen'
+import {
+  BookingOfferResponse,
+  OfferResponse,
+  PostOneReactionRequest,
+  ReactionTypeEnum,
+} from 'api/gen'
 import { ReactionToggleButton } from 'features/reactions/components/ReactionToggleButton/ReactionToggleButton'
 import { ReactionFromEnum } from 'features/reactions/enum'
 import { useSubcategory } from 'libs/subcategories'
@@ -24,8 +29,8 @@ type Props = {
   visible: boolean
   defaultReaction?: ReactionTypeEnum | null
   closeModal: () => void
-  onSave?: ({ offerId, reactionType }: PostReactionRequest) => void
   from: ReactionFromEnum
+  onSave?: ({ offerId, reactionType }: PostOneReactionRequest) => void
 }
 
 export const ReactionChoiceModal: FunctionComponent<Props> = ({

--- a/src/features/venue/components/TabLayout/TabLayout.tsx
+++ b/src/features/venue/components/TabLayout/TabLayout.tsx
@@ -10,7 +10,7 @@ import { InfoTab } from './InfoTab'
 
 type TabLayoutProps<TabKeyType extends string> = {
   tabPanels: Record<TabKeyType, React.JSX.Element | null>
-  onTabChange?: Partial<Record<TabKeyType, () => void>>
+  onTabChange?: Partial<Record<TabKeyType, () => void>> | ((tab: TabKeyType) => void)
   tabs: { key: TabKeyType; Icon?: React.FC<AccessibleIcon> }[]
   defaultTab: TabKeyType
 }
@@ -30,7 +30,11 @@ export const TabLayout = <TabKeyType extends string>({
 
   const onTabPress = (tab: TabKeyType) => {
     setSelectedTab(tab)
-    onTabChange?.[tab]?.()
+    if (typeof onTabChange === 'object') {
+      onTabChange?.[tab]?.()
+    } else if (typeof onTabChange === 'function') {
+      onTabChange(tab)
+    }
   }
 
   useTabArrowNavigation<TabKeyType>({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-31778

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots



https://github.com/user-attachments/assets/4910b557-ceff-458e-8b7d-8b5e89f84bcc





[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
