### PR TITLE
(PC-33435) fix(ios): universal links with instagram

### DIFF
--- a/ios/PassCulture/Info.plist
+++ b/ios/PassCulture/Info.plist
@@ -33,8 +33,7 @@
 			<array>
 				<string>https</string>
 				<string>app.passculture</string>
-				<string>app.passculture.staging</string>
-				<string>app.passculture.test</string>
+				<string>app.passculture.$(ENV)</string>
 				<string>$(GOOGLE_IOS_REVERSED_CLIENT_ID)</string>
 			</array>
 		</dict>

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,6 +2,7 @@ import { dirname, join } from 'path'
 
 import express from 'express'
 
+import { universalLinksMiddleware } from './middlewares/universalLinksMiddleware'
 import { webAppProxyMiddleware } from './middlewares/webAppProxyMiddleware'
 import { getVersion } from './routes/version'
 
@@ -19,4 +20,5 @@ const rootFolder = dirname(__dirname)
 app.use(express.static(join(rootFolder, 'public'), options))
 
 app.get('/version.txt', getVersion)
+app.use('*', universalLinksMiddleware)
 app.use('*', webAppProxyMiddleware)

--- a/server/src/middlewares/tests/universalLinksMiddleware.test.ts
+++ b/server/src/middlewares/tests/universalLinksMiddleware.test.ts
@@ -20,7 +20,7 @@ describe('universalLinksMiddleware', () => {
         const res = getMockResponse()
 
         universalLinksMiddleware(req, res, mockNext)
-        expect(mockNext).toHaveBeenCalled()
+        expect(mockNext).toHaveBeenCalledTimes(1)
     })
 
     it('should pass to next middleware if user agent is not iOS', () => {
@@ -28,7 +28,7 @@ describe('universalLinksMiddleware', () => {
         const res = getMockResponse()
 
         universalLinksMiddleware(req, res, mockNext)
-        expect(mockNext).toHaveBeenCalled()
+        expect(mockNext).toHaveBeenCalledTimes(1)
     })
 
     it('should pass to next middleware if request is not coming from Instagram', () => {
@@ -36,7 +36,7 @@ describe('universalLinksMiddleware', () => {
         const res = getMockResponse()
 
         universalLinksMiddleware(req, res, mockNext)
-        expect(mockNext).toHaveBeenCalled()
+        expect(mockNext).toHaveBeenCalledTimes(1)
     })
 
     it('should redirect with URL scheme if coming from Instagram / iOS', () => {
@@ -44,6 +44,6 @@ describe('universalLinksMiddleware', () => {
         const res = getMockResponse()
 
         universalLinksMiddleware(req, res, mockNext)
-        expect(mockRedirect).toHaveBeenCalledWith('app.passculture://offre/986?deeplink=true')
+        expect(mockRedirect).toHaveBeenCalledWith('app.passculture.test://offre/986?deeplink=true')
     })
 })

--- a/server/src/middlewares/tests/universalLinksMiddleware.test.ts
+++ b/server/src/middlewares/tests/universalLinksMiddleware.test.ts
@@ -1,0 +1,49 @@
+import { Request, Response } from 'express'
+import {universalLinksMiddleware} from '../universalLinksMiddleware'
+
+const mockNext = jest.fn()
+const mockRedirect = jest.fn()
+
+const getMockRequest = (params:Partial<Request> = {}) => ({...params, get: (name: string) => params.headers?.[name]}) as Request
+const getMockResponse = (params:Partial<Response> = {}) => ({...params, redirect:mockRedirect}) as Response
+
+
+describe('universalLinksMiddleware', () => {
+
+    beforeEach(() => {
+        mockRedirect.mockReset()
+        mockNext.mockReset()
+    })    
+    
+    it('should pass to next middleware if resource is not document', () => {
+        const req = getMockRequest({headers:{}})
+        const res = getMockResponse()
+
+        universalLinksMiddleware(req, res, mockNext)
+        expect(mockNext).toHaveBeenCalled()
+    })
+
+    it('should pass to next middleware if user agent is not iOS', () => {
+        const req = getMockRequest({headers:{'Sec-Fetch-Dest':'document', 'User-Agent':'Android'}})
+        const res = getMockResponse()
+
+        universalLinksMiddleware(req, res, mockNext)
+        expect(mockNext).toHaveBeenCalled()
+    })
+
+    it('should pass to next middleware if request is not coming from Instagram', () => {
+        const req = getMockRequest({headers:{'Sec-Fetch-Dest':'document', 'User-Agent':'Mobile; iPad'}})
+        const res = getMockResponse()
+
+        universalLinksMiddleware(req, res, mockNext)
+        expect(mockNext).toHaveBeenCalled()
+    })
+
+    it('should redirect with URL scheme if coming from Instagram / iOS', () => {
+        const req = getMockRequest({headers:{'Sec-Fetch-Dest':'document', 'User-Agent':'Mobile; iPhone; Instagram',host:'passculture.app'}, originalUrl:'/offre/986?deeplink=true'})
+        const res = getMockResponse()
+
+        universalLinksMiddleware(req, res, mockNext)
+        expect(mockRedirect).toHaveBeenCalledWith('app.passculture://offre/986?deeplink=true')
+    })
+})

--- a/server/src/middlewares/universalLinksMiddleware.ts
+++ b/server/src/middlewares/universalLinksMiddleware.ts
@@ -1,5 +1,7 @@
 import { NextFunction, Request, Response } from 'express'
 
+import { env } from '../libs/environment/env'
+
 const hasMobileIOS = (userAgent: string) =>
   userAgent.includes('Mobile') && (userAgent.includes('iPhone') || userAgent.includes('iPad'))
 const hasInstagram = (userAgent: string) => userAgent.includes('Instagram')
@@ -15,7 +17,7 @@ export const universalLinksMiddleware = (
   if (destinationHeader === 'document' && hasMobileIOS(userAgent) && hasInstagram(userAgent)) {
     const fullUrl = 'https://' + request.get('host') + request.originalUrl
     const url = new URL(fullUrl)
-    response.redirect(`app.passculture://${url.pathname.substring(1)}${url.search}`)
+    response.redirect(`app.passculture.${env.ENV}://${url.pathname.substring(1)}${url.search}`)
   } else {
     next()
   }

--- a/server/src/middlewares/universalLinksMiddleware.ts
+++ b/server/src/middlewares/universalLinksMiddleware.ts
@@ -1,0 +1,22 @@
+import { NextFunction, Request, Response } from 'express'
+
+const hasMobileIOS = (userAgent: string) =>
+  userAgent.includes('Mobile') && (userAgent.includes('iPhone') || userAgent.includes('iPad'))
+const hasInstagram = (userAgent: string) => userAgent.includes('Instagram')
+
+export const universalLinksMiddleware = (
+  request: Request,
+  response: Response,
+  next: NextFunction
+) => {
+  const userAgent = request.get('User-Agent') ?? ''
+  const destinationHeader = request.get('Sec-Fetch-Dest') ?? '' // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest
+
+  if (destinationHeader === 'document' && hasMobileIOS(userAgent) && hasInstagram(userAgent)) {
+    const fullUrl = 'https://' + request.get('host') + request.originalUrl
+    const url = new URL(fullUrl)
+    response.redirect(`app.passculture://${url.pathname.substring(1)}${url.search}`)
+  } else {
+    next()
+  }
+}

--- a/src/features/navigation/RootNavigator/linking/index.ts
+++ b/src/features/navigation/RootNavigator/linking/index.ts
@@ -2,7 +2,7 @@ import { LinkingOptions } from '@react-navigation/native'
 
 import { rootScreensConfig } from 'features/navigation/RootNavigator/screens'
 import { RootStackParamList } from 'features/navigation/RootNavigator/types'
-import { WEBAPP_V2_URL } from 'libs/environment'
+import { WEBAPP_V2_URL, env } from 'libs/environment'
 import { RequireField } from 'libs/typesUtils/typeHelpers'
 
 import { getInitialURL } from './getInitialUrl'
@@ -10,7 +10,7 @@ import { customGetPathFromState } from './getPathFromState'
 import { customGetStateFromPath } from './getStateFromPath'
 import { subscribe } from './subscribe'
 
-const PASS_CULTURE_PREFIX_URL = 'passculture://'
+const PASS_CULTURE_PREFIX_URL = [`app.passculture.${env.ENV}://`, 'app.passculture://']
 
 export const linking: RequireField<
   LinkingOptions<RootStackParamList>,
@@ -19,7 +19,7 @@ export const linking: RequireField<
   prefixes: [
     // must NOT be empty
     WEBAPP_V2_URL,
-    PASS_CULTURE_PREFIX_URL,
+    ...PASS_CULTURE_PREFIX_URL,
   ],
   getInitialURL: getInitialURL,
   subscribe: subscribe,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33435

- Ajout d'un middleware côté serveur pour gérer la redirection des appels venant d'une app Instagram / iOS
- Fix sur les URL Schemes côté react-navigation

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
