### PR TITLE
(PC-33155) fix(IncomingReactionModalContainer): display the modal 31 one days later for most of categories (except SEANCE_CINEMA)

### DIFF
--- a/src/features/home/components/helpers/filterBookingsWithoutReaction/filterBookingsWithoutReaction.test.ts
+++ b/src/features/home/components/helpers/filterBookingsWithoutReaction/filterBookingsWithoutReaction.test.ts
@@ -64,7 +64,7 @@ describe('filterBookingsWithoutReaction', () => {
         ...baseBooking.stock,
         offer: { ...baseBooking.stock.offer, subcategoryId: SubcategoryIdEnum.ABO_BIBLIOTHEQUE },
       },
-      dateUsed: new Date(CURRENT_DATE.getTime() - TWENTY_FOUR_HOURS - 1).toISOString(), // Plus de 24 heures
+      dateUsed: new Date(CURRENT_DATE.getTime() - TWENTY_FOUR_HOURS - 1).toISOString(), // More than 24 hours
       userReaction: null,
     }
     const result = filterBookingsWithoutReaction(

--- a/src/features/home/components/helpers/filterBookingsWithoutReaction/filterBookingsWithoutReaction.test.ts
+++ b/src/features/home/components/helpers/filterBookingsWithoutReaction/filterBookingsWithoutReaction.test.ts
@@ -19,7 +19,15 @@ describe('filterBookingsWithoutReaction', () => {
   })
 
   const reactionCategories = {
-    categories: [NativeCategoryIdEnumv2.SEANCES_DE_CINEMA],
+    categories: [
+      NativeCategoryIdEnumv2.SEANCES_DE_CINEMA,
+      NativeCategoryIdEnumv2.DVD_BLU_RAY,
+      NativeCategoryIdEnumv2.CD,
+      NativeCategoryIdEnumv2.VINYLES,
+      NativeCategoryIdEnumv2.LIVRES_AUDIO_PHYSIQUES,
+      NativeCategoryIdEnumv2.LIVRES_NUMERIQUE_ET_AUDIO,
+      NativeCategoryIdEnumv2.LIVRES_PAPIER,
+    ],
   }
 
   const baseBooking: BookingReponse = {
@@ -75,7 +83,7 @@ describe('filterBookingsWithoutReaction', () => {
         ...baseBooking.stock,
         offer: { ...baseBooking.stock.offer, subcategoryId: SubcategoryIdEnum.SEANCE_CINE },
       },
-      dateUsed: new Date(CURRENT_DATE.getTime() - TWENTY_FOUR_HOURS - 1).toISOString(), // Plus de 24 heures
+      dateUsed: new Date(CURRENT_DATE.getTime() - TWENTY_FOUR_HOURS - 1).toISOString(), // More than 24 hours
       userReaction: ReactionTypeEnum.LIKE,
     }
     const result = filterBookingsWithoutReaction(
@@ -87,14 +95,14 @@ describe('filterBookingsWithoutReaction', () => {
     expect(result).toBe(false)
   })
 
-  it('should return false if elapsed time is less than 24 hours', () => {
+  it('should return false if elapsed time is less than 24 hours for SEANCES_DE_CINEMA', () => {
     const bookingWithin24Hours = {
       ...baseBooking,
       stock: {
         ...baseBooking.stock,
         offer: { ...baseBooking.stock.offer, subcategoryId: SubcategoryIdEnum.SEANCE_CINE },
       },
-      dateUsed: new Date(CURRENT_DATE.getTime() - TWENTY_FOUR_HOURS + 1).toISOString(), // Moins de 24 heures
+      dateUsed: new Date(CURRENT_DATE.getTime() - TWENTY_FOUR_HOURS + 1).toISOString(), // Less than 24 hours
       userReaction: null,
     }
     const result = filterBookingsWithoutReaction(
@@ -106,14 +114,52 @@ describe('filterBookingsWithoutReaction', () => {
     expect(result).toBe(false)
   })
 
-  it('should return true if elapsed time is more than 24 hours and all conditions are met', () => {
+  it('should return true if elapsed time is more than 24 hours for SEANCES_DE_CINEMA', () => {
     const validBooking = {
       ...baseBooking,
       stock: {
         ...baseBooking.stock,
         offer: { ...baseBooking.stock.offer, subcategoryId: SubcategoryIdEnum.SEANCE_CINE },
       },
-      dateUsed: new Date(CURRENT_DATE.getTime() - TWENTY_FOUR_HOURS - 1).toISOString(), // Plus de 24 heures
+      dateUsed: new Date(CURRENT_DATE.getTime() - TWENTY_FOUR_HOURS - 1).toISOString(), // More than 24 hours
+      userReaction: null,
+    }
+    const result = filterBookingsWithoutReaction(
+      validBooking,
+      subcategoriesMapping,
+      reactionCategories
+    )
+
+    expect(result).toBe(true)
+  })
+
+  it('should return false if elapsed time is less than 31 days for eligible categories', () => {
+    const bookingWithin31Days = {
+      ...baseBooking,
+      stock: {
+        ...baseBooking.stock,
+        offer: { ...baseBooking.stock.offer, subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER },
+      },
+      dateUsed: new Date(CURRENT_DATE.getTime() - 30 * TWENTY_FOUR_HOURS).toISOString(), // Less than 31 days
+      userReaction: null,
+    }
+    const result = filterBookingsWithoutReaction(
+      bookingWithin31Days,
+      subcategoriesMapping,
+      reactionCategories
+    )
+
+    expect(result).toBe(false)
+  })
+
+  it('should return true if elapsed time is more than 31 days for eligible categories and all conditions are met', () => {
+    const validBooking = {
+      ...baseBooking,
+      stock: {
+        ...baseBooking.stock,
+        offer: { ...baseBooking.stock.offer, subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER },
+      },
+      dateUsed: new Date(CURRENT_DATE.getTime() - 31 * TWENTY_FOUR_HOURS - 1).toISOString(), // More than 31 days
       userReaction: null,
     }
     const result = filterBookingsWithoutReaction(

--- a/src/features/home/components/helpers/filterBookingsWithoutReaction/filterBookingsWithoutReaction.ts
+++ b/src/features/home/components/helpers/filterBookingsWithoutReaction/filterBookingsWithoutReaction.ts
@@ -1,5 +1,5 @@
 import { BookingReponse, NativeCategoryIdEnumv2 } from 'api/gen'
-import { TWENTY_FOUR_HOURS } from 'features/home/constants'
+import { THIRTY_ONE_DAYS, TWENTY_FOUR_HOURS } from 'features/home/constants'
 import { SubcategoriesMapping } from 'libs/subcategories/types'
 
 export function filterBookingsWithoutReaction(
@@ -17,6 +17,10 @@ export function filterBookingsWithoutReaction(
     return false
   }
 
+  const isCinemaCategory = subcategory.nativeCategoryId === NativeCategoryIdEnumv2.SEANCES_DE_CINEMA
+
   const elapsedTime = now.getTime() - new Date(dateUsed).getTime()
-  return elapsedTime > TWENTY_FOUR_HOURS
+  const timeThreshold = isCinemaCategory ? TWENTY_FOUR_HOURS : THIRTY_ONE_DAYS
+
+  return elapsedTime > timeThreshold
 }

--- a/src/features/home/constants.ts
+++ b/src/features/home/constants.ts
@@ -1,4 +1,4 @@
 export const PERFORMANCE_HOME_CREATION = 'HOME:CREATION'
 export const PERFORMANCE_HOME_LOADING = 'HOME:LOADING'
 export const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000 // 24 hours in milliseconds
-export const THIRTY_ONE_DAYS = 31 * 24 * 60 * 60 * 1000 // 31 jours in milliseconds
+export const THIRTY_ONE_DAYS = 31 * TWENTY_FOUR_HOURS // 31 days in milliseconds

--- a/src/features/home/constants.ts
+++ b/src/features/home/constants.ts
@@ -1,3 +1,4 @@
 export const PERFORMANCE_HOME_CREATION = 'HOME:CREATION'
 export const PERFORMANCE_HOME_LOADING = 'HOME:LOADING'
 export const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000 // 24 hours in milliseconds
+export const THIRTY_ONE_DAYS = 31 * 24 * 60 * 60 * 1000 // 31 jours in milliseconds


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33155

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
