### PR TITLE
(BSR) test(web): implements user-events for web + update some tests

### DIFF
--- a/src/features/offer/components/OfferContent/OfferContent.web.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.test.tsx
@@ -13,7 +13,7 @@ import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
 import { mockAuthContextWithoutUser } from 'tests/AuthContextUtils'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen, waitFor } from 'tests/utils/web'
+import { render, screen, waitFor, userEvent } from 'tests/utils/web'
 import * as useModalAPI from 'ui/components/modals/useModal'
 
 import { OfferContent } from './OfferContent.web'
@@ -85,34 +85,41 @@ function renderOfferContent({
 }
 
 describe('<OfferContent />', () => {
+  const user = userEvent.setup()
+
   beforeEach(() => {
-    jest.useRealTimers()
     mockServer.getApi<SubcategoriesResponseModelv2>('/v1/subcategories/v2', subcategoriesDataTest)
     mockPosition = { latitude: 90.4773245, longitude: 90.4773245 }
     mockAuthContextWithoutUser({ persist: true })
   })
 
   it('should not display sticky booking button on desktop', async () => {
-    renderOfferContent({ isDesktopViewport: true })
+    const { unmount } = renderOfferContent({ isDesktopViewport: true })
 
     await screen.findByText('Réserver l’offre')
 
     expect(screen.queryByTestId('sticky-booking-button')).not.toBeInTheDocument()
+
+    unmount()
   })
 
   it('should display sticky booking button on mobile', async () => {
-    renderOfferContent({ isDesktopViewport: false })
+    const { unmount } = renderOfferContent({ isDesktopViewport: false })
     await screen.findByText('Réserver l’offre')
 
     expect(screen.getByTestId('sticky-booking-button')).toBeInTheDocument()
+
+    unmount()
   })
 
   it('should not display mobile body on desktop', async () => {
-    renderOfferContent({ isDesktopViewport: true })
+    const { unmount } = renderOfferContent({ isDesktopViewport: true })
 
     await screen.findByText('Réserver l’offre')
 
     expect(screen.queryByTestId('offer-body-mobile')).not.toBeInTheDocument()
+
+    unmount()
   })
 
   it('should display mobile body on mobile', async () => {
@@ -145,15 +152,17 @@ describe('<OfferContent />', () => {
   })
 
   it('should display linear gradient on offer image', async () => {
-    renderOfferContent({ isDesktopViewport: false })
+    const { unmount } = renderOfferContent({ isDesktopViewport: false })
 
     expect(await screen.findByTestId('imageGradient')).toBeInTheDocument()
+
+    unmount()
   })
 
   it('should not display tag on offer image when enableOfferPreview feature flag activated', async () => {
     const { unmount } = renderOfferContent({ isDesktopViewport: false })
 
-    await waitFor(async () => {
+    await waitFor(() => {
       expect(screen.queryByTestId('imageTag')).not.toBeInTheDocument()
     })
     unmount()
@@ -166,7 +175,7 @@ describe('<OfferContent />', () => {
     }
     const { unmount } = renderOfferContent({ offer })
 
-    fireEvent.click(await screen.findByLabelText('Carousel image 1'))
+    user.click(await screen.findByLabelText('Carousel image 1'))
 
     await waitFor(() => expect(mockShowModal).toHaveBeenCalledTimes(1))
     unmount()

--- a/src/features/offer/components/OfferHeader/OfferHeader.web.test.tsx
+++ b/src/features/offer/components/OfferHeader/OfferHeader.web.test.tsx
@@ -7,7 +7,7 @@ import { offerResponseSnap as mockOffer } from 'features/offer/fixtures/offerRes
 import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen } from 'tests/utils/web'
+import { act, render, screen, userEvent } from 'tests/utils/web'
 
 import { OfferHeader } from '../OfferHeader/OfferHeader'
 
@@ -51,6 +51,7 @@ describe('<OfferHeader />', () => {
   })
 
   it('should display the share modal when clicking on the share button', async () => {
+    const user = userEvent.setup()
     const animatedValue = new Animated.Value(0)
 
     render(
@@ -64,10 +65,11 @@ describe('<OfferHeader />', () => {
     )
 
     const shareButton = screen.getByLabelText('Partager')
+
     await act(async () => {
-      fireEvent.click(shareButton)
+      await user.click(shareButton)
     })
 
-    expect(screen.getByText('Partager l’offre')).toBeInTheDocument()
+    expect(await screen.findByText('Partager l’offre')).toBeInTheDocument()
   })
 })

--- a/src/features/offer/components/OfferImageCarousel/OfferImageCarousel.web.test.tsx
+++ b/src/features/offer/components/OfferImageCarousel/OfferImageCarousel.web.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import { SharedValue } from 'react-native-reanimated'
 
-import { render, screen, fireEvent } from 'tests/utils/web'
+import { render, screen, userEvent, act } from 'tests/utils/web'
 
 import { OfferImageCarousel } from './OfferImageCarousel'
 
 describe('OfferImageCarousel', () => {
+  const user = userEvent.setup({ delay: 50 })
+
   beforeEach(() => {
     jest.spyOn(console, 'warn').mockImplementation()
   })
@@ -59,7 +61,9 @@ describe('OfferImageCarousel', () => {
       />
     )
 
-    await fireEvent.click(screen.getByLabelText('Carousel image 3'))
+    await act(async () => {
+      await user.click(screen.getByLabelText('Carousel image 3'))
+    })
 
     expect(mockOnItemPress).toHaveBeenCalledWith(2)
   })

--- a/src/features/offer/components/OfferImageCarouselPagination/OfferImageCarouselPagination.web.test.tsx
+++ b/src/features/offer/components/OfferImageCarouselPagination/OfferImageCarouselPagination.web.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 
 import { OfferImageCarouselPagination } from 'features/offer/components/OfferImageCarouselPagination/OfferImageCarouselPagination.web'
-import { fireEvent, render, screen } from 'tests/utils/web'
+import { render, screen, userEvent } from 'tests/utils/web'
 
 const mockHandlePressButton = jest.fn()
 
 describe('<OfferImageCarouselPagination />', () => {
+  const user = userEvent.setup()
+
   it('should display pagination with dots and buttons', () => {
     render(
       <OfferImageCarouselPagination
@@ -30,7 +32,7 @@ describe('<OfferImageCarouselPagination />', () => {
     expect(screen.queryByTestId('onlyDotsContainer')).not.toBeInTheDocument()
   })
 
-  it('should handle previous button clicking', () => {
+  it('should handle previous button clicking', async () => {
     render(
       <OfferImageCarouselPagination
         progressValue={{ value: 0 }}
@@ -40,12 +42,12 @@ describe('<OfferImageCarouselPagination />', () => {
     )
 
     const previousButton = screen.getByTestId('Image précédente')
-    fireEvent.click(previousButton)
+    await user.click(previousButton)
 
     expect(mockHandlePressButton).toHaveBeenNthCalledWith(1, -1)
   })
 
-  it('should handle next button clicking', () => {
+  it('should handle next button clicking', async () => {
     render(
       <OfferImageCarouselPagination
         progressValue={{ value: 0 }}
@@ -55,7 +57,7 @@ describe('<OfferImageCarouselPagination />', () => {
     )
 
     const nextButton = screen.getByTestId('Image suivante')
-    fireEvent.click(nextButton)
+    await user.click(nextButton)
 
     expect(mockHandlePressButton).toHaveBeenNthCalledWith(1, 1)
   })

--- a/src/features/offer/components/OfferImageContainer/OfferImageContainer.web.test.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageContainer.web.test.tsx
@@ -24,7 +24,7 @@ describe('<OfferImageContainer />', () => {
 
   // TODO(PC-30559) : test flaky sur la CI
   // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('should display carousel with several images', () => {
+  it('should display carousel with several images', () => {
     render(
       <OfferImageContainer
         imageUrls={['some_url_to_some_resource', 'some_url2_to_some_resource']}

--- a/src/tests/utils/web.tsx
+++ b/src/tests/utils/web.tsx
@@ -27,9 +27,10 @@ type PropsWithTheme = {
 }
 
 const DefaultWrapper = ({ children, theme }: PropsWithTheme) => {
+  const innerTheme = deepmerge(computedTheme, theme || {})
   return (
-    <ThemeProviderWeb theme={deepmerge(computedTheme, theme || {})}>
-      <ThemeProvider theme={deepmerge(computedTheme, theme || {})}>
+    <ThemeProviderWeb theme={innerTheme}>
+      <ThemeProvider theme={innerTheme}>
         <IconFactoryProvider>{children}</IconFactoryProvider>
       </ThemeProvider>
     </ThemeProviderWeb>
@@ -58,6 +59,7 @@ function customRender(ui: React.ReactElement<any>, options?: CustomRenderOptions
 
 // eslint-disable-next-line no-restricted-imports
 export * from '@testing-library/react'
+export { userEvent } from '@testing-library/user-event'
 
 export { axe as checkAccessibilityFor } from 'jest-axe'
 


### PR DESCRIPTION
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
