### PR TITLE
(PC-33308) fix(home): use releaseDate on home playlists

### DIFF
--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -30,7 +30,7 @@
 ./src/features/deeplinks/helpers/getScreenFromDeeplink.ts:24
 ./src/features/home/api/helpers/mapVenuesDataAndModules.ts:13
 ./src/features/home/api/helpers/mapVenuesDataAndModules.ts:15
-./src/features/home/components/modules/OffersModule.tsx:70
+./src/features/home/components/modules/OffersModule.tsx:69
 ./src/features/home/components/modules/video/OldVideoModuleDesktop.tsx:96
 ./src/features/home/components/modules/video/OldVideoModuleMobile.tsx:70
 ./src/features/home/components/modules/video/VideoModuleDesktop.tsx:86

--- a/src/features/home/components/modules/OffersModule.tsx
+++ b/src/features/home/components/modules/OffersModule.tsx
@@ -17,7 +17,6 @@ import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureF
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import useFunctionOnce from 'libs/hooks/useFunctionOnce'
 import { useLocation } from 'libs/location'
-import { formatDates } from 'libs/parsers/formatDates'
 import { Offer } from 'shared/offer/types'
 import { PassPlaylist } from 'ui/components/PassPlaylist'
 import { CustomListRenderItem, ItemDimensions, RenderFooterItem } from 'ui/components/Playlist'
@@ -100,11 +99,9 @@ export const OffersModule = (props: OffersModuleProps) => {
 
   const renderItem: CustomListRenderItem<Offer> = useCallback(
     ({ item, width, height }) => {
-      const timestampsInMillis = item.offer.dates?.map((timestampInSec) => timestampInSec * 1000)
       return (
         <OfferTileWrapper
           item={item}
-          date={formatDates(timestampsInMillis)}
           moduleName={moduleName}
           moduleId={moduleId}
           homeEntryId={homeEntryId}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33308

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [X] Made sure my feature is working on web.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change


## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome | <img width="1027" alt="Capture d’écran 2024-12-02 à 13 06 20" src="https://github.com/user-attachments/assets/d292abfe-d8cc-4d46-89aa-580ef872937a"> | <img width="1034" alt="Capture d’écran 2024-12-02 à 13 05 18" src="https://github.com/user-attachments/assets/49734613-bd68-4941-a3e3-610c1a2ee77e"> |
