### PR TITLE
(PC-31943) fix(DeleteProfileSuccess): prevent redirection to connection after anonymization

### DIFF
--- a/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.tsx
@@ -1,6 +1,7 @@
 import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 
+import { useLogoutRoutine } from 'features/auth/helpers/useLogoutRoutine'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { useAnonymizeAccount } from 'features/profile/api/useAnonymizeAccount'
@@ -20,9 +21,11 @@ import { Spacer, Typo } from 'ui/theme'
 
 export const DeleteProfileConfirmation = () => {
   const { navigate } = useNavigation<UseNavigationType>()
+  const signOut = useLogoutRoutine()
   const { showErrorSnackBar } = useSnackBarContext()
   const { anonymizeAccount } = useAnonymizeAccount({
-    onSuccess: () => {
+    onSuccess: async () => {
+      await signOut()
       navigate('DeleteProfileSuccess')
     },
     onError: () => {


### PR DESCRIPTION
https://passculture.atlassian.net/browse/PC-31943

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change