### PR TITLE
(BSR) chore(setup): remove local Nix

### DIFF
--- a/doc/installation/setup.md
+++ b/doc/installation/setup.md
@@ -12,7 +12,7 @@ In that case, you will need to install Nix as follows :
 curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install  --ssl-cert-file '/Library/Application Support'/*/*/data/*cacert.pem
 ```
 
-_If you want more information or if you have a problem you can consult [`nix` package manager installation](https://github.com/DeterminateSystems/nix-installer#the-determinate-nix-installer)._
+_If you want more information or if you have a problem you can consult [`nix` package manager installation](https://docs.determinate.systems/getting-started/)._
 
 #### Install DirEnv
 

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,6 @@
         in
         pkgs.mkShellNoCC {
           packages = [
-            pkgs.nix # ensure to have always the same version
             pkgs.devbox
           ];
         };


### PR DESCRIPTION
this was a false good idea

the Nix used is one in the daemon which is globally installed

having `nix` here can make confusions about which version is used

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
