### PR TITLE
(PC-32810) fix(VenuePreview): correct UI

### DIFF
--- a/src/ui/components/VenuePreview/VenuePreview.tsx
+++ b/src/ui/components/VenuePreview/VenuePreview.tsx
@@ -4,7 +4,6 @@ import LinearGradient from 'react-native-linear-gradient'
 import styled from 'styled-components/native'
 
 import { Image } from 'libs/resizing-image-on-demand/Image'
-import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { All } from 'ui/svg/icons/bicolor/All'
 import { RightFilled } from 'ui/svg/icons/RightFilled'
 import { Spacer, TypoDS } from 'ui/theme'
@@ -39,7 +38,7 @@ export const VenuePreview: FunctionComponent<Props> = ({
       <ImagePlaceholder height={imageHeight} width={imageWidth} testID="VenuePreviewPlaceholder" />
     )}
     <Spacer.Row numberOfSpaces={2} />
-    <VenueRightContainer gap={1} imageHeight={imageHeight}>
+    <VenueRightContainer>
       {children}
       <VenueTitleContainer>
         <VenueName>{venueName}</VenueName>
@@ -60,11 +59,10 @@ const StyledView = styled.View({
   flexDirection: 'row',
 })
 
-const VenueRightContainer = styled(ViewGap)<{ imageHeight: number }>(({ imageHeight }) => ({
+const VenueRightContainer = styled.View({
   flexShrink: 1,
   justifyContent: 'center',
-  maxHeight: imageHeight,
-}))
+})
 
 const VenueTitleContainer = styled.View({
   flexDirection: 'row',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32810

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |![Capture d’écran 2024-11-04 à 16 51 33](https://github.com/user-attachments/assets/cef7d840-afa2-4d65-b2af-9d5142d94e93)|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |![Capture d’écran 2024-10-31 à 16 23 58](https://github.com/user-attachments/assets/c271616a-705f-43f4-b3b5-b9c8b9967f6a)|![Capture d’écran 2024-11-04 à 17 03 20](https://github.com/user-attachments/assets/a863099c-eb8d-4028-bfb4-2b440cadd752)|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
