### PR TITLE
(BSR) fix(CI): set plist path output with correct env

### DIFF
--- a/.github/workflows/dev_on_workflow_environment_ios_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_ios_deploy.yml
@@ -82,7 +82,7 @@ jobs:
           sed '$d' .sentryclirc
           echo "token=${{ steps.secrets.outputs.SENTRY_AUTH_TOKEN }}" >> .sentryclirc
       - name: Setup iOS Google services config
-        run: echo '${{ steps.secrets.outputs.IOS_GOOGLE_SERVICES_PLIST }}' > ios/GoogleService-Info.plist
+        run: echo '${{ steps.secrets.outputs.IOS_GOOGLE_SERVICES_PLIST }}' > ios/GoogleService-Info-{{ inputs.ENV }}.plist
       - name: Add ssh key needed
         uses: webfactory/ssh-agent@v0.8.0
         with:


### PR DESCRIPTION
After the firebase split we need to give the right plist path in our GA workflow