### PR TITLE
(PC-32821) feat(NC): update conditions in useGetCurrencyToDisplay

### DIFF
--- a/src/shared/currency/useGetCurrencyToDisplay.native.test.ts
+++ b/src/shared/currency/useGetCurrencyToDisplay.native.test.ts
@@ -23,6 +23,7 @@ const mockUseAuthContext = jest.mocked(useAuthContext)
 describe('useGetCurrencyToDisplay', () => {
   beforeEach(() => {
     activateFeatureFlags()
+    mockUseGeolocation.mockReturnValue({ userLocation: null } as ILocationContext)
     mockUseAuthContext.mockReturnValue({
       isLoggedIn: true,
       user: undefined,
@@ -33,13 +34,12 @@ describe('useGetCurrencyToDisplay', () => {
   })
 
   it('should return Euro by default when location and user are not provided', () => {
-    mockUseGeolocation.mockReturnValueOnce({ userLocation: null } as ILocationContext)
     const { result } = renderHook(() => useGetCurrencyToDisplay())
 
     expect(result.current).toBe('€')
   })
 
-  describe('when location is outside New Caledonia', () => {
+  describe('when user is not connected and location is outside New Caledonia', () => {
     beforeEach(() => {
       mockUseGeolocation.mockReturnValue({
         userLocation: PARIS_DEFAULT_POSITION,
@@ -66,7 +66,7 @@ describe('useGetCurrencyToDisplay', () => {
     })
   })
 
-  describe('when location is in New Caledonia', () => {
+  describe('when user is not connected and location is in New Caledonia', () => {
     beforeEach(() => {
       mockUseGeolocation.mockReturnValue({
         userLocation: NOUMEA_DEFAULT_POSITION,
@@ -117,7 +117,7 @@ describe('useGetCurrencyToDisplay', () => {
     })
   })
 
-  describe('when user is in Euro region', () => {
+  describe('when user is registered in Euro region', () => {
     beforeEach(() => {
       mockUseAuthContext.mockReturnValue({
         isLoggedIn: true,
@@ -147,9 +147,7 @@ describe('useGetCurrencyToDisplay', () => {
     })
 
     describe('and the feature flag is disabled', () => {
-      beforeEach(() => {
-        activateFeatureFlags()
-      })
+      beforeEach(() => activateFeatureFlags())
 
       it('should return Euro when displayFormat is "short"', () => {
         const { result } = renderHook(() => useGetCurrencyToDisplay('short'))
@@ -165,7 +163,7 @@ describe('useGetCurrencyToDisplay', () => {
     })
   })
 
-  describe('when user is in Pacific Franc region', () => {
+  describe('when user is registered in Pacific Franc region', () => {
     beforeEach(() => {
       mockUseAuthContext.mockReturnValue({
         isLoggedIn: true,
@@ -195,9 +193,7 @@ describe('useGetCurrencyToDisplay', () => {
     })
 
     describe('and the feature flag is disabled', () => {
-      beforeEach(() => {
-        activateFeatureFlags()
-      })
+      beforeEach(() => activateFeatureFlags())
 
       it('should return Euro when displayFormat is "short"', () => {
         const { result } = renderHook(() => useGetCurrencyToDisplay('short'))

--- a/src/shared/currency/useGetCurrencyToDisplay.ts
+++ b/src/shared/currency/useGetCurrencyToDisplay.ts
@@ -25,20 +25,22 @@ export const useGetCurrencyToDisplay = (
 
   const { selectedPlace } = useLocation()
   const isNewCaledonianLocationSelected = selectedPlace?.info === 'Nouvelle-Calédonie'
-  const isNotNewCaledonianLocationSelected = !isNewCaledonianLocationSelected
+  const isNotNewCaledonianLocationSelected = selectedPlace?.info !== 'Nouvelle-Calédonie'
 
   const pacificFrancCurrency =
     displayFormat === 'full' ? Currency.PACIFIC_FRANC_FULL : Currency.PACIFIC_FRANC_SHORT
 
-  switch (true) {
-    case disablePacificFrancCurrency:
-    case isUserRegisteredInEuroRegion:
-    case isNotNewCaledonianLocationSelected:
-      return Currency.EURO
-    case enablePacificFrancCurrency &&
-      (isUserRegisteredInPacificFrancRegion || isNewCaledonianLocationSelected):
-      return pacificFrancCurrency
-    default:
-      return Currency.EURO
+  if (disablePacificFrancCurrency) return Currency.EURO
+
+  if (selectedPlace) {
+    if (isNotNewCaledonianLocationSelected) return Currency.EURO
+    if (isNewCaledonianLocationSelected) return pacificFrancCurrency
   }
+
+  if (user) {
+    if (isUserRegisteredInEuroRegion) return Currency.EURO
+    if (isUserRegisteredInPacificFrancRegion) return pacificFrancCurrency
+  }
+
+  return Currency.EURO
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32821

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |  ![Capture d’écran 2024-11-29 à 18 45 04](https://github.com/user-attachments/assets/b7f4ef03-ae6c-46fd-9492-34bbb9d64706) ![Capture d’écran 2024-11-29 à 18 43 02](https://github.com/user-attachments/assets/c92a7de9-242c-4b27-8929-dfeee34f5993) ![Capture d’écran 2024-11-29 à 18 43 30](https://github.com/user-attachments/assets/01e6c7e7-68b1-46c3-828d-5283c978e24a)  |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
