### PR TITLE
(BSR) fix(filter): SingleFilterButton accessiblity props

### DIFF
--- a/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
@@ -529,7 +529,6 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       "paddingLeft": 16,
                       "paddingRight": 16,
                     },
-                    {},
                   ],
                   {
                     "opacity": 1,
@@ -626,7 +625,6 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       "paddingLeft": 16,
                       "paddingRight": 16,
                     },
-                    {},
                   ],
                   {
                     "opacity": 1,
@@ -723,7 +721,6 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       "paddingLeft": 16,
                       "paddingRight": 16,
                     },
-                    {},
                   ],
                   {
                     "opacity": 1,
@@ -820,7 +817,6 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       "paddingLeft": 16,
                       "paddingRight": 16,
                     },
-                    {},
                   ],
                   {
                     "opacity": 1,
@@ -909,7 +905,6 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       "paddingLeft": 16,
                       "paddingRight": 16,
                     },
-                    {},
                   ],
                   {
                     "opacity": 1,

--- a/src/features/search/components/Buttons/SingleFilterButton/SingleFilterButton.tsx
+++ b/src/features/search/components/Buttons/SingleFilterButton/SingleFilterButton.tsx
@@ -1,5 +1,4 @@
 import React, { FunctionComponent, ReactElement } from 'react'
-import { AccessibilityProps } from 'react-native'
 import styled from 'styled-components/native'
 
 import { styledButton } from 'ui/components/buttons/styledButton'
@@ -12,14 +11,13 @@ type IsSelectedProps = {
   isSelected?: boolean
 }
 
-type SingleFilterButtonProps = IsSelectedProps &
-  Partial<AccessibilityProps> & {
-    label: string
-    testID?: string
-    icon?: ReactElement
-    onPress: () => void
-    children?: never
-  }
+type SingleFilterButtonProps = IsSelectedProps & {
+  label: string
+  testID?: string
+  icon?: ReactElement
+  onPress: () => void
+  children?: never
+}
 
 export const SingleFilterButton: FunctionComponent<SingleFilterButtonProps> = ({
   label,
@@ -27,7 +25,6 @@ export const SingleFilterButton: FunctionComponent<SingleFilterButtonProps> = ({
   onPress,
   icon,
   testID,
-  ...accessibilityProps
 }) => {
   const filterButtonLabel = testID ? `${testID}Label` : 'filterButtonLabel'
 
@@ -36,8 +33,7 @@ export const SingleFilterButton: FunctionComponent<SingleFilterButtonProps> = ({
     <TouchableContainer
       isSelected={isSelected}
       onPress={onPress}
-      accessibilityLabel={accessibilityLabel}
-      {...accessibilityProps}>
+      accessibilityLabel={accessibilityLabel}>
       <Label testID={filterButtonLabel}>{label}</Label>
       {icon}
     </TouchableContainer>

--- a/src/features/venueMap/components/FilterBannerContainer/FilterCategoriesBannerContainer.tsx
+++ b/src/features/venueMap/components/FilterBannerContainer/FilterCategoriesBannerContainer.tsx
@@ -8,7 +8,6 @@ import { FilterButton } from 'features/search/components/Buttons/FilterButton/Fi
 import { SingleFilterButton } from 'features/search/components/Buttons/SingleFilterButton/SingleFilterButton'
 import { FILTERS_VENUE_TYPE_MAPPING } from 'features/venueMap/constant'
 import { useVenueMapFilters } from 'features/venueMap/hook/useVenueMapFilters'
-import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { theme } from 'theme'
 import { getSpacing } from 'ui/theme'
 
@@ -37,7 +36,7 @@ export const FilterCategoriesBannerContainer = () => {
   }
 
   return (
-    <Container accessibilityRole={AccessibilityRole.LIST}>
+    <Container>
       <FilterButton navigateTo={{ screen: 'VenueMapFiltersStackNavigator' }} />
       {filterGroups.map(({ color, id, label }) => (
         <SingleFilterButton
@@ -47,7 +46,6 @@ export const FilterCategoriesBannerContainer = () => {
           label={label}
           isSelected={selectedGroups.includes(id)}
           onPress={() => handleCategoryPress(id)}
-          accessibilityRole={AccessibilityRole.LISTITEM}
         />
       ))}
     </Container>


### PR DESCRIPTION
Fix sur le SingleFilterButton qui faisait planter la page de recherche côté web

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
