### PR TITLE
(PC-32582) feat(deeplinks): AROUND-ME with all radius replace EVERYWHERE in SearchResults deeplinks

### DIFF
--- a/src/features/home/components/banners/GeolocationBanner.native.test.tsx
+++ b/src/features/home/components/banners/GeolocationBanner.native.test.tsx
@@ -9,7 +9,7 @@ import { fireEvent, render, screen } from 'tests/utils'
 const useFeatureFlagSpy = jest.spyOn(useFeatureFlag, 'useFeatureFlag')
 
 jest.mock('libs/location')
-const mockUseGeolocation = useLocation as jest.Mock
+const mockUseLocation = useLocation as jest.Mock
 
 describe('<GeolocationBanner />', () => {
   describe('When wipAppV2SystemBlock feature flag activated', () => {
@@ -18,7 +18,7 @@ describe('<GeolocationBanner />', () => {
     })
 
     it('should display system banner for geolocation incitation', () => {
-      mockUseGeolocation.mockReturnValueOnce({
+      mockUseLocation.mockReturnValueOnce({
         permissionState: GeolocPermissionState.NEVER_ASK_AGAIN,
         showGeolocPermissionModal,
       })
@@ -40,7 +40,7 @@ describe('<GeolocationBanner />', () => {
     })
 
     it('should display generic banner for geolocation incitation', () => {
-      mockUseGeolocation.mockReturnValueOnce({
+      mockUseLocation.mockReturnValueOnce({
         permissionState: GeolocPermissionState.NEVER_ASK_AGAIN,
         showGeolocPermissionModal,
       })
@@ -57,7 +57,7 @@ describe('<GeolocationBanner />', () => {
   })
 
   it('should open "Paramètres de localisation" modal when pressing button and permission is never ask again', () => {
-    mockUseGeolocation.mockReturnValueOnce({
+    mockUseLocation.mockReturnValueOnce({
       permissionState: GeolocPermissionState.NEVER_ASK_AGAIN,
       showGeolocPermissionModal,
     })
@@ -76,7 +76,7 @@ describe('<GeolocationBanner />', () => {
   })
 
   it('should ask for permission when pressing button and permission is denied', () => {
-    mockUseGeolocation.mockReturnValueOnce({
+    mockUseLocation.mockReturnValueOnce({
       permissionState: GeolocPermissionState.DENIED,
       requestGeolocPermission,
     })

--- a/src/features/internal/marketingAndCommunication/components/DeeplinksGeneratorForm.native.test.tsx
+++ b/src/features/internal/marketingAndCommunication/components/DeeplinksGeneratorForm.native.test.tsx
@@ -132,7 +132,7 @@ describe('getDefaultScreenParams', () => {
     const defaultParams = getDefaultScreenParams('SearchResults')
 
     expect(defaultParams).toEqual({
-      locationFilter: { locationType: LocationMode.EVERYWHERE },
+      locationFilter: { locationType: LocationMode.AROUND_ME, aroundRadius: 'all' },
       from: 'deeplink',
     })
   })

--- a/src/features/internal/marketingAndCommunication/components/DeeplinksGeneratorForm.tsx
+++ b/src/features/internal/marketingAndCommunication/components/DeeplinksGeneratorForm.tsx
@@ -59,7 +59,7 @@ type DeeplinksAppParams = Record<string, unknown> & {
 export function getDefaultScreenParams(screenName: ScreensUsedByMarketing) {
   if (screenName === 'SearchResults') {
     return {
-      locationFilter: { locationType: LocationMode.EVERYWHERE },
+      locationFilter: { locationType: LocationMode.AROUND_ME, aroundRadius: 'all' },
       from: 'deeplink',
     }
   }

--- a/src/features/internal/marketingAndCommunication/config/deeplinksExportConfig.ts
+++ b/src/features/internal/marketingAndCommunication/config/deeplinksExportConfig.ts
@@ -83,11 +83,6 @@ export const SCREENS_CONFIG: {
       required: false,
       description: 'Une URL de recherche a convertir',
     },
-    locationFilter: {
-      type: 'locationFilter',
-      required: false,
-      description: 'Lieu',
-    },
     query: {
       type: 'string',
       required: false,

--- a/src/features/location/components/LocationSearchWidget.native.test.tsx
+++ b/src/features/location/components/LocationSearchWidget.native.test.tsx
@@ -16,7 +16,7 @@ jest.mock('ui/components/modals/useModal', () => ({
 }))
 
 jest.mock('libs/location')
-const mockUseGeolocation = useLocation as jest.Mock
+const mockUseLocation = useLocation as jest.Mock
 
 jest.mock('features/search/context/SearchWrapper', () => ({
   useSearch: () => ({
@@ -26,7 +26,7 @@ jest.mock('features/search/context/SearchWrapper', () => ({
 
 describe('LocationSearchWidget', () => {
   it('should show modal when pressing widget', async () => {
-    mockUseGeolocation.mockReturnValueOnce({
+    mockUseLocation.mockReturnValueOnce({
       hasGeolocPosition: true,
       place: { label: 'test' },
     })
@@ -46,7 +46,7 @@ describe('LocationSearchWidget', () => {
   `(
     "should render a filled location pointer and the text 'Ma position' if the user is geolocated",
     async ({ hasGeolocPosition, place }) => {
-      mockUseGeolocation.mockReturnValueOnce({
+      mockUseLocation.mockReturnValueOnce({
         hasGeolocPosition,
         place,
         selectedLocationMode: LocationMode.AROUND_ME,
@@ -66,7 +66,7 @@ describe('LocationSearchWidget', () => {
   `(
     "should render a location pointer(not filled ) and the text 'Me localiser' if the user is not geolocated and has not selected a custom position",
     async ({ hasGeolocPosition, place }) => {
-      mockUseGeolocation.mockReturnValueOnce({
+      mockUseLocation.mockReturnValueOnce({
         hasGeolocPosition,
         place,
         geolocPosition: null,
@@ -81,7 +81,7 @@ describe('LocationSearchWidget', () => {
   )
 
   it('should render a filled location pointer and label of the place if the user has selected a place', async () => {
-    mockUseGeolocation.mockReturnValueOnce({
+    mockUseLocation.mockReturnValueOnce({
       hasGeolocPosition: true,
       place: { label: 'my place' },
       geolocPosition: null,

--- a/src/features/location/components/LocationWidgetDesktop.native.test.tsx
+++ b/src/features/location/components/LocationWidgetDesktop.native.test.tsx
@@ -21,13 +21,13 @@ jest.mock('ui/components/modals/useModal', () => ({
 }))
 
 jest.mock('libs/location')
-const mockUseGeolocation = useLocation as jest.Mock
+const mockUseLocation = useLocation as jest.Mock
 
 jest.spyOn(useFeatureFlag, 'useFeatureFlag').mockReturnValue(false)
 
 describe('LocationWidgetDesktop', () => {
   it('should show modal when pressing widget', async () => {
-    mockUseGeolocation.mockReturnValueOnce({
+    mockUseLocation.mockReturnValueOnce({
       hasGeolocPosition: true,
       place: { label: 'test' },
       isCurrentLocationMode: jest.fn(),
@@ -48,7 +48,7 @@ describe('LocationWidgetDesktop', () => {
   `(
     "should render a filled location pointer and the text 'Ma position' if the user is geolocated",
     async ({ hasGeolocPosition, place }) => {
-      mockUseGeolocation.mockReturnValueOnce({
+      mockUseLocation.mockReturnValueOnce({
         hasGeolocPosition,
         place,
         isCurrentLocationMode: jest.fn(),
@@ -69,7 +69,7 @@ describe('LocationWidgetDesktop', () => {
   `(
     "should render a location pointer(not filled ) and the text 'Me localiser' if the user is not geolocated and has not selected a custom position",
     async ({ hasGeolocPosition, place }) => {
-      mockUseGeolocation.mockReturnValueOnce({
+      mockUseLocation.mockReturnValueOnce({
         hasGeolocPosition,
         place,
         geolocPosition: null,
@@ -85,7 +85,7 @@ describe('LocationWidgetDesktop', () => {
   )
 
   it('should render a filled location pointer and label of the place if the user has selected a custom place', async () => {
-    mockUseGeolocation.mockReturnValueOnce({
+    mockUseLocation.mockReturnValueOnce({
       hasGeolocPosition: true,
       place: { label: 'my place' },
       geolocPosition: null,
@@ -100,7 +100,7 @@ describe('LocationWidgetDesktop', () => {
   })
 
   describe('tooltip', () => {
-    mockUseGeolocation.mockReturnValue({
+    mockUseLocation.mockReturnValue({
       hasGeolocPosition: true,
       place: null,
       geolocPosition: null,

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -29,15 +29,14 @@ import { theme } from 'theme'
 const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(false)
 
 const searchId = uuidv4()
-const searchState = { ...initialSearchState, searchId }
-let mockSearchState = searchState
+const mockSearchState: SearchState = { ...initialSearchState, searchId }
 const mockDispatch = jest.fn()
-
+const mockUseSearch = jest.fn(() => ({
+  searchState: mockSearchState,
+  dispatch: mockDispatch,
+}))
 jest.mock('features/search/context/SearchWrapper', () => ({
-  useSearch: () => ({
-    searchState: mockSearchState,
-    dispatch: mockDispatch,
-  }),
+  useSearch: () => mockUseSearch(),
 }))
 
 jest.mock('features/venueMap/useGetAllVenues')
@@ -245,7 +244,10 @@ describe('SearchResultsContent component', () => {
       nbHits: 0,
       userData: [],
     })
-    mockSearchState = searchState
+    mockUseSearch.mockReturnValue({
+      searchState: mockSearchState,
+      dispatch: mockDispatch,
+    })
 
     mockUseLocation.mockReturnValue({
       ...everywhereUseLocation,
@@ -321,10 +323,14 @@ describe('SearchResultsContent component', () => {
     })
 
     it('should display an icon and change color in category button when has category selected', async () => {
-      mockSearchState = {
-        ...mockSearchState,
-        offerCategories: [SearchGroupNameEnumv2.CD_VINYLE_MUSIQUE_EN_LIGNE],
-      }
+      mockUseSearch.mockReturnValueOnce({
+        searchState: {
+          ...mockSearchState,
+          offerCategories: [SearchGroupNameEnumv2.CD_VINYLE_MUSIQUE_EN_LIGNE],
+        },
+        dispatch: mockDispatch,
+      })
+
       renderSearchResultsContent()
 
       const categoryButtonIcon = await screen.findByTestId('categoryButtonIcon')
@@ -359,10 +365,14 @@ describe('SearchResultsContent component', () => {
     })
 
     it('should display an icon and change color in prices filter button when has prices filter selected', async () => {
-      mockSearchState = {
-        ...mockSearchState,
-        minPrice: '5',
-      }
+      mockUseSearch.mockReturnValueOnce({
+        searchState: {
+          ...mockSearchState,
+          minPrice: '5',
+        },
+        dispatch: mockDispatch,
+      })
+
       renderSearchResultsContent()
 
       const priceButtonIcon = await screen.findByTestId('priceButtonIcon')
@@ -460,10 +470,14 @@ describe('SearchResultsContent component', () => {
 
     it('when a category filter is selected and position is null', async () => {
       mockUseLocation.mockReturnValueOnce(everywhereUseLocation)
-      mockSearchState = {
-        ...mockSearchState,
-        offerCategories: [SearchGroupNameEnumv2.EVENEMENTS_EN_LIGNE],
-      }
+      mockUseSearch.mockReturnValueOnce({
+        searchState: {
+          ...mockSearchState,
+          offerCategories: [SearchGroupNameEnumv2.EVENEMENTS_EN_LIGNE],
+          searchId,
+        },
+        dispatch: mockDispatch,
+      })
 
       renderSearchResultsContent()
 
@@ -483,7 +497,13 @@ describe('SearchResultsContent component', () => {
   })
 
   it(`should display ${venue.label} in location filter button label when a venue is selected`, async () => {
-    mockSearchState = { ...searchState, venue }
+    mockUseSearch.mockReturnValueOnce({
+      searchState: {
+        ...mockSearchState,
+        venue,
+      },
+      dispatch: mockDispatch,
+    })
     renderSearchResultsContent()
 
     expect(await screen.findByText(venue.label)).toBeOnTheScreen()
@@ -525,30 +545,40 @@ describe('SearchResultsContent component', () => {
     })
 
     it('should display venueButtonLabel in venue filter if a venue is selected', async () => {
-      mockSearchState = {
-        ...searchState,
-        venue,
-      }
+      mockUseSearch.mockReturnValueOnce({
+        searchState: {
+          ...mockSearchState,
+          venue,
+        },
+        dispatch: mockDispatch,
+      })
       renderSearchResultsContent()
 
       expect(await screen.findByTestId('venueButtonLabel')).toHaveTextContent(venue.label)
     })
 
     it('should display "Lieu culturel" in venue filter if location type is AROUND_ME', async () => {
-      mockSearchState = {
-        ...searchState,
-        locationFilter: { locationType: LocationMode.AROUND_ME, aroundRadius: MAX_RADIUS },
-      }
+      mockUseSearch.mockReturnValueOnce({
+        searchState: {
+          ...mockSearchState,
+          locationFilter: { locationType: LocationMode.AROUND_ME, aroundRadius: MAX_RADIUS },
+        },
+        dispatch: mockDispatch,
+      })
+
       renderSearchResultsContent()
 
       expect(await screen.findByTestId('venueButtonLabel')).toHaveTextContent('Lieu culturel')
     })
 
     it('should display "Lieu culturel" in venue filter if location type is EVERYWHERE', async () => {
-      mockSearchState = {
-        ...searchState,
-        locationFilter: { locationType: LocationMode.EVERYWHERE },
-      }
+      mockUseSearch.mockReturnValueOnce({
+        searchState: {
+          ...mockSearchState,
+          locationFilter: { locationType: LocationMode.EVERYWHERE },
+        },
+        dispatch: mockDispatch,
+      })
       renderSearchResultsContent()
 
       expect(await screen.findByTestId('venueButtonLabel')).toHaveTextContent('Lieu culturel')
@@ -580,10 +610,13 @@ describe('SearchResultsContent component', () => {
     `(
       'should display an icon and change color in dates and hours filter button when has $type selected',
       async ({ params }: { params: SearchState }) => {
-        mockSearchState = {
-          ...mockSearchState,
-          ...params,
-        }
+        mockUseSearch.mockReturnValueOnce({
+          searchState: {
+            ...mockSearchState,
+            ...params,
+          },
+          dispatch: mockDispatch,
+        })
         renderSearchResultsContent()
 
         const datesHoursButtonIcon = await screen.findByTestId('datesHoursButtonIcon')
@@ -701,7 +734,10 @@ describe('SearchResultsContent component', () => {
 
     mockUseSearchResults.mockReturnValueOnce({ ...initialSearchResults, isLoading: false })
 
-    mockSearchState = searchState
+    mockUseSearch.mockReturnValueOnce({
+      searchState: mockSearchState,
+      dispatch: mockDispatch,
+    })
     const mockAccessibilityFilter = {
       isAudioDisabilityCompliant: undefined,
       isMentalDisabilityCompliant: undefined,
@@ -746,7 +782,10 @@ describe('SearchResultsContent component', () => {
 
     mockUseSearchResults.mockReturnValueOnce({ ...initialSearchResults, isLoading: false })
 
-    mockSearchState = searchState
+    mockUseSearch.mockReturnValueOnce({
+      searchState: mockSearchState,
+      dispatch: mockDispatch,
+    })
 
     screen.rerender(<SearchResultsContent />)
 
@@ -791,7 +830,10 @@ describe('SearchResultsContent component', () => {
 
     mockUseSearchResults.mockReturnValueOnce({ ...initialSearchResults, isLoading: false })
 
-    mockSearchState = searchState
+    mockUseSearch.mockReturnValueOnce({
+      searchState: mockSearchState,
+      dispatch: mockDispatch,
+    })
     screen.rerender(<SearchResultsContent />)
 
     await waitFor(() => {
@@ -842,7 +884,11 @@ describe('SearchResultsContent component', () => {
         nbHits: mockedAlgoliaResponse.nbHits,
         userData: [{ message: 'n’est pas disponible sur le pass Culture.' }],
       })
-      mockSearchState = { ...searchState, query: 'iPhone' }
+      mockUseSearch.mockReturnValueOnce({
+        searchState: { ...mockSearchState, query: 'iPhone' },
+        dispatch: mockDispatch,
+      })
+
       renderSearchResultsContent()
       await screen.findByText('Lieu culturel')
 
@@ -859,7 +905,10 @@ describe('SearchResultsContent component', () => {
         userData: [{ message: 'Offre non disponible sur le pass Culture.' }],
       })
 
-      mockSearchState = { ...searchState, query: 'iPhone' }
+      mockUseSearch.mockReturnValueOnce({
+        searchState: { ...mockSearchState, query: 'iPhone' },
+        dispatch: mockDispatch,
+      })
       renderSearchResultsContent()
 
       expect(await screen.findByText('Offre non disponible sur le pass Culture.')).toBeOnTheScreen()
@@ -872,7 +921,10 @@ describe('SearchResultsContent component', () => {
         nbHits: mockedAlgoliaResponse.nbHits,
         userData: [],
       })
-      mockSearchState = { ...searchState, query: 'Deezer' }
+      mockUseSearch.mockReturnValueOnce({
+        searchState: { ...mockSearchState, query: 'Deezer' },
+        dispatch: mockDispatch,
+      })
       renderSearchResultsContent()
       await screen.findByText('Lieu culturel')
 
@@ -882,11 +934,10 @@ describe('SearchResultsContent component', () => {
 
   describe('Main filter button', () => {
     it('should display filter button with the number of active filters', async () => {
-      mockSearchState = {
-        ...searchState,
-        priceRange: [5, 300],
-        offerIsDuo: true,
-      }
+      mockUseSearch.mockReturnValueOnce({
+        searchState: { ...mockSearchState, priceRange: [5, 300], offerIsDuo: true },
+        dispatch: mockDispatch,
+      })
 
       renderSearchResultsContent()
 

--- a/src/features/search/helpers/useSync/useSync.native.test.ts
+++ b/src/features/search/helpers/useSync/useSync.native.test.ts
@@ -1,0 +1,273 @@
+import { useRoute } from '__mocks__/@react-navigation/native'
+import { initialSearchState } from 'features/search/context/reducer'
+import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { GeolocPermissionState } from 'libs/location'
+import { LocationMode, Position } from 'libs/location/types'
+import { SuggestedPlace } from 'libs/place/types'
+import { act, renderHook } from 'tests/utils'
+
+import { useSync } from './useSync'
+
+const mockSearchState = initialSearchState
+const mockDispatch = jest.fn()
+jest.mock('features/search/context/SearchWrapper', () => ({
+  useSearch: () => ({
+    searchState: mockSearchState,
+    dispatch: mockDispatch,
+  }),
+}))
+
+jest.mock('libs/subcategories/useSubcategories')
+
+jest.mock('libs/firebase/analytics/analytics')
+jest.mock('features/navigation/TabBar/routes')
+const useFeatureFlagSpy = jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag')
+useFeatureFlagSpy.mockReturnValue(false)
+
+jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
+
+const mockedPlace: SuggestedPlace = {
+  label: 'Kourou',
+  info: 'Guyane',
+  type: 'street',
+  geolocation: { longitude: -52.669736, latitude: 5.16186 },
+}
+
+const mockShowGeolocPermissionModal = jest.fn()
+const mockSelectedLocationMode = jest.fn()
+const mockSetAroundMeRadius = jest.fn()
+const mockedPosition = { latitude: 2, longitude: 40 } as Position
+const mockedNoPosition = null as Position
+const DEFAULT_RADIUS = 50
+const everywhereUseLocation = {
+  geolocPosition: mockedNoPosition,
+  geolocPositionError: null,
+  place: mockedPlace,
+  userLocation: mockedNoPosition,
+  selectedLocationMode: LocationMode.EVERYWHERE,
+  hasGeolocPosition: false,
+  permissionState: GeolocPermissionState.DENIED,
+  onModalHideRef: jest.fn(),
+  setPlace: jest.fn(),
+  isCurrentLocationMode: jest.fn(),
+  setSelectedLocationMode: mockSelectedLocationMode,
+  showGeolocPermissionModal: mockShowGeolocPermissionModal,
+  requestGeolocPermission: jest.fn(),
+  triggerPositionUpdate: jest.fn(),
+  onPressGeolocPermissionModalButton: jest.fn(),
+  onResetPlace: jest.fn(),
+  onSetSelectedPlace: jest.fn(),
+  selectedPlace: null,
+  setSelectedPlace: jest.fn(),
+  placeQuery: '',
+  setPlaceQuery: jest.fn(),
+  aroundPlaceRadius: DEFAULT_RADIUS,
+  setAroundPlaceRadius: jest.fn(),
+  aroundMeRadius: DEFAULT_RADIUS,
+  setAroundMeRadius: mockSetAroundMeRadius,
+}
+
+const mockUseLocation = jest.fn(() => everywhereUseLocation)
+jest.mock('libs/location/LocationWrapper', () => ({
+  useLocation: () => mockUseLocation(),
+}))
+mockUseLocation.mockReturnValue(everywhereUseLocation)
+
+const mockRemoveSelectedVenue = jest.fn()
+jest.mock('features/venueMap/store/selectedVenueStore', () => ({
+  useSelectedVenueActions: () => ({
+    removeSelectedVenue: mockRemoveSelectedVenue,
+    setSelectedVenue: jest.fn(),
+  }),
+  useSelectedVenue: jest.fn(),
+}))
+
+describe('useSync', () => {
+  it('should update search state with locationType params when user has geolocPosition', async () => {
+    mockUseLocation
+      .mockReturnValueOnce({
+        ...everywhereUseLocation,
+        hasGeolocPosition: true,
+        geolocPosition: mockedPosition,
+      })
+      .mockReturnValueOnce({
+        ...everywhereUseLocation,
+        hasGeolocPosition: true,
+        geolocPosition: mockedPosition,
+      })
+      .mockReturnValueOnce({
+        ...everywhereUseLocation,
+        hasGeolocPosition: true,
+        geolocPosition: mockedPosition,
+      })
+
+    useRoute
+      .mockReturnValueOnce({
+        params: {
+          locationFilter: {
+            locationType: LocationMode.AROUND_ME,
+            aroundRadius: 'all',
+          },
+        },
+      })
+      .mockReturnValueOnce({
+        params: {
+          locationFilter: {
+            locationType: LocationMode.AROUND_ME,
+            aroundRadius: 'all',
+          },
+        },
+      })
+      .mockReturnValueOnce({
+        params: {
+          locationFilter: {
+            locationType: LocationMode.AROUND_ME,
+            aroundRadius: 'all',
+          },
+        },
+      })
+    renderHook(() => {
+      useSync()
+    })
+    await act(async () => {})
+    await act(async () => {})
+    await act(async () => {})
+
+    expect(mockSelectedLocationMode).toHaveBeenCalledWith(LocationMode.AROUND_ME)
+  })
+
+  it('should update search state with aroundRadius params when user has geolocPosition', async () => {
+    mockUseLocation
+      .mockReturnValueOnce({
+        ...everywhereUseLocation,
+        hasGeolocPosition: true,
+        geolocPosition: mockedPosition,
+      })
+      .mockReturnValueOnce({
+        ...everywhereUseLocation,
+        hasGeolocPosition: true,
+        geolocPosition: mockedPosition,
+      })
+      .mockReturnValueOnce({
+        ...everywhereUseLocation,
+        hasGeolocPosition: true,
+        geolocPosition: mockedPosition,
+      })
+
+    useRoute
+      .mockReturnValueOnce({
+        params: {
+          locationFilter: {
+            locationType: LocationMode.AROUND_ME,
+            aroundRadius: 'all',
+          },
+        },
+      })
+      .mockReturnValueOnce({
+        params: {
+          locationFilter: {
+            locationType: LocationMode.AROUND_ME,
+            aroundRadius: 'all',
+          },
+        },
+      })
+      .mockReturnValueOnce({
+        params: {
+          locationFilter: {
+            locationType: LocationMode.AROUND_ME,
+            aroundRadius: 'all',
+          },
+        },
+      })
+    renderHook(() => {
+      useSync()
+    })
+    await act(async () => {})
+    await act(async () => {})
+    await act(async () => {})
+
+    expect(mockSetAroundMeRadius).toHaveBeenCalledWith('all')
+  })
+
+  it('should not update search state with aroundRadius params when user has no geolocPosition', async () => {
+    mockUseLocation
+      .mockReturnValueOnce(everywhereUseLocation)
+      .mockReturnValueOnce(everywhereUseLocation)
+      .mockReturnValueOnce(everywhereUseLocation)
+
+    useRoute
+      .mockReturnValueOnce({
+        params: {
+          locationFilter: {
+            locationType: LocationMode.AROUND_ME,
+            aroundRadius: 'all',
+          },
+        },
+      })
+      .mockReturnValueOnce({
+        params: {
+          locationFilter: {
+            locationType: LocationMode.AROUND_ME,
+            aroundRadius: 'all',
+          },
+        },
+      })
+      .mockReturnValueOnce({
+        params: {
+          locationFilter: {
+            locationType: LocationMode.AROUND_ME,
+            aroundRadius: 'all',
+          },
+        },
+      })
+    renderHook(() => {
+      useSync()
+    })
+    await act(async () => {})
+    await act(async () => {})
+    await act(async () => {})
+
+    expect(mockSetAroundMeRadius).not.toHaveBeenCalledWith('all')
+  })
+
+  it('should not update search state with locationType params when user has no geolocPosition', async () => {
+    mockUseLocation
+      .mockReturnValueOnce(everywhereUseLocation)
+      .mockReturnValueOnce(everywhereUseLocation)
+      .mockReturnValueOnce(everywhereUseLocation)
+
+    useRoute
+      .mockReturnValueOnce({
+        params: {
+          locationFilter: {
+            locationType: LocationMode.AROUND_ME,
+            aroundRadius: 'all',
+          },
+        },
+      })
+      .mockReturnValueOnce({
+        params: {
+          locationFilter: {
+            locationType: LocationMode.AROUND_ME,
+            aroundRadius: 'all',
+          },
+        },
+      })
+      .mockReturnValueOnce({
+        params: {
+          locationFilter: {
+            locationType: LocationMode.AROUND_ME,
+            aroundRadius: 'all',
+          },
+        },
+      })
+    renderHook(() => {
+      useSync()
+    })
+    await act(async () => {})
+    await act(async () => {})
+    await act(async () => {})
+
+    expect(mockSelectedLocationMode).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/search/helpers/useSync/useSync.ts
+++ b/src/features/search/helpers/useSync/useSync.ts
@@ -18,15 +18,35 @@ export const useSync = (shouldUpdate = true) => {
   const disabilitiesParams: Partial<DisabilitiesProperties> = accessibilityFilter || {}
   const { setParams } = useNavigation<UseNavigationType>()
   const { searchState, dispatch } = useSearch()
-  const { setPlace, setSelectedLocationMode, hasGeolocPosition, setSelectedPlace } = useLocation()
+  const {
+    setPlace,
+    setSelectedLocationMode,
+    hasGeolocPosition,
+    setSelectedPlace,
+    setAroundMeRadius,
+  } = useLocation()
   const { disabilities, setDisabilities } = useAccessibilityFiltersContext()
 
   useEffect(() => {
     if (canSwitchToAroundMe && hasGeolocPosition) {
       setSelectedLocationMode(LocationMode.AROUND_ME)
       setCanSwitchToAroundMe(false)
+      if (
+        params?.locationFilter?.locationType === LocationMode.AROUND_ME &&
+        params?.locationFilter?.aroundRadius
+      ) {
+        setAroundMeRadius(params.locationFilter.aroundRadius)
+      }
     }
-  }, [hasGeolocPosition, canSwitchToAroundMe, setSelectedLocationMode])
+    // locationFilter.aroundRadius does not exist on every locationFilter so we don't want it in dependencies
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    hasGeolocPosition,
+    canSwitchToAroundMe,
+    setSelectedLocationMode,
+    setAroundMeRadius,
+    params?.locationFilter?.locationType,
+  ])
 
   // update params -> accessibilityContext
   useEffect(() => {

--- a/src/features/search/pages/SearchResults/SearchResults.native.test.tsx
+++ b/src/features/search/pages/SearchResults/SearchResults.native.test.tsx
@@ -22,22 +22,23 @@ jest.spyOn(useFeatureFlag, 'useFeatureFlag').mockReturnValue(false)
 
 const venue = mockedSuggestedVenue
 
-let mockSearchState: SearchState = {
+const mockSearchState: SearchState = {
   ...initialSearchState,
   offerCategories: [SearchGroupNameEnumv2.CINEMA],
   venue,
   priceRange: [0, 20],
 }
-
 const mockDispatch = jest.fn()
-let mockIsFocusOnSuggestions = false
+const mockIsFocusOnSuggestions = false
+
+const mockUseSearch = jest.fn(() => ({
+  searchState: mockSearchState,
+  dispatch: mockDispatch,
+  isFocusOnSuggestions: mockIsFocusOnSuggestions,
+  hideSuggestions: jest.fn(),
+}))
 jest.mock('features/search/context/SearchWrapper', () => ({
-  useSearch: () => ({
-    searchState: mockSearchState,
-    dispatch: mockDispatch,
-    isFocusOnSuggestions: mockIsFocusOnSuggestions,
-    hideSuggestions: jest.fn(),
-  }),
+  useSearch: () => mockUseSearch(),
 }))
 
 const mockData = { pages: [{ nbHits: 0, hits: [], page: 0 }] }
@@ -223,13 +224,12 @@ describe('<SearchResults/>', () => {
   mockUseNetInfoContext.mockReturnValue({ isConnected: true })
 
   afterEach(() => {
-    mockSearchState = {
-      ...initialSearchState,
-      offerCategories: [SearchGroupNameEnumv2.CINEMA],
-      venue,
-      priceRange: [0, 20],
-    }
-    mockIsFocusOnSuggestions = false
+    mockUseSearch.mockReturnValue({
+      searchState: mockSearchState,
+      dispatch: mockDispatch,
+      isFocusOnSuggestions: false,
+      hideSuggestions: jest.fn(),
+    })
   })
 
   it('should render SearchResults', async () => {
@@ -244,7 +244,12 @@ describe('<SearchResults/>', () => {
 
   describe('When SearchResults is focus on suggestions', () => {
     beforeEach(() => {
-      mockIsFocusOnSuggestions = true
+      mockUseSearch.mockReturnValue({
+        searchState: mockSearchState,
+        dispatch: mockDispatch,
+        isFocusOnSuggestions: true,
+        hideSuggestions: jest.fn(),
+      })
     })
 
     it('should display offer suggestions', async () => {


### PR DESCRIPTION

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32582

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.


## Screenshots

https://github.com/user-attachments/assets/0297ccc9-85ef-4852-ac3c-ff6eb8db4d8c



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
