### PR TITLE
(PC-33184) refactor(filter): custom icon for SingleFilterButton

### DIFF
--- a/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
@@ -522,6 +522,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       "borderRadius": 24,
                       "borderWidth": 2,
                       "boxSizing": "border-box",
+                      "columnGap": 4,
                       "flexDirection": "row-reverse",
                       "height": 32,
                       "justifyContent": "center",
@@ -552,17 +553,6 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                 Le Petit Rintintin 1
               </Text>
               <View
-                numberOfSpaces={1}
-                style={
-                  [
-                    {
-                      "width": 4,
-                    },
-                  ]
-                }
-              />
-              <View
-                accessibilityLabel="Filtre sélectionné"
                 height={16}
                 testID="venueButtonIcon"
                 width={16}
@@ -628,6 +618,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       "borderRadius": 24,
                       "borderWidth": 2,
                       "boxSizing": "border-box",
+                      "columnGap": 4,
                       "flexDirection": "row-reverse",
                       "height": 32,
                       "justifyContent": "center",
@@ -658,17 +649,6 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                 Catégories
               </Text>
               <View
-                numberOfSpaces={1}
-                style={
-                  [
-                    {
-                      "width": 4,
-                    },
-                  ]
-                }
-              />
-              <View
-                accessibilityLabel="Filtre sélectionné"
                 height={16}
                 testID="categoryButtonIcon"
                 width={16}
@@ -734,6 +714,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       "borderRadius": 24,
                       "borderWidth": 2,
                       "boxSizing": "border-box",
+                      "columnGap": 4,
                       "flexDirection": "row-reverse",
                       "height": 32,
                       "justifyContent": "center",
@@ -764,17 +745,6 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                 Prix
               </Text>
               <View
-                numberOfSpaces={1}
-                style={
-                  [
-                    {
-                      "width": 4,
-                    },
-                  ]
-                }
-              />
-              <View
-                accessibilityLabel="Filtre sélectionné"
                 height={16}
                 testID="priceButtonIcon"
                 width={16}
@@ -840,6 +810,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       "borderRadius": 24,
                       "borderWidth": 1,
                       "boxSizing": "border-box",
+                      "columnGap": 4,
                       "flexDirection": "row-reverse",
                       "height": 32,
                       "justifyContent": "center",
@@ -927,6 +898,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       "borderRadius": 24,
                       "borderWidth": 1,
                       "boxSizing": "border-box",
+                      "columnGap": 4,
                       "flexDirection": "row-reverse",
                       "height": 32,
                       "justifyContent": "center",

--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -64,8 +64,6 @@
 ./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts:231
 ./src/features/profile/components/CreditInfo/CreditProgressBar.tsx:32
 ./src/features/search/api/useSearchResults/useSearchResults.ts:106
-./src/features/search/components/SearchResultsContent/SearchResultsContent.tsx:223
-./src/features/search/components/SearchResultsContent/SearchResultsContent.tsx:225
 ./src/features/search/components/sections/Accessibility/Accessibility.tsx:33
 ./src/features/search/pages/SuggestedPlacesOrVenues/SuggestedVenues.native.test.tsx:43
 ./src/features/search/pages/modals/CategoriesModal/CategoriesModal.tsx:118

--- a/src/features/search/components/Buttons/SingleFilterButton/SingleFilterButton.stories.tsx
+++ b/src/features/search/components/Buttons/SingleFilterButton/SingleFilterButton.stories.tsx
@@ -1,5 +1,7 @@
 import { ComponentMeta } from '@storybook/react'
 import React from 'react'
+import LinearGradient from 'react-native-linear-gradient'
+import styled from 'styled-components/native'
 
 import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storybook/VariantsTemplate'
 
@@ -11,10 +13,26 @@ const meta: ComponentMeta<typeof SingleFilterButton> = {
 }
 export default meta
 
+const GradientBullet = styled(LinearGradient).attrs(({ theme }) => ({
+  colors: [theme.colors.primary, theme.colors.primaryDark],
+}))({
+  width: 10,
+  height: 10,
+  borderRadius: 5,
+})
+
 const variantConfig: Variants<typeof SingleFilterButton> = [
   {
     label: 'SingleFilterButton selected',
     props: { label: 'CD, vinyles, musique en ligne', isSelected: true },
+  },
+  {
+    label: 'SingleFilterButton selected with custom icon',
+    props: {
+      label: 'CD, vinyles, musique en ligne',
+      isSelected: true,
+      icon: <GradientBullet />,
+    },
   },
   {
     label: 'SingleFilterButton not selected',

--- a/src/features/search/components/Buttons/SingleFilterButton/SingleFilterButton.tsx
+++ b/src/features/search/components/Buttons/SingleFilterButton/SingleFilterButton.tsx
@@ -1,10 +1,9 @@
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, ReactElement } from 'react'
 import styled from 'styled-components/native'
 
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Touchable } from 'ui/components/touchable/Touchable'
-import { Check } from 'ui/svg/icons/Check'
-import { getSpacing, Spacer, TypoDS } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 import { getHoverStyle } from 'ui/theme/getHoverStyle/getHoverStyle'
 
@@ -15,6 +14,7 @@ type IsSelectedProps = {
 type SingleFilterButtonProps = IsSelectedProps & {
   label: string
   testID?: string
+  icon?: ReactElement
   onPress: () => void
   children?: never
 }
@@ -23,9 +23,9 @@ export const SingleFilterButton: FunctionComponent<SingleFilterButtonProps> = ({
   label,
   isSelected,
   onPress,
+  icon,
   testID,
 }) => {
-  const filterButtonIcon = testID ? `${testID}Icon` : 'filterButtonIcon'
   const filterButtonLabel = testID ? `${testID}Label` : 'filterButtonLabel'
 
   const accessibilityLabel = isSelected ? `${label}\u00a0: Filtre sélectionné` : label
@@ -35,12 +35,7 @@ export const SingleFilterButton: FunctionComponent<SingleFilterButtonProps> = ({
       onPress={onPress}
       accessibilityLabel={accessibilityLabel}>
       <Label testID={filterButtonLabel}>{label}</Label>
-      {isSelected ? (
-        <React.Fragment>
-          <Spacer.Row numberOfSpaces={1} />
-          <StyledIcon testID={filterButtonIcon} accessibilityLabel="Filtre sélectionné" />
-        </React.Fragment>
-      ) : null}
+      {icon}
     </TouchableContainer>
   )
 }
@@ -52,6 +47,7 @@ const TouchableContainer = styledButton(Touchable)<IsSelectedProps>(({ theme, is
   alignItems: 'center',
   paddingLeft: getSpacing(4),
   paddingRight: getSpacing(4),
+  columnGap: getSpacing(1),
   height: getSpacing(8),
   backgroundColor: isSelected ? theme.colors.greyLight : theme.colors.white,
   borderColor: theme.colors.black,
@@ -60,11 +56,6 @@ const TouchableContainer = styledButton(Touchable)<IsSelectedProps>(({ theme, is
   ...customFocusOutline({ color: theme.colors.accent }),
   ...getHoverStyle(theme.colors.black),
 }))
-
-const StyledIcon = styled(Check).attrs(({ theme }) => ({
-  size: theme.icons.sizes.extraSmall,
-  color: theme.colors.black,
-}))``
 
 const Label = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.black,

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -51,6 +51,7 @@ import { HitPlaceholder, NumberOfResultsPlaceholder } from 'ui/components/placeh
 import { ScrollToTopButton } from 'ui/components/ScrollToTopButton'
 import { HorizontalOfferTile } from 'ui/components/tiles/HorizontalOfferTile'
 import { Ul } from 'ui/components/Ul'
+import { Check } from 'ui/svg/icons/Check'
 import { Map } from 'ui/svg/icons/Map'
 import { Sort } from 'ui/svg/icons/Sort'
 import { getSpacing, Spacer } from 'ui/theme'
@@ -220,9 +221,7 @@ export const SearchResultsContent: React.FC = () => {
     if (data && hasNextPage) {
       const [lastPage] = data.pages.slice(-1)
 
-      // @ts-expect-error: because of noUncheckedIndexedAccess
-      if (lastPage.offers.page > 0) {
-        // @ts-expect-error: because of noUncheckedIndexedAccess
+      if (lastPage && lastPage.offers.page > 0) {
         analytics.logSearchScrollToPage(lastPage.offers.page, searchState.searchId)
       }
       fetchNextPage()
@@ -398,7 +397,7 @@ export const SearchResultsContent: React.FC = () => {
             </StyledLi>
 
             <StyledLi>
-              <SingleFilterButton
+              <StyledSingleFilterButton
                 label={
                   searchState.venue
                     ? ellipseString(searchState.venue.label, MAX_VENUE_CHARACTERS)
@@ -410,7 +409,7 @@ export const SearchResultsContent: React.FC = () => {
               />
             </StyledLi>
             <StyledLi>
-              <SingleFilterButton
+              <StyledSingleFilterButton
                 label="Catégories"
                 testID="categoryButton"
                 onPress={showCategoriesModal}
@@ -419,7 +418,7 @@ export const SearchResultsContent: React.FC = () => {
             </StyledLi>
 
             <StyledLi>
-              <SingleFilterButton
+              <StyledSingleFilterButton
                 label="Prix"
                 testID="priceButton"
                 onPress={showSearchPriceModal}
@@ -429,7 +428,7 @@ export const SearchResultsContent: React.FC = () => {
 
             {hasDuoOfferToggle ? (
               <StyledLi>
-                <SingleFilterButton
+                <StyledSingleFilterButton
                   label="Duo"
                   testID="DuoButton"
                   onPress={showOfferDuoModal}
@@ -438,7 +437,7 @@ export const SearchResultsContent: React.FC = () => {
               </StyledLi>
             ) : null}
             <StyledLi>
-              <SingleFilterButton
+              <StyledSingleFilterButton
                 label="Dates & heures"
                 testID="datesHoursButton"
                 onPress={showDatesHoursModal}
@@ -446,7 +445,7 @@ export const SearchResultsContent: React.FC = () => {
               />
             </StyledLi>
             <StyledLastLi>
-              <SingleFilterButton
+              <StyledSingleFilterButton
                 label="Accessibilité"
                 testID="lieuxAccessiblesButton"
                 onPress={showAccessibilityModal}
@@ -550,6 +549,17 @@ const StyledLi = styled(Li)({
 const StyledLastLi = styled(StyledLi)({
   marginRight: getSpacing(1),
 })
+
+const FilterSelectedIcon = styled(Check).attrs(({ theme }) => ({
+  size: theme.icons.sizes.extraSmall,
+  color: theme.colors.black,
+}))``
+
+const StyledSingleFilterButton = styled(SingleFilterButton).attrs((props) => ({
+  icon: props.isSelected ? (
+    <FilterSelectedIcon testID={props.testID ? `${props.testID}Icon` : 'filterButtonIcon'} />
+  ) : undefined,
+}))``
 
 const ScrollToTopContainer = styled.View(({ theme }) => ({
   alignSelf: 'center',

--- a/src/features/venueMap/pages/VenueMap/VenueMapBase.tsx
+++ b/src/features/venueMap/pages/VenueMap/VenueMapBase.tsx
@@ -19,6 +19,7 @@ import {
 import { Li } from 'ui/components/Li'
 import { useModal } from 'ui/components/modals/useModal'
 import { Ul } from 'ui/components/Ul'
+import { Check } from 'ui/svg/icons/Check'
 import { getSpacing } from 'ui/theme'
 
 const MAX_VENUE_CHARACTERS = 20
@@ -57,6 +58,7 @@ export const VenueMapBase: FunctionComponent<PropsWithChildren> = ({ children })
                 label={ellipseString(venueTypeLabel, MAX_VENUE_CHARACTERS)}
                 isSelected={venueTypeCode !== null}
                 onPress={showVenueTypeModal}
+                icon={venueTypeCode ? <FilterSelectedIcon /> : undefined}
               />
             </StyledLi>
           </StyledUl>
@@ -99,3 +101,9 @@ const StyledLi = styled(Li)({
   marginLeft: getSpacing(1),
   marginVertical: getSpacing(1),
 })
+
+const FilterSelectedIcon = styled(Check).attrs<{ testID?: string }>(({ theme, testID }) => ({
+  size: theme.icons.sizes.extraSmall,
+  color: theme.colors.black,
+  testID: testID ? `${testID}Icon` : 'filterButtonIcon',
+}))``


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33184

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

<img width="1505" alt="Capture d’écran 2024-11-22 à 14 29 11" src="https://github.com/user-attachments/assets/d75d538d-1a04-40ae-8e2c-6cb64284997a">


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
