### PR TITLE
(BSR) fix(ThematicSearch): remove duplicate useEffect causing crashes

### DIFF
--- a/src/features/search/pages/Search/ThematicSearch/ThematicSearch.tsx
+++ b/src/features/search/pages/Search/ThematicSearch/ThematicSearch.tsx
@@ -40,6 +40,7 @@ export const ThematicSearch: React.FC = () => {
       ? env.ALGOLIA_OFFERS_INDEX_NAME_B
       : env.ALGOLIA_OFFERS_INDEX_NAME,
   })
+  const isWeb = Platform.OS === 'web'
   const { disabilities } = useAccessibilityFiltersContext()
   const { selectedLocationMode } = useLocation()
 
@@ -49,24 +50,14 @@ export const ThematicSearch: React.FC = () => {
   } = useSearchResults()
 
   const { searchState, dispatch } = useSearch()
-  useEffect(() => {
-    if (params?.offerCategories) {
-      dispatch({
-        type: 'SET_STATE',
-        payload: {
-          ...searchState,
-          offerCategories: params.offerCategories,
-        },
-      })
-    }
-  }, [dispatch, params?.offerCategories, searchState])
+
   const shouldDisplayVenuesPlaylist = !searchState.venue && !!venues?.length
 
   const isLocated = useMemo(
     () => selectedLocationMode !== LocationMode.EVERYWHERE,
     [selectedLocationMode]
   )
-  const isWeb = Platform.OS === 'web'
+
   const offerCategories = params?.offerCategories as SearchGroupNameEnumv2[]
   const offerCategory = offerCategories?.[0] || SearchGroupNameEnumv2.LIVRES
   const isBookCategory = offerCategory === SearchGroupNameEnumv2.LIVRES


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
