### PR TITLE
(PC-32564) feat(culturalSurvey): fix cultural survey questions to dis…

### DIFF
--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -30,7 +30,7 @@
 ./src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx:551
 ./src/features/bookings/pages/BookingDetails/BookingDetails.tsx:97
 ./src/features/culturalSurvey/helpers/useGetNextQuestion.ts:13
-./src/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx:150
+./src/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx:166
 ./src/features/deeplinks/helpers/getScreenFromDeeplink.ts:13
 ./src/features/deeplinks/helpers/getScreenFromDeeplink.ts:15
 ./src/features/deeplinks/helpers/getScreenFromDeeplink.ts:17

--- a/src/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx
@@ -120,12 +120,28 @@ describe('CulturalSurveyQuestions page', () => {
     const GoBackButton = screen.getByTestId('Revenir en arrière')
     fireEvent.press(GoBackButton)
 
-    expect(dispatch).toHaveBeenCalledWith({
+    expect(dispatch).toHaveBeenNthCalledWith(1, {
       type: 'SET_ANSWERS',
       payload: {
         questionId: navigationProps.route.params.question,
         answers: [],
       },
+    })
+  })
+
+  it('should dispatch default questions on go back when current question is "sorties"', () => {
+    render(<CulturalSurveyQuestions {...navigationProps} />)
+
+    const GoBackButton = screen.getByTestId('Revenir en arrière')
+    fireEvent.press(GoBackButton)
+
+    expect(dispatch).toHaveBeenNthCalledWith(2, {
+      type: 'SET_QUESTIONS',
+      payload: [
+        CulturalSurveyQuestionEnum.SORTIES,
+        CulturalSurveyQuestionEnum.ACTIVITES,
+        CulturalSurveyQuestionEnum.PROJECTIONS,
+      ],
     })
   })
 

--- a/src/features/culturalSurvey/pages/CulturalSurveyQuestions.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyQuestions.tsx
@@ -155,6 +155,19 @@ export function CulturalSurveyQuestions({ route }: CulturalSurveyQuestionsProps)
         answers: [],
       },
     })
+
+    if (currentQuestion === CulturalSurveyQuestionEnum.SORTIES) {
+      const INITIAL_CULTURAL_SURVEY_QUESTIONS = [
+        CulturalSurveyQuestionEnum.SORTIES,
+        CulturalSurveyQuestionEnum.ACTIVITES,
+        CulturalSurveyQuestionEnum.PROJECTIONS,
+      ]
+
+      dispatch({
+        type: 'SET_QUESTIONS',
+        payload: INITIAL_CULTURAL_SURVEY_QUESTIONS,
+      })
+    }
   }
 
   function onScroll({ nativeEvent }: { nativeEvent: NativeScrollEvent }) {


### PR DESCRIPTION
…play

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32564

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
