### PR TITLE
(PC-32699) feat(NC): display non eligible banner in SetCity input

### DIFF
--- a/src/features/profile/components/CitySearchInput/CitySearchInput.native.test.tsx
+++ b/src/features/profile/components/CitySearchInput/CitySearchInput.native.test.tsx
@@ -11,8 +11,9 @@ jest.mock('libs/subcategories/useSubcategory')
 jest.mock('libs/network/NetInfoWrapper')
 
 const POSTAL_CODE = '83570'
+const NEW_CALEDONIA_NORTHERN_PROVINCE_POSTAL_CODE = '98825'
 
-describe('<CitySelector />', () => {
+describe('<CitySearchInput />', () => {
   it('should display error message when the user enters a valid postal code but no city found', async () => {
     mockServer.universalGet<CitiesResponse>(CITIES_API_URL, [])
     render(reactQueryProviderHOC(<CitySearchInput />))
@@ -29,6 +30,22 @@ describe('<CitySelector />', () => {
     })
   })
 
+  it('should display an ineligible postal code message', async () => {
+    mockServer.universalGet<CitiesResponse>(CITIES_API_URL, mockedSuggestedCities)
+    render(reactQueryProviderHOC(<CitySearchInput />))
+
+    const input = screen.getByPlaceholderText('Ex\u00a0: 75017')
+    fireEvent.changeText(input, NEW_CALEDONIA_NORTHERN_PROVINCE_POSTAL_CODE)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Malheureusement, tu n’es pas éligible au pass Culture. Ton code postal est dans une région où nous ne sommes pas présents.'
+        )
+      ).toBeOnTheScreen()
+    })
+  })
+
   it('should display cities when the user enters a valid postal code', async () => {
     mockServer.universalGet<CitiesResponse>(CITIES_API_URL, mockedSuggestedCities)
     render(reactQueryProviderHOC(<CitySearchInput />))
@@ -39,6 +56,21 @@ describe('<CitySelector />', () => {
     await waitFor(() => {
       expect(screen.getByText(mockedSuggestedCities[0].nom)).toBeOnTheScreen()
       expect(screen.getByText(mockedSuggestedCities[1].nom)).toBeOnTheScreen()
+    })
+  })
+
+  it('should reset the search input when pressing the reset icon', async () => {
+    mockServer.universalGet<CitiesResponse>(CITIES_API_URL, mockedSuggestedCities)
+    render(reactQueryProviderHOC(<CitySearchInput />))
+
+    const input = screen.getByPlaceholderText('Ex\u00a0: 75017')
+    fireEvent.changeText(input, POSTAL_CODE)
+
+    const resetIcon = screen.getByTestId('Réinitialiser la recherche')
+    fireEvent.press(resetIcon)
+
+    await waitFor(() => {
+      expect(input.props.value).toBe('')
     })
   })
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32699

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
