### PR TITLE
(PC-33290) feat(venueMap): preserve safe area in venue map filters modal in Android

### DIFF
--- a/src/features/navigation/RootNavigator/RootNavigator.tsx
+++ b/src/features/navigation/RootNavigator/RootNavigator.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
-import { View } from 'react-native'
+import { Platform, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled, { useTheme } from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -27,6 +28,8 @@ import { RootStack } from './Stack'
 
 const RootStackNavigator = withWebWrapper(
   ({ initialRouteName }: { initialRouteName: RootScreenNames }) => {
+    const { top } = useSafeAreaInsets()
+
     return (
       <IconFactoryProvider>
         <RootStack.Navigator
@@ -36,7 +39,15 @@ const RootStackNavigator = withWebWrapper(
           <RootStack.Screen
             name="VenueMapFiltersStackNavigator"
             component={VenueMapFiltersStackNavigator}
-            options={{ presentation: 'modal' }}
+            options={{
+              presentation: 'modal',
+              cardStyle:
+                Platform.OS === 'android'
+                  ? {
+                      marginTop: top,
+                    }
+                  : undefined,
+            }}
           />
         </RootStack.Navigator>
       </IconFactoryProvider>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33290

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

Avant :

https://github.com/user-attachments/assets/a8601c2c-f656-42f6-8a8e-e566e70315c8


https://github.com/user-attachments/assets/f2956925-5a84-49c5-9554-555d5568faa7

Après :

https://github.com/user-attachments/assets/46639cf0-e3c8-4287-82a2-9c2b8c907878


https://github.com/user-attachments/assets/b597415d-cb49-4e6d-8dce-14c761f044f4



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
