### PR TITLE
(BSR) chore(vscode): confirm before closing VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,4 +33,5 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "devbox.autoShellOnTerminal": false,
+  "window.confirmBeforeClose": "keyboardOnly",
 }


### PR DESCRIPTION
j'en ai marre de faire kicker de Live Share parce qu'il y a une erreur de raccourci clavier (CMD+Q est juste à coté de CMD+S)

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]


