### PR TITLE
(PC-31573) fix(sentry): usage of sentry-cli changed in 5.x.x

### DIFF
--- a/ios/PassCulture.xcodeproj/project.pbxproj
+++ b/ios/PassCulture.xcodeproj/project.pbxproj
@@ -259,7 +259,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export SENTRY_PROPERTIES=sentry.properties\n../node_modules/@sentry/cli/bin/sentry-cli upload-dsym";
+			shellScript = "export SENTRY_PROPERTIES=sentry.properties\n../node_modules/@sentry/cli/bin/sentry-cli debug-files upload "$DWARF_DSYM_FOLDER_PATH"";
 		};
 		62B05EC9D758E294D517745E /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-31573

One of the things that caught my attention during my first hour of investigation, is that the Debug Symbols were being uploaded regularly and then suddenly, 14 months ago, they stopped.

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/231c01a7-3edc-4e72-a107-363ce30b8cc3">

_Please note: I chose to ignore the 3 latest debug files in march as they appear out of nowhere (my guess is that they were manually uploaded). Ignoring those 3 latest one in march, debug files were uploaded several times a week (probably during deploys of releases)._

14 months ago seems to coincide exactly with the moment at which `sentry/react-native` was updated ([from 4.2.2 to 5.3.0](https://github.com/getsentry/sentry-react-native/compare/4.2.2...5.3.0)). 

When looking in the breaking changes to rn-sentry 5:
The bundled `sentry-cli` version has been bumped to [v2.10.0](https://github.com/getsentry/sentry-cli/releases/tag/2.10.0). Check your usage of `sentry-cli` to reflect [breaking changes](https://github.com/getsentry/sentry-cli/releases/tag/2.0.0). Note, that `upload-dsym` has been replaced by `debug-files upload` and requires a path. Make sure to check your `Upload Debug Symbols` build step in your Xcode project.

I made that change in this PR and hope debug files will be uploaded again.