### PR TITLE
(PC-31874) feat(Offer): Create `See more` button on new XP Cine block

### DIFF
--- a/src/features/offer/components/OfferNewXPCine/OfferNewXPCineBlock.tsx
+++ b/src/features/offer/components/OfferNewXPCine/OfferNewXPCineBlock.tsx
@@ -9,6 +9,8 @@ import { useSelectedDateScreening } from 'features/offer/components/MovieScreeni
 import { useOfferCTAButton } from 'features/offer/components/OfferCTAButton/useOfferCTAButton'
 import { CineBlock } from 'features/offer/components/OfferNewXPCine/CineBlock'
 import { Subcategory } from 'libs/subcategories/types'
+import { ButtonSecondary } from 'ui/components/buttons/ButtonSecondary'
+import { PlainMore } from 'ui/svg/icons/PlainMore'
 import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
@@ -18,6 +20,7 @@ type Props = {
   offer: OfferResponseV2
   subcategory: Subcategory
   onSeeVenuePress?: VoidFunction
+  onPress?: VoidFunction
 }
 
 export function OfferNewXPCineBlock({
@@ -26,6 +29,7 @@ export function OfferNewXPCineBlock({
   onSeeVenuePress,
   offer,
   subcategory,
+  onPress,
 }: Readonly<Props>) {
   const theme = useTheme()
   const { stocks, isExternalBookingsDisabled } = offer
@@ -86,6 +90,18 @@ export function OfferNewXPCineBlock({
         />
         <Spacer.Column numberOfSpaces={theme.isDesktopViewport ? 6 : 4} />
         <Divider />
+        <SeeMoreContainer>
+          <Spacer.Column numberOfSpaces={6} />
+          <Text>Aucune séance ne te correspond&nbsp;?</Text>
+          <Spacer.Column numberOfSpaces={4} />
+          <ButtonSecondary
+            mediumWidth
+            icon={PlainMore}
+            wording="Afficher plus de cinémas"
+            onPress={onPress}
+            color={theme.colors.black}
+          />
+        </SeeMoreContainer>
       </View>
     </Container>
   )
@@ -106,4 +122,13 @@ const TitleContainer = styled(View)(({ theme }) => ({
 const Divider = styled.View(({ theme }) => ({
   height: 1,
   backgroundColor: theme.colors.greyMedium,
+  marginHorizontal: theme.isDesktopViewport ? undefined : theme.contentPage.marginHorizontal,
+}))
+
+const SeeMoreContainer = styled.View({
+  alignItems: 'center',
+})
+
+const Text = styled(TypoDS.Body)(({ theme }) => ({
+  color: theme.colors.greyDark,
 }))

--- a/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
@@ -130,7 +130,7 @@ describe('<OfferPlace />', () => {
     expect(screen.getByText('Changer le lieu de retrait')).toBeOnTheScreen()
   })
 
-  it('should display new xp cine block when offer subcategory is "Seance cine" and FF is on', () => {
+  it('should display new xp cine block when offer subcategory is "Seance cine" and FF is on', async () => {
     useFeatureFlagSpy.mockReturnValueOnce(true) // this value corresponds to TARGET_XP_CINE_FROM_OFFER feature flag
     renderOfferPlace({
       ...offerPlaceProps,
@@ -140,6 +140,8 @@ describe('<OfferPlace />', () => {
         extraData: { allocineId: 2765410054 },
       },
     })
+
+    await screen.findByLabelText('Afficher plus de cinémas')
 
     expect(screen.getByTestId('offer-new-xp-cine-block')).toBeOnTheScreen()
   })

--- a/src/ui/components/buttons/AppButton/types.ts
+++ b/src/ui/components/buttons/AppButton/types.ts
@@ -69,6 +69,7 @@ export interface BaseButtonProps {
   textSize?: number
   type?: 'button' | 'submit' | 'reset'
   wording: string
+  color?: ColorsEnum
 }
 
 export interface AppButtonProps extends BaseButtonProps {

--- a/src/ui/components/buttons/ButtonSecondary.ts
+++ b/src/ui/components/buttons/ButtonSecondary.ts
@@ -8,14 +8,14 @@ import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
 import { Typo } from 'ui/theme'
 
 export const ButtonSecondary = styledButton(AppButton).attrs<BaseButtonProps>(
-  ({ icon, disabled, textSize, theme, ...rest }) => {
+  ({ icon, disabled, textSize, theme, color, ...rest }) => {
     let Icon
 
     if (icon) {
       Icon = styled(icon).attrs({
         color: disabled
           ? theme.buttons.disabled.secondary.iconColor
-          : theme.buttons.secondary.iconColor,
+          : color ?? theme.buttons.secondary.iconColor,
         size: theme.buttons.secondary.iconSize,
       })``
     }
@@ -24,7 +24,7 @@ export const ButtonSecondary = styledButton(AppButton).attrs<BaseButtonProps>(
       maxWidth: '100%',
       color: disabled
         ? theme.buttons.disabled.secondary.textColor
-        : theme.buttons.secondary.textColor,
+        : color ?? theme.buttons.secondary.textColor,
       fontSize: textSize,
     })
 
@@ -34,12 +34,12 @@ export const ButtonSecondary = styledButton(AppButton).attrs<BaseButtonProps>(
       title: Title,
       loadingIndicator: LoadingIndicator,
       backgroundColor: theme.buttons.secondary.backgroundColor,
-      hoverUnderlineColor: theme.buttons.secondary.textColor,
+      hoverUnderlineColor: color ?? theme.buttons.secondary.textColor,
     }
   }
-)(({ theme, isLoading, disabled }) => {
+)(({ theme, isLoading, disabled, color }) => {
   const borderWidth = theme.buttons.secondary.borderWidth
-  let borderColor: string = theme.buttons.secondary.borderColor
+  let borderColor: string = color ?? theme.buttons.secondary.borderColor
 
   if (isLoading) {
     borderColor = theme.buttons.loading.secondary.borderColor

--- a/src/ui/components/buttons/ButtonSecondary.ts
+++ b/src/ui/components/buttons/ButtonSecondary.ts
@@ -10,12 +10,10 @@ import { Typo } from 'ui/theme'
 export const ButtonSecondary = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ icon, disabled, textSize, theme, color, ...rest }) => {
     let Icon
-
+    const defaultColor = color ?? theme.buttons.secondary.iconColor
     if (icon) {
       Icon = styled(icon).attrs({
-        color: disabled
-          ? theme.buttons.disabled.secondary.iconColor
-          : color ?? theme.buttons.secondary.iconColor,
+        color: disabled ? theme.buttons.disabled.secondary.iconColor : defaultColor,
         size: theme.buttons.secondary.iconSize,
       })``
     }

--- a/src/ui/svg/icons/PlainMore.tsx
+++ b/src/ui/svg/icons/PlainMore.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+import { Path, Circle } from 'react-native-svg'
+import styled from 'styled-components/native'
+
+import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
+
+import { AccessibleIcon } from './types'
+
+const PlainMoreSvg: React.FunctionComponent<AccessibleIcon> = ({
+  size,
+  color,
+  color2,
+  testID,
+  accessibilityLabel,
+}) => (
+  <AccessibleSvg
+    width={size}
+    height={size}
+    viewBox="0 0 22 22"
+    fill="none"
+    accessibilityLabel={accessibilityLabel}
+    testID={testID}>
+    <Circle cx="11" cy="11" r="11" fill={color} />
+    <Path
+      fill={color2}
+      stroke={color2}
+      strokeWidth="1"
+      d="M10.8645 5.45711C11.1406 5.45738 11.3643 5.68145 11.364 5.95759L11.359 10.6082L15.9932 10.614C16.2693 10.6144 16.4929 10.8385 16.4926 11.1146C16.4923 11.3908 16.2682 11.6144 15.992 11.614L11.3614 11.6082L11.3781 16.2551C11.379 16.5312 11.1559 16.7558 10.8798 16.7567C10.6036 16.7576 10.379 16.5345 10.3781 16.2584L10.3614 11.6122L5.72454 11.6296C5.4484 11.6306 5.22378 11.4075 5.22285 11.1313C5.22191 10.8552 5.44501 10.6306 5.72115 10.6296L10.359 10.6122L10.364 5.95662C10.3643 5.68048 10.5884 5.45684 10.8645 5.45711Z"
+    />
+  </AccessibleSvg>
+)
+
+export const PlainMore = styled(PlainMoreSvg).attrs(({ color, color2, size, theme }) => ({
+  color: color ?? theme.colors.black,
+  color2: color2 ?? theme.colors.white,
+  size: size ?? theme.icons.sizes.standard,
+}))``


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-31874

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [X] Made sure my feature is working on web.
- [X] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change

## Screenshots

**delete** _if no UI change_

| iOS | Desktop - Chrome |
| :-----------: | :---: |
| <img width="520" alt="Simulator Screenshot - iPhone 15 - 2024-10-07 at 13 21 13" src="https://github.com/user-attachments/assets/5f00a40f-d130-4474-8dc7-054153a9071e" /> | <img width="1022" alt="Capture d’écran 2024-10-07 à 13 23 59" src="https://github.com/user-attachments/assets/421554b0-fc37-415a-9997-2911a14cb30a"> |



