### PR TITLE
(PC-32103) feat(venueMap): add prop to hide points of interest

### DIFF
--- a/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.tsx
@@ -22,7 +22,7 @@ import { useInitialVenuesActions } from 'features/venueMap/store/initialVenuesSt
 import { analytics } from 'libs/analytics'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import MapView, { Map, Marker, MarkerPressEvent, Region } from 'libs/maps/maps'
+import MapView, { MapViewProps, Map, Marker, MarkerPressEvent, Region } from 'libs/maps/maps'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { LENGTH_L, getSpacing } from 'ui/theme'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
@@ -38,6 +38,7 @@ interface Props {
   currentRegion: Region
   setCurrentRegion: (region: Region) => void
   setLastRegionSearched: (region: Region) => void
+  hidePointsOfInterest?: boolean
   playlistType: PlaylistType
 }
 
@@ -55,6 +56,7 @@ export const VenueMapView: FunctionComponent<Props> = ({
   setCurrentRegion,
   setLastRegionSearched,
   playlistType,
+  hidePointsOfInterest = false,
 }) => {
   const { navigate } = useNavigation<UseNavigationType>()
   const { tabBarHeight } = useCustomSafeInsets()
@@ -203,6 +205,27 @@ export const VenueMapView: FunctionComponent<Props> = ({
     })
   }, [tabBarHeight, from])
 
+  const pointsOfInterestProps = useMemo(
+    () =>
+      ({
+        showsPointsOfInterest: !hidePointsOfInterest,
+        customMapStyle: hidePointsOfInterest
+          ? [
+              {
+                featureType: 'poi',
+                elementType: 'labels',
+                stylers: [
+                  {
+                    visibility: 'off',
+                  },
+                ],
+              },
+            ]
+          : undefined,
+      }) satisfies Pick<MapViewProps, 'showsPointsOfInterest' | 'customMapStyle'>,
+    [hidePointsOfInterest]
+  )
+
   return (
     <React.Fragment>
       <VenueMapBottomSheet
@@ -231,7 +254,8 @@ export const VenueMapView: FunctionComponent<Props> = ({
         radius={50}
         animationEnabled={false}
         height={height}
-        testID="venue-map-view">
+        testID="venue-map-view"
+        {...pointsOfInterestProps}>
         {filteredVenues.map((venue) => (
           <Marker
             key={venue.venueId}

--- a/src/features/venueMap/pages/VenueMap/VenueMap.tsx
+++ b/src/features/venueMap/pages/VenueMap/VenueMap.tsx
@@ -42,6 +42,7 @@ export const VenueMap: FunctionComponent = () => {
           setCurrentRegion={setCurrentRegion}
           setLastRegionSearched={setLastRegionSearched}
           playlistType={PlaylistType.TOP_OFFERS}
+          hidePointsOfInterest
         />
       </MapContainer>
     </VenueMapBase>

--- a/src/libs/maps/maps.tsx
+++ b/src/libs/maps/maps.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import MapView from 'react-native-map-clustering'
-import Map, { Marker, Region, MarkerPressEvent } from 'react-native-maps'
+import Map, { Marker, Region, MarkerPressEvent, MapViewProps } from 'react-native-maps'
 
 export default MapView
 export { Marker }
-export type { Map, Region, MarkerPressEvent }
+export type { Map, Region, MarkerPressEvent, MapViewProps }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32103

Ajout d'une prop permettant de masquer différents lieux inutiles pour soulager la carte visuellement

TODO: Mettre cette fonctionnalité sous FF

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots
Android: 
<img width="355" alt="image" src="https://github.com/user-attachments/assets/45d58c90-5706-4a3e-b2c3-9e62f2bc5b54">

iOS : 
<img width="374" alt="image" src="https://github.com/user-attachments/assets/c738356e-677e-4528-8ae2-68ebddf46f86">




[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
