### PR TITLE
(PC-32617) feat(venueMap): navigate to venue page when fling on bottom-sheet

### DIFF
--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -189,9 +189,9 @@ jest.mock('@batch.com/react-native-plugin', () =>
 )
 
 jest.mock('@gorhom/bottom-sheet', () => {
-  const ActualBottomSheet = jest.requireActual('@gorhom/bottom-sheet/mock').default
+  const { View } = jest.requireActual('react-native')
 
-  class MockBottomSheet extends ActualBottomSheet {
+  class MockBottomSheet extends View {
     close() {
       this.props.onAnimate(0, -1)
     }

--- a/src/libs/firebase/firestore/types.ts
+++ b/src/libs/firebase/firestore/types.ts
@@ -71,6 +71,7 @@ export enum RemoteStoreFeatureFlags {
   WIP_SEARCH_N1_FILMS_DOCUMENTAIRES_ET_SERIES = 'wipSearchN1FilmsDocumentairesEtSeries',
   WIP_STEPPER_RETRY_UBBLE = 'wipStepperRetryUbble',
   WIP_VENUE_MAP = 'wipVenueMap',
+  WIP_FLING_BOTTOM_SHEET_NAVIGATE_TO_VENUE = 'wipFlingBottomSheetNavigateToVenue',
   WIP_VENUE_MAP_HIDDEN_POI = 'wipVenueMapHiddenPOI',
   WIP_VENUE_MAP_IN_SEARCH = 'wipVenueMapInSearch',
   WIP_VENUE_MAP_PIN_V2 = 'wipVenueMapPinV2',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32617

Navigation vers la page du lieu sélectionné quand on force le swipe vers le haut sur la bottom-sheet dans la carte

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

iOS

https://github.com/user-attachments/assets/bc7ae1b4-495f-4371-8ca8-717d0aae3d8e

Android


https://github.com/user-attachments/assets/0451334b-77ad-4a83-af3f-799bef047d4b




[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
