### PR TITLE
(PC-31805) feat(home): verify cookies consent before displaying reaction modal

### DIFF
--- a/src/features/cookies/helpers/useIsCookiesListUpToDate.native.test.ts
+++ b/src/features/cookies/helpers/useIsCookiesListUpToDate.native.test.ts
@@ -49,7 +49,10 @@ describe('isCookiesListUpToDate', () => {
     const { result } = renderHook(useIsCookiesListUpToDate)
 
     await waitFor(() => {
-      expect(result.current).toEqual(false)
+      expect(result.current).toEqual({
+        cookiesLastUpdate: defaultMockFirestore,
+        isCookiesListUpToDate: false,
+      })
     })
   })
 
@@ -61,7 +64,10 @@ describe('isCookiesListUpToDate', () => {
     const { result } = renderHook(useIsCookiesListUpToDate)
 
     await waitFor(() => {
-      expect(result.current).toEqual(false)
+      expect(result.current).toEqual({
+        cookiesLastUpdate: defaultMockFirestore,
+        isCookiesListUpToDate: false,
+      })
     })
   })
 
@@ -76,7 +82,10 @@ describe('isCookiesListUpToDate', () => {
       const { result } = renderHook(useIsCookiesListUpToDate)
 
       await waitFor(() => {
-        expect(result.current).toEqual(false)
+        expect(result.current).toEqual({
+          cookiesLastUpdate: defaultMockFirestore,
+          isCookiesListUpToDate: false,
+        })
       })
     }
   )
@@ -87,7 +96,10 @@ describe('isCookiesListUpToDate', () => {
     const { result } = renderHook(useIsCookiesListUpToDate)
 
     await waitFor(() => {
-      expect(result.current).toEqual(true)
+      expect(result.current).toEqual({
+        cookiesLastUpdate: undefined,
+        isCookiesListUpToDate: true,
+      })
     })
   })
 
@@ -99,7 +111,10 @@ describe('isCookiesListUpToDate', () => {
 
     const { result } = renderHook(useIsCookiesListUpToDate)
     await waitFor(() => {
-      expect(result.current).toEqual(true)
+      expect(result.current).toEqual({
+        cookiesLastUpdate: defaultMockFirestore,
+        isCookiesListUpToDate: true,
+      })
     })
   })
 
@@ -116,7 +131,13 @@ describe('isCookiesListUpToDate', () => {
 
     const { result } = renderHook(useIsCookiesListUpToDate)
     await waitFor(() => {
-      expect(result.current).toEqual(true)
+      expect(result.current).toEqual({
+        cookiesLastUpdate: {
+          ...defaultMockFirestore,
+          lastUpdateBuildVersion: buildVersion + 1,
+        },
+        isCookiesListUpToDate: true,
+      })
     })
   })
 
@@ -130,7 +151,10 @@ describe('isCookiesListUpToDate', () => {
 
     const { result } = renderHook(useIsCookiesListUpToDate)
     await waitFor(() => {
-      expect(result.current).toEqual(true)
+      expect(result.current).toEqual({
+        cookiesLastUpdate: { ...defaultMockFirestore, lastUpdated: TOMORROW },
+        isCookiesListUpToDate: true,
+      })
     })
   })
 })

--- a/src/features/cookies/pages/PrivacyPolicy.native.test.tsx
+++ b/src/features/cookies/pages/PrivacyPolicy.native.test.tsx
@@ -26,7 +26,7 @@ const mockUseCookies = jest.spyOn(Cookies, 'useCookies').mockReturnValue(default
 
 const mockUseIsCookiesListUpToDate = jest
   .spyOn(CookiesUpToDate, 'useIsCookiesListUpToDate')
-  .mockReturnValue(true)
+  .mockReturnValue({ isCookiesListUpToDate: true, cookiesLastUpdate: undefined })
 
 jest.mock('features/navigation/navigationRef')
 
@@ -75,7 +75,10 @@ describe('<PrivacyPolicy />', () => {
   })
 
   it('should not show cookies modal when fetching cookies is defined but user has made cookie choice', async () => {
-    mockUseIsCookiesListUpToDate.mockReturnValueOnce(true)
+    mockUseIsCookiesListUpToDate.mockReturnValueOnce({
+      isCookiesListUpToDate: true,
+      cookiesLastUpdate: undefined,
+    })
     mockUseCookies.mockReturnValueOnce({
       ...defaultUseCookies,
       cookiesConsent: {
@@ -91,7 +94,10 @@ describe('<PrivacyPolicy />', () => {
   })
 
   it('should show cookies modal when fetching cookies is defined and user has made cookie choice', async () => {
-    mockUseIsCookiesListUpToDate.mockReturnValueOnce(false)
+    mockUseIsCookiesListUpToDate.mockReturnValueOnce({
+      isCookiesListUpToDate: false,
+      cookiesLastUpdate: undefined,
+    })
     mockUseCookies.mockReturnValueOnce({
       ...defaultUseCookies,
       cookiesConsent: {

--- a/src/features/cookies/pages/PrivacyPolicy.tsx
+++ b/src/features/cookies/pages/PrivacyPolicy.tsx
@@ -13,7 +13,7 @@ export function PrivacyPolicy() {
     hideModal: hideCookiesConsentModal,
     showModal: showCookiesConsentModal,
   } = useModal(false)
-  const isCookiesListUpToDate = useIsCookiesListUpToDate()
+  const { isCookiesListUpToDate } = useIsCookiesListUpToDate()
 
   useEffect(() => {
     switch (hasUserMadeCookieChoiceV2.state) {

--- a/src/features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer.tsx
+++ b/src/features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react'
 
 import { PostOneReactionRequest, PostReactionRequest, ReactionTypeEnum } from 'api/gen'
 import { useBookings } from 'features/bookings/api'
+import { useIsCookiesListUpToDate } from 'features/cookies/helpers/useIsCookiesListUpToDate'
 import { filterBookingsWithoutReaction } from 'features/home/components/helpers/filterBookingsWithoutReaction/filterBookingsWithoutReaction'
 import { useReactionMutation } from 'features/reactions/api/useReactionMutation'
 import { ReactionChoiceModal } from 'features/reactions/components/ReactionChoiceModal/ReactionChoiceModal'
@@ -14,6 +15,8 @@ import { useModal } from 'ui/components/modals/useModal'
 
 export const IncomingReactionModalContainer = () => {
   const { reactionCategories } = useRemoteConfigContext()
+  const { isCookiesListUpToDate, cookiesLastUpdate } = useIsCookiesListUpToDate()
+  const isCookieConsentChecked = cookiesLastUpdate && isCookiesListUpToDate
   const { data: bookings } = useBookings()
   const { mutate: addReaction } = useReactionMutation()
   const { visible: reactionModalVisible, hideModal: hideReactionModal } = useModal(true)
@@ -66,7 +69,7 @@ export const IncomingReactionModalContainer = () => {
     hideReactionModal()
   }
 
-  if (!firstBooking) return null
+  if (!firstBooking || !isCookieConsentChecked) return null
 
   const { stock, dateUsed } = firstBooking
   const { offer } = stock

--- a/src/features/navigation/RootNavigator/RootNavigator.web.test.tsx
+++ b/src/features/navigation/RootNavigator/RootNavigator.web.test.tsx
@@ -2,6 +2,7 @@ import { NavigationContainer } from '@react-navigation/native'
 import React from 'react'
 
 import { FavoritesCountResponse, SubcategoriesResponseModelv2 } from 'api/gen'
+import * as CookiesUpToDate from 'features/cookies/helpers/useIsCookiesListUpToDate'
 import { useCurrentRoute } from 'features/navigation/helpers/useCurrentRoute'
 import { initialSearchState } from 'features/search/context/reducer'
 import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
@@ -16,7 +17,9 @@ import { RootNavigator } from './RootNavigator'
 const mockUseSplashScreenContext = jest.mocked(useSplashScreenContext)
 const mockUseCurrentRoute = jest.mocked(useCurrentRoute)
 
-jest.mock('features/cookies/helpers/useIsCookiesListUpToDate')
+jest
+  .spyOn(CookiesUpToDate, 'useIsCookiesListUpToDate')
+  .mockReturnValue({ isCookiesListUpToDate: true, cookiesLastUpdate: undefined })
 jest.mock('features/forceUpdate/helpers/useMustUpdateApp')
 jest.unmock('@react-navigation/native')
 jest.mock('features/auth/context/AuthContext')

--- a/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.tsx
+++ b/src/features/reactions/components/ReactionChoiceModal/ReactionChoiceModal.tsx
@@ -137,5 +137,6 @@ export const ReactionChoiceModal: FunctionComponent<Props> = ({
 }
 
 const ButtonsContainer = styled(ViewGap)({
+  alignItems: 'center',
   marginTop: getSpacing(2),
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-31805

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

J'ai remarqué un petit bug visuel en testant que j'ai fix au passage (visible en mode tablette) :
Avant :
<img width="908" alt="Capture d’écran 2024-09-30 à 17 46 59" src="https://github.com/user-attachments/assets/8149cf3a-a5d2-4d5e-b6a7-7bbf84b5727f">
Après :
<img width="906" alt="Capture d’écran 2024-09-30 à 17 46 48" src="https://github.com/user-attachments/assets/85906f9a-6557-4e23-b6b5-68f94f0a67cc">

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
