### PR TITLE
(PC-32910) feat(Achievements): add achievements tracker

### DIFF
--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -310,7 +310,7 @@ export type RootStackParamList = {
   ThematicHeaders: undefined
   MarketingBlocks: undefined
   MovieCalendar: undefined
-  Achievements: undefined
+  Achievements: { from: 'profile' | 'success' }
 } & AccessibilityRootStackParamList &
   CulturalSurveyRootStackParamList &
   TutorialRootStackParamList &

--- a/src/features/profile/components/Achievements/BadgeBanner.tsx
+++ b/src/features/profile/components/Achievements/BadgeBanner.tsx
@@ -11,6 +11,7 @@ export const BadgeBanner: React.FC = () => {
     <InternalTouchableLink
       navigateTo={{
         screen: 'Achievements',
+        params: { from: 'profile' },
       }}>
       <GenericBanner LeftIcon={<BicolorTrophy size={theme.icons.sizes.standard} />}>
         <Typo.ButtonText>Mes badges</Typo.ButtonText>

--- a/src/features/profile/components/Modals/AchievementSuccessModal.tsx
+++ b/src/features/profile/components/Modals/AchievementSuccessModal.tsx
@@ -67,7 +67,7 @@ export const AchievementSuccessModal = ({ visible, hideModal, ids }: Props) => {
         <InternalTouchableLink
           as={ButtonPrimary}
           wording="Accéder à mes succès"
-          navigateTo={{ screen: 'Achievements' }}
+          navigateTo={{ screen: 'Achievements', params: { from: 'success' } }}
           onBeforeNavigate={() => {
             hideModal()
           }}

--- a/src/features/profile/pages/Achievements/Achievements.tsx
+++ b/src/features/profile/pages/Achievements/Achievements.tsx
@@ -1,9 +1,11 @@
-import React, { FC } from 'react'
+import { useRoute } from '@react-navigation/native'
+import React, { FC, useEffect } from 'react'
 import { View } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
 import { useTheme } from 'styled-components'
 import styled from 'styled-components/native'
 
+import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { Badge } from 'features/profile/components/Achievements/Badge'
 import {
   achievementCategoryDisplayNames,
@@ -28,11 +30,18 @@ const emptyBadge = {
 }
 
 export const Achievements = () => {
+  const {
+    params: { from },
+  } = useRoute<UseRouteType<'Achievements'>>()
   const { uniqueColors } = useTheme()
-  const { categories } = useAchievements({
+  const { categories, track } = useAchievements({
     achievements: mockAchievements,
     completedAchievements: mockCompletedAchievements,
   })
+
+  useEffect(() => {
+    track(from)
+  }, [from, track])
 
   return (
     <SecondaryPageWithBlurHeader title="">

--- a/src/features/profile/pages/Achievements/Achievements.tsx
+++ b/src/features/profile/pages/Achievements/Achievements.tsx
@@ -29,7 +29,7 @@ const emptyBadge = {
 
 export const Achievements = () => {
   const { uniqueColors } = useTheme()
-  const categories = useAchievements({
+  const { categories } = useAchievements({
     achievements: mockAchievements,
     completedAchievements: mockCompletedAchievements,
   })

--- a/src/features/profile/pages/Achievements/useAchievements.native.test.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.native.test.ts
@@ -14,6 +14,7 @@ import {
   UseAchivementsProps,
   useAchievements,
 } from 'features/profile/pages/Achievements/useAchievements'
+import { analytics } from 'libs/analytics/__mocks__/provider'
 import { renderHook } from 'tests/utils'
 import { BicolorTrophy, Trophy } from 'ui/svg/icons/Trophy'
 
@@ -57,17 +58,17 @@ const testUseAchievements = ({
 
 describe('useAchievements', () => {
   it('should return empty array when there are no achievements', () => {
-    const badges = testUseAchievements()
+    const { categories } = testUseAchievements()
 
-    expect(badges).toEqual([])
+    expect(categories).toEqual([])
   })
 
   it('should return achievements grouped by category', () => {
-    const badges = testUseAchievements({
+    const { categories } = testUseAchievements({
       achievements: [firstArtLessonBooking, testAchievement as unknown as Achievement],
     })
 
-    expect(badges).toEqual([
+    expect(categories).toEqual([
       expect.objectContaining({
         id: CombinedAchievementCategory.FIRST_BOOKINGS,
         badges: [
@@ -88,11 +89,11 @@ describe('useAchievements', () => {
   })
 
   it('achievement is NOT completed when user has not already completed it', () => {
-    const badges = testUseAchievements({
+    const { categories } = testUseAchievements({
       achievements: [firstArtLessonBooking, firstBookBooking],
     })
 
-    expect(badges).toEqual([
+    expect(categories).toEqual([
       expect.objectContaining({
         id: CombinedAchievementCategory.FIRST_BOOKINGS,
         badges: [
@@ -110,12 +111,12 @@ describe('useAchievements', () => {
   })
 
   it('achievement is completed when user has already completed it', () => {
-    const badges = testUseAchievements({
+    const { categories } = testUseAchievements({
       achievements: [firstArtLessonBooking, firstBookBooking],
       completedAchievements: [userCompletedArtLessonBooking, userCompletedBookBooking],
     })
 
-    expect(badges).toEqual([
+    expect(categories).toEqual([
       expect.objectContaining({
         id: CombinedAchievementCategory.FIRST_BOOKINGS,
         badges: [
@@ -133,12 +134,12 @@ describe('useAchievements', () => {
   })
 
   it('achievement name is "Badge non débloqué" when achievement is not completed', () => {
-    const badges = testUseAchievements({
+    const { categories } = testUseAchievements({
       achievements: [firstArtLessonBooking, firstBookBooking],
       completedAchievements: [],
     })
 
-    expect(badges).toEqual([
+    expect(categories).toEqual([
       expect.objectContaining({
         id: CombinedAchievementCategory.FIRST_BOOKINGS,
         badges: [
@@ -156,12 +157,12 @@ describe('useAchievements', () => {
   })
 
   it('achievement completed name is the achievement name', () => {
-    const badges = testUseAchievements({
+    const { categories } = testUseAchievements({
       achievements: [firstArtLessonBooking, firstBookBooking],
       completedAchievements: [userCompletedArtLessonBooking, userCompletedBookBooking],
     })
 
-    expect(badges).toEqual([
+    expect(categories).toEqual([
       expect.objectContaining({
         id: CombinedAchievementCategory.FIRST_BOOKINGS,
         badges: [
@@ -179,12 +180,12 @@ describe('useAchievements', () => {
   })
 
   it('achivements are sorted by name', () => {
-    const badges = testUseAchievements({
+    const { categories } = testUseAchievements({
       achievements: [firstArtLessonBooking, firstBookBooking],
       completedAchievements: [userCompletedArtLessonBooking, userCompletedBookBooking],
     })
 
-    expect(badges).toEqual([
+    expect(categories).toEqual([
       expect.objectContaining({
         id: CombinedAchievementCategory.FIRST_BOOKINGS,
         badges: [
@@ -200,12 +201,12 @@ describe('useAchievements', () => {
   })
 
   it('achievement completed is sorted before achievement not completed', () => {
-    const badges = testUseAchievements({
+    const { categories } = testUseAchievements({
       achievements: [firstBookBooking, firstArtLessonBooking],
       completedAchievements: [userCompletedArtLessonBooking],
     })
 
-    expect(badges).toEqual([
+    expect(categories).toEqual([
       expect.objectContaining({
         id: CombinedAchievementCategory.FIRST_BOOKINGS,
         badges: [
@@ -223,12 +224,12 @@ describe('useAchievements', () => {
   describe('Category Achievements completion', () => {
     describe('Remaining achievements to complete', () => {
       it('should return "0 badge restant" when all achievements of category are completed', () => {
-        const badges = testUseAchievements({
+        const { categories } = testUseAchievements({
           achievements: [firstArtLessonBooking, firstBookBooking],
           completedAchievements: [userCompletedArtLessonBooking, userCompletedBookBooking],
         })
 
-        expect(badges).toEqual([
+        expect(categories).toEqual([
           expect.objectContaining({
             id: CombinedAchievementCategory.FIRST_BOOKINGS,
             remainingAchievementsText: '0 badge restant',
@@ -237,12 +238,12 @@ describe('useAchievements', () => {
       })
 
       it('should return "1 badge restants" when 1 achievement are not completed', () => {
-        const badges = testUseAchievements({
+        const { categories } = testUseAchievements({
           achievements: [firstArtLessonBooking, firstBookBooking],
           completedAchievements: [userCompletedArtLessonBooking],
         })
 
-        expect(badges).toEqual([
+        expect(categories).toEqual([
           expect.objectContaining({
             id: CombinedAchievementCategory.FIRST_BOOKINGS,
             remainingAchievementsText: '1 badge restant',
@@ -251,11 +252,11 @@ describe('useAchievements', () => {
       })
 
       it('should return "2 badges restants" when 2 achievement are not completed', () => {
-        const badges = testUseAchievements({
+        const { categories } = testUseAchievements({
           achievements: [firstArtLessonBooking, firstBookBooking],
         })
 
-        expect(badges).toEqual([
+        expect(categories).toEqual([
           expect.objectContaining({
             id: CombinedAchievementCategory.FIRST_BOOKINGS,
             remainingAchievementsText: '2 badges restant',
@@ -266,12 +267,12 @@ describe('useAchievements', () => {
 
     describe('Achievements progression', () => {
       it('should be 1 when all achievements are completed', () => {
-        const badges = testUseAchievements({
+        const { categories } = testUseAchievements({
           achievements: [firstArtLessonBooking],
           completedAchievements: [userCompletedArtLessonBooking],
         })
 
-        expect(badges).toEqual([
+        expect(categories).toEqual([
           expect.objectContaining({
             id: CombinedAchievementCategory.FIRST_BOOKINGS,
             progress: 1,
@@ -280,11 +281,11 @@ describe('useAchievements', () => {
       })
 
       it('should be 0 when no achievements are completed', () => {
-        const badges = testUseAchievements({
+        const { categories } = testUseAchievements({
           achievements: [firstArtLessonBooking],
         })
 
-        expect(badges).toEqual([
+        expect(categories).toEqual([
           expect.objectContaining({
             id: CombinedAchievementCategory.FIRST_BOOKINGS,
             progress: 0,
@@ -293,12 +294,12 @@ describe('useAchievements', () => {
       })
 
       it('should be 0.5 when 1 achievement of 2 are completed', () => {
-        const badges = testUseAchievements({
+        const { categories } = testUseAchievements({
           achievements: [firstArtLessonBooking, firstBookBooking],
           completedAchievements: [userCompletedArtLessonBooking],
         })
 
-        expect(badges).toEqual([
+        expect(categories).toEqual([
           expect.objectContaining({
             id: CombinedAchievementCategory.FIRST_BOOKINGS,
             progress: 0.5,
@@ -307,7 +308,7 @@ describe('useAchievements', () => {
       })
 
       it('should be 0.75 when 3 achievement of 4 are completed', () => {
-        const badges = testUseAchievements({
+        const { categories } = testUseAchievements({
           achievements: [
             firstArtLessonBooking,
             firstBookBooking,
@@ -321,7 +322,7 @@ describe('useAchievements', () => {
           ],
         })
 
-        expect(badges).toEqual([
+        expect(categories).toEqual([
           expect.objectContaining({
             id: CombinedAchievementCategory.FIRST_BOOKINGS,
             progress: 0.75,
@@ -331,11 +332,11 @@ describe('useAchievements', () => {
 
       describe('text', () => {
         it('should return 0/2 when no achievements are completed', () => {
-          const badges = testUseAchievements({
+          const { categories } = testUseAchievements({
             achievements: [firstArtLessonBooking, firstBookBooking],
           })
 
-          expect(badges).toEqual([
+          expect(categories).toEqual([
             expect.objectContaining({
               id: CombinedAchievementCategory.FIRST_BOOKINGS,
               progressText: '0/2',
@@ -344,12 +345,12 @@ describe('useAchievements', () => {
         })
 
         it('should return 2/2 when all achievements are completed', () => {
-          const badges = testUseAchievements({
+          const { categories } = testUseAchievements({
             achievements: [firstArtLessonBooking, firstBookBooking],
             completedAchievements: [userCompletedArtLessonBooking, userCompletedBookBooking],
           })
 
-          expect(badges).toEqual([
+          expect(categories).toEqual([
             expect.objectContaining({
               id: CombinedAchievementCategory.FIRST_BOOKINGS,
               progressText: '2/2',
@@ -358,12 +359,12 @@ describe('useAchievements', () => {
         })
 
         it('should return 1/2 when 1 achievement of 2 are completed', () => {
-          const badges = testUseAchievements({
+          const { categories } = testUseAchievements({
             achievements: [firstArtLessonBooking, firstBookBooking],
             completedAchievements: [userCompletedArtLessonBooking],
           })
 
-          expect(badges).toEqual([
+          expect(categories).toEqual([
             expect.objectContaining({
               id: CombinedAchievementCategory.FIRST_BOOKINGS,
               progressText: '1/2',
@@ -371,6 +372,49 @@ describe('useAchievements', () => {
           ])
         })
       })
+    })
+  })
+
+  describe('Tracking', () => {
+    describe('From', () => {
+      it.each`
+        from
+        ${'profile'}
+        ${'success'}
+      `('send DisplayAchievements event with from $from when track from $from', ({ from }) => {
+        const { track } = testUseAchievements()
+
+        track(from)
+
+        expect(analytics.logDisplayAchievements).toHaveBeenCalledWith(
+          expect.objectContaining({ from })
+        )
+      })
+    })
+  })
+
+  describe('Number unlocked', () => {
+    it('send 0 when no achievements are completed', () => {
+      const { track } = testUseAchievements()
+
+      track('profile')
+
+      expect(analytics.logDisplayAchievements).toHaveBeenCalledWith(
+        expect.objectContaining({ numberUnlocked: 0 })
+      )
+    })
+
+    it('send 2 when 2 achievement are completed', () => {
+      const { track } = testUseAchievements({
+        achievements: [firstArtLessonBooking, firstBookBooking],
+        completedAchievements: [userCompletedArtLessonBooking, userCompletedBookBooking],
+      })
+
+      track('profile')
+
+      expect(analytics.logDisplayAchievements).toHaveBeenCalledWith(
+        expect.objectContaining({ numberUnlocked: 2 })
+      )
     })
   })
 })

--- a/src/features/profile/pages/Achievements/useAchievements.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.ts
@@ -4,6 +4,7 @@ import {
   AchievementId,
   UserAchievement,
 } from 'features/profile/pages/Achievements/AchievementData'
+import { analytics } from 'libs/analytics'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 
 type Categories = {
@@ -19,6 +20,11 @@ type Categories = {
   }[]
 }[]
 
+type UseAchivements = {
+  categories: Categories
+  track: (from: 'profile' | 'success') => void
+}
+
 export type UseAchivementsProps = {
   achievements: Achievement[]
   completedAchievements: UserAchievement[]
@@ -27,8 +33,20 @@ export type UseAchivementsProps = {
 export const useAchievements = ({
   achievements,
   completedAchievements,
-}: UseAchivementsProps): Categories =>
-  getAchievementsCategories(achievements).map(createCategory(achievements, completedAchievements))
+}: UseAchivementsProps): UseAchivements => {
+  const categories = getAchievementsCategories(achievements).map(
+    createCategory(achievements, completedAchievements)
+  )
+
+  const track = (from: 'profile' | 'success') => {
+    analytics.logDisplayAchievements({ from, numberUnlocked: completedAchievements.length })
+  }
+
+  return {
+    categories,
+    track,
+  }
+}
 
 const getAchievementsCategories = (achievements: Achievement[]) =>
   Array.from(new Set(achievements.map((achievement) => achievement.category)))

--- a/src/features/profile/pages/Achievements/useAchievements.ts
+++ b/src/features/profile/pages/Achievements/useAchievements.ts
@@ -20,7 +20,7 @@ type Categories = {
   }[]
 }[]
 
-type UseAchivements = {
+type UseAchievements = {
   categories: Categories
   track: (from: 'profile' | 'success') => void
 }
@@ -33,7 +33,7 @@ export type UseAchivementsProps = {
 export const useAchievements = ({
   achievements,
   completedAchievements,
-}: UseAchivementsProps): UseAchivements => {
+}: UseAchivementsProps): UseAchievements => {
   const categories = getAchievementsCategories(achievements).map(
     createCategory(achievements, completedAchievements)
   )

--- a/src/features/profile/pages/Profile.native.test.tsx
+++ b/src/features/profile/pages/Profile.native.test.tsx
@@ -191,7 +191,7 @@ describe('Profile component', () => {
 
       fireEvent.press(badgeBanner)
 
-      expect(navigate).toHaveBeenCalledWith('Achievements', undefined)
+      expect(navigate).toHaveBeenCalledWith('Achievements', { from: 'profile' })
     })
   })
 

--- a/src/libs/analytics/__mocks__/logEventAnalytics.ts
+++ b/src/libs/analytics/__mocks__/logEventAnalytics.ts
@@ -203,4 +203,5 @@ export const logEventAnalytics: typeof actualLogEventAnalytics = {
   logVenueSeeAllOffersClicked: jest.fn(),
   logVenueSeeMoreClicked: jest.fn(),
   logVideoPaused: jest.fn(),
+  logDisplayAchievements: jest.fn(),
 }

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -299,6 +299,8 @@ export const logEventAnalytics = {
     analytics.logEvent({ firebase: AnalyticsEvent.DISMISS_NOTIFICATIONS }),
   logDismissShareApp: (type: ShareAppModalType) =>
     analytics.logEvent({ firebase: AnalyticsEvent.DISMISS_SHARE_APP }, { type }),
+  logDisplayAchievements: (params: { from: 'profile' | 'success'; numberUnlocked: number }) =>
+    analytics.logEvent({ firebase: AnalyticsEvent.DISPLAY_ACHIEVEMENTS }, params),
   logDisplayForcedLoginHelpMessage: () =>
     analytics.logEvent({ firebase: AnalyticsEvent.DISPLAY_FORCED_LOGIN_HELP_MESSAGE }),
   logEduconnectExplanationClicked: () =>

--- a/src/libs/firebase/analytics/events.ts
+++ b/src/libs/firebase/analytics/events.ts
@@ -177,6 +177,7 @@ export enum AnalyticsEvent {
   VENUE_SEE_ALL_OFFERS_CLICKED = 'VenueSeeAllOffersClicked',
   VENUE_SEE_MORE_CLICKED = 'VenueSeeMoreClicked',
   VIDEO_PAUSED = 'VideoPaused',
+  DISPLAY_ACHIEVEMENTS = 'DisplayAchievements',
 }
 
 const RESERVED_PREFIXES = ['firebase_', 'google_', 'ga_']


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32910

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
