### PR TITLE
(PC-32738) fix(venueMap): fix cluster confusion between cultural center and distribution store

### DIFF
--- a/src/features/venueMap/helpers/venueMapCluster/getClusterColorByDominantVenueType.test.ts
+++ b/src/features/venueMap/helpers/venueMapCluster/getClusterColorByDominantVenueType.test.ts
@@ -28,7 +28,7 @@ describe('getClusterColorByDominantVenueType', () => {
   it('should return the color upon venue type occurences (blue)', () => {
     const types: VenueTypeCode[] = [
       VenueTypeCodeKey.PATRIMONY_TOURISM,
-      VenueTypeCodeKey.DISTRIBUTION_STORE,
+      VenueTypeCodeKey.CULTURAL_CENTRE,
       VenueTypeCodeKey.OTHER,
     ]
 
@@ -39,7 +39,7 @@ describe('getClusterColorByDominantVenueType', () => {
     const types: VenueTypeCode[] = [
       VenueTypeCodeKey.BOOKSTORE,
       VenueTypeCodeKey.CREATIVE_ARTS_STORE,
-      VenueTypeCodeKey.CULTURAL_CENTRE,
+      VenueTypeCodeKey.DISTRIBUTION_STORE,
     ]
 
     expect(getClusterColorByDominantVenueType(types)).toBe('pink')
@@ -50,7 +50,7 @@ describe('getClusterColorByDominantVenueType', () => {
       VenueTypeCodeKey.GAMES,
       VenueTypeCodeKey.BOOKSTORE,
       VenueTypeCodeKey.CREATIVE_ARTS_STORE,
-      VenueTypeCodeKey.CULTURAL_CENTRE,
+      VenueTypeCodeKey.DISTRIBUTION_STORE,
     ]
 
     expect(getClusterColorByDominantVenueType(types)).toBe('orange_pink')

--- a/src/features/venueMap/helpers/venueMapCluster/getClusterColorByDominantVenueType.ts
+++ b/src/features/venueMap/helpers/venueMapCluster/getClusterColorByDominantVenueType.ts
@@ -17,9 +17,9 @@ const getClusterColorFromVenueType = (venueType?: VenueTypeCode): ClusterImageCo
       return CLUSTER_IMAGE_COLOR_NAME.ORANGE
     case VenueTypeCodeKey.BOOKSTORE:
     case VenueTypeCodeKey.CREATIVE_ARTS_STORE:
-    case VenueTypeCodeKey.CULTURAL_CENTRE:
     case VenueTypeCodeKey.MUSICAL_INSTRUMENT_STORE:
     case VenueTypeCodeKey.RECORD_STORE:
+    case VenueTypeCodeKey.DISTRIBUTION_STORE:
       return CLUSTER_IMAGE_COLOR_NAME.PINK
     default:
       return CLUSTER_IMAGE_COLOR_NAME.BLUE


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32738

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |![Capture d’écran 2024-10-29 à 17 38 46](https://github.com/user-attachments/assets/2ee0ef1c-72d7-4eda-b84d-7629fb9803d8) ![Capture d’écran 2024-10-29 à 17 38 52](https://github.com/user-attachments/assets/4ba722af-aa73-488c-8323-6b9dda12320e)|![Capture d’écran 2024-10-29 à 17 39 39](https://github.com/user-attachments/assets/ecac23e1-d678-4524-923b-904e1c4aa199) ![Capture d’écran 2024-10-29 à 17 38 52](https://github.com/user-attachments/assets/4060326c-2591-409c-8266-ae2c78a55a2b)|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
