### PR TITLE
(PC-32419) feat(booking): display a pastille in ended booking tab when user has bookings without reaction

### DIFF
--- a/src/features/bookings/pages/Bookings/Bookings.web.test.tsx
+++ b/src/features/bookings/pages/Bookings/Bookings.web.test.tsx
@@ -2,7 +2,13 @@ import React from 'react'
 import { QueryObserverResult, UseQueryResult } from 'react-query'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import { BookingsResponse, SubcategoriesResponseModelv2 } from 'api/gen'
+import {
+  BookingsResponse,
+  CategoryIdEnum,
+  NativeCategoryIdEnumv2,
+  SubcategoriesResponseModelv2,
+  SubcategoryIdEnum,
+} from 'api/gen'
 import * as bookingsAPI from 'features/bookings/api/useBookings'
 import { bookingsSnap, emptyBookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
@@ -33,6 +39,30 @@ jest.mock('react-native-safe-area-context', () => ({
   ...(jest.requireActual('react-native-safe-area-context') as Record<string, unknown>),
   useSafeAreaInsets: () => ({ bottom: 16, right: 16, left: 16, top: 16 }),
 }))
+jest.mock('libs/subcategories/useSubcategory')
+
+const mockUseSubcategoriesMapping = jest.fn()
+const mockUseCategoryIdMapping = jest.fn()
+jest.mock('libs/subcategories/mappings', () => ({
+  useSubcategoriesMapping: jest.fn(() => mockUseSubcategoriesMapping()),
+  useCategoryIdMapping: jest.fn(() => mockUseSubcategoriesMapping()),
+}))
+mockUseSubcategoriesMapping.mockReturnValue({
+  [SubcategoryIdEnum.SEANCE_CINE]: {
+    isEvent: false,
+    categoryId: CategoryIdEnum.CINEMA,
+    nativeCategoryId: NativeCategoryIdEnumv2.SEANCES_DE_CINEMA,
+  },
+  [SubcategoryIdEnum.EVENEMENT_PATRIMOINE]: {
+    isEvent: false,
+    categoryId: CategoryIdEnum.CONFERENCE,
+    nativeCategoryId: NativeCategoryIdEnumv2.EVENEMENTS_PATRIMOINE,
+  },
+})
+mockUseCategoryIdMapping.mockReturnValue({
+  [SubcategoryIdEnum.SEANCE_CINE]: CategoryIdEnum.FILM,
+  [SubcategoryIdEnum.EVENEMENT_PATRIMOINE]: CategoryIdEnum.MUSEE,
+})
 
 describe('Bookings', () => {
   describe('Accessibility', () => {
@@ -52,7 +82,7 @@ describe('Bookings', () => {
     renderBookings(bookingsSnap)
 
     await waitFor(() => {
-      expect(useBookings).toHaveBeenCalledTimes(2)
+      expect(useBookings).toHaveBeenCalledTimes(3)
     })
   })
 

--- a/src/features/venue/components/TabLayout/InfoTab.tsx
+++ b/src/features/venue/components/TabLayout/InfoTab.tsx
@@ -2,25 +2,28 @@ import React, { useMemo } from 'react'
 import { Platform } from 'react-native'
 import styled from 'styled-components/native'
 
+import { PastilleType } from 'features/venue/types'
 import { useHandleHover } from 'libs/hooks/useHandleHover'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { AccessibleIcon } from 'ui/svg/icons/types'
-import { getSpacing, Spacer, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
 
 import { TouchableTab } from './TouchableTab'
 
 type InfoTabProps<TabKeyType extends string> = {
   tab: TabKeyType
   selectedTab: TabKeyType
-  Icon?: React.FC<AccessibleIcon>
   onPress: () => void
+  Icon?: React.FC<AccessibleIcon>
+  pastille?: PastilleType
 }
 
 export const InfoTab = <TabKeyType extends string>({
   tab,
   selectedTab,
-  Icon,
   onPress,
+  Icon,
+  pastille,
 }: InfoTabProps<TabKeyType>) => {
   const isSelected = selectedTab === tab
   const { isHover, ...webHoverProps } = useHandleHover()
@@ -42,6 +45,11 @@ export const InfoTab = <TabKeyType extends string>({
         <TabTitle isHover={isHover} isSelected={isSelected}>
           {tab}
         </TabTitle>
+        {pastille ? (
+          <PastilleContainer accessibilityLabel={pastille.accessibilityLabel} testID="pastille">
+            <Counter>{pastille.label}</Counter>
+          </PastilleContainer>
+        ) : null}
       </TabTitleContainer>
       <Spacer.Column numberOfSpaces={2} />
       <BarOfSelectedTab isSelected={isSelected} />
@@ -74,4 +82,14 @@ const BarOfSelectedTab = styled.View<{ isSelected: boolean }>(({ theme, isSelect
   width: '100%',
   backgroundColor: isSelected ? theme.colors.primary : 'transparent',
   borderRadius: getSpacing(1),
+}))
+
+const PastilleContainer = styled.View(({ theme }) => ({
+  backgroundColor: theme.colors.primary,
+  borderRadius: getSpacing(3.25),
+  paddingHorizontal: getSpacing(1),
+}))
+
+const Counter = styled(Typo.Hint)(({ theme }) => ({
+  color: theme.colors.white,
 }))

--- a/src/features/venue/components/TabLayout/TabLayout.native.test.tsx
+++ b/src/features/venue/components/TabLayout/TabLayout.native.test.tsx
@@ -76,4 +76,31 @@ describe('TabLayout', () => {
 
     expect(screen.getByText('Infos pratiques content')).toBeOnTheScreen()
   })
+
+  it('should display a pastille on tab when specified', () => {
+    render(
+      <TabLayout
+        tabPanels={tabPanels}
+        tabs={[
+          { key: Tab.OFFERS, pastille: { label: '1', accessibilityLabel: '1 offre' } },
+          { key: Tab.INFOS },
+        ]}
+        defaultTab={Tab.OFFERS}
+      />
+    )
+
+    expect(screen.getByText('1')).toBeOnTheScreen()
+  })
+
+  it('should not display a pastille on tab when not specified', () => {
+    render(
+      <TabLayout
+        tabPanels={tabPanels}
+        tabs={[{ key: Tab.OFFERS }, { key: Tab.INFOS }]}
+        defaultTab={Tab.OFFERS}
+      />
+    )
+
+    expect(screen.queryByTestId('pastille')).toBeNull()
+  })
 })

--- a/src/features/venue/components/TabLayout/TabLayout.tsx
+++ b/src/features/venue/components/TabLayout/TabLayout.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components/native'
 
 import { useTabArrowNavigation } from 'features/venue/components/TabLayout/useTabArrowNavigation'
+import { TabType } from 'features/venue/types'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
-import { AccessibleIcon } from 'ui/svg/icons/types'
 import { getSpacing, Spacer } from 'ui/theme'
 
 import { InfoTab } from './InfoTab'
@@ -11,7 +11,7 @@ import { InfoTab } from './InfoTab'
 type TabLayoutProps<TabKeyType extends string> = {
   tabPanels: Record<TabKeyType, React.JSX.Element | null>
   onTabChange?: Partial<Record<TabKeyType, () => void>> | ((tab: TabKeyType) => void)
-  tabs: { key: TabKeyType; Icon?: React.FC<AccessibleIcon> }[]
+  tabs: TabType<TabKeyType>[]
   defaultTab: TabKeyType
 }
 
@@ -56,6 +56,7 @@ export const TabLayout = <TabKeyType extends string>({
             selectedTab={selectedTab}
             onPress={() => onTabPress(tab.key)}
             Icon={tab.Icon}
+            pastille={tab.pastille}
           />
         ))}
         <Spacer.Row numberOfSpaces={6} />

--- a/src/features/venue/types.ts
+++ b/src/features/venue/types.ts
@@ -1,5 +1,6 @@
 import { Geoloc } from 'libs/algolia/types'
 import { VenueTypeCode } from 'libs/parsers/venueType'
+import { AccessibleIcon } from 'ui/svg/icons/types'
 
 export interface Venue {
   label: string
@@ -40,3 +41,14 @@ export type OpeningHour = {
 }
 
 export type OpeningHoursStatusState = 'open' | 'open-soon' | 'close-soon' | 'close'
+
+export type PastilleType = {
+  label: string
+  accessibilityLabel: string
+}
+
+export type TabType<TabKeyType extends string> = {
+  key: TabKeyType
+  Icon?: React.FC<AccessibleIcon>
+  pastille?: PastilleType
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32419

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="298" alt="Capture d’écran 2024-10-16 à 12 41 43" src="https://github.com/user-attachments/assets/efe39eea-5bb0-49c7-8895-556235a0288b">|![Capture d’écran 2024-10-16 à 13 03 51](https://github.com/user-attachments/assets/ce90c128-fa2a-439a-8884-63f085fc37e7)|
| Android          |               |![Capture d’écran 2024-10-16 à 13 05 12](https://github.com/user-attachments/assets/2bbdcf2d-0c4f-4088-af99-d65238a15a6e)|
| Phone - Chrome   |               |<img width="213" alt="Capture d’écran 2024-10-16 à 12 40 02" src="https://github.com/user-attachments/assets/7ef57d58-93c5-42a7-87fd-25a781650ef0">|
| Desktop - Chrome |               |<img width="1726" alt="Capture d’écran 2024-10-16 à 12 39 51" src="https://github.com/user-attachments/assets/c8d41cea-9f90-449b-b0a5-a6f2343508f4">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
