### PR TITLE
(PC-33411) fix(OfferTile): fix UI max height on Offer tile

### DIFF
--- a/src/libs/styled/useComputedTheme.ts
+++ b/src/libs/styled/useComputedTheme.ts
@@ -7,6 +7,14 @@ import { useMediaQuery } from 'libs/react-responsive/useMediaQuery'
 import { BaseAppThemeType, AppThemeType } from 'theme'
 import { getSpacing } from 'ui/theme'
 
+const OFFER_TILE_MAX_LINES =
+  1 + // category
+  2 + // title
+  1 + // date
+  1 // price
+
+const OFFER_TILE_GAP = getSpacing(1)
+
 export function useComputedTheme(theme: BaseAppThemeType) {
   const enableTabBarV2 = useFeatureFlag(RemoteStoreFeatureFlags.WIP_APP_V2_TAB_BAR)
   const enableNewOfferTile = useFeatureFlag(RemoteStoreFeatureFlags.WIP_NEW_OFFER_TILE)
@@ -25,7 +33,8 @@ export function useComputedTheme(theme: BaseAppThemeType) {
   const tabBarHeight = enableTabBarV2 ? theme.tabBar.heightV2 : theme.tabBar.height
   const appContentWidth = Math.min(desktopMinWidth, windowWidth)
   const offerMaxCaptionHeight = enableNewOfferTile
-    ? getSpacing(26)
+    ? Number(theme.designSystem.typography.bodyAccentXs.lineHeight) * OFFER_TILE_MAX_LINES +
+      OFFER_TILE_GAP
     : theme.tiles.maxCaptionHeight.offer
 
   return useMemo<AppThemeType>(

--- a/src/ui/components/NewOfferCaption.tsx
+++ b/src/ui/components/NewOfferCaption.tsx
@@ -15,6 +15,8 @@ type Props = {
   isBeneficiary?: boolean
 }
 
+// IF we increase the height of the component (e.g., numberOfLines / number of items),
+// we also need to update the OFFER_TILE_MAX_LINES variable in useComputedTheme.
 export const NewOfferCaption: FC<Props> = ({
   name,
   date,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33411

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

Avant : 
<img width="393" alt="Capture d’écran 2024-12-03 à 16 48 42" src="https://github.com/user-attachments/assets/539512b1-94c5-40a6-ab30-51b1638583d5">

Après : 
![Capture d’écran 2024-12-03 à 16 49 54](https://github.com/user-attachments/assets/9c0fc0fe-a411-4818-9ab8-0971f2f00666)

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
