### PR TITLE
(BSR) docs(andorid): update android doc

### DIFF
--- a/doc/installation/Android.md
+++ b/doc/installation/Android.md
@@ -50,7 +50,7 @@ yarn start
 
 In Android Studio: File > Settings > Experimental > Gradle -> uncheck "Only sync the active variant" checkbox.
 
-En cas de soucis avec le JDK installer via `brew install --cask zulu11` et ajouter le chemin `JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home` dans .zshrc
+En cas de soucis avec le JDK installer via `brew install --cask zulu17` et ajouter le chemin `JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home` dans .zshrc
 
 </details>
 <details>

--- a/scripts/generate_api_client_silicon.sh
+++ b/scripts/generate_api_client_silicon.sh
@@ -14,7 +14,8 @@ docker run \
     --network="host" \
     --rm \
     --volume "${PWD}:/local" \
-    "parsertongue/swagger-codegen-cli:${SWAGGER_CODEGEN_CLI_VERSION:-'latest'}" generate \
+    --volume "$JAVA_HOME/lib/security/cacerts:/opt/java/openjdk/lib/security/cacerts" \
+    "parsertongue/swagger-codegen-cli:latest" generate \
         --input-spec https://backend.testing.passculture.team/native/openapi.json `# schema location` \
         --lang typescript-fetch `# client type` \
         --config /local/swagger_codegen/swagger_codegen_config.json `# swagger codegen config` \


### PR DESCRIPTION
Lorsque j'ai voulu suivre la [doc pour mettre à jour l'API avec le proxy](https://www.notion.so/passcultureapp/G-n-rer-les-sch-mas-d-API-83c8f44b019a436798995f9b8294ae2b?cookie_sync_completed=true), j'ai eu un problème de version de Java qui était dans mon .zshrc, car j'avais suivis la doc d'installation d'Android. 

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
