### PR TITLE
(BSR) docs(test): userEvent using in native tests

### DIFF
--- a/doc/development/tests/unit-test/component-test.md
+++ b/doc/development/tests/unit-test/component-test.md
@@ -9,11 +9,13 @@ Some examples
 ```jsx
 import { render, screen } from 'tests/utils'
 
+jest.useFakeTimers()
 it('should navigate to the previous when back navigation triggered', () => {
   render(<SetBirthday />)
 
   const leftIcon = screen.getByLabelText('Revenir en arrière')
-  fireEvent.press(leftIcon)
+  const user = userEvent.setup()
+  await user.press(leftIcon)
 
   expect(goBack).toHaveBeenCalledTimes(1)
 })
@@ -22,16 +24,16 @@ it('should navigate to the previous when back navigation triggered', () => {
 ```jsx
 import { render, screen } from 'tests/utils'
 
+jest.useFakeTimers()
 it('should redirect to home page when signin is successful', async () => {
   render(<Login />)
   mockSignIn.mockReturnValueOnce(true)
 
   const connexionButton = await screen.findByText('Se connecter')
-  fireEvent.press(connexionButton)
+  const user = userEvent.setup()
+  await user.press(connexionButton)
 
-  await waitFor(() => {
-    expect(navigate).toHaveBeenCalledTimes(1)
-  })
+  expect(navigate).toHaveBeenCalledTimes(1)
 })
 ```
 
@@ -48,25 +50,3 @@ How to do it?
 
 - When a component is created to be used in several places and when it contains logic, it is better to test it in its own file, and (when necessary) mock it in the files where it is called
 - When refactoring, when you extract a component to put it in its own file, it is better to accompany it with its own test file to test its own responsibility
-
----
-
-## How to use act(...)
-
-Overall, you should try to use it as little as possible because it often hides important information, like promise resolutions.
-
-You should definitely not use it around a fireEvent or render because it's useless, they are already wrapped in their operation.
-
-We can use it to test our hooks
-
-```jsx
-const { result } = renderHook(() => useCount())
-
-act(() => result.current.incrementCount())
-
-expect(result.current.count).toBe(1)
-```
-
-It can be used when using fake timers
-
-More details on the use of act [here](https://www.notion.so/passcultureapp/Comment-retirer-les-erreurs-act-de-nos-tests-150b31296d4d4770a74b4f9f340402fd)

--- a/doc/development/tests/unit-test/general-guidelines.md
+++ b/doc/development/tests/unit-test/general-guidelines.md
@@ -17,6 +17,25 @@ use `MyComponent.native.test.tsx` either if
 
 - the logic is shared between web and native
 - there is a file `MyComponent.native.tsx.`
+  -> in that case, you should use userEvent instead of fireEvent in case of pressing
+
+Example with userEvent :
+
+```tsx
+jest.useFakeTimers()
+it('should navigate to ended bookings page on press ended bookings CTA', async () => {
+  renderBookings()
+
+  const cta = await screen.findByText('Réservations terminées')
+
+  const user = userEvent.setup()
+  await user.press(cta)
+
+  expect(navigate).toHaveBeenCalledWith('EndedBookings', undefined)
+})
+```
+
+If you don't use `jest.useFakeTimers()` you have this error : `It is recommended to use userEvent with fake timers\nSome events involve duration so your tests may take a long time to run.\nFor instance calling userEvent.longPress with real timers will take 500 ms.`
 
 use `MyComponent.web.test.tsx` either if
 


### PR DESCRIPTION
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
