### PR TITLE
(PC-32245) fix(ui): ellipsis for offer name on HorizontalTile

### DIFF
--- a/src/ui/components/tiles/HorizontalTile.tsx
+++ b/src/ui/components/tiles/HorizontalTile.tsx
@@ -42,7 +42,9 @@ export const HorizontalTile: FC<HorizontalTileProps> = ({
             </React.Fragment>
           ) : (
             <Row>
-              <OfferName title={title} />
+              <OfferNameContainer>
+                <OfferName title={title} />
+              </OfferNameContainer>
               {withRightArrow ? (
                 <React.Fragment>
                   <Spacer.Row numberOfSpaces={1} />
@@ -67,6 +69,7 @@ const Column = styled.View({
 const Row = styled.View({
   flexDirection: 'row',
   alignItems: 'center',
+  width: '100%',
 })
 
 const Distance = styled(TypoDS.BodySemiBoldS)(({ theme }) => ({
@@ -78,4 +81,8 @@ const RightIcon = styled(RightFilled).attrs(({ theme }) => ({
   size: theme.icons.sizes.extraSmall,
 }))({
   flexShrink: 0,
+})
+
+const OfferNameContainer = styled.View({
+  flexShrink: 1,
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32245

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="436" alt="Capture d’écran 2024-10-08 à 11 01 51" src="https://github.com/user-attachments/assets/19dd5113-ffd1-47ea-833e-0ad0d6486831"> <img width="450" alt="Capture d’écran 2024-10-08 à 11 02 14" src="https://github.com/user-attachments/assets/b8c4bf78-c0ab-4f63-99c3-dd970b544db9">|![Capture d’écran 2024-10-08 à 11 31 52](https://github.com/user-attachments/assets/9241afd2-e88e-42e0-828d-ba084e31d109) ![Capture d’écran 2024-10-08 à 11 31 38](https://github.com/user-attachments/assets/52369e1d-2fd9-4bd1-baec-b3b4fabcffd9)|
| Android          |![Capture d’écran 2024-10-08 à 11 08 28](https://github.com/user-attachments/assets/18ab9641-5978-42f7-aeb9-ba543dd103e4) ![Capture d’écran 2024-10-08 à 11 08 55](https://github.com/user-attachments/assets/65b966da-67ea-4d04-8852-1c1675cc821a)|![Capture d’écran 2024-10-08 à 11 31 11](https://github.com/user-attachments/assets/7c497059-2ffe-4a3a-b62b-755576372a96) ![Capture d’écran 2024-10-08 à 11 31 26](https://github.com/user-attachments/assets/cd73aa89-e75c-4b80-9175-9a5f3644a2bd)|
| Phone - Chrome   |<img width="397" alt="Capture d’écran 2024-10-08 à 10 59 45" src="https://github.com/user-attachments/assets/6375c41d-fb7f-48a1-a185-6e82cb71d804"> <img width="397" alt="Capture d’écran 2024-10-08 à 11 00 13" src="https://github.com/user-attachments/assets/3e78c48a-5d1b-4493-9872-fece571679ec">|<img width="395" alt="Capture d’écran 2024-10-08 à 11 30 08" src="https://github.com/user-attachments/assets/3230b3df-c7bc-40e5-b7a1-9677a6b380f9"> <img width="390" alt="Capture d’écran 2024-10-08 à 11 30 51" src="https://github.com/user-attachments/assets/4c9e71ce-c637-4c78-83a2-5e9c28fafa35">|
| Desktop - Chrome |<img width="1724" alt="Capture d’écran 2024-10-08 à 11 09 15" src="https://github.com/user-attachments/assets/2b3a5d6e-157b-4424-adef-8cf8631a418b"> <img width="1727" alt="Capture d’écran 2024-10-08 à 11 09 29" src="https://github.com/user-attachments/assets/adb2583c-cc29-4603-b1f7-e91a5fbd711b">|<img width="1460" alt="Capture d’écran 2024-10-08 à 11 30 18" src="https://github.com/user-attachments/assets/63683265-bd70-4934-9434-e3933d68b0d5"> <img width="1463" alt="Capture d’écran 2024-10-08 à 11 30 38" src="https://github.com/user-attachments/assets/0fa6b189-c8fb-4e4d-8e89-b98b73470969">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
