### PR TITLE
(PC-33447) feat(ThematicSearch): update playlist order and remove offers without images

### DIFF
--- a/src/features/search/pages/ThematicSearch/Cinema/CinemaPlaylist.tsx
+++ b/src/features/search/pages/ThematicSearch/Cinema/CinemaPlaylist.tsx
@@ -5,7 +5,7 @@ import { useThematicSearchPlaylists } from 'features/search/pages/ThematicSearch
 import { ThematicSearchPlaylistList } from 'features/search/pages/ThematicSearch/ThematicSearchPlaylistList'
 import { QueryKeys } from 'libs/queryKeys'
 
-export const CINEMA_PLAYLIST_TITLES = ['Films à l’affiche', 'Films de la semaine', 'Cartes ciné']
+const CINEMA_PLAYLIST_TITLES = ['Films à l’affiche', 'Films de la semaine', 'Cartes ciné']
 
 export const CinemaPlaylist: React.FC = () => {
   const { playlists: cinemaPlaylists, isLoading } = useThematicSearchPlaylists({

--- a/src/features/search/pages/ThematicSearch/Films/FilmsPlaylist.tsx
+++ b/src/features/search/pages/ThematicSearch/Films/FilmsPlaylist.tsx
@@ -6,9 +6,9 @@ import { ThematicSearchPlaylistList } from 'features/search/pages/ThematicSearch
 import { QueryKeys } from 'libs/queryKeys'
 
 export const FILMS_PLAYLIST_TITLES = [
+  'Abonnements streaming',
   'Vidéos et documentaires',
   'DVD et Blu-ray',
-  'Abonnements streaming',
 ]
 
 export const FilmsPlaylist: React.FC = () => {

--- a/src/features/search/pages/ThematicSearch/Films/FilmsPlaylist.tsx
+++ b/src/features/search/pages/ThematicSearch/Films/FilmsPlaylist.tsx
@@ -5,11 +5,7 @@ import { useThematicSearchPlaylists } from 'features/search/pages/ThematicSearch
 import { ThematicSearchPlaylistList } from 'features/search/pages/ThematicSearch/ThematicSearchPlaylistList'
 import { QueryKeys } from 'libs/queryKeys'
 
-export const FILMS_PLAYLIST_TITLES = [
-  'Abonnements streaming',
-  'Vidéos et documentaires',
-  'DVD et Blu-ray',
-]
+const FILMS_PLAYLIST_TITLES = ['Abonnements streaming', 'Vidéos et documentaires', 'DVD et Blu-ray']
 
 export const FilmsPlaylist: React.FC = () => {
   const { playlists: filmsPlaylists, isLoading } = useThematicSearchPlaylists({

--- a/src/features/search/pages/ThematicSearch/Music/MusicPlaylist.tsx
+++ b/src/features/search/pages/ThematicSearch/Music/MusicPlaylist.tsx
@@ -6,12 +6,12 @@ import { ThematicSearchPlaylistList } from 'features/search/pages/ThematicSearch
 import { QueryKeys } from 'libs/queryKeys'
 
 const MUSIC_PLAYLIST_TITLES = [
+  'Musique en ligne',
   'Concerts',
   'Festivals',
   'Instruments de musique',
   'CDs',
   'Vinyles',
-  'Musique en ligne',
 ]
 
 export const MusicPlaylist: React.FC = () => {

--- a/src/features/search/pages/ThematicSearch/api/fetchFilmsOffers.native.test.ts
+++ b/src/features/search/pages/ThematicSearch/api/fetchFilmsOffers.native.test.ts
@@ -25,6 +25,11 @@ function buildQueries(userLocation: Position) {
     buildQuery({
       ...commonQueryParams,
       indexName: 'algoliaOffersIndexNameB',
+      filters: 'offer.subcategoryId:"ABO_PLATEFORME_VIDEO"',
+    }),
+    buildQuery({
+      ...commonQueryParams,
+      indexName: 'algoliaOffersIndexNameB',
       filters: 'offer.subcategoryId:"VOD"',
     }),
     buildQuery({
@@ -33,11 +38,6 @@ function buildQueries(userLocation: Position) {
       filters:
         'offer.nativeCategoryId:"DVD_BLU_RAY" AND offer.subcategoryId:"SUPPORT_PHYSIQUE_FILM" AND NOT offer.last30DaysBookingsRange:"very-low"',
       userLocation,
-    }),
-    buildQuery({
-      ...commonQueryParams,
-      indexName: 'algoliaOffersIndexNameB',
-      filters: 'offer.subcategoryId:"ABO_PLATEFORME_VIDEO"',
     }),
   ]
 }

--- a/src/features/search/pages/ThematicSearch/api/fetchFilmsOffers.ts
+++ b/src/features/search/pages/ThematicSearch/api/fetchFilmsOffers.ts
@@ -18,6 +18,11 @@ export const fetchFilmsOffers = async (userLocation?: Position) => {
     buildQuery({
       ...commonQueryParams,
       indexName: env.ALGOLIA_OFFERS_INDEX_NAME_B,
+      filters: `offer.subcategoryId:"${SubcategoryIdEnum.ABO_PLATEFORME_VIDEO}"`,
+    }),
+    buildQuery({
+      ...commonQueryParams,
+      indexName: env.ALGOLIA_OFFERS_INDEX_NAME_B,
       filters: `offer.subcategoryId:"${SubcategoryIdEnum.VOD}"`,
     }),
     buildQuery({
@@ -25,11 +30,6 @@ export const fetchFilmsOffers = async (userLocation?: Position) => {
       indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
       userLocation,
       filters: `offer.nativeCategoryId:"${NativeCategoryIdEnumv2.DVD_BLU_RAY}" AND offer.subcategoryId:"${SubcategoryIdEnum.SUPPORT_PHYSIQUE_FILM}" AND NOT offer.last30DaysBookingsRange:"very-low"`,
-    }),
-    buildQuery({
-      ...commonQueryParams,
-      indexName: env.ALGOLIA_OFFERS_INDEX_NAME_B,
-      filters: `offer.subcategoryId:"${SubcategoryIdEnum.ABO_PLATEFORME_VIDEO}"`,
     }),
   ]
 

--- a/src/features/search/pages/ThematicSearch/api/fetchMusicOffers.native.test.ts
+++ b/src/features/search/pages/ThematicSearch/api/fetchMusicOffers.native.test.ts
@@ -25,6 +25,12 @@ function buildQueries(userLocation: Position) {
   return [
     buildQuery({
       ...commonQueryParams,
+      userLocation: undefined,
+      filters:
+        '(offer.subcategoryId:"ABO_PLATEFORME_MUSIQUE" OR offer.subcategoryId:"LIVESTREAM_MUSIQUE" OR offer.subcategoryId:"TELECHARGEMENT_MUSIQUE") AND NOT offer.last30DaysBookingsRange:"very-low"',
+    }),
+    buildQuery({
+      ...commonQueryParams,
       filters: 'offer.subcategoryId:"CONCERT" AND NOT offer.last30DaysBookingsRange:"very-low"',
     }),
     buildQuery({
@@ -46,12 +52,6 @@ function buildQueries(userLocation: Position) {
       ...commonQueryParams,
       filters:
         'offer.subcategoryId:"SUPPORT_PHYSIQUE_MUSIQUE_VINYLE" AND NOT offer.last30DaysBookingsRange:"very-low"',
-    }),
-    buildQuery({
-      ...commonQueryParams,
-      userLocation: undefined,
-      filters:
-        '(offer.subcategoryId:"ABO_PLATEFORME_MUSIQUE" OR offer.subcategoryId:"LIVESTREAM_MUSIQUE" OR offer.subcategoryId:"TELECHARGEMENT_MUSIQUE") AND NOT offer.last30DaysBookingsRange:"very-low"',
     }),
   ]
 }

--- a/src/features/search/pages/ThematicSearch/api/fetchMusicOffers.ts
+++ b/src/features/search/pages/ThematicSearch/api/fetchMusicOffers.ts
@@ -16,6 +16,11 @@ export const fetchMusicOffers = async (userLocation?: Position) => {
   const queries: MultipleQueriesQuery[] = [
     buildQuery({
       ...commonQueryParams,
+      userLocation: undefined,
+      filters: `(offer.subcategoryId:"${SubcategoryIdEnum.ABO_PLATEFORME_MUSIQUE}" OR offer.subcategoryId:"${SubcategoryIdEnum.LIVESTREAM_MUSIQUE}" OR offer.subcategoryId:"${SubcategoryIdEnum.TELECHARGEMENT_MUSIQUE}") AND NOT offer.last30DaysBookingsRange:"very-low"`,
+    }),
+    buildQuery({
+      ...commonQueryParams,
       filters: `offer.subcategoryId:"${SubcategoryIdEnum.CONCERT}" AND NOT offer.last30DaysBookingsRange:"very-low"`,
     }),
     buildQuery({
@@ -33,11 +38,6 @@ export const fetchMusicOffers = async (userLocation?: Position) => {
     buildQuery({
       ...commonQueryParams,
       filters: `offer.subcategoryId:"${SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE}" AND NOT offer.last30DaysBookingsRange:"very-low"`,
-    }),
-    buildQuery({
-      ...commonQueryParams,
-      userLocation: undefined,
-      filters: `(offer.subcategoryId:"${SubcategoryIdEnum.ABO_PLATEFORME_MUSIQUE}" OR offer.subcategoryId:"${SubcategoryIdEnum.LIVESTREAM_MUSIQUE}" OR offer.subcategoryId:"${SubcategoryIdEnum.TELECHARGEMENT_MUSIQUE}") AND NOT offer.last30DaysBookingsRange:"very-low"`,
     }),
   ]
 

--- a/src/features/search/pages/ThematicSearch/api/useThematicSearchPlaylists.native.test.ts
+++ b/src/features/search/pages/ThematicSearch/api/useThematicSearchPlaylists.native.test.ts
@@ -1,11 +1,5 @@
-import * as fetchCinemaOffersModule from 'features/search/pages/ThematicSearch/api/fetchCinemaOffers'
-import * as fetchFilmsOffersModule from 'features/search/pages/ThematicSearch/api/fetchFilmsOffers'
-import { fetchFilmsOffers } from 'features/search/pages/ThematicSearch/api/fetchFilmsOffers'
 import { useThematicSearchPlaylists } from 'features/search/pages/ThematicSearch/api/useThematicSearchPlaylists'
-import { CINEMA_PLAYLIST_TITLES } from 'features/search/pages/ThematicSearch/Cinema/CinemaPlaylist'
-import { FILMS_PLAYLIST_TITLES } from 'features/search/pages/ThematicSearch/Films/FilmsPlaylist'
 import { LocationMode, Position } from 'libs/location/types'
-import { QueryKeys } from 'libs/queryKeys'
 import { mockBuilder } from 'tests/mockBuilder'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, renderHook } from 'tests/utils'
@@ -21,58 +15,62 @@ jest.mock('libs/location/LocationWrapper', () => ({
   }),
 }))
 
-const filmsOffer = mockBuilder.searchResponseOffer({})
+const defaultThematicSearchOffer = mockBuilder.searchResponseOffer({})
 
-const fetchCinemaOffersSpy = jest
-  .spyOn(fetchCinemaOffersModule, 'fetchCinemaOffers')
-  .mockResolvedValue([filmsOffer])
-
-const fetchFilmOffersSpy = jest
-  .spyOn(fetchFilmsOffersModule, 'fetchFilmsOffers')
-  .mockResolvedValue([filmsOffer])
+const fetchThematicSearchPlaylistsOffers = jest.fn().mockResolvedValue([defaultThematicSearchOffer])
 
 jest.mock('libs/firebase/analytics/analytics')
 
-describe('useCinemaOffers', () => {
-  it('should fetch film offers', async () => {
-    renderHook(
-      () =>
-        useThematicSearchPlaylists({
-          playlistTitles: FILMS_PLAYLIST_TITLES,
-          fetchMethod: fetchFilmsOffers,
-          queryKey: QueryKeys.FILMS_OFFERS,
-        }),
-      {
-        wrapper: ({ children }) => reactQueryProviderHOC(children),
-      }
-    )
+const PLAYLISTS_TITLES = ['Titre de la playlist - 1', 'Titre de la playlist - 2']
 
-    await act(() => {})
+it('should fetch thematic search playlists offers', async () => {
+  renderHook(
+    () =>
+      useThematicSearchPlaylists({
+        playlistTitles: PLAYLISTS_TITLES,
+        fetchMethod: fetchThematicSearchPlaylistsOffers,
+        queryKey: '',
+      }),
+    {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    }
+  )
 
-    expect(fetchFilmOffersSpy).toHaveBeenCalledWith(mockUserLocation),
-      expect.any(Object),
-      false,
-      undefined
-  })
+  await act(() => {})
 
-  it('should fetch cinema offers', async () => {
-    renderHook(
-      () =>
-        useThematicSearchPlaylists({
-          playlistTitles: CINEMA_PLAYLIST_TITLES,
-          fetchMethod: fetchCinemaOffersModule.fetchCinemaOffers,
-          queryKey: QueryKeys.CINEMA_OFFERS,
-        }),
-      {
-        wrapper: ({ children }) => reactQueryProviderHOC(children),
-      }
-    )
+  expect(fetchThematicSearchPlaylistsOffers).toHaveBeenCalledWith(mockUserLocation),
+    expect.any(Object),
+    false,
+    undefined
+})
 
-    await act(() => {})
+it('should only return offers with images', async () => {
+  const OFFER_WITH_IMAGE = defaultThematicSearchOffer.hits.find((hit) => hit.offer.thumbUrl)
+  const { result } = renderHook(
+    () =>
+      useThematicSearchPlaylists({
+        playlistTitles: PLAYLISTS_TITLES,
+        fetchMethod: fetchThematicSearchPlaylistsOffers,
+        queryKey: '',
+      }),
+    {
+      wrapper: ({ children }) => reactQueryProviderHOC(children),
+    }
+  )
 
-    expect(fetchCinemaOffersSpy).toHaveBeenCalledWith(mockUserLocation),
-      expect.any(Object),
-      false,
-      undefined
+  await act(() => {})
+
+  expect(result).toEqual({
+    current: {
+      playlists: [
+        {
+          title: PLAYLISTS_TITLES[0],
+          offers: {
+            hits: [OFFER_WITH_IMAGE],
+          },
+        },
+      ],
+      isLoading: false,
+    },
   })
 })

--- a/src/features/search/pages/ThematicSearch/api/useThematicSearchPlaylists.ts
+++ b/src/features/search/pages/ThematicSearch/api/useThematicSearchPlaylists.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react'
 import { useQuery } from 'react-query'
 
 import { ThematicSearchPlaylistListProps } from 'features/search/pages/ThematicSearch/ThematicSearchPlaylistList'
-import { useTransformOfferHits } from 'libs/algolia/fetchAlgolia/transformOfferHit'
+import { filterOfferHit, useTransformOfferHits } from 'libs/algolia/fetchAlgolia/transformOfferHit'
 import { Position, useLocation } from 'libs/location'
 import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
 import { Offer } from 'shared/offer/types'
@@ -50,7 +50,7 @@ export function useThematicSearchPlaylists({
         ? data
             .map((item, index) => ({
               title: playlistTitles[index] || '',
-              offers: { hits: item.hits.map(transformHits) },
+              offers: { hits: item.hits.filter(filterOfferHit).map(transformHits) },
             }))
             .filter((playlist) => playlist.offers.hits.length > 0)
         : [{ title: '', offers: { hits: [] } }],

--- a/src/tests/mockBuilder.ts
+++ b/src/tests/mockBuilder.ts
@@ -47,6 +47,7 @@ const searchResponseOffer = {
       offer: {
         name: 'Harry potter et le prisonnier d’Azkhaban',
         subcategoryId: SubcategoryIdEnum.SEANCE_CINE,
+        thumbUrl: 'image',
       },
       venue: {},
       _geoloc: {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33447

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [X] Made sure my feature is working on web.
- [X] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [X] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [X] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome |<img width="1038" alt="Capture d’écran 2024-12-06 à 18 04 38" src="https://github.com/user-attachments/assets/0f62776c-3397-48dc-8373-87cf113fd6df"> | <img width="1032" alt="Capture d’écran 2024-12-06 à 18 04 17" src="https://github.com/user-attachments/assets/f6284d4d-36ed-48e9-9c9d-4ce4a24c741c"> |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
