### PR TITLE
(PC-32744) fix(ThematicHome): selectedLocationMode is Everywhere when app is first oppened

### DIFF
--- a/src/features/home/pages/ThematicHome.native.test.tsx
+++ b/src/features/home/pages/ThematicHome.native.test.tsx
@@ -293,6 +293,7 @@ describe('ThematicHome', () => {
       ${true}           | ${'deeplink'}       | ${LocationMode.EVERYWHERE}   | ${LocationMode.AROUND_ME}
       ${true}           | ${'deeplink'}       | ${LocationMode.AROUND_PLACE} | ${LocationMode.AROUND_ME}
       ${true}           | ${'category_block'} | ${LocationMode.AROUND_ME}    | ${LocationMode.AROUND_ME}
+      ${true}           | ${'category_block'} | ${LocationMode.EVERYWHERE}   | ${LocationMode.AROUND_ME}
       ${false}          | ${'deeplink'}       | ${LocationMode.EVERYWHERE}   | ${LocationMode.EVERYWHERE}
       ${false}          | ${'category_block'} | ${LocationMode.EVERYWHERE}   | ${LocationMode.EVERYWHERE}
       ${false}          | ${'deeplink'}       | ${LocationMode.AROUND_PLACE} | ${LocationMode.AROUND_PLACE}

--- a/src/features/home/pages/ThematicHome.tsx
+++ b/src/features/home/pages/ThematicHome.tsx
@@ -148,7 +148,7 @@ export const ThematicHome: FunctionComponent = () => {
       case selectedLocationMode === LocationMode.AROUND_PLACE:
         setSelectedLocationMode(LocationMode.AROUND_PLACE)
         break
-      case selectedLocationMode === LocationMode.AROUND_ME:
+      case selectedLocationMode === LocationMode.AROUND_ME || hasGeolocPosition:
         setSelectedLocationMode(LocationMode.AROUND_ME)
         break
       default:


### PR DESCRIPTION

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32744

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
