### PR TITLE
(PC-33337) feat(ui): fix flex Checkbox component

### DIFF
--- a/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
@@ -537,6 +537,9 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                         {
                           "alignSelf": "center",
                           "color": "#161617",
+                          "flexBasis": 0,
+                          "flexGrow": 1,
+                          "flexShrink": 1,
                           "fontFamily": "Montserrat-Medium",
                           "fontSize": 16,
                           "lineHeight": 25.6,
@@ -621,6 +624,9 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                         {
                           "alignSelf": "center",
                           "color": "#161617",
+                          "flexBasis": 0,
+                          "flexGrow": 1,
+                          "flexShrink": 1,
                           "fontFamily": "Montserrat-Medium",
                           "fontSize": 16,
                           "lineHeight": 25.6,
@@ -705,6 +711,9 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                         {
                           "alignSelf": "center",
                           "color": "#161617",
+                          "flexBasis": 0,
+                          "flexGrow": 1,
+                          "flexShrink": 1,
                           "fontFamily": "Montserrat-Medium",
                           "fontSize": 16,
                           "lineHeight": 25.6,
@@ -789,6 +798,9 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                         {
                           "alignSelf": "center",
                           "color": "#161617",
+                          "flexBasis": 0,
+                          "flexGrow": 1,
+                          "flexShrink": 1,
                           "fontFamily": "Montserrat-Medium",
                           "fontSize": 16,
                           "lineHeight": 25.6,

--- a/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
@@ -115,6 +115,9 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
           {
             "alignSelf": "center",
             "color": "#161617",
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "fontFamily": "Montserrat-Medium",
             "fontSize": 16,
             "lineHeight": 25.6,
@@ -210,6 +213,9 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
           {
             "alignSelf": "center",
             "color": "#161617",
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "fontFamily": "Montserrat-Medium",
             "fontSize": 16,
             "lineHeight": 25.6,
@@ -747,6 +753,9 @@ exports[`<AcceptCgu/> should render correctly for SSO subscription 1`] = `
           {
             "alignSelf": "center",
             "color": "#161617",
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "fontFamily": "Montserrat-Medium",
             "fontSize": 16,
             "lineHeight": 25.6,
@@ -862,6 +871,9 @@ exports[`<AcceptCgu/> should render correctly for SSO subscription 1`] = `
           {
             "alignSelf": "center",
             "color": "#161617",
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "fontFamily": "Montserrat-Medium",
             "fontSize": 16,
             "lineHeight": 25.6,
@@ -957,6 +969,9 @@ exports[`<AcceptCgu/> should render correctly for SSO subscription 1`] = `
           {
             "alignSelf": "center",
             "color": "#161617",
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
             "fontFamily": "Montserrat-Medium",
             "fontSize": 16,
             "lineHeight": 25.6,

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -441,6 +441,9 @@ exports[`Signup Form should render correctly for AcceptCgu 1`] = `
                 {
                   "alignSelf": "center",
                   "color": "#161617",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
                   "fontFamily": "Montserrat-Medium",
                   "fontSize": 16,
                   "lineHeight": 25.6,
@@ -536,6 +539,9 @@ exports[`Signup Form should render correctly for AcceptCgu 1`] = `
                 {
                   "alignSelf": "center",
                   "color": "#161617",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
                   "fontFamily": "Montserrat-Medium",
                   "fontSize": 16,
                   "lineHeight": 25.6,
@@ -2241,6 +2247,9 @@ exports[`Signup Form should render correctly for SetEmail 1`] = `
                 {
                   "alignSelf": "center",
                   "color": "#161617",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
                   "fontFamily": "Montserrat-Medium",
                   "fontSize": 16,
                   "lineHeight": 25.6,

--- a/__snapshots__/features/internal/marketingAndCommunication/pages/DeeplinksGenerator.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/marketingAndCommunication/pages/DeeplinksGenerator.native.test.tsx.native-snap
@@ -3522,6 +3522,9 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                       {
                         "alignSelf": "center",
                         "color": "#161617",
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
                         "fontFamily": "Montserrat-Medium",
                         "fontSize": 16,
                         "lineHeight": 25.6,

--- a/src/ui/components/inputs/Checkbox/Checkbox.tsx
+++ b/src/ui/components/inputs/Checkbox/Checkbox.tsx
@@ -80,4 +80,5 @@ const Box = styled.View<IsCheckedProps>(({ isChecked, theme }) => ({
 const StyledBody = styled(TypoDS.Body)({
   alignSelf: 'center',
   paddingLeft: getSpacing(4),
+  flex: 1,
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33337

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |  <img width="346" alt="Capture d’écran 2024-11-28 à 18 46 02" src="https://github.com/user-attachments/assets/5a27596c-e936-4c1d-b3e5-50ffaedd26de"> <img width="344" alt="Capture d’écran 2024-11-28 à 18 45 34" src="https://github.com/user-attachments/assets/fbb34c98-4eef-40f5-88c5-26112f2b6af2"> |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
