### PR TITLE
(PC-32805) fix(TouchableLink): add default debounce delay to avoid press spamming

### DIFF
--- a/src/features/navigation/RootNavigator/Header/AccessibleTabBar.web.test.tsx
+++ b/src/features/navigation/RootNavigator/Header/AccessibleTabBar.web.test.tsx
@@ -119,12 +119,13 @@ describe('AccessibleTabBar', () => {
 
   it('should reset params on press "Recherche" when already on Search tab', async () => {
     const navigateFromRefSpy = jest.spyOn(navigationRefAPI, 'navigateFromRef')
+    jest.useFakeTimers()
     renderTabBar()
     const searchButton = screen.getByText('Recherche')
     await act(() => {
       fireEvent.click(searchButton)
     })
-
+    jest.advanceTimersByTime(300)
     await act(() => {
       fireEvent.click(searchButton)
     })
@@ -132,6 +133,8 @@ describe('AccessibleTabBar', () => {
     expect(navigateFromRefSpy).toHaveBeenCalledWith(
       ...getSearchStackConfig('SearchLanding', mockSearchState)
     )
+
+    jest.useRealTimers()
   })
 })
 

--- a/src/ui/components/SocialNetworkCard.tsx
+++ b/src/ui/components/SocialNetworkCard.tsx
@@ -29,8 +29,7 @@ function SocialNetworkCardComponent(props: SocialNetworkCardProps) {
   return (
     <ExternalTouchableLink
       externalNav={{ url: link, params: { shouldLogEvent: false, fallbackUrl: fallbackLink } }}
-      onBeforeNavigate={onBeforeNavigate}
-      isOnPressThrottled>
+      onBeforeNavigate={onBeforeNavigate}>
       <Container>
         <NetworkIconBox>
           <StyledIcon />

--- a/src/ui/components/touchableLink/TouchableLink.native.test.tsx
+++ b/src/ui/components/touchableLink/TouchableLink.native.test.tsx
@@ -67,5 +67,55 @@ describe('<TouchableLink />', () => {
       expect(screen.getByText(buttonText)).toBeOnTheScreen()
       expect(link.props.style).toEqual(expectedStyle)
     })
+
+    it('should trigger handleNavigation only once in case of press spamming', async () => {
+      render(
+        <TouchableLink handleNavigation={handleNavigationMock}>
+          <TouchableLinkContent />
+        </TouchableLink>
+      )
+
+      fireEvent.press(screen.getByText(linkText))
+      fireEvent.press(screen.getByText(linkText))
+      fireEvent.press(screen.getByText(linkText))
+
+      await waitFor(() => {
+        expect(handleNavigationMock).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    it('should trigger handleNavigation with multiple press respecting cooldown delay', async () => {
+      jest.useFakeTimers()
+      render(
+        <TouchableLink handleNavigation={handleNavigationMock}>
+          <TouchableLinkContent />
+        </TouchableLink>
+      )
+
+      fireEvent.press(screen.getByText(linkText))
+      jest.advanceTimersByTime(400)
+      fireEvent.press(screen.getByText(linkText))
+      jest.advanceTimersByTime(400)
+      fireEvent.press(screen.getByText(linkText))
+
+      await waitFor(() => {
+        expect(handleNavigationMock).toHaveBeenCalledTimes(3)
+      })
+    })
+
+    it('should not trigger handleNavigation when Link is disabled', async () => {
+      jest.useFakeTimers()
+      render(
+        <TouchableLink handleNavigation={handleNavigationMock} disabled>
+          <TouchableLinkContent />
+        </TouchableLink>
+      )
+
+      fireEvent.press(screen.getByText(linkText))
+
+      await waitFor(() => {
+        expect(handleNavigationMock).not.toHaveBeenCalledTimes(3)
+      })
+    })
   })
 })

--- a/src/ui/components/touchableLink/TouchableLink.web.test.tsx
+++ b/src/ui/components/touchableLink/TouchableLink.web.test.tsx
@@ -20,6 +20,18 @@ describe('<TouchableLink />', () => {
     expect(handleNavigationMock).toHaveBeenCalledTimes(1)
   })
 
+  it('should not call handleNavigation when disabled', async () => {
+    render(
+      <TouchableLink handleNavigation={handleNavigationMock} disabled>
+        <Text>linkText</Text>
+      </TouchableLink>
+    )
+
+    fireEvent.click(screen.getByText('linkText'))
+
+    expect(handleNavigationMock).not.toHaveBeenCalled()
+  })
+
   it('should not handleNavigation when metaKey', async () => {
     render(
       <TouchableLink handleNavigation={handleNavigationMock}>

--- a/src/ui/components/touchableLink/types.ts
+++ b/src/ui/components/touchableLink/types.ts
@@ -41,7 +41,7 @@ type TouchableLinkGenericProps = {
   onAfterNavigate?: (event: GestureResponderEvent | MouseEvent) => void
   highlight?: boolean // If true, uses TouchableHighlight instead of TouchableOpacity to render component
   hoverUnderlineColor?: ColorsEnum // Color to be used for underline effect on hover. Black if not specified
-  isOnPressThrottled?: boolean
+  pressCooldownDelay?: number
 } & Omit<TouchableOpacityProps, 'onPress'> &
   AsProps
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -129,7 +129,7 @@ export default ({ mode }) => {
         },
       ],
     },
-    server: proxyConfig,
+    server: {...proxyConfig, open:true},
     preview: proxyConfig,
     optimizeDeps: {
       include: ['react-native', 'react-native-web'],


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32805

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
