### PR TITLE
(PC-33066) feat(Achievements): hide locked badge title

### DIFF
--- a/__snapshots__/features/profile/pages/Achievements/Achievements.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Achievements/Achievements.native.test.tsx.native-snap
@@ -380,7 +380,6 @@ exports[`<Achievements/> should match snapshot 1`] = `
             data={
               [
                 {
-                  "description": "Tu as réservé ta première séance de cinéma",
                   "id": "FIRST_MOVIE_BOOKING",
                   "illustration": {
                     "$$typeof": Symbol(react.forward_ref),
@@ -402,7 +401,6 @@ exports[`<Achievements/> should match snapshot 1`] = `
                   "name": "Cinéphile en herbe",
                 },
                 {
-                  "description": "Tu as réservé ton premier livre",
                   "id": "FIRST_BOOK_BOOKING",
                   "illustration": {
                     "$$typeof": Symbol(react.forward_ref),
@@ -424,7 +422,6 @@ exports[`<Achievements/> should match snapshot 1`] = `
                   "name": "Rat de bibliothèque",
                 },
                 {
-                  "description": "Tu as réservé ton premier atelier ou cours artistique",
                   "id": "FIRST_ART_LESSON_BOOKING",
                   "illustration": {
                     "$$typeof": Symbol(react.forward_ref),
@@ -446,7 +443,6 @@ exports[`<Achievements/> should match snapshot 1`] = `
                   "name": "Se mettre à la pratique",
                 },
                 {
-                  "description": "Réserve ton premier CD ou vinyle",
                   "id": "FIRST_RECORDED_MUSIC_BOOKING",
                   "illustration": {
                     "$$typeof": Symbol(react.forward_ref),
@@ -468,7 +464,6 @@ exports[`<Achievements/> should match snapshot 1`] = `
                   "name": "Badge non débloqué",
                 },
                 {
-                  "description": "Réserve ton premier spectacle",
                   "id": "FIRST_SHOW_BOOKING",
                   "illustration": {
                     "$$typeof": Symbol(react.forward_ref),
@@ -490,7 +485,6 @@ exports[`<Achievements/> should match snapshot 1`] = `
                   "name": "Badge non débloqué",
                 },
                 {
-                  "description": "Réserve ta première visite",
                   "id": "FIRST_MUSEUM_BOOKING",
                   "illustration": {
                     "$$typeof": Symbol(react.forward_ref),
@@ -512,7 +506,6 @@ exports[`<Achievements/> should match snapshot 1`] = `
                   "name": "Badge non débloqué",
                 },
                 {
-                  "description": "Réserve ton premier concert ou festival",
                   "id": "FIRST_LIVE_MUSIC_BOOKING",
                   "illustration": {
                     "$$typeof": Symbol(react.forward_ref),
@@ -534,7 +527,6 @@ exports[`<Achievements/> should match snapshot 1`] = `
                   "name": "Badge non débloqué",
                 },
                 {
-                  "description": "Abonne-toi à un média",
                   "id": "FIRST_NEWS_BOOKING",
                   "illustration": {
                     "$$typeof": Symbol(react.forward_ref),
@@ -556,7 +548,6 @@ exports[`<Achievements/> should match snapshot 1`] = `
                   "name": "Badge non débloqué",
                 },
                 {
-                  "description": "Réserve du matériel créatif",
                   "id": "FIRST_INSTRUMENT_BOOKING",
                   "illustration": {
                     "$$typeof": Symbol(react.forward_ref),

--- a/__snapshots__/features/profile/pages/Achievements/Achievements.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Achievements/Achievements.native.test.tsx.native-snap
@@ -250,6 +250,9 @@ exports[`<Achievements/> should match snapshot 1`] = `
                   [
                     {
                       "color": "#90949D",
+                      "fontFamily": "Montserrat-SemiBold",
+                      "fontSize": 12,
+                      "lineHeight": 19.2,
                     },
                   ]
                 }

--- a/__snapshots__/features/profile/pages/Achievements/Achievements.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Achievements/Achievements.native.test.tsx.native-snap
@@ -250,9 +250,6 @@ exports[`<Achievements/> should match snapshot 1`] = `
                   [
                     {
                       "color": "#90949D",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 12,
-                      "lineHeight": 19.2,
                     },
                   ]
                 }
@@ -383,7 +380,7 @@ exports[`<Achievements/> should match snapshot 1`] = `
             data={
               [
                 {
-                  "description": "Réserve ta première place de cinéma",
+                  "description": "Tu as réservé ta première séance de cinéma",
                   "id": "FIRST_MOVIE_BOOKING",
                   "illustration": {
                     "$$typeof": Symbol(react.forward_ref),
@@ -449,94 +446,6 @@ exports[`<Achievements/> should match snapshot 1`] = `
                   "name": "Se mettre à la pratique",
                 },
                 {
-                  "description": "Réserve du matériel créatif",
-                  "id": "FIRST_INSTRUMENT_BOOKING",
-                  "illustration": {
-                    "$$typeof": Symbol(react.forward_ref),
-                    "attrs": [
-                      [Function],
-                    ],
-                    "inlineStyle": InlineStyle {
-                      "rules": [
-                        "",
-                      ],
-                    },
-                    "render": [Function],
-                    "shouldForwardProp": undefined,
-                    "styledComponentId": "StyledNativeComponent",
-                    "target": [Function],
-                    "withComponent": [Function],
-                  },
-                  "isCompleted": false,
-                  "name": "Artiste en devenir",
-                },
-                {
-                  "description": "Réserve ta première visite",
-                  "id": "FIRST_MUSEUM_BOOKING",
-                  "illustration": {
-                    "$$typeof": Symbol(react.forward_ref),
-                    "attrs": [
-                      [Function],
-                    ],
-                    "inlineStyle": InlineStyle {
-                      "rules": [
-                        "",
-                      ],
-                    },
-                    "render": [Function],
-                    "shouldForwardProp": undefined,
-                    "styledComponentId": "StyledNativeComponent",
-                    "target": [Function],
-                    "withComponent": [Function],
-                  },
-                  "isCompleted": false,
-                  "name": "Explorateur culturel",
-                },
-                {
-                  "description": "Abonne-toi à un média",
-                  "id": "FIRST_NEWS_BOOKING",
-                  "illustration": {
-                    "$$typeof": Symbol(react.forward_ref),
-                    "attrs": [
-                      [Function],
-                    ],
-                    "inlineStyle": InlineStyle {
-                      "rules": [
-                        "",
-                      ],
-                    },
-                    "render": [Function],
-                    "shouldForwardProp": undefined,
-                    "styledComponentId": "StyledNativeComponent",
-                    "target": [Function],
-                    "withComponent": [Function],
-                  },
-                  "isCompleted": false,
-                  "name": "Futur Hugo Décrypte",
-                },
-                {
-                  "description": "Réserve ton premier concert ou festival",
-                  "id": "FIRST_LIVE_MUSIC_BOOKING",
-                  "illustration": {
-                    "$$typeof": Symbol(react.forward_ref),
-                    "attrs": [
-                      [Function],
-                    ],
-                    "inlineStyle": InlineStyle {
-                      "rules": [
-                        "",
-                      ],
-                    },
-                    "render": [Function],
-                    "shouldForwardProp": undefined,
-                    "styledComponentId": "StyledNativeComponent",
-                    "target": [Function],
-                    "withComponent": [Function],
-                  },
-                  "isCompleted": false,
-                  "name": "Premier Beat",
-                },
-                {
                   "description": "Réserve ton premier CD ou vinyle",
                   "id": "FIRST_RECORDED_MUSIC_BOOKING",
                   "illustration": {
@@ -556,7 +465,7 @@ exports[`<Achievements/> should match snapshot 1`] = `
                     "withComponent": [Function],
                   },
                   "isCompleted": false,
-                  "name": "Premier tour de platine",
+                  "name": "Badge non débloqué",
                 },
                 {
                   "description": "Réserve ton premier spectacle",
@@ -578,7 +487,95 @@ exports[`<Achievements/> should match snapshot 1`] = `
                     "withComponent": [Function],
                   },
                   "isCompleted": false,
-                  "name": "Rideau rouge levé",
+                  "name": "Badge non débloqué",
+                },
+                {
+                  "description": "Réserve ta première visite",
+                  "id": "FIRST_MUSEUM_BOOKING",
+                  "illustration": {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": [
+                      [Function],
+                    ],
+                    "inlineStyle": InlineStyle {
+                      "rules": [
+                        "",
+                      ],
+                    },
+                    "render": [Function],
+                    "shouldForwardProp": undefined,
+                    "styledComponentId": "StyledNativeComponent",
+                    "target": [Function],
+                    "withComponent": [Function],
+                  },
+                  "isCompleted": false,
+                  "name": "Badge non débloqué",
+                },
+                {
+                  "description": "Réserve ton premier concert ou festival",
+                  "id": "FIRST_LIVE_MUSIC_BOOKING",
+                  "illustration": {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": [
+                      [Function],
+                    ],
+                    "inlineStyle": InlineStyle {
+                      "rules": [
+                        "",
+                      ],
+                    },
+                    "render": [Function],
+                    "shouldForwardProp": undefined,
+                    "styledComponentId": "StyledNativeComponent",
+                    "target": [Function],
+                    "withComponent": [Function],
+                  },
+                  "isCompleted": false,
+                  "name": "Badge non débloqué",
+                },
+                {
+                  "description": "Abonne-toi à un média",
+                  "id": "FIRST_NEWS_BOOKING",
+                  "illustration": {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": [
+                      [Function],
+                    ],
+                    "inlineStyle": InlineStyle {
+                      "rules": [
+                        "",
+                      ],
+                    },
+                    "render": [Function],
+                    "shouldForwardProp": undefined,
+                    "styledComponentId": "StyledNativeComponent",
+                    "target": [Function],
+                    "withComponent": [Function],
+                  },
+                  "isCompleted": false,
+                  "name": "Badge non débloqué",
+                },
+                {
+                  "description": "Réserve du matériel créatif",
+                  "id": "FIRST_INSTRUMENT_BOOKING",
+                  "illustration": {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": [
+                      [Function],
+                    ],
+                    "inlineStyle": InlineStyle {
+                      "rules": [
+                        "",
+                      ],
+                    },
+                    "render": [Function],
+                    "shouldForwardProp": undefined,
+                    "styledComponentId": "StyledNativeComponent",
+                    "target": [Function],
+                    "withComponent": [Function],
+                  },
+                  "isCompleted": false,
+                  "name": "Badge non débloqué",
                 },
                 {
                   "description": "",
@@ -1112,7 +1109,7 @@ exports[`<Achievements/> should match snapshot 1`] = `
                           ]
                         }
                       >
-                        Artiste en devenir
+                        Badge non débloqué
                       </Text>
                     </View>
                   </View>
@@ -1248,7 +1245,7 @@ exports[`<Achievements/> should match snapshot 1`] = `
                           ]
                         }
                       >
-                        Explorateur culturel
+                        Badge non débloqué
                       </Text>
                     </View>
                   </View>
@@ -1365,260 +1362,7 @@ exports[`<Achievements/> should match snapshot 1`] = `
                           ]
                         }
                       >
-                        Futur Hugo Décrypte
-                      </Text>
-                    </View>
-                  </View>
-                  <Modal
-                    animationType="fade"
-                    hardwareAccelerated={false}
-                    onRequestClose={[Function]}
-                    statusBarTranslucent={true}
-                    testID="modal-achievement-details"
-                    transparent={true}
-                    visible={false}
-                  />
-                </View>
-              </View>
-              <View
-                onFocusCapture={[Function]}
-                onLayout={[Function]}
-                style={null}
-              >
-                <View
-                  style={
-                    [
-                      {
-                        "flexDirection": "row",
-                      },
-                      {
-                        "gap": 24,
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    accessibilityState={
-                      {
-                        "busy": undefined,
-                        "checked": undefined,
-                        "disabled": undefined,
-                        "expanded": undefined,
-                        "selected": undefined,
-                      }
-                    }
-                    accessibilityValue={
-                      {
-                        "max": undefined,
-                        "min": undefined,
-                        "now": undefined,
-                        "text": undefined,
-                      }
-                    }
-                    accessible={false}
-                    collapsable={false}
-                    focusable={true}
-                    onClick={[Function]}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
-                    style={
-                      {
-                        "flexBasis": 0,
-                        "flexGrow": 0.5,
-                        "flexShrink": 1,
-                        "height": 220,
-                        "opacity": 1,
-                        "userSelect": "auto",
-                      }
-                    }
-                  >
-                    <View
-                      isCompleted={false}
-                      style={
-                        [
-                          {
-                            "alignItems": "center",
-                            "backgroundColor": "#F1F1F4",
-                            "borderColor": "#696A6F",
-                            "borderRadius": 8,
-                            "borderStyle": "solid",
-                            "borderWidth": 1,
-                            "flexBasis": 0,
-                            "flexGrow": 1,
-                            "flexShrink": 1,
-                            "justifyContent": "center",
-                            "paddingHorizontal": 8,
-                            "paddingVertical": 24,
-                          },
-                        ]
-                      }
-                    >
-                      <View
-                        style={
-                          [
-                            {
-                              "height": 100,
-                              "width": 100,
-                            },
-                          ]
-                        }
-                      >
-                        <View
-                          height={100}
-                          width={100}
-                        >
-                          <Text>
-                            undefined-SVG-Mock
-                          </Text>
-                        </View>
-                      </View>
-                      <View
-                        numberOfSpaces={2}
-                        style={
-                          [
-                            {
-                              "height": 8,
-                            },
-                          ]
-                        }
-                      />
-                      <Text
-                        isCompleted={false}
-                        numberOfLines={2}
-                        style={
-                          [
-                            {
-                              "color": "#90949D",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                              "textAlign": "center",
-                            },
-                          ]
-                        }
-                      >
-                        Premier Beat
-                      </Text>
-                    </View>
-                  </View>
-                  <Modal
-                    animationType="fade"
-                    hardwareAccelerated={false}
-                    onRequestClose={[Function]}
-                    statusBarTranslucent={true}
-                    testID="modal-achievement-details"
-                    transparent={true}
-                    visible={false}
-                  />
-                  <View
-                    accessibilityState={
-                      {
-                        "busy": undefined,
-                        "checked": undefined,
-                        "disabled": undefined,
-                        "expanded": undefined,
-                        "selected": undefined,
-                      }
-                    }
-                    accessibilityValue={
-                      {
-                        "max": undefined,
-                        "min": undefined,
-                        "now": undefined,
-                        "text": undefined,
-                      }
-                    }
-                    accessible={false}
-                    collapsable={false}
-                    focusable={true}
-                    onClick={[Function]}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
-                    style={
-                      {
-                        "flexBasis": 0,
-                        "flexGrow": 0.5,
-                        "flexShrink": 1,
-                        "height": 220,
-                        "opacity": 1,
-                        "userSelect": "auto",
-                      }
-                    }
-                  >
-                    <View
-                      isCompleted={false}
-                      style={
-                        [
-                          {
-                            "alignItems": "center",
-                            "backgroundColor": "#F1F1F4",
-                            "borderColor": "#696A6F",
-                            "borderRadius": 8,
-                            "borderStyle": "solid",
-                            "borderWidth": 1,
-                            "flexBasis": 0,
-                            "flexGrow": 1,
-                            "flexShrink": 1,
-                            "justifyContent": "center",
-                            "paddingHorizontal": 8,
-                            "paddingVertical": 24,
-                          },
-                        ]
-                      }
-                    >
-                      <View
-                        style={
-                          [
-                            {
-                              "height": 100,
-                              "width": 100,
-                            },
-                          ]
-                        }
-                      >
-                        <View
-                          height={100}
-                          width={100}
-                        >
-                          <Text>
-                            undefined-SVG-Mock
-                          </Text>
-                        </View>
-                      </View>
-                      <View
-                        numberOfSpaces={2}
-                        style={
-                          [
-                            {
-                              "height": 8,
-                            },
-                          ]
-                        }
-                      />
-                      <Text
-                        isCompleted={false}
-                        numberOfLines={2}
-                        style={
-                          [
-                            {
-                              "color": "#90949D",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                              "textAlign": "center",
-                            },
-                          ]
-                        }
-                      >
-                        Premier tour de platine
+                        Badge non débloqué
                       </Text>
                     </View>
                   </View>
@@ -1754,7 +1498,260 @@ exports[`<Achievements/> should match snapshot 1`] = `
                           ]
                         }
                       >
-                        Rideau rouge levé
+                        Badge non débloqué
+                      </Text>
+                    </View>
+                  </View>
+                  <Modal
+                    animationType="fade"
+                    hardwareAccelerated={false}
+                    onRequestClose={[Function]}
+                    statusBarTranslucent={true}
+                    testID="modal-achievement-details"
+                    transparent={true}
+                    visible={false}
+                  />
+                  <View
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={false}
+                    collapsable={false}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      {
+                        "flexBasis": 0,
+                        "flexGrow": 0.5,
+                        "flexShrink": 1,
+                        "height": 220,
+                        "opacity": 1,
+                        "userSelect": "auto",
+                      }
+                    }
+                  >
+                    <View
+                      isCompleted={false}
+                      style={
+                        [
+                          {
+                            "alignItems": "center",
+                            "backgroundColor": "#F1F1F4",
+                            "borderColor": "#696A6F",
+                            "borderRadius": 8,
+                            "borderStyle": "solid",
+                            "borderWidth": 1,
+                            "flexBasis": 0,
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                            "justifyContent": "center",
+                            "paddingHorizontal": 8,
+                            "paddingVertical": 24,
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "height": 100,
+                              "width": 100,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          height={100}
+                          width={100}
+                        >
+                          <Text>
+                            undefined-SVG-Mock
+                          </Text>
+                        </View>
+                      </View>
+                      <View
+                        numberOfSpaces={2}
+                        style={
+                          [
+                            {
+                              "height": 8,
+                            },
+                          ]
+                        }
+                      />
+                      <Text
+                        isCompleted={false}
+                        numberOfLines={2}
+                        style={
+                          [
+                            {
+                              "color": "#90949D",
+                              "fontFamily": "Montserrat-Bold",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                              "textAlign": "center",
+                            },
+                          ]
+                        }
+                      >
+                        Badge non débloqué
+                      </Text>
+                    </View>
+                  </View>
+                  <Modal
+                    animationType="fade"
+                    hardwareAccelerated={false}
+                    onRequestClose={[Function]}
+                    statusBarTranslucent={true}
+                    testID="modal-achievement-details"
+                    transparent={true}
+                    visible={false}
+                  />
+                </View>
+              </View>
+              <View
+                onFocusCapture={[Function]}
+                onLayout={[Function]}
+                style={null}
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "flexDirection": "row",
+                      },
+                      {
+                        "gap": 24,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={false}
+                    collapsable={false}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      {
+                        "flexBasis": 0,
+                        "flexGrow": 0.5,
+                        "flexShrink": 1,
+                        "height": 220,
+                        "opacity": 1,
+                        "userSelect": "auto",
+                      }
+                    }
+                  >
+                    <View
+                      isCompleted={false}
+                      style={
+                        [
+                          {
+                            "alignItems": "center",
+                            "backgroundColor": "#F1F1F4",
+                            "borderColor": "#696A6F",
+                            "borderRadius": 8,
+                            "borderStyle": "solid",
+                            "borderWidth": 1,
+                            "flexBasis": 0,
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                            "justifyContent": "center",
+                            "paddingHorizontal": 8,
+                            "paddingVertical": 24,
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "height": 100,
+                              "width": 100,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          height={100}
+                          width={100}
+                        >
+                          <Text>
+                            undefined-SVG-Mock
+                          </Text>
+                        </View>
+                      </View>
+                      <View
+                        numberOfSpaces={2}
+                        style={
+                          [
+                            {
+                              "height": 8,
+                            },
+                          ]
+                        }
+                      />
+                      <Text
+                        isCompleted={false}
+                        numberOfLines={2}
+                        style={
+                          [
+                            {
+                              "color": "#90949D",
+                              "fontFamily": "Montserrat-Bold",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                              "textAlign": "center",
+                            },
+                          ]
+                        }
+                      >
+                        Badge non débloqué
                       </Text>
                     </View>
                   </View>

--- a/src/features/profile/components/Achievements/Badge.tsx
+++ b/src/features/profile/components/Achievements/Badge.tsx
@@ -2,7 +2,6 @@ import React, { FC } from 'react'
 import styled, { useTheme } from 'styled-components/native'
 
 import { AchievementDetailsModal } from 'features/profile/components/Modals/AchievementDetailsModal'
-import { useAchievementDetails } from 'features/profile/components/Modals/useAchievementDetails'
 import { AchievementId } from 'features/profile/pages/Achievements/AchievementData'
 import { useModal } from 'ui/components/modals/useModal'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
@@ -12,11 +11,11 @@ import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 type BadgeProps = {
   id: AchievementId
   Illustration: React.FC<AccessibleIcon>
+  name: string
   isCompleted?: boolean
 }
 
-export const Badge: FC<BadgeProps> = ({ Illustration, id, isCompleted }) => {
-  const achievement = useAchievementDetails(id)
+export const Badge: FC<BadgeProps> = ({ Illustration, id, name, isCompleted }) => {
   const { visible, showModal, hideModal } = useModal(false)
   const theme = useTheme()
 
@@ -29,7 +28,7 @@ export const Badge: FC<BadgeProps> = ({ Illustration, id, isCompleted }) => {
           </IllustrationContainer>
           <Spacer.Column numberOfSpaces={2} />
           <TypoBadgeName numberOfLines={2} isCompleted={!!isCompleted}>
-            {achievement?.name}
+            {name}
           </TypoBadgeName>
         </BadgeContainer>
       </StyledTouchableOpacity>

--- a/src/features/profile/components/Modals/AchievementDetailsModal.tsx
+++ b/src/features/profile/components/Modals/AchievementDetailsModal.tsx
@@ -44,8 +44,12 @@ export const AchievementDetailsModal = ({ visible, hideModal, id }: Props) => {
           )}
         </BodyWrapper>
         <Spacer.Column numberOfSpaces={4} />
-        <TypoDS.Title3>{achievement.name}</TypoDS.Title3>
-        <Spacer.Column numberOfSpaces={4} />
+        {achievement.completed ? (
+          <React.Fragment>
+            <TypoDS.Title3>{achievement.name}</TypoDS.Title3>
+            <Spacer.Column numberOfSpaces={4} />
+          </React.Fragment>
+        ) : null}
         <StyledDescrption>
           {achievement.completed ? achievement.descriptionUnlocked : achievement.descriptionLocked}
         </StyledDescrption>

--- a/src/features/profile/pages/Achievements/Achievements.tsx
+++ b/src/features/profile/pages/Achievements/Achievements.tsx
@@ -39,8 +39,6 @@ export const Achievements = () => {
       <ViewGap gap={4}>
         <TypoDS.Title2 {...getHeadingAttrs(1)}>Mes Succès</TypoDS.Title2>
         {badges.map((badge) => {
-          const remainingAchievementsText = `${badge.remainingAchievements} badge${badge.remainingAchievements > 1 ? 's' : ''} restant`
-
           const completedAchievements = badge.achievements.filter((item) => item.isCompleted)
           const incompleteAchievements = badge.achievements.filter((item) => !item.isCompleted)
 
@@ -63,7 +61,7 @@ export const Achievements = () => {
                   <TypoDS.Title4 {...getHeadingAttrs(2)}>
                     {achievementCategoryDisplayNames[badge.category]}
                   </TypoDS.Title4>
-                  <StyledBody>{remainingAchievementsText}</StyledBody>
+                  <StyledBody>{badge.remainingAchievementsText}</StyledBody>
                 </View>
                 <CompletionContainer>
                   <ProgressBarContainer>

--- a/src/features/profile/pages/Achievements/Achievements.tsx
+++ b/src/features/profile/pages/Achievements/Achievements.tsx
@@ -29,7 +29,7 @@ const emptyBadge = {
 
 export const Achievements = () => {
   const { uniqueColors } = useTheme()
-  const badges = useAchievements({
+  const categories = useAchievements({
     achievements: mockAchievements,
     completedAchievements: mockCompletedAchievements,
   })
@@ -38,33 +38,33 @@ export const Achievements = () => {
     <SecondaryPageWithBlurHeader title="">
       <ViewGap gap={4}>
         <TypoDS.Title2 {...getHeadingAttrs(1)}>Mes Succès</TypoDS.Title2>
-        {badges.map((badge) => {
-          let sortedAchievements = badge.achievements
-          const oddAchievements = sortedAchievements.length % 2 !== 0
-          if (oddAchievements) sortedAchievements = [...sortedAchievements, emptyBadge]
+        {categories.map((category) => {
+          let badges = category.badges
+          const oddAchievements = badges.length % 2 !== 0
+          if (oddAchievements) badges = [...badges, emptyBadge]
 
           return (
-            <ViewGap gap={4} key={badge.category}>
+            <ViewGap gap={4} key={category.id}>
               <AchievementsGroupeHeader>
                 <View>
                   <TypoDS.Title4 {...getHeadingAttrs(2)}>
-                    {achievementCategoryDisplayNames[badge.category]}
+                    {achievementCategoryDisplayNames[category.id]}
                   </TypoDS.Title4>
-                  <StyledBody>{badge.remainingAchievementsText}</StyledBody>
+                  <StyledBody>{category.remainingAchievementsText}</StyledBody>
                 </View>
                 <CompletionContainer>
                   <ProgressBarContainer>
                     <ProgressBar
-                      progress={badge.progress}
+                      progress={category.progress}
                       colors={[uniqueColors.brand]}
                       height={2.5}
                     />
                   </ProgressBarContainer>
-                  <TypoDS.BodyS>{badge.progressText}</TypoDS.BodyS>
+                  <TypoDS.BodyS>{category.progressText}</TypoDS.BodyS>
                 </CompletionContainer>
               </AchievementsGroupeHeader>
               <FlatList
-                data={sortedAchievements}
+                data={badges}
                 numColumns={2}
                 keyExtractor={(item) => item.id}
                 contentContainerStyle={{

--- a/src/features/profile/pages/Achievements/Achievements.tsx
+++ b/src/features/profile/pages/Achievements/Achievements.tsx
@@ -39,9 +39,8 @@ export const Achievements = () => {
       <ViewGap gap={4}>
         <TypoDS.Title2 {...getHeadingAttrs(1)}>Mes Succès</TypoDS.Title2>
         {categories.map((category) => {
-          let badges = category.badges
-          const oddAchievements = badges.length % 2 !== 0
-          if (oddAchievements) badges = [...badges, emptyBadge]
+          const isOddBadges = category.badges.length % 2 !== 0
+          const badges = isOddBadges ? [...category.badges, emptyBadge] : category.badges
 
           return (
             <ViewGap gap={4} key={category.id}>

--- a/src/features/profile/pages/Achievements/Achievements.tsx
+++ b/src/features/profile/pages/Achievements/Achievements.tsx
@@ -92,6 +92,7 @@ export const Achievements = () => {
                   item.illustration ? (
                     <Badge
                       id={item.id}
+                      name={item.name}
                       Illustration={item.illustration}
                       isCompleted={item.isCompleted}
                     />

--- a/src/features/profile/pages/Achievements/Achievements.tsx
+++ b/src/features/profile/pages/Achievements/Achievements.tsx
@@ -39,18 +39,7 @@ export const Achievements = () => {
       <ViewGap gap={4}>
         <TypoDS.Title2 {...getHeadingAttrs(1)}>Mes Succès</TypoDS.Title2>
         {badges.map((badge) => {
-          const completedAchievements = badge.achievements.filter((item) => item.isCompleted)
-          const incompleteAchievements = badge.achievements.filter((item) => !item.isCompleted)
-
-          const sortedCompletedAchievements = [...completedAchievements].sort((a, b) =>
-            a.name.localeCompare(b.name)
-          )
-
-          const sortedIncompleteAchievements = [...incompleteAchievements].sort((a, b) =>
-            a.name.localeCompare(b.name)
-          )
-
-          let sortedAchievements = [...sortedCompletedAchievements, ...sortedIncompleteAchievements]
+          let sortedAchievements = badge.achievements
           const oddAchievements = sortedAchievements.length % 2 !== 0
           if (oddAchievements) sortedAchievements = [...sortedAchievements, emptyBadge]
 

--- a/src/features/profile/pages/Achievements/Achievements.tsx
+++ b/src/features/profile/pages/Achievements/Achievements.tsx
@@ -29,7 +29,7 @@ const emptyBadge = {
 
 export const Achievements = () => {
   const { uniqueColors } = useTheme()
-  const { badges } = useAchievements({
+  const badges = useAchievements({
     achievements: mockAchievements,
     completedAchievements: mockCompletedAchievements,
   })

--- a/src/features/profile/pages/Achievements/useAchievements.native.test.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.native.test.ts
@@ -192,41 +192,7 @@ describe('useAchievements', () => {
 
   describe('Category Achievements completion', () => {
     describe('Remaining achievements to complete', () => {
-      it('should return 2 when there are 2 achievements and no one is completed', () => {
-        const { result } = renderHook(() =>
-          useAchievements({
-            achievements: [firstArtLessonBooking, firstBookBooking],
-            completedAchievements: [],
-          })
-        )
-        const { badges } = result.current
-
-        expect(badges).toEqual([
-          expect.objectContaining({
-            category: CombinedAchievementCategory.FIRST_BOOKINGS,
-            remainingAchievements: 2,
-          }),
-        ])
-      })
-
-      it('should return 1 when only 1 achievement is remaining', () => {
-        const { result } = renderHook(() =>
-          useAchievements({
-            achievements: [firstArtLessonBooking, firstBookBooking],
-            completedAchievements: [userCompletedArtLessonBooking],
-          })
-        )
-        const { badges } = result.current
-
-        expect(badges).toEqual([
-          expect.objectContaining({
-            category: CombinedAchievementCategory.FIRST_BOOKINGS,
-            remainingAchievements: 1,
-          }),
-        ])
-      })
-
-      it('should return 0 when all achievement is completed', () => {
+      it('should return "0 badge restant" when all achievements of category are completed', () => {
         const { result } = renderHook(() =>
           useAchievements({
             achievements: [firstArtLessonBooking, firstBookBooking],
@@ -238,7 +204,41 @@ describe('useAchievements', () => {
         expect(badges).toEqual([
           expect.objectContaining({
             category: CombinedAchievementCategory.FIRST_BOOKINGS,
-            remainingAchievements: 0,
+            remainingAchievementsText: '0 badge restant',
+          }),
+        ])
+      })
+
+      it('should return "1 badge restants" when 1 achievement are not completed', () => {
+        const { result } = renderHook(() =>
+          useAchievements({
+            achievements: [firstArtLessonBooking, firstBookBooking],
+            completedAchievements: [userCompletedArtLessonBooking],
+          })
+        )
+        const { badges } = result.current
+
+        expect(badges).toEqual([
+          expect.objectContaining({
+            category: CombinedAchievementCategory.FIRST_BOOKINGS,
+            remainingAchievementsText: '1 badge restant',
+          }),
+        ])
+      })
+
+      it('should return "2 badges restants" when 2 achievement are not completed', () => {
+        const { result } = renderHook(() =>
+          useAchievements({
+            achievements: [firstArtLessonBooking, firstBookBooking],
+            completedAchievements: [],
+          })
+        )
+        const { badges } = result.current
+
+        expect(badges).toEqual([
+          expect.objectContaining({
+            category: CombinedAchievementCategory.FIRST_BOOKINGS,
+            remainingAchievementsText: '2 badges restant',
           }),
         ])
       })
@@ -357,7 +357,7 @@ describe('useAchievements', () => {
           ])
         })
 
-        it('should return 50% when 1 achievement of 2 are completed', () => {
+        it('should return 1/2 when 1 achievement of 2 are completed', () => {
           const { result } = renderHook(() =>
             useAchievements({
               achievements: [firstArtLessonBooking, firstBookBooking],

--- a/src/features/profile/pages/Achievements/useAchievements.native.test.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.native.test.ts
@@ -10,7 +10,10 @@ import {
   userCompletedBookBooking,
   userCompletedMovieBooking,
 } from 'features/profile/pages/Achievements/AchievementData'
-import { useAchievements } from 'features/profile/pages/Achievements/useAchievements'
+import {
+  UseAchivementsProps,
+  useAchievements,
+} from 'features/profile/pages/Achievements/useAchievements'
 import { renderHook } from 'tests/utils'
 import { BicolorTrophy, Trophy } from 'ui/svg/icons/Trophy'
 
@@ -41,28 +44,28 @@ const testAchievement = {
   category: CombinedAchievementCategory.TEST,
 }
 
+const testUseAchievements = ({
+  achievements = [],
+  completedAchievements = [],
+}: Partial<UseAchivementsProps> = {}) =>
+  renderHook(() =>
+    useAchievements({
+      achievements,
+      completedAchievements,
+    })
+  ).result.current
+
 describe('useAchievements', () => {
   it('should return empty array when there are no achievements', () => {
-    const { result } = renderHook(() =>
-      useAchievements({
-        achievements: [],
-        completedAchievements: [],
-      })
-    )
-
-    const { badges } = result.current
+    const badges = testUseAchievements()
 
     expect(badges).toEqual([])
   })
 
   it('should return achievements grouped by category', () => {
-    const { result } = renderHook(() =>
-      useAchievements({
-        achievements: [firstArtLessonBooking, testAchievement as unknown as Achievement],
-        completedAchievements: [],
-      })
-    )
-    const { badges } = result.current
+    const badges = testUseAchievements({
+      achievements: [firstArtLessonBooking, testAchievement as unknown as Achievement],
+    })
 
     expect(badges).toEqual([
       expect.objectContaining({
@@ -85,13 +88,9 @@ describe('useAchievements', () => {
   })
 
   it('achievement is NOT completed when user has not already completed it', () => {
-    const { result } = renderHook(() =>
-      useAchievements({
-        achievements: [firstArtLessonBooking, firstBookBooking],
-        completedAchievements: [],
-      })
-    )
-    const { badges } = result.current
+    const badges = testUseAchievements({
+      achievements: [firstArtLessonBooking, firstBookBooking],
+    })
 
     expect(badges).toEqual([
       expect.objectContaining({
@@ -111,13 +110,10 @@ describe('useAchievements', () => {
   })
 
   it('achievement is completed when user has already completed it', () => {
-    const { result } = renderHook(() =>
-      useAchievements({
-        achievements: [firstArtLessonBooking, firstBookBooking],
-        completedAchievements: [userCompletedArtLessonBooking, userCompletedBookBooking],
-      })
-    )
-    const { badges } = result.current
+    const badges = testUseAchievements({
+      achievements: [firstArtLessonBooking, firstBookBooking],
+      completedAchievements: [userCompletedArtLessonBooking, userCompletedBookBooking],
+    })
 
     expect(badges).toEqual([
       expect.objectContaining({
@@ -137,14 +133,10 @@ describe('useAchievements', () => {
   })
 
   it('achievement name is "Badge non débloqué" when achievement is not completed', () => {
-    const { result } = renderHook(() =>
-      useAchievements({
-        achievements: [firstArtLessonBooking, firstBookBooking],
-        completedAchievements: [],
-      })
-    )
-
-    const { badges } = result.current
+    const badges = testUseAchievements({
+      achievements: [firstArtLessonBooking, firstBookBooking],
+      completedAchievements: [],
+    })
 
     expect(badges).toEqual([
       expect.objectContaining({
@@ -164,14 +156,10 @@ describe('useAchievements', () => {
   })
 
   it('achievement completed name is the achievement name', () => {
-    const { result } = renderHook(() =>
-      useAchievements({
-        achievements: [firstArtLessonBooking, firstBookBooking],
-        completedAchievements: [userCompletedArtLessonBooking, userCompletedBookBooking],
-      })
-    )
-
-    const { badges } = result.current
+    const badges = testUseAchievements({
+      achievements: [firstArtLessonBooking, firstBookBooking],
+      completedAchievements: [userCompletedArtLessonBooking, userCompletedBookBooking],
+    })
 
     expect(badges).toEqual([
       expect.objectContaining({
@@ -193,13 +181,10 @@ describe('useAchievements', () => {
   describe('Category Achievements completion', () => {
     describe('Remaining achievements to complete', () => {
       it('should return "0 badge restant" when all achievements of category are completed', () => {
-        const { result } = renderHook(() =>
-          useAchievements({
-            achievements: [firstArtLessonBooking, firstBookBooking],
-            completedAchievements: [userCompletedArtLessonBooking, userCompletedBookBooking],
-          })
-        )
-        const { badges } = result.current
+        const badges = testUseAchievements({
+          achievements: [firstArtLessonBooking, firstBookBooking],
+          completedAchievements: [userCompletedArtLessonBooking, userCompletedBookBooking],
+        })
 
         expect(badges).toEqual([
           expect.objectContaining({
@@ -210,13 +195,10 @@ describe('useAchievements', () => {
       })
 
       it('should return "1 badge restants" when 1 achievement are not completed', () => {
-        const { result } = renderHook(() =>
-          useAchievements({
-            achievements: [firstArtLessonBooking, firstBookBooking],
-            completedAchievements: [userCompletedArtLessonBooking],
-          })
-        )
-        const { badges } = result.current
+        const badges = testUseAchievements({
+          achievements: [firstArtLessonBooking, firstBookBooking],
+          completedAchievements: [userCompletedArtLessonBooking],
+        })
 
         expect(badges).toEqual([
           expect.objectContaining({
@@ -227,13 +209,9 @@ describe('useAchievements', () => {
       })
 
       it('should return "2 badges restants" when 2 achievement are not completed', () => {
-        const { result } = renderHook(() =>
-          useAchievements({
-            achievements: [firstArtLessonBooking, firstBookBooking],
-            completedAchievements: [],
-          })
-        )
-        const { badges } = result.current
+        const badges = testUseAchievements({
+          achievements: [firstArtLessonBooking, firstBookBooking],
+        })
 
         expect(badges).toEqual([
           expect.objectContaining({
@@ -246,13 +224,10 @@ describe('useAchievements', () => {
 
     describe('Achievements progression', () => {
       it('should be 1 when all achievements are completed', () => {
-        const { result } = renderHook(() =>
-          useAchievements({
-            achievements: [firstArtLessonBooking],
-            completedAchievements: [userCompletedArtLessonBooking],
-          })
-        )
-        const { badges } = result.current
+        const badges = testUseAchievements({
+          achievements: [firstArtLessonBooking],
+          completedAchievements: [userCompletedArtLessonBooking],
+        })
 
         expect(badges).toEqual([
           expect.objectContaining({
@@ -263,13 +238,9 @@ describe('useAchievements', () => {
       })
 
       it('should be 0 when no achievements are completed', () => {
-        const { result } = renderHook(() =>
-          useAchievements({
-            achievements: [firstArtLessonBooking],
-            completedAchievements: [],
-          })
-        )
-        const { badges } = result.current
+        const badges = testUseAchievements({
+          achievements: [firstArtLessonBooking],
+        })
 
         expect(badges).toEqual([
           expect.objectContaining({
@@ -280,13 +251,10 @@ describe('useAchievements', () => {
       })
 
       it('should be 0.5 when 1 achievement of 2 are completed', () => {
-        const { result } = renderHook(() =>
-          useAchievements({
-            achievements: [firstArtLessonBooking, firstBookBooking],
-            completedAchievements: [userCompletedArtLessonBooking],
-          })
-        )
-        const { badges } = result.current
+        const badges = testUseAchievements({
+          achievements: [firstArtLessonBooking, firstBookBooking],
+          completedAchievements: [userCompletedArtLessonBooking],
+        })
 
         expect(badges).toEqual([
           expect.objectContaining({
@@ -297,22 +265,19 @@ describe('useAchievements', () => {
       })
 
       it('should be 0.75 when 3 achievement of 4 are completed', () => {
-        const { result } = renderHook(() =>
-          useAchievements({
-            achievements: [
-              firstArtLessonBooking,
-              firstBookBooking,
-              firstInstrumentBooking,
-              firstMovieBooking,
-            ],
-            completedAchievements: [
-              userCompletedArtLessonBooking,
-              userCompletedBookBooking,
-              userCompletedMovieBooking,
-            ],
-          })
-        )
-        const { badges } = result.current
+        const badges = testUseAchievements({
+          achievements: [
+            firstArtLessonBooking,
+            firstBookBooking,
+            firstInstrumentBooking,
+            firstMovieBooking,
+          ],
+          completedAchievements: [
+            userCompletedArtLessonBooking,
+            userCompletedBookBooking,
+            userCompletedMovieBooking,
+          ],
+        })
 
         expect(badges).toEqual([
           expect.objectContaining({
@@ -324,13 +289,9 @@ describe('useAchievements', () => {
 
       describe('text', () => {
         it('should return 0/2 when no achievements are completed', () => {
-          const { result } = renderHook(() =>
-            useAchievements({
-              achievements: [firstArtLessonBooking, firstBookBooking],
-              completedAchievements: [],
-            })
-          )
-          const { badges } = result.current
+          const badges = testUseAchievements({
+            achievements: [firstArtLessonBooking, firstBookBooking],
+          })
 
           expect(badges).toEqual([
             expect.objectContaining({
@@ -341,13 +302,10 @@ describe('useAchievements', () => {
         })
 
         it('should return 2/2 when all achievements are completed', () => {
-          const { result } = renderHook(() =>
-            useAchievements({
-              achievements: [firstArtLessonBooking, firstBookBooking],
-              completedAchievements: [userCompletedArtLessonBooking, userCompletedBookBooking],
-            })
-          )
-          const { badges } = result.current
+          const badges = testUseAchievements({
+            achievements: [firstArtLessonBooking, firstBookBooking],
+            completedAchievements: [userCompletedArtLessonBooking, userCompletedBookBooking],
+          })
 
           expect(badges).toEqual([
             expect.objectContaining({
@@ -358,13 +316,10 @@ describe('useAchievements', () => {
         })
 
         it('should return 1/2 when 1 achievement of 2 are completed', () => {
-          const { result } = renderHook(() =>
-            useAchievements({
-              achievements: [firstArtLessonBooking, firstBookBooking],
-              completedAchievements: [userCompletedArtLessonBooking],
-            })
-          )
-          const { badges } = result.current
+          const badges = testUseAchievements({
+            achievements: [firstArtLessonBooking, firstBookBooking],
+            completedAchievements: [userCompletedArtLessonBooking],
+          })
 
           expect(badges).toEqual([
             expect.objectContaining({

--- a/src/features/profile/pages/Achievements/useAchievements.native.test.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.native.test.ts
@@ -69,16 +69,16 @@ describe('useAchievements', () => {
 
     expect(badges).toEqual([
       expect.objectContaining({
-        category: CombinedAchievementCategory.FIRST_BOOKINGS,
-        achievements: [
+        id: CombinedAchievementCategory.FIRST_BOOKINGS,
+        badges: [
           expect.objectContaining({
             id: CombinedAchievementId.FIRST_ART_LESSON_BOOKING,
           }),
         ],
       }),
       expect.objectContaining({
-        category: CombinedAchievementCategory.TEST,
-        achievements: [
+        id: CombinedAchievementCategory.TEST,
+        badges: [
           expect.objectContaining({
             id: 'TEST',
           }),
@@ -94,8 +94,8 @@ describe('useAchievements', () => {
 
     expect(badges).toEqual([
       expect.objectContaining({
-        category: CombinedAchievementCategory.FIRST_BOOKINGS,
-        achievements: [
+        id: CombinedAchievementCategory.FIRST_BOOKINGS,
+        badges: [
           expect.objectContaining({
             id: CombinedAchievementId.FIRST_ART_LESSON_BOOKING,
             isCompleted: false,
@@ -117,8 +117,8 @@ describe('useAchievements', () => {
 
     expect(badges).toEqual([
       expect.objectContaining({
-        category: CombinedAchievementCategory.FIRST_BOOKINGS,
-        achievements: [
+        id: CombinedAchievementCategory.FIRST_BOOKINGS,
+        badges: [
           expect.objectContaining({
             id: CombinedAchievementId.FIRST_BOOK_BOOKING,
             isCompleted: true,
@@ -140,8 +140,8 @@ describe('useAchievements', () => {
 
     expect(badges).toEqual([
       expect.objectContaining({
-        category: CombinedAchievementCategory.FIRST_BOOKINGS,
-        achievements: [
+        id: CombinedAchievementCategory.FIRST_BOOKINGS,
+        badges: [
           expect.objectContaining({
             id: CombinedAchievementId.FIRST_ART_LESSON_BOOKING,
             name: 'Badge non débloqué',
@@ -163,8 +163,8 @@ describe('useAchievements', () => {
 
     expect(badges).toEqual([
       expect.objectContaining({
-        category: CombinedAchievementCategory.FIRST_BOOKINGS,
-        achievements: [
+        id: CombinedAchievementCategory.FIRST_BOOKINGS,
+        badges: [
           expect.objectContaining({
             id: CombinedAchievementId.FIRST_BOOK_BOOKING,
             name: firstBookBooking.name,
@@ -186,8 +186,8 @@ describe('useAchievements', () => {
 
     expect(badges).toEqual([
       expect.objectContaining({
-        category: CombinedAchievementCategory.FIRST_BOOKINGS,
-        achievements: [
+        id: CombinedAchievementCategory.FIRST_BOOKINGS,
+        badges: [
           expect.objectContaining({
             id: CombinedAchievementId.FIRST_BOOK_BOOKING,
           }),
@@ -207,8 +207,8 @@ describe('useAchievements', () => {
 
     expect(badges).toEqual([
       expect.objectContaining({
-        category: CombinedAchievementCategory.FIRST_BOOKINGS,
-        achievements: [
+        id: CombinedAchievementCategory.FIRST_BOOKINGS,
+        badges: [
           expect.objectContaining({
             id: CombinedAchievementId.FIRST_ART_LESSON_BOOKING,
           }),
@@ -230,7 +230,7 @@ describe('useAchievements', () => {
 
         expect(badges).toEqual([
           expect.objectContaining({
-            category: CombinedAchievementCategory.FIRST_BOOKINGS,
+            id: CombinedAchievementCategory.FIRST_BOOKINGS,
             remainingAchievementsText: '0 badge restant',
           }),
         ])
@@ -244,7 +244,7 @@ describe('useAchievements', () => {
 
         expect(badges).toEqual([
           expect.objectContaining({
-            category: CombinedAchievementCategory.FIRST_BOOKINGS,
+            id: CombinedAchievementCategory.FIRST_BOOKINGS,
             remainingAchievementsText: '1 badge restant',
           }),
         ])
@@ -257,7 +257,7 @@ describe('useAchievements', () => {
 
         expect(badges).toEqual([
           expect.objectContaining({
-            category: CombinedAchievementCategory.FIRST_BOOKINGS,
+            id: CombinedAchievementCategory.FIRST_BOOKINGS,
             remainingAchievementsText: '2 badges restant',
           }),
         ])
@@ -273,7 +273,7 @@ describe('useAchievements', () => {
 
         expect(badges).toEqual([
           expect.objectContaining({
-            category: CombinedAchievementCategory.FIRST_BOOKINGS,
+            id: CombinedAchievementCategory.FIRST_BOOKINGS,
             progress: 1,
           }),
         ])
@@ -286,7 +286,7 @@ describe('useAchievements', () => {
 
         expect(badges).toEqual([
           expect.objectContaining({
-            category: CombinedAchievementCategory.FIRST_BOOKINGS,
+            id: CombinedAchievementCategory.FIRST_BOOKINGS,
             progress: 0,
           }),
         ])
@@ -300,7 +300,7 @@ describe('useAchievements', () => {
 
         expect(badges).toEqual([
           expect.objectContaining({
-            category: CombinedAchievementCategory.FIRST_BOOKINGS,
+            id: CombinedAchievementCategory.FIRST_BOOKINGS,
             progress: 0.5,
           }),
         ])
@@ -323,7 +323,7 @@ describe('useAchievements', () => {
 
         expect(badges).toEqual([
           expect.objectContaining({
-            category: CombinedAchievementCategory.FIRST_BOOKINGS,
+            id: CombinedAchievementCategory.FIRST_BOOKINGS,
             progress: 0.75,
           }),
         ])
@@ -337,7 +337,7 @@ describe('useAchievements', () => {
 
           expect(badges).toEqual([
             expect.objectContaining({
-              category: CombinedAchievementCategory.FIRST_BOOKINGS,
+              id: CombinedAchievementCategory.FIRST_BOOKINGS,
               progressText: '0/2',
             }),
           ])
@@ -351,7 +351,7 @@ describe('useAchievements', () => {
 
           expect(badges).toEqual([
             expect.objectContaining({
-              category: CombinedAchievementCategory.FIRST_BOOKINGS,
+              id: CombinedAchievementCategory.FIRST_BOOKINGS,
               progressText: '2/2',
             }),
           ])
@@ -365,7 +365,7 @@ describe('useAchievements', () => {
 
           expect(badges).toEqual([
             expect.objectContaining({
-              category: CombinedAchievementCategory.FIRST_BOOKINGS,
+              id: CombinedAchievementCategory.FIRST_BOOKINGS,
               progressText: '1/2',
             }),
           ])

--- a/src/features/profile/pages/Achievements/useAchievements.native.test.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.native.test.ts
@@ -136,6 +136,60 @@ describe('useAchievements', () => {
     ])
   })
 
+  it('achievement name is "Badge non débloqué" when achievement is not completed', () => {
+    const { result } = renderHook(() =>
+      useAchievements({
+        achievements: [firstArtLessonBooking, firstBookBooking],
+        completedAchievements: [],
+      })
+    )
+
+    const { badges } = result.current
+
+    expect(badges).toEqual([
+      expect.objectContaining({
+        category: CombinedAchievementCategory.FIRST_BOOKINGS,
+        achievements: [
+          expect.objectContaining({
+            id: CombinedAchievementId.FIRST_ART_LESSON_BOOKING,
+            name: 'Badge non débloqué',
+          }),
+          expect.objectContaining({
+            id: CombinedAchievementId.FIRST_BOOK_BOOKING,
+            name: 'Badge non débloqué',
+          }),
+        ],
+      }),
+    ])
+  })
+
+  it('achievement completed name is the achievement name', () => {
+    const { result } = renderHook(() =>
+      useAchievements({
+        achievements: [firstArtLessonBooking, firstBookBooking],
+        completedAchievements: [userCompletedArtLessonBooking, userCompletedBookBooking],
+      })
+    )
+
+    const { badges } = result.current
+
+    expect(badges).toEqual([
+      expect.objectContaining({
+        category: CombinedAchievementCategory.FIRST_BOOKINGS,
+        achievements: [
+          expect.objectContaining({
+            id: CombinedAchievementId.FIRST_ART_LESSON_BOOKING,
+            name: firstArtLessonBooking.name,
+          }),
+          expect.objectContaining({
+            id: CombinedAchievementId.FIRST_BOOK_BOOKING,
+            name: firstBookBooking.name,
+          }),
+        ],
+      }),
+    ])
+  })
+
   describe('Category Achievements completion', () => {
     describe('Remaining achievements to complete', () => {
       it('should return 2 when there are 2 achievements and no one is completed', () => {

--- a/src/features/profile/pages/Achievements/useAchievements.native.test.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.native.test.ts
@@ -120,11 +120,11 @@ describe('useAchievements', () => {
         category: CombinedAchievementCategory.FIRST_BOOKINGS,
         achievements: [
           expect.objectContaining({
-            id: CombinedAchievementId.FIRST_ART_LESSON_BOOKING,
+            id: CombinedAchievementId.FIRST_BOOK_BOOKING,
             isCompleted: true,
           }),
           expect.objectContaining({
-            id: CombinedAchievementId.FIRST_BOOK_BOOKING,
+            id: CombinedAchievementId.FIRST_ART_LESSON_BOOKING,
             isCompleted: true,
           }),
         ],
@@ -166,12 +166,54 @@ describe('useAchievements', () => {
         category: CombinedAchievementCategory.FIRST_BOOKINGS,
         achievements: [
           expect.objectContaining({
+            id: CombinedAchievementId.FIRST_BOOK_BOOKING,
+            name: firstBookBooking.name,
+          }),
+          expect.objectContaining({
             id: CombinedAchievementId.FIRST_ART_LESSON_BOOKING,
             name: firstArtLessonBooking.name,
           }),
+        ],
+      }),
+    ])
+  })
+
+  it('achivements are sorted by name', () => {
+    const badges = testUseAchievements({
+      achievements: [firstArtLessonBooking, firstBookBooking],
+      completedAchievements: [userCompletedArtLessonBooking, userCompletedBookBooking],
+    })
+
+    expect(badges).toEqual([
+      expect.objectContaining({
+        category: CombinedAchievementCategory.FIRST_BOOKINGS,
+        achievements: [
           expect.objectContaining({
             id: CombinedAchievementId.FIRST_BOOK_BOOKING,
-            name: firstBookBooking.name,
+          }),
+          expect.objectContaining({
+            id: CombinedAchievementId.FIRST_ART_LESSON_BOOKING,
+          }),
+        ],
+      }),
+    ])
+  })
+
+  it('achievement completed is sorted before achievement not completed', () => {
+    const badges = testUseAchievements({
+      achievements: [firstBookBooking, firstArtLessonBooking],
+      completedAchievements: [userCompletedArtLessonBooking],
+    })
+
+    expect(badges).toEqual([
+      expect.objectContaining({
+        category: CombinedAchievementCategory.FIRST_BOOKINGS,
+        achievements: [
+          expect.objectContaining({
+            id: CombinedAchievementId.FIRST_ART_LESSON_BOOKING,
+          }),
+          expect.objectContaining({
+            id: CombinedAchievementId.FIRST_BOOK_BOOKING,
           }),
         ],
       }),

--- a/src/features/profile/pages/Achievements/useAchievements.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.ts
@@ -8,7 +8,7 @@ import { AccessibleIcon } from 'ui/svg/icons/types'
 
 type Badges = {
   category: AchievementCategory
-  remainingAchievements: number
+  remainingAchievementsText: string
   progress: number
   progressText: string
   achievements: {
@@ -72,7 +72,7 @@ const createCategory =
       category,
       progress,
       progressText,
-      remainingAchievements,
+      remainingAchievementsText: `${remainingAchievements} badge${remainingAchievements > 1 ? 's' : ''} restant`,
       achievements: categoryAchievements.map(createAchievement(completedAchievements)),
     }
   }

--- a/src/features/profile/pages/Achievements/useAchievements.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.ts
@@ -6,7 +6,7 @@ import {
 } from 'features/profile/pages/Achievements/AchievementData'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 
-type Badges = {
+type Categories = {
   id: AchievementCategory
   remainingAchievementsText: string
   progress: number
@@ -28,7 +28,7 @@ export type UseAchivementsProps = {
 export const useAchievements = ({
   achievements,
   completedAchievements,
-}: UseAchivementsProps): Badges =>
+}: UseAchivementsProps): Categories =>
   getAchievementsCategories(achievements).map(createCategory(achievements, completedAchievements))
 
 const getAchievementsCategories = (achievements: Achievement[]) =>

--- a/src/features/profile/pages/Achievements/useAchievements.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.ts
@@ -7,11 +7,11 @@ import {
 import { AccessibleIcon } from 'ui/svg/icons/types'
 
 type Badges = {
-  category: AchievementCategory
+  id: AchievementCategory
   remainingAchievementsText: string
   progress: number
   progressText: string
-  achievements: {
+  badges: {
     id: AchievementId
     name: string
     description: string
@@ -60,7 +60,7 @@ const createCategory =
 
     const remainingAchievements = categoryAchievements.length - completedCategoryAchievements.length
 
-    const badges = categoryAchievements.map(createAchievement(completedAchievements))
+    const badges = categoryAchievements.map(createBadge(completedAchievements))
 
     const completedBadges = badges
       .filter((a) => a.isCompleted)
@@ -69,25 +69,24 @@ const createCategory =
     const uncompletedBadges = badges.filter((a) => !a.isCompleted)
 
     return {
-      category,
+      id: category,
       progress: completedCategoryAchievements.length / categoryAchievements.length,
       progressText: `${completedCategoryAchievements.length}/${categoryAchievements.length}`,
       remainingAchievementsText: `${remainingAchievements} badge${remainingAchievements > 1 ? 's' : ''} restant`,
-      achievements: [...completedBadges, ...uncompletedBadges],
+      badges: [...completedBadges, ...uncompletedBadges],
     }
   }
 
 const LOCKED_BADGE_NAME = 'Badge non débloqué'
 
-const createAchievement =
-  (completedAchievements: UserAchievement[]) => (achievement: Achievement) => {
-    const isCompleted = isAchievementCompleted(achievement, completedAchievements)
+const createBadge = (completedAchievements: UserAchievement[]) => (achievement: Achievement) => {
+  const isCompleted = isAchievementCompleted(achievement, completedAchievements)
 
-    return {
-      id: achievement.id,
-      name: isCompleted ? achievement.name : LOCKED_BADGE_NAME,
-      description: isCompleted ? achievement.descriptionUnlocked : achievement.descriptionLocked,
-      illustration: isCompleted ? achievement.illustrationUnlocked : achievement.illustrationLocked,
-      isCompleted,
-    }
+  return {
+    id: achievement.id,
+    name: isCompleted ? achievement.name : LOCKED_BADGE_NAME,
+    description: isCompleted ? achievement.descriptionUnlocked : achievement.descriptionLocked,
+    illustration: isCompleted ? achievement.illustrationUnlocked : achievement.illustrationLocked,
+    isCompleted,
   }
+}

--- a/src/features/profile/pages/Achievements/useAchievements.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.ts
@@ -30,16 +30,16 @@ export const useAchievements = ({ achievements, completedAchievements }: Props) 
     const category = acc.find((badge) => badge.category === achievement.category)
     const isCompleted = completedAchievements.some((u) => u.id === achievement.id)
 
+    const badge = {
+      id: achievement.id,
+      name: isCompleted ? achievement.name : 'Badge non débloqué',
+      description: isCompleted ? achievement.descriptionUnlocked : achievement.descriptionLocked,
+      illustration: isCompleted ? achievement.illustrationUnlocked : achievement.illustrationLocked,
+      isCompleted,
+    }
+
     if (category) {
-      category.achievements.push({
-        id: achievement.id,
-        name: achievement.name,
-        description: isCompleted ? achievement.descriptionUnlocked : achievement.descriptionLocked,
-        illustration: isCompleted
-          ? achievement.illustrationUnlocked
-          : achievement.illustrationLocked,
-        isCompleted,
-      })
+      category.achievements.push(badge)
 
       if (!isCompleted) {
         category.remainingAchievements++
@@ -57,18 +57,9 @@ export const useAchievements = ({ achievements, completedAchievements }: Props) 
       progressText: isCompleted ? '100%' : '0%',
       remainingAchievements: isCompleted ? 0 : 1,
 
-      achievements: [
-        {
-          id: achievement.id,
-          name: achievement.name,
-          description: achievement.descriptionLocked,
-          illustration: isCompleted
-            ? achievement.illustrationUnlocked
-            : achievement.illustrationLocked,
-          isCompleted,
-        },
-      ],
+      achievements: [badge],
     })
+
     return acc
   }, [] as Badges)
 

--- a/src/features/profile/pages/Achievements/useAchievements.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.ts
@@ -14,7 +14,6 @@ type Categories = {
   badges: {
     id: AchievementId
     name: string
-    description: string
     illustration: React.FC<AccessibleIcon>
     isCompleted: boolean
   }[]
@@ -85,7 +84,6 @@ const createBadge = (completedAchievements: UserAchievement[]) => (achievement: 
   return {
     id: achievement.id,
     name: isCompleted ? achievement.name : LOCKED_BADGE_NAME,
-    description: isCompleted ? achievement.descriptionUnlocked : achievement.descriptionLocked,
     illustration: isCompleted ? achievement.illustrationUnlocked : achievement.illustrationLocked,
     isCompleted,
   }

--- a/src/features/profile/pages/Achievements/useAchievements.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.ts
@@ -20,25 +20,19 @@ type Badges = {
   }[]
 }[]
 
-type Props = {
+export type UseAchivementsProps = {
   achievements: Achievement[]
   completedAchievements: UserAchievement[]
-}
-
-type UseAchievements = {
-  badges: Badges
 }
 
 export const useAchievements = ({
   achievements,
   completedAchievements,
-}: Props): UseAchievements => {
-  return {
-    badges: getAchievementsCategories(achievements).map(
-      createCategory(achievements, completedAchievements)
-    ),
-  }
-}
+}: UseAchivementsProps): Badges =>
+  getAchievementsCategories(achievements).map(createCategory(achievements, completedAchievements))
+
+const getAchievementsCategories = (achievements: Achievement[]) =>
+  Array.from(new Set(achievements.map((achievement) => achievement.category)))
 
 const isAchievementCompleted = (
   achievement: Achievement,
@@ -87,6 +81,3 @@ const createAchievement =
       isCompleted,
     }
   }
-
-const getAchievementsCategories = (achievements: Achievement[]) =>
-  Array.from(new Set(achievements.map((achievement) => achievement.category)))

--- a/src/features/profile/pages/Achievements/useAchievements.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.ts
@@ -60,12 +60,20 @@ const createCategory =
 
     const remainingAchievements = categoryAchievements.length - completedCategoryAchievements.length
 
+    const badges = categoryAchievements.map(createAchievement(completedAchievements))
+
+    const completedBadges = badges
+      .filter((a) => a.isCompleted)
+      .sort((a, b) => a.name.localeCompare(b.name))
+
+    const uncompletedBadges = badges.filter((a) => !a.isCompleted)
+
     return {
       category,
       progress: completedCategoryAchievements.length / categoryAchievements.length,
       progressText: `${completedCategoryAchievements.length}/${categoryAchievements.length}`,
       remainingAchievementsText: `${remainingAchievements} badge${remainingAchievements > 1 ? 's' : ''} restant`,
-      achievements: categoryAchievements.map(createAchievement(completedAchievements)),
+      achievements: [...completedBadges, ...uncompletedBadges],
     }
   }
 

--- a/src/features/profile/pages/Achievements/useAchievements.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.ts
@@ -64,14 +64,12 @@ const createCategory =
       completedAchievements
     )
 
-    const progress = completedCategoryAchievements.length / categoryAchievements.length
-    const progressText = `${completedCategoryAchievements.length}/${categoryAchievements.length}`
     const remainingAchievements = categoryAchievements.length - completedCategoryAchievements.length
 
     return {
       category,
-      progress,
-      progressText,
+      progress: completedCategoryAchievements.length / categoryAchievements.length,
+      progressText: `${completedCategoryAchievements.length}/${categoryAchievements.length}`,
       remainingAchievementsText: `${remainingAchievements} badge${remainingAchievements > 1 ? 's' : ''} restant`,
       achievements: categoryAchievements.map(createAchievement(completedAchievements)),
     }

--- a/src/features/profile/pages/Achievements/useAchievements.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.ts
@@ -69,13 +69,15 @@ const createCategory =
     }
   }
 
+const LOCKED_BADGE_NAME = 'Badge non débloqué'
+
 const createAchievement =
   (completedAchievements: UserAchievement[]) => (achievement: Achievement) => {
     const isCompleted = isAchievementCompleted(achievement, completedAchievements)
 
     return {
       id: achievement.id,
-      name: isCompleted ? achievement.name : 'Badge non débloqué',
+      name: isCompleted ? achievement.name : LOCKED_BADGE_NAME,
       description: isCompleted ? achievement.descriptionUnlocked : achievement.descriptionLocked,
       illustration: isCompleted ? achievement.illustrationUnlocked : achievement.illustrationLocked,
       isCompleted,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33066

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |   ![image](https://github.com/user-attachments/assets/cddde7f3-9030-4eda-ba0d-0e1b13c5793c)    ![image](https://github.com/user-attachments/assets/6aab518b-b8a8-4206-8ccf-4ced06f9da7d)|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
