### PR TITLE
(PC-32319) feat(culturalSurvey): adapt CTA wording in Cultural Survey

### DIFF
--- a/src/features/culturalSurvey/helpers/useGetCulturalSurveyContent.ts
+++ b/src/features/culturalSurvey/helpers/useGetCulturalSurveyContent.ts
@@ -8,7 +8,7 @@ import { analytics } from 'libs/analytics'
 import { ClockFilled } from 'ui/svg/icons/ClockFilled'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
 
-export const useGetCulturalSurveyContent = (enableQPIInIdentityCheck: boolean) => {
+export const useGetCulturalSurveyContent = (enableCulturalSurveyMandatory: boolean) => {
   const { reset } = useNavigation<UseNavigationType>()
   const { goBack } = useGoBack(...homeNavConfig)
 
@@ -20,7 +20,7 @@ export const useGetCulturalSurveyContent = (enableQPIInIdentityCheck: boolean) =
     analytics.logHasSkippedCulturalSurvey()
   }
 
-  if (enableQPIInIdentityCheck) {
+  if (enableCulturalSurveyMandatory) {
     return {
       intro: {
         title: 'Tu y es presque\u00a0!',

--- a/src/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx
@@ -134,7 +134,7 @@ describe('CulturalSurveyIntro page', () => {
 
   describe('When FF is enabled', () => {
     beforeEach(() => {
-      activateFeatureFlags([RemoteStoreFeatureFlags.ENABLE_QPI_IN_IDENTITY_CHECK])
+      activateFeatureFlags([RemoteStoreFeatureFlags.ENABLE_CULTURAL_SURVEY_MANDATORY])
     })
 
     it('should render the page with correct layout and content', () => {

--- a/src/features/culturalSurvey/pages/CulturalSurveyIntro.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyIntro.tsx
@@ -26,8 +26,8 @@ const FAQTouchableLinkProps = {
 }
 
 export const CulturalSurveyIntro = (): React.JSX.Element => {
-  const enableQPIInIdentityCheck = useFeatureFlag(
-    RemoteStoreFeatureFlags.ENABLE_QPI_IN_IDENTITY_CHECK
+  const enableCulturalSurveyMandatory = useFeatureFlag(
+    RemoteStoreFeatureFlags.ENABLE_CULTURAL_SURVEY_MANDATORY
   )
   const { questionsToDisplay: initialQuestions } = useCulturalSurveyContext()
 
@@ -45,7 +45,7 @@ export const CulturalSurveyIntro = (): React.JSX.Element => {
     incrementTotalCulturalSurveyDisplay()
   }, [])
 
-  const { intro } = useGetCulturalSurveyContent(enableQPIInIdentityCheck)
+  const { intro } = useGetCulturalSurveyContent(enableCulturalSurveyMandatory)
 
   return (
     <GenericInfoPageWhite

--- a/src/features/culturalSurvey/pages/CulturalSurveyIntro.web.test.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyIntro.web.test.tsx
@@ -48,7 +48,7 @@ describe('CulturalSurveyIntro page', () => {
 
   describe('When FF is enabled', () => {
     beforeEach(() => {
-      activateFeatureFlags([RemoteStoreFeatureFlags.ENABLE_QPI_IN_IDENTITY_CHECK])
+      activateFeatureFlags([RemoteStoreFeatureFlags.ENABLE_CULTURAL_SURVEY_MANDATORY])
     })
 
     it('should not have basic accessibility issues', async () => {

--- a/src/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx
@@ -76,7 +76,7 @@ describe('CulturalSurveyQuestions page', () => {
   it('should navigate to next page when pressing Continuer', async () => {
     render(<CulturalSurveyQuestions {...navigationProps} />)
 
-    const NextQuestionButton = screen.getByTestId('Continuer vers l’étape suivante')
+    const NextQuestionButton = screen.getByLabelText('Continuer vers l’étape suivante')
     fireEvent.press(NextQuestionButton)
 
     expect(push).toHaveBeenCalledWith('CulturalSurveyQuestions', {
@@ -91,7 +91,7 @@ describe('CulturalSurveyQuestions page', () => {
     }
     render(<CulturalSurveyQuestions {...navigationProps} />)
 
-    const NextQuestionButton = screen.getByTestId('Continuer vers l’étape suivante')
+    const NextQuestionButton = screen.getByLabelText('Valider le formulaire')
     fireEvent.press(NextQuestionButton)
 
     expect(dispatch).toHaveBeenCalledWith({ type: 'FLUSH_ANSWERS' })
@@ -108,7 +108,7 @@ describe('CulturalSurveyQuestions page', () => {
 
     render(<CulturalSurveyQuestions {...navigationProps} />)
 
-    const NextQuestionButton = screen.getByTestId('Continuer vers l’étape suivante')
+    const NextQuestionButton = screen.getByLabelText('Valider le formulaire')
     fireEvent.press(NextQuestionButton)
 
     expect(navigateToHome).toHaveBeenCalledTimes(1)

--- a/src/features/culturalSurvey/pages/CulturalSurveyQuestions.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyQuestions.tsx
@@ -201,8 +201,12 @@ export function CulturalSurveyQuestions({ route }: CulturalSurveyQuestionsProps)
             navigateToNextQuestion()
           }}
           disabled={!currentAnswers.length}
-          wording="Continuer"
-          accessibilityLabel="Continuer vers l’étape suivante"
+          wording={isCurrentQuestionLastQuestion ? 'Valider' : 'Continuer'}
+          accessibilityLabel={
+            isCurrentQuestionLastQuestion
+              ? 'Valider le formulaire'
+              : 'Continuer vers l’étape suivante'
+          }
         />
         <Spacer.BottomScreen />
       </FixedBottomChildrenView>

--- a/src/libs/firebase/firestore/types.ts
+++ b/src/libs/firebase/firestore/types.ts
@@ -16,8 +16,8 @@ export enum RemoteStoreDocuments {
 }
 
 export enum RemoteStoreFeatureFlags {
+  ENABLE_CULTURAL_SURVEY_MANDATORY = 'enableCulturalSurveyMandatory',
   ENABLE_MUSIC_LIVE_BOOKING_SURVEY = 'enableMusicLiveBookingSurvey',
-  ENABLE_QPI_IN_IDENTITY_CHECK = 'enableQpiInIdentityCheck',
   ENABLE_REPLICA_ALGOLIA_INDEX = 'enableReplicaAlgoliaIndex',
   FAKE_DOOR_ARTIST = 'fakeDoorArtist',
   TARGET_XP_CINE_FROM_OFFER = 'targetXpCineFromOffer',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32319

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |  <img width="374" alt="Capture d’écran 2024-10-14 à 14 42 03" src="https://github.com/user-attachments/assets/5b15ae50-3ad0-47bb-9bc2-ad98bc63d487">   |  <img width="376" alt="Capture d’écran 2024-10-14 à 14 34 54" src="https://github.com/user-attachments/assets/c5d37620-1aec-4f5a-bf57-0e49948b9abc">  |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
