### PR TITLE
(PC-32721) feat(venuePlalists): location indication comes from code instead of Algolia's rules

### DIFF
--- a/src/features/search/components/SearchListHeader/SearchListHeader.native.test.tsx
+++ b/src/features/search/components/SearchListHeader/SearchListHeader.native.test.tsx
@@ -131,31 +131,52 @@ describe('<SearchListHeader />', () => {
       expect(screen.getByText('10 résultats')).toBeOnTheScreen()
     })
 
-    it('should show correct title when NO userData exists', () => {
-      render(
-        <SearchListHeader
-          nbHits={10}
-          userData={[]}
-          venuesUserData={[]}
-          venues={mockAlgoliaVenues}
-        />
+    describe('venuePlaylistTitle', () => {
+      const accessibilityFilterActivated = {
+        ...defaultValuesAccessibilityContext,
+        disabilities: { ...mockDisabilities, [DisplayedDisabilitiesEnum.AUDIO]: true },
+      }
+
+      it.each`
+        mockVenuesUserData                              | accessibilityFilter                  | selectedLocationMode         | geolocPosition  | expectedTitle
+        ${[{ venue_playlist_title: 'Les disquaires' }]} | ${accessibilityFilterActivated}      | ${LocationMode.EVERYWHERE}   | ${undefined}    | ${'Les disquaires accessibles'}
+        ${[{ venue_playlist_title: 'Les disquaires' }]} | ${defaultValuesAccessibilityContext} | ${LocationMode.AROUND_ME}    | ${mockPosition} | ${'Les disquaires près de toi'}
+        ${[{ venue_playlist_title: 'Les disquaires' }]} | ${defaultValuesAccessibilityContext} | ${LocationMode.AROUND_PLACE} | ${undefined}    | ${'Les disquaires près de toi'}
+        ${[{ venue_playlist_title: 'Les disquaires' }]} | ${defaultValuesAccessibilityContext} | ${LocationMode.EVERYWHERE}   | ${undefined}    | ${'Les disquaires'}
+        ${[{ venue_playlist_title: 'Les disquaires' }]} | ${accessibilityFilterActivated}      | ${LocationMode.AROUND_ME}    | ${mockPosition} | ${'Les disquaires accessibles près de toi'}
+        ${[{ venue_playlist_title: 'Les disquaires' }]} | ${accessibilityFilterActivated}      | ${LocationMode.AROUND_PLACE} | ${undefined}    | ${'Les disquaires accessibles près de toi'}
+        ${[]}                                           | ${accessibilityFilterActivated}      | ${LocationMode.EVERYWHERE}   | ${undefined}    | ${'Les lieux culturels accessibles'}
+        ${[]}                                           | ${defaultValuesAccessibilityContext} | ${LocationMode.AROUND_ME}    | ${mockPosition} | ${'Les lieux culturels près de toi'}
+        ${[]}                                           | ${defaultValuesAccessibilityContext} | ${LocationMode.AROUND_PLACE} | ${undefined}    | ${'Les lieux culturels près de toi'}
+        ${[]}                                           | ${accessibilityFilterActivated}      | ${LocationMode.AROUND_ME}    | ${mockPosition} | ${'Les lieux culturels accessibles près de toi'}
+        ${[]}                                           | ${accessibilityFilterActivated}      | ${LocationMode.AROUND_PLACE} | ${undefined}    | ${'Les lieux culturels accessibles près de toi'}
+        ${[]}                                           | ${defaultValuesAccessibilityContext} | ${LocationMode.EVERYWHERE}   | ${undefined}    | ${'Les lieux culturels'}
+      `(
+        'should show correct title',
+        ({
+          accessibilityFilter,
+          mockVenuesUserData,
+          selectedLocationMode,
+          geolocPosition,
+          expectedTitle,
+        }) => {
+          mockUseAccessibilityFiltersContext.mockReturnValueOnce(accessibilityFilter)
+          mockUseLocation.mockReturnValueOnce({
+            geolocPosition,
+            selectedLocationMode,
+          })
+          render(
+            <SearchListHeader
+              nbHits={10}
+              userData={[]}
+              venuesUserData={mockVenuesUserData}
+              venues={mockAlgoliaVenues}
+            />
+          )
+
+          expect(screen.getByText(expectedTitle)).toBeOnTheScreen()
+        }
       )
-
-      expect(screen.getByText('Les lieux culturels')).toBeOnTheScreen()
-    })
-
-    it('should show correct title when userData exists', () => {
-      render(
-        <SearchListHeader
-          nbHits={10}
-          userData={[]}
-          venuesUserData={[{ venue_playlist_title: 'test' }]}
-          venues={mockAlgoliaVenues}
-        />
-      )
-
-      expect(screen.queryByText('Les lieux culturels')).not.toBeOnTheScreen()
-      expect(screen.getByText('test')).toBeOnTheScreen()
     })
 
     it('should not display the geolocation button if position is not null', () => {

--- a/src/features/search/components/SearchListHeader/SearchListHeader.tsx
+++ b/src/features/search/components/SearchListHeader/SearchListHeader.tsx
@@ -52,7 +52,8 @@ export const SearchListHeader: React.FC<SearchListHeaderProps> = ({
     Object.values(disabilities).filter((disability) => disability).length > 0
   const venuePlaylistTitle = getSearchVenuePlaylistTitle(
     shouldDisplayAccessibilityContent,
-    venuesUserData?.[0]?.venue_playlist_title
+    venuesUserData?.[0]?.venue_playlist_title,
+    isLocated
   )
 
   const previousRoute = usePreviousRoute()

--- a/src/features/search/helpers/getSearchVenuePlaylistTitle/getSearchVenuePlaylistTitle.test.ts
+++ b/src/features/search/helpers/getSearchVenuePlaylistTitle/getSearchVenuePlaylistTitle.test.ts
@@ -2,17 +2,21 @@ import { getSearchVenuePlaylistTitle } from 'features/search/helpers/getSearchVe
 
 describe('getSearchVenuePlaylistTitle', () => {
   it.each`
-    playlistTitle                           | accessibilityFilter | expected
-    ${'Les salles de concerts & festivals'} | ${true}             | ${'Les salles de concerts & festivals accessibles'}
-    ${'Les salles de concerts & festivals'} | ${false}            | ${'Les salles de concerts & festivals'}
-    ${'Les librairies près de toi'}         | ${true}             | ${'Les librairies accessibles près de toi'}
-    ${'Les librairies près de toi'}         | ${false}            | ${'Les librairies près de toi'}
-    ${undefined}                            | ${true}             | ${'Les lieux culturels accessibles'}
-    ${undefined}                            | ${false}            | ${'Les lieux culturels'}
+    playlistTitleFromAlgolia                 | accessibilityFilter | isLocated | expected
+    ${'Les salles de concerts et festivals'} | ${true}             | ${false}  | ${'Les salles de concerts et festivals accessibles'}
+    ${'Les salles de concerts et festivals'} | ${false}            | ${true}   | ${'Les salles de concerts et festivals près de toi'}
+    ${'Les salles de concerts et festivals'} | ${false}            | ${false}  | ${'Les salles de concerts et festivals'}
+    ${'Les salles de concerts et festivals'} | ${true}             | ${true}   | ${'Les salles de concerts et festivals accessibles près de toi'}
+    ${undefined}                             | ${true}             | ${false}  | ${'Les lieux culturels accessibles'}
+    ${undefined}                             | ${false}            | ${true}   | ${'Les lieux culturels près de toi'}
+    ${undefined}                             | ${true}             | ${true}   | ${'Les lieux culturels accessibles près de toi'}
+    ${undefined}                             | ${false}            | ${false}  | ${'Les lieux culturels'}
   `(
     'getSearchVenuePlaylistTitle($playlistTitle,$accessibilityFilter) \t= $expected',
-    ({ accessibilityFilter, playlistTitle, expected }) => {
-      expect(getSearchVenuePlaylistTitle(accessibilityFilter, playlistTitle)).toEqual(expected)
+    ({ accessibilityFilter, playlistTitleFromAlgolia, isLocated, expected }) => {
+      expect(
+        getSearchVenuePlaylistTitle(accessibilityFilter, playlistTitleFromAlgolia, isLocated)
+      ).toEqual(expected)
     }
   )
 })

--- a/src/features/search/helpers/getSearchVenuePlaylistTitle/getSearchVenuePlaylistTitle.ts
+++ b/src/features/search/helpers/getSearchVenuePlaylistTitle/getSearchVenuePlaylistTitle.ts
@@ -1,12 +1,16 @@
 export const getSearchVenuePlaylistTitle = (
-  accessibilityFiltered: boolean,
-  venuePlaylistTitleFromUserData: string | undefined
+  isAccessibilityFiltered: boolean,
+  venuePlaylistTitleFromUserData: string | undefined,
+  isLocated: boolean
 ) => {
-  if (venuePlaylistTitleFromUserData && accessibilityFiltered) {
-    return venuePlaylistTitleFromUserData.endsWith('près de toi')
-      ? venuePlaylistTitleFromUserData.replace('près de toi', `accessibles près de toi`)
-      : `${venuePlaylistTitleFromUserData} accessibles`
+  let venuePlaylistTitle = venuePlaylistTitleFromUserData ?? 'Les lieux culturels'
+
+  if (isAccessibilityFiltered) {
+    venuePlaylistTitle += ' accessibles'
   }
-  if (venuePlaylistTitleFromUserData) return venuePlaylistTitleFromUserData
-  return accessibilityFiltered ? 'Les lieux culturels accessibles' : 'Les lieux culturels'
+  if (isLocated) {
+    venuePlaylistTitle += ' près de toi'
+  }
+
+  return venuePlaylistTitle
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32721

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
