### PR TITLE
(PC-33181) feat(cinema): add tracker for screening ab test

### DIFF
--- a/src/features/bookOffer/pages/BookingOfferModal.native.test.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { navigate, useRoute } from '__mocks__/@react-navigation/native'
 import { ApiError } from 'api/ApiError'
-import { RecommendationApiParams } from 'api/gen'
+import { RecommendationApiParams, SubcategoryIdEnum } from 'api/gen'
 import * as Auth from 'features/auth/context/AuthContext'
 import * as useBookOfferMutation from 'features/bookOffer/api/useBookOfferMutation'
 import { BookingState, Step } from 'features/bookOffer/context/reducer'
@@ -29,7 +29,7 @@ const mockDispatch = jest.fn()
 
 jest.spyOn(useFeatureFlag, 'useFeatureFlag').mockReturnValue(false)
 
-const mockOffer = baseOffer
+const mockOffer = { ...baseOffer, subcategoryId: SubcategoryIdEnum.SEANCE_CINE }
 
 const mockUseBookingContext: jest.Mock<IBookingContext> = jest.fn(() => ({
   bookingState: { offerId: mockOffer.id, step: Step.DATE } as BookingState,
@@ -481,6 +481,28 @@ describe('<BookingOfferModalComponent />', () => {
           type: 'SELECT_DATE',
           payload: bookingDataMovieScreening.date,
         })
+      })
+
+      it('should log HAS_BOOKED_CINE_SCREENING_OFFER', async () => {
+        render(
+          reactQueryProviderHOC(
+            <BookingOfferModalComponent
+              visible
+              offerId={20}
+              bookingDataMovieScreening={bookingDataMovieScreening}
+            />
+          )
+        )
+
+        fireEvent.press(
+          await screen.findByRole('checkbox', {
+            name: 'J’ai lu et j’accepte les conditions générales d’utilisation',
+          })
+        )
+
+        fireEvent.press(screen.getByText('Confirmer la réservation'))
+
+        expect(analytics.logHasBookedCineScreeningOffer).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/src/features/bookOffer/pages/BookingOfferModal.tsx
+++ b/src/features/bookOffer/pages/BookingOfferModal.tsx
@@ -5,7 +5,7 @@ import { useTheme } from 'styled-components/native'
 
 import { ApiError } from 'api/ApiError'
 import { isApiError } from 'api/apiHelpers'
-import { RecommendationApiParams } from 'api/gen'
+import { RecommendationApiParams, SubcategoryIdEnum } from 'api/gen'
 import { useBookOfferMutation } from 'features/bookOffer/api/useBookOfferMutation'
 import { BookingCloseInformation } from 'features/bookOffer/components/BookingCloseInformation'
 import { BookingOfferModalFooter } from 'features/bookOffer/components/BookingOfferModalFooter'
@@ -83,7 +83,11 @@ export const BookingOfferModalComponent: React.FC<BookingOfferModalComponentProp
         if (isFromSearch && algoliaOfferId) {
           logOfferConversion(algoliaOfferId)
         }
-
+        if (offer?.subcategoryId === SubcategoryIdEnum.SEANCE_CINE) {
+          analytics.logHasBookedCineScreeningOffer({
+            offerId,
+          })
+        }
         if (!!selectedStock && !!offer?.subcategoryId) {
           campaignTracker.logEvent(CampaignEvents.COMPLETE_BOOK_OFFER, {
             af_offer_id: offerId,

--- a/src/libs/analytics/__mocks__/logEventAnalytics.ts
+++ b/src/libs/analytics/__mocks__/logEventAnalytics.ts
@@ -96,6 +96,7 @@ export const logEventAnalytics: typeof actualLogEventAnalytics = {
   logHasMadeAChoiceForCookies: jest.fn(),
   logHasOpenedAccessibilityAccordion: jest.fn(),
   logHasOpenedCookiesAccordion: jest.fn(),
+  logHasBookedCineScreeningOffer: jest.fn(),
   logHasRefusedCookie: jest.fn(),
   logHasRequestedCode: jest.fn(),
   logHasSeenAllVideo: jest.fn(),

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -352,6 +352,8 @@ export const logEventAnalytics = {
         type: sortBy,
       }
     ),
+  logHasBookedCineScreeningOffer: (params: { offerId: number }) =>
+    analytics.logEvent({ firebase: AnalyticsEvent.HAS_BOOKED_CINE_SCREENING_OFFER }, params),
   logHasChangedPassword: ({
     from,
     reason,

--- a/src/libs/firebase/analytics/events.ts
+++ b/src/libs/firebase/analytics/events.ts
@@ -81,6 +81,7 @@ export enum AnalyticsEvent {
   HAS_ACTIVATE_GEOLOC_FROM_TUTORIAL = 'HasActivateGeolocFromTutorial',
   HAS_ADDED_OFFER_TO_FAVORITES = 'HasAddedOfferToFavorites',
   HAS_APPLIED_FAVORITES_SORTING = 'HasAppliedFavoritesSorting',
+  HAS_BOOKED_CINE_SCREENING_OFFER = 'HasBookedCineScreeningOffer',
   HAS_CHANGED_PASSWORD = 'HasChangedPassword',
   HAS_CHOSEN_PRICE = 'HasChosenPrice',
   HAS_CHOSEN_TIME = 'HasChosenTime',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33181

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mobile | Web |
| :--------------- | :-----------: | :---: |
| Result |<img width="606" alt="Capture d’écran 2024-12-09 à 10 20 09" src="https://github.com/user-attachments/assets/f19c87dd-50d3-4f6d-a891-4b9030a32c00">|<img width="1512" alt="Capture d’écran 2024-12-09 à 10 12 07" src="https://github.com/user-attachments/assets/0eefa11c-7cd6-4524-ad5c-3cd81f41a616">|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).

Test specific:

- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.

</details>
