### PR TITLE
(BSR) refactor(auth): remove some @ts-expect-error

### DIFF
--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -1,11 +1,3 @@
-./src/features/accessibility/components/AccessibilityFiltersModal.tsx:69
-./src/features/auth/pages/signup/SignupForm.tsx:101
-./src/features/auth/pages/signup/SignupForm.tsx:179
-./src/features/auth/pages/signup/SignupForm.tsx:45
-./src/features/auth/pages/signup/SignupForm.tsx:50
-./src/features/auth/pages/signup/SignupForm.tsx:83
-./src/features/auth/pages/signup/SignupForm.tsx:85
-./src/features/auth/pages/signup/SignupForm.tsx:88
 ./src/features/bookOffer/components/BookHourChoice.tsx:122
 ./src/features/bookOffer/components/Calendar/useMarkedDates.native.test.ts:35
 ./src/features/bookOffer/components/Calendar/useMarkedDates.native.test.ts:41

--- a/src/features/accessibility/components/AccessibilityFiltersModal.tsx
+++ b/src/features/accessibility/components/AccessibilityFiltersModal.tsx
@@ -1,13 +1,13 @@
 import isEqual from 'lodash/isEqual'
-import React, { useState, useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled, { useTheme } from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
 
 import {
-  useAccessibilityFiltersContext,
   defaultDisabilitiesProperties,
+  useAccessibilityFiltersContext,
 } from 'features/accessibility/context/AccessibilityFiltersWrapper'
-import { HandicapEnum, DisplayedDisabilitiesEnum } from 'features/accessibility/enums'
+import { DisplayedDisabilitiesEnum, HandicapEnum } from 'features/accessibility/enums'
 import { DisabilitiesProperties } from 'features/accessibility/types'
 import { SearchCustomModalHeader } from 'features/search/components/SearchCustomModalHeader'
 import { SearchFixedModalBottom } from 'features/search/components/SearchFixedModalBottom'
@@ -63,10 +63,9 @@ export const AccessibilityFiltersModal: React.FC<AccessibilityModalProps> = ({
     return word.charAt(0).toUpperCase() + word.slice(1)
   }
 
-  const handleOnPress = (disability: string) => {
+  const handleOnPress = (disability: DisplayedDisabilitiesEnum) => {
     setDisplayedDisabilities({
       ...displayedDisabilities,
-      // @ts-expect-error: because of noUncheckedIndexedAccess
       [disability]: !displayedDisabilities[disability],
     })
   }


### PR DESCRIPTION
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
