### PR TITLE
(PC-32510) chore(pipeline): slack message only on failure or success

### DIFF
--- a/.github/workflows/dev_on_workflow_environment_android_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_android_deploy.yml
@@ -104,7 +104,7 @@ jobs:
 
   slack_notify:
     runs-on: ubuntu-22.04
-    if: ${{ always() }}
+    if: ${{contains(needs.sentry_and_deploy.result, 'success') && contains(needs.sentry_and_deploy.result, 'failure')}}
     needs: sentry_and_deploy
     steps:
       - name: Connect to Secret Manager
@@ -129,13 +129,13 @@ jobs:
               "attachments": [
                   {
                       "mrkdwn_in": ["text"],
-                      "color": "${{ fromJSON('["#A30002","#36a64f"]')[steps.sentry_and_deploy.outputs.status == 'success'] }}",
+                      "color": "${{ fromJSON('["#36a64f", "#A30002"]')[needs.sentry_and_deploy.result == 'failure'] }}",
                       "author_name": "${{github.actor}}",
                       "author_link": "https://github.com/${{github.actor}}",
                       "author_icon": "https://github.com/${{github.actor}}.png",
                       "title": "PCAPPNATIVE Deployment",
                       "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                      "text": "Le déploiement Android sur `${{ inputs.ENV }}` a ${{ fromJSON('["échoué :boom:","réussi :rocket:"]')[steps.sentry_and_deploy.outputs.status == 'success'] }}"
+                      "text": "Le déploiement Android sur `${{ inputs.ENV }}` a ${{ fromJSON('["réussi :rocket:", "échoué :boom:"]')[needs.sentry_and_deploy.result == 'failure'] }}"
                   }
               ],
               "unfurl_links": false,

--- a/.github/workflows/dev_on_workflow_environment_ios_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_ios_deploy.yml
@@ -95,7 +95,7 @@ jobs:
 
   slack_notify:
     runs-on: ubuntu-22.04
-    if: ${{ always() }}
+    if: ${{ contains(needs.sentry_and_deploy.result, 'success') && contains(needs.sentry_and_deploy.result, 'failure')}}
     needs: sentry_and_deploy
     steps:
       - name: Connect to Secret Manager
@@ -120,13 +120,13 @@ jobs:
               "attachments": [
                   {
                       "mrkdwn_in": ["text"],
-                      "color": "${{ fromJSON('["#A30002", "#36a64f"]')[steps.sentry_and_deploy.outputs.status == 'success'] }}",
+                      "color": "${{ fromJSON('["#36a64f", "#A30002"]')[needs.sentry_and_deploy.result == 'failure'] }}",
                       "author_name": "${{github.actor}}",
                       "author_link": "https://github.com/${{github.actor}}",
                       "author_icon": "https://github.com/${{github.actor}}.png",
                       "title": "PCAPPNATIVE Deployment",
                       "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                      "text": "Le déploiement iOS sur `${{ inputs.ENV }}` a ${{ fromJSON('["échoué :boom:","réussi :rocket:"]')[steps.sentry_and_deploy.outputs.status == 'success'] }}"
+                      "text": "Le déploiement iOS sur `${{ inputs.ENV }}` a ${{ fromJSON('["réussi :rocket:", "échoué :boom:"]')[needs.sentry_and_deploy.result == 'failure'] }}"
                   }
               ],
               "unfurl_links": false,

--- a/.github/workflows/dev_on_workflow_environment_soft_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_soft_deploy.yml
@@ -86,7 +86,7 @@ jobs:
 
   slack_notify:
     runs-on: ubuntu-22.04
-    if: ${{ always() }}
+    if: ${{ contains(needs.sentry_and_deploy.result, 'success') && contains(needs.sentry_and_deploy.result, 'failure')}}
     needs: sentry_and_deploy
     steps:
       - name: Connect to Secret Manager
@@ -111,13 +111,13 @@ jobs:
               "attachments": [
                   {
                       "mrkdwn_in": ["text"],
-                      "color": "${{ fromJSON('["#A30002","#36a64f"]')[steps.sentry_and_deploy.outputs.status == 'success'] }}",
+                      "color": "${{ fromJSON('["#36a64f", "#A30002"]')[needs.sentry_and_deploy.result == 'failure'] }}",
                       "author_name": "${{github.actor}}",
                       "author_link": "https://github.com/${{github.actor}}",
                       "author_icon": "https://github.com/${{github.actor}}.png",
                       "title": "PCAPPNATIVE Deployment",
                       "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                      "text": "Le déploiement codePush Android/iOS sur `${{ inputs.ENV }}` a ${{ fromJSON('["échoué :boom:","réussi :rocket:"]')[steps.sentry_and_deploy.outputs.status == 'success'] }}"
+                      "text": "Le déploiement codePush Android/iOS sur `${{ inputs.ENV }}` a ${{ fromJSON('["réussi :rocket:", "échoué :boom:"]')[needs.sentry_and_deploy.result == 'failure'] }}"
                   }
               ],
               "unfurl_links": false,

--- a/.github/workflows/dev_on_workflow_web_deploy.yml
+++ b/.github/workflows/dev_on_workflow_web_deploy.yml
@@ -76,7 +76,7 @@ jobs:
           gsutil cp dist/index.html gs://${{ inputs.BUCKET_NAME }}
   slack_notify:
     runs-on: ubuntu-22.04
-    if: ${{ always() }}
+    if: ${{ contains(needs.web_deploy.result, 'success') && contains(needs.web_deploy.result, 'failure')}}
     needs: web_deploy
     steps:
       - name: Connect to Secret Manager
@@ -101,13 +101,13 @@ jobs:
               "attachments": [
                   {
                       "mrkdwn_in": ["text"],
-                      "color": "${{ fromJSON('["#A30002","#36a64f"]')[steps.web_deploy.outputs.status == 'success'] }}",
+                      "color": "${{ fromJSON('["#36a64f", "#A30002"]')[needs.web_deploy.result == 'failure'] }}",
                       "author_name": "${{github.actor}}",
                       "author_link": "https://github.com/${{github.actor}}",
                       "author_icon": "https://github.com/${{github.actor}}.png",
                       "title": "PCAPPNATIVE Deployment",
                       "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                      "text": "Le déploiement Web sur `${{ inputs.ENV }}` a ${{ fromJSON('["échoué :boom:","réussi :rocket:"]')[steps.web_deploy.outputs.status == 'success'] }}"
+                      "text": "Le déploiement Web sur `${{ inputs.ENV }}` a ${{ fromJSON('["réussi :rocket:", "échoué :boom:"]')[needs.web_deploy.result == 'failure'] }}"
                   }
               ],
               "unfurl_links": false,

--- a/.github/workflows/dev_on_workflow_web_proxy_deploy.yml
+++ b/.github/workflows/dev_on_workflow_web_proxy_deploy.yml
@@ -75,7 +75,7 @@ jobs:
             | xargs gcloud app versions delete --service=web-proxy-${{ inputs.ENV }}
   slack_notify:
     runs-on: ubuntu-22.04
-    if: ${{ always() }}
+    if: ${{ contains(needs.web_proxy_deploy.result, 'success') && contains(needs.web_proxy_deploy.result, 'failure')}}
     needs: web_proxy_deploy
     steps:
       - name: Connect to Secret Manager
@@ -100,13 +100,13 @@ jobs:
               "attachments": [
                   {
                       "mrkdwn_in": ["text"],
-                      "color": "${{ fromJSON('["#A30002","#36a64f"]')[steps.web_proxy_deploy.outputs.status == 'success'] }}",
+                      "color": "${{ fromJSON('["#36a64f", "#A30002"]')[needs.web_proxy_deploy.result == 'failure'] }}",
                       "author_name": "${{github.actor}}",
                       "author_link": "https://github.com/${{github.actor}}",
                       "author_icon": "https://github.com/${{github.actor}}.png",
                       "title": "PCAPPNATIVE Deployment",
                       "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                      "text": "Le déploiement Web proxy sur `${{ inputs.ENV }}` a ${{ fromJSON('["échoué :boom:","réussi :rocket:"]')[steps.web_proxy_deploy.outputs.status == 'success'] }}"
+                      "text": "Le déploiement Web proxy sur `${{ inputs.ENV }}` a ${{ fromJSON('["réussi :rocket:", "échoué :boom:"]')[needs.web_proxy_deploy.result == 'failure'] }}"
                   }
               ],
               "unfurl_links": false,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
