### PR TITLE
(PC-33149) fix(CineButton): center on android

### DIFF
--- a/src/features/offer/components/MoviesScreeningCalendar/NextScreeningButton.tsx
+++ b/src/features/offer/components/MoviesScreeningCalendar/NextScreeningButton.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from 'react'
+import { Text } from 'react-native'
 import styled from 'styled-components/native'
 
 import { extractDate } from 'features/offer/components/MovieCalendar/hooks/useMovieCalendarDay'
-import { theme } from 'theme'
 import { InfoBanner } from 'ui/components/banners/InfoBanner'
 import { ButtonQuaternarySecondary } from 'ui/components/buttons/ButtonQuaternarySecondary'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
@@ -18,9 +18,7 @@ export const NextScreeningButton: FC<Props> = ({ onPress, date }) => {
   return (
     <TouchableOpacity onPress={onPress}>
       <Container>
-        <InfoBanner
-          message={<StyledMessage>{NEXT_SCREENING_WORDING}</StyledMessage>}
-          backgroundColor={theme.colors.greyLight}>
+        <StyledInfoBanner message={<Text>{NEXT_SCREENING_WORDING}</Text>}>
           <ButtonQuaternarySecondary
             numberOfLines={1}
             icon={PlainArrowNext}
@@ -29,7 +27,7 @@ export const NextScreeningButton: FC<Props> = ({ onPress, date }) => {
             fullWidth
             onPress={onPress}
           />
-        </InfoBanner>
+        </StyledInfoBanner>
       </Container>
     </TouchableOpacity>
   )
@@ -37,9 +35,9 @@ export const NextScreeningButton: FC<Props> = ({ onPress, date }) => {
 
 const Container = styled.View({
   width: '100%',
-  textAlign: 'center',
 })
 
-const StyledMessage = styled.Text({
-  textAlign: 'center',
-})
+const StyledInfoBanner = styled(InfoBanner).attrs(({ theme }) => ({
+  messageContainerStyle: { alignItems: 'center' },
+  backgroundColor: theme.colors.greyLight,
+}))({})

--- a/src/ui/components/banners/GenericColoredBanner.tsx
+++ b/src/ui/components/banners/GenericColoredBanner.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, ReactNode } from 'react'
+import { ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
 
 import { AccessibleIcon } from 'ui/svg/icons/types'
@@ -14,6 +15,7 @@ type Props = ColorMessageProps & {
   children?: React.ReactNode
   Icon?: FunctionComponent<AccessibleIcon>
   testID?: string
+  messageContainerStyle?: ViewStyle
 }
 
 export const GenericColoredBanner: FunctionComponent<Props> = ({
@@ -23,6 +25,7 @@ export const GenericColoredBanner: FunctionComponent<Props> = ({
   testID,
   children,
   backgroundColor,
+  messageContainerStyle,
 }) => {
   return (
     <Container testID={testID} backgroundColor={backgroundColor}>
@@ -31,7 +34,7 @@ export const GenericColoredBanner: FunctionComponent<Props> = ({
           <Icon />
         </IconContainer>
       ) : null}
-      <TextContainer>
+      <TextContainer style={messageContainerStyle}>
         <Caption textColor={textColor}>{message}</Caption>
         {children}
       </TextContainer>

--- a/src/ui/components/banners/InfoBanner.tsx
+++ b/src/ui/components/banners/InfoBanner.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, ReactNode } from 'react'
+import { ViewStyle } from 'react-native'
 import { useTheme } from 'styled-components'
 import styled from 'styled-components/native'
 
@@ -17,6 +18,7 @@ type Props = ColorMessageProps & {
   testID?: string
   backgroundColor?: ColorsEnum
   children?: React.ReactNode
+  messageContainerStyle?: ViewStyle
 }
 
 export const InfoBanner: FunctionComponent<Props> = ({
@@ -26,6 +28,7 @@ export const InfoBanner: FunctionComponent<Props> = ({
   testID,
   backgroundColor,
   children,
+  messageContainerStyle,
 }) => {
   const theme = useTheme()
   const Icon =
@@ -39,6 +42,7 @@ export const InfoBanner: FunctionComponent<Props> = ({
   const textColor = withLightColorMessage ? theme.colors.greyDark : theme.colors.black
   return (
     <GenericColoredBanner
+      messageContainerStyle={messageContainerStyle}
       message={message}
       Icon={Icon}
       backgroundColor={backgroundColor ?? theme.colors.secondaryLight100}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33149

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [X] Made sure my feature is working on web.
- [X] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [X] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [X] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Android          | <img src="https://github.com/user-attachments/assets/2e8cba5a-97bb-4b19-a3ae-c2ebf1d3d43f" />             | <img src="https://github.com/user-attachments/assets/106f1973-c79c-4fd8-bd3c-d7932bcb79e7" /> |



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4




## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
