### PR TITLE
(PC-29416) feat(ReactionChoiceValidation): add reactions buttons to Offer

### DIFF
--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -191,28 +191,11 @@ describe('<OfferBody />', () => {
   })
 
   describe('Reaction section', () => {
-    it('should display reaction button when feature flag is enabled and native category included in reactionFakeDoorCategories remote config', async () => {
+    it("should display 'J'aime' or 'Je n'aime pas' button when feature flag is enabled", async () => {
       renderOfferBody({})
 
-      expect(await screen.findByText('Réagir')).toBeOnTheScreen()
-    })
-
-    it('should open survey modal when pressing "Réagir" button', async () => {
-      renderOfferBody({})
-
-      fireEvent.press(await screen.findByText('Réagir'))
-
-      expect(screen.getByText('Encore un peu de patience…')).toBeOnTheScreen()
-    })
-
-    it('should log reaction fake door consultation when pressing "Réagir" button', async () => {
-      renderOfferBody({})
-
-      fireEvent.press(await screen.findByText('Réagir'))
-
-      expect(analytics.logConsultReactionFakeDoor).toHaveBeenNthCalledWith(1, {
-        from: NativeCategoryIdEnumv2.SEANCES_DE_CINEMA,
-      })
+      expect(await screen.findByText('J’aime')).toBeOnTheScreen()
+      expect(await screen.findByText('Je n’aime pas')).toBeOnTheScreen()
     })
 
     it('should display reaction count when FF is enabled and other users have reacted to the offer', async () => {

--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -10,7 +10,6 @@ import {
   SearchGroupNameEnumv2,
   SubcategoryIdEnum,
 } from 'api/gen'
-import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import { OfferBody } from 'features/offer/components/OfferBody/OfferBody'
 import { mockSubcategory, mockSubcategoryBook } from 'features/offer/fixtures/mockSubcategory'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
@@ -75,8 +74,6 @@ jest.mock('libs/firebase/remoteConfig/RemoteConfigProvider', () => ({
 
 jest.mock('libs/firebase/analytics/analytics')
 
-jest.mock('features/auth/context/AuthContext')
-
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
 
 jest.mock('react-native-safe-area-context', () => ({
@@ -97,25 +94,6 @@ const useArtistResultsSpy = jest
   })
 
 const useRemoteConfigContextSpy = jest.spyOn(useRemoteConfigContext, 'useRemoteConfigContext')
-
-const mockBookings = {
-  ...bookingsSnap,
-  ended_bookings: [
-    {
-      ...bookingsSnap.ended_bookings[1],
-      stock: {
-        ...bookingsSnap.ended_bookings[1].stock,
-        offer: { ...bookingsSnap.ended_bookings[1].stock.offer, id: offerResponseSnap.id },
-      },
-    },
-  ],
-}
-const mockUseBookings = jest.fn(() => ({
-  data: mockBookings,
-}))
-jest.mock('features/bookings/api/useBookings', () => ({
-  useBookings: jest.fn(() => mockUseBookings()),
-}))
 
 describe('<OfferBody />', () => {
   beforeAll(() => {
@@ -221,55 +199,6 @@ describe('<OfferBody />', () => {
     await screen.findByText(offerFree.name)
 
     expect(screen.queryByText('5,00 €')).not.toBeOnTheScreen()
-  })
-
-  describe('Reaction section', () => {
-    it("should display 'J'aime' or 'Je n'aime pas' button when feature flag is enabled and user booked the offer", async () => {
-      renderOfferBody({})
-
-      expect(await screen.findByText('J’aime')).toBeOnTheScreen()
-      expect(await screen.findByText('Je n’aime pas')).toBeOnTheScreen()
-    })
-
-    it('should display reaction count when FF is enabled and other users have reacted to the offer', async () => {
-      renderOfferBody({})
-
-      expect(await screen.findByText('Aimé par 1 jeune')).toBeOnTheScreen()
-    })
-
-    it('should not display reaction count when FF is disabled', async () => {
-      activateFeatureFlags()
-      renderOfferBody({})
-
-      await screen.findByText(offerResponseSnap.name)
-
-      expect(screen.queryByText('Aimé par 1 jeune')).not.toBeOnTheScreen()
-    })
-
-    it('should not display reaction button when feature flag is enabled and native category not included in reactionFakeDoorCategories remote config', async () => {
-      renderOfferBody({
-        offer: {
-          ...offerResponseSnap,
-          subcategoryId: SubcategoryIdEnum.FESTIVAL_MUSIQUE,
-        },
-        subcategory: {
-          ...mockSubcategory,
-          nativeCategoryId: NativeCategoryIdEnumv2.FESTIVALS,
-        },
-      })
-      await screen.findByText(offerResponseSnap.name)
-
-      expect(screen.queryByText('Réagir')).not.toBeOnTheScreen()
-    })
-
-    it('should not display reaction button when feature flag is disabled', async () => {
-      activateFeatureFlags()
-
-      renderOfferBody({})
-      await screen.findByText(offerResponseSnap.name)
-
-      expect(screen.queryByText('Réagir')).not.toBeOnTheScreen()
-    })
   })
 
   describe('Venue button section & Summary info section', () => {

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -29,13 +29,12 @@ import { getOfferPrices } from 'features/offer/helpers/getOfferPrice/getOfferPri
 import { getOfferTags } from 'features/offer/helpers/getOfferTags/getOfferTags'
 import { useArtistResults } from 'features/offer/helpers/useArtistResults/useArtistResults'
 import { useOfferSummaryInfoList } from 'features/offer/helpers/useOfferSummaryInfoList/useOfferSummaryInfoList'
+import { ReactionChoiceValidation } from 'features/reactions/components/ReactionChoiceValidation/ReactionChoiceValidation'
 import { analytics } from 'libs/analytics'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import { useRemoteConfigContext } from 'libs/firebase/remoteConfig/RemoteConfigProvider'
 import { Subcategory } from 'libs/subcategories/types'
 import { isNullOrUndefined } from 'shared/isNullOrUndefined/isNullOrUndefined'
-import { ToggleButton } from 'ui/components/buttons/ToggleButton'
 import { SurveyModal } from 'ui/components/modals/SurveyModal'
 import { useModal } from 'ui/components/modals/useModal'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
@@ -43,7 +42,6 @@ import { Separator } from 'ui/components/Separator'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { InformationTags } from 'ui/InformationTags/InformationTags'
 import { BicolorCircledClock } from 'ui/svg/icons/BicolorCircledClock'
-import { ThumbUp } from 'ui/svg/icons/ThumbUp'
 import { getSpacing, Spacer } from 'ui/theme'
 
 type Props = {
@@ -57,7 +55,6 @@ export const OfferBody: FunctionComponent<Props> = ({
   subcategory,
   trackEventHasSeenOfferOnce,
 }) => {
-  const { reactionFakeDoorCategories } = useRemoteConfigContext()
   const { isDesktopViewport } = useTheme()
   const { visible, showModal, hideModal } = useModal()
   const { navigate } = useNavigation<UseNavigationType>()
@@ -68,12 +65,8 @@ export const OfferBody: FunctionComponent<Props> = ({
   const hasArtistPage = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ARTIST_PAGE)
   const isReactionFeatureActive = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
 
-  const enableReactionFakeDoor = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FAKE_DOOR)
   const shouldDisplayFakeDoorArtist =
     hasFakeDoorArtist && FAKE_DOOR_ARTIST_SEARCH_GROUPS.includes(subcategory.searchGroupName)
-  const shouldDisplayReactionButton =
-    enableReactionFakeDoor &&
-    reactionFakeDoorCategories.categories.includes(subcategory.nativeCategoryId)
 
   const extraData = offer.extraData ?? undefined
   const tags = getOfferTags(subcategory.appLabel, extraData)
@@ -109,12 +102,6 @@ export const OfferBody: FunctionComponent<Props> = ({
   const shouldDisplayAboutSection =
     shouldDisplayAccessibilitySection || !!offer.description || hasMetadata
 
-  const onReactButtonPress = () => {
-    setSurveyModalState(DEFAULT_SURVEY_MODAL_DATA)
-    analytics.logConsultReactionFakeDoor({ from: subcategory.nativeCategoryId })
-    showModal()
-  }
-
   const handleArtistLinkPress = () => {
     if (shouldDisplayFakeDoorArtist) {
       setSurveyModalState(ARTIST_SURVEY_MODAL_DATA)
@@ -148,21 +135,12 @@ export const OfferBody: FunctionComponent<Props> = ({
 
           {prices ? <OfferPrice prices={prices} /> : null}
 
-          <ViewGap gap={4}>
-            {isReactionFeatureActive ? (
+          {isReactionFeatureActive ? (
+            <ViewGap gap={4}>
               <OfferReactions user={user} isLoggedIn={isLoggedIn} offer={offer} />
-            ) : null}
-
-            {shouldDisplayReactionButton ? (
-              <ToggleButton
-                active={false}
-                onPress={onReactButtonPress}
-                label={{ active: 'Réagir', inactive: 'Réagir' }}
-                accessibilityLabel={{ active: 'Réagir', inactive: 'Réagir' }}
-                Icon={{ active: StyledThumbUp, inactive: StyledThumbUp }}
-              />
-            ) : null}
-          </ViewGap>
+              <ReactionChoiceValidation handleOnPressReactionButton={() => ''} />
+            </ViewGap>
+          ) : null}
 
           <GroupWithSeparator
             showTopComponent={offer.venue.isPermanent}
@@ -255,7 +233,3 @@ const GroupWithSeparator = ({
     </GroupWithoutGap>
   ) : null
 }
-
-const StyledThumbUp = styled(ThumbUp).attrs(({ theme }) => ({
-  size: theme.icons.sizes.small,
-}))``

--- a/src/features/offer/components/OfferReactionSection/OfferReactionSection.native.test.tsx
+++ b/src/features/offer/components/OfferReactionSection/OfferReactionSection.native.test.tsx
@@ -1,0 +1,101 @@
+import React, { ComponentProps } from 'react'
+
+import { NativeCategoryIdEnumv2 } from 'api/gen'
+import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
+import { OfferReactionSection } from 'features/offer/components/OfferReactionSection/OfferReactionSection'
+import { mockSubcategory } from 'features/offer/fixtures/mockSubcategory'
+import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
+import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
+import * as useRemoteConfigContext from 'libs/firebase/remoteConfig/RemoteConfigProvider'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { render, screen } from 'tests/utils'
+
+const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
+
+const activateFeatureFlags = (activeFeatureFlags: RemoteStoreFeatureFlags[] = []) => {
+  useFeatureFlagSpy.mockImplementation((flag) => activeFeatureFlags.includes(flag))
+}
+
+const useRemoteConfigContextSpy = jest.spyOn(useRemoteConfigContext, 'useRemoteConfigContext')
+
+const mockBookings = {
+  ...bookingsSnap,
+  ended_bookings: [
+    {
+      ...bookingsSnap.ended_bookings[1],
+      stock: {
+        ...bookingsSnap.ended_bookings[1].stock,
+        offer: { ...bookingsSnap.ended_bookings[1].stock.offer, id: offerResponseSnap.id },
+      },
+    },
+  ],
+}
+const mockUseBookings = jest.fn(() => ({
+  data: mockBookings,
+}))
+jest.mock('features/bookings/api/useBookings', () => ({
+  useBookings: jest.fn(() => mockUseBookings()),
+}))
+
+jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
+jest.mock('features/auth/context/AuthContext')
+
+describe('<OfferReactionSection />', () => {
+  beforeAll(() => {
+    useRemoteConfigContextSpy.mockReturnValue({
+      ...DEFAULT_REMOTE_CONFIG,
+      reactionCategories: {
+        categories: [NativeCategoryIdEnumv2.SEANCES_DE_CINEMA],
+      },
+    })
+  })
+
+  describe('When FF is enabled', () => {
+    beforeEach(() => {
+      activateFeatureFlags([RemoteStoreFeatureFlags.WIP_REACTION_FEATURE])
+    })
+
+    it("should display 'J'aime' or 'Je n'aime pas' button when user booked the offer", async () => {
+      renderOfferReactionSection({})
+
+      expect(await screen.findByText('J’aime')).toBeOnTheScreen()
+      expect(await screen.findByText('Je n’aime pas')).toBeOnTheScreen()
+    })
+
+    it('should display reaction count when other users have reacted to the offer', async () => {
+      renderOfferReactionSection({})
+
+      expect(await screen.findByText('Aimé par 1 jeune')).toBeOnTheScreen()
+    })
+  })
+
+  describe('When FF is disabled', () => {
+    beforeEach(() => {
+      activateFeatureFlags()
+    })
+
+    it("should not display 'J'aime' or 'Je n'aime pas' button when user booked the offer", () => {
+      renderOfferReactionSection({})
+
+      expect(screen.queryByText('J’aime')).not.toBeOnTheScreen()
+      expect(screen.queryByText('Je n’aime pas')).not.toBeOnTheScreen()
+    })
+
+    it('should not display reaction count when other users have reacted to the offer', () => {
+      renderOfferReactionSection({})
+
+      expect(screen.queryByText('Aimé par 1 jeune')).not.toBeOnTheScreen()
+    })
+  })
+})
+
+type RenderOfferReactionSectionType = Partial<ComponentProps<typeof OfferReactionSection>>
+
+function renderOfferReactionSection({
+  offer = offerResponseSnap,
+  subcategory = mockSubcategory,
+}: RenderOfferReactionSectionType) {
+  render(reactQueryProviderHOC(<OfferReactionSection offer={offer} subcategory={subcategory} />))
+}

--- a/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
+++ b/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
@@ -1,0 +1,63 @@
+import React, { FunctionComponent, useMemo } from 'react'
+
+import { OfferResponseV2 } from 'api/gen'
+import { useAuthContext } from 'features/auth/context/AuthContext'
+import { useBookings } from 'features/bookings/api'
+import { OfferReactions } from 'features/offer/components/OfferReactions/OfferReactions'
+import { ReactionChoiceValidation } from 'features/reactions/components/ReactionChoiceValidation/ReactionChoiceValidation'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { useRemoteConfigContext } from 'libs/firebase/remoteConfig/RemoteConfigProvider'
+import { Subcategory } from 'libs/subcategories/types'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+
+type Props = {
+  offer: OfferResponseV2
+  subcategory: Subcategory
+}
+
+export const OfferReactionSection: FunctionComponent<Props> = ({ offer, subcategory }) => {
+  const isReactionFeatureActive = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
+  const { reactionCategories } = useRemoteConfigContext()
+  const { isLoggedIn, user } = useAuthContext()
+  const { data: bookings } = useBookings()
+
+  const endedBookingWithoutCancellation = bookings?.ended_bookings?.find(
+    (booking) => booking.stock.offer.id === offer.id && !booking.cancellationDate
+  )
+
+  const userBooking = useMemo(
+    () =>
+      bookings?.ended_bookings?.find(
+        (booking) => booking.stock.offer.id === offer.id && !booking.cancellationDate
+      ),
+    [bookings, offer.id]
+  )
+
+  const shouldDisplayReactionButtons =
+    isLoggedIn &&
+    user?.isBeneficiary &&
+    reactionCategories.categories.includes(subcategory.nativeCategoryId) &&
+    !!endedBookingWithoutCancellation
+
+  const canDisplayReactionSection =
+    isReactionFeatureActive && (offer.reactionsCount.likes > 0 || shouldDisplayReactionButtons)
+
+  if (!canDisplayReactionSection) return null
+
+  return (
+    <ViewGap gap={4}>
+      <OfferReactions
+        user={user}
+        isLoggedIn={isLoggedIn}
+        offer={offer}
+        userCanReact={shouldDisplayReactionButtons}
+        userBooking={userBooking}
+      />
+
+      {shouldDisplayReactionButtons ? (
+        <ReactionChoiceValidation handleOnPressReactionButton={() => ''} />
+      ) : null}
+    </ViewGap>
+  )
+}

--- a/src/features/offer/components/OfferReactions/OfferReactions.tsx
+++ b/src/features/offer/components/OfferReactions/OfferReactions.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useMemo } from 'react'
 import styled from 'styled-components/native'
 
-import { OfferResponseV2, UserProfileResponse } from 'api/gen'
+import { BookingReponse, OfferResponseV2, ReactionTypeEnum, UserProfileResponse } from 'api/gen'
 import { useBookings } from 'features/bookings/api'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { ThumbUpFilled } from 'ui/svg/icons/ThumbUpFilled'
@@ -11,9 +11,17 @@ type Props = {
   isLoggedIn: boolean
   offer: OfferResponseV2
   user?: UserProfileResponse
+  userCanReact?: boolean
+  userBooking?: BookingReponse
 }
 
-export const OfferReactions: FunctionComponent<Props> = ({ isLoggedIn, user, offer }) => {
+export const OfferReactions: FunctionComponent<Props> = ({
+  isLoggedIn,
+  user,
+  offer,
+  userCanReact,
+  userBooking,
+}) => {
   const { data: bookings } = useBookings()
   const { reactionsCount } = offer
   const hasLikes = reactionsCount?.likes > 0
@@ -38,8 +46,10 @@ export const OfferReactions: FunctionComponent<Props> = ({ isLoggedIn, user, off
           </TypoDS.BodySemiBoldXs>
         </StyledView>
       )
-    } else {
+    } else if (userCanReact && userBooking?.userReaction !== ReactionTypeEnum.DISLIKE) {
       return <TypoDS.BodySemiBoldXs>Sois le premier à réagir&nbsp;:</TypoDS.BodySemiBoldXs>
+    } else {
+      return null
     }
   }
 

--- a/src/features/reactions/components/ReactionChoiceModalBodyWithValidation/ReactionChoiceModalBodyWithValidation.tsx
+++ b/src/features/reactions/components/ReactionChoiceModalBodyWithValidation/ReactionChoiceModalBodyWithValidation.tsx
@@ -1,12 +1,9 @@
-import React, { FunctionComponent, useCallback, useMemo } from 'react'
-import { useTheme } from 'styled-components'
+import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
 import { BookingOfferResponse, OfferResponse, ReactionTypeEnum } from 'api/gen'
-import { ReactionToggleButton } from 'features/reactions/components/ReactionToggleButton/ReactionToggleButton'
+import { ReactionChoiceValidation } from 'features/reactions/components/ReactionChoiceValidation/ReactionChoiceValidation'
 import { useSubcategory } from 'libs/subcategories'
-import { IconNames } from 'ui/components/icons/iconFactory'
-import { useIconFactory } from 'ui/components/icons/useIconFactory'
 import { Separator } from 'ui/components/Separator'
 import { HorizontalTile } from 'ui/components/tiles/HorizontalTile'
 import { ValidationMark } from 'ui/components/ValidationMark'
@@ -26,39 +23,8 @@ export const ReactionChoiceModalBodyWithValidation: FunctionComponent<Props> = (
   reactionStatus,
   handleOnPressReactionButton,
 }) => {
-  const iconFactory = useIconFactory()
   const { categoryId } = useSubcategory(offer.subcategoryId)
-  const theme = useTheme()
 
-  const getStyledIcon = useCallback(
-    (name: IconNames, props?: object) =>
-      styled(iconFactory.getIcon(name)).attrs(({ theme }) => ({
-        size: theme.icons.sizes.small,
-        ...props,
-      }))``,
-    [iconFactory]
-  )
-
-  const ThumbUpIcon = useMemo(
-    () => ({
-      default: getStyledIcon('like', { testID: 'thumbUp' }),
-      pressed: getStyledIcon('like-filled', {
-        testID: 'thumbUpFilled',
-        color: theme.colors.primary,
-      }),
-    }),
-    [getStyledIcon, theme.colors.primary]
-  )
-
-  const ThumbDownIcon = useMemo(
-    () => ({
-      default: getStyledIcon('dislike', { testID: 'thumbDown' }),
-      pressed: getStyledIcon('dislike-filled', {
-        testID: 'thumbDownFilled',
-      }),
-    }),
-    [getStyledIcon]
-  )
   return (
     <React.Fragment>
       <Spacer.Column numberOfSpaces={6} />
@@ -77,22 +43,10 @@ export const ReactionChoiceModalBodyWithValidation: FunctionComponent<Props> = (
           </HorizontalTileContainer>
           <Separator.Horizontal />
         </ViewGap>
-        <ButtonsContainer gap={4}>
-          <ReactionToggleButton
-            active={reactionStatus === ReactionTypeEnum.LIKE}
-            label="J’aime"
-            Icon={ThumbUpIcon.default}
-            FilledIcon={ThumbUpIcon.pressed}
-            onPress={() => handleOnPressReactionButton(ReactionTypeEnum.LIKE)}
-          />
-          <ReactionToggleButton
-            active={reactionStatus === ReactionTypeEnum.DISLIKE}
-            label="Je n’aime pas"
-            Icon={ThumbDownIcon.default}
-            FilledIcon={ThumbDownIcon.pressed}
-            onPress={() => handleOnPressReactionButton(ReactionTypeEnum.DISLIKE)}
-          />
-        </ButtonsContainer>
+        <StyledReactionChoiceValidation
+          reactionStatus={reactionStatus}
+          handleOnPressReactionButton={handleOnPressReactionButton}
+        />
       </ViewGap>
     </React.Fragment>
   )
@@ -116,7 +70,6 @@ const DateUsedText = styled(Typo.Caption)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 
-const ButtonsContainer = styled(ViewGap)({
-  flexDirection: 'row',
+const StyledReactionChoiceValidation = styled(ReactionChoiceValidation)({
   marginBottom: getSpacing(12),
 })

--- a/src/features/reactions/components/ReactionChoiceValidation/ReactionChoiceValidation.native.test.tsx
+++ b/src/features/reactions/components/ReactionChoiceValidation/ReactionChoiceValidation.native.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+import { ReactionTypeEnum } from 'api/gen'
+import { ReactionChoiceValidation } from 'features/reactions/components/ReactionChoiceValidation/ReactionChoiceValidation'
+import { fireEvent, render, screen } from 'tests/utils'
+
+describe('ReactionChoiceValidation', () => {
+  it('should display like and dislike buttons', () => {
+    render(
+      <ReactionChoiceValidation
+        reactionStatus={ReactionTypeEnum.LIKE}
+        handleOnPressReactionButton={jest.fn()}
+      />
+    )
+
+    expect(screen.getByText('J’aime')).toBeOnTheScreen()
+    expect(screen.getByText('Je n’aime pas')).toBeOnTheScreen()
+  })
+
+  it('should show filled thumb up and unfilled thumb down icons when like is active', () => {
+    render(
+      <ReactionChoiceValidation
+        reactionStatus={ReactionTypeEnum.LIKE}
+        handleOnPressReactionButton={jest.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('thumbUpFilled')).toBeOnTheScreen()
+    expect(screen.getByTestId('thumbDown')).toBeOnTheScreen()
+  })
+
+  it('should trigger handleOnPressReactionButton when pressing like button', () => {
+    const mockHandleOnPress = jest.fn()
+    render(
+      <ReactionChoiceValidation
+        reactionStatus={ReactionTypeEnum.DISLIKE}
+        handleOnPressReactionButton={mockHandleOnPress}
+      />
+    )
+
+    fireEvent.press(screen.getByText('J’aime'))
+
+    expect(mockHandleOnPress).toHaveBeenCalledWith(ReactionTypeEnum.LIKE)
+  })
+})

--- a/src/features/reactions/components/ReactionChoiceValidation/ReactionChoiceValidation.tsx
+++ b/src/features/reactions/components/ReactionChoiceValidation/ReactionChoiceValidation.tsx
@@ -1,0 +1,74 @@
+import React, { FunctionComponent, useCallback, useMemo } from 'react'
+import styled, { useTheme } from 'styled-components/native'
+
+import { ReactionTypeEnum } from 'api/gen'
+import { ReactionToggleButton } from 'features/reactions/components/ReactionToggleButton/ReactionToggleButton'
+import { IconNames } from 'ui/components/icons/iconFactory'
+import { useIconFactory } from 'ui/components/icons/useIconFactory'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+
+type Props = {
+  handleOnPressReactionButton: (reactionType: ReactionTypeEnum) => void
+  reactionStatus?: ReactionTypeEnum | null
+}
+
+export const ReactionChoiceValidation: FunctionComponent<Props> = ({
+  reactionStatus,
+  handleOnPressReactionButton,
+  ...props
+}) => {
+  const iconFactory = useIconFactory()
+  const theme = useTheme()
+
+  const getStyledIcon = useCallback(
+    (name: IconNames, props?: object) =>
+      styled(iconFactory.getIcon(name)).attrs(({ theme }) => ({
+        size: theme.icons.sizes.small,
+        ...props,
+      }))``,
+    [iconFactory]
+  )
+
+  const ThumbUpIcon = useMemo(
+    () => ({
+      default: getStyledIcon('like', { testID: 'thumbUp' }),
+      pressed: getStyledIcon('like-filled', {
+        testID: 'thumbUpFilled',
+        color: theme.colors.primary,
+      }),
+    }),
+    [getStyledIcon, theme.colors.primary]
+  )
+
+  const ThumbDownIcon = useMemo(
+    () => ({
+      default: getStyledIcon('dislike', { testID: 'thumbDown' }),
+      pressed: getStyledIcon('dislike-filled', {
+        testID: 'thumbDownFilled',
+      }),
+    }),
+    [getStyledIcon]
+  )
+  return (
+    <ButtonsContainer gap={4} {...props}>
+      <ReactionToggleButton
+        active={reactionStatus === ReactionTypeEnum.LIKE}
+        label="J’aime"
+        Icon={ThumbUpIcon.default}
+        FilledIcon={ThumbUpIcon.pressed}
+        onPress={() => handleOnPressReactionButton(ReactionTypeEnum.LIKE)}
+      />
+      <ReactionToggleButton
+        active={reactionStatus === ReactionTypeEnum.DISLIKE}
+        label="Je n’aime pas"
+        Icon={ThumbDownIcon.default}
+        FilledIcon={ThumbDownIcon.pressed}
+        onPress={() => handleOnPressReactionButton(ReactionTypeEnum.DISLIKE)}
+      />
+    </ButtonsContainer>
+  )
+}
+
+const ButtonsContainer = styled(ViewGap)({
+  flexDirection: 'row',
+})


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29416

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |![Capture d’écran 2024-10-08 à 14 51 33](https://github.com/user-attachments/assets/81dfe4aa-e4b7-4596-b506-4aa5f6c3a8e3)|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
