### PR TITLE
(PC-32380) feat(culturalSurvey): hide cultural survey after activation when in identity check

### DIFF
--- a/src/features/auth/components/SSOButton/SSOButton.native.test.tsx
+++ b/src/features/auth/components/SSOButton/SSOButton.native.test.tsx
@@ -24,7 +24,7 @@ jest.mock('features/identityCheck/context/SubscriptionContextProvider', () => ({
 
 jest.mock('libs/network/NetInfoWrapper')
 
-const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
+jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true)
 const apiPostGoogleAuthorize = jest.spyOn(API.api, 'postNativeV1OauthGoogleAuthorize')
 const getModelSpy = jest.spyOn(DeviceInfo, 'getModel')
 const getSystemNameSpy = jest.spyOn(DeviceInfo, 'getSystemName')
@@ -56,7 +56,6 @@ describe('<SSOButton />', () => {
   })
 
   it('should sign in with device info when sso button is clicked', async () => {
-    useFeatureFlagSpy.mockReturnValueOnce(true)
     getModelSpy.mockReturnValueOnce('iPhone 13')
     getSystemNameSpy.mockReturnValueOnce('iOS')
     mockServer.postApi<SigninResponse>('/v1/oauth/google/authorize', {
@@ -82,7 +81,6 @@ describe('<SSOButton />', () => {
   })
 
   it('should call onSignInFailure when signin fails', async () => {
-    useFeatureFlagSpy.mockReturnValueOnce(true)
     mockServer.postApi<SigninResponse>('/v1/oauth/google/authorize', {
       responseOptions: { statusCode: 500 },
     })
@@ -97,7 +95,6 @@ describe('<SSOButton />', () => {
   })
 
   it('should log analytics when logging in with sso from signup', async () => {
-    useFeatureFlagSpy.mockReturnValueOnce(true)
     mockServer.postApi<SigninResponse>('/v1/oauth/google/authorize', {
       accessToken: 'accessToken',
       refreshToken: 'refreshToken',
@@ -113,7 +110,6 @@ describe('<SSOButton />', () => {
   })
 
   it('should log analytics when logging in with sso from login', async () => {
-    useFeatureFlagSpy.mockReturnValueOnce(true)
     mockServer.postApi<SigninResponse>('/v1/oauth/google/authorize', {
       accessToken: 'accessToken',
       refreshToken: 'refreshToken',
@@ -137,7 +133,6 @@ describe('<SSOButton />', () => {
     })
 
     it('should not log to Sentry on SSO login error', async () => {
-      useFeatureFlagSpy.mockReturnValueOnce(true)
       jest.spyOn(GoogleSignin, 'signIn').mockRejectedValueOnce('GoogleSignIn Error')
 
       renderSSOButton()
@@ -160,7 +155,6 @@ describe('<SSOButton />', () => {
     })
 
     it('should log to Sentry on SSO login error', async () => {
-      useFeatureFlagSpy.mockReturnValueOnce(true)
       jest.spyOn(GoogleSignin, 'signIn').mockRejectedValueOnce('GoogleSignIn Error')
 
       renderSSOButton()

--- a/src/features/auth/pages/login/Login.native.test.tsx
+++ b/src/features/auth/pages/login/Login.native.test.tsx
@@ -26,6 +26,7 @@ import { analytics } from 'libs/analytics'
 // eslint-disable-next-line no-restricted-imports
 import { firebaseAnalytics } from 'libs/firebase/analytics'
 import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { captureMonitoringError } from 'libs/monitoring'
 import { NetworkErrorFixture, UnknownErrorFixture } from 'libs/recaptcha/fixtures'
 import { storage } from 'libs/storage'
@@ -36,6 +37,10 @@ import { SUGGESTION_DELAY_IN_MS } from 'ui/components/inputs/EmailInputWithSpell
 import { SNACK_BAR_TIME_OUT_LONG } from 'ui/components/snackBar/SnackBarContext'
 
 import { Login } from './Login'
+
+const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag')
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
+
 jest.mock('libs/network/NetInfoWrapper')
 
 jest.mock('libs/monitoring')
@@ -68,7 +73,6 @@ const apiSignInSpy = jest.spyOn(API.api, 'postNativeV1Signin')
 const apiPostGoogleAuthorize = jest.spyOn(API.api, 'postNativeV1OauthGoogleAuthorize')
 const getModelSpy = jest.spyOn(DeviceInfo, 'getModel')
 const getSystemNameSpy = jest.spyOn(DeviceInfo, 'getSystemName')
-const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
 
 jest.useFakeTimers()
 
@@ -93,6 +97,7 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 
 describe('<Login/>', () => {
   beforeEach(() => {
+    activateFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_GOOGLE_SSO])
     mockServer.postApi<FavoriteResponse>('/v1/me/favorites', favoriteResponseSnap)
     mockServer.getApi<OauthStateResponse>('/v1/oauth/state', {
       oauthStateToken: 'oauth_state_token',
@@ -110,10 +115,6 @@ describe('<Login/>', () => {
   })
 
   it('should render correctly when feature flag is enabled', async () => {
-    // We use this hook twice but due to multiple rerender we have to mock the return value this way
-    // eslint-disable-next-line local-rules/independent-mocks
-    useFeatureFlagSpy.mockReturnValue(true)
-
     renderLogin()
 
     await screen.findByText('Connecte-toi')
@@ -145,9 +146,6 @@ describe('<Login/>', () => {
   })
 
   it('should sign in when SSO button is clicked with device info', async () => {
-    // We use this hook twice but due to multiple rerender we have to mock the return value this way
-    // eslint-disable-next-line local-rules/independent-mocks
-    useFeatureFlagSpy.mockReturnValue(true)
     getModelSpy.mockReturnValueOnce('iPhone 13')
     getSystemNameSpy.mockReturnValueOnce('iOS')
     mockServer.postApi<SigninResponse>('/v1/oauth/google/authorize', {
@@ -256,6 +254,9 @@ describe('<Login/>', () => {
   })
 
   it('should redirect to NATIVE Cultural Survey WHEN signin is successful and user needs to fill cultural survey', async () => {
+    activateFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_GOOGLE_SSO])
+    activateFeatureFlags() // disabled ENABLE_CULTURAL_SURVEY_MANDATORY feature flag
+
     mockMeApiCall({
       needsToFillCulturalSurvey: true,
       showEligibleCard: false,
@@ -265,8 +266,23 @@ describe('<Login/>', () => {
     await fillInputs()
     await act(() => fireEvent.press(screen.getByText('Se connecter')))
 
-    expect(navigate).toHaveBeenCalledTimes(1)
-    expect(navigate).toHaveBeenCalledWith('CulturalSurveyIntro')
+    expect(navigate).toHaveBeenNthCalledWith(1, 'CulturalSurveyIntro')
+  })
+
+  it('should redirect to home WHEN signin is successful and ENABLE_CULTURAL_SURVEY_MANDATORY enabled', async () => {
+    activateFeatureFlags([RemoteStoreFeatureFlags.WIP_ENABLE_GOOGLE_SSO])
+    activateFeatureFlags([RemoteStoreFeatureFlags.ENABLE_CULTURAL_SURVEY_MANDATORY])
+
+    mockMeApiCall({
+      needsToFillCulturalSurvey: true,
+      showEligibleCard: false,
+    } as UserProfileResponse)
+    renderLogin()
+
+    await fillInputs()
+    await act(() => fireEvent.press(screen.getByText('Se connecter')))
+
+    expect(navigateToHome).toHaveBeenCalledTimes(1)
   })
 
   it('should not redirect to EighteenBirthday WHEN signin is successful and user has already seen eligible card and needs to see it', async () => {
@@ -482,8 +498,7 @@ describe('<Login/>', () => {
 
     await screen.findByText('Connecte-toi')
 
-    expect(analytics.logStepperDisplayed).toHaveBeenCalledTimes(1)
-    expect(analytics.logStepperDisplayed).toHaveBeenCalledWith(StepperOrigin.PROFILE, 'Login')
+    expect(analytics.logStepperDisplayed).toHaveBeenNthCalledWith(1, StepperOrigin.PROFILE, 'Login')
   })
 
   it('should log analytics when clicking on "Créer un compte" button', async () => {
@@ -885,4 +900,8 @@ function simulateSigninNetworkFailure() {
 
 function simulateAddToFavorites() {
   mockServer.postApi<FavoriteResponse>('/v1/me/favorites', favoriteResponseSnap)
+}
+
+const activateFeatureFlags = (activeFeatureFlags: RemoteStoreFeatureFlags[] = []) => {
+  useFeatureFlagSpy.mockImplementation((flag) => activeFeatureFlags.includes(flag))
 }

--- a/src/features/auth/pages/signup/AccountCreated/AccountCreated.web.test.tsx
+++ b/src/features/auth/pages/signup/AccountCreated/AccountCreated.web.test.tsx
@@ -1,11 +1,14 @@
 import React from 'react'
 
+import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { checkAccessibilityFor, render, screen } from 'tests/utils/web'
 
 import { AccountCreated } from './AccountCreated'
 
-jest.mock('libs/firebase/analytics/analytics')
+jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
+
+jest.mock('libs/firebase/analytics/analytics')
 
 jest.mock('react-native-safe-area-context', () => ({
   ...(jest.requireActual('react-native-safe-area-context') as Record<string, unknown>),

--- a/src/features/auth/pages/signup/SetEmail/SetEmail.native.test.tsx
+++ b/src/features/auth/pages/signup/SetEmail/SetEmail.native.test.tsx
@@ -295,6 +295,7 @@ describe('<SetEmail />', () => {
 
       useFeatureFlagSpy.mockReturnValueOnce(true) // first call in SetEmail
       useFeatureFlagSpy.mockReturnValueOnce(true) // second call in useOAuthState
+      useFeatureFlagSpy.mockReturnValueOnce(true) // third call in CulturalSurvey
 
       renderSetEmail()
 
@@ -323,6 +324,7 @@ describe('<SetEmail />', () => {
 
       useFeatureFlagSpy.mockReturnValueOnce(true) // first call in SetEmail
       useFeatureFlagSpy.mockReturnValueOnce(true) // second call in useOAuthState
+      useFeatureFlagSpy.mockReturnValueOnce(true) // third call in CulturalSurvey
 
       renderSetEmail()
 

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx
@@ -1,13 +1,19 @@
 import React from 'react'
 
+import { navigate } from '__mocks__/@react-navigation/native'
 import { BeneficiaryAccountCreated } from 'features/identityCheck/pages/confirmation/BeneficiaryAccountCreated'
 import * as ShareAppWrapperModule from 'features/share/context/ShareAppWrapper'
 import { ShareAppWrapper } from 'features/share/context/ShareAppWrapper'
 import { ShareAppModalType } from 'features/share/types'
 import { beneficiaryUser, underageBeneficiaryUser } from 'fixtures/user'
+import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { BatchUser } from 'libs/react-native-batch'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
-import { fireEvent, render, screen } from 'tests/utils'
+import { fireEvent, render, screen, waitFor } from 'tests/utils'
+
+const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag')
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 
 jest.mock('features/auth/context/AuthContext')
 
@@ -35,6 +41,7 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 
 describe('<BeneficiaryAccountCreated/>', () => {
   beforeEach(() => {
+    activateFeatureFlags()
     mockAuthContextWithUser(underageBeneficiaryUser, { persist: true })
   })
 
@@ -57,6 +64,7 @@ describe('<BeneficiaryAccountCreated/>', () => {
 
   it('should track Batch event when button is clicked', async () => {
     renderBeneficiaryAccountCreated()
+
     fireEvent.press(await screen.findByLabelText('C’est parti !'))
 
     expect(BatchUser.trackEvent).toHaveBeenCalledWith('has_validated_subscription')
@@ -69,8 +77,8 @@ describe('<BeneficiaryAccountCreated/>', () => {
       { ...beneficiaryUser, needsToFillCulturalSurvey: false },
       { persist: true }
     )
-
     renderBeneficiaryAccountCreated()
+
     fireEvent.press(await screen.findByLabelText('C’est parti !'))
 
     expect(mockShowAppModal).toHaveBeenNthCalledWith(1, ShareAppModalType.BENEFICIARY)
@@ -78,11 +86,37 @@ describe('<BeneficiaryAccountCreated/>', () => {
 
   it('should not show share app modal when user is supposed to see cultural survey', async () => {
     renderBeneficiaryAccountCreated()
+
     fireEvent.press(await screen.findByLabelText('C’est parti !'))
 
     expect(mockShowAppModal).not.toHaveBeenCalled()
+  })
+
+  it('should redirect to native cultural survey page when "C’est parti !"button is clicked and user is supposed to see cultural survey', async () => {
+    renderBeneficiaryAccountCreated()
+
+    fireEvent.press(await screen.findByLabelText('C’est parti !'))
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenNthCalledWith(1, 'CulturalSurveyIntro', undefined)
+    })
+  })
+
+  it('should redirect to home page when "C’est parti !" button is clicked BUT feature flag enableCulturalSurveyMandatory is enabled', async () => {
+    activateFeatureFlags([RemoteStoreFeatureFlags.ENABLE_CULTURAL_SURVEY_MANDATORY])
+    renderBeneficiaryAccountCreated()
+
+    fireEvent.press(await screen.findByLabelText('C’est parti !'))
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenNthCalledWith(1, 'TabNavigator', { screen: 'Home' })
+    })
   })
 })
 
 const renderBeneficiaryAccountCreated = () =>
   render(<BeneficiaryAccountCreated />, { wrapper: ShareAppWrapper })
+
+const activateFeatureFlags = (activeFeatureFlags: RemoteStoreFeatureFlags[] = []) => {
+  useFeatureFlagSpy.mockImplementation((flag) => activeFeatureFlags.includes(flag))
+}

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.web.test.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.web.test.tsx
@@ -1,8 +1,12 @@
 import React from 'react'
 
+import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { render, checkAccessibilityFor, screen } from 'tests/utils/web'
 
 import { BeneficiaryAccountCreated } from './BeneficiaryAccountCreated'
+
+jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 
 jest.mock('features/auth/context/AuthContext')
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx
@@ -5,9 +5,14 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { navigateFromRef } from 'features/navigation/navigationRef'
+import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { render, fireEvent, screen } from 'tests/utils'
 
 import { BeneficiaryRequestSent } from './BeneficiaryRequestSent'
+
+const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag')
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 
 jest.mock('features/navigation/helpers/navigateToHome')
 jest.mock('features/navigation/navigationRef')
@@ -27,6 +32,10 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 })
 
 describe('<BeneficiaryRequestSent />', () => {
+  beforeEach(() => {
+    activateFeatureFlags()
+  })
+
   it('should render correctly', async () => {
     render(<BeneficiaryRequestSent />)
 
@@ -41,8 +50,20 @@ describe('<BeneficiaryRequestSent />', () => {
     fireEvent.press(await screen.findByLabelText('On y va\u00a0!'))
 
     expect(navigateFromRef).not.toHaveBeenCalled()
-    expect(navigate).toHaveBeenCalledTimes(1)
-    expect(navigate).toHaveBeenCalledWith('CulturalSurveyIntro', undefined)
+    expect(navigate).toHaveBeenNthCalledWith(1, 'CulturalSurveyIntro', undefined)
+  })
+
+  it('should redirect to home page when "On y va !" button is clicked BUT feature flag enableCulturalSurveyMandatory is enabled', async () => {
+    activateFeatureFlags([RemoteStoreFeatureFlags.ENABLE_CULTURAL_SURVEY_MANDATORY])
+    render(<BeneficiaryRequestSent />)
+
+    fireEvent.press(await screen.findByLabelText('On y va\u00a0!'))
+
+    expect(navigateFromRef).toHaveBeenCalledWith(
+      navigateToHomeConfig.screen,
+      navigateToHomeConfig.params
+    )
+    expect(navigate).not.toHaveBeenCalled()
   })
 
   it('should redirect to home page WHEN "On y va !" button is clicked and user does not need to fill cultural survey', async () => {
@@ -52,7 +73,6 @@ describe('<BeneficiaryRequestSent />', () => {
     mockedUseAuthContext.mockImplementationOnce(() => ({
       user: { needsToFillCulturalSurvey: false },
     })) // re-render because local storage value has been read and set
-
     render(<BeneficiaryRequestSent />)
 
     fireEvent.press(await screen.findByLabelText('On y va\u00a0!'))
@@ -61,6 +81,10 @@ describe('<BeneficiaryRequestSent />', () => {
       navigateToHomeConfig.screen,
       navigateToHomeConfig.params
     )
-    expect(navigate).not.toHaveBeenCalledWith('CulturalSurvey', undefined)
+    expect(navigate).not.toHaveBeenNthCalledWith(1, 'CulturalSurvey', undefined)
   })
 })
+
+const activateFeatureFlags = (activeFeatureFlags: RemoteStoreFeatureFlags[] = []) => {
+  useFeatureFlagSpy.mockImplementation((flag) => activeFeatureFlags.includes(flag))
+}

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.web.test.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.web.test.tsx
@@ -1,8 +1,12 @@
 import React from 'react'
 
+import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { render, checkAccessibilityFor, screen } from 'tests/utils/web'
 
 import { BeneficiaryRequestSent } from './BeneficiaryRequestSent'
+
+jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 
 jest.mock('features/auth/context/AuthContext')
 

--- a/src/features/navigation/RootNavigator/useInitialScreenConfig.native.test.tsx
+++ b/src/features/navigation/RootNavigator/useInitialScreenConfig.native.test.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 
 import { beneficiaryUser } from 'fixtures/user'
 import { analytics } from 'libs/analytics'
+import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { SplashScreenProvider } from 'libs/splashscreen'
 import { storage } from 'libs/storage'
 import { mockAuthContextWithoutUser, mockAuthContextWithUser } from 'tests/AuthContextUtils'
@@ -9,10 +11,17 @@ import { renderHook, waitFor } from 'tests/utils'
 
 import { useInitialScreen } from './useInitialScreenConfig'
 
+const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag')
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
+
 jest.mock('features/auth/context/AuthContext')
 jest.mock('libs/jwt/jwt')
 
 describe('useInitialScreen()', () => {
+  beforeEach(() => {
+    activateFeatureFlags()
+  })
+
   afterAll(async () => {
     await storage.clear('has_seen_tutorials')
     await storage.clear('has_seen_eligible_card')
@@ -147,4 +156,8 @@ async function renderUseInitialScreen() {
   )
   const { result } = renderHook(useInitialScreen, { wrapper })
   return result
+}
+
+const activateFeatureFlags = (activeFeatureFlags: RemoteStoreFeatureFlags[] = []) => {
+  useFeatureFlagSpy.mockImplementation((flag) => activeFeatureFlags.includes(flag))
 }

--- a/src/features/navigation/RootNavigator/useInitialScreenConfig.web.test.tsx
+++ b/src/features/navigation/RootNavigator/useInitialScreenConfig.web.test.tsx
@@ -3,13 +3,15 @@ import React from 'react'
 import { analytics } from 'libs/analytics'
 import { SplashScreenProvider } from 'libs/splashscreen'
 import { storage } from 'libs/storage'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { renderHook, waitFor } from 'tests/utils/web'
 
 import { useInitialScreen } from './useInitialScreenConfig'
 
-const wrapper = (props: { children: unknown }) => (
-  <SplashScreenProvider>{props.children as React.JSX.Element}</SplashScreenProvider>
-)
+const wrapper = (props: { children: unknown }) =>
+  reactQueryProviderHOC(
+    <SplashScreenProvider>{props.children as React.JSX.Element}</SplashScreenProvider>
+  )
 
 jest.mock('libs/firebase/analytics/analytics')
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')

--- a/src/shared/culturalSurvey/useShouldShowCulturalSurvey.native.test.ts
+++ b/src/shared/culturalSurvey/useShouldShowCulturalSurvey.native.test.ts
@@ -1,14 +1,44 @@
 import { beneficiaryUser } from 'fixtures/user'
+import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { storage } from 'libs/storage'
 import { renderHook, act } from 'tests/utils'
 
 import { useShouldShowCulturalSurvey } from './useShouldShowCulturalSurvey'
 
+const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag')
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
+
 const CULTURAL_SURVEY_DISPLAYS_STORAGE_KEY = 'times_cultural_survey_has_been_requested'
+
+const activateFeatureFlags = (activeFeatureFlags: RemoteStoreFeatureFlags[] = []) => {
+  useFeatureFlagSpy.mockImplementation((flag) => activeFeatureFlags.includes(flag))
+}
 
 describe('useShouldShowCulturalSurvey()', () => {
   beforeEach(() => {
     storage.clear(CULTURAL_SURVEY_DISPLAYS_STORAGE_KEY)
+    activateFeatureFlags()
+  })
+
+  it('should return true when feature flag is disabled and user has never seen cultural survey', async () => {
+    const { result } = renderHook(useShouldShowCulturalSurvey)
+
+    await act(() => {})
+    const shouldShowCulturalSurvey = result.current(beneficiaryUser)
+
+    expect(shouldShowCulturalSurvey).toBe(true)
+  })
+
+  it('should return undefined when cultural survey feature flag is enabled', async () => {
+    activateFeatureFlags([RemoteStoreFeatureFlags.ENABLE_CULTURAL_SURVEY_MANDATORY])
+
+    const { result } = renderHook(useShouldShowCulturalSurvey)
+
+    await act(() => {})
+    const shouldShowCulturalSurvey = result.current(beneficiaryUser)
+
+    expect(shouldShowCulturalSurvey).toBeUndefined()
   })
 
   it('should return undefined while reading information', async () => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32380

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]