### PR TITLE
(PC-32644) fix(deeplink): ThematicSearch should be right after Search…

### DIFF
--- a/__snapshots__/features/internal/marketingAndCommunication/pages/DeeplinksGenerator.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/marketingAndCommunication/pages/DeeplinksGenerator.native.test.tsx.native-snap
@@ -1215,6 +1215,138 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                   }
                 />
                 <View
+                  accessibilityLabel="ThematicSearch"
+                  accessibilityRole="radio"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": false,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      [
+                        {
+                          "userSelect": "auto",
+                        },
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "justifyContent": "space-between",
+                          "minHeight": 24,
+                          "paddingVertical": 12,
+                        },
+                      ],
+                      {
+                        "opacity": 1,
+                      },
+                    ]
+                  }
+                  testID="ThematicSearch"
+                >
+                  <View
+                    flex={0.9}
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "flexBasis": 0,
+                          "flexDirection": "row",
+                          "flexGrow": 0.9,
+                          "flexShrink": 0,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexBasis": 0,
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        isSelected={false}
+                        numberOfLines={2}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "flexGrow": 1,
+                              "flexShrink": 1,
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        ThematicSearch
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    style={
+                      [
+                        {
+                          "alignItems": "flex-end",
+                          "flexBasis": 0,
+                          "flexGrow": 0.1,
+                          "flexShrink": 1,
+                          "height": 20,
+                          "justifyContent": "center",
+                          "width": 20,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      accessibilityLabel="Non sélectionné"
+                      height={20}
+                      width={20}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+                <View
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#F1F1F4",
+                        "height": 1,
+                        "width": "100%",
+                      },
+                    ]
+                  }
+                />
+                <View
                   accessibilityLabel="Profile"
                   accessibilityRole="radio"
                   accessibilityState={
@@ -1570,138 +1702,6 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                         }
                       >
                         Stepper
-                      </Text>
-                    </View>
-                  </View>
-                  <View
-                    style={
-                      [
-                        {
-                          "alignItems": "flex-end",
-                          "flexBasis": 0,
-                          "flexGrow": 0.1,
-                          "flexShrink": 1,
-                          "height": 20,
-                          "justifyContent": "center",
-                          "width": 20,
-                        },
-                      ]
-                    }
-                  >
-                    <View
-                      accessibilityLabel="Non sélectionné"
-                      height={20}
-                      width={20}
-                    >
-                      <Text>
-                        undefined-SVG-Mock
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-                <View
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#F1F1F4",
-                        "height": 1,
-                        "width": "100%",
-                      },
-                    ]
-                  }
-                />
-                <View
-                  accessibilityLabel="ThematicSearch"
-                  accessibilityRole="radio"
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": false,
-                      "disabled": undefined,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  focusable={true}
-                  onClick={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    [
-                      [
-                        {
-                          "userSelect": "auto",
-                        },
-                        {
-                          "alignItems": "center",
-                          "flexDirection": "row",
-                          "justifyContent": "space-between",
-                          "minHeight": 24,
-                          "paddingVertical": 12,
-                        },
-                      ],
-                      {
-                        "opacity": 1,
-                      },
-                    ]
-                  }
-                  testID="ThematicSearch"
-                >
-                  <View
-                    flex={0.9}
-                    style={
-                      [
-                        {
-                          "alignItems": "center",
-                          "flexBasis": 0,
-                          "flexDirection": "row",
-                          "flexGrow": 0.9,
-                          "flexShrink": 0,
-                        },
-                      ]
-                    }
-                  >
-                    <View
-                      style={
-                        [
-                          {
-                            "flexBasis": 0,
-                            "flexGrow": 1,
-                            "flexShrink": 1,
-                          },
-                        ]
-                      }
-                    >
-                      <Text
-                        isSelected={false}
-                        numberOfLines={2}
-                        style={
-                          [
-                            {
-                              "color": "#161617",
-                              "flexGrow": 1,
-                              "flexShrink": 1,
-                              "fontFamily": "Montserrat-SemiBold",
-                              "fontSize": 16,
-                              "lineHeight": 25.6,
-                            },
-                          ]
-                        }
-                      >
-                        ThematicSearch
                       </Text>
                     </View>
                   </View>

--- a/src/features/internal/marketingAndCommunication/config/deeplinksExportConfig.ts
+++ b/src/features/internal/marketingAndCommunication/config/deeplinksExportConfig.ts
@@ -131,9 +131,6 @@ export const SCREENS_CONFIG: {
       description: 'Date de fin',
     },
   },
-  Profile: {},
-  SignupForm: {},
-  Stepper: {},
   ThematicSearch: {
     offerCategories: {
       type: 'thematicSearchCategories',
@@ -141,6 +138,9 @@ export const SCREENS_CONFIG: {
       description: 'Categories',
     },
   },
+  Profile: {},
+  SignupForm: {},
+  Stepper: {},
 }
 
 type MarketingParams = 'utm_campaign' | 'utm_source' | 'utm_medium' | 'utm_content' | 'utm_gen'


### PR DESCRIPTION
…Results in the list

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32644

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome |<img width="1435" alt="Capture d’écran 2024-11-29 à 17 30 13" src="https://github.com/user-attachments/assets/2f186f24-7f3e-4080-a486-258505c939af">|<img width="1430" alt="Capture d’écran 2024-11-29 à 17 29 47" src="https://github.com/user-attachments/assets/ff03c04c-f246-4ff6-ad1c-b2fa9838e8d0">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
