### PR TITLE
(BSR) fix(touchableLink): use throttle instead of debounce

### DIFF
--- a/src/ui/components/touchableLink/InternalTouchableLink.native.test.tsx
+++ b/src/ui/components/touchableLink/InternalTouchableLink.native.test.tsx
@@ -3,7 +3,7 @@ import { Text } from 'react-native'
 
 import { navigate, push } from '__mocks__/@react-navigation/native'
 import { navigateFromRef, pushFromRef } from 'features/navigation/navigationRef'
-import { render, fireEvent, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 
 jest.mock('features/navigation/navigationRef')
@@ -20,6 +20,16 @@ const linkText = 'linkText'
 const InternalTouchableLinkContent = () => <Text>{linkText}</Text>
 
 describe('<InternalTouchableLink />', () => {
+  const user = userEvent.setup()
+
+  beforeAll(() => {
+    jest.useFakeTimers()
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
   it('should navigate to right screen with expected params (nominal case)', async () => {
     render(
       <InternalTouchableLink navigateTo={{ screen: 'TabNavigator', params: { screen: 'Home' } }}>
@@ -27,11 +37,9 @@ describe('<InternalTouchableLink />', () => {
       </InternalTouchableLink>
     )
 
-    fireEvent.press(screen.getByText(linkText))
+    await user.press(screen.getByText(linkText))
 
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('TabNavigator', { screen: 'Home', params: undefined })
-    })
+    expect(navigate).toHaveBeenCalledWith('TabNavigator', { screen: 'Home', params: undefined })
   })
 
   it('should push right screen with expected params if withPush={true}', async () => {
@@ -42,13 +50,29 @@ describe('<InternalTouchableLink />', () => {
       </InternalTouchableLink>
     )
 
-    fireEvent.press(screen.getByText(linkText))
+    await user.press(screen.getByText(linkText))
 
-    await waitFor(() => {
-      expect(push).toHaveBeenCalledWith('TabNavigator', {
-        screen: 'Home',
-        params: undefined,
-      })
+    expect(push).toHaveBeenCalledWith('TabNavigator', {
+      screen: 'Home',
+      params: undefined,
+    })
+  })
+
+  it('should push screen only once in case of press spamming when withPush={true}', async () => {
+    render(
+      <InternalTouchableLink
+        navigateTo={{ screen: 'TabNavigator', params: { screen: 'Home' }, withPush: true }}>
+        <InternalTouchableLinkContent />
+      </InternalTouchableLink>
+    )
+
+    await user.press(screen.getByText(linkText))
+    await user.press(screen.getByText(linkText))
+    await user.press(screen.getByText(linkText))
+
+    expect(push).toHaveBeenNthCalledWith(1, 'TabNavigator', {
+      screen: 'Home',
+      params: undefined,
     })
   })
 
@@ -60,13 +84,11 @@ describe('<InternalTouchableLink />', () => {
       </InternalTouchableLink>
     )
 
-    fireEvent.press(screen.getByText(linkText))
+    await user.press(screen.getByText(linkText))
 
-    await waitFor(() => {
-      expect(navigateFromRef).toHaveBeenCalledWith('TabNavigator', {
-        screen: 'Home',
-        params: undefined,
-      })
+    expect(navigateFromRef).toHaveBeenCalledWith('TabNavigator', {
+      screen: 'Home',
+      params: undefined,
     })
   })
 
@@ -83,13 +105,11 @@ describe('<InternalTouchableLink />', () => {
       </InternalTouchableLink>
     )
 
-    fireEvent.press(screen.getByText(linkText))
+    await user.press(screen.getByText(linkText))
 
-    await waitFor(() => {
-      expect(pushFromRef).toHaveBeenCalledWith('TabNavigator', {
-        screen: 'Home',
-        params: undefined,
-      })
+    expect(pushFromRef).toHaveBeenCalledWith('TabNavigator', {
+      screen: 'Home',
+      params: undefined,
     })
   })
 
@@ -107,13 +127,11 @@ describe('<InternalTouchableLink />', () => {
       </InternalTouchableLink>
     )
 
-    fireEvent.press(screen.getByText(linkText))
+    await user.press(screen.getByText(linkText))
 
-    await waitFor(() => {
-      expect(navigate).not.toHaveBeenCalledWith('TabNavigator', {
-        screen: 'Home',
-        params: undefined,
-      })
+    expect(navigate).not.toHaveBeenCalledWith('TabNavigator', {
+      screen: 'Home',
+      params: undefined,
     })
   })
 })

--- a/src/ui/components/touchableLink/InternalTouchableLink.tsx
+++ b/src/ui/components/touchableLink/InternalTouchableLink.tsx
@@ -6,6 +6,8 @@ import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { TouchableLink } from 'ui/components/touchableLink/TouchableLink'
 import { InternalTouchableLinkProps } from 'ui/components/touchableLink/types'
 
+const PUSH_LINK_COOLDOWN = 1500
+
 export const InternalTouchableLink: FunctionComponent<InternalTouchableLinkProps> = ({
   navigateTo,
   enableNavigate = true,
@@ -14,17 +16,23 @@ export const InternalTouchableLink: FunctionComponent<InternalTouchableLinkProps
   // We use nullish operator here because TabBar uses InternalTouchableLink but navigateTo is undefined during launch
   const internalLinkProps = useLinkProps({ to: navigateTo ?? '' })
   const { navigate, push } = useNavigation<UseNavigationType>()
+  const { screen, params, fromRef, withPush } = navigateTo ?? {}
   const handleNavigation = useCallback(() => {
     if (enableNavigate) {
-      const { screen, params, fromRef, withPush } = navigateTo
       if (withPush) {
         fromRef ? pushFromRef(screen, params) : push(screen, params)
       } else {
         fromRef ? navigateFromRef(screen, params) : navigate(screen, params)
       }
     }
-  }, [enableNavigate, navigateTo, navigate, push])
+  }, [enableNavigate, navigate, push, fromRef, withPush, params, screen])
+  // For link in push mode, we want to avoid double tap. So we put a pretty large cooldown wait value
   return (
-    <TouchableLink handleNavigation={handleNavigation} linkProps={internalLinkProps} {...rest} />
+    <TouchableLink
+      handleNavigation={handleNavigation}
+      linkProps={internalLinkProps}
+      {...rest}
+      pressCooldownDelay={withPush ? PUSH_LINK_COOLDOWN : undefined}
+    />
   )
 }

--- a/src/ui/components/touchableLink/TouchableLink.native.test.tsx
+++ b/src/ui/components/touchableLink/TouchableLink.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Text } from 'react-native'
 
 import { analytics } from 'libs/analytics'
-import { render, fireEvent, screen, waitFor } from 'tests/utils'
+import { act, render, screen, userEvent } from 'tests/utils'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 
 import { TouchableLink } from './TouchableLink'
@@ -13,6 +13,16 @@ const linkText = 'linkText'
 const TouchableLinkContent = () => <Text>{linkText}</Text>
 
 describe('<TouchableLink />', () => {
+  const user = userEvent.setup()
+
+  beforeAll(() => {
+    jest.useFakeTimers()
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
   describe('Internal Navigation', () => {
     it('should fire onBeforeNavigate if given, before navigation', async () => {
       render(
@@ -23,14 +33,11 @@ describe('<TouchableLink />', () => {
         </TouchableLink>
       )
 
-      fireEvent.press(screen.getByText(linkText))
+      await user.press(screen.getByText(linkText))
 
       expect(analytics.logConsultTutorial).toHaveBeenCalledWith({ from: 'profile' })
-      expect(handleNavigationMock).not.toHaveBeenCalled()
 
-      await waitFor(() => {
-        expect(handleNavigationMock).toHaveBeenCalledTimes(1)
-      })
+      expect(handleNavigationMock).toHaveBeenCalledTimes(1)
     })
 
     it('should fire onAfterNavigate after navigate', async () => {
@@ -43,13 +50,11 @@ describe('<TouchableLink />', () => {
         </TouchableLink>
       )
 
-      fireEvent.press(screen.getByText(linkText))
+      await user.press(screen.getByText(linkText))
 
       expect(handleNavigationMock).toHaveBeenCalledTimes(1)
 
-      await waitFor(() => {
-        expect(mockedOnAfterNavigate).toHaveBeenCalledTimes(1)
-      })
+      expect(mockedOnAfterNavigate).toHaveBeenCalledTimes(1)
     })
 
     it('should render with correct style if component tag is given', () => {
@@ -68,23 +73,43 @@ describe('<TouchableLink />', () => {
       expect(link.props.style).toEqual(expectedStyle)
     })
 
-    it('should trigger handleNavigation only once in case of press spamming', async () => {
+    it('should trigger handleNavigation only once in case of press spamming with correct cooldown delay', async () => {
       render(
-        <TouchableLink handleNavigation={handleNavigationMock}>
+        <TouchableLink handleNavigation={handleNavigationMock} pressCooldownDelay={300}>
           <TouchableLinkContent />
         </TouchableLink>
       )
 
-      fireEvent.press(screen.getByText(linkText))
-      fireEvent.press(screen.getByText(linkText))
-      fireEvent.press(screen.getByText(linkText))
+      await user.press(screen.getByText(linkText))
+      await user.press(screen.getByText(linkText))
+      await user.press(screen.getByText(linkText))
 
-      await waitFor(() => {
-        expect(handleNavigationMock).toHaveBeenCalledTimes(1)
-      })
+      expect(handleNavigationMock).toHaveBeenCalledTimes(1)
     })
 
-    it('should trigger handleNavigation with multiple press respecting cooldown delay', async () => {
+    it('should trigger handleNavigation multiple time if cooldown delay is respected', async () => {
+      render(
+        <TouchableLink handleNavigation={handleNavigationMock} pressCooldownDelay={300}>
+          <TouchableLinkContent />
+        </TouchableLink>
+      )
+
+      await act(async () => {
+        await user.press(screen.getByText(linkText))
+
+        jest.advanceTimersByTime(300)
+
+        await user.press(screen.getByText(linkText))
+
+        jest.advanceTimersByTime(300)
+
+        await user.press(screen.getByText(linkText))
+      })
+
+      expect(handleNavigationMock).toHaveBeenCalledTimes(3)
+    })
+
+    it('should trigger handleNavigation with multiple press when no cooldown delay is set', async () => {
       jest.useFakeTimers()
       render(
         <TouchableLink handleNavigation={handleNavigationMock}>
@@ -92,30 +117,23 @@ describe('<TouchableLink />', () => {
         </TouchableLink>
       )
 
-      fireEvent.press(screen.getByText(linkText))
-      jest.advanceTimersByTime(400)
-      fireEvent.press(screen.getByText(linkText))
-      jest.advanceTimersByTime(400)
-      fireEvent.press(screen.getByText(linkText))
+      await user.press(screen.getByText(linkText))
+      await user.press(screen.getByText(linkText))
+      await user.press(screen.getByText(linkText))
 
-      await waitFor(() => {
-        expect(handleNavigationMock).toHaveBeenCalledTimes(3)
-      })
+      expect(handleNavigationMock).toHaveBeenCalledTimes(3)
     })
 
     it('should not trigger handleNavigation when Link is disabled', async () => {
-      jest.useFakeTimers()
       render(
         <TouchableLink handleNavigation={handleNavigationMock} disabled>
           <TouchableLinkContent />
         </TouchableLink>
       )
 
-      fireEvent.press(screen.getByText(linkText))
+      await user.press(screen.getByText(linkText))
 
-      await waitFor(() => {
-        expect(handleNavigationMock).not.toHaveBeenCalledTimes(3)
-      })
+      expect(handleNavigationMock).not.toHaveBeenCalledTimes(3)
     })
   })
 })


### PR DESCRIPTION
Pour éviter le spam de press sur les tuiles d'offres en mode push

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
