### PR TITLE
(PC-32559) fix(EndedBookings): legacy endedBooking not working because of a refacto

### DIFF
--- a/src/features/bookings/components/OnGoingBookingsList.native.test.tsx
+++ b/src/features/bookings/components/OnGoingBookingsList.native.test.tsx
@@ -185,5 +185,5 @@ describe('<OnGoingBookingsList /> - Analytics', () => {
 })
 
 function renderOnGoingBookingsList() {
-  render(<OnGoingBookingsList enableBookingImprove={false} />)
+  render(<OnGoingBookingsList />)
 }

--- a/src/features/bookings/components/OnGoingBookingsList.tsx
+++ b/src/features/bookings/components/OnGoingBookingsList.tsx
@@ -7,6 +7,8 @@ import { EndedBookingsSection } from 'features/bookings/components/EndedBookings
 import { getEligibleBookingsForArchive } from 'features/bookings/helpers/expirationDateUtils'
 import { Booking } from 'features/bookings/types'
 import { analytics, isCloseToBottom } from 'libs/analytics'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import useFunctionOnce from 'libs/hooks/useFunctionOnce'
 import { useIsFalseWithDelay } from 'libs/hooks/useIsFalseWithDelay'
 import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
@@ -29,11 +31,8 @@ const emptyBookings: Booking[] = []
 
 const ANIMATION_DURATION = 700
 
-type Props = {
-  enableBookingImprove: boolean
-}
-
-export const OnGoingBookingsList: FunctionComponent<Props> = ({ enableBookingImprove }) => {
+export const OnGoingBookingsList: FunctionComponent = () => {
+  const enableBookingImprove = useFeatureFlag(RemoteStoreFeatureFlags.WIP_BOOKING_IMPROVE)
   const netInfo = useNetInfoContext()
   const { data: bookings, isLoading, isFetching, refetch } = useBookings()
   const { isLoading: subcategoriesIsLoading } = useSubcategories()

--- a/src/features/bookings/pages/Bookings/Bookings.tsx
+++ b/src/features/bookings/pages/Bookings/Bookings.tsx
@@ -62,10 +62,8 @@ export function Bookings() {
   )
 
   const tabPanels = {
-    [BookingsTab.CURRENT]: <OnGoingBookingsList enableBookingImprove={enableBookingImprove} />,
-    [BookingsTab.COMPLETED]: (
-      <EndedBookings enableBookingImprove={enableBookingImprove} bookings={bookings} />
-    ),
+    [BookingsTab.CURRENT]: <OnGoingBookingsList />,
+    [BookingsTab.COMPLETED]: <EndedBookings />,
   }
 
   const shouldDisplayPastille = enableReactionFeature && bookingsAwaitingReaction > 0
@@ -95,7 +93,7 @@ export function Bookings() {
       ) : (
         <Container>
           <PageHeader title="Mes réservations" />
-          <OnGoingBookingsList enableBookingImprove={enableBookingImprove} />
+          <OnGoingBookingsList />
         </Container>
       )}
     </React.Fragment>

--- a/src/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx
+++ b/src/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx
@@ -1,6 +1,8 @@
 import React, { Fragment, FunctionComponent } from 'react'
+import { QueryObserverResult } from 'react-query'
 
 import { BookingsResponse } from 'api/gen'
+import * as bookingsAPI from 'features/bookings/api/useBookings'
 import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import * as useGoBack from 'features/navigation/useGoBack'
 import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
@@ -53,21 +55,27 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const useBookingsSpy = jest.spyOn(bookingsAPI, 'useBookings')
+useBookingsSpy.mockReturnValue({
+  data: bookingsSnap,
+  isFetching: false,
+} as unknown as QueryObserverResult<BookingsResponse, unknown>)
+
 describe('EndedBookings', () => {
   it('should render correctly', () => {
-    renderEndedBookings(bookingsSnap)
+    renderEndedBookings()
 
     expect(screen).toMatchSnapshot()
   })
 
   it('should display the right number of ended bookings', () => {
-    renderEndedBookings(bookingsSnap)
+    renderEndedBookings()
 
     expect(screen.getByText('2 réservations terminées')).toBeOnTheScreen()
   })
 
   it('should goBack when we press on the back button', () => {
-    renderEndedBookings(bookingsSnap)
+    renderEndedBookings()
 
     fireEvent.press(screen.getByTestId('Revenir en arrière'))
 
@@ -80,7 +88,7 @@ describe('EndedBookings', () => {
     })
 
     it('should send reaction from cinema offer', async () => {
-      renderEndedBookings(bookingsSnap, RemoteConfigProvider)
+      renderEndedBookings(RemoteConfigProvider)
 
       fireEvent.press(await screen.findByLabelText('Réagis à ta réservation'))
 
@@ -94,13 +102,6 @@ describe('EndedBookings', () => {
   })
 })
 
-const renderEndedBookings = (
-  bookings: BookingsResponse,
-  Wrapper: FunctionComponent<{ children: JSX.Element }> = Fragment
-) => {
-  return render(
-    <Wrapper>
-      {reactQueryProviderHOC(<EndedBookings enableBookingImprove={false} bookings={bookings} />)}
-    </Wrapper>
-  )
+const renderEndedBookings = (Wrapper: FunctionComponent<{ children: JSX.Element }> = Fragment) => {
+  return render(<Wrapper>{reactQueryProviderHOC(<EndedBookings />)}</Wrapper>)
 }

--- a/src/features/bookings/pages/EndedBookings/EndedBookings.perf.test.tsx
+++ b/src/features/bookings/pages/EndedBookings/EndedBookings.perf.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
+import { QueryObserverResult } from 'react-query'
 
 import * as jwt from '__mocks__/jwt-decode'
 import { BookingsResponse, SubcategoriesResponseModelv2, UserProfileResponse } from 'api/gen'
 import { AuthWrapper } from 'features/auth/context/AuthWrapper'
+import * as bookingsAPI from 'features/bookings/api/useBookings'
 import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import { EndedBookings } from 'features/bookings/pages/EndedBookings/EndedBookings'
 import { beneficiaryUser } from 'fixtures/user'
@@ -35,6 +37,12 @@ jest.mock('libs/subcategories/useCategoryId')
 jest.mock('libs/network/NetInfoWrapper')
 jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
 
+const useBookingsSpy = jest.spyOn(bookingsAPI, 'useBookings')
+useBookingsSpy.mockReturnValue({
+  data: bookingsSnap,
+  isFetching: false,
+} as unknown as QueryObserverResult<BookingsResponse, unknown>)
+
 jest.useFakeTimers()
 
 describe('<EndedBookings />', () => {
@@ -50,7 +58,7 @@ describe('<EndedBookings />', () => {
     await measurePerformance(
       reactQueryProviderHOC(
         <AuthWrapper>
-          <EndedBookings enableBookingImprove={false} bookings={bookingsSnap} />
+          <EndedBookings />
         </AuthWrapper>
       ),
       {

--- a/src/features/bookings/pages/EndedBookings/EndedBookings.perf.test.tsx
+++ b/src/features/bookings/pages/EndedBookings/EndedBookings.perf.test.tsx
@@ -1,10 +1,8 @@
 import React from 'react'
-import { QueryObserverResult } from 'react-query'
 
 import * as jwt from '__mocks__/jwt-decode'
 import { BookingsResponse, SubcategoriesResponseModelv2, UserProfileResponse } from 'api/gen'
 import { AuthWrapper } from 'features/auth/context/AuthWrapper'
-import * as bookingsAPI from 'features/bookings/api/useBookings'
 import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import { EndedBookings } from 'features/bookings/pages/EndedBookings/EndedBookings'
 import { beneficiaryUser } from 'fixtures/user'
@@ -36,12 +34,6 @@ jest.mock('features/favorites/context/FavoritesWrapper')
 jest.mock('libs/subcategories/useCategoryId')
 jest.mock('libs/network/NetInfoWrapper')
 jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
-
-const useBookingsSpy = jest.spyOn(bookingsAPI, 'useBookings')
-useBookingsSpy.mockReturnValue({
-  data: bookingsSnap,
-  isFetching: false,
-} as unknown as QueryObserverResult<BookingsResponse, unknown>)
 
 jest.useFakeTimers()
 

--- a/src/features/bookings/pages/EndedBookings/EndedBookings.tsx
+++ b/src/features/bookings/pages/EndedBookings/EndedBookings.tsx
@@ -2,13 +2,16 @@ import React, { FunctionComponent, useCallback } from 'react'
 import { FlatList, ListRenderItem } from 'react-native'
 import styled from 'styled-components/native'
 
-import { BookingsResponse, PostOneReactionRequest, PostReactionRequest } from 'api/gen'
+import { PostOneReactionRequest, PostReactionRequest } from 'api/gen'
+import { useBookings } from 'features/bookings/api'
 import { EndedBookingItem } from 'features/bookings/components/EndedBookingItem'
 import { NoBookingsView } from 'features/bookings/components/NoBookingsView'
 import { Booking } from 'features/bookings/types'
 import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { useReactionMutation } from 'features/reactions/api/useReactionMutation'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { plural } from 'libs/plural'
 import { BlurHeader } from 'ui/components/headers/BlurHeader'
 import {
@@ -22,12 +25,9 @@ import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 const keyExtractor: (item: Booking) => string = (item) => item.id.toString()
 
-type Props = {
-  enableBookingImprove: boolean
-  bookings: BookingsResponse | undefined
-}
-
-export const EndedBookings: FunctionComponent<Props> = ({ enableBookingImprove, bookings }) => {
+export const EndedBookings: FunctionComponent = () => {
+  const enableBookingImprove = useFeatureFlag(RemoteStoreFeatureFlags.WIP_BOOKING_IMPROVE)
+  const { data: bookings } = useBookings()
   const { goBack } = useGoBack(...getTabNavConfig('Bookings'))
   const headerHeight = useGetHeaderHeight()
   const { mutate: addReaction } = useReactionMutation()

--- a/src/features/bookings/pages/EndedBookings/EndedBookings.web.test.tsx
+++ b/src/features/bookings/pages/EndedBookings/EndedBookings.web.test.tsx
@@ -45,7 +45,5 @@ const renderEndedBookings = (bookings: BookingsResponse) => {
     .spyOn(bookingsAPI, 'useBookings')
     .mockReturnValue({ data: bookings } as QueryObserverResult<BookingsResponse, unknown>)
 
-  return render(
-    reactQueryProviderHOC(<EndedBookings enableBookingImprove={false} bookings={bookingsSnap} />)
-  )
+  return render(reactQueryProviderHOC(<EndedBookings />))
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32559

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
