### PR TITLE
(PC-32488) chore(proxy): load certificate only when proxy is enabled

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -38,7 +38,7 @@ if [ "$(uname)" == "Darwin" ]; then
 	fi
 	popd
 
-	if [ -f "$SSL_CERT_FILE" ]; then
+	if ./scripts/is_proxy_enabled.sh; then
 		xcrun simctl keychain booted add-root-cert "$SSL_CERT_FILE" || log_status "no iOS simulator currently booted, don't add certificate"
 	fi
 fi

--- a/scripts/ensure_nix_use_certificate.sh
+++ b/scripts/ensure_nix_use_certificate.sh
@@ -41,6 +41,6 @@ ensure_nix_use_certificate() {
 	restart_nix
 }
 
-if [ -f "$SSL_CERT_FILE" ]; then
+if ./is_proxy_enabled.sh; then
 	ensure_nix_use_certificate
 fi

--- a/scripts/is_proxy_enabled.sh
+++ b/scripts/is_proxy_enabled.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+PROXY_DIAGNOSTIC="$(realpath '/Library/Application Support'/*/*/*diag 2>/dev/null || true)"
+
+if [ -f "$PROXY_DIAGNOSTIC" ]; then
+	"$PROXY_DIAGNOSTIC" -f | grep "TUNNEL_CONNECTED" >/dev/null
+else
+	return 1
+fi

--- a/scripts/load_certificate.sh
+++ b/scripts/load_certificate.sh
@@ -3,7 +3,7 @@ set -o errexit -o nounset -o pipefail
 
 SSL_CERT_FILE="$(realpath '/Library/Application Support'/*/*/data/*cacert.pem 2>/dev/null || true)"
 
-if [ -f "$SSL_CERT_FILE" ]; then
+if ./is_proxy_enabled.sh; then
 	export SSL_CERT_FILE="$SSL_CERT_FILE"
 	export NODE_EXTRA_CA_CERTS="$SSL_CERT_FILE"
 	export NIX_SSL_CERT_FILE="$SSL_CERT_FILE"

--- a/scripts/start_android_emulator_with_certificate.sh
+++ b/scripts/start_android_emulator_with_certificate.sh
@@ -27,7 +27,7 @@ add_certificate_to_this_session() {
 	adb unroot
 }
 
-if [ -f "$SSL_CERT_FILE" ]; then
+if ./is_proxy_enabled.sh; then
 	if [ -z "${ANDROID_SERIAL+x}" ]; then
 		echo "You didn't set the ANDROID_SERIAL environment variable"
 		echo "Choosing one for you :"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32488

pour tester, il faut

1. aller sur la branche

   ```sh
   git fetch
   git switch --detach origin/proxy_disabled
   ```

1. supprimer ses node_modules et/ou pods
   
   ```sh
   rm -rf node_modules ios/Pods
   ```

1. réactiver direnv qui va essayer de réinstaller les dépendances vu que les dossiers sont absents

   ```sh
   direnv allow
   ```

et tout devrait fonctionner normalement

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
