### PR TITLE
(PC-33251) feat(NC): convert euro to pacific franc to the nearest mul…

### DIFF
--- a/src/shared/currency/convertEuroToPacificFranc.native.test.ts
+++ b/src/shared/currency/convertEuroToPacificFranc.native.test.ts
@@ -4,39 +4,45 @@ import { convertEuroToPacificFranc, RoundUnit } from './convertEuroToPacificFran
 
 describe('convertEuroToPacificFranc', () => {
   describe('when rounding is NONE', () => {
-    it('should convert 1€ without rounding', () => {
+    it('should convert 1€ into 119.33F when without rounding', () => {
       const result = convertEuroToPacificFranc(1, DEFAULT_PACIFIC_FRANC_TO_EURO_RATE)
 
       expect(result).toBe(119.33)
     })
 
-    it('should convert 300€ without rounding', () => {
+    it('should convert 300€ into 35799.52F when without rounding', () => {
       const result = convertEuroToPacificFranc(300, DEFAULT_PACIFIC_FRANC_TO_EURO_RATE)
 
       expect(result).toBe(35799.52)
     })
 
-    it('should convert 30€ without rounding', () => {
+    it('should convert 30€ into 3579.95F when without rounding', () => {
       const result = convertEuroToPacificFranc(30, DEFAULT_PACIFIC_FRANC_TO_EURO_RATE)
 
       expect(result).toBe(3579.95)
     })
 
-    it('should convert 20€ without rounding', () => {
+    it('should convert 20€ into 2386.63F when without rounding', () => {
       const result = convertEuroToPacificFranc(20, DEFAULT_PACIFIC_FRANC_TO_EURO_RATE)
 
       expect(result).toBe(2386.63)
     })
 
-    it('should convert 8.38€ without rounding', () => {
+    it('should convert 8.38€ into 1000F when without rounding', () => {
       const result = convertEuroToPacificFranc(8.38, DEFAULT_PACIFIC_FRANC_TO_EURO_RATE)
 
       expect(result).toBe(1000)
     })
+
+    it('should convert and round 10€ into 1193.31F when without rounding', () => {
+      const result = convertEuroToPacificFranc(10, DEFAULT_PACIFIC_FRANC_TO_EURO_RATE)
+
+      expect(result).toBe(1193.31)
+    })
   })
 
   describe('when rounding is UNITS', () => {
-    it('should convert and round 1€ to the nearest unit', () => {
+    it('should convert and round 1€ into 120F when to the nearest multiple of 5 unit', () => {
       const result = convertEuroToPacificFranc(
         1,
         DEFAULT_PACIFIC_FRANC_TO_EURO_RATE,
@@ -46,7 +52,7 @@ describe('convertEuroToPacificFranc', () => {
       expect(result).toBe(120)
     })
 
-    it('should convert and round 300€ to the nearest unit', () => {
+    it('should convert and round 300€ into 35800F when to the nearest multiple of 5 unit', () => {
       const result = convertEuroToPacificFranc(
         300,
         DEFAULT_PACIFIC_FRANC_TO_EURO_RATE,
@@ -56,7 +62,7 @@ describe('convertEuroToPacificFranc', () => {
       expect(result).toBe(35800)
     })
 
-    it('should convert and round 30€ to the nearest unit', () => {
+    it('should convert and round 30€ into 3580F when to the nearest multiple of 5 unit', () => {
       const result = convertEuroToPacificFranc(
         30,
         DEFAULT_PACIFIC_FRANC_TO_EURO_RATE,
@@ -66,17 +72,17 @@ describe('convertEuroToPacificFranc', () => {
       expect(result).toBe(3580)
     })
 
-    it('should convert and round 20€ to the nearest unit', () => {
+    it('should convert and round 20€ into 2385F when to the nearest multiple of 5 unit', () => {
       const result = convertEuroToPacificFranc(
         20,
         DEFAULT_PACIFIC_FRANC_TO_EURO_RATE,
         RoundUnit.UNITS
       )
 
-      expect(result).toBe(2387)
+      expect(result).toBe(2385)
     })
 
-    it('should convert and round 8.38€ to the nearest unit', () => {
+    it('should convert and round 8.38€ into 1000F when to the nearest multiple of 5 unit', () => {
       const result = convertEuroToPacificFranc(
         8.38,
         DEFAULT_PACIFIC_FRANC_TO_EURO_RATE,
@@ -84,6 +90,16 @@ describe('convertEuroToPacificFranc', () => {
       )
 
       expect(result).toBe(1000)
+    })
+
+    it('should convert and round 10€ into 1195F into to the nearest multiple of 5 unit', () => {
+      const result = convertEuroToPacificFranc(
+        10,
+        DEFAULT_PACIFIC_FRANC_TO_EURO_RATE,
+        RoundUnit.UNITS
+      )
+
+      expect(result).toBe(1195)
     })
   })
 })

--- a/src/shared/currency/convertEuroToPacificFranc.ts
+++ b/src/shared/currency/convertEuroToPacificFranc.ts
@@ -11,6 +11,7 @@ export const convertEuroToPacificFranc = (
   let result = priceInEuro / pacificFrancToEuroRate
   result = Math.floor(result * 100) / 100
 
-  if (rounding === RoundUnit.UNITS) result = Math.ceil(result)
+  if (rounding === RoundUnit.UNITS) result = Math.round(result / 5) * 5
+
   return result
 }


### PR DESCRIPTION
…tiple of 5 unit

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33251

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |   ![Capture d’écran 2024-12-02 à 11 12 57](https://github.com/user-attachments/assets/62a45440-743b-4d30-b232-17f3ae485cd3)   |  ![Capture d’écran 2024-12-02 à 11 12 11](https://github.com/user-attachments/assets/ebaabd32-12e7-44e1-a76a-a7f31b2cfca4)  |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
