### PR TITLE
(PC-32963) feat(NC): update BadgeBanner showing condition in profile …

### DIFF
--- a/src/features/profile/components/Achievements/BadgeBanner.stories.tsx
+++ b/src/features/profile/components/Achievements/BadgeBanner.stories.tsx
@@ -1,0 +1,22 @@
+import { NavigationContainer } from '@react-navigation/native'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+import React from 'react'
+
+import { BadgeBanner } from './BadgeBanner'
+
+const meta: ComponentMeta<typeof BadgeBanner> = {
+  title: 'features/profile/achievements/BadgeBanner',
+  component: BadgeBanner,
+  decorators: [
+    (Story) => (
+      <NavigationContainer>
+        <Story />
+      </NavigationContainer>
+    ),
+  ],
+}
+export default meta
+
+const Template: ComponentStory<typeof BadgeBanner> = (props) => <BadgeBanner {...props} />
+export const Default = Template.bind({})
+Default.storyName = 'BadgeBanner'

--- a/src/features/profile/components/Achievements/BadgeBanner.tsx
+++ b/src/features/profile/components/Achievements/BadgeBanner.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+import { theme } from 'theme'
+import { GenericBanner } from 'ui/components/ModuleBanner/GenericBanner'
+import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
+import { BicolorTrophy } from 'ui/svg/icons/Trophy'
+import { Spacer, Typo } from 'ui/theme'
+
+export const BadgeBanner: React.FC = () => {
+  return (
+    <InternalTouchableLink
+      navigateTo={{
+        screen: 'Achievements',
+      }}>
+      <GenericBanner LeftIcon={<BicolorTrophy size={theme.icons.sizes.standard} />}>
+        <Typo.ButtonText>Mes badges</Typo.ButtonText>
+        <Spacer.Column numberOfSpaces={1} />
+        <Typo.Body numberOfLines={2}>Consulte tes prouesses</Typo.Body>
+      </GenericBanner>
+    </InternalTouchableLink>
+  )
+}

--- a/src/features/profile/components/Header/ProfileHeader/ProfileHeader.native.test.tsx
+++ b/src/features/profile/components/Header/ProfileHeader/ProfileHeader.native.test.tsx
@@ -68,7 +68,7 @@ jest.mock('features/auth/context/AuthContext', () => ({
   useAuthContext: jest.fn(() => ({ isLoggedIn: true })),
 }))
 
-jest.spyOn(useFeatureFlag, 'useFeatureFlag').mockReturnValue(false)
+jest.spyOn(useFeatureFlag, 'useFeatureFlag').mockReturnValue(true)
 
 jest.mock('libs/firebase/analytics/analytics')
 

--- a/src/features/profile/components/Header/ProfileHeader/ProfileHeader.tsx
+++ b/src/features/profile/components/Header/ProfileHeader/ProfileHeader.tsx
@@ -1,12 +1,17 @@
 import React, { useMemo } from 'react'
+import styled from 'styled-components/native'
 
 import { UserProfileResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { CheatMenuButton } from 'features/internal/cheatcodes/components/CheatMenuButton'
+import { BadgeBanner } from 'features/profile/components/Achievements/BadgeBanner'
 import { CreditHeader } from 'features/profile/components/Header/CreditHeader/CreditHeader'
 import { LoggedOutHeader } from 'features/profile/components/Header/LoggedOutHeader/LoggedOutHeader'
 import { NonBeneficiaryHeader } from 'features/profile/components/Header/NonBeneficiaryHeader/NonBeneficiaryHeader'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { getAge } from 'shared/user/getAge'
+import { Spacer, getSpacing } from 'ui/theme'
 
 type ProfileHeaderProps = {
   user?: UserProfileResponse
@@ -15,6 +20,9 @@ type ProfileHeaderProps = {
 export function ProfileHeader(props: ProfileHeaderProps) {
   const { user } = props
   const { isLoggedIn } = useAuthContext()
+
+  const enableAchievements = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_ACHIEVEMENTS)
+  const shouldShowBadgesBanner = enableAchievements && user?.isBeneficiary
 
   const ProfileHeader = useMemo(() => {
     if (!isLoggedIn || !user) {
@@ -31,15 +39,23 @@ export function ProfileHeader(props: ProfileHeaderProps) {
     }
 
     return (
-      <CreditHeader
-        firstName={user.firstName}
-        lastName={user.lastName}
-        age={getAge(user.birthDate)}
-        domainsCredit={user.domainsCredit}
-        depositExpirationDate={user.depositExpirationDate ?? undefined}
-      />
+      <React.Fragment>
+        <CreditHeader
+          firstName={user.firstName}
+          lastName={user.lastName}
+          age={getAge(user.birthDate)}
+          domainsCredit={user.domainsCredit}
+          depositExpirationDate={user.depositExpirationDate ?? undefined}
+        />
+        <Spacer.Column numberOfSpaces={4} />
+        {shouldShowBadgesBanner ? (
+          <BadgeBannerContainer>
+            <BadgeBanner />
+          </BadgeBannerContainer>
+        ) : null}
+      </React.Fragment>
     )
-  }, [isLoggedIn, user])
+  }, [isLoggedIn, shouldShowBadgesBanner, user])
 
   return (
     <React.Fragment>
@@ -48,3 +64,8 @@ export function ProfileHeader(props: ProfileHeaderProps) {
     </React.Fragment>
   )
 }
+
+const BadgeBannerContainer = styled.View(({ theme }) => ({
+  paddingHorizontal: theme.contentPage.marginHorizontal,
+  marginBottom: getSpacing(4),
+}))

--- a/src/features/profile/components/Header/ProfileHeader/ProfileHeader.web.test.tsx
+++ b/src/features/profile/components/Header/ProfileHeader/ProfileHeader.web.test.tsx
@@ -4,7 +4,10 @@ import React from 'react'
 import { CurrencyEnum, UserProfileResponse, YoungStatusType } from 'api/gen'
 import { ProfileHeader } from 'features/profile/components/Header/ProfileHeader/ProfileHeader'
 import { domains_credit_v1 } from 'features/profile/fixtures/domainsCredit'
+import * as useFeatureFlag from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { render, screen } from 'tests/utils/web'
+
+jest.spyOn(useFeatureFlag, 'useFeatureFlag').mockReturnValue(true)
 
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -16,8 +16,6 @@ import { TutorialTypes } from 'features/tutorial/enums'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { analytics, isCloseToBottom } from 'libs/analytics'
 import { env } from 'libs/environment'
-import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
-import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { useRemoteConfigContext } from 'libs/firebase/remoteConfig/RemoteConfigProvider'
 import useFunctionOnce from 'libs/hooks/useFunctionOnce'
 import { GeolocPermissionState, useLocation } from 'libs/location'
@@ -25,15 +23,12 @@ import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { OfflinePage } from 'libs/network/OfflinePage'
 import { AccessibilityFooter } from 'shared/AccessibilityFooter/AccessibilityFooter'
 import { getAge } from 'shared/user/getAge'
-import { theme } from 'theme'
 import { InputError } from 'ui/components/inputs/InputError'
 import { Li } from 'ui/components/Li'
 import { BannerWithBackground } from 'ui/components/ModuleBanner/BannerWithBackground'
-import { GenericBanner } from 'ui/components/ModuleBanner/GenericBanner'
 import { Section } from 'ui/components/Section'
 import { SectionRow } from 'ui/components/SectionRow'
 import { StatusBarBlurredBackground } from 'ui/components/statusBar/statusBarBlurredBackground'
-import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { VerticalUl } from 'ui/components/Ul'
 import { useDebounce } from 'ui/hooks/useDebounce'
@@ -48,7 +43,6 @@ import { LegalNotices } from 'ui/svg/icons/LegalNotices'
 import { LifeBuoy } from 'ui/svg/icons/LifeBuoy'
 import { LocationPointer } from 'ui/svg/icons/LocationPointer'
 import { SignOut } from 'ui/svg/icons/SignOut'
-import { BicolorTrophy } from 'ui/svg/icons/Trophy'
 import { LogoMinistere } from 'ui/svg/LogoMinistere'
 import { getSpacing, Spacer, Typo } from 'ui/theme'
 import { SECTION_ROW_ICON_SIZE } from 'ui/theme/constants'
@@ -65,8 +59,6 @@ const OnlineProfile: React.FC = () => {
   const scrollViewRef = useRef<ScrollView | null>(null)
   const locationActivationErrorId = uuidv4()
   const userAge = getAge(user?.birthDate)
-  const enableAchievements = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_ACHIEVEMENTS)
-  const shouldShowBadgesBanner = enableAchievements && user?.isBeneficiary
   const { displayInAppFeedback } = useRemoteConfigContext()
   const {
     geolocPositionError,
@@ -160,7 +152,6 @@ const OnlineProfile: React.FC = () => {
             <ProfileHeader user={user} />
             <ProfileContainer>
               <Spacer.Column numberOfSpaces={4} />
-              <BadgeBanner shouldShow={!!shouldShowBadgesBanner} />
               <Section title={isLoggedIn ? 'Paramètres du compte' : 'Paramètres de l’application'}>
                 <VerticalUl>
                   {isLoggedIn ? (
@@ -335,25 +326,6 @@ export function Profile() {
   return <OfflinePage />
 }
 
-const BadgeBanner: React.FC<{ shouldShow: boolean }> = ({ shouldShow = false }) => {
-  if (!shouldShow) return null
-  return (
-    <React.Fragment>
-      <InternalTouchableLink
-        navigateTo={{
-          screen: 'Achievements',
-        }}>
-        <GenericBanner LeftIcon={<BicolorTrophy size={theme.icons.sizes.standard} />}>
-          <Typo.ButtonText>Mes badges</Typo.ButtonText>
-          <Spacer.Column numberOfSpaces={1} />
-          <Typo.Body numberOfLines={2}>Consulte tes prouesses</Typo.Body>
-        </GenericBanner>
-      </InternalTouchableLink>
-      <Spacer.Column numberOfSpaces={4} />
-    </React.Fragment>
-  )
-}
-
 const Container = styled.View({ flex: 1 })
 
 const ProfileContainer = styled.View(({ theme }) => ({
@@ -367,10 +339,8 @@ const ScrollViewContentContainer = styled.View({
   flexDirection: 'column',
 })
 
-const paddingVertical = getSpacing(4)
-
 const Row = styled(SectionRow).attrs({ iconSize: SECTION_ROW_ICON_SIZE })({
-  paddingVertical,
+  paddingVertical: getSpacing(4),
 })
 
 const ShareAppContainer = styled.View(({ theme }) => ({


### PR DESCRIPTION
…header

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32963

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |  ![Capture d’écran 2024-11-22 à 19 00 10](https://github.com/user-attachments/assets/955eb9fc-088c-466a-b536-df2b57eb2f7b) ![Capture d’écran 2024-11-22 à 18 54 12](https://github.com/user-attachments/assets/9d75b4b5-607b-406d-8942-4c8697a01c06)   |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
