### PR TITLE
(BSR) chore(tests): Isolate Favorites a11y tests in separate files

### DIFF
--- a/__snapshots__/features/venue/pages/Venue/Venue.web.test.tsx.web-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.web.test.tsx.web-snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Venue /> Accessibility should render correctly 1`] = `
+exports[`<Venue /> should render correctly 1`] = `
 .c0 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
@@ -2149,7 +2149,7 @@ d’options
 </div>
 `;
 
-exports[`<Venue /> Accessibility should render correctly with practical information 1`] = `
+exports[`<Venue /> should render correctly with practical information 1`] = `
 .c0 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;

--- a/doc/development/tests/unit-test/full-page-test.md
+++ b/doc/development/tests/unit-test/full-page-test.md
@@ -127,3 +127,10 @@ Then we no longer ran into the "Exceeded timeout" error in the CI.
 Accessibility tests are heavy tests and sometimes, in the CI were performances and not the highest, they take extra time to finish, sometimes running into the maximum timeout.
 
 By putting each accessibility test in its own file, each test will have its own timeout counter, thus is less likely to trigger the timeout.
+
+I was able to reproduce CI flakiness locally by:
+
+- Starting all the native unit tests in a terminal: `yarn test:unit -u`
+- In another terminal, run several suites of tests: `yarn test:unit:web Venue -u`
+- Out of my 5 runs that I attempted for the `Venue` tests, at least 1 test would fail that wouldn't fail otherwise (if all the native unit tests hadn't been running in another terminal).
+- But I believe that this reproduction scenario is not ideal because: you can force the tests to fail, but then when separating the accessibility tests in isolated files which fixes CI flakiness, the tests still fail locally under these conditions.

--- a/doc/development/tests/unit-test/full-page-test.md
+++ b/doc/development/tests/unit-test/full-page-test.md
@@ -102,3 +102,28 @@ jest.mock('uuid', () => {
   }
 })
 ```
+
+### Exceeded timeout of 15000 ms for a test
+
+If you get failing accessibility tests in the CI with the following message:
+
+```
+thrown: "Exceeded timeout of 15000 ms for a test.
+Add a timeout value to this test to increase the timeout, if this is a long-running test.
+```
+
+A quick fix is to isolate the test in it's own file.
+
+For example, previously inside `Favorites.web.test.tsx` there were 3 different accessibility tests. We separated the tests into 3 different files:
+
+```
+- Favorites.accessibility.offline.web.test.tsx
+- Favorites.accessibility.loggedIn.web.test.tsx
+- Favorites.accessibility.loggedOut.web.test.tsx
+```
+
+Then we no longer ran into the "Exceeded timeout" error in the CI.
+
+Accessibility tests are heavy tests and sometimes, in the CI were performances and not the highest, they take extra time to finish, sometimes running into the maximum timeout.
+
+By putting each accessibility test in its own file, each test will have its own timeout counter, thus is less likely to trigger the timeout.

--- a/src/features/favorites/pages/Favorites.accessibility.loggedIn.web.test.tsx
+++ b/src/features/favorites/pages/Favorites.accessibility.loggedIn.web.test.tsx
@@ -20,6 +20,7 @@ jest.mock('features/favorites/context/FavoritesWrapper', () => ({
 }))
 
 jest.mock('libs/firebase/analytics/analytics')
+
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 
 jest.mock('react-native-safe-area-context', () => ({

--- a/src/features/favorites/pages/Favorites.accessibility.loggedIn.web.test.tsx
+++ b/src/features/favorites/pages/Favorites.accessibility.loggedIn.web.test.tsx
@@ -4,7 +4,6 @@ import { PaginatedFavoritesResponse } from 'api/gen'
 import { initialFavoritesState as mockInitialFavoritesState } from 'features/favorites/context/reducer'
 import { paginatedFavoritesResponseSnap } from 'features/favorites/fixtures/paginatedFavoritesResponseSnap'
 import * as useNetInfoContextDefault from 'libs/network/NetInfoWrapper'
-import { mockAuthContextWithoutUser } from 'tests/AuthContextUtils'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, checkAccessibilityFor, render } from 'tests/utils/web'
@@ -20,8 +19,6 @@ jest.mock('features/favorites/context/FavoritesWrapper', () => ({
   }),
 }))
 
-jest.mock('features/auth/context/AuthContext')
-
 jest.mock('libs/firebase/analytics/analytics')
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 
@@ -32,12 +29,8 @@ jest.mock('react-native-safe-area-context', () => ({
 
 describe('<Favorites/>', () => {
   describe('Accessibility', () => {
-    beforeEach(() => {
-      mockUseNetInfoContext.mockReturnValue({ isConnected: true })
-    })
-
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('should not have basic accessibility issues when user is logged in', async () => {
+    it('should not have basic accessibility issues when user is logged in', async () => {
+      mockUseNetInfoContext.mockReturnValueOnce({ isConnected: true })
       mockServer.getApi<PaginatedFavoritesResponse>(
         '/v1/me/favorites',
         paginatedFavoritesResponseSnap
@@ -50,25 +43,6 @@ describe('<Favorites/>', () => {
 
         expect(results).toHaveNoViolations()
       })
-    })
-
-    it('should not have basic accessibility issues when user is not logged in', async () => {
-      mockAuthContextWithoutUser()
-
-      const { container } = renderFavorites()
-
-      const results = await checkAccessibilityFor(container)
-
-      expect(results).toHaveNoViolations()
-    })
-
-    it('should not have basic accessibility issues when user is logged in but offline', async () => {
-      mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false })
-      const { container } = renderFavorites()
-
-      const results = await checkAccessibilityFor(container)
-
-      expect(results).toHaveNoViolations()
     })
   })
 })

--- a/src/features/favorites/pages/Favorites.accessibility.loggedOut.web.test.tsx
+++ b/src/features/favorites/pages/Favorites.accessibility.loggedOut.web.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+import { initialFavoritesState as mockInitialFavoritesState } from 'features/favorites/context/reducer'
+import { mockAuthContextWithoutUser } from 'tests/AuthContextUtils'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { checkAccessibilityFor, render } from 'tests/utils/web'
+
+import { Favorites } from './Favorites'
+
+jest.mock('features/favorites/context/FavoritesWrapper', () => ({
+  useFavoritesState: () => ({
+    ...mockInitialFavoritesState,
+    dispatch: jest.fn(),
+  }),
+}))
+
+jest.mock('features/auth/context/AuthContext')
+
+jest.mock('libs/firebase/analytics/analytics')
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
+
+jest.mock('react-native-safe-area-context', () => ({
+  ...(jest.requireActual('react-native-safe-area-context') as Record<string, unknown>),
+  useSafeAreaInsets: () => ({ bottom: 16, right: 16, left: 16, top: 16 }),
+}))
+
+describe('<Favorites/>', () => {
+  describe('Accessibility', () => {
+    it('should not have basic accessibility issues when user is not logged in', async () => {
+      mockAuthContextWithoutUser()
+
+      const { container } = renderFavorites()
+
+      const results = await checkAccessibilityFor(container)
+
+      expect(results).toHaveNoViolations()
+    })
+  })
+})
+
+function renderFavorites() {
+  return render(reactQueryProviderHOC(<Favorites />))
+}

--- a/src/features/favorites/pages/Favorites.accessibility.loggedOut.web.test.tsx
+++ b/src/features/favorites/pages/Favorites.accessibility.loggedOut.web.test.tsx
@@ -17,6 +17,7 @@ jest.mock('features/favorites/context/FavoritesWrapper', () => ({
 jest.mock('features/auth/context/AuthContext')
 
 jest.mock('libs/firebase/analytics/analytics')
+
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 
 jest.mock('react-native-safe-area-context', () => ({

--- a/src/features/favorites/pages/Favorites.accessibility.offline.web.test.tsx
+++ b/src/features/favorites/pages/Favorites.accessibility.offline.web.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+
+import { initialFavoritesState as mockInitialFavoritesState } from 'features/favorites/context/reducer'
+import * as useNetInfoContextDefault from 'libs/network/NetInfoWrapper'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { checkAccessibilityFor, render } from 'tests/utils/web'
+
+import { Favorites } from './Favorites'
+
+const mockUseNetInfoContext = jest.spyOn(useNetInfoContextDefault, 'useNetInfoContext') as jest.Mock
+
+jest.mock('features/favorites/context/FavoritesWrapper', () => ({
+  useFavoritesState: () => ({
+    ...mockInitialFavoritesState,
+    dispatch: jest.fn(),
+  }),
+}))
+
+jest.mock('libs/firebase/analytics/analytics')
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
+
+jest.mock('react-native-safe-area-context', () => ({
+  ...(jest.requireActual('react-native-safe-area-context') as Record<string, unknown>),
+  useSafeAreaInsets: () => ({ bottom: 16, right: 16, left: 16, top: 16 }),
+}))
+
+describe('<Favorites/>', () => {
+  describe('Accessibility', () => {
+    it('should not have basic accessibility issues when user is logged in but offline', async () => {
+      mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false })
+      const { container } = renderFavorites()
+
+      const results = await checkAccessibilityFor(container)
+
+      expect(results).toHaveNoViolations()
+    })
+  })
+})
+
+function renderFavorites() {
+  return render(reactQueryProviderHOC(<Favorites />))
+}

--- a/src/features/favorites/pages/Favorites.accessibility.offline.web.test.tsx
+++ b/src/features/favorites/pages/Favorites.accessibility.offline.web.test.tsx
@@ -17,6 +17,7 @@ jest.mock('features/favorites/context/FavoritesWrapper', () => ({
 }))
 
 jest.mock('libs/firebase/analytics/analytics')
+
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 
 jest.mock('react-native-safe-area-context', () => ({

--- a/src/features/offer/pages/Offer/Offer.web.test.tsx
+++ b/src/features/offer/pages/Offer/Offer.web.test.tsx
@@ -9,6 +9,8 @@ import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, checkAccessibilityFor, render } from 'tests/utils/web'
 
+jest.setTimeout(50000) // to avoid "Exceeded timeout of 10000 ms for a test"
+
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 
 jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true)

--- a/src/features/search/pages/SearchLanding/SearchLanding.accessibility.offline.web.test.tsx
+++ b/src/features/search/pages/SearchLanding/SearchLanding.accessibility.offline.web.test.tsx
@@ -82,8 +82,8 @@ jest.mock('uuid', () => ({
 
 jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true)
 
-jest.mock('libs/firebase/analytics/analytics')
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
+jest.mock('libs/firebase/analytics/analytics')
 jest.mock('features/navigation/TabBar/routes')
 jest.mock('ui/theme/customFocusOutline/customFocusOutline')
 

--- a/src/features/search/pages/SearchLanding/SearchLanding.accessibility.offline.web.test.tsx
+++ b/src/features/search/pages/SearchLanding/SearchLanding.accessibility.offline.web.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react'
+
+import { SearchGroupNameEnumv2, SubcategoriesResponseModelv2 } from 'api/gen'
+import { initialSearchState } from 'features/search/context/reducer'
+import * as useFilterCountAPI from 'features/search/helpers/useFilterCount/useFilterCount'
+import { SearchLanding } from 'features/search/pages/SearchLanding/SearchLanding'
+import { SearchState } from 'features/search/types'
+import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import * as useNetInfoContextDefault from 'libs/network/NetInfoWrapper'
+import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
+import { mockedSuggestedVenue } from 'libs/venue/fixtures/mockedSuggestedVenues'
+import { mockServer } from 'tests/mswServer'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { checkAccessibilityFor, render, screen } from 'tests/utils/web'
+
+jest.mock('libs/network/NetInfoWrapper')
+
+const venue = mockedSuggestedVenue
+
+const mockSearchState: SearchState = {
+  ...initialSearchState,
+  offerCategories: [SearchGroupNameEnumv2.CINEMA],
+  venue,
+  priceRange: [0, 20],
+}
+
+jest.mock('features/search/context/SearchWrapper', () => ({
+  useSearch: () => ({ searchState: mockSearchState, dispatch: jest.fn() }),
+}))
+
+jest.mock('features/auth/context/AuthContext')
+
+jest.mock('features/search/api/useSearchResults/useSearchResults', () => ({
+  useSearchResults: () => ({
+    data: { pages: [{ nbHits: 0, hits: [], page: 0 }] },
+    hits: [],
+    nbHits: 0,
+    isFetching: false,
+    isLoading: false,
+    hasNextPage: true,
+    fetchNextPage: jest.fn(),
+    isFetchingNextPage: false,
+  }),
+}))
+
+const mockUseNetInfoContext = jest.spyOn(useNetInfoContextDefault, 'useNetInfoContext') as jest.Mock
+
+const mockSettings = jest.fn().mockReturnValue({ data: {} })
+jest.mock('features/auth/context/SettingsContext', () => ({
+  useSettingsContext: jest.fn(() => mockSettings()),
+}))
+
+jest.mock('react-instantsearch-core', () => ({
+  ...jest.requireActual('react-instantsearch-core'),
+  useSearchBox: () => ({
+    query: '',
+    refine: jest.fn,
+  }),
+  useInfiniteHits: () => ({
+    hits: [
+      {
+        objectID: '1',
+        offer: { name: 'Test1', searchGroupName: 'MUSIQUE' },
+        _geoloc: {},
+      },
+      {
+        objectID: '2',
+        offer: { name: 'Test2', searchGroupName: 'MUSIQUE' },
+        _geoloc: {},
+      },
+    ],
+  }),
+}))
+
+jest.spyOn(useFilterCountAPI, 'useFilterCount').mockReturnValue(3)
+jest.mock('algoliasearch')
+
+jest.mock('uuid', () => ({
+  v1: jest.fn(),
+  v4: jest.fn(),
+}))
+
+jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true)
+
+jest.mock('libs/firebase/analytics/analytics')
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
+jest.mock('features/navigation/TabBar/routes')
+jest.mock('ui/theme/customFocusOutline/customFocusOutline')
+
+jest.mock('react-native-safe-area-context', () => ({
+  ...(jest.requireActual('react-native-safe-area-context') as Record<string, unknown>),
+  useSafeAreaInsets: () => ({ bottom: 16, right: 16, left: 16, top: 16 }),
+}))
+
+describe('<SearchLanding />', () => {
+  describe('Accessibility', () => {
+    beforeEach(() => {
+      mockServer.getApi<SubcategoriesResponseModelv2>('/v1/subcategories/v2', subcategoriesDataTest)
+    })
+
+    it('should not have basic accessibility issues when offline', async () => {
+      mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false })
+
+      const { container } = render(reactQueryProviderHOC(<SearchLanding />))
+
+      await screen.findByText('Rechercher')
+
+      const results = await checkAccessibilityFor(container)
+
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/src/features/search/pages/SearchLanding/SearchLanding.accessibility.offline.web.test.tsx
+++ b/src/features/search/pages/SearchLanding/SearchLanding.accessibility.offline.web.test.tsx
@@ -82,8 +82,8 @@ jest.mock('uuid', () => ({
 
 jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true)
 
-jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 jest.mock('libs/firebase/analytics/analytics')
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 jest.mock('features/navigation/TabBar/routes')
 jest.mock('ui/theme/customFocusOutline/customFocusOutline')
 

--- a/src/features/search/pages/SearchLanding/SearchLanding.accessibility.online.web.test.tsx
+++ b/src/features/search/pages/SearchLanding/SearchLanding.accessibility.online.web.test.tsx
@@ -98,20 +98,8 @@ describe('<SearchLanding />', () => {
       mockServer.getApi<SubcategoriesResponseModelv2>('/v1/subcategories/v2', subcategoriesDataTest)
     })
 
-    it('should not have basic accessibility issues', async () => {
+    it('should not have basic accessibility issues when online', async () => {
       mockUseNetInfoContext.mockReturnValueOnce({ isConnected: true })
-
-      const { container } = render(reactQueryProviderHOC(<SearchLanding />))
-
-      await screen.findByText('Rechercher')
-
-      const results = await checkAccessibilityFor(container)
-
-      expect(results).toHaveNoViolations()
-    })
-
-    it('should not have basic accessibility issues when offline', async () => {
-      mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false })
 
       const { container } = render(reactQueryProviderHOC(<SearchLanding />))
 

--- a/src/features/search/pages/SearchLanding/SearchLanding.accessibility.online.web.test.tsx
+++ b/src/features/search/pages/SearchLanding/SearchLanding.accessibility.online.web.test.tsx
@@ -82,8 +82,8 @@ jest.mock('uuid', () => ({
 
 jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true)
 
-jest.mock('libs/firebase/analytics/analytics')
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
+jest.mock('libs/firebase/analytics/analytics')
 jest.mock('features/navigation/TabBar/routes')
 jest.mock('ui/theme/customFocusOutline/customFocusOutline')
 

--- a/src/features/search/pages/SearchLanding/SearchLanding.accessibility.online.web.test.tsx
+++ b/src/features/search/pages/SearchLanding/SearchLanding.accessibility.online.web.test.tsx
@@ -82,8 +82,8 @@ jest.mock('uuid', () => ({
 
 jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true)
 
-jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 jest.mock('libs/firebase/analytics/analytics')
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 jest.mock('features/navigation/TabBar/routes')
 jest.mock('ui/theme/customFocusOutline/customFocusOutline')
 

--- a/src/features/search/pages/SearchLanding/SearchLanding.web.test.tsx
+++ b/src/features/search/pages/SearchLanding/SearchLanding.web.test.tsx
@@ -98,8 +98,7 @@ describe('<SearchLanding />', () => {
       mockServer.getApi<SubcategoriesResponseModelv2>('/v1/subcategories/v2', subcategoriesDataTest)
     })
 
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('should not have basic accessibility issues', async () => {
+    it('should not have basic accessibility issues', async () => {
       mockUseNetInfoContext.mockReturnValueOnce({ isConnected: true })
 
       const { container } = render(reactQueryProviderHOC(<SearchLanding />))
@@ -111,8 +110,7 @@ describe('<SearchLanding />', () => {
       expect(results).toHaveNoViolations()
     })
 
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('should not have basic accessibility issues when offline', async () => {
+    it('should not have basic accessibility issues when offline', async () => {
       mockUseNetInfoContext.mockReturnValueOnce({ isConnected: false })
 
       const { container } = render(reactQueryProviderHOC(<SearchLanding />))

--- a/src/features/venue/pages/Venue/Venue.web.test.tsx
+++ b/src/features/venue/pages/Venue/Venue.web.test.tsx
@@ -96,8 +96,7 @@ describe('<Venue />', () => {
     mockServer.getApi<SubcategoriesResponseModelv2>('/v1/subcategories/v2', subcategoriesDataTest)
   })
 
-  // eslint-disable-next-line jest/no-disabled-tests
-  describe.skip('Accessibility', () => {
+  describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       const { container } = render(reactQueryProviderHOC(<Venue />))
 


### PR DESCRIPTION
We have a11y tests that timeout often and make our CI fail.
This is attempt of fixing that by running Accessibility Tests Separately: 
Isolate these tests in their own test suite so that long-running accessibility checks don’t impact the overall test suite's timing.

I ran the CI 10 times on the branch to make sure the flakiness was fixed:
<img width="1239" alt="image" src="https://github.com/user-attachments/assets/0174d520-985a-4b8d-af45-3ad909b8ea50">
