### PR TITLE
(PC-33140) fix(booking): no notification when booking without reaction cancelled

### DIFF
--- a/src/features/bookings/helpers/useBookingsAwaitingReaction.ts
+++ b/src/features/bookings/helpers/useBookingsAwaitingReaction.ts
@@ -14,7 +14,8 @@ export function useBookingsAwaitingReaction() {
     const subCategory = subcategoriesMapping[data.stock.offer.subcategoryId]
     return (
       reactionCategories.categories.includes(subCategory.nativeCategoryId) &&
-      data.userReaction === null
+      data.userReaction === null &&
+      !data.cancellationDate
     )
   }).length
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33140

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
