### PR TITLE
(BSR) chore(tests): use findByText instead await act async

### DIFF
--- a/src/features/home/components/headers/HomeHeader.native.test.tsx
+++ b/src/features/home/components/headers/HomeHeader.native.test.tsx
@@ -16,7 +16,7 @@ import { LocationLabel } from 'libs/location/types'
 import { Credit, useAvailableCredit } from 'shared/user/useAvailableCredit'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, render, screen, waitFor } from 'tests/utils'
+import { render, screen, waitFor } from 'tests/utils'
 
 import { HomeHeader } from './HomeHeader'
 
@@ -84,7 +84,6 @@ describe('HomeHeader', () => {
       mockGeolocBannerFromBackend()
 
       renderHomeHeader()
-      await act(async () => {})
 
       expect(await screen.findByText(subtitle)).toBeOnTheScreen()
     }

--- a/src/features/internal/cheatcodes/components/CheatMenuButton.native.test.tsx
+++ b/src/features/internal/cheatcodes/components/CheatMenuButton.native.test.tsx
@@ -2,13 +2,12 @@ import React from 'react'
 
 import { CheatMenuButton } from 'features/internal/cheatcodes/components/CheatMenuButton'
 import { env } from 'libs/environment'
-import { act, render, screen } from 'tests/utils'
+import { render, screen } from 'tests/utils'
 
 describe('CheatMenuButton', () => {
   it('should have CheatMenu button when FEATURE_FLIPPING_ONLY_VISIBLE_ON_TESTING=true', async () => {
     env.FEATURE_FLIPPING_ONLY_VISIBLE_ON_TESTING = true
     render(<CheatMenuButton />)
-    await act(async () => {})
 
     expect(await screen.findByText('CheatMenu')).toBeOnTheScreen()
   })
@@ -16,7 +15,6 @@ describe('CheatMenuButton', () => {
   it('should NOT have CheatMenu button when NOT FEATURE_FLIPPING_ONLY_VISIBLE_ON_TESTING=false', async () => {
     env.FEATURE_FLIPPING_ONLY_VISIBLE_ON_TESTING = false
     render(<CheatMenuButton />)
-    await act(async () => {})
 
     expect(screen.queryByText('CheatMenu')).not.toBeOnTheScreen()
   })

--- a/src/features/offer/components/MoviesScreeningCalendar/MoviesScreeningCalendar.native.test.tsx
+++ b/src/features/offer/components/MoviesScreeningCalendar/MoviesScreeningCalendar.native.test.tsx
@@ -16,7 +16,7 @@ import * as useFeatureFlag from 'libs/firebase/firestore/featureFlags/useFeature
 import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, render, screen } from 'tests/utils'
+import { render, screen } from 'tests/utils'
 import { AnchorProvider } from 'ui/components/anchor/AnchorContext'
 
 jest.mock('libs/network/NetInfoWrapper')
@@ -93,8 +93,6 @@ describe('MoviesScreeningCalendar', () => {
   it('should render MoviesScreeningCalendar correctly on mobile', async () => {
     renderMoviesScreeningCalendar({ isDesktopViewport: false, venueOffers: venueOffersMock })
 
-    await act(async () => {})
-
     expect((await screen.findAllByText('Mer.'))[0]).toBeOnTheScreen()
     expect(screen.getByText('8')).toBeOnTheScreen()
     expect(screen.getAllByText('Mai')[0]).toBeOnTheScreen()
@@ -102,8 +100,6 @@ describe('MoviesScreeningCalendar', () => {
 
   it('should render MoviesScreeningCalendar correctly on desktop', async () => {
     renderMoviesScreeningCalendar({ isDesktopViewport: true, venueOffers: venueOffersMock })
-
-    await act(async () => {})
 
     expect((await screen.findAllByText('Mercredi'))[0]).toBeOnTheScreen()
     expect(screen.getByText('8')).toBeOnTheScreen()

--- a/src/features/search/pages/SearchLanding/SearchLanding.native.test.tsx
+++ b/src/features/search/pages/SearchLanding/SearchLanding.native.test.tsx
@@ -17,7 +17,7 @@ import { LocationMode } from 'libs/location/types'
 import * as useNetInfoContextDefault from 'libs/network/NetInfoWrapper'
 import { SuggestedPlace } from 'libs/place/types'
 import { mockedSuggestedVenue } from 'libs/venue/fixtures/mockedSuggestedVenues'
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { fireEvent, render, screen } from 'tests/utils'
 
 const venue = mockedSuggestedVenue
 
@@ -251,8 +251,6 @@ describe('<SearchLanding />', () => {
 
       await screen.findByText('Rechercher')
 
-      await act(() => {})
-
       expect(screen).toMatchSnapshot()
     })
 
@@ -274,8 +272,6 @@ describe('<SearchLanding />', () => {
       render(<SearchLanding />)
 
       await screen.findByText('Rechercher')
-
-      await act(() => {})
 
       expect(screen).toMatchSnapshot()
     })
@@ -302,7 +298,7 @@ describe('<SearchLanding />', () => {
 
     it('should display offer suggestions', async () => {
       render(<SearchLanding />)
-      await act(async () => {})
+      await screen.findByText('Rechercher')
 
       expect(screen.getByTestId('autocompleteOfferItem_1')).toBeOnTheScreen()
       expect(screen.getByTestId('autocompleteOfferItem_2')).toBeOnTheScreen()
@@ -310,7 +306,7 @@ describe('<SearchLanding />', () => {
 
     it('should display venue suggestions', async () => {
       render(<SearchLanding />)
-      await act(async () => {})
+      await screen.findByText('Rechercher')
 
       expect(screen.getByTestId('autocompleteVenueItem_1')).toBeOnTheScreen()
       expect(screen.getByTestId('autocompleteVenueItem_2')).toBeOnTheScreen()
@@ -318,7 +314,7 @@ describe('<SearchLanding />', () => {
 
     it('should handle venue press', async () => {
       render(<SearchLanding />)
-      await act(async () => {})
+      await screen.findByText('Rechercher')
 
       expect(screen.getByTestId('autocompleteVenueItem_1')).toBeOnTheScreen()
 
@@ -332,7 +328,7 @@ describe('<SearchLanding />', () => {
 
     it('should hide suggestions when pressing a venue', async () => {
       render(<SearchLanding />)
-      await act(async () => {})
+      await screen.findByText('Rechercher')
 
       expect(screen.getByTestId('autocompleteVenueItem_1')).toBeOnTheScreen()
 
@@ -351,7 +347,7 @@ describe('<SearchLanding />', () => {
       }
       const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss')
       render(<SearchLanding />)
-      await act(async () => {})
+      await screen.findByText('Rechercher')
 
       const scrollView = screen.getByTestId('autocompleteScrollView')
       // 1st scroll to bottom => trigger
@@ -363,7 +359,7 @@ describe('<SearchLanding />', () => {
     it('should display search history when it has items', async () => {
       mockdate.set(TODAY_DATE)
       render(<SearchLanding />)
-      await act(async () => {})
+      await screen.findByText('Rechercher')
 
       expect(screen.getByText('Historique de recherche')).toBeOnTheScreen()
     })
@@ -375,7 +371,7 @@ describe('<SearchLanding />', () => {
       mockUseSearchHistory.mockReturnValueOnce(mockedEmptyHistory)
 
       render(<SearchLanding />)
-      await act(async () => {})
+      await screen.findByText('Rechercher')
 
       expect(screen.queryByText('Historique de recherche')).not.toBeOnTheScreen()
     })
@@ -384,7 +380,7 @@ describe('<SearchLanding />', () => {
       mockdate.set(TODAY_DATE)
       const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss')
       render(<SearchLanding />)
-      await act(async () => {})
+      await screen.findByText('Rechercher')
 
       fireEvent.press(screen.getByText('manga'))
 
@@ -395,7 +391,7 @@ describe('<SearchLanding />', () => {
       it('When it has not category and native category', async () => {
         mockdate.set(TODAY_DATE)
         render(<SearchLanding />)
-        await act(async () => {})
+        await screen.findByText('Rechercher')
 
         fireEvent.press(screen.getByText('manga'))
 
@@ -417,7 +413,7 @@ describe('<SearchLanding />', () => {
       it('When it has category and native category', async () => {
         mockdate.set(TODAY_DATE)
         render(<SearchLanding />)
-        await act(async () => {})
+        await screen.findByText('Rechercher')
 
         fireEvent.press(screen.getByText('tolkien'))
 
@@ -439,7 +435,7 @@ describe('<SearchLanding />', () => {
       it('When it has only a category', async () => {
         mockdate.set(TODAY_DATE)
         render(<SearchLanding />)
-        await act(async () => {})
+        await screen.findByText('Rechercher')
 
         fireEvent.press(screen.getByText('foresti'))
 


### PR DESCRIPTION
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
