### PR TITLE
(PC-33471) feat(passForAll): AgeSelectionScreen

### DIFF
--- a/__snapshots__/features/tutorial/pages/AgeSelection.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/AgeSelection.native.test.tsx.native-snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AgeSelection onboarding should render correctly 1`] = `
+exports[`AgeSelection with passForAll feature flag off onboarding should render correctly 1`] = `
 [
   <View
     style={
@@ -1023,7 +1023,7 @@ exports[`AgeSelection onboarding should render correctly 1`] = `
 ]
 `;
 
-exports[`AgeSelection profileTutorial should render correctly 1`] = `
+exports[`AgeSelection with passForAll feature flag off profileTutorial should render correctly 1`] = `
 [
   <View
     style={
@@ -2018,6 +2018,798 @@ exports[`AgeSelection profileTutorial should render correctly 1`] = `
               </View>
             </View>
           </View>
+        </View>
+      </View>
+      <View
+        numberOfSpaces={6}
+        style={
+          [
+            {
+              "height": 24,
+            },
+          ]
+        }
+      />
+    </View>
+  </RCTScrollView>,
+  <View
+    customHeight={8}
+    enable={true}
+    style={
+      [
+        {
+          "height": 8,
+        },
+      ]
+    }
+  />,
+]
+`;
+
+exports[`AgeSelection with passForAll feature flag on onboarding should render correctly 1`] = `
+[
+  <View
+    style={
+      [
+        {
+          "height": 64,
+        },
+      ]
+    }
+    top={16}
+  />,
+  <View
+    style={
+      [
+        {
+          "position": "absolute",
+          "top": 0,
+          "width": "100%",
+          "zIndex": 1,
+        },
+      ]
+    }
+  >
+    <View
+      customHeight={16}
+      enable={true}
+      style={
+        [
+          {
+            "height": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        [
+          {
+            "height": 48,
+            "justifyContent": "center",
+            "paddingHorizontal": 12,
+          },
+        ]
+      }
+    >
+      <View
+        accessibilityLabel="Revenir en arrière"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            [
+              {
+                "userSelect": "auto",
+              },
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "height": 40,
+                "justifyContent": "center",
+                "maxWidth": 40,
+              },
+            ],
+            {
+              "opacity": 1,
+            },
+          ]
+        }
+        testID="Revenir en arrière"
+      >
+        <View
+          height={24}
+          testID="icon-back"
+          width={24}
+        >
+          <Text>
+            icon-back-SVG-Mock
+          </Text>
+        </View>
+        <Text
+          style={
+            [
+              {
+                "display": "none",
+              },
+            ]
+          }
+        >
+          Retour
+        </Text>
+      </View>
+    </View>
+  </View>,
+  <RCTScrollView
+    contentContainerStyle={
+      {
+        "alignSelf": "center",
+        "maxWidth": 500,
+        "width": "100%",
+      }
+    }
+    style={
+      [
+        {},
+      ]
+    }
+  >
+    <View>
+      <View
+        style={
+          [
+            {
+              "marginHorizontal": 24,
+            },
+          ]
+        }
+      >
+        <View
+          numberOfSpaces={6}
+          style={
+            [
+              {
+                "height": 24,
+              },
+            ]
+          }
+        />
+        <Text
+          numberOfLines={3}
+          style={
+            [
+              {
+                "color": "#161617",
+                "fontFamily": "Montserrat-Bold",
+                "fontSize": 19,
+                "lineHeight": 30.4,
+              },
+            ]
+          }
+        >
+          C’est noté ! Maintenant, quel est ton âge précis ?
+        </Text>
+        <View
+          numberOfSpaces={4}
+          style={
+            [
+              {
+                "height": 16,
+              },
+            ]
+          }
+        />
+        <View
+          accessibilityRole="list"
+          style={
+            [
+              {
+                "flexDirection": "column",
+                "paddingLeft": 0,
+                "width": "100%",
+              },
+            ]
+          }
+        >
+          <View
+            accessibilityRole="none"
+            style={
+              [
+                {
+                  "display": "flex",
+                },
+              ]
+            }
+          >
+            <View
+              accessibilityLabel="J’ai 15 ans"
+              accessibilityRole="link"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                [
+                  [
+                    {
+                      "userSelect": "auto",
+                    },
+                    {},
+                  ],
+                  {
+                    "opacity": 1,
+                  },
+                ]
+              }
+              testID="J’ai 15 ans"
+            >
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "borderColor": "#90949D",
+                      "borderRadius": 7,
+                      "borderStyle": "solid",
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "padding": 16,
+                      "width": "100%",
+                    },
+                    [
+                      {
+                        "paddingVertical": 24,
+                      },
+                    ],
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                        "marginRight": 16,
+                        "textAlign": "start",
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#320096",
+                          "fontFamily": "Montserrat-Bold",
+                          "fontSize": 17,
+                          "lineHeight": 27.2,
+                        },
+                      ]
+                    }
+                  >
+                    J’ai
+                    <Text
+                      style={
+                        [
+                          {
+                            "color": "#320096",
+                            "fontFamily": "Montserrat-Bold",
+                            "fontSize": 19,
+                            "lineHeight": 30.4,
+                          },
+                        ]
+                      }
+                    >
+                       
+                      15
+                       ans
+                    </Text>
+                  </Text>
+                </View>
+                <View>
+                  <View
+                    height={24}
+                    width={24}
+                  >
+                    <Text>
+                      undefined-SVG-Mock
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+            <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "height": 16,
+                  },
+                ]
+              }
+            />
+          </View>
+          <View
+            accessibilityRole="none"
+            style={
+              [
+                {
+                  "display": "flex",
+                },
+              ]
+            }
+          >
+            <View
+              accessibilityLabel="J’ai 16 ans"
+              accessibilityRole="link"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                [
+                  [
+                    {
+                      "userSelect": "auto",
+                    },
+                    {},
+                  ],
+                  {
+                    "opacity": 1,
+                  },
+                ]
+              }
+              testID="J’ai 16 ans"
+            >
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "borderColor": "#90949D",
+                      "borderRadius": 7,
+                      "borderStyle": "solid",
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "padding": 16,
+                      "width": "100%",
+                    },
+                    [
+                      {
+                        "paddingVertical": 24,
+                      },
+                    ],
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                        "marginRight": 16,
+                        "textAlign": "start",
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#320096",
+                          "fontFamily": "Montserrat-Bold",
+                          "fontSize": 17,
+                          "lineHeight": 27.2,
+                        },
+                      ]
+                    }
+                  >
+                    J’ai
+                    <Text
+                      style={
+                        [
+                          {
+                            "color": "#320096",
+                            "fontFamily": "Montserrat-Bold",
+                            "fontSize": 19,
+                            "lineHeight": 30.4,
+                          },
+                        ]
+                      }
+                    >
+                       
+                      16
+                       ans
+                    </Text>
+                  </Text>
+                </View>
+                <View>
+                  <View
+                    height={24}
+                    width={24}
+                  >
+                    <Text>
+                      undefined-SVG-Mock
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+            <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "height": 16,
+                  },
+                ]
+              }
+            />
+          </View>
+          <View
+            accessibilityRole="none"
+            style={
+              [
+                {
+                  "display": "flex",
+                },
+              ]
+            }
+          >
+            <View
+              accessibilityLabel="J’ai 17 ans"
+              accessibilityRole="link"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                [
+                  [
+                    {
+                      "userSelect": "auto",
+                    },
+                    {},
+                  ],
+                  {
+                    "opacity": 1,
+                  },
+                ]
+              }
+              testID="J’ai 17 ans"
+            >
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "borderColor": "#90949D",
+                      "borderRadius": 7,
+                      "borderStyle": "solid",
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "padding": 16,
+                      "width": "100%",
+                    },
+                    [
+                      {
+                        "paddingVertical": 24,
+                      },
+                    ],
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                        "marginRight": 16,
+                        "textAlign": "start",
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#320096",
+                          "fontFamily": "Montserrat-Bold",
+                          "fontSize": 17,
+                          "lineHeight": 27.2,
+                        },
+                      ]
+                    }
+                  >
+                    J’ai
+                    <Text
+                      style={
+                        [
+                          {
+                            "color": "#320096",
+                            "fontFamily": "Montserrat-Bold",
+                            "fontSize": 19,
+                            "lineHeight": 30.4,
+                          },
+                        ]
+                      }
+                    >
+                       
+                      17
+                       ans
+                    </Text>
+                  </Text>
+                </View>
+                <View>
+                  <View
+                    height={24}
+                    width={24}
+                  >
+                    <Text>
+                      undefined-SVG-Mock
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+            <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "height": 16,
+                  },
+                ]
+              }
+            />
+          </View>
+          <View
+            accessibilityRole="none"
+            style={
+              [
+                {
+                  "display": "flex",
+                },
+              ]
+            }
+          >
+            <View
+              accessibilityLabel="J’ai 18 ans"
+              accessibilityRole="link"
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                [
+                  [
+                    {
+                      "userSelect": "auto",
+                    },
+                    {},
+                  ],
+                  {
+                    "opacity": 1,
+                  },
+                ]
+              }
+              testID="J’ai 18 ans"
+            >
+              <View
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "borderColor": "#90949D",
+                      "borderRadius": 7,
+                      "borderStyle": "solid",
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "padding": 16,
+                      "width": "100%",
+                    },
+                    [
+                      {
+                        "paddingVertical": 24,
+                      },
+                    ],
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                        "marginRight": 16,
+                        "textAlign": "start",
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#320096",
+                          "fontFamily": "Montserrat-Bold",
+                          "fontSize": 17,
+                          "lineHeight": 27.2,
+                        },
+                      ]
+                    }
+                  >
+                    J’ai
+                    <Text
+                      style={
+                        [
+                          {
+                            "color": "#320096",
+                            "fontFamily": "Montserrat-Bold",
+                            "fontSize": 19,
+                            "lineHeight": 30.4,
+                          },
+                        ]
+                      }
+                    >
+                       
+                      18
+                       ans
+                    </Text>
+                  </Text>
+                </View>
+                <View>
+                  <View
+                    height={24}
+                    width={24}
+                  >
+                    <Text>
+                      undefined-SVG-Mock
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+            <View
+              numberOfSpaces={4}
+              style={
+                [
+                  {
+                    "height": 16,
+                  },
+                ]
+              }
+            />
+          </View>
+          <View
+            accessibilityRole="none"
+            style={
+              [
+                {
+                  "display": "flex",
+                },
+              ]
+            }
+          />
         </View>
       </View>
       <View

--- a/__snapshots__/features/tutorial/pages/AgeSelection.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/AgeSelection.native.test.tsx.native-snap
@@ -225,7 +225,7 @@ exports[`AgeSelection onboarding should render correctly 1`] = `
             }
           >
             <View
-              accessibilityLabel="j’ai 15 ans"
+              accessibilityLabel="J’ai 15 ans"
               accessibilityRole="link"
               accessibilityState={
                 {
@@ -266,7 +266,7 @@ exports[`AgeSelection onboarding should render correctly 1`] = `
                   },
                 ]
               }
-              testID="j’ai 15 ans"
+              testID="J’ai 15 ans"
             >
               <View
                 style={
@@ -332,7 +332,7 @@ exports[`AgeSelection onboarding should render correctly 1`] = `
                       ]
                     }
                   >
-                    j’ai
+                    J’ai
                     <Text
                       style={
                         [
@@ -385,7 +385,7 @@ exports[`AgeSelection onboarding should render correctly 1`] = `
             }
           >
             <View
-              accessibilityLabel="j’ai 16 ans"
+              accessibilityLabel="J’ai 16 ans"
               accessibilityRole="link"
               accessibilityState={
                 {
@@ -426,7 +426,7 @@ exports[`AgeSelection onboarding should render correctly 1`] = `
                   },
                 ]
               }
-              testID="j’ai 16 ans"
+              testID="J’ai 16 ans"
             >
               <View
                 style={
@@ -492,7 +492,7 @@ exports[`AgeSelection onboarding should render correctly 1`] = `
                       ]
                     }
                   >
-                    j’ai
+                    J’ai
                     <Text
                       style={
                         [
@@ -545,7 +545,7 @@ exports[`AgeSelection onboarding should render correctly 1`] = `
             }
           >
             <View
-              accessibilityLabel="j’ai 17 ans"
+              accessibilityLabel="J’ai 17 ans"
               accessibilityRole="link"
               accessibilityState={
                 {
@@ -586,7 +586,7 @@ exports[`AgeSelection onboarding should render correctly 1`] = `
                   },
                 ]
               }
-              testID="j’ai 17 ans"
+              testID="J’ai 17 ans"
             >
               <View
                 style={
@@ -652,7 +652,7 @@ exports[`AgeSelection onboarding should render correctly 1`] = `
                       ]
                     }
                   >
-                    j’ai
+                    J’ai
                     <Text
                       style={
                         [
@@ -705,7 +705,7 @@ exports[`AgeSelection onboarding should render correctly 1`] = `
             }
           >
             <View
-              accessibilityLabel="j’ai 18 ans"
+              accessibilityLabel="J’ai 18 ans"
               accessibilityRole="link"
               accessibilityState={
                 {
@@ -746,7 +746,7 @@ exports[`AgeSelection onboarding should render correctly 1`] = `
                   },
                 ]
               }
-              testID="j’ai 18 ans"
+              testID="J’ai 18 ans"
             >
               <View
                 style={
@@ -812,7 +812,7 @@ exports[`AgeSelection onboarding should render correctly 1`] = `
                       ]
                     }
                   >
-                    j’ai
+                    J’ai
                     <Text
                       style={
                         [
@@ -865,7 +865,7 @@ exports[`AgeSelection onboarding should render correctly 1`] = `
             }
           >
             <View
-              accessibilityLabel="j’ai moins de 15 ans ou plus de 18 ans"
+              accessibilityLabel="J’ai moins de 15 ans ou plus de 18 ans"
               accessibilityRole="link"
               accessibilityState={
                 {
@@ -906,7 +906,7 @@ exports[`AgeSelection onboarding should render correctly 1`] = `
                   },
                 ]
               }
-              testID="j’ai moins de 15 ans ou plus de 18 ans"
+              testID="J’ai moins de 15 ans ou plus de 18 ans"
             >
               <View
                 style={
@@ -978,7 +978,7 @@ exports[`AgeSelection onboarding should render correctly 1`] = `
                       ]
                     }
                   >
-                    j’ai
+                    J’ai
                      moins de 15 ans ou plus de 18 ans
                   </Text>
                 </View>

--- a/src/features/tutorial/pages/AgeSelection.native.test.tsx
+++ b/src/features/tutorial/pages/AgeSelection.native.test.tsx
@@ -6,6 +6,7 @@ import { TutorialRootStackParamList } from 'features/navigation/RootNavigator/ty
 import * as useGoBack from 'features/navigation/useGoBack'
 import { TutorialTypes } from 'features/tutorial/enums'
 import { analytics } from 'libs/analytics'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { storage } from 'libs/storage'
 import { fireEvent, render, screen, waitFor } from 'tests/utils'
 
@@ -29,6 +30,7 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 describe('AgeSelection', () => {
   beforeEach(async () => {
     await storage.clear('user_age')
+    setFeatureFlags()
   })
 
   describe('onboarding', () => {

--- a/src/features/tutorial/pages/AgeSelection.native.test.tsx
+++ b/src/features/tutorial/pages/AgeSelection.native.test.tsx
@@ -7,6 +7,7 @@ import * as useGoBack from 'features/navigation/useGoBack'
 import { TutorialTypes } from 'features/tutorial/enums'
 import { analytics } from 'libs/analytics'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { storage } from 'libs/storage'
 import { fireEvent, render, screen, waitFor } from 'tests/utils'
 
@@ -28,117 +29,140 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 })
 
 describe('AgeSelection', () => {
-  beforeEach(async () => {
-    await storage.clear('user_age')
-    setFeatureFlags()
-  })
-
-  describe('onboarding', () => {
-    it('should render correctly', () => {
-      renderAgeSelection({ type: TutorialTypes.ONBOARDING })
-
-      expect(screen).toMatchSnapshot()
+  describe('with passForAll feature flag off', () => {
+    beforeEach(async () => {
+      await storage.clear('user_age')
+      setFeatureFlags()
     })
 
-    it.each(AGES)(
-      'should navigate to OnboardingAgeInformation page with params age=%s when pressing "j’ai %s ans"',
-      async (age) => {
+    describe('onboarding', () => {
+      it('should render correctly', () => {
         renderAgeSelection({ type: TutorialTypes.ONBOARDING })
 
-        const button = screen.getByText(`${age} ans`)
+        expect(screen).toMatchSnapshot()
+      })
+
+      it.each(AGES)(
+        'should navigate to OnboardingAgeInformation page with params age=%s when pressing "j’ai %s ans"',
+        async (age) => {
+          renderAgeSelection({ type: TutorialTypes.ONBOARDING })
+
+          const button = screen.getByText(`${age} ans`)
+          fireEvent.press(button)
+
+          await waitFor(() => {
+            expect(navigate).toHaveBeenCalledWith('OnboardingAgeInformation', { age })
+          })
+        }
+      )
+
+      it('should navigate to AgeSelectionOther page when pressing "Autre"', async () => {
+        useRoute.mockReturnValueOnce({ params: { type: TutorialTypes.ONBOARDING } })
+        renderAgeSelection({ type: TutorialTypes.ONBOARDING })
+
+        const button = screen.getByText('Autre')
         fireEvent.press(button)
 
         await waitFor(() => {
-          expect(navigate).toHaveBeenCalledWith('OnboardingAgeInformation', { age })
-        })
-      }
-    )
-
-    it('should navigate to AgeSelectionOther page when pressing "Autre"', async () => {
-      useRoute.mockReturnValueOnce({ params: { type: TutorialTypes.ONBOARDING } })
-      renderAgeSelection({ type: TutorialTypes.ONBOARDING })
-
-      const button = screen.getByText('Autre')
-      fireEvent.press(button)
-
-      await waitFor(() => {
-        expect(navigate).toHaveBeenCalledWith('AgeSelectionOther', {
-          type: TutorialTypes.ONBOARDING,
-        })
-      })
-    })
-
-    it.each(AGES)('should log analytics with params age=%s when pressing "j’ai %s ans"', (age) => {
-      renderAgeSelection({ type: TutorialTypes.ONBOARDING })
-
-      const button = screen.getByText(`${age} ans`)
-      fireEvent.press(button)
-
-      expect(analytics.logSelectAge).toHaveBeenCalledWith({
-        age: age,
-        from: TutorialTypes.ONBOARDING,
-      })
-    })
-
-    it('should log analytics when pressing "Autre"', () => {
-      renderAgeSelection({ type: TutorialTypes.ONBOARDING })
-
-      const button = screen.getByText('Autre')
-      fireEvent.press(button)
-
-      expect(analytics.logSelectAge).toHaveBeenCalledWith({
-        age: 'other',
-        from: TutorialTypes.ONBOARDING,
-      })
-    })
-
-    it.each(AGES)(
-      'should set user age to %s in local storage  when pressing "j’ai %s ans"',
-      async (age) => {
-        renderAgeSelection({ type: TutorialTypes.ONBOARDING })
-
-        const button = screen.getByText(`${age} ans`)
-        fireEvent.press(button)
-
-        const userAge = await storage.readObject('user_age')
-
-        expect(userAge).toBe(age)
-      }
-    )
-  })
-
-  describe('profileTutorial', () => {
-    it('should render correctly', () => {
-      renderAgeSelection({ type: TutorialTypes.PROFILE_TUTORIAL })
-
-      expect(screen).toMatchSnapshot()
-    })
-
-    it.each(AGES)(
-      'should navigate to ProfileTutorialAgeInformation page with params age=%s when pressing "à %s ans"',
-      async (age) => {
-        renderAgeSelection({ type: TutorialTypes.PROFILE_TUTORIAL })
-
-        const button = screen.getByText(`à ${age} ans`)
-        fireEvent.press(button)
-
-        await waitFor(() => {
-          expect(navigate).toHaveBeenCalledWith('ProfileTutorialAgeInformation', {
-            age,
+          expect(navigate).toHaveBeenCalledWith('AgeSelectionOther', {
+            type: TutorialTypes.ONBOARDING,
           })
         })
-      }
-    )
+      })
 
-    it.each(AGES)('should log analytics with params age=%s when pressing "j’ai %s ans"', (age) => {
-      renderAgeSelection({ type: TutorialTypes.PROFILE_TUTORIAL })
+      it.each(AGES)(
+        'should log analytics with params age=%s when pressing "j’ai %s ans"',
+        (age) => {
+          renderAgeSelection({ type: TutorialTypes.ONBOARDING })
 
-      const button = screen.getByText(`${age} ans`)
-      fireEvent.press(button)
+          const button = screen.getByText(`${age} ans`)
+          fireEvent.press(button)
 
-      expect(analytics.logSelectAge).toHaveBeenCalledWith({
-        age: age,
-        from: TutorialTypes.PROFILE_TUTORIAL,
+          expect(analytics.logSelectAge).toHaveBeenCalledWith({
+            age: age,
+            from: TutorialTypes.ONBOARDING,
+          })
+        }
+      )
+
+      it('should log analytics when pressing "Autre"', () => {
+        renderAgeSelection({ type: TutorialTypes.ONBOARDING })
+
+        const button = screen.getByText('Autre')
+        fireEvent.press(button)
+
+        expect(analytics.logSelectAge).toHaveBeenCalledWith({
+          age: 'other',
+          from: TutorialTypes.ONBOARDING,
+        })
+      })
+
+      it.each(AGES)(
+        'should set user age to %s in local storage  when pressing "j’ai %s ans"',
+        async (age) => {
+          renderAgeSelection({ type: TutorialTypes.ONBOARDING })
+
+          const button = screen.getByText(`${age} ans`)
+          fireEvent.press(button)
+
+          const userAge = await storage.readObject('user_age')
+
+          expect(userAge).toBe(age)
+        }
+      )
+    })
+
+    describe('profileTutorial', () => {
+      it('should render correctly', () => {
+        renderAgeSelection({ type: TutorialTypes.PROFILE_TUTORIAL })
+
+        expect(screen).toMatchSnapshot()
+      })
+
+      it.each(AGES)(
+        'should navigate to ProfileTutorialAgeInformation page with params age=%s when pressing "à %s ans"',
+        async (age) => {
+          renderAgeSelection({ type: TutorialTypes.PROFILE_TUTORIAL })
+
+          const button = screen.getByText(`à ${age} ans`)
+          fireEvent.press(button)
+
+          await waitFor(() => {
+            expect(navigate).toHaveBeenCalledWith('ProfileTutorialAgeInformation', {
+              age,
+            })
+          })
+        }
+      )
+
+      it.each(AGES)(
+        'should log analytics with params age=%s when pressing "j’ai %s ans"',
+        (age) => {
+          renderAgeSelection({ type: TutorialTypes.PROFILE_TUTORIAL })
+
+          const button = screen.getByText(`${age} ans`)
+          fireEvent.press(button)
+
+          expect(analytics.logSelectAge).toHaveBeenCalledWith({
+            age: age,
+            from: TutorialTypes.PROFILE_TUTORIAL,
+          })
+        }
+      )
+    })
+  })
+
+  describe('with passForAll feature flag on', () => {
+    beforeEach(async () => {
+      await storage.clear('user_age')
+      setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_PASS_FOR_ALL])
+    })
+
+    describe('onboarding', () => {
+      it('should render correctly', () => {
+        renderAgeSelection({ type: TutorialTypes.ONBOARDING })
+
+        expect(screen).toMatchSnapshot()
       })
     })
   })

--- a/src/features/tutorial/pages/AgeSelection.tsx
+++ b/src/features/tutorial/pages/AgeSelection.tsx
@@ -8,6 +8,8 @@ import { TutorialTypes } from 'features/tutorial/enums'
 import { TutorialPage } from 'features/tutorial/pages/TutorialPage'
 import { EligibleAges } from 'features/tutorial/types'
 import { analytics } from 'libs/analytics'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { storage } from 'libs/storage'
 import { AccessibleUnorderedList } from 'ui/components/accessibility/AccessibleUnorderedList'
 import { All } from 'ui/svg/icons/bicolor/All'
@@ -32,6 +34,8 @@ const onBeforeNavigate = async (type: TutorialTypes, age?: EligibleAges) => {
 }
 
 export const AgeSelection: FunctionComponent<Props> = ({ route }: Props) => {
+  const isPassForAllEnabled = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_PASS_FOR_ALL)
+
   const type = route.params.type
 
   const AgeSelectionButtons = ageButtons.map(({ age }) => {
@@ -45,7 +49,7 @@ export const AgeSelection: FunctionComponent<Props> = ({ route }: Props) => {
       return (
         <AgeButton
           key={age}
-          Icon={<BicolorAll />}
+          Icon={isPassForAllEnabled ? undefined : <BicolorAll />}
           onBeforeNavigate={async () => onBeforeNavigate(type, age)}
           navigateTo={{ screen: AgeInformationScreen, params: { age } }}
           accessibilityLabel={`${startButtonTitle} ${age} ans`}>
@@ -56,28 +60,33 @@ export const AgeSelection: FunctionComponent<Props> = ({ route }: Props) => {
         </AgeButton>
       )
     }
-    return (
-      <AgeButton
-        key="other"
-        dense
-        onBeforeNavigate={async () => onBeforeNavigate(type)}
-        navigateTo={{ screen: 'AgeSelectionOther', params: { type } }}
-        accessibilityLabel={`${startButtonTitle} moins de 15 ans ou plus de 18 ans`}>
-        <Title4Text>Autre</Title4Text>
-        <React.Fragment>
-          <Spacer.Column numberOfSpaces={1} />
-          <StyledBodyAccentXs numberOfLines={2}>
-            {startButtonTitle} moins de 15 ans ou plus de 18 ans
-          </StyledBodyAccentXs>
-        </React.Fragment>
-      </AgeButton>
-    )
+    if (isPassForAllEnabled) {
+      return null
+    } else {
+      return (
+        <AgeButton
+          key="other"
+          dense
+          onBeforeNavigate={async () => onBeforeNavigate(type)}
+          navigateTo={{ screen: 'AgeSelectionOther', params: { type } }}
+          accessibilityLabel={`${startButtonTitle} moins de 15 ans ou plus de 18 ans`}>
+          <Title4Text>Autre</Title4Text>
+          <React.Fragment>
+            <Spacer.Column numberOfSpaces={1} />
+            <StyledBodyAccentXs numberOfLines={2}>
+              {startButtonTitle} moins de 15 ans ou plus de 18 ans
+            </StyledBodyAccentXs>
+          </React.Fragment>
+        </AgeButton>
+      )
+    }
   })
 
   const title =
     type === TutorialTypes.ONBOARDING
       ? 'Pour commencer, peux-tu nous dire ton âge\u00a0?'
       : 'Comment ça marche\u00a0?'
+  const titleForAll = 'C’est noté! Maintenant, quel est ton âge précis?'
 
   const subtitle =
     type === TutorialTypes.ONBOARDING
@@ -85,7 +94,9 @@ export const AgeSelection: FunctionComponent<Props> = ({ route }: Props) => {
       : 'De 15 à 18 ans, le pass Culture offre un crédit à dépenser dans l’application pour des activités culturelles.'
 
   return (
-    <TutorialPage title={title} subtitle={subtitle}>
+    <TutorialPage
+      title={isPassForAllEnabled ? titleForAll : title}
+      subtitle={isPassForAllEnabled ? undefined : subtitle}>
       <AccessibleUnorderedList
         items={AgeSelectionButtons}
         Separator={<Spacer.Column numberOfSpaces={4} />}

--- a/src/features/tutorial/pages/AgeSelection.tsx
+++ b/src/features/tutorial/pages/AgeSelection.tsx
@@ -40,7 +40,7 @@ export const AgeSelection: FunctionComponent<Props> = ({ route }: Props) => {
 
   const AgeSelectionButtons = ageButtons.map(({ age }) => {
     const isOnboarding = type === TutorialTypes.ONBOARDING
-    const startButtonTitle = isOnboarding ? 'j’ai' : 'à'
+    const startButtonTitle = isOnboarding ? 'J’ai' : 'à'
     const AgeInformationScreen = isOnboarding
       ? 'OnboardingAgeInformation'
       : 'ProfileTutorialAgeInformation'

--- a/src/features/tutorial/pages/AgeSelection.tsx
+++ b/src/features/tutorial/pages/AgeSelection.tsx
@@ -86,7 +86,7 @@ export const AgeSelection: FunctionComponent<Props> = ({ route }: Props) => {
     type === TutorialTypes.ONBOARDING
       ? 'Pour commencer, peux-tu nous dire ton âge\u00a0?'
       : 'Comment ça marche\u00a0?'
-  const titleForAll = 'C’est noté! Maintenant, quel est ton âge précis?'
+  const titleForAll = 'C’est noté\u00a0! Maintenant, quel est ton âge précis\u00a0?'
 
   const subtitle =
     type === TutorialTypes.ONBOARDING

--- a/src/features/tutorial/pages/AgeSelection.web.test.tsx
+++ b/src/features/tutorial/pages/AgeSelection.web.test.tsx
@@ -3,11 +3,18 @@ import React from 'react'
 
 import { TutorialRootStackParamList } from 'features/navigation/RootNavigator/types'
 import { TutorialTypes } from 'features/tutorial/enums'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { render, checkAccessibilityFor } from 'tests/utils/web'
 
 import { AgeSelection } from './AgeSelection'
 
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services') // I had to add this mock after adding the usage of useFeatureFlag to the AgeSelection screen, but I have no idea why?
+
 describe('<AgeSelection/>', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Accessibility', () => {
     it('should not have basic accessibility issues for onboarding tutorial', async () => {
       const { container } = renderAgeSelection({ type: TutorialTypes.ONBOARDING })

--- a/src/libs/firebase/firestore/types.ts
+++ b/src/libs/firebase/firestore/types.ts
@@ -35,6 +35,7 @@ export enum RemoteStoreFeatureFlags {
   ENABLE_ACHIEVEMENTS = 'enableAchievements',
   ENABLE_CULTURAL_SURVEY_MANDATORY = 'enableCulturalSurveyMandatory',
   ENABLE_PACIFIC_FRANC_CURRENCY = 'enablePacificFrancCurrency',
+  ENABLE_PASS_FOR_ALL = 'enablePassForAll',
   ENABLE_REPLICA_ALGOLIA_INDEX = 'enableReplicaAlgoliaIndex',
   FAKE_DOOR_ARTIST = 'fakeDoorArtist',
   TARGET_XP_CINE_FROM_OFFER = 'targetXpCineFromOffer',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33471

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |  ![image](https://github.com/user-attachments/assets/249bd2a5-98f6-4b88-ad75-cea87194b7c2) | ![image](https://github.com/user-attachments/assets/03607fca-352c-4112-a6d3-8dd9a203065d) |
| Android          |  ![image](https://github.com/user-attachments/assets/56c605c4-0f3f-45b7-9133-afa5ca43538c) |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
