### PR TITLE
(PC-32015) fix(reco): query reco only if focus and internet is reachable

### DIFF
--- a/src/features/home/api/useHomeRecommendedOffers.ts
+++ b/src/features/home/api/useHomeRecommendedOffers.ts
@@ -1,3 +1,5 @@
+import { useIsFocused } from '@react-navigation/native'
+
 import { PlaylistRequestBody, RecommendationApiParams, SubcategoryIdEnumv2 } from 'api/gen'
 import { buildRecommendationOfferTypesList } from 'features/home/api/helpers/buildRecommendationOfferTypesList'
 import { computeBeginningAndEndingDatetimes } from 'features/home/api/helpers/computeBeginningAndEndingDatetimes'
@@ -53,6 +55,7 @@ export const useHomeRecommendedOffers = (
   userId?: number
 ): { offers?: Offer[]; recommendationApiParams?: RecommendationApiParams } => {
   const subcategoryLabelMapping = useSubcategoryLabelMapping()
+  const isFocused = useIsFocused()
   const requestParameters = getRecommendationParameters(
     recommendationParameters,
     subcategoryLabelMapping
@@ -64,6 +67,7 @@ export const useHomeRecommendedOffers = (
       longitude: position?.longitude,
       modelEndpoint: recommendationParameters?.modelEndpoint,
     },
+    shouldFetch: isFocused,
     userId,
   })
 

--- a/src/libs/recommendation/useHomeRecommendedIdsQuery.native.test.ts
+++ b/src/libs/recommendation/useHomeRecommendedIdsQuery.native.test.ts
@@ -26,6 +26,7 @@ describe('useHomeRecommendedIdsQuery', () => {
           playlistRequestBody: {},
           playlistRequestQuery: {},
           userId: 1,
+          shouldFetch: true,
         }),
       {
         wrapper: ({ children }) => reactQueryProviderHOC(children),
@@ -57,6 +58,7 @@ describe('useHomeRecommendedIdsQuery', () => {
           playlistRequestBody: {},
           playlistRequestQuery: {},
           userId: 1,
+          shouldFetch: true,
         }),
       {
         wrapper: ({ children }) => reactQueryProviderHOC(children),
@@ -89,6 +91,7 @@ describe('useHomeRecommendedIdsQuery', () => {
           playlistRequestBody: {},
           playlistRequestQuery: {},
           userId: 1,
+          shouldFetch: true,
         }),
       {
         wrapper: ({ children }) => reactQueryProviderHOC(children),
@@ -128,6 +131,7 @@ describe('useHomeRecommendedIdsQuery', () => {
             playlistRequestBody: {},
             playlistRequestQuery: {},
             userId: 1,
+            shouldFetch: true,
           }),
         {
           wrapper: ({ children }) => reactQueryProviderHOC(children),
@@ -156,6 +160,7 @@ describe('useHomeRecommendedIdsQuery', () => {
           playlistRequestBody: {},
           playlistRequestQuery: {},
           userId: 1,
+          shouldFetch: true,
         }),
       {
         wrapper: ({ children }) => reactQueryProviderHOC(children),
@@ -175,7 +180,6 @@ describe('useHomeRecommendedIdsQuery', () => {
   it('should not make request if user is disconnected (and undefined in context)', async () => {
     mockServer.postApi<PlaylistResponse>('/v1/recommendation/playlist', {
       responseOptions: {
-        statusCode: 200,
         data: {
           params: {},
           playlistRecommendedOffers: ['102280', '102272', '102249', '102310'],
@@ -190,6 +194,34 @@ describe('useHomeRecommendedIdsQuery', () => {
           playlistRequestBody: {},
           playlistRequestQuery: {},
           userId: 1,
+          shouldFetch: true,
+        }),
+      {
+        wrapper: (props) => reactQueryProviderHOC(props.children),
+      }
+    )
+    await waitFor(() => {
+      expect(result.current.isFetching).toEqual(false)
+    })
+  })
+
+  it('should not make request when should Fetch is false', async () => {
+    mockServer.postApi<PlaylistResponse>('/v1/recommendation/playlist', {
+      responseOptions: {
+        statusCode: 200,
+        data: {
+          params: {},
+          playlistRecommendedOffers: ['102280', '102272', '102249', '102310'],
+        },
+      },
+    })
+    const { result } = renderHook(
+      () =>
+        useHomeRecommendedIdsQuery({
+          playlistRequestBody: {},
+          playlistRequestQuery: {},
+          userId: 1,
+          shouldFetch: false,
         }),
       {
         wrapper: (props) => reactQueryProviderHOC(props.children),

--- a/src/libs/recommendation/useHomeRecommendedIdsQuery.ts
+++ b/src/libs/recommendation/useHomeRecommendedIdsQuery.ts
@@ -12,11 +12,12 @@ import { QueryKeys } from 'libs/queryKeys'
 type Parameters = {
   playlistRequestBody: PlaylistRequestBody
   playlistRequestQuery: PlaylistRequestQuery
+  shouldFetch: boolean
   userId?: number
 }
 
 export const useHomeRecommendedIdsQuery = (parameters: Parameters) => {
-  const { playlistRequestBody, playlistRequestQuery, userId } = parameters
+  const { playlistRequestBody, playlistRequestQuery, userId, shouldFetch } = parameters
   const { modelEndpoint, longitude, latitude } = playlistRequestQuery
   const { isLoggedIn } = useAuthContext()
   const netInfo = useNetInfoContext()
@@ -45,7 +46,12 @@ export const useHomeRecommendedIdsQuery = (parameters: Parameters) => {
     },
     {
       staleTime: 1000 * 60 * 5,
-      enabled: isLoggedIn && !!userId && !!netInfo.isConnected,
+      enabled:
+        isLoggedIn &&
+        !!userId &&
+        !!netInfo.isConnected &&
+        !!netInfo.isInternetReachable &&
+        shouldFetch,
     }
   )
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32015

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
