### PR TITLE
(PC-32947) feat(VenueBlock): remove link if offer and venue address different

### DIFF
--- a/src/features/offer/components/OfferVenueBlock/OfferVenueBlock.native.test.tsx
+++ b/src/features/offer/components/OfferVenueBlock/OfferVenueBlock.native.test.tsx
@@ -9,13 +9,14 @@ import { OfferVenueBlock } from './OfferVenueBlock'
 
 // Mock useVenueBlock hook to avoid using Clipboard API
 const mockOnCopyAddressPress = jest.fn()
-
+const mockUseVenueBlock = jest.fn(() => ({
+  venueName: 'PATHE BEAUGRENELLE',
+  venueAddress: '75008 PARIS 8, 2 RUE LAMENNAIS',
+  isOfferAddressDifferent: false,
+  onCopyAddressPress: mockOnCopyAddressPress,
+}))
 jest.mock('features/offer/components/OfferVenueBlock/useVenueBlock', () => ({
-  useVenueBlock: jest.fn(() => ({
-    venueName: 'PATHE BEAUGRENELLE',
-    venueAddress: '75008 PARIS 8, 2 RUE LAMENNAIS',
-    onCopyAddressPress: mockOnCopyAddressPress,
-  })),
+  useVenueBlock: jest.fn(() => mockUseVenueBlock()),
 }))
 
 const mockNavigateToItinerary = jest.fn()
@@ -224,6 +225,18 @@ describe('<OfferVenueBlock />', () => {
   })
 
   it('should not render see venue button when onSeeVenuePress is undefined', () => {
+    render(<OfferVenueBlock title="Lieu de retrait" offer={offerResponseSnap} />)
+
+    expect(screen.queryByTestId('RightFilled')).not.toBeOnTheScreen()
+  })
+
+  it('should not render see venue button when onSeeVenuePress is undefined', () => {
+    mockUseVenueBlock.mockReturnValueOnce({
+      venueName: 'PATHE BEAUGRENELLE',
+      venueAddress: '75008 PARIS 8, 2 RUE LAMENNAIS',
+      isOfferAddressDifferent: true,
+      onCopyAddressPress: mockOnCopyAddressPress,
+    })
     render(<OfferVenueBlock title="Lieu de retrait" offer={offerResponseSnap} />)
 
     expect(screen.queryByTestId('RightFilled')).not.toBeOnTheScreen()

--- a/src/features/offer/components/OfferVenueBlock/OfferVenueBlock.tsx
+++ b/src/features/offer/components/OfferVenueBlock/OfferVenueBlock.tsx
@@ -33,7 +33,7 @@ export function OfferVenueBlock({
   const { venue, address } = offer
   const { onCopyAddressPress, venueAddress } = useVenueBlock({
     venue,
-    address,
+    offerAddress: address,
   })
 
   const isCinema = offer.subcategoryId === SubcategoryIdEnum.SEANCE_CINE

--- a/src/features/offer/components/OfferVenueBlock/VenueBlock.tsx
+++ b/src/features/offer/components/OfferVenueBlock/VenueBlock.tsx
@@ -19,7 +19,10 @@ type Props = {
 
 export function VenueBlock({ onSeeVenuePress, offer }: Readonly<Props>) {
   const { venue, address } = offer
-  const { venueName, venueAddress, isOfferAddressDifferent } = useVenueBlock({ venue, address })
+  const { venueName, venueAddress, isOfferAddressDifferent } = useVenueBlock({
+    venue,
+    offerAddress: address,
+  })
 
   const { latitude: lat, longitude: lng } = offer.venue.coordinates
   const distance = useDistance({ lat, lng })

--- a/src/features/offer/components/OfferVenueBlock/VenueBlock.tsx
+++ b/src/features/offer/components/OfferVenueBlock/VenueBlock.tsx
@@ -19,11 +19,11 @@ type Props = {
 
 export function VenueBlock({ onSeeVenuePress, offer }: Readonly<Props>) {
   const { venue, address } = offer
-  const { venueName, venueAddress } = useVenueBlock({ venue, address })
+  const { venueName, venueAddress, isOfferAddressDifferent } = useVenueBlock({ venue, address })
 
   const { latitude: lat, longitude: lng } = offer.venue.coordinates
   const distance = useDistance({ lat, lng })
-  const hasVenuePage = !!onSeeVenuePress
+  const hasVenuePage = !!onSeeVenuePress && !isOfferAddressDifferent
   const TouchableContainer: FunctionComponent<ComponentProps<typeof InternalTouchableLink>> =
     useMemo(
       () =>

--- a/src/features/offer/components/OfferVenueBlock/useVenueBlock.native.test.ts
+++ b/src/features/offer/components/OfferVenueBlock/useVenueBlock.native.test.ts
@@ -107,7 +107,7 @@ describe('useVenueBlock with offer address', () => {
     expect(result.current.venueAddress).toBe('75013 PARIS 13, 1 RUE DES CAFÉS')
   })
 
-  it('should return isOfferAddressDifferent to true if offer address different than venue address', () => {
+  it('should return isOfferAddressDifferent to true if offer and venue address are different', () => {
     const { result } = renderHook(() =>
       useVenueBlock({
         venue: offerWithAddress.venue,
@@ -118,7 +118,7 @@ describe('useVenueBlock with offer address', () => {
     expect(result.current.isOfferAddressDifferent).toEqual(true)
   })
 
-  it('should return isOfferAddressDifferent to false if offer address different and venue address are the same', () => {
+  it('should return isOfferAddressDifferent to false if offer and venue address are the same', () => {
     const offerWithSameAddress = {
       ...offerResponseSnap,
       address: {

--- a/src/features/offer/components/OfferVenueBlock/useVenueBlock.native.test.ts
+++ b/src/features/offer/components/OfferVenueBlock/useVenueBlock.native.test.ts
@@ -42,6 +42,12 @@ describe('useVenueBlock without offer address', () => {
     expect(result.current.venueAddress).toBe('75008 PARIS 8, 2 RUE LAMENNAIS')
   })
 
+  it('should return isOfferAddressDifferent to false if offer address is not present', () => {
+    const { result } = renderHook(() => useVenueBlock({ venue: offerResponseSnap.venue }))
+
+    expect(result.current.isOfferAddressDifferent).toEqual(false)
+  })
+
   it('should copy address to clipboard', async () => {
     const spy = jest.spyOn(Clipboard, 'setString')
     const { result } = renderHook(() => useVenueBlock({ venue: offerResponseSnap.venue }))
@@ -83,22 +89,55 @@ describe('useVenueBlock with offer address', () => {
     const { result } = renderHook(() =>
       useVenueBlock({
         venue: offerWithAddress.venue,
-        address: offerWithAddress.address,
+        offerAddress: offerWithAddress.address,
       })
     )
 
     expect(result.current.venueName).toBe('PATHE MONTPARNASSE')
   })
 
-  it('should return address from metadata Location', () => {
+  it('should return address from  offer address', () => {
     const { result } = renderHook(() =>
       useVenueBlock({
         venue: offerWithAddress.venue,
-        address: offerWithAddress.address,
+        offerAddress: offerWithAddress.address,
       })
     )
 
     expect(result.current.venueAddress).toBe('75013 PARIS 13, 1 RUE DES CAFÉS')
+  })
+
+  it('should return isOfferAddressDifferent to true if offer address different than venue address', () => {
+    const { result } = renderHook(() =>
+      useVenueBlock({
+        venue: offerWithAddress.venue,
+        offerAddress: offerWithAddress.address,
+      })
+    )
+
+    expect(result.current.isOfferAddressDifferent).toEqual(true)
+  })
+
+  it('should return isOfferAddressDifferent to false if offer address different and venue address are the same', () => {
+    const offerWithSameAddress = {
+      ...offerResponseSnap,
+      address: {
+        street: '2 RUE LAMENNAIS',
+        postalCode: '75008',
+        city: 'PARIS 8',
+        label: 'PATHE BEAUGRENELLE',
+        coordinates: { latitude: 20, longitude: 2 },
+        timezone: 'Europe/Paris',
+      },
+    }
+    const { result } = renderHook(() =>
+      useVenueBlock({
+        venue: offerWithSameAddress.venue,
+        offerAddress: offerWithSameAddress.address,
+      })
+    )
+
+    expect(result.current.isOfferAddressDifferent).toEqual(false)
   })
 
   it('should copy address to clipboard', async () => {
@@ -106,7 +145,7 @@ describe('useVenueBlock with offer address', () => {
     const { result } = renderHook(() =>
       useVenueBlock({
         venue: offerWithAddress.venue,
-        address: offerWithAddress.address,
+        offerAddress: offerWithAddress.address,
       })
     )
 

--- a/src/features/offer/components/OfferVenueBlock/useVenueBlock.ts
+++ b/src/features/offer/components/OfferVenueBlock/useVenueBlock.ts
@@ -7,30 +7,35 @@ import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/S
 
 export function useVenueBlock({
   venue,
-  address,
+  offerAddress,
 }: {
   venue: OfferVenueResponse
-  address?: OfferAddressResponse
+  offerAddress?: OfferAddressResponse
 }) {
   const { showSuccessSnackBar, showErrorSnackBar } = useSnackBarContext()
 
-  const venueStreet = address?.street || venue.address
-  const venuePostalCode = address?.postalCode || venue.postalCode
-  const venueCity = address?.city || venue.city
+  const street = offerAddress?.street || venue.address
+  const postalCode = offerAddress?.postalCode || venue.postalCode
+  const city = offerAddress?.city || venue.city
 
-  const venueName = address?.label || venue.publicName || venue.name
+  const venueName = offerAddress?.label || venue.publicName || venue.name
+  const address = useMemo(
+    () => formatFullAddressStartsWithPostalCode(street, postalCode, city),
+    [street, postalCode, city]
+  )
   const venueAddress = useMemo(
-    () => formatFullAddressStartsWithPostalCode(venueStreet, venuePostalCode, venueCity),
-    [venueStreet, venuePostalCode, venueCity]
+    () => formatFullAddressStartsWithPostalCode(venue.address, venue.postalCode, venue.city),
+    [venue.address, venue.postalCode, venue.city]
   )
 
   return useMemo(
     () => ({
       venueName,
-      venueAddress,
+      venueAddress: address,
+      isOfferAddressDifferent: address !== venueAddress,
       onCopyAddressPress: async () => {
-        Clipboard.setString(venueAddress)
-        if ((await Clipboard.getString()) === venueAddress) {
+        Clipboard.setString(address)
+        if ((await Clipboard.getString()) === address) {
           showSuccessSnackBar({
             message: 'L’adresse a bien été copiée',
             timeout: SNACK_BAR_TIME_OUT,
@@ -43,6 +48,6 @@ export function useVenueBlock({
         }
       },
     }),
-    [venueAddress, showErrorSnackBar, showSuccessSnackBar, venueName]
+    [address, venueAddress, showErrorSnackBar, showSuccessSnackBar, venueName]
   )
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32947

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [x] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
