### PR TITLE
(PC-32251) refactor(SubcategoryButtonListWrapper): remove hard coded nativeCategory label

### DIFF
--- a/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.native.test.tsx
+++ b/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.native.test.tsx
@@ -73,7 +73,7 @@ describe('AutocompleteOfferItem component', () => {
       }
     )
 
-    await screen.findByText('Séances de cinéma')
+    await screen.findByText('Films à l’affiche')
 
     expect(screen.queryByText('Cinéma')).not.toBeOnTheScreen()
   })
@@ -174,7 +174,7 @@ describe('AutocompleteOfferItem component', () => {
 
       await screen.findByText('cinéma')
 
-      expect(screen.queryByText('Séances de cinéma')).not.toBeOnTheScreen()
+      expect(screen.queryByText('Films à l’affiche')).not.toBeOnTheScreen()
     })
 
     it('should not display the most popular native category of the query suggestion', async () => {
@@ -191,7 +191,7 @@ describe('AutocompleteOfferItem component', () => {
 
       await screen.findByText('cinéma')
 
-      expect(screen.queryByText('Séances de cinéma')).not.toBeOnTheScreen()
+      expect(screen.queryByText('Films à l’affiche')).not.toBeOnTheScreen()
     })
 
     it('should not execute the search with the category, native category and genre of the previous search on hit click', async () => {
@@ -496,7 +496,7 @@ describe('AutocompleteOfferItem component', () => {
           }
         )
 
-        expect(await screen.findByText('Séances de cinéma')).toBeOnTheScreen()
+        expect(await screen.findByText('Films à l’affiche')).toBeOnTheScreen()
       })
 
       it('when it associated to the most popular category', async () => {
@@ -746,7 +746,7 @@ describe('AutocompleteOfferItem component', () => {
         }
       )
 
-      expect(await screen.findByText('Séances de cinéma')).toBeOnTheScreen()
+      expect(await screen.findByText('Films à l’affiche')).toBeOnTheScreen()
     })
   })
 })

--- a/src/features/search/helpers/categoriesHelpers/mapping-tree.ts
+++ b/src/features/search/helpers/categoriesHelpers/mapping-tree.ts
@@ -153,11 +153,9 @@ export function createMappingTree(data?: SubcategoriesResponseModelv2, facetsDat
     })
     .reduce<MappingTree>((result, searchGroup) => {
       let mappedNativeCategories: MappedNativeCategories | undefined = undefined
-      let mappedNativeCategoriesBooks: MappedNativeCategories | undefined = undefined
+      const mappedNativeCategoriesBooks: MappedNativeCategories | undefined =
+        searchGroup.name === SearchGroupNameEnumv2.LIVRES ? mapBookCategories(data) : undefined
 
-      if (searchGroup.name === SearchGroupNameEnumv2.LIVRES) {
-        mappedNativeCategoriesBooks = mapBookCategories(data)
-      }
       const nativeCategories = getNativeCategories(data, searchGroup.name)
       mappedNativeCategories = nativeCategories.length
         ? nativeCategories.reduce<MappedNativeCategories>(

--- a/src/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx
+++ b/src/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx
@@ -193,7 +193,7 @@ describe('<CategoriesModal/>', () => {
     it('should render native categories', () => {
       renderCategories()
 
-      expect(screen.getByText('Séances de cinéma')).toBeOnTheScreen()
+      expect(screen.getByText('Films à l’affiche')).toBeOnTheScreen()
     })
 
     it('should go back to categories view', () => {
@@ -209,7 +209,7 @@ describe('<CategoriesModal/>', () => {
     it('should set search state when search button is pressed', async () => {
       renderCategories()
 
-      const someCategoryFilterCheckbox = screen.getByText('Séances de cinéma')
+      const someCategoryFilterCheckbox = screen.getByText('Films à l’affiche')
       fireEvent.press(someCategoryFilterCheckbox)
 
       const button = screen.getByText('Rechercher')

--- a/src/libs/subcategories/placeholderData.ts
+++ b/src/libs/subcategories/placeholderData.ts
@@ -1027,7 +1027,7 @@ export const PLACEHOLDER_DATA: SubcategoriesResponseModelv2 = {
     },
     {
       name: NativeCategoryIdEnumv2.SEANCES_DE_CINEMA,
-      value: 'S\u00e9ances de cin\u00e9ma',
+      value: 'Films à l’affiche',
       genreType: GenreType.MOVIE,
       parents: [SearchGroupNameEnumv2.FILMS_SERIES_CINEMA, SearchGroupNameEnumv2.CINEMA],
     },

--- a/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonListWrapper.native.test.tsx
+++ b/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonListWrapper.native.test.tsx
@@ -18,7 +18,7 @@ jest.mock('libs/firebase/analytics/analytics')
 jest.mock('features/navigation/TabBar/routes')
 
 describe('<SubcategoryButtonListWrapper/>', () => {
-  it('should display "Films à l’affiche" instead of "Séances de cinéma" if offerCategory is "Cinema"', async () => {
+  it('should display "Films à l’affiche" when offerCategory is "Cinema"', async () => {
     render(
       reactQueryProviderHOC(
         <SubcategoryButtonListWrapper offerCategory={SearchGroupNameEnumv2.CINEMA} />
@@ -28,7 +28,7 @@ describe('<SubcategoryButtonListWrapper/>', () => {
     expect(await screen.findByText('Films à l’affiche')).toBeOnTheScreen()
   })
 
-  it('should display "Romans et littérature" if offerCategory is "Livres"', async () => {
+  it('should display "Romans et littérature" when offerCategory is "Livres"', async () => {
     render(
       reactQueryProviderHOC(
         <SubcategoryButtonListWrapper offerCategory={SearchGroupNameEnumv2.LIVRES} />

--- a/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonListWrapper.tsx
+++ b/src/ui/components/buttons/SubcategoryButton/SubcategoryButtonListWrapper.tsx
@@ -47,15 +47,11 @@ export const SubcategoryButtonListWrapper: React.FC<Props> = ({ offerCategory })
   const { navigateToSearch: navigateToSearchResults } = useNavigateToSearch('SearchResults')
   const { params } = useRoute<UseRouteType<SearchStackRouteName>>()
   const { dispatch, searchState } = useSearch()
-
   const subcategoryButtonContent = useMemo(
     () =>
       nativeCategories.map(
         (nativeCategory): SubcategoryButtonItem => ({
-          label:
-            nativeCategory[1].label === 'Séances de cinéma'
-              ? 'Films à l’affiche'
-              : nativeCategory[1].label,
+          label: nativeCategory[1].label,
           backgroundColor: offerCategoryTheme.backgroundColor || colors.white,
           borderColor: offerCategoryTheme.borderColor || colors.black,
           nativeCategory: nativeCategory[0] as NativeCategoryEnum,

--- a/src/ui/components/tiles/HorizontalTile.stories.tsx
+++ b/src/ui/components/tiles/HorizontalTile.stories.tsx
@@ -27,7 +27,7 @@ const Body = styled(Typo.Body)(({ theme }) => ({
 const Template: ComponentStory<typeof HorizontalTile> = (props) => (
   <Container>
     <HorizontalTile {...props}>
-      {['Séances de cinéma', '14 avril 2024'].map((subtitle, index) => (
+      {['Films à l’affiche', '14 avril 2024'].map((subtitle, index) => (
         <Body
           ellipsizeMode="tail"
           numberOfLines={1}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32251
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

no UI change :

avant :
<img width="1440" alt="Capture d’écran 2024-12-06 à 17 12 38" src="https://github.com/user-attachments/assets/950c1360-3fe5-429b-9910-38b390e967ae">
après : 
<img width="1440" alt="Capture d’écran 2024-12-06 à 17 12 17" src="https://github.com/user-attachments/assets/6c971ba0-011d-47c5-a9c0-ae105e669a56">


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
