### PR TITLE
(PC-31728) chore(deps): Bump workbox-navigation-preload from 6.1.5 7.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -356,7 +356,7 @@
     "workbox-core": "^6.1.5",
     "workbox-expiration": "^6.1.5",
     "workbox-google-analytics": "^6.1.5",
-    "workbox-navigation-preload": "^6.1.5",
+    "workbox-navigation-preload": "^7.1.0",
     "workbox-precaching": "^6.1.5",
     "workbox-range-requests": "^6.1.5",
     "workbox-routing": "^6.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25089,6 +25089,11 @@ workbox-core@6.4.2, workbox-core@^6.1.5:
   resolved "https://registry.yarnpkg.com/workbox-core/-/workbox-core-6.4.2.tgz#f99fd36a211cc01dce90aa7d5f2c255e8fe9d6bc"
   integrity sha512-1U6cdEYPcajRXiboSlpJx6U7TvhIKbxRRerfepAJu2hniKwJ3DHILjpU/zx3yvzSBCWcNJDoFalf7Vgd7ey/rw==
 
+workbox-core@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/workbox-core/-/workbox-core-7.1.0.tgz#1867576f994f20d9991b71a7d0b2581af22db170"
+  integrity sha512-5KB4KOY8rtL31nEF7BfvU7FMzKT4B5TkbYa2tzkS+Peqj0gayMT9SytSFtNzlrvMaWgv6y/yvP9C0IbpFjV30Q==
+
 workbox-expiration@^6.1.5:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/workbox-expiration/-/workbox-expiration-6.4.2.tgz#61613459fd6ddd1362730767618d444c6b9c9139"
@@ -25107,12 +25112,12 @@ workbox-google-analytics@^6.1.5:
     workbox-routing "6.4.2"
     workbox-strategies "6.4.2"
 
-workbox-navigation-preload@^6.1.5:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/workbox-navigation-preload/-/workbox-navigation-preload-6.4.2.tgz#35cd4ba416a530796af135410ca07db5bee11668"
-  integrity sha512-viyejlCtlKsbJCBHwhSBbWc57MwPXvUrc8P7d+87AxBGPU+JuWkT6nvBANgVgFz6FUhCvRC8aYt+B1helo166g==
+workbox-navigation-preload@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/workbox-navigation-preload/-/workbox-navigation-preload-7.1.0.tgz#2610674d412a1774b5d9f03c9644c9964407b8b6"
+  integrity sha512-4wyAbo0vNI/X0uWNJhCMKxnPanNyhybsReMGN9QUpaePLTiDpKxPqFxl4oUmBNddPwIXug01eTSLVIFXimRG/A==
   dependencies:
-    workbox-core "6.4.2"
+    workbox-core "7.1.0"
 
 workbox-precaching@^6.1.5:
   version "6.4.2"


### PR DESCRIPTION
Link to JIRA ticket: [passculture.atlassian.net/browse/PC-31728](https://passculture.atlassian.net/browse/PC-31728)

Bumps [workbox-navigation](https://developer.chrome.com/docs/workbox/modules/workbox-navigation-preload?hl=fr) from 8.7.0 to 9.14.1.