### PR TITLE
(BSR) feat(Jest): add the possibility to create empty mocks from types

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
   plugins: [
@@ -23,7 +25,7 @@ module.exports = {
         },
       },
     ],
-    "@babel/plugin-transform-numeric-separator",
+    '@babel/plugin-transform-numeric-separator',
     '@babel/plugin-proposal-unicode-property-regex',
     '@babel/plugin-proposal-export-namespace-from',
     'react-native-reanimated/plugin',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,28 @@
 const { excludeCollectCoverageFrom } = require('./jest.excludeCollectCoverageFrom.config')
 
+const { createJsWithBabelPreset } = require('ts-jest')
+
+const jsWithBabelPreset = createJsWithBabelPreset({
+  tsconfig: 'tsconfig.spec.json',
+  babelConfig: true,
+})
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+
 module.exports = {
   preset: 'react-native',
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node','android.tsx','android.ts','android.jsx','android.js'],
+  moduleFileExtensions: [
+    'ts',
+    'tsx',
+    'js',
+    'jsx',
+    'json',
+    'node',
+    'android.tsx',
+    'android.ts',
+    'android.jsx',
+    'android.js',
+  ],
   testEnvironmentOptions: { customExportConditions: [''] },
   moduleNameMapper: {
     '^api(.*)$': '<rootDir>/src/api$1',
@@ -23,9 +43,7 @@ module.exports = {
     '@react-native-google-signin/google-signin/jest/build/setup.js',
   ],
   setupFilesAfterEnv: ['./src/tests/setupTests.js'],
-  transform: {
-    '^.+\\.[jt]sx?$': 'babel-jest',
-  },
+  transform: jsWithBabelPreset.transform,
   transformIgnorePatterns: [
     'node_modules/(?!(jest-)?react-native' +
       '|@react-navigation' +

--- a/jest/jest.setup.ts
+++ b/jest/jest.setup.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-undef */
 import 'cross-fetch/polyfill'
+import 'jest-ts-auto-mock'
 
 // @ts-ignore jest can have access to this file but typescript does not know it
 // We can see it
-import mockRNDeviceInfo from 'react-native-device-info/jest/react-native-device-info-mock'
 
 jest.unmock('react-query')
 
@@ -24,6 +24,11 @@ jest.mock('libs/analytics/provider')
 jest.mock('libs/environment/env')
 
 // I have a problem with mockRNDeviceInfo doesn't recognize by TS
-jest.mock('react-native-device-info', () => mockRNDeviceInfo)
+jest.mock('react-native-device-info', () => {
+  const mockRNDeviceInfo = jest.requireActual(
+    'react-native-device-info/jest/react-native-device-info-mock'
+  )
+  return mockRNDeviceInfo
+})
 
 jest.unmock('react-native-modal')

--- a/jest/jest.web.setup.ts
+++ b/jest/jest.web.setup.ts
@@ -3,7 +3,6 @@ import 'jest-canvas-mock'
 jest.unmock('react-native-modal')
 jest.mock('libs/firebase/firestore/client.web', () => {
   const firestoreRemoteStore = jest.requireActual('libs/firebase/shims/firestore/index.web')
-  firestoreRemoteStore.settings({ experimentalAutoDetectLongPolling: true, merge: true })
   return {
     __esModule: true,
     default: firestoreRemoteStore,

--- a/jest/jest.web.setup.ts
+++ b/jest/jest.web.setup.ts
@@ -1,9 +1,8 @@
 import 'jest-canvas-mock'
-import mockFirestore from 'libs/firebase/shims/firestore/index.web'
 
 jest.unmock('react-native-modal')
 jest.mock('libs/firebase/firestore/client.web', () => {
-  const firestoreRemoteStore = mockFirestore()
+  const firestoreRemoteStore = jest.requireActual('libs/firebase/shims/firestore/index.web')
   firestoreRemoteStore.settings({ experimentalAutoDetectLongPolling: true, merge: true })
   return {
     __esModule: true,

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     ]
   },
   "scripts": {
+    "prepare": "ts-patch install -s",
     "preandroid": "./scripts/start_android_emulator_with_certificate.sh",
     "android": "react-native run-android",
     "android:prod": "yarn android --variant=productionDebug --appId=app.passculture.webapp",
@@ -322,6 +323,7 @@
     "jest-environment-jsdom": "^29.6.2",
     "jest-junit": "^13.2.0",
     "jest-styled-components": "^7.0.8",
+    "jest-ts-auto-mock": "^2.1.0",
     "jetifier": "^1.6.5",
     "json": "^11.0.0",
     "mailparser": "^3.6.3",
@@ -342,7 +344,10 @@
     "sass-loader": "^11.0.1",
     "style-loader": "^2.0.0",
     "timezone-mock": "^1.2.1",
+    "ts-auto-mock": "^3.7.4",
+    "ts-jest": "^29.2.5",
     "ts-node": "^10.8.0",
+    "ts-patch": "^3.2.1",
     "ts-prune": "^0.10.3",
     "type-fest": "^4.15.0",
     "typescript": "5.0.4",

--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -15,7 +15,6 @@
 ./src/features/bookOffer/components/Calendar/useMarkedDates.native.test.ts:74
 ./src/features/bookOffer/components/Calendar/useMarkedDates.native.test.ts:85
 ./src/features/bookOffer/components/Calendar/useMarkedDates.native.test.ts:87
-./src/features/bookOffer/helpers/useReviewInAppInformation.ts:16
 ./src/features/bookOffer/helpers/useRotatingText.ts:44
 ./src/features/bookOffer/helpers/useRotatingText.ts:47
 ./src/features/bookOffer/helpers/useRotatingText.ts:54

--- a/src/features/artist/pages/Artist.tsx
+++ b/src/features/artist/pages/Artist.tsx
@@ -39,3 +39,5 @@ export const Artist: FunctionComponent = () => {
     <PageNotFound />
   )
 }
+
+export default Artist

--- a/src/features/bookOffer/helpers/useReviewInAppInformation.ts
+++ b/src/features/bookOffer/helpers/useReviewInAppInformation.ts
@@ -13,7 +13,6 @@ export const useReviewInAppInformation = () => {
   useEffect(() => {
     storage
       .readMultiString(['times_review_has_been_requested', 'first_time_review_has_been_requested'])
-      // @ts-expect-error: because of noUncheckedIndexedAccess
       .then(([[, reviewsRequested], [, firstReview]]) => {
         const timesReviewsRequested = parseInt(reviewsRequested ?? '0')
         setTimesReviewHasBeenRequested(timesReviewsRequested)

--- a/src/features/deeplinks/helpers/getScreenFromDeeplink.ts
+++ b/src/features/deeplinks/helpers/getScreenFromDeeplink.ts
@@ -1,11 +1,12 @@
 import { linking } from 'features/navigation/RootNavigator/linking'
+import { linkingPrefixes } from 'features/navigation/RootNavigator/linking/linkingPrefixes'
 import { NavigationResultState } from 'features/navigation/RootNavigator/types'
 
 import { DeeplinkParts } from '../types'
 
 export function getScreenFromDeeplink(url: string): DeeplinkParts {
   let pathWithQueryString = url
-  for (const prefix of linking.prefixes) {
+  for (const prefix of linkingPrefixes) {
     pathWithQueryString = pathWithQueryString.replace(prefix, '')
   }
   const navigationState = linking.getStateFromPath(pathWithQueryString, linking.config)

--- a/src/features/home/components/helpers/filterBookingsWithoutReaction/filterBookingsWithoutReaction.test.ts
+++ b/src/features/home/components/helpers/filterBookingsWithoutReaction/filterBookingsWithoutReaction.test.ts
@@ -1,4 +1,5 @@
 import mockdate from 'mockdate'
+import { createMock } from 'ts-auto-mock'
 
 import {
   BookingReponse,
@@ -39,15 +40,10 @@ describe('filterBookingsWithoutReaction', () => {
     subcategoriesMappingSnap as SubcategoriesMapping
 
   it('should return false if dateUsed is missing', () => {
-    const bookingWithoutDateUsed = {
-      ...baseBooking,
-      stock: {
-        ...baseBooking.stock,
-        offer: { ...baseBooking.stock.offer, subcategoryId: SubcategoryIdEnum.SEANCE_CINE },
-      },
-      dateUsed: null,
+    const bookingWithoutDateUsed = createMock<BookingReponse>({
       userReaction: null,
-    }
+    })
+
     const result = filterBookingsWithoutReaction(
       bookingWithoutDateUsed,
       subcategoriesMapping,

--- a/src/features/navigation/RootNavigator/linking/index.ts
+++ b/src/features/navigation/RootNavigator/linking/index.ts
@@ -1,8 +1,8 @@
 import { LinkingOptions } from '@react-navigation/native'
 
+import { linkingPrefixes } from 'features/navigation/RootNavigator/linking/linkingPrefixes'
 import { rootScreensConfig } from 'features/navigation/RootNavigator/screens'
 import { RootStackParamList } from 'features/navigation/RootNavigator/types'
-import { WEBAPP_V2_URL } from 'libs/environment'
 import { RequireField } from 'libs/typesUtils/typeHelpers'
 
 import { getInitialURL } from './getInitialUrl'
@@ -10,17 +10,11 @@ import { customGetPathFromState } from './getPathFromState'
 import { customGetStateFromPath } from './getStateFromPath'
 import { subscribe } from './subscribe'
 
-const PASS_CULTURE_PREFIX_URL = 'passculture://'
-
 export const linking: RequireField<
   LinkingOptions<RootStackParamList>,
   'getStateFromPath' | 'getPathFromState'
 > = {
-  prefixes: [
-    // must NOT be empty
-    WEBAPP_V2_URL,
-    PASS_CULTURE_PREFIX_URL,
-  ],
+  prefixes: linkingPrefixes,
   getInitialURL: getInitialURL,
   subscribe: subscribe,
   getStateFromPath: customGetStateFromPath,

--- a/src/features/navigation/RootNavigator/linking/linkingPrefixes.ts
+++ b/src/features/navigation/RootNavigator/linking/linkingPrefixes.ts
@@ -1,0 +1,9 @@
+import { WEBAPP_V2_URL } from 'libs/environment'
+
+const PASS_CULTURE_PREFIX_URL = 'passculture://'
+
+export const linkingPrefixes = [
+  // must NOT be empty
+  WEBAPP_V2_URL,
+  PASS_CULTURE_PREFIX_URL,
+]

--- a/src/features/navigation/RootNavigator/routes.ts
+++ b/src/features/navigation/RootNavigator/routes.ts
@@ -1,4 +1,6 @@
-import { Artist } from 'features/artist/pages/Artist'
+import React from 'react'
+
+const Artist = React.lazy(() => import('features/artist/pages/Artist'))
 import { ForgottenPassword } from 'features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword'
 import { ReinitializePassword } from 'features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword'
 import { ResetPasswordEmailSent } from 'features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent'

--- a/src/features/navigation/helpers/isAppUrl.ts
+++ b/src/features/navigation/helpers/isAppUrl.ts
@@ -1,7 +1,7 @@
-import { linking } from 'features/navigation/RootNavigator/linking'
+import { linkingPrefixes } from 'features/navigation/RootNavigator/linking/linkingPrefixes'
 
 export const isAppUrl = (url: string) => {
-  for (const prefix of linking.prefixes) {
+  for (const prefix of linkingPrefixes) {
     if (url.match('^' + prefix)) {
       return true
     }

--- a/src/features/navigation/helpers/openUrl.ts
+++ b/src/features/navigation/helpers/openUrl.ts
@@ -1,6 +1,5 @@
 import { Alert, Linking, NativeModules, Platform } from 'react-native'
 
-import { getScreenFromDeeplink } from 'features/deeplinks/helpers'
 import { navigateFromRef } from 'features/navigation/navigationRef'
 import { analytics } from 'libs/analytics'
 import { OfferAnalyticsData } from 'libs/analytics/logEventAnalytics'
@@ -8,7 +7,9 @@ import { OfferAnalyticsData } from 'libs/analytics/logEventAnalytics'
 import { isAppUrl } from './isAppUrl'
 import { navigateToHome } from './navigateToHome'
 
-const openAppUrl = (url: string) => {
+const openAppUrl = async (url: string) => {
+  const { getScreenFromDeeplink } = await import('features/deeplinks/helpers')
+
   try {
     const { screen, params } = getScreenFromDeeplink(url)
     return navigateFromRef(screen, params)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,18 @@
     "paths": {
       "*": ["src/*", "*"]
     },
+    "plugins": [
+      {
+        "transform": "ts-auto-mock/transformer",
+        "cacheBetweenTests": false
+      }
+    ],
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "isolatedModules": true,
     "jsx": "react",
-    "lib": ["es2022","dom", "dom.iterable", "esnext"],
+    "lib": ["es2022", "dom", "dom.iterable", "esnext"],
     "module": "ESNext",
     "moduleResolution": "node",
     "noEmit": true,
@@ -20,7 +26,7 @@
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "resolveJsonModule": true,
-    "target": "es5",
+    "target": "es6",
     "skipLibCheck": true,
     "sourceMap": true,
     "removeComments": true,

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10688,6 +10688,13 @@ browserslist@^4.12.0, browserslist@^4.16.5, browserslist@^4.17.5, browserslist@^
     node-releases "^2.0.1"
     picocolors "^1.0.0"
 
+bs-logger@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -12797,7 +12804,7 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-ejs@^3.1.6:
+ejs@^3.1.10, ejs@^3.1.6:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
   integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
@@ -13907,7 +13914,7 @@ fast-json-patch@^3.0.0-1:
   resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-3.1.1.tgz#85064ea1b1ebf97a3f7ad01e23f9337e72c66947"
   integrity sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==
 
-fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -14859,6 +14866,15 @@ global-dirs@^3.0.0:
   integrity sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==
   dependencies:
     ini "2.0.0"
+
+global-prefix@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-3.0.0.tgz#fc85f73064df69f50421f47f883fe5b913ba9b97"
+  integrity sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==
+  dependencies:
+    ini "^1.3.5"
+    kind-of "^6.0.2"
+    which "^1.3.1"
 
 global@^4.4.0:
   version "4.4.0"
@@ -17197,6 +17213,11 @@ jest-styled-components@^7.0.8:
   dependencies:
     css "^3.0.0"
 
+jest-ts-auto-mock@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jest-ts-auto-mock/-/jest-ts-auto-mock-2.1.0.tgz#56d665c1617944ebc7fe8efbc862e8c80e323991"
+  integrity sha512-ubL0pweKUHQNY2xCgwXjYllEQMgpKDojcEODpraQVevHqBFBsFDJZkpZp/2JsmujMu4TNJPzmSugXOLfKndmlQ==
+
 jest-util@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"
@@ -17221,24 +17242,24 @@ jest-util@^27.2.0:
     graceful-fs "^4.2.9"
     picomatch "^2.2.3"
 
-jest-util@^29.6.2:
-  version "29.6.2"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.6.2.tgz#8a052df8fff2eebe446769fd88814521a517664d"
-  integrity sha512-3eX1qb6L88lJNCFlEADKOkjpXJQyZRiavX1INZ4tRnrBVr2COd3RgcTLyUiEXMNBlDU/cgYq6taUS0fExrWW4w==
+jest-util@^29.0.0, jest-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
+  integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
   dependencies:
-    "@jest/types" "^29.6.1"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
     chalk "^4.0.0"
     ci-info "^3.2.0"
     graceful-fs "^4.2.9"
     picomatch "^2.2.3"
 
-jest-util@^29.7.0:
-  version "29.7.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
-  integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
+jest-util@^29.6.2:
+  version "29.6.2"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.6.2.tgz#8a052df8fff2eebe446769fd88814521a517664d"
+  integrity sha512-3eX1qb6L88lJNCFlEADKOkjpXJQyZRiavX1INZ4tRnrBVr2COd3RgcTLyUiEXMNBlDU/cgYq6taUS0fExrWW4w==
   dependencies:
-    "@jest/types" "^29.6.3"
+    "@jest/types" "^29.6.1"
     "@types/node" "*"
     chalk "^4.0.0"
     ci-info "^3.2.0"
@@ -17898,7 +17919,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.21:
+lodash-es@4.17.21, lodash-es@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
@@ -18128,7 +18149,7 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@^1.1.1:
+make-error@^1.1.1, make-error@^1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -18816,6 +18837,14 @@ microevent.ts@~0.1.1:
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
   integrity sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==
 
+micromatch@4.0.8, micromatch@^4.0.2, micromatch@^4.0.4:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
+  dependencies:
+    braces "^3.0.3"
+    picomatch "^2.3.1"
+
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -18834,14 +18863,6 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
-
-micromatch@^4.0.2, micromatch@^4.0.4:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
-  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
-  dependencies:
-    braces "^3.0.3"
-    picomatch "^2.3.1"
 
 microseconds@0.2.0:
   version "0.2.0"
@@ -18965,7 +18986,7 @@ minimist@1.2.6, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
-minimist@^1.1.1:
+minimist@^1.1.1, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -22209,7 +22230,7 @@ resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.1
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-resolve@^1.3.2:
+resolve@^1.22.2, resolve@^1.3.2:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -22608,7 +22629,7 @@ semver@^7.5.2:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@^7.5.4:
+semver@^7.5.4, semver@^7.6.3:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
@@ -23953,10 +23974,33 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/true-myth/-/true-myth-4.1.1.tgz#ff4ac9d5130276e34aa338757e2416ec19248ba2"
   integrity sha512-rqy30BSpxPznbbTcAcci90oZ1YR4DqvKcNXNerG5gQBU2v4jk0cygheiul5J6ExIMrgDVuanv/MkGfqZbKrNNg==
 
+ts-auto-mock@^3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/ts-auto-mock/-/ts-auto-mock-3.7.4.tgz#e7ff8c226864e75e9bfccba1852a7baa468de743"
+  integrity sha512-+/X+7yjpUBsIJBRxl/hs9aq3pA76w3Pcu70uHDxdr4C8TbXXwd/gq6t3b81xqU9N/KPFIFata1HcQZ2lwGKDRQ==
+  dependencies:
+    lodash-es "4.17.21"
+    micromatch "4.0.8"
+
 ts-dedent@^2.0.0, ts-dedent@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
+
+ts-jest@^29.2.5:
+  version "29.2.5"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.2.5.tgz#591a3c108e1f5ebd013d3152142cb5472b399d63"
+  integrity sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==
+  dependencies:
+    bs-logger "^0.2.6"
+    ejs "^3.1.10"
+    fast-json-stable-stringify "^2.1.0"
+    jest-util "^29.0.0"
+    json5 "^2.2.3"
+    lodash.memoize "^4.1.2"
+    make-error "^1.3.6"
+    semver "^7.6.3"
+    yargs-parser "^21.1.1"
 
 ts-morph@^13.0.1:
   version "13.0.3"
@@ -23989,6 +24033,18 @@ ts-object-utils@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/ts-object-utils/-/ts-object-utils-0.0.5.tgz#95361cdecd7e52167cfc5e634c76345e90a26077"
   integrity sha1-lTYc3s1+UhZ8/F5jTHY0XpCiYHc=
+
+ts-patch@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ts-patch/-/ts-patch-3.2.1.tgz#0c1ecfcb6b6633bf23e533016ffda4d566518628"
+  integrity sha512-hlR43v+GUIUy8/ZGFP1DquEqPh7PFKQdDMTAmYt671kCCA6AkDQMoeFaFmZ7ObPLYOmpMgyKUqL1C+coFMf30w==
+  dependencies:
+    chalk "^4.1.2"
+    global-prefix "^3.0.0"
+    minimist "^1.2.8"
+    resolve "^1.22.2"
+    semver "^7.5.4"
+    strip-ansi "^6.0.1"
 
 ts-pnp@^1.1.6:
   version "1.2.0"
@@ -25088,7 +25144,7 @@ which@2.0.2, which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-which@^1.2.9:
+which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
L'un des principaux problèmes des mocks de test est qu'il faut souvent créer une fixture avec de la fausse donnée juste pour la structure.

### Observation 1

Ils sont utilisés dans les tests de deux manières:
- utilisés avec des spread operators pour mettre en évidence la donnée importante pour le test ce qui est une bonne pratique mais réduit la lisibilité

```ts
    const bookingWithoutDateUsed = {
      ...baseBooking,
      stock: {
        ...baseBooking.stock,
        offer: { ...baseBooking.stock.offer, subcategoryId: SubcategoryIdEnum.SEANCE_CINE },
      },
      dateUsed: null,
      userReaction: null,
    }
```
- utilisés pour le test avec leur valeur non modifiée, ce qui est une mauvaise pratique car il faut se référer à la fixture et si sa donnée change les tests cassent
```ts
expect(fixture[0].id).toBe(1)
```

Pour une première conclusion, il faudrait faire en sorte que le test se suffise à lui même en terme de lisibilité, et ne soit pas dépendant de valeurs dans les fixtures

### Observation 2

Sachant que le test ne doit pas se baser sur les valeurs écrites en dur dans les fixtures, les valeurs des fixtures deviennent inutiles
Le copier-coller de fixtures dans la codebase peut-être redondant et difficile à maintenir.

Il faudrait trouver un outil qui permette de créer un mock à partir d'un type, mais Typescript ne le permet pas directement.

### Solution proposée

Le plugin `ts-auto-mock` le permet mais demande pas mal de config:
- `ts-jest` doit être utilisé car babel-jest ne conserve pas le typage lors de la transpilation alors que cela est nécessaire pour [`ts-auto-mock`](https://github.com/Typescript-TDD/ts-auto-mock#readme) afin de créer des objets à partir de types.
- `ts-patch` doit être utilisé pour permettre au transformer `ts-auto-mock` d'effectuer correctement ses transformations

#### Exemple

```ts
import { createMock } from 'ts-auto-mock';

interface Person {
    id: string;
    name: string;
    details: {
        phone: number
    }
}

const mock = createMock<Person>({ name: "John" });
mock.id // ""
mock.name // "John"
mock.details // "{ phone: 0 }"
```

### Limites
- je ne connais pas les impacts de l'utilisation de `ts-jest` par rapport à `babel-jest` en terme de performances et d'efficacité