### PR TITLE
(PC-33548) fix(venueMap): VenueMap layout + centering method

### DIFF
--- a/src/features/home/components/modules/video/VideoCarouselModule.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoCarouselModule.native.test.tsx
@@ -17,7 +17,7 @@ import { analytics } from 'libs/analytics'
 import { ContentTypes } from 'libs/contentful/types'
 import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { act, render, screen, userEvent, waitFor } from 'tests/utils'
 
 jest.mock('libs/firebase/analytics/analytics')
 
@@ -32,7 +32,18 @@ const DEFAULT_ITEM_WITH_TAG = videoCarouselModuleFixture.items[1]
 const DEFAULT_ITEM_WITH_HOME_ENTRY_ID = videoCarouselModuleFixture.items[2]
 const MOCKED_ALGOLIA_RESPONSE_OFFER = mockedAlgoliaResponse.hits[0]
 
-describe('<VideoCarouselModule />', () => {
+// Unskip when it's working in CI
+describe.skip('<VideoCarouselModule />', () => {
+  const user = userEvent.setup()
+
+  beforeAll(() => {
+    jest.useFakeTimers()
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
   beforeEach(() => {
     MockedYouTubePlayer.setPlayerState(PLAYER_STATES.UNSTARTED)
     MockedYouTubePlayer.setError(false)
@@ -142,7 +153,7 @@ describe('<VideoCarouselModule />', () => {
     await screen.findByText(MOCKED_ALGOLIA_RESPONSE_OFFER.offer.name)
 
     const attachedOfferButton = screen.getByText(THEMATIC_HOME_TITLE)
-    fireEvent.press(attachedOfferButton)
+    await act(() => user.press(attachedOfferButton))
 
     expect(navigate).toHaveBeenCalledWith('ThematicHome', {
       homeId: HOME_ENTRY_ID,
@@ -164,7 +175,7 @@ describe('<VideoCarouselModule />', () => {
     })
 
     const attachedOfferButton = await screen.findByText(OFFER_NAME)
-    await act(async () => fireEvent.press(attachedOfferButton))
+    await act(async () => user.press(attachedOfferButton))
 
     expect(navigate).toHaveBeenCalledWith('Offer', {
       id: +OFFER_ID,
@@ -197,7 +208,7 @@ describe('<VideoCarouselModule />', () => {
       const nextVideoButton = await screen.findByRole(AccessibilityRole.BUTTON, {
         name: VideoPlayerButtonsWording.NEXT_VIDEO,
       })
-      await act(async () => fireEvent.press(nextVideoButton))
+      await act(async () => user.press(nextVideoButton))
 
       await waitFor(() => {
         expect(analytics.logConsultVideo).toHaveBeenNthCalledWith(1, {
@@ -221,7 +232,7 @@ describe('<VideoCarouselModule />', () => {
       })
 
       const attachedOfferButton = await screen.findByText(OFFER_NAME)
-      await act(async () => fireEvent.press(attachedOfferButton))
+      await act(async () => user.press(attachedOfferButton))
 
       expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {
         offerId: +OFFER_ID,

--- a/src/features/home/components/modules/video/VideoCarouselModule.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoCarouselModule.native.test.tsx
@@ -17,7 +17,7 @@ import { analytics } from 'libs/analytics'
 import { ContentTypes } from 'libs/contentful/types'
 import * as useFeatureFlagAPI from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, render, screen, userEvent, waitFor } from 'tests/utils'
+import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
 
 jest.mock('libs/firebase/analytics/analytics')
 
@@ -32,18 +32,7 @@ const DEFAULT_ITEM_WITH_TAG = videoCarouselModuleFixture.items[1]
 const DEFAULT_ITEM_WITH_HOME_ENTRY_ID = videoCarouselModuleFixture.items[2]
 const MOCKED_ALGOLIA_RESPONSE_OFFER = mockedAlgoliaResponse.hits[0]
 
-// Unskip when it's working in CI
-describe.skip('<VideoCarouselModule />', () => {
-  const user = userEvent.setup()
-
-  beforeAll(() => {
-    jest.useFakeTimers()
-  })
-
-  afterAll(() => {
-    jest.useRealTimers()
-  })
-
+describe('<VideoCarouselModule />', () => {
   beforeEach(() => {
     MockedYouTubePlayer.setPlayerState(PLAYER_STATES.UNSTARTED)
     MockedYouTubePlayer.setError(false)
@@ -153,7 +142,7 @@ describe.skip('<VideoCarouselModule />', () => {
     await screen.findByText(MOCKED_ALGOLIA_RESPONSE_OFFER.offer.name)
 
     const attachedOfferButton = screen.getByText(THEMATIC_HOME_TITLE)
-    await act(() => user.press(attachedOfferButton))
+    fireEvent.press(attachedOfferButton)
 
     expect(navigate).toHaveBeenCalledWith('ThematicHome', {
       homeId: HOME_ENTRY_ID,
@@ -175,7 +164,7 @@ describe.skip('<VideoCarouselModule />', () => {
     })
 
     const attachedOfferButton = await screen.findByText(OFFER_NAME)
-    await act(async () => user.press(attachedOfferButton))
+    await act(async () => fireEvent.press(attachedOfferButton))
 
     expect(navigate).toHaveBeenCalledWith('Offer', {
       id: +OFFER_ID,
@@ -208,7 +197,7 @@ describe.skip('<VideoCarouselModule />', () => {
       const nextVideoButton = await screen.findByRole(AccessibilityRole.BUTTON, {
         name: VideoPlayerButtonsWording.NEXT_VIDEO,
       })
-      await act(async () => user.press(nextVideoButton))
+      await act(async () => fireEvent.press(nextVideoButton))
 
       await waitFor(() => {
         expect(analytics.logConsultVideo).toHaveBeenNthCalledWith(1, {
@@ -232,7 +221,7 @@ describe.skip('<VideoCarouselModule />', () => {
       })
 
       const attachedOfferButton = await screen.findByText(OFFER_NAME)
-      await act(async () => user.press(attachedOfferButton))
+      await act(async () => fireEvent.press(attachedOfferButton))
 
       expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {
         offerId: +OFFER_ID,

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -2,7 +2,7 @@ import { useIsFocused } from '@react-navigation/native'
 import { FlashList } from '@shopify/flash-list'
 import debounce from 'lodash/debounce'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { FlatList, Platform, ScrollView, useWindowDimensions, View } from 'react-native'
+import { FlatList, Platform, ScrollView, View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { AccessibilityFiltersModal } from 'features/accessibility/components/AccessibilityFiltersModal'
@@ -16,7 +16,6 @@ import { FilterButton } from 'features/search/components/Buttons/FilterButton/Fi
 import { SingleFilterButton } from 'features/search/components/Buttons/SingleFilterButton/SingleFilterButton'
 import { NoSearchResult } from 'features/search/components/NoSearchResults/NoSearchResult'
 import { SearchList } from 'features/search/components/SearchList/SearchList'
-import { HEADER_SEARCH_VENUE_MAP } from 'features/search/constants'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { FilterBehaviour } from 'features/search/enums'
 import { getStringifySearchStateWithoutLocation } from 'features/search/helpers/getStringifySearchStateWithoutLocation/getStringifySearchStateWithoutLocation'
@@ -55,7 +54,6 @@ import { Check } from 'ui/svg/icons/Check'
 import { Map } from 'ui/svg/icons/Map'
 import { Sort } from 'ui/svg/icons/Sort'
 import { getSpacing, Spacer } from 'ui/theme'
-import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 import { Helmet } from 'ui/web/global/Helmet'
 
 const ANIMATION_DURATION = 700
@@ -100,9 +98,7 @@ export const SearchResultsContent: React.FC = () => {
     RemoteStoreFeatureFlags.WIP_VENUE_MAP_IN_SEARCH
   )
   const venueMapHiddenPOI = useFeatureFlag(RemoteStoreFeatureFlags.WIP_VENUE_MAP_HIDDEN_POI)
-  const { height } = useWindowDimensions()
-  const { top, tabBarHeight } = useCustomSafeInsets()
-  const venueMapHeight = height - top - tabBarHeight - HEADER_SEARCH_VENUE_MAP
+
   const [isSearchListTab, setIsSearchListTab] = useState(true)
   const [defaultTab, setDefaultTab] = useState(Tab.SEARCHLIST)
   const [tempLocationMode, setTempLocationMode] = useState<LocationMode>(selectedLocationMode)
@@ -336,7 +332,6 @@ export const SearchResultsContent: React.FC = () => {
     [Tab.MAP]:
       selectedLocationMode === LocationMode.EVERYWHERE ? null : (
         <VenueMapView
-          height={venueMapHeight}
           from="searchResults"
           venues={venuesMap}
           selectedVenue={selectedVenue}

--- a/src/features/search/constants.ts
+++ b/src/features/search/constants.ts
@@ -5,5 +5,4 @@ export const LIST_ITEM_HEIGHT = 130
 export const SCROLL_TO_TOP_BUTTON_LINEAR_GRADIENT_START = { x: 0, y: 0 }
 export const SCROLL_TO_TOP_BUTTON_LINEAR_GRADIENT_END = { x: 0, y: 1 }
 export const DEFAULT_RADIUS = 50
-export const HEADER_SEARCH_VENUE_MAP = 212
 export const EVERY_CATEGORIES = 'Toutes les catégories'

--- a/src/features/venueMap/components/FilterBannerContainer/FilterBannerContainer.tsx
+++ b/src/features/venueMap/components/FilterBannerContainer/FilterBannerContainer.tsx
@@ -30,11 +30,7 @@ export const FilterBannerContainer = () => {
 
 const Container = styled.View<{ headerHeight: number }>(({ headerHeight }) => ({
   height: FILTER_BANNER_HEIGHT,
-  position: 'absolute',
-  zIndex: 1,
-  top: headerHeight,
-  left: 0,
-  right: 0,
+  marginTop: headerHeight,
   paddingHorizontal: getSpacing(6),
   paddingVertical: getSpacing(1),
 }))

--- a/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapView.native.test.tsx
@@ -328,7 +328,6 @@ function getVenueMapViewComponent({
 }: RenderVenueMapViewType) {
   return reactQueryProviderHOC(
     <VenueMapView
-      height={700}
       from="venueMap"
       venues={venues}
       selectedVenue={selectedVenue}

--- a/src/features/venueMap/pages/VenueMap/VenueMap.tsx
+++ b/src/features/venueMap/pages/VenueMap/VenueMap.tsx
@@ -1,21 +1,15 @@
 import React, { FunctionComponent } from 'react'
-import { useWindowDimensions } from 'react-native'
 import styled from 'styled-components/native'
 
 import { PlaylistType } from 'features/offer/enums'
 import { VenueMapView } from 'features/venueMap/components/VenueMapView/VenueMapView'
-import { FILTER_BANNER_HEIGHT } from 'features/venueMap/constant'
 import { useVenuesMapData } from 'features/venueMap/hook/useVenuesMapData'
 import { VenueMapBase } from 'features/venueMap/pages/VenueMap/VenueMapBase'
 import { useInitialVenues } from 'features/venueMap/store/initialVenuesStore'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import { useGetHeaderHeight } from 'ui/components/headers/PageHeaderWithoutPlaceholder'
 
 export const VenueMap: FunctionComponent = () => {
-  const headerHeight = useGetHeaderHeight()
-  const { height } = useWindowDimensions()
-  const venueMapHeight = height - (headerHeight + FILTER_BANNER_HEIGHT)
   const venueMapHiddenPOI = useFeatureFlag(RemoteStoreFeatureFlags.WIP_VENUE_MAP_HIDDEN_POI)
 
   const initialVenues = useInitialVenues()
@@ -34,7 +28,6 @@ export const VenueMap: FunctionComponent = () => {
     <VenueMapBase>
       <MapContainer>
         <VenueMapView
-          height={venueMapHeight}
           from="venueMap"
           venues={venuesMap}
           selectedVenue={selectedVenue}

--- a/src/features/venueMap/pages/VenueMap/VenueMapBase.tsx
+++ b/src/features/venueMap/pages/VenueMap/VenueMapBase.tsx
@@ -4,18 +4,12 @@ import styled from 'styled-components/native'
 import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { FilterBannerContainer } from 'features/venueMap/components/FilterBannerContainer/FilterBannerContainer'
-import { FILTER_BANNER_HEIGHT } from 'features/venueMap/constant'
 import { useVenueTypeCodeActions } from 'features/venueMap/store/venueTypeCodeStore'
-import {
-  PageHeaderWithoutPlaceholder,
-  useGetHeaderHeight,
-} from 'ui/components/headers/PageHeaderWithoutPlaceholder'
+import { PageHeaderWithoutPlaceholder } from 'ui/components/headers/PageHeaderWithoutPlaceholder'
 
 export const VenueMapBase: FunctionComponent<PropsWithChildren> = ({ children }) => {
   const { goBack } = useGoBack(...getSearchStackConfig('SearchLanding'))
   const { setVenueTypeCode } = useVenueTypeCodeActions()
-
-  const headerHeight = useGetHeaderHeight()
 
   const handleGoBack = () => {
     setVenueTypeCode(null)
@@ -25,7 +19,6 @@ export const VenueMapBase: FunctionComponent<PropsWithChildren> = ({ children })
   return (
     <Container>
       <StyledHeader title="Carte des lieux" onGoBack={handleGoBack} />
-      <PlaceHolder headerHeight={headerHeight + FILTER_BANNER_HEIGHT} />
       <FilterBannerContainer />
       {children}
     </Container>
@@ -38,8 +31,4 @@ const Container = styled.View({
 
 const StyledHeader = styled(PageHeaderWithoutPlaceholder)(({ theme }) => ({
   backgroundColor: theme.colors.white,
-}))
-
-const PlaceHolder = styled.View<{ headerHeight: number }>(({ headerHeight }) => ({
-  height: headerHeight,
 }))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33548

Fix sur la hauteur de la map qui ne prenait pas tout l'espace disponible.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
