### PR TITLE
(PC-32705) feat(NC): add no-currency-symbols eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,17 +32,18 @@ module.exports = {
   rules: {
     'react/no-unused-prop-types': 'off', // has false positives
     'react/no-unstable-nested-components': 'off', // TODO(PC-25291): enable when its issues are fixed
-    'local-rules/independent-mocks': ['error'],
+    'local-rules/independent-mocks': 'error',
     'local-rules/no-empty-arrow-function': 'off',
-    'local-rules/no-hardcoded-id-in-svg': ['error'],
-    'local-rules/no-raw-text': ['error'],
-    'local-rules/use-ternary-operator-in-jsx': ['error'],
-    'local-rules/nbsp-in-text': ['error'],
-    'local-rules/apostrophe-in-text': ['error'],
-    'local-rules/no-truthy-check-after-queryAll-matchers': ['error'],
-    'local-rules/todo-format': ['error'],
-    'local-rules/use-the-right-test-utils': ['error'],
-    'local-rules/no-use-of-algolia-multiple-queries': ['error'],
+    'local-rules/no-hardcoded-id-in-svg': 'error',
+    'local-rules/no-raw-text': 'error',
+    'local-rules/use-ternary-operator-in-jsx': 'error',
+    'local-rules/nbsp-in-text': 'error',
+    'local-rules/apostrophe-in-text': 'error',
+    'local-rules/no-truthy-check-after-queryAll-matchers': 'error',
+    'local-rules/todo-format': 'error',
+    'local-rules/use-the-right-test-utils': 'error',
+    'local-rules/no-use-of-algolia-multiple-queries': 'error',
+    'local-rules/no-currency-symbols': 'off', // TODO(LucasBeneston): enable when all currency symbols will be dynamic
     'no-negated-condition': 'warn',
     '@typescript-eslint/switch-exhaustiveness-check': 'error',
     '@typescript-eslint/ban-ts-comment': [
@@ -359,8 +360,13 @@ module.exports = {
     },
   ],
 
-  // Test overrides
   overrides: [
+    // Stories overrides
+    {
+      files: ['**/*.stories.tsx'],
+      rules: { 'local-rules/no-currency-symbols': 'off' },
+    },
+    // Tests overrides
     {
       files: ['**/*.test.ts', '**/*.test.tsx', '__mocks__'],
       env: { jest: true },
@@ -368,6 +374,7 @@ module.exports = {
       rules: {
         '@typescript-eslint/no-empty-function': 'off',
         'local-rules/nbsp-in-text': 'off',
+        'local-rules/no-currency-symbols': 'off',
         'local-rules/no-empty-arrow-function': 'error',
         'react/jsx-no-constructed-context-values': 'off',
         'jest/prefer-called-with': 'warn',

--- a/eslint-custom-rules/no-currency-symbols.js
+++ b/eslint-custom-rules/no-currency-symbols.js
@@ -1,0 +1,40 @@
+module.exports = {
+  name: 'no-currency-symbols',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow the use of the euro symbol (€) and pacific franc symbol (CFP)',
+      recommended: false,
+    },
+    messages: {
+      euroSymbol: 'Usage of the euro symbol (€) is not allowed.',
+      pacificFrancSymbol: 'Usage of the pacific franc symbol (CFP) is not allowed.',
+    },
+  },
+  create(context) {
+    function checkForSymbols(node, value) {
+      if (value.includes('€')) {
+        context.report({ node, messageId: 'euroSymbol' })
+      }
+      if (value.includes('CFP')) {
+        context.report({ node, messageId: 'pacificFrancSymbol' })
+      }
+    }
+
+    return {
+      Literal(node) {
+        if (typeof node.value === 'string') {
+          checkForSymbols(node, node.value)
+        }
+      },
+      JSXText(node) {
+        checkForSymbols(node, node.value)
+      },
+      TemplateLiteral(node) {
+        node.quasis.forEach((templateElement) => {
+          checkForSymbols(templateElement, templateElement.value.cooked || '')
+        })
+      },
+    }
+  },
+}

--- a/eslint-custom-rules/no-currency-symbols.test.js
+++ b/eslint-custom-rules/no-currency-symbols.test.js
@@ -1,0 +1,45 @@
+import { RuleTester } from 'eslint'
+import rule from './no-currency-symbols'
+import { config } from './config'
+
+const ruleTester = new RuleTester()
+
+const tests = {
+  valid: [
+    { code: 'const price = "10 USD";' },
+    { code: 'const symbol = "$";' },
+    { code: '<div>Price: $10</div>', parserOptions: { ecmaFeatures: { jsx: true } } },
+    { code: '`Price: $10`' },
+    { code: '<Text>Price in dollars</Text>', parserOptions: { ecmaFeatures: { jsx: true } } },
+  ],
+
+  invalid: [
+    // Literal
+    { code: `"10€"`, errors: 1 },
+    { code: `"10CFP"`, errors: 1 },
+    // JSXText
+    { code: '<div>10€</div>', parserOptions: { ecmaFeatures: { jsx: true } }, errors: 1 },
+    { code: '<div>10CFP</div>', parserOptions: { ecmaFeatures: { jsx: true } }, errors: 1 },
+
+    // TemplateLiteral
+    { code: '`50€`', errors: 1 },
+    { code: '`50CFP`', errors: 1 },
+
+    // non-breaking space
+    { code: `"300\\u00a0€"`, errors: 1 },
+    { code: '`300\\u00a0€`', errors: 1 },
+    { code: '<Text>300&nbsp;€</Text>', parserOptions: { ecmaFeatures: { jsx: true } }, errors: 1 },
+    { code: `"300\\u00a0CFP"`, errors: 1 },
+    { code: '`300\\u00a0CFP`', errors: 1 },
+    {
+      code: '<Text>300&nbsp;CFP</Text>',
+      parserOptions: { ecmaFeatures: { jsx: true } },
+      errors: 1,
+    },
+  ],
+}
+
+tests.valid.forEach((t) => Object.assign(t, config))
+tests.invalid.forEach((t) => Object.assign(t, config))
+
+ruleTester.run('no-currency-symbols', rule, tests)

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -1,25 +1,27 @@
+const apostropheInText = require('./eslint-custom-rules/apostrophe-in-text')
 const independentMocks = require('./eslint-custom-rules/independent-mocks')
 const nbspInText = require('./eslint-custom-rules/nbsp-in-text')
+const noEmptyArrowFunction = require('./eslint-custom-rules/no-empty-arrow-function')
+const noCurrencySymbols = require('./eslint-custom-rules/no-currency-symbols')
+const noHardcodeIdInSvg = require('./eslint-custom-rules/no-hardcoded-id-in-svg')
 const noRawText = require('./eslint-custom-rules/no-raw-text')
 const noStringCheckBeforeComponent = require('./eslint-custom-rules/use-ternary-operator-in-jsx')
-const todoFormat = require('./eslint-custom-rules/todo-format')
-const apostropheInText = require('./eslint-custom-rules/apostrophe-in-text')
-const useTheRightTestUtils = require('./eslint-custom-rules/use-the-right-test-utils')
-const noUseOfAlgoliaMultipleQueries = require('./eslint-custom-rules/no-use-of-algolia-multiple-queries')
-const noHardcodeIdInSvg = require('./eslint-custom-rules/no-hardcoded-id-in-svg')
 const noTruthyCheckAfterQueryAllMatchers = require('./eslint-custom-rules/no-truthy-check-after-queryAll-matchers')
-const noEmptyArrowFunction = require('./eslint-custom-rules/no-empty-arrow-function')
+const noUseOfAlgoliaMultipleQueries = require('./eslint-custom-rules/no-use-of-algolia-multiple-queries')
+const todoFormat = require('./eslint-custom-rules/todo-format')
+const useTheRightTestUtils = require('./eslint-custom-rules/use-the-right-test-utils')
 
 module.exports = {
+  'apostrophe-in-text': apostropheInText,
   'independent-mocks': independentMocks,
   'nbsp-in-text': nbspInText,
   'no-empty-arrow-function': noEmptyArrowFunction,
+  'no-currency-symbols': noCurrencySymbols,
   'no-hardcoded-id-in-svg': noHardcodeIdInSvg,
   'no-raw-text': noRawText,
-  'use-ternary-operator-in-jsx': noStringCheckBeforeComponent,
-  'todo-format': todoFormat,
-  'apostrophe-in-text': apostropheInText,
-  'use-the-right-test-utils': useTheRightTestUtils,
-  'no-use-of-algolia-multiple-queries': noUseOfAlgoliaMultipleQueries,
   'no-truthy-check-after-queryAll-matchers': noTruthyCheckAfterQueryAllMatchers,
+  'no-use-of-algolia-multiple-queries': noUseOfAlgoliaMultipleQueries,
+  'todo-format': todoFormat,
+  'use-ternary-operator-in-jsx': noStringCheckBeforeComponent,
+  'use-the-right-test-utils': useTheRightTestUtils,
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32705

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform          | problems |
| :--------------- | :---: |
| eslint              |     <img width="911" alt="Capture d’écran 2024-10-31 à 16 22 08" src="https://github.com/user-attachments/assets/6719ae9a-e79e-48cf-8b80-1d246af0e4be">   |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
