### PR TITLE
(PC-33463) refactor(Venue): refacto Venue page

### DIFF
--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -38,6 +38,7 @@ exports[`<Venue /> should match snapshot 1`] = `
           [
             {
               "flexDirection": "column",
+              "marginBottom": 24,
               "marginHorizontal": 0,
               "marginTop": 0,
             },
@@ -199,10 +200,9 @@ exports[`<Venue /> should match snapshot 1`] = `
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 16,
-                          "lineHeight": 25.6,
-                          "maxWidth": "100%",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -452,8 +452,8 @@ exports[`<Venue /> should match snapshot 1`] = `
                             {
                               "color": "#161617",
                               "fontFamily": "Montserrat-Bold",
-                              "fontSize": 15,
-                              "lineHeight": 20,
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
                               "maxWidth": "100%",
                             },
                           ]
@@ -548,13 +548,66 @@ exports[`<Venue /> should match snapshot 1`] = `
                 }
               >
                 <View
-                  gap={1}
                   style={
                     [
                       {
-                        "gap": 4,
+                        "backgroundColor": "#F1F1F4",
+                        "bottom": 0,
+                        "height": 4,
+                        "position": "absolute",
+                        "width": "100%",
                       },
                     ]
+                  }
+                />
+                <View
+                  numberOfSpaces={6}
+                  style={
+                    [
+                      {
+                        "width": 24,
+                      },
+                    ]
+                  }
+                />
+                <View
+                  accessibilityRole="tab"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": true,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "flexBasis": 0,
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                      "maxWidth": 180,
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
                   }
                 >
                   <View
@@ -683,986 +736,8 @@ exports[`<Venue /> should match snapshot 1`] = `
                         ]
                       }
                     >
-                      <View>
-                        <View
-                          style={
-                            {
-                              "flexDirection": "row",
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              {
-                                "paddingLeft": 0,
-                                "paddingTop": 0,
-                              }
-                            }
-                          />
-                          <View
-                            style={
-                              [
-                                undefined,
-                                undefined,
-                              ]
-                            }
-                          >
-                            <View
-                              style={
-                                [
-                                  {
-                                    "width": 24,
-                                  },
-                                ]
-                              }
-                              width={24}
-                            />
-                          </View>
-                          <AutoLayoutView
-                            enableInstrumentation={false}
-                            horizontal={true}
-                            onBlankAreaEvent={[Function]}
-                            onLayout={[Function]}
-                            renderAheadOffset={0}
-                            scrollOffset={0}
-                            style={
-                              {
-                                "height": 250,
-                                "width": 432,
-                              }
-                            }
-                            windowSize={800}
-                          >
-                            <CellContainer
-                              index={1}
-                              onLayout={[Function]}
-                              style={
-                                {
-                                  "alignItems": "stretch",
-                                  "flexDirection": "row",
-                                  "height": 250,
-                                  "left": 144,
-                                  "position": "absolute",
-                                  "top": 0,
-                                }
-                              }
-                            >
-                              <View
-                                style={
-                                  {
-                                    "flexDirection": "column",
-                                  }
-                                }
-                              >
-                                <View>
-                                  <View
-                                    accessibilityLabel="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
-                                    accessibilityRole="link"
-                                    accessibilityValue={
-                                      {
-                                        "max": undefined,
-                                        "min": undefined,
-                                        "now": undefined,
-                                        "text": undefined,
-                                      }
-                                    }
-                                    accessible={true}
-                                    focusable={true}
-                                    onClick={[Function]}
-                                    onResponderGrant={[Function]}
-                                    onResponderMove={[Function]}
-                                    onResponderRelease={[Function]}
-                                    onResponderTerminate={[Function]}
-                                    onResponderTerminationRequest={[Function]}
-                                    onStartShouldSetResponder={[Function]}
-                                    style={
-                                      [
-                                        {
-                                          "textDecorationColor": "black",
-                                          "textDecorationLine": "none",
-                                          "textDecorationStyle": "solid",
-                                        },
-                                        {
-                                          "borderRadius": 8,
-                                          "height": 344,
-                                          "marginVertical": 4,
-                                        },
-                                      ]
-                                    }
-                                    testID="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
-                                  >
-                                    <View
-                                      gap={2}
-                                      maxWidth={144}
-                                      style={
-                                        [
-                                          {
-                                            "flexDirection": "column-reverse",
-                                            "gap": 8,
-                                            "maxWidth": 144,
-                                          },
-                                        ]
-                                      }
-                                    >
-                                      <View
-                                        gap={1}
-                                        style={
-                                          [
-                                            {
-                                              "gap": 4,
-                                            },
-                                          ]
-                                        }
-                                      >
-                                        <Text
-                                          numberOfLines={1}
-                                          style={
-                                            [
-                                              {
-                                                "color": "#696A6F",
-                                                "fontFamily": "Montserrat-SemiBold",
-                                                "fontSize": 12,
-                                                "lineHeight": 19.2,
-                                              },
-                                            ]
-                                          }
-                                        >
-                                          Cinéma
-                                        </Text>
-                                        <View>
-                                          <Text
-                                            numberOfLines={2}
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#161617",
-                                                  "fontFamily": "Montserrat-SemiBold",
-                                                  "fontSize": 12,
-                                                  "lineHeight": 19.2,
-                                                },
-                                              ]
-                                            }
-                                          >
-                                            Bac Nord - VF
-                                          </Text>
-                                          <Text
-                                            numberOfLines={1}
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#161617",
-                                                  "fontFamily": "Montserrat-SemiBold",
-                                                  "fontSize": 12,
-                                                  "lineHeight": 19.2,
-                                                },
-                                              ]
-                                            }
-                                          >
-                                            Dès le 18 août 2021
-                                          </Text>
-                                          <Text
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#161617",
-                                                  "fontFamily": "Montserrat-SemiBold",
-                                                  "fontSize": 12,
-                                                  "lineHeight": 19.2,
-                                                },
-                                              ]
-                                            }
-                                            testID="priceIsDuo"
-                                          >
-                                            Gratuit
-                                          </Text>
-                                        </View>
-                                      </View>
-                                      <View
-                                        style={
-                                          [
-                                            {},
-                                          ]
-                                        }
-                                      >
-                                        <View
-                                          style={
-                                            [
-                                              {
-                                                "overflow": "hidden",
-                                              },
-                                              [
-                                                {
-                                                  "backgroundColor": "#F1F1F4",
-                                                },
-                                                {
-                                                  "borderRadius": 8,
-                                                  "height": 216,
-                                                  "width": 144,
-                                                },
-                                              ],
-                                            ]
-                                          }
-                                        >
-                                          <FastImageView
-                                            defaultSource={null}
-                                            resizeMode="cover"
-                                            source={
-                                              {
-                                                "uri": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
-                                              }
-                                            }
-                                            style={
-                                              {
-                                                "bottom": 0,
-                                                "left": 0,
-                                                "position": "absolute",
-                                                "right": 0,
-                                                "top": 0,
-                                              }
-                                            }
-                                            testID="tileImage"
-                                          />
-                                        </View>
-                                      </View>
-                                    </View>
-                                  </View>
-                                </View>
-                              </View>
-                              <View
-                                leadingItem={
-                                  {
-                                    "_geoloc": {
-                                      "lat": 47.8898,
-                                      "lng": -2.83593,
-                                    },
-                                    "objectID": "223338",
-                                    "offer": {
-                                      "dates": [
-                                        1629312300,
-                                        1629485100,
-                                        1629657900,
-                                      ],
-                                      "isDigital": false,
-                                      "isDuo": true,
-                                      "name": "Bac Nord - VF",
-                                      "prices": [
-                                        0,
-                                        0,
-                                        0,
-                                      ],
-                                      "subcategoryId": "CINE_PLEIN_AIR",
-                                      "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
-                                    },
-                                    "venue": {},
-                                  }
-                                }
-                                style={
-                                  [
-                                    {
-                                      "width": 16,
-                                    },
-                                  ]
-                                }
-                                trailingItem={
-                                  {
-                                    "_geoloc": {
-                                      "lat": 47.8898,
-                                      "lng": -2.83593,
-                                    },
-                                    "objectID": "223339",
-                                    "offer": {
-                                      "dates": [
-                                        1629312300,
-                                        1629485100,
-                                        1629657900,
-                                      ],
-                                      "isDigital": false,
-                                      "isDuo": true,
-                                      "name": "Black Widow - VF",
-                                      "prices": [
-                                        0,
-                                        0,
-                                        0,
-                                      ],
-                                      "subcategoryId": "CINE_PLEIN_AIR",
-                                      "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMA",
-                                    },
-                                    "venue": {},
-                                  }
-                                }
-                                width={16}
-                              />
-                            </CellContainer>
-                            <CellContainer
-                              index={2}
-                              onLayout={[Function]}
-                              style={
-                                {
-                                  "alignItems": "stretch",
-                                  "flexDirection": "row",
-                                  "height": 250,
-                                  "left": 288,
-                                  "position": "absolute",
-                                  "top": 0,
-                                }
-                              }
-                            >
-                              <View
-                                style={
-                                  {
-                                    "flexDirection": "column",
-                                  }
-                                }
-                              >
-                                <View>
-                                  <View
-                                    accessibilityLabel="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
-                                    accessibilityRole="link"
-                                    accessibilityValue={
-                                      {
-                                        "max": undefined,
-                                        "min": undefined,
-                                        "now": undefined,
-                                        "text": undefined,
-                                      }
-                                    }
-                                    accessible={true}
-                                    focusable={true}
-                                    onClick={[Function]}
-                                    onResponderGrant={[Function]}
-                                    onResponderMove={[Function]}
-                                    onResponderRelease={[Function]}
-                                    onResponderTerminate={[Function]}
-                                    onResponderTerminationRequest={[Function]}
-                                    onStartShouldSetResponder={[Function]}
-                                    style={
-                                      [
-                                        {
-                                          "textDecorationColor": "black",
-                                          "textDecorationLine": "none",
-                                          "textDecorationStyle": "solid",
-                                        },
-                                        {
-                                          "borderRadius": 8,
-                                          "height": 344,
-                                          "marginVertical": 4,
-                                        },
-                                      ]
-                                    }
-                                    testID="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
-                                  >
-                                    <View
-                                      gap={2}
-                                      maxWidth={144}
-                                      style={
-                                        [
-                                          {
-                                            "flexDirection": "column-reverse",
-                                            "gap": 8,
-                                            "maxWidth": 144,
-                                          },
-                                        ]
-                                      }
-                                    >
-                                      <View
-                                        gap={1}
-                                        style={
-                                          [
-                                            {
-                                              "gap": 4,
-                                            },
-                                          ]
-                                        }
-                                      >
-                                        <Text
-                                          numberOfLines={1}
-                                          style={
-                                            [
-                                              {
-                                                "color": "#696A6F",
-                                                "fontFamily": "Montserrat-SemiBold",
-                                                "fontSize": 12,
-                                                "lineHeight": 19.2,
-                                              },
-                                            ]
-                                          }
-                                        >
-                                          Cinéma
-                                        </Text>
-                                        <View>
-                                          <Text
-                                            numberOfLines={2}
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#161617",
-                                                  "fontFamily": "Montserrat-SemiBold",
-                                                  "fontSize": 12,
-                                                  "lineHeight": 19.2,
-                                                },
-                                              ]
-                                            }
-                                          >
-                                            Black Widow - VF
-                                          </Text>
-                                          <Text
-                                            numberOfLines={1}
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#161617",
-                                                  "fontFamily": "Montserrat-SemiBold",
-                                                  "fontSize": 12,
-                                                  "lineHeight": 19.2,
-                                                },
-                                              ]
-                                            }
-                                          >
-                                            Dès le 18 août 2021
-                                          </Text>
-                                          <Text
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#161617",
-                                                  "fontFamily": "Montserrat-SemiBold",
-                                                  "fontSize": 12,
-                                                  "lineHeight": 19.2,
-                                                },
-                                              ]
-                                            }
-                                            testID="priceIsDuo"
-                                          >
-                                            Gratuit
-                                          </Text>
-                                        </View>
-                                      </View>
-                                      <View
-                                        style={
-                                          [
-                                            {},
-                                          ]
-                                        }
-                                      >
-                                        <View
-                                          style={
-                                            [
-                                              {
-                                                "overflow": "hidden",
-                                              },
-                                              [
-                                                {
-                                                  "backgroundColor": "#F1F1F4",
-                                                },
-                                                {
-                                                  "borderRadius": 8,
-                                                  "height": 216,
-                                                  "width": 144,
-                                                },
-                                              ],
-                                            ]
-                                          }
-                                        >
-                                          <FastImageView
-                                            defaultSource={null}
-                                            resizeMode="cover"
-                                            source={
-                                              {
-                                                "uri": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMA",
-                                              }
-                                            }
-                                            style={
-                                              {
-                                                "bottom": 0,
-                                                "left": 0,
-                                                "position": "absolute",
-                                                "right": 0,
-                                                "top": 0,
-                                              }
-                                            }
-                                            testID="tileImage"
-                                          />
-                                        </View>
-                                      </View>
-                                    </View>
-                                  </View>
-                                </View>
-                              </View>
-                            </CellContainer>
-                            <CellContainer
-                              index={0}
-                              onLayout={[Function]}
-                              style={
-                                {
-                                  "alignItems": "stretch",
-                                  "flexDirection": "row",
-                                  "height": 250,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "top": 0,
-                                }
-                              }
-                            >
-                              <View
-                                style={
-                                  {
-                                    "flexDirection": "column",
-                                  }
-                                }
-                              >
-                                <View>
-                                  <View
-                                    accessibilityLabel="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
-                                    accessibilityRole="link"
-                                    accessibilityValue={
-                                      {
-                                        "max": undefined,
-                                        "min": undefined,
-                                        "now": undefined,
-                                        "text": undefined,
-                                      }
-                                    }
-                                    accessible={true}
-                                    focusable={true}
-                                    onClick={[Function]}
-                                    onResponderGrant={[Function]}
-                                    onResponderMove={[Function]}
-                                    onResponderRelease={[Function]}
-                                    onResponderTerminate={[Function]}
-                                    onResponderTerminationRequest={[Function]}
-                                    onStartShouldSetResponder={[Function]}
-                                    style={
-                                      [
-                                        {
-                                          "textDecorationColor": "black",
-                                          "textDecorationLine": "none",
-                                          "textDecorationStyle": "solid",
-                                        },
-                                        {
-                                          "borderRadius": 8,
-                                          "height": 344,
-                                          "marginVertical": 4,
-                                        },
-                                      ]
-                                    }
-                                    testID="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
-                                  >
-                                    <View
-                                      gap={2}
-                                      maxWidth={144}
-                                      style={
-                                        [
-                                          {
-                                            "flexDirection": "column-reverse",
-                                            "gap": 8,
-                                            "maxWidth": 144,
-                                          },
-                                        ]
-                                      }
-                                    >
-                                      <View
-                                        gap={1}
-                                        style={
-                                          [
-                                            {
-                                              "gap": 4,
-                                            },
-                                          ]
-                                        }
-                                      >
-                                        <Text
-                                          numberOfLines={1}
-                                          style={
-                                            [
-                                              {
-                                                "color": "#696A6F",
-                                                "fontFamily": "Montserrat-SemiBold",
-                                                "fontSize": 12,
-                                                "lineHeight": 19.2,
-                                              },
-                                            ]
-                                          }
-                                        >
-                                          Cinéma
-                                        </Text>
-                                        <View>
-                                          <Text
-                                            numberOfLines={2}
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#161617",
-                                                  "fontFamily": "Montserrat-SemiBold",
-                                                  "fontSize": 12,
-                                                  "lineHeight": 19.2,
-                                                },
-                                              ]
-                                            }
-                                          >
-                                            Titane - VF
-                                          </Text>
-                                          <Text
-                                            numberOfLines={1}
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#161617",
-                                                  "fontFamily": "Montserrat-SemiBold",
-                                                  "fontSize": 12,
-                                                  "lineHeight": 19.2,
-                                                },
-                                              ]
-                                            }
-                                          >
-                                            Dès le 18 août 2021
-                                          </Text>
-                                          <Text
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#161617",
-                                                  "fontFamily": "Montserrat-SemiBold",
-                                                  "fontSize": 12,
-                                                  "lineHeight": 19.2,
-                                                },
-                                              ]
-                                            }
-                                            testID="priceIsDuo"
-                                          >
-                                            Gratuit
-                                          </Text>
-                                        </View>
-                                      </View>
-                                      <View
-                                        style={
-                                          [
-                                            {},
-                                          ]
-                                        }
-                                      >
-                                        <View
-                                          style={
-                                            [
-                                              {
-                                                "overflow": "hidden",
-                                              },
-                                              [
-                                                {
-                                                  "backgroundColor": "#F1F1F4",
-                                                },
-                                                {
-                                                  "borderRadius": 8,
-                                                  "height": 216,
-                                                  "width": 144,
-                                                },
-                                              ],
-                                            ]
-                                          }
-                                        >
-                                          <FastImageView
-                                            defaultSource={null}
-                                            resizeMode="cover"
-                                            source={
-                                              {
-                                                "uri": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
-                                              }
-                                            }
-                                            style={
-                                              {
-                                                "bottom": 0,
-                                                "left": 0,
-                                                "position": "absolute",
-                                                "right": 0,
-                                                "top": 0,
-                                              }
-                                            }
-                                            testID="tileImage"
-                                          />
-                                        </View>
-                                      </View>
-                                    </View>
-                                  </View>
-                                </View>
-                              </View>
-                              <View
-                                leadingItem={
-                                  {
-                                    "_geoloc": {
-                                      "lat": 47.8898,
-                                      "lng": -2.83593,
-                                    },
-                                    "objectID": "223342",
-                                    "offer": {
-                                      "dates": [
-                                        1629312300,
-                                        1629485100,
-                                        1629657900,
-                                      ],
-                                      "isDigital": false,
-                                      "isDuo": true,
-                                      "name": "Titane - VF",
-                                      "prices": [
-                                        0,
-                                        0,
-                                        0,
-                                      ],
-                                      "subcategoryId": "CINE_PLEIN_AIR",
-                                      "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
-                                    },
-                                    "venue": {},
-                                  }
-                                }
-                                style={
-                                  [
-                                    {
-                                      "width": 16,
-                                    },
-                                  ]
-                                }
-                                trailingItem={
-                                  {
-                                    "_geoloc": {
-                                      "lat": 47.8898,
-                                      "lng": -2.83593,
-                                    },
-                                    "objectID": "223338",
-                                    "offer": {
-                                      "dates": [
-                                        1629312300,
-                                        1629485100,
-                                        1629657900,
-                                      ],
-                                      "isDigital": false,
-                                      "isDuo": true,
-                                      "name": "Bac Nord - VF",
-                                      "prices": [
-                                        0,
-                                        0,
-                                        0,
-                                      ],
-                                      "subcategoryId": "CINE_PLEIN_AIR",
-                                      "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
-                                    },
-                                    "venue": {},
-                                  }
-                                }
-                                width={16}
-                              />
-                            </CellContainer>
-                          </AutoLayoutView>
-                          <CellContainer
-                            index={-1}
-                            style={
-                              [
-                                undefined,
-                                undefined,
-                              ]
-                            }
-                          >
-                            <View
-                              style={
-                                [
-                                  {
-                                    "width": 24,
-                                  },
-                                ]
-                              }
-                              width={24}
-                            />
-                          </CellContainer>
-                          <View
-                            style={
-                              {
-                                "paddingBottom": 0,
-                                "paddingRight": 0,
-                              }
-                            }
-                          />
-                          <View
-                            pointerEvents="none"
-                            style={
-                              {
-                                "opacity": 0,
-                              }
-                            }
-                          >
-                            <View>
-                              <View
-                                accessibilityLabel="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
-                                accessibilityRole="link"
-                                accessibilityValue={
-                                  {
-                                    "max": undefined,
-                                    "min": undefined,
-                                    "now": undefined,
-                                    "text": undefined,
-                                  }
-                                }
-                                accessible={true}
-                                focusable={true}
-                                onClick={[Function]}
-                                onResponderGrant={[Function]}
-                                onResponderMove={[Function]}
-                                onResponderRelease={[Function]}
-                                onResponderTerminate={[Function]}
-                                onResponderTerminationRequest={[Function]}
-                                onStartShouldSetResponder={[Function]}
-                                style={
-                                  [
-                                    {
-                                      "textDecorationColor": "black",
-                                      "textDecorationLine": "none",
-                                      "textDecorationStyle": "solid",
-                                    },
-                                    {
-                                      "borderRadius": 8,
-                                      "height": 344,
-                                      "marginVertical": 4,
-                                    },
-                                  ]
-                                }
-                                testID="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
-                              >
-                                <View
-                                  gap={2}
-                                  maxWidth={144}
-                                  style={
-                                    [
-                                      {
-                                        "flexDirection": "column-reverse",
-                                        "gap": 8,
-                                        "maxWidth": 144,
-                                      },
-                                    ]
-                                  }
-                                >
-                                  <View
-                                    gap={1}
-                                    style={
-                                      [
-                                        {
-                                          "gap": 4,
-                                        },
-                                      ]
-                                    }
-                                  >
-                                    <Text
-                                      numberOfLines={1}
-                                      style={
-                                        [
-                                          {
-                                            "color": "#696A6F",
-                                            "fontFamily": "Montserrat-SemiBold",
-                                            "fontSize": 12,
-                                            "lineHeight": 19.2,
-                                          },
-                                        ]
-                                      }
-                                    >
-                                      Cinéma
-                                    </Text>
-                                    <View>
-                                      <Text
-                                        numberOfLines={2}
-                                        style={
-                                          [
-                                            {
-                                              "color": "#161617",
-                                              "fontFamily": "Montserrat-SemiBold",
-                                              "fontSize": 12,
-                                              "lineHeight": 19.2,
-                                            },
-                                          ]
-                                        }
-                                      >
-                                        Bac Nord - VF
-                                      </Text>
-                                      <Text
-                                        numberOfLines={1}
-                                        style={
-                                          [
-                                            {
-                                              "color": "#161617",
-                                              "fontFamily": "Montserrat-SemiBold",
-                                              "fontSize": 12,
-                                              "lineHeight": 19.2,
-                                            },
-                                          ]
-                                        }
-                                      >
-                                        Dès le 18 août 2021
-                                      </Text>
-                                      <Text
-                                        style={
-                                          [
-                                            {
-                                              "color": "#161617",
-                                              "fontFamily": "Montserrat-SemiBold",
-                                              "fontSize": 12,
-                                              "lineHeight": 19.2,
-                                            },
-                                          ]
-                                        }
-                                        testID="priceIsDuo"
-                                      >
-                                        Gratuit
-                                      </Text>
-                                    </View>
-                                  </View>
-                                  <View
-                                    style={
-                                      [
-                                        {},
-                                      ]
-                                    }
-                                  >
-                                    <View
-                                      style={
-                                        [
-                                          {
-                                            "overflow": "hidden",
-                                          },
-                                          [
-                                            {
-                                              "backgroundColor": "#F1F1F4",
-                                            },
-                                            {
-                                              "borderRadius": 8,
-                                              "height": 216,
-                                              "width": 144,
-                                            },
-                                          ],
-                                        ]
-                                      }
-                                    >
-                                      <FastImageView
-                                        defaultSource={null}
-                                        resizeMode="cover"
-                                        source={
-                                          {
-                                            "uri": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
-                                          }
-                                        }
-                                        style={
-                                          {
-                                            "bottom": 0,
-                                            "left": 0,
-                                            "position": "absolute",
-                                            "right": 0,
-                                            "top": 0,
-                                          }
-                                        }
-                                        testID="tileImage"
-                                      />
-                                    </View>
-                                  </View>
-                                </View>
-                              </View>
-                            </View>
-                          </View>
-                        </View>
-                      </View>
-                    </RCTScrollView>
+                      Infos pratiques
+                    </Text>
                   </View>
                   <View
                     numberOfSpaces={2}
@@ -2440,7 +1515,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                           },
                                           {
                                             "borderRadius": 8,
-                                            "height": 416,
+                                            "height": 344,
                                             "marginVertical": 4,
                                           },
                                         ]
@@ -2449,13 +1524,13 @@ exports[`<Venue /> should match snapshot 1`] = `
                                     >
                                       <View
                                         gap={2}
-                                        maxWidth={192}
+                                        maxWidth={144}
                                         style={
                                           [
                                             {
                                               "flexDirection": "column-reverse",
                                               "gap": 8,
-                                              "maxWidth": 192,
+                                              "maxWidth": 144,
                                             },
                                           ]
                                         }
@@ -2483,7 +1558,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                               ]
                                             }
                                           >
-                                            Livre
+                                            Cinéma
                                           </Text>
                                           <View>
                                             <Text
@@ -2499,7 +1574,22 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                 ]
                                               }
                                             >
-                                              Test
+                                              Bac Nord - VF
+                                            </Text>
+                                            <Text
+                                              numberOfLines={1}
+                                              style={
+                                                [
+                                                  {
+                                                    "color": "#161617",
+                                                    "fontFamily": "Montserrat-SemiBold",
+                                                    "fontSize": 12,
+                                                    "lineHeight": 19.2,
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              Dès le 18 août 2021
                                             </Text>
                                             <Text
                                               style={
@@ -2513,7 +1603,9 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                 ]
                                               }
                                               testID="priceIsDuo"
-                                            />
+                                            >
+                                              Gratuit
+                                            </Text>
                                           </View>
                                         </View>
                                         <View
@@ -2524,21 +1616,18 @@ exports[`<Venue /> should match snapshot 1`] = `
                                           }
                                         >
                                           <View
-                                            height={288}
                                             style={
                                               [
                                                 {
-                                                  "height": 288,
-                                                  "width": 192,
+                                                  "overflow": "hidden",
                                                 },
                                                 [
                                                   {
                                                     "backgroundColor": "#F1F1F4",
                                                   },
                                                   {
-                                                    "borderTopLeftRadius": 8,
-                                                    "borderTopRightRadius": 8,
-                                                    "height": 192,
+                                                    "borderRadius": 8,
+                                                    "height": 216,
                                                     "width": 144,
                                                   },
                                                 ],
@@ -2550,34 +1639,17 @@ exports[`<Venue /> should match snapshot 1`] = `
                                               resizeMode="cover"
                                               source={
                                                 {
-                                                  "x": 0.5,
-                                                  "y": 1,
-                                                }
-                                              }
-                                              locations={null}
-                                              onlyTopBorderRadius={false}
-                                              startPoint={
-                                                {
-                                                  "x": 0.5,
-                                                  "y": 0,
+                                                  "uri": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
                                                 }
                                               }
                                               style={
-                                                [
-                                                  {
-                                                    "alignItems": "center",
-                                                    "backgroundColor": "#F1F1F4",
-                                                    "borderRadius": 8,
-                                                    "height": "100%",
-                                                    "justifyContent": "center",
-                                                    "width": "100%",
-                                                  },
-                                                  {
-                                                    "borderRadius": 8,
-                                                    "borderTopLeftRadius": 8,
-                                                    "borderTopRightRadius": 8,
-                                                  },
-                                                ]
+                                                {
+                                                  "bottom": 0,
+                                                  "left": 0,
+                                                  "position": "absolute",
+                                                  "right": 0,
+                                                  "top": 0,
+                                                }
                                               }
                                               testID="tileImage"
                                             />
@@ -2703,7 +1775,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                           },
                                           {
                                             "borderRadius": 8,
-                                            "height": 288,
+                                            "height": 344,
                                             "marginVertical": 4,
                                           },
                                         ]
@@ -2711,40 +1783,28 @@ exports[`<Venue /> should match snapshot 1`] = `
                                       testID="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                                     >
                                       <View
+                                        gap={2}
+                                        maxWidth={144}
                                         style={
                                           [
                                             {
                                               "flexDirection": "column-reverse",
+                                              "gap": 8,
+                                              "maxWidth": 144,
                                             },
                                           ]
                                         }
                                       >
                                         <View
-                                          imageWidth={144}
+                                          gap={1}
                                           style={
                                             [
                                               {
-                                                "marginTop": 8,
-                                                "maxWidth": 144,
+                                                "gap": 4,
                                               },
                                             ]
                                           }
                                         >
-                                          <Text
-                                            numberOfLines={2}
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#161617",
-                                                  "fontFamily": "Montserrat-SemiBold",
-                                                  "fontSize": 12,
-                                                  "lineHeight": 19.2,
-                                                },
-                                              ]
-                                            }
-                                          >
-                                            Black Widow - VF
-                                          </Text>
                                           <Text
                                             numberOfLines={1}
                                             style={
@@ -2758,25 +1818,63 @@ exports[`<Venue /> should match snapshot 1`] = `
                                               ]
                                             }
                                           >
-                                            Dès le 18 août 2021
+                                            Cinéma
                                           </Text>
-                                          <Text
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#696A6F",
-                                                  "fontFamily": "Montserrat-SemiBold",
-                                                  "fontSize": 12,
-                                                  "lineHeight": 19.2,
-                                                },
-                                              ]
-                                            }
-                                            testID="priceIsDuo"
-                                          >
-                                            Gratuit
-                                          </Text>
+                                          <View>
+                                            <Text
+                                              numberOfLines={2}
+                                              style={
+                                                [
+                                                  {
+                                                    "color": "#161617",
+                                                    "fontFamily": "Montserrat-SemiBold",
+                                                    "fontSize": 12,
+                                                    "lineHeight": 19.2,
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              Black Widow - VF
+                                            </Text>
+                                            <Text
+                                              numberOfLines={1}
+                                              style={
+                                                [
+                                                  {
+                                                    "color": "#161617",
+                                                    "fontFamily": "Montserrat-SemiBold",
+                                                    "fontSize": 12,
+                                                    "lineHeight": 19.2,
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              Dès le 18 août 2021
+                                            </Text>
+                                            <Text
+                                              style={
+                                                [
+                                                  {
+                                                    "color": "#161617",
+                                                    "fontFamily": "Montserrat-SemiBold",
+                                                    "fontSize": 12,
+                                                    "lineHeight": 19.2,
+                                                  },
+                                                ]
+                                              }
+                                              testID="priceIsDuo"
+                                            >
+                                              Gratuit
+                                            </Text>
+                                          </View>
                                         </View>
-                                        <View>
+                                        <View
+                                          style={
+                                            [
+                                              {},
+                                            ]
+                                          }
+                                        >
                                           <View
                                             style={
                                               [
@@ -2788,9 +1886,8 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                     "backgroundColor": "#F1F1F4",
                                                   },
                                                   {
-                                                    "borderTopLeftRadius": 8,
-                                                    "borderTopRightRadius": 8,
-                                                    "height": 192,
+                                                    "borderRadius": 8,
+                                                    "height": 216,
                                                     "width": 144,
                                                   },
                                                 ],
@@ -2816,55 +1913,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                                               }
                                               testID="tileImage"
                                             />
-                                          </View>
-                                          <View
-                                            height={24}
-                                            style={
-                                              [
-                                                {
-                                                  "alignItems": "center",
-                                                  "backgroundColor": "#161617",
-                                                  "borderBottomLeftRadius": 8,
-                                                  "borderBottomRightRadius": 8,
-                                                  "flexDirection": "row",
-                                                  "height": 24,
-                                                  "width": 144,
-                                                },
-                                              ]
-                                            }
-                                            width={144}
-                                          >
-                                            <View
-                                              style={
-                                                [
-                                                  {
-                                                    "alignItems": "center",
-                                                    "flexBasis": 0,
-                                                    "flexGrow": 1,
-                                                    "flexShrink": 1,
-                                                    "justifyContent": "center",
-                                                    "paddingHorizontal": 2,
-                                                  },
-                                                ]
-                                              }
-                                            >
-                                              <Text
-                                                numberOfLines={1}
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": "#ffffff",
-                                                      "fontFamily": "Montserrat-SemiBold",
-                                                      "fontSize": 12,
-                                                      "lineHeight": 19.2,
-                                                    },
-                                                  ]
-                                                }
-                                                testID="categoryImageCaption"
-                                              >
-                                                Cinéma
-                                              </Text>
-                                            </View>
                                           </View>
                                         </View>
                                       </View>
@@ -2923,7 +1971,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                           },
                                           {
                                             "borderRadius": 8,
-                                            "height": 288,
+                                            "height": 344,
                                             "marginVertical": 4,
                                           },
                                         ]
@@ -2931,40 +1979,28 @@ exports[`<Venue /> should match snapshot 1`] = `
                                       testID="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                                     >
                                       <View
+                                        gap={2}
+                                        maxWidth={144}
                                         style={
                                           [
                                             {
                                               "flexDirection": "column-reverse",
+                                              "gap": 8,
+                                              "maxWidth": 144,
                                             },
                                           ]
                                         }
                                       >
                                         <View
-                                          imageWidth={144}
+                                          gap={1}
                                           style={
                                             [
                                               {
-                                                "marginTop": 8,
-                                                "maxWidth": 144,
+                                                "gap": 4,
                                               },
                                             ]
                                           }
                                         >
-                                          <Text
-                                            numberOfLines={2}
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#161617",
-                                                  "fontFamily": "Montserrat-SemiBold",
-                                                  "fontSize": 12,
-                                                  "lineHeight": 19.2,
-                                                },
-                                              ]
-                                            }
-                                          >
-                                            Titane - VF
-                                          </Text>
                                           <Text
                                             numberOfLines={1}
                                             style={
@@ -2978,25 +2014,63 @@ exports[`<Venue /> should match snapshot 1`] = `
                                               ]
                                             }
                                           >
-                                            Dès le 18 août 2021
+                                            Cinéma
                                           </Text>
-                                          <Text
-                                            style={
-                                              [
-                                                {
-                                                  "color": "#696A6F",
-                                                  "fontFamily": "Montserrat-SemiBold",
-                                                  "fontSize": 12,
-                                                  "lineHeight": 19.2,
-                                                },
-                                              ]
-                                            }
-                                            testID="priceIsDuo"
-                                          >
-                                            Gratuit
-                                          </Text>
+                                          <View>
+                                            <Text
+                                              numberOfLines={2}
+                                              style={
+                                                [
+                                                  {
+                                                    "color": "#161617",
+                                                    "fontFamily": "Montserrat-SemiBold",
+                                                    "fontSize": 12,
+                                                    "lineHeight": 19.2,
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              Titane - VF
+                                            </Text>
+                                            <Text
+                                              numberOfLines={1}
+                                              style={
+                                                [
+                                                  {
+                                                    "color": "#161617",
+                                                    "fontFamily": "Montserrat-SemiBold",
+                                                    "fontSize": 12,
+                                                    "lineHeight": 19.2,
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              Dès le 18 août 2021
+                                            </Text>
+                                            <Text
+                                              style={
+                                                [
+                                                  {
+                                                    "color": "#161617",
+                                                    "fontFamily": "Montserrat-SemiBold",
+                                                    "fontSize": 12,
+                                                    "lineHeight": 19.2,
+                                                  },
+                                                ]
+                                              }
+                                              testID="priceIsDuo"
+                                            >
+                                              Gratuit
+                                            </Text>
+                                          </View>
                                         </View>
-                                        <View>
+                                        <View
+                                          style={
+                                            [
+                                              {},
+                                            ]
+                                          }
+                                        >
                                           <View
                                             style={
                                               [
@@ -3008,9 +2082,8 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                     "backgroundColor": "#F1F1F4",
                                                   },
                                                   {
-                                                    "borderTopLeftRadius": 8,
-                                                    "borderTopRightRadius": 8,
-                                                    "height": 192,
+                                                    "borderRadius": 8,
+                                                    "height": 216,
                                                     "width": 144,
                                                   },
                                                 ],
@@ -3036,55 +2109,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                                               }
                                               testID="tileImage"
                                             />
-                                          </View>
-                                          <View
-                                            height={24}
-                                            style={
-                                              [
-                                                {
-                                                  "alignItems": "center",
-                                                  "backgroundColor": "#161617",
-                                                  "borderBottomLeftRadius": 8,
-                                                  "borderBottomRightRadius": 8,
-                                                  "flexDirection": "row",
-                                                  "height": 24,
-                                                  "width": 144,
-                                                },
-                                              ]
-                                            }
-                                            width={144}
-                                          >
-                                            <View
-                                              style={
-                                                [
-                                                  {
-                                                    "alignItems": "center",
-                                                    "flexBasis": 0,
-                                                    "flexGrow": 1,
-                                                    "flexShrink": 1,
-                                                    "justifyContent": "center",
-                                                    "paddingHorizontal": 2,
-                                                  },
-                                                ]
-                                              }
-                                            >
-                                              <Text
-                                                numberOfLines={1}
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": "#ffffff",
-                                                      "fontFamily": "Montserrat-SemiBold",
-                                                      "fontSize": 12,
-                                                      "lineHeight": 19.2,
-                                                    },
-                                                  ]
-                                                }
-                                                testID="categoryImageCaption"
-                                              >
-                                                Cinéma
-                                              </Text>
-                                            </View>
                                           </View>
                                         </View>
                                       </View>
@@ -3223,7 +2247,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                       },
                                       {
                                         "borderRadius": 8,
-                                        "height": 416,
+                                        "height": 344,
                                         "marginVertical": 4,
                                       },
                                     ]
@@ -3232,13 +2256,13 @@ exports[`<Venue /> should match snapshot 1`] = `
                                 >
                                   <View
                                     gap={2}
-                                    maxWidth={192}
+                                    maxWidth={144}
                                     style={
                                       [
                                         {
                                           "flexDirection": "column-reverse",
                                           "gap": 8,
-                                          "maxWidth": 192,
+                                          "maxWidth": 144,
                                         },
                                       ]
                                     }
@@ -3266,7 +2290,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                           ]
                                         }
                                       >
-                                        Livre
+                                        Cinéma
                                       </Text>
                                       <View>
                                         <Text
@@ -3282,7 +2306,22 @@ exports[`<Venue /> should match snapshot 1`] = `
                                             ]
                                           }
                                         >
-                                          Test
+                                          Bac Nord - VF
+                                        </Text>
+                                        <Text
+                                          numberOfLines={1}
+                                          style={
+                                            [
+                                              {
+                                                "color": "#161617",
+                                                "fontFamily": "Montserrat-SemiBold",
+                                                "fontSize": 12,
+                                                "lineHeight": 19.2,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Dès le 18 août 2021
                                         </Text>
                                         <Text
                                           style={
@@ -3296,7 +2335,9 @@ exports[`<Venue /> should match snapshot 1`] = `
                                             ]
                                           }
                                           testID="priceIsDuo"
-                                        />
+                                        >
+                                          Gratuit
+                                        </Text>
                                       </View>
                                     </View>
                                     <View
@@ -3307,21 +2348,18 @@ exports[`<Venue /> should match snapshot 1`] = `
                                       }
                                     >
                                       <View
-                                        height={288}
                                         style={
                                           [
                                             {
-                                              "height": 288,
-                                              "width": 192,
+                                              "overflow": "hidden",
                                             },
                                             [
                                               {
                                                 "backgroundColor": "#F1F1F4",
                                               },
                                               {
-                                                "borderTopLeftRadius": 8,
-                                                "borderTopRightRadius": 8,
-                                                "height": 192,
+                                                "borderRadius": 8,
+                                                "height": 216,
                                                 "width": 144,
                                               },
                                             ],
@@ -3333,34 +2371,17 @@ exports[`<Venue /> should match snapshot 1`] = `
                                           resizeMode="cover"
                                           source={
                                             {
-                                              "x": 0.5,
-                                              "y": 1,
-                                            }
-                                          }
-                                          locations={null}
-                                          onlyTopBorderRadius={false}
-                                          startPoint={
-                                            {
-                                              "x": 0.5,
-                                              "y": 0,
+                                              "uri": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
                                             }
                                           }
                                           style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#F1F1F4",
-                                                "borderRadius": 8,
-                                                "height": "100%",
-                                                "justifyContent": "center",
-                                                "width": "100%",
-                                              },
-                                              {
-                                                "borderRadius": 8,
-                                                "borderTopLeftRadius": 8,
-                                                "borderTopRightRadius": 8,
-                                              },
-                                            ]
+                                            {
+                                              "bottom": 0,
+                                              "left": 0,
+                                              "position": "absolute",
+                                              "right": 0,
+                                              "top": 0,
+                                            }
                                           }
                                           testID="tileImage"
                                         />
@@ -3414,7 +2435,16 @@ exports[`<Venue /> should match snapshot 1`] = `
                       ]
                     }
                   >
-                    <View>
+                    <View
+                      gap={1}
+                      style={
+                        [
+                          {
+                            "gap": 4,
+                          },
+                        ]
+                      }
+                    >
                       <View
                         style={
                           [
@@ -3915,7 +2945,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                             },
                                             {
                                               "borderRadius": 8,
-                                              "height": 360,
+                                              "height": 416,
                                               "marginVertical": 4,
                                             },
                                           ]
@@ -3923,41 +2953,30 @@ exports[`<Venue /> should match snapshot 1`] = `
                                         testID="Offre Test de la catégorie Livre,   prix . "
                                       >
                                         <View
+                                          gap={2}
+                                          maxWidth={192}
                                           style={
                                             [
                                               {
                                                 "flexDirection": "column-reverse",
+                                                "gap": 8,
+                                                "maxWidth": 192,
                                               },
                                             ]
                                           }
                                         >
                                           <View
-                                            imageWidth={192}
+                                            gap={1}
                                             style={
                                               [
                                                 {
-                                                  "marginTop": 8,
-                                                  "maxWidth": 192,
+                                                  "gap": 4,
                                                 },
                                               ]
                                             }
                                           >
                                             <Text
-                                              numberOfLines={2}
-                                              style={
-                                                [
-                                                  {
-                                                    "color": "#161617",
-                                                    "fontFamily": "Montserrat-SemiBold",
-                                                    "fontSize": 12,
-                                                    "lineHeight": 19.2,
-                                                  },
-                                                ]
-                                              }
-                                            >
-                                              Test
-                                            </Text>
-                                            <Text
+                                              numberOfLines={1}
                                               style={
                                                 [
                                                   {
@@ -3968,16 +2987,53 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                   },
                                                 ]
                                               }
-                                              testID="priceIsDuo"
-                                            />
+                                            >
+                                              Livre
+                                            </Text>
+                                            <View>
+                                              <Text
+                                                numberOfLines={2}
+                                                style={
+                                                  [
+                                                    {
+                                                      "color": "#161617",
+                                                      "fontFamily": "Montserrat-SemiBold",
+                                                      "fontSize": 12,
+                                                      "lineHeight": 19.2,
+                                                    },
+                                                  ]
+                                                }
+                                              >
+                                                Test
+                                              </Text>
+                                              <Text
+                                                style={
+                                                  [
+                                                    {
+                                                      "color": "#161617",
+                                                      "fontFamily": "Montserrat-SemiBold",
+                                                      "fontSize": 12,
+                                                      "lineHeight": 19.2,
+                                                    },
+                                                  ]
+                                                }
+                                                testID="priceIsDuo"
+                                              />
+                                            </View>
                                           </View>
-                                          <View>
+                                          <View
+                                            style={
+                                              [
+                                                {},
+                                              ]
+                                            }
+                                          >
                                             <View
-                                              height={264}
+                                              height={288}
                                               style={
                                                 [
                                                   {
-                                                    "height": 264,
+                                                    "height": 288,
                                                     "width": 192,
                                                   },
                                                 ]
@@ -3999,7 +3055,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                   }
                                                 }
                                                 locations={null}
-                                                onlyTopBorderRadius={true}
+                                                onlyTopBorderRadius={false}
                                                 startPoint={
                                                   {
                                                     "x": 0.5,
@@ -4017,7 +3073,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                       "width": "100%",
                                                     },
                                                     {
-                                                      "borderRadius": 0,
+                                                      "borderRadius": 8,
                                                       "borderTopLeftRadius": 8,
                                                       "borderTopRightRadius": 8,
                                                     },
@@ -4035,55 +3091,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                   </Text>
                                                 </View>
                                               </BVLinearGradient>
-                                            </View>
-                                            <View
-                                              height={24}
-                                              style={
-                                                [
-                                                  {
-                                                    "alignItems": "center",
-                                                    "backgroundColor": "#161617",
-                                                    "borderBottomLeftRadius": 8,
-                                                    "borderBottomRightRadius": 8,
-                                                    "flexDirection": "row",
-                                                    "height": 24,
-                                                    "width": 192,
-                                                  },
-                                                ]
-                                              }
-                                              width={192}
-                                            >
-                                              <View
-                                                style={
-                                                  [
-                                                    {
-                                                      "alignItems": "center",
-                                                      "flexBasis": 0,
-                                                      "flexGrow": 1,
-                                                      "flexShrink": 1,
-                                                      "justifyContent": "center",
-                                                      "paddingHorizontal": 2,
-                                                    },
-                                                  ]
-                                                }
-                                              >
-                                                <Text
-                                                  numberOfLines={1}
-                                                  style={
-                                                    [
-                                                      {
-                                                        "color": "#ffffff",
-                                                        "fontFamily": "Montserrat-SemiBold",
-                                                        "fontSize": 12,
-                                                        "lineHeight": 19.2,
-                                                      },
-                                                    ]
-                                                  }
-                                                  testID="categoryImageCaption"
-                                                >
-                                                  Livre
-                                                </Text>
-                                              </View>
                                             </View>
                                           </View>
                                         </View>
@@ -4158,7 +3165,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                         },
                                         {
                                           "borderRadius": 8,
-                                          "height": 360,
+                                          "height": 416,
                                           "marginVertical": 4,
                                         },
                                       ]
@@ -4166,41 +3173,30 @@ exports[`<Venue /> should match snapshot 1`] = `
                                     testID="Offre Test de la catégorie Livre,   prix . "
                                   >
                                     <View
+                                      gap={2}
+                                      maxWidth={192}
                                       style={
                                         [
                                           {
                                             "flexDirection": "column-reverse",
+                                            "gap": 8,
+                                            "maxWidth": 192,
                                           },
                                         ]
                                       }
                                     >
                                       <View
-                                        imageWidth={192}
+                                        gap={1}
                                         style={
                                           [
                                             {
-                                              "marginTop": 8,
-                                              "maxWidth": 192,
+                                              "gap": 4,
                                             },
                                           ]
                                         }
                                       >
                                         <Text
-                                          numberOfLines={2}
-                                          style={
-                                            [
-                                              {
-                                                "color": "#161617",
-                                                "fontFamily": "Montserrat-SemiBold",
-                                                "fontSize": 12,
-                                                "lineHeight": 19.2,
-                                              },
-                                            ]
-                                          }
-                                        >
-                                          Test
-                                        </Text>
-                                        <Text
+                                          numberOfLines={1}
                                           style={
                                             [
                                               {
@@ -4211,16 +3207,53 @@ exports[`<Venue /> should match snapshot 1`] = `
                                               },
                                             ]
                                           }
-                                          testID="priceIsDuo"
-                                        />
+                                        >
+                                          Livre
+                                        </Text>
+                                        <View>
+                                          <Text
+                                            numberOfLines={2}
+                                            style={
+                                              [
+                                                {
+                                                  "color": "#161617",
+                                                  "fontFamily": "Montserrat-SemiBold",
+                                                  "fontSize": 12,
+                                                  "lineHeight": 19.2,
+                                                },
+                                              ]
+                                            }
+                                          >
+                                            Test
+                                          </Text>
+                                          <Text
+                                            style={
+                                              [
+                                                {
+                                                  "color": "#161617",
+                                                  "fontFamily": "Montserrat-SemiBold",
+                                                  "fontSize": 12,
+                                                  "lineHeight": 19.2,
+                                                },
+                                              ]
+                                            }
+                                            testID="priceIsDuo"
+                                          />
+                                        </View>
                                       </View>
-                                      <View>
+                                      <View
+                                        style={
+                                          [
+                                            {},
+                                          ]
+                                        }
+                                      >
                                         <View
-                                          height={264}
+                                          height={288}
                                           style={
                                             [
                                               {
-                                                "height": 264,
+                                                "height": 288,
                                                 "width": 192,
                                               },
                                             ]
@@ -4242,7 +3275,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                               }
                                             }
                                             locations={null}
-                                            onlyTopBorderRadius={true}
+                                            onlyTopBorderRadius={false}
                                             startPoint={
                                               {
                                                 "x": 0.5,
@@ -4260,7 +3293,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                   "width": "100%",
                                                 },
                                                 {
-                                                  "borderRadius": 0,
+                                                  "borderRadius": 8,
                                                   "borderTopLeftRadius": 8,
                                                   "borderTopRightRadius": 8,
                                                 },
@@ -4278,55 +3311,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                                               </Text>
                                             </View>
                                           </BVLinearGradient>
-                                        </View>
-                                        <View
-                                          height={24}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#161617",
-                                                "borderBottomLeftRadius": 8,
-                                                "borderBottomRightRadius": 8,
-                                                "flexDirection": "row",
-                                                "height": 24,
-                                                "width": 192,
-                                              },
-                                            ]
-                                          }
-                                          width={192}
-                                        >
-                                          <View
-                                            style={
-                                              [
-                                                {
-                                                  "alignItems": "center",
-                                                  "flexBasis": 0,
-                                                  "flexGrow": 1,
-                                                  "flexShrink": 1,
-                                                  "justifyContent": "center",
-                                                  "paddingHorizontal": 2,
-                                                },
-                                              ]
-                                            }
-                                          >
-                                            <Text
-                                              numberOfLines={1}
-                                              style={
-                                                [
-                                                  {
-                                                    "color": "#ffffff",
-                                                    "fontFamily": "Montserrat-SemiBold",
-                                                    "fontSize": 12,
-                                                    "lineHeight": 19.2,
-                                                  },
-                                                ]
-                                              }
-                                              testID="categoryImageCaption"
-                                            >
-                                              Livre
-                                            </Text>
-                                          </View>
                                         </View>
                                       </View>
                                     </View>
@@ -4664,17 +3648,7 @@ exports[`<Venue /> should match snapshot 1`] = `
             style={
               [
                 {
-                  "backgroundColor": "#F1F1F4",
-                  "height": 8,
-                },
-              ]
-            }
-          />
-          <View
-            style={
-              [
-                {
-                  "paddingHorizontal": 24,
+                  "gap": 24,
                 },
               ]
             }
@@ -4693,7 +3667,7 @@ exports[`<Venue /> should match snapshot 1`] = `
               style={
                 [
                   {
-                    "marginHorizontal": 24,
+                    "paddingHorizontal": 24,
                   },
                 ]
               }
@@ -5831,6 +4805,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
           [
             {
               "flexDirection": "column",
+              "marginBottom": 24,
               "marginHorizontal": 0,
               "marginTop": 0,
             },
@@ -5900,2183 +4875,6 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
             style={
               [
                 {
-                  "flexDirection": "row",
-                  "flexWrap": "wrap",
-                  "gap": 8,
-                  "maxHeight": 56,
-                  "overflow": "hidden",
-                },
-              ]
-            }
-            testID="tagsContainer"
-          >
-            <View
-              style={
-                [
-                  {
-                    "alignSelf": "baseline",
-                    "backgroundColor": "#F1F1F4",
-                    "borderRadius": 6,
-                    "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 4,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 12,
-                      "lineHeight": 16,
-                    },
-                  ]
-                }
-              >
-                Librairie
-              </Text>
-            </View>
-          </View>
-          <View
-            numberOfSpaces={4}
-            style={
-              [
-                {
-                  "height": 16,
-                },
-              ]
-            }
-          />
-          <View
-            gap={1}
-            style={
-              [
-                {
-                  "gap": 4,
-                },
-              ]
-            }
-          >
-            <Text
-              accessibilityLabel="Nom du lieu : Le Petit Rintintin 1"
-              adjustsFontSizeToFit={true}
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Bold",
-                    "fontSize": 19,
-                    "lineHeight": 30.4,
-                  },
-                ]
-              }
-            >
-              Le Petit Rintintin 1
-            </Text>
-            <View
-              gap={3}
-              style={
-                [
-                  {
-                    "gap": 12,
-                  },
-                ]
-              }
-            >
-              <View>
-                <Text
-                  style={
-                    [
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-SemiBold",
-                        "fontSize": 12,
-                        "lineHeight": 19.2,
-                      },
-                    ]
-                  }
-                >
-                  Adresse
-                </Text>
-                <Text
-                  style={
-                    [
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-Medium",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      },
-                    ]
-                  }
-                >
-                  1 boulevard Poissonnière, 75000 Paris
-                </Text>
-              </View>
-              <View
-                style={
-                  [
-                    {
-                      "backgroundColor": "#F1F1F4",
-                      "height": 1,
-                      "width": "100%",
-                    },
-                  ]
-                }
-              />
-              <View
-                accessibilityLabel="Copier l’adresse"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "alignItems": "center",
-                    "backgroundColor": "transparent",
-                    "borderRadius": 24,
-                    "flexDirection": "row",
-                    "justifyContent": "flex-start",
-                    "maxWidth": 500,
-                    "minHeight": 40,
-                    "opacity": 1,
-                    "paddingBottom": 2,
-                    "paddingLeft": 2,
-                    "paddingRight": 2,
-                    "paddingTop": 2,
-                    "userSelect": "auto",
-                    "width": "100%",
-                  }
-                }
-                testID="Copier l’adresse"
-              >
-                <View
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    style={
-                      [
-                        {
-                          "flexDirection": "row",
-                          "flexShrink": 0,
-                        },
-                      ]
-                    }
-                  >
-                    <View
-                      height={20}
-                      testID="button-icon-left"
-                      width={20}
-                    >
-                      <Text>
-                        button-icon-left-SVG-Mock
-                      </Text>
-                    </View>
-                    <View
-                      numberOfSpaces={2}
-                      style={
-                        [
-                          {
-                            "width": 8,
-                          },
-                        ]
-                      }
-                    />
-                  </View>
-                  <Text
-                    adjustsFontSizeToFit={false}
-                    numberOfLines={1}
-                    style={
-                      [
-                        {
-                          "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 16,
-                          "lineHeight": 25.6,
-                          "maxWidth": "100%",
-                        },
-                      ]
-                    }
-                  >
-                    Copier l’adresse
-                  </Text>
-                </View>
-              </View>
-              <View
-                style={
-                  [
-                    {
-                      "alignItems": "flex-start",
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityLabel="Voir l’itinéraire"
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": undefined,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onClick={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "backgroundColor": "transparent",
-                      "borderRadius": 0,
-                      "borderWidth": 0,
-                      "flexDirection": "row",
-                      "justifyContent": "center",
-                      "marginTop": 0,
-                      "maxWidth": 500,
-                      "minHeight": 20,
-                      "opacity": 1,
-                      "paddingBottom": 0,
-                      "paddingLeft": 0,
-                      "paddingRight": 0,
-                      "paddingTop": 0,
-                      "userSelect": "auto",
-                      "width": "auto",
-                    }
-                  }
-                  testID="Voir l’itinéraire"
-                >
-                  <View
-                    style={
-                      [
-                        {
-                          "alignItems": "center",
-                          "flexDirection": "row",
-                        },
-                      ]
-                    }
-                  >
-                    <View
-                      style={
-                        [
-                          {
-                            "flexDirection": "row",
-                            "flexShrink": 0,
-                          },
-                        ]
-                      }
-                    >
-                      <View
-                        accessibilityLabel="Nouvelle fenêtre"
-                        height={20}
-                        testID="button-icon-left"
-                        width={20}
-                      >
-                        <Text>
-                          button-icon-left-SVG-Mock
-                        </Text>
-                      </View>
-                      <View
-                        numberOfSpaces={2}
-                        style={
-                          [
-                            {
-                              "width": 8,
-                            },
-                          ]
-                        }
-                      />
-                    </View>
-                    <Text
-                      adjustsFontSizeToFit={false}
-                      numberOfLines={1}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                            "maxWidth": "100%",
-                          },
-                        ]
-                      }
-                    >
-                      Voir l’itinéraire
-                    </Text>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-      <View
-        numberOfSpaces={6}
-        style={
-          [
-            {
-              "height": 24,
-            },
-          ]
-        }
-      />
-      <View
-        animatedStyle={
-          {
-            "value": {},
-          }
-        }
-        collapsable={false}
-        layout={
-          LinearTransition {
-            "build": [Function],
-            "callbackV": undefined,
-            "dampingV": undefined,
-            "delayV": undefined,
-            "durationV": 200,
-            "easingV": undefined,
-            "initialValues": undefined,
-            "massV": undefined,
-            "overshootClampingV": undefined,
-            "randomizeDelay": false,
-            "restDisplacementThresholdV": undefined,
-            "restSpeedThresholdV": undefined,
-            "rotateV": undefined,
-            "stiffnessV": undefined,
-            "type": undefined,
-          }
-        }
-      >
-        <View
-          gap={6}
-          style={
-            [
-              {
-                "gap": 24,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              [
-                {
-                  "backgroundColor": "#F1F1F4",
-                  "height": 8,
-                },
-              ]
-            }
-          />
-          <View
-            style={
-              [
-                {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                  "width": "100%",
-                },
-              ]
-            }
-          >
-            <View
-              accessibilityRole="tablist"
-              style={
-                [
-                  {
-                    "flexDirection": "row",
-                  },
-                ]
-              }
-            >
-              <View
-                style={
-                  [
-                    {
-                      "backgroundColor": "#F1F1F4",
-                      "bottom": 0,
-                      "height": 4,
-                      "position": "absolute",
-                      "width": "100%",
-                    },
-                  ]
-                }
-              />
-              <View
-                numberOfSpaces={6}
-                style={
-                  [
-                    {
-                      "width": 24,
-                    },
-                  ]
-                }
-              />
-              <View
-                accessibilityRole="tab"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": false,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "flexBasis": 0,
-                    "flexGrow": 1,
-                    "flexShrink": 1,
-                    "maxWidth": 180,
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-              >
-                <View
-                  gap={2}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "flexGrow": 1,
-                        "gap": 8,
-                        "justifyContent": "center",
-                      },
-                    ]
-                  }
-                >
-                  <Text
-                    isHover={false}
-                    isSelected={false}
-                    style={
-                      [
-                        {
-                          "color": "#696A6F",
-                          "fontFamily": "Montserrat-SemiBold",
-                          "fontSize": 16,
-                          "lineHeight": 25.6,
-                          "textAlign": "center",
-                        },
-                      ]
-                    }
-                  >
-                    Offres disponibles
-                  </Text>
-                </View>
-                <View
-                  numberOfSpaces={2}
-                  style={
-                    [
-                      {
-                        "height": 8,
-                      },
-                    ]
-                  }
-                />
-                <View
-                  isSelected={false}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "transparent",
-                        "borderRadius": 4,
-                        "bottom": 0,
-                        "height": 4,
-                        "width": "100%",
-                      },
-                    ]
-                  }
-                />
-              </View>
-              <View
-                accessibilityRole="tab"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": true,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "flexBasis": 0,
-                    "flexGrow": 1,
-                    "flexShrink": 1,
-                    "maxWidth": 180,
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-              >
-                <View
-                  gap={2}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "flexGrow": 1,
-                        "gap": 8,
-                        "justifyContent": "center",
-                      },
-                    ]
-                  }
-                >
-                  <Text
-                    isHover={false}
-                    isSelected={true}
-                    style={
-                      [
-                        {
-                          "color": "#eb0055",
-                          "fontFamily": "Montserrat-SemiBold",
-                          "fontSize": 16,
-                          "lineHeight": 25.6,
-                          "textAlign": "center",
-                        },
-                      ]
-                    }
-                  >
-                    Infos pratiques
-                  </Text>
-                </View>
-                <View
-                  numberOfSpaces={2}
-                  style={
-                    [
-                      {
-                        "height": 8,
-                      },
-                    ]
-                  }
-                />
-                <View
-                  isSelected={true}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#eb0055",
-                        "borderRadius": 4,
-                        "bottom": 0,
-                        "height": 4,
-                        "width": "100%",
-                      },
-                    ]
-                  }
-                />
-              </View>
-              <View
-                numberOfSpaces={6}
-                style={
-                  [
-                    {
-                      "width": 24,
-                    },
-                  ]
-                }
-              />
-            </View>
-            <View
-              accessibilityRole="none"
-              style={
-                [
-                  {
-                    "flexGrow": 1,
-                    "flexShrink": 1,
-                  },
-                ]
-              }
-            >
-              <View
-                style={
-                  [
-                    {
-                      "marginHorizontal": 24,
-                    },
-                  ]
-                }
-              >
-                <View
-                  numberOfSpaces={2}
-                  style={
-                    [
-                      {
-                        "height": 8,
-                      },
-                    ]
-                  }
-                />
-                <View
-                  numberOfSpaces={4}
-                  style={
-                    [
-                      {
-                        "height": 16,
-                      },
-                    ]
-                  }
-                />
-                <Text
-                  style={
-                    [
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-SemiBold",
-                        "fontSize": 12,
-                        "lineHeight": 19.2,
-                      },
-                    ]
-                  }
-                >
-                  Modalités de retrait
-                </Text>
-                <View
-                  numberOfSpaces={4}
-                  style={
-                    [
-                      {
-                        "height": 16,
-                      },
-                    ]
-                  }
-                />
-                <Text
-                  style={
-                    [
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-Medium",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      },
-                    ]
-                  }
-                >
-                  How to withdraw, https://test.com
-                </Text>
-                <View
-                  numberOfSpaces={4}
-                  style={
-                    [
-                      {
-                        "height": 16,
-                      },
-                    ]
-                  }
-                />
-                <View
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#F1F1F4",
-                        "height": 1,
-                        "width": "100%",
-                      },
-                    ]
-                  }
-                />
-                <View
-                  numberOfSpaces={4}
-                  style={
-                    [
-                      {
-                        "height": 16,
-                      },
-                    ]
-                  }
-                />
-                <Text
-                  style={
-                    [
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-SemiBold",
-                        "fontSize": 12,
-                        "lineHeight": 19.2,
-                      },
-                    ]
-                  }
-                >
-                  Description
-                </Text>
-                <View
-                  numberOfSpaces={4}
-                  style={
-                    [
-                      {
-                        "height": 16,
-                      },
-                    ]
-                  }
-                />
-                <Text
-                  style={
-                    [
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-Medium",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      },
-                    ]
-                  }
-                >
-                  https://pass.culture.fr/ lorem ipsum consectetur adipisicing elit. Debitis officiis maiores quia unde, hic quisquam odit ea quo ipsam possimus, labore nesciunt numquam. Id itaque in sed sapiente blanditiis necessitatibus. consectetur adipisicing elit. Debitis officiis maiores quia unde, hic quisquam odit ea quo ipsam possimus, consectetur adipisicing elit. Debitis officiis maiores quia unde, hic quisquam odit ea quo ipsam possimus,
-                </Text>
-                <View
-                  numberOfSpaces={4}
-                  style={
-                    [
-                      {
-                        "height": 16,
-                      },
-                    ]
-                  }
-                />
-                <View
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#F1F1F4",
-                        "height": 1,
-                        "width": "100%",
-                      },
-                    ]
-                  }
-                />
-                <View
-                  numberOfSpaces={4}
-                  style={
-                    [
-                      {
-                        "height": 16,
-                      },
-                    ]
-                  }
-                />
-                <Text
-                  style={
-                    [
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-SemiBold",
-                        "fontSize": 12,
-                        "lineHeight": 19.2,
-                      },
-                    ]
-                  }
-                >
-                  Contact
-                </Text>
-                <View
-                  numberOfSpaces={4}
-                  style={
-                    [
-                      {
-                        "height": 16,
-                      },
-                    ]
-                  }
-                />
-                <View
-                  accessibilityLabel="contact@venue.com"
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": undefined,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onClick={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "backgroundColor": "transparent",
-                      "borderRadius": 24,
-                      "flexDirection": "row",
-                      "justifyContent": "flex-start",
-                      "maxWidth": 500,
-                      "minHeight": 40,
-                      "opacity": 1,
-                      "paddingBottom": 2,
-                      "paddingLeft": 2,
-                      "paddingRight": 2,
-                      "paddingTop": 2,
-                      "userSelect": "auto",
-                      "width": "100%",
-                    }
-                  }
-                  testID="contact@venue.com"
-                >
-                  <View
-                    style={
-                      [
-                        {
-                          "alignItems": "center",
-                          "flexDirection": "row",
-                        },
-                      ]
-                    }
-                  >
-                    <View
-                      style={
-                        [
-                          {
-                            "flexDirection": "row",
-                            "flexShrink": 0,
-                          },
-                        ]
-                      }
-                    >
-                      <View
-                        height={20}
-                        testID="button-icon-left"
-                        width={20}
-                      >
-                        <Text>
-                          button-icon-left-SVG-Mock
-                        </Text>
-                      </View>
-                      <View
-                        numberOfSpaces={2}
-                        style={
-                          [
-                            {
-                              "width": 8,
-                            },
-                          ]
-                        }
-                      />
-                    </View>
-                    <Text
-                      adjustsFontSizeToFit={false}
-                      numberOfLines={1}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                            "maxWidth": "100%",
-                          },
-                        ]
-                      }
-                    >
-                      contact@venue.com
-                    </Text>
-                  </View>
-                </View>
-                <View
-                  accessibilityLabel="+33102030405"
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": undefined,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onClick={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "backgroundColor": "transparent",
-                      "borderRadius": 24,
-                      "flexDirection": "row",
-                      "justifyContent": "flex-start",
-                      "maxWidth": 500,
-                      "minHeight": 40,
-                      "opacity": 1,
-                      "paddingBottom": 2,
-                      "paddingLeft": 2,
-                      "paddingRight": 2,
-                      "paddingTop": 2,
-                      "userSelect": "auto",
-                      "width": "100%",
-                    }
-                  }
-                  testID="+33102030405"
-                >
-                  <View
-                    style={
-                      [
-                        {
-                          "alignItems": "center",
-                          "flexDirection": "row",
-                        },
-                      ]
-                    }
-                  >
-                    <View
-                      style={
-                        [
-                          {
-                            "flexDirection": "row",
-                            "flexShrink": 0,
-                          },
-                        ]
-                      }
-                    >
-                      <View
-                        height={20}
-                        testID="button-icon-left"
-                        width={20}
-                      >
-                        <Text>
-                          button-icon-left-SVG-Mock
-                        </Text>
-                      </View>
-                      <View
-                        numberOfSpaces={2}
-                        style={
-                          [
-                            {
-                              "width": 8,
-                            },
-                          ]
-                        }
-                      />
-                    </View>
-                    <Text
-                      adjustsFontSizeToFit={false}
-                      numberOfLines={1}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                            "maxWidth": "100%",
-                          },
-                        ]
-                      }
-                    >
-                      +33102030405
-                    </Text>
-                  </View>
-                </View>
-                <View
-                  accessibilityLabel="https://my@website.com"
-                  accessibilityState={
-                    {
-                      "busy": undefined,
-                      "checked": undefined,
-                      "disabled": undefined,
-                      "expanded": undefined,
-                      "selected": undefined,
-                    }
-                  }
-                  accessibilityValue={
-                    {
-                      "max": undefined,
-                      "min": undefined,
-                      "now": undefined,
-                      "text": undefined,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onClick={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                  style={
-                    {
-                      "alignItems": "center",
-                      "backgroundColor": "transparent",
-                      "borderRadius": 24,
-                      "flexDirection": "row",
-                      "justifyContent": "flex-start",
-                      "maxWidth": 500,
-                      "minHeight": 40,
-                      "opacity": 1,
-                      "paddingBottom": 2,
-                      "paddingLeft": 2,
-                      "paddingRight": 2,
-                      "paddingTop": 2,
-                      "userSelect": "auto",
-                      "width": "100%",
-                    }
-                  }
-                  testID="https://my@website.com"
-                >
-                  <View
-                    style={
-                      [
-                        {
-                          "alignItems": "center",
-                          "flexDirection": "row",
-                        },
-                      ]
-                    }
-                  >
-                    <View
-                      style={
-                        [
-                          {
-                            "flexDirection": "row",
-                            "flexShrink": 0,
-                          },
-                        ]
-                      }
-                    >
-                      <View
-                        accessibilityLabel="Nouvelle fenêtre"
-                        height={20}
-                        testID="button-icon-left"
-                        width={20}
-                      >
-                        <Text>
-                          button-icon-left-SVG-Mock
-                        </Text>
-                      </View>
-                      <View
-                        numberOfSpaces={2}
-                        style={
-                          [
-                            {
-                              "width": 8,
-                            },
-                          ]
-                        }
-                      />
-                    </View>
-                    <Text
-                      adjustsFontSizeToFit={false}
-                      numberOfLines={1}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                            "maxWidth": "100%",
-                          },
-                        ]
-                      }
-                    >
-                      https://my@website.com
-                    </Text>
-                  </View>
-                </View>
-                <View
-                  numberOfSpaces={4}
-                  style={
-                    [
-                      {
-                        "height": 16,
-                      },
-                    ]
-                  }
-                />
-                <View
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#F1F1F4",
-                        "height": 1,
-                        "width": "100%",
-                      },
-                    ]
-                  }
-                />
-                <View
-                  numberOfSpaces={4}
-                  style={
-                    [
-                      {
-                        "height": 16,
-                      },
-                    ]
-                  }
-                />
-                <Text
-                  style={
-                    [
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-SemiBold",
-                        "fontSize": 12,
-                        "lineHeight": 19.2,
-                      },
-                    ]
-                  }
-                >
-                  Accessibilité
-                </Text>
-                <View
-                  numberOfSpaces={4}
-                  style={
-                    [
-                      {
-                        "height": 16,
-                      },
-                    ]
-                  }
-                />
-                <View
-                  accessibilityRole="list"
-                  style={
-                    [
-                      {
-                        "flexDirection": "row",
-                        "gap": 0,
-                        "justifyContent": "space-between",
-                        "overflow": "visible",
-                        "paddingLeft": 0,
-                        "width": "100%",
-                      },
-                    ]
-                  }
-                  testID="BasicAccessibilityInfo"
-                >
-                  <View
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "display": "flex",
-                          "maxWidth": 72,
-                        },
-                      ]
-                    }
-                  >
-                    <View
-                      accessibilityLabel="Handicap visuel : Accessible"
-                      accessibilityRole="image"
-                      style={
-                        [
-                          {
-                            "alignItems": "center",
-                          },
-                        ]
-                      }
-                      testID="accessibilityBadgeContainer"
-                    >
-                      <View
-                        accessibilityHidden={true}
-                        style={
-                          [
-                            {
-                              "alignItems": "center",
-                              "borderColor": "#CBCDD2",
-                              "borderRadius": 8,
-                              "borderWidth": 1,
-                              "height": 48,
-                              "width": 48,
-                            },
-                          ]
-                        }
-                      >
-                        <View
-                          style={
-                            [
-                              {
-                                "flexBasis": 0,
-                                "flexGrow": 1,
-                                "flexShrink": 1,
-                              },
-                            ]
-                          }
-                        />
-                        <View
-                          fill="#161617"
-                          height={24}
-                          width={24}
-                        >
-                          <Text>
-                            undefined-SVG-Mock
-                          </Text>
-                        </View>
-                        <View
-                          style={
-                            [
-                              {
-                                "flexBasis": 0,
-                                "flexGrow": 1,
-                                "flexShrink": 1,
-                              },
-                            ]
-                          }
-                        />
-                        <View
-                          style={
-                            [
-                              {
-                                "bottom": -8,
-                                "position": "absolute",
-                              },
-                            ]
-                          }
-                        >
-                          <View
-                            accessibilityLabel="Accessible"
-                            height={16}
-                            testID="valid-icon"
-                            width={16}
-                          >
-                            <Text>
-                              valid-icon-SVG-Mock
-                            </Text>
-                          </View>
-                        </View>
-                      </View>
-                      <View
-                        numberOfSpaces={4}
-                        style={
-                          [
-                            {
-                              "height": 16,
-                            },
-                          ]
-                        }
-                      />
-                      <Text
-                        style={
-                          [
-                            {
-                              "color": "#161617",
-                              "fontFamily": "Montserrat-SemiBold",
-                              "fontSize": 12,
-                              "lineHeight": 19.2,
-                              "paddingHorizontal": 1,
-                              "textAlign": "center",
-                            },
-                          ]
-                        }
-                      >
-                        Handicap visuel
-                      </Text>
-                    </View>
-                  </View>
-                  <View
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "display": "flex",
-                          "maxWidth": 72,
-                        },
-                      ]
-                    }
-                  >
-                    <View
-                      accessibilityLabel="Handicap psychique ou cognitif : Non accessible"
-                      accessibilityRole="image"
-                      style={
-                        [
-                          {
-                            "alignItems": "center",
-                          },
-                        ]
-                      }
-                      testID="accessibilityBadgeContainer"
-                    >
-                      <View
-                        accessibilityHidden={true}
-                        style={
-                          [
-                            {
-                              "alignItems": "center",
-                              "borderColor": "#CBCDD2",
-                              "borderRadius": 8,
-                              "borderWidth": 1,
-                              "height": 48,
-                              "width": 48,
-                            },
-                          ]
-                        }
-                      >
-                        <View
-                          style={
-                            [
-                              {
-                                "flexBasis": 0,
-                                "flexGrow": 1,
-                                "flexShrink": 1,
-                              },
-                            ]
-                          }
-                        />
-                        <View
-                          fill="#161617"
-                          height={24}
-                          width={24}
-                        >
-                          <Text>
-                            undefined-SVG-Mock
-                          </Text>
-                        </View>
-                        <View
-                          style={
-                            [
-                              {
-                                "flexBasis": 0,
-                                "flexGrow": 1,
-                                "flexShrink": 1,
-                              },
-                            ]
-                          }
-                        />
-                        <View
-                          style={
-                            [
-                              {
-                                "bottom": -8,
-                                "position": "absolute",
-                              },
-                            ]
-                          }
-                        >
-                          <View
-                            accessibilityLabel="Non accessible"
-                            fill="#696A6F"
-                            height={16}
-                            testID="invalid-icon"
-                            width={16}
-                          >
-                            <Text>
-                              invalid-icon-SVG-Mock
-                            </Text>
-                          </View>
-                        </View>
-                      </View>
-                      <View
-                        numberOfSpaces={4}
-                        style={
-                          [
-                            {
-                              "height": 16,
-                            },
-                          ]
-                        }
-                      />
-                      <Text
-                        style={
-                          [
-                            {
-                              "color": "#161617",
-                              "fontFamily": "Montserrat-SemiBold",
-                              "fontSize": 12,
-                              "lineHeight": 19.2,
-                              "paddingHorizontal": 1,
-                              "textAlign": "center",
-                            },
-                          ]
-                        }
-                      >
-                        Handicap psychique ou cognitif
-                      </Text>
-                    </View>
-                  </View>
-                  <View
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "display": "flex",
-                          "maxWidth": 72,
-                        },
-                      ]
-                    }
-                  >
-                    <View
-                      accessibilityLabel="Handicap moteur : Non accessible"
-                      accessibilityRole="image"
-                      style={
-                        [
-                          {
-                            "alignItems": "center",
-                          },
-                        ]
-                      }
-                      testID="accessibilityBadgeContainer"
-                    >
-                      <View
-                        accessibilityHidden={true}
-                        style={
-                          [
-                            {
-                              "alignItems": "center",
-                              "borderColor": "#CBCDD2",
-                              "borderRadius": 8,
-                              "borderWidth": 1,
-                              "height": 48,
-                              "width": 48,
-                            },
-                          ]
-                        }
-                      >
-                        <View
-                          style={
-                            [
-                              {
-                                "flexBasis": 0,
-                                "flexGrow": 1,
-                                "flexShrink": 1,
-                              },
-                            ]
-                          }
-                        />
-                        <View
-                          fill="#161617"
-                          height={24}
-                          width={24}
-                        >
-                          <Text>
-                            undefined-SVG-Mock
-                          </Text>
-                        </View>
-                        <View
-                          style={
-                            [
-                              {
-                                "flexBasis": 0,
-                                "flexGrow": 1,
-                                "flexShrink": 1,
-                              },
-                            ]
-                          }
-                        />
-                        <View
-                          style={
-                            [
-                              {
-                                "bottom": -8,
-                                "position": "absolute",
-                              },
-                            ]
-                          }
-                        >
-                          <View
-                            accessibilityLabel="Non accessible"
-                            fill="#696A6F"
-                            height={16}
-                            testID="invalid-icon"
-                            width={16}
-                          >
-                            <Text>
-                              invalid-icon-SVG-Mock
-                            </Text>
-                          </View>
-                        </View>
-                      </View>
-                      <View
-                        numberOfSpaces={4}
-                        style={
-                          [
-                            {
-                              "height": 16,
-                            },
-                          ]
-                        }
-                      />
-                      <Text
-                        style={
-                          [
-                            {
-                              "color": "#161617",
-                              "fontFamily": "Montserrat-SemiBold",
-                              "fontSize": 12,
-                              "lineHeight": 19.2,
-                              "paddingHorizontal": 1,
-                              "textAlign": "center",
-                            },
-                          ]
-                        }
-                      >
-                        Handicap moteur
-                      </Text>
-                    </View>
-                  </View>
-                  <View
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "display": "flex",
-                          "maxWidth": 72,
-                        },
-                      ]
-                    }
-                  >
-                    <View
-                      accessibilityLabel="Handicap auditif : Non accessible"
-                      accessibilityRole="image"
-                      style={
-                        [
-                          {
-                            "alignItems": "center",
-                          },
-                        ]
-                      }
-                      testID="accessibilityBadgeContainer"
-                    >
-                      <View
-                        accessibilityHidden={true}
-                        style={
-                          [
-                            {
-                              "alignItems": "center",
-                              "borderColor": "#CBCDD2",
-                              "borderRadius": 8,
-                              "borderWidth": 1,
-                              "height": 48,
-                              "width": 48,
-                            },
-                          ]
-                        }
-                      >
-                        <View
-                          style={
-                            [
-                              {
-                                "flexBasis": 0,
-                                "flexGrow": 1,
-                                "flexShrink": 1,
-                              },
-                            ]
-                          }
-                        />
-                        <View
-                          fill="#161617"
-                          height={24}
-                          width={24}
-                        >
-                          <Text>
-                            undefined-SVG-Mock
-                          </Text>
-                        </View>
-                        <View
-                          style={
-                            [
-                              {
-                                "flexBasis": 0,
-                                "flexGrow": 1,
-                                "flexShrink": 1,
-                              },
-                            ]
-                          }
-                        />
-                        <View
-                          style={
-                            [
-                              {
-                                "bottom": -8,
-                                "position": "absolute",
-                              },
-                            ]
-                          }
-                        >
-                          <View
-                            accessibilityLabel="Non accessible"
-                            fill="#696A6F"
-                            height={16}
-                            testID="invalid-icon"
-                            width={16}
-                          >
-                            <Text>
-                              invalid-icon-SVG-Mock
-                            </Text>
-                          </View>
-                        </View>
-                      </View>
-                      <View
-                        numberOfSpaces={4}
-                        style={
-                          [
-                            {
-                              "height": 16,
-                            },
-                          ]
-                        }
-                      />
-                      <Text
-                        style={
-                          [
-                            {
-                              "color": "#161617",
-                              "fontFamily": "Montserrat-SemiBold",
-                              "fontSize": 12,
-                              "lineHeight": 19.2,
-                              "paddingHorizontal": 1,
-                              "textAlign": "center",
-                            },
-                          ]
-                        }
-                      >
-                        Handicap auditif
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-                <View
-                  numberOfSpaces={4}
-                  style={
-                    [
-                      {
-                        "height": 16,
-                      },
-                    ]
-                  }
-                />
-                <View
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#F1F1F4",
-                        "height": 1,
-                        "width": "100%",
-                      },
-                    ]
-                  }
-                />
-                <View
-                  numberOfSpaces={4}
-                  style={
-                    [
-                      {
-                        "height": 16,
-                      },
-                    ]
-                  }
-                />
-                <Text
-                  style={
-                    [
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-SemiBold",
-                        "fontSize": 12,
-                        "lineHeight": 19.2,
-                      },
-                    ]
-                  }
-                >
-                  Horaires d’ouverture
-                </Text>
-                <View
-                  numberOfSpaces={4}
-                  style={
-                    [
-                      {
-                        "height": 16,
-                      },
-                    ]
-                  }
-                />
-                <View
-                  accessibilityRole="list"
-                  style={
-                    [
-                      {
-                        "display": "flex",
-                        "flexDirection": "column",
-                        "gap": 8,
-                        "paddingLeft": 0,
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    accessibilityLabel="Lundi 09:00 - 19:00"
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "display": "flex",
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      accessibilityHidden={true}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Medium",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                          },
-                        ]
-                      }
-                    >
-                      Lundi
-                    </Text>
-                    <Text
-                      accessibilityHidden={true}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Medium",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                          },
-                        ]
-                      }
-                    >
-                      09:00 - 19:00
-                    </Text>
-                  </View>
-                  <View
-                    accessibilityLabel="Mardi 09:00 - 12:00  puis  14:00 - 19:00"
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "display": "flex",
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      accessibilityHidden={true}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Medium",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                          },
-                        ]
-                      }
-                    >
-                      Mardi
-                    </Text>
-                    <Text
-                      accessibilityHidden={true}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Medium",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                          },
-                        ]
-                      }
-                    >
-                      09:00 - 12:00 / 14:00 - 19:00
-                    </Text>
-                  </View>
-                  <View
-                    accessibilityLabel="Mercredi 09:00 - 12:00  puis  14:00 - 19:00"
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "display": "flex",
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      accessibilityHidden={true}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Medium",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                          },
-                        ]
-                      }
-                    >
-                      Mercredi
-                    </Text>
-                    <Text
-                      accessibilityHidden={true}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Medium",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                          },
-                        ]
-                      }
-                    >
-                      09:00 - 12:00 / 14:00 - 19:00
-                    </Text>
-                  </View>
-                  <View
-                    accessibilityLabel="Jeudi 09:00 - 12:00  puis  14:00 - 19:00"
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "display": "flex",
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      accessibilityHidden={true}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Medium",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                          },
-                        ]
-                      }
-                    >
-                      Jeudi
-                    </Text>
-                    <Text
-                      accessibilityHidden={true}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Medium",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                          },
-                        ]
-                      }
-                    >
-                      09:00 - 12:00 / 14:00 - 19:00
-                    </Text>
-                  </View>
-                  <View
-                    accessibilityLabel="Vendredi 09:00 - 19:00"
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "display": "flex",
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      accessibilityHidden={true}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Medium",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                          },
-                        ]
-                      }
-                    >
-                      Vendredi
-                    </Text>
-                    <Text
-                      accessibilityHidden={true}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Medium",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                          },
-                        ]
-                      }
-                    >
-                      09:00 - 19:00
-                    </Text>
-                  </View>
-                  <View
-                    accessibilityLabel="Samedi Fermé"
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "display": "flex",
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      accessibilityHidden={true}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Medium",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                          },
-                        ]
-                      }
-                    >
-                      Samedi
-                    </Text>
-                    <Text
-                      accessibilityHidden={true}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Medium",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                          },
-                        ]
-                      }
-                    >
-                      Fermé
-                    </Text>
-                  </View>
-                  <View
-                    accessibilityLabel="Dimanche Fermé"
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "display": "flex",
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      accessibilityHidden={true}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Medium",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                          },
-                        ]
-                      }
-                    >
-                      Dimanche
-                    </Text>
-                    <Text
-                      accessibilityHidden={true}
-                      style={
-                        [
-                          {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Medium",
-                            "fontSize": 16,
-                            "lineHeight": 25.6,
-                          },
-                        ]
-                      }
-                    >
-                      Fermé
-                    </Text>
-                  </View>
-                </View>
-                <View
-                  numberOfSpaces={4}
-                  style={
-                    [
-                      {
-                        "height": 16,
-                      },
-                    ]
-                  }
-                />
-                <View
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#F1F1F4",
-                        "height": 1,
-                        "width": "100%",
-                      },
-                    ]
-                  }
-                />
-                <View
-                  numberOfSpaces={2}
-                  style={
-                    [
-                      {
-                        "height": 8,
-                      },
-                    ]
-                  }
-                />
-              </View>
-            </View>
-          </View>
-        </View>
-        <View
-          numberOfSpaces={6}
-          style={
-            [
-              {
-                "height": 24,
-              },
-            ]
-          }
-        />
-        <View
-          gap={0}
-          style={
-            [
-              {
-                "gap": 0,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              [
-                {
-                  "backgroundColor": "#F1F1F4",
-                  "height": 8,
-                },
-              ]
-            }
-          />
-          <View
-            style={
-              [
-                {
-                  "flexDirection": "row",
                   "gap": 16,
                 },
               ]
@@ -8127,127 +4925,6 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                 </Text>
               </View>
             </View>
-          </View>
-          <Modal
-            accessibilityLabelledBy="testUuidV4"
-            accessibilityModal={true}
-            animationType="none"
-            deviceHeight={1334}
-            deviceWidth={750}
-            hardwareAccelerated={false}
-            hideModalContentWhileAnimating={false}
-            onBackdropPress={[Function]}
-            onModalHide={[Function]}
-            onModalWillHide={[Function]}
-            onModalWillShow={[Function]}
-            onRequestClose={[Function]}
-            panResponderThreshold={4}
-            scrollHorizontal={false}
-            scrollOffset={0}
-            scrollOffsetMax={0}
-            scrollTo={null}
-            statusBarTranslucent={true}
-            supportedOrientations={
-              [
-                "portrait",
-                "landscape",
-              ]
-            }
-            swipeThreshold={100}
-            testID="modal"
-            transparent={true}
-            visible={false}
-          />
-          <Modal
-            accessibilityLabelledBy="testUuidV4"
-            accessibilityModal={true}
-            animationType="none"
-            deviceHeight={1334}
-            deviceWidth={750}
-            hardwareAccelerated={false}
-            hideModalContentWhileAnimating={false}
-            onBackdropPress={[Function]}
-            onModalHide={[Function]}
-            onModalWillHide={[Function]}
-            onModalWillShow={[Function]}
-            onRequestClose={[Function]}
-            panResponderThreshold={4}
-            scrollHorizontal={false}
-            scrollOffset={0}
-            scrollOffsetMax={0}
-            scrollTo={null}
-            statusBarTranslucent={true}
-            supportedOrientations={
-              [
-                "portrait",
-                "landscape",
-              ]
-            }
-            swipeThreshold={100}
-            testID="modal"
-            transparent={true}
-            visible={false}
-          />
-          <Modal
-            accessibilityLabelledBy="testUuidV4"
-            accessibilityModal={true}
-            animationType="none"
-            deviceHeight={1334}
-            deviceWidth={750}
-            hardwareAccelerated={false}
-            hideModalContentWhileAnimating={false}
-            onBackdropPress={[Function]}
-            onModalHide={[Function]}
-            onModalWillHide={[Function]}
-            onModalWillShow={[Function]}
-            onRequestClose={[Function]}
-            panResponderThreshold={4}
-            scrollHorizontal={false}
-            scrollOffset={0}
-            scrollOffsetMax={0}
-            scrollTo={null}
-            statusBarTranslucent={true}
-            supportedOrientations={
-              [
-                "portrait",
-                "landscape",
-              ]
-            }
-            swipeThreshold={100}
-            testID="modal"
-            transparent={true}
-            visible={false}
-          />
-        </View>
-        <View
-          gap={6}
-          style={
-            [
-              {
-                "gap": 24,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              [
-                {
-                  "backgroundColor": "#F1F1F4",
-                  "height": 8,
-                },
-              ]
-            }
-          />
-          <View
-            style={
-              [
-                {
-                  "paddingHorizontal": 24,
-                },
-              ]
-            }
-          >
             <View
               gap={1}
               style={
@@ -8422,8 +5099,8 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -8542,8 +5219,8 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                             {
                               "color": "#161617",
                               "fontFamily": "Montserrat-Bold",
-                              "fontSize": 15,
-                              "lineHeight": 20,
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
                               "maxWidth": "100%",
                             },
                           ]
@@ -9164,8 +5841,8 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                             {
                               "color": "#161617",
                               "fontFamily": "Montserrat-Bold",
-                              "fontSize": 15,
-                              "lineHeight": 20,
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
                               "maxWidth": "100%",
                             },
                           ]
@@ -9272,8 +5949,8 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                             {
                               "color": "#161617",
                               "fontFamily": "Montserrat-Bold",
-                              "fontSize": 15,
-                              "lineHeight": 20,
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
                               "maxWidth": "100%",
                             },
                           ]
@@ -9381,8 +6058,8 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                             {
                               "color": "#161617",
                               "fontFamily": "Montserrat-Bold",
-                              "fontSize": 15,
-                              "lineHeight": 20,
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
                               "maxWidth": "100%",
                             },
                           ]
@@ -10681,7 +7358,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
               style={
                 [
                   {
-                    "marginHorizontal": 24,
+                    "paddingHorizontal": 24,
                   },
                 ]
               }

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -103,97 +103,44 @@ exports[`<Venue /> should match snapshot 1`] = `
           }
         >
           <View
-            maxHeight={56}
+            gap={4}
             style={
               [
                 {
-                  "flexDirection": "row",
-                  "flexWrap": "wrap",
-                  "gap": 8,
-                  "maxHeight": 56,
-                  "overflow": "hidden",
+                  "gap": 16,
                 },
               ]
             }
-            testID="tagsContainer"
           >
             <View
+              maxHeight={56}
               style={
                 [
                   {
-                    "alignSelf": "baseline",
-                    "backgroundColor": "#F1F1F4",
-                    "borderRadius": 6,
                     "flexDirection": "row",
-                    "paddingHorizontal": 8,
-                    "paddingVertical": 4,
+                    "flexWrap": "wrap",
+                    "gap": 8,
+                    "maxHeight": 56,
+                    "overflow": "hidden",
                   },
                 ]
               }
+              testID="tagsContainer"
             >
-              <Text
+              <View
                 style={
                   [
                     {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 12,
-                      "lineHeight": 16,
+                      "alignSelf": "baseline",
+                      "backgroundColor": "#F1F1F4",
+                      "borderRadius": 6,
+                      "flexDirection": "row",
+                      "paddingHorizontal": 8,
+                      "paddingVertical": 4,
                     },
                   ]
                 }
               >
-                Librairie
-              </Text>
-            </View>
-          </View>
-          <View
-            numberOfSpaces={4}
-            style={
-              [
-                {
-                  "height": 16,
-                },
-              ]
-            }
-          />
-          <View
-            gap={1}
-            style={
-              [
-                {
-                  "gap": 4,
-                },
-              ]
-            }
-          >
-            <Text
-              accessibilityLabel="Nom du lieu : Le Petit Rintintin 1"
-              adjustsFontSizeToFit={true}
-              style={
-                [
-                  {
-                    "color": "#161617",
-                    "fontFamily": "Montserrat-Bold",
-                    "fontSize": 19,
-                    "lineHeight": 30.4,
-                  },
-                ]
-              }
-            >
-              Le Petit Rintintin 1
-            </Text>
-            <View
-              gap={3}
-              style={
-                [
-                  {
-                    "gap": 12,
-                  },
-                ]
-              }
-            >
-              <View>
                 <Text
                   style={
                     [
@@ -201,131 +148,53 @@ exports[`<Venue /> should match snapshot 1`] = `
                         "color": "#161617",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 19.2,
+                        "lineHeight": 16,
                       },
                     ]
                   }
                 >
-                  Adresse
-                </Text>
-                <Text
-                  style={
-                    [
-                      {
-                        "color": "#161617",
-                        "fontFamily": "Montserrat-Medium",
-                        "fontSize": 16,
-                        "lineHeight": 25.6,
-                      },
-                    ]
-                  }
-                >
-                  1 boulevard Poissonnière, 75000 Paris
+                  Librairie
                 </Text>
               </View>
-              <View
+            </View>
+            <View
+              gap={1}
+              style={
+                [
+                  {
+                    "gap": 4,
+                  },
+                ]
+              }
+            >
+              <Text
+                accessibilityLabel="Nom du lieu : Le Petit Rintintin 1"
+                adjustsFontSizeToFit={true}
                 style={
                   [
                     {
-                      "backgroundColor": "#F1F1F4",
-                      "height": 1,
-                      "width": "100%",
+                      "color": "#161617",
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 19,
+                      "lineHeight": 30.4,
                     },
                   ]
                 }
-              />
-              <View
-                accessibilityLabel="Copier l’adresse"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "alignItems": "center",
-                    "backgroundColor": "transparent",
-                    "borderRadius": 24,
-                    "flexDirection": "row",
-                    "justifyContent": "flex-start",
-                    "maxWidth": 500,
-                    "minHeight": 40,
-                    "opacity": 1,
-                    "paddingBottom": 2,
-                    "paddingLeft": 2,
-                    "paddingRight": 2,
-                    "paddingTop": 2,
-                    "userSelect": "auto",
-                    "width": "100%",
-                  }
-                }
-                testID="Copier l’adresse"
               >
-                <View
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    style={
-                      [
-                        {
-                          "flexDirection": "row",
-                          "flexShrink": 0,
-                        },
-                      ]
-                    }
-                  >
-                    <View
-                      height={20}
-                      testID="button-icon-left"
-                      width={20}
-                    >
-                      <Text>
-                        button-icon-left-SVG-Mock
-                      </Text>
-                    </View>
-                    <View
-                      numberOfSpaces={2}
-                      style={
-                        [
-                          {
-                            "width": 8,
-                          },
-                        ]
-                      }
-                    />
-                  </View>
+                Le Petit Rintintin 1
+              </Text>
+              <View
+                gap={3}
+                style={
+                  [
+                    {
+                      "gap": 12,
+                    },
+                  ]
+                }
+              >
+                <View>
                   <Text
-                    adjustsFontSizeToFit={false}
-                    numberOfLines={1}
                     style={
                       [
                         {
@@ -338,21 +207,36 @@ exports[`<Venue /> should match snapshot 1`] = `
                       ]
                     }
                   >
-                    Copier l’adresse
+                    Adresse
+                  </Text>
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
+                        },
+                      ]
+                    }
+                  >
+                    1 boulevard Poissonnière, 75000 Paris
                   </Text>
                 </View>
-              </View>
-              <View
-                style={
-                  [
-                    {
-                      "alignItems": "flex-start",
-                    },
-                  ]
-                }
-              >
                 <View
-                  accessibilityLabel="Voir l’itinéraire"
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#F1F1F4",
+                        "height": 1,
+                        "width": "100%",
+                      },
+                    ]
+                  }
+                />
+                <View
+                  accessibilityLabel="Copier l’adresse"
                   accessibilityState={
                     {
                       "busy": undefined,
@@ -384,23 +268,21 @@ exports[`<Venue /> should match snapshot 1`] = `
                     {
                       "alignItems": "center",
                       "backgroundColor": "transparent",
-                      "borderRadius": 0,
-                      "borderWidth": 0,
+                      "borderRadius": 24,
                       "flexDirection": "row",
-                      "justifyContent": "center",
-                      "marginTop": 0,
+                      "justifyContent": "flex-start",
                       "maxWidth": 500,
-                      "minHeight": 20,
+                      "minHeight": 40,
                       "opacity": 1,
-                      "paddingBottom": 0,
-                      "paddingLeft": 0,
-                      "paddingRight": 0,
-                      "paddingTop": 0,
+                      "paddingBottom": 2,
+                      "paddingLeft": 2,
+                      "paddingRight": 2,
+                      "paddingTop": 2,
                       "userSelect": "auto",
-                      "width": "auto",
+                      "width": "100%",
                     }
                   }
-                  testID="Voir l’itinéraire"
+                  testID="Copier l’adresse"
                 >
                   <View
                     style={
@@ -423,7 +305,6 @@ exports[`<Venue /> should match snapshot 1`] = `
                       }
                     >
                       <View
-                        accessibilityLabel="Nouvelle fenêtre"
                         height={20}
                         testID="button-icon-left"
                         width={20}
@@ -458,8 +339,129 @@ exports[`<Venue /> should match snapshot 1`] = `
                         ]
                       }
                     >
-                      Voir l’itinéraire
+                      Copier l’adresse
                     </Text>
+                  </View>
+                </View>
+                <View
+                  style={
+                    [
+                      {
+                        "alignItems": "flex-start",
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    accessibilityLabel="Voir l’itinéraire"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "transparent",
+                        "borderRadius": 0,
+                        "borderWidth": 0,
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                        "marginTop": 0,
+                        "maxWidth": 500,
+                        "minHeight": 20,
+                        "opacity": 1,
+                        "paddingBottom": 0,
+                        "paddingLeft": 0,
+                        "paddingRight": 0,
+                        "paddingTop": 0,
+                        "userSelect": "auto",
+                        "width": "auto",
+                      }
+                    }
+                    testID="Voir l’itinéraire"
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                              "flexShrink": 0,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          accessibilityLabel="Nouvelle fenêtre"
+                          height={20}
+                          testID="button-icon-left"
+                          width={20}
+                        >
+                          <Text>
+                            button-icon-left-SVG-Mock
+                          </Text>
+                        </View>
+                        <View
+                          numberOfSpaces={2}
+                          style={
+                            [
+                              {
+                                "width": 8,
+                              },
+                            ]
+                          }
+                        />
+                      </View>
+                      <Text
+                        adjustsFontSizeToFit={false}
+                        numberOfLines={1}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Bold",
+                              "fontSize": 15,
+                              "lineHeight": 20,
+                              "maxWidth": "100%",
+                            },
+                          ]
+                        }
+                      >
+                        Voir l’itinéraire
+                      </Text>
+                    </View>
                   </View>
                 </View>
               </View>
@@ -468,339 +470,79 @@ exports[`<Venue /> should match snapshot 1`] = `
         </View>
       </View>
       <View
-        numberOfSpaces={6}
+        gap={6}
         style={
           [
             {
-              "height": 24,
+              "gap": 24,
             },
           ]
         }
-      />
-      <View
-        animatedStyle={
-          {
-            "value": {},
-          }
-        }
-        collapsable={false}
-        layout={
-          LinearTransition {
-            "build": [Function],
-            "callbackV": undefined,
-            "dampingV": undefined,
-            "delayV": undefined,
-            "durationV": 200,
-            "easingV": undefined,
-            "initialValues": undefined,
-            "massV": undefined,
-            "overshootClampingV": undefined,
-            "randomizeDelay": false,
-            "restDisplacementThresholdV": undefined,
-            "restSpeedThresholdV": undefined,
-            "rotateV": undefined,
-            "stiffnessV": undefined,
-            "type": undefined,
-          }
-        }
       >
         <View
-          gap={6}
-          style={
-            [
-              {
-                "gap": 24,
-              },
-            ]
+          animatedStyle={
+            {
+              "value": {},
+            }
+          }
+          collapsable={false}
+          layout={
+            LinearTransition {
+              "build": [Function],
+              "callbackV": undefined,
+              "dampingV": undefined,
+              "delayV": undefined,
+              "durationV": 200,
+              "easingV": undefined,
+              "initialValues": undefined,
+              "massV": undefined,
+              "overshootClampingV": undefined,
+              "randomizeDelay": false,
+              "restDisplacementThresholdV": undefined,
+              "restSpeedThresholdV": undefined,
+              "rotateV": undefined,
+              "stiffnessV": undefined,
+              "type": undefined,
+            }
           }
         >
           <View
+            gap={6}
             style={
               [
                 {
-                  "backgroundColor": "#F1F1F4",
-                  "height": 8,
-                },
-              ]
-            }
-          />
-          <View
-            style={
-              [
-                {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                  "width": "100%",
+                  "gap": 24,
                 },
               ]
             }
           >
             <View
-              accessibilityRole="tablist"
               style={
                 [
                   {
-                    "flexDirection": "row",
+                    "backgroundColor": "#F1F1F4",
+                    "height": 8,
                   },
                 ]
               }
-            >
-              <View
-                style={
-                  [
-                    {
-                      "backgroundColor": "#F1F1F4",
-                      "bottom": 0,
-                      "height": 4,
-                      "position": "absolute",
-                      "width": "100%",
-                    },
-                  ]
-                }
-              />
-              <View
-                numberOfSpaces={6}
-                style={
-                  [
-                    {
-                      "width": 24,
-                    },
-                  ]
-                }
-              />
-              <View
-                accessibilityRole="tab"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": true,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "flexBasis": 0,
-                    "flexGrow": 1,
-                    "flexShrink": 1,
-                    "maxWidth": 180,
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-              >
-                <View
-                  gap={2}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "flexGrow": 1,
-                        "gap": 8,
-                        "justifyContent": "center",
-                      },
-                    ]
-                  }
-                >
-                  <Text
-                    isHover={false}
-                    isSelected={true}
-                    style={
-                      [
-                        {
-                          "color": "#eb0055",
-                          "fontFamily": "Montserrat-SemiBold",
-                          "fontSize": 16,
-                          "lineHeight": 25.6,
-                          "textAlign": "center",
-                        },
-                      ]
-                    }
-                  >
-                    Offres disponibles
-                  </Text>
-                </View>
-                <View
-                  numberOfSpaces={2}
-                  style={
-                    [
-                      {
-                        "height": 8,
-                      },
-                    ]
-                  }
-                />
-                <View
-                  isSelected={true}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "#eb0055",
-                        "borderRadius": 4,
-                        "bottom": 0,
-                        "height": 4,
-                        "width": "100%",
-                      },
-                    ]
-                  }
-                />
-              </View>
-              <View
-                accessibilityRole="tab"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": false,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={false}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "flexBasis": 0,
-                    "flexGrow": 1,
-                    "flexShrink": 1,
-                    "maxWidth": 180,
-                    "opacity": 1,
-                    "userSelect": "auto",
-                  }
-                }
-              >
-                <View
-                  gap={2}
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "flexGrow": 1,
-                        "gap": 8,
-                        "justifyContent": "center",
-                      },
-                    ]
-                  }
-                >
-                  <Text
-                    isHover={false}
-                    isSelected={false}
-                    style={
-                      [
-                        {
-                          "color": "#696A6F",
-                          "fontFamily": "Montserrat-SemiBold",
-                          "fontSize": 16,
-                          "lineHeight": 25.6,
-                          "textAlign": "center",
-                        },
-                      ]
-                    }
-                  >
-                    Infos pratiques
-                  </Text>
-                </View>
-                <View
-                  numberOfSpaces={2}
-                  style={
-                    [
-                      {
-                        "height": 8,
-                      },
-                    ]
-                  }
-                />
-                <View
-                  isSelected={false}
-                  style={
-                    [
-                      {
-                        "backgroundColor": "transparent",
-                        "borderRadius": 4,
-                        "bottom": 0,
-                        "height": 4,
-                        "width": "100%",
-                      },
-                    ]
-                  }
-                />
-              </View>
-              <View
-                numberOfSpaces={6}
-                style={
-                  [
-                    {
-                      "width": 24,
-                    },
-                  ]
-                }
-              />
-            </View>
+            />
             <View
-              accessibilityRole="none"
               style={
                 [
                   {
                     "flexGrow": 1,
                     "flexShrink": 1,
+                    "width": "100%",
                   },
                 ]
               }
             >
               <View
-                numberOfSpaces={6}
+                accessibilityRole="tablist"
                 style={
                   [
                     {
-                      "height": 24,
-                    },
-                  ]
-                }
-              />
-              <View
-                gap={4}
-                style={
-                  [
-                    {
-                      "gap": 16,
-                      "paddingBottom": 24,
+                      "flexDirection": "row",
                     },
                   ]
                 }
@@ -816,600 +558,129 @@ exports[`<Venue /> should match snapshot 1`] = `
                   }
                 >
                   <View
+                    gap={2}
                     style={
                       [
                         {
+                          "alignItems": "center",
                           "flexDirection": "row",
+                          "flexGrow": 1,
+                          "gap": 8,
+                          "justifyContent": "center",
                         },
                       ]
                     }
                   >
                     <Text
-                      numberOfLines={2}
+                      isHover={false}
+                      isSelected={true}
                       style={
                         [
                           {
-                            "color": "#161617",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 19,
-                            "lineHeight": 30.4,
-                            "marginHorizontal": 24,
+                            "color": "#eb0055",
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
+                            "textAlign": "center",
                           },
                         ]
                       }
-                      testID="playlistTitle"
                     >
-                      Toutes les offres
+                      Offres disponibles
                     </Text>
                   </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "height": 8,
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    isSelected={true}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#eb0055",
+                          "borderRadius": 4,
+                          "bottom": 0,
+                          "height": 4,
+                          "width": "100%",
+                        },
+                      ]
+                    }
+                  />
                 </View>
                 <View
-                  onLayout={[Function]}
+                  accessibilityRole="tab"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": false,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
                   style={
-                    [
-                      {
-                        "position": "relative",
-                        "width": "100%",
-                      },
-                    ]
+                    {
+                      "flexBasis": 0,
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                      "maxWidth": 180,
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
                   }
                 >
                   <View
-                    style={{}}
+                    gap={2}
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "flexGrow": 1,
+                          "gap": 8,
+                          "justifyContent": "center",
+                        },
+                      ]
+                    }
                   >
-                    <RCTScrollView
-                      ItemSeparatorComponent={
-                        {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "attrs": [
-                            {
-                              "width": 16,
-                            },
-                          ],
-                          "inlineStyle": InlineStyle {
-                            "rules": [
-                              [Function],
-                              "",
-                            ],
-                          },
-                          "render": [Function],
-                          "shouldForwardProp": undefined,
-                          "styledComponentId": "StyledNativeComponent",
-                          "target": [Function],
-                          "withComponent": [Function],
-                        }
-                      }
-                      ListFooterComponent={
-                        {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "attrs": [
-                            {
-                              "width": 24,
-                            },
-                          ],
-                          "inlineStyle": InlineStyle {
-                            "rules": [
-                              [Function],
-                              "",
-                            ],
-                          },
-                          "render": [Function],
-                          "shouldForwardProp": undefined,
-                          "styledComponentId": "StyledNativeComponent",
-                          "target": [Function],
-                          "withComponent": [Function],
-                        }
-                      }
-                      ListHeaderComponent={
-                        {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "attrs": [
-                            {
-                              "width": 24,
-                            },
-                          ],
-                          "inlineStyle": InlineStyle {
-                            "rules": [
-                              [Function],
-                              "",
-                            ],
-                          },
-                          "render": [Function],
-                          "shouldForwardProp": undefined,
-                          "styledComponentId": "StyledNativeComponent",
-                          "target": [Function],
-                          "withComponent": [Function],
-                        }
-                      }
-                      applyWindowCorrection={[Function]}
-                      canChangeSize={true}
-                      contentContainerStyle={
-                        {
-                          "backgroundColor": undefined,
-                          "minHeight": 1,
-                          "minWidth": 1,
-                          "paddingBottom": 0,
-                          "paddingTop": 0,
-                        }
-                      }
-                      contentHeight={250}
-                      contentWidth={432}
-                      data={
+                    <Text
+                      isHover={false}
+                      isSelected={false}
+                      style={
                         [
                           {
-                            "_geoloc": {
-                              "lat": 47.8898,
-                              "lng": -2.83593,
-                            },
-                            "objectID": "223342",
-                            "offer": {
-                              "dates": [
-                                1629312300,
-                                1629485100,
-                                1629657900,
-                              ],
-                              "isDigital": false,
-                              "isDuo": true,
-                              "name": "Titane - VF",
-                              "prices": [
-                                0,
-                                0,
-                                0,
-                              ],
-                              "subcategoryId": "CINE_PLEIN_AIR",
-                              "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
-                            },
-                            "venue": {},
-                          },
-                          {
-                            "_geoloc": {
-                              "lat": 47.8898,
-                              "lng": -2.83593,
-                            },
-                            "objectID": "223338",
-                            "offer": {
-                              "dates": [
-                                1629312300,
-                                1629485100,
-                                1629657900,
-                              ],
-                              "isDigital": false,
-                              "isDuo": true,
-                              "name": "Bac Nord - VF",
-                              "prices": [
-                                0,
-                                0,
-                                0,
-                              ],
-                              "subcategoryId": "CINE_PLEIN_AIR",
-                              "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
-                            },
-                            "venue": {},
-                          },
-                          {
-                            "_geoloc": {
-                              "lat": 47.8898,
-                              "lng": -2.83593,
-                            },
-                            "objectID": "223339",
-                            "offer": {
-                              "dates": [
-                                1629312300,
-                                1629485100,
-                                1629657900,
-                              ],
-                              "isDigital": false,
-                              "isDuo": true,
-                              "name": "Black Widow - VF",
-                              "prices": [
-                                0,
-                                0,
-                                0,
-                              ],
-                              "subcategoryId": "CINE_PLEIN_AIR",
-                              "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMA",
-                            },
-                            "venue": {},
+                            "color": "#696A6F",
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
+                            "textAlign": "center",
                           },
                         ]
-                      }
-                      dataProvider={
-                        DataProvider {
-                          "_data": [
-                            {
-                              "_geoloc": {
-                                "lat": 47.8898,
-                                "lng": -2.83593,
-                              },
-                              "objectID": "223342",
-                              "offer": {
-                                "dates": [
-                                  1629312300,
-                                  1629485100,
-                                  1629657900,
-                                ],
-                                "isDigital": false,
-                                "isDuo": true,
-                                "name": "Titane - VF",
-                                "prices": [
-                                  0,
-                                  0,
-                                  0,
-                                ],
-                                "subcategoryId": "CINE_PLEIN_AIR",
-                                "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
-                              },
-                              "venue": {},
-                            },
-                            {
-                              "_geoloc": {
-                                "lat": 47.8898,
-                                "lng": -2.83593,
-                              },
-                              "objectID": "223338",
-                              "offer": {
-                                "dates": [
-                                  1629312300,
-                                  1629485100,
-                                  1629657900,
-                                ],
-                                "isDigital": false,
-                                "isDuo": true,
-                                "name": "Bac Nord - VF",
-                                "prices": [
-                                  0,
-                                  0,
-                                  0,
-                                ],
-                                "subcategoryId": "CINE_PLEIN_AIR",
-                                "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
-                              },
-                              "venue": {},
-                            },
-                            {
-                              "_geoloc": {
-                                "lat": 47.8898,
-                                "lng": -2.83593,
-                              },
-                              "objectID": "223339",
-                              "offer": {
-                                "dates": [
-                                  1629312300,
-                                  1629485100,
-                                  1629657900,
-                                ],
-                                "isDigital": false,
-                                "isDuo": true,
-                                "name": "Black Widow - VF",
-                                "prices": [
-                                  0,
-                                  0,
-                                  0,
-                                ],
-                                "subcategoryId": "CINE_PLEIN_AIR",
-                                "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMA",
-                              },
-                              "venue": {},
-                            },
-                          ],
-                          "_firstIndexToProcess": 0,
-                          "_hasStableIds": true,
-                          "_requiresDataChangeHandling": false,
-                          "_size": 3,
-                          "getStableId": [Function],
-                          "rowHasChanged": [Function],
-                        }
-                      }
-                      disableRecycling={false}
-                      estimatedItemSize={144}
-                      extendedState={{}}
-                      externalScrollView={[Function]}
-                      finalRenderAheadOffset={187.5}
-                      forceNonDeterministicRendering={true}
-                      horizontal={true}
-                      initialOffset={0}
-                      initialRenderIndex={0}
-                      isHorizontal={true}
-                      keyExtractor={[Function]}
-                      layoutProvider={
-                        GridLayoutProviderWithProps {
-                          "_acceptableRelayoutDelta": 1,
-                          "_getHeightOrWidth": [Function],
-                          "_getLayoutTypeForIndex": [Function],
-                          "_getSpan": [Function],
-                          "_hasExpired": false,
-                          "_isHorizontal": true,
-                          "_lastLayoutManager": GridLayoutManager {
-                            "_acceptableRelayoutDelta": 1,
-                            "_getSpan": [Function],
-                            "_isGridHorizontal": true,
-                            "_isHorizontal": true,
-                            "_layoutProvider": [Circular],
-                            "_layouts": [
-                              {
-                                "height": 250,
-                                "type": 0,
-                                "width": 144,
-                                "x": 0,
-                                "y": 0,
-                              },
-                              {
-                                "height": 250,
-                                "type": 0,
-                                "width": 144,
-                                "x": 144,
-                                "y": 0,
-                              },
-                              {
-                                "height": 250,
-                                "type": 0,
-                                "width": 144,
-                                "x": 288,
-                                "y": 0,
-                              },
-                            ],
-                            "_maxSpan": 1,
-                            "_renderWindowSize": {
-                              "height": 250,
-                              "width": 800,
-                            },
-                            "_totalHeight": 250,
-                            "_totalWidth": 432,
-                            "_window": {
-                              "height": 250,
-                              "width": 800,
-                            },
-                          },
-                          "_maxSpan": 1,
-                          "_renderWindowSize": {
-                            "height": 250,
-                            "width": 800,
-                          },
-                          "_setLayoutForType": [Function],
-                          "_tempDim": {
-                            "height": 0,
-                            "width": 0,
-                          },
-                          "averageWindow": AverageWindow {
-                            "currentAverage": 144,
-                            "currentCount": 1,
-                            "inputValues": [
-                              144,
-                              ,
-                              ,
-                              ,
-                              ,
-                              ,
-                              ,
-                              ,
-                              ,
-                              ,
-                              ,
-                              ,
-                            ],
-                            "nextIndex": 1,
-                          },
-                          "defaultEstimatedItemSize": 100,
-                          "layoutObject": {
-                            "size": undefined,
-                            "span": undefined,
-                          },
-                          "props": {
-                            "ItemSeparatorComponent": {
-                              "$$typeof": Symbol(react.forward_ref),
-                              "attrs": [
-                                {
-                                  "width": 16,
-                                },
-                              ],
-                              "inlineStyle": InlineStyle {
-                                "rules": [
-                                  [Function],
-                                  "",
-                                ],
-                              },
-                              "render": [Function],
-                              "shouldForwardProp": undefined,
-                              "styledComponentId": "StyledNativeComponent",
-                              "target": [Function],
-                              "withComponent": [Function],
-                            },
-                            "ListFooterComponent": {
-                              "$$typeof": Symbol(react.forward_ref),
-                              "attrs": [
-                                {
-                                  "width": 24,
-                                },
-                              ],
-                              "inlineStyle": InlineStyle {
-                                "rules": [
-                                  [Function],
-                                  "",
-                                ],
-                              },
-                              "render": [Function],
-                              "shouldForwardProp": undefined,
-                              "styledComponentId": "StyledNativeComponent",
-                              "target": [Function],
-                              "withComponent": [Function],
-                            },
-                            "ListHeaderComponent": {
-                              "$$typeof": Symbol(react.forward_ref),
-                              "attrs": [
-                                {
-                                  "width": 24,
-                                },
-                              ],
-                              "inlineStyle": InlineStyle {
-                                "rules": [
-                                  [Function],
-                                  "",
-                                ],
-                              },
-                              "render": [Function],
-                              "shouldForwardProp": undefined,
-                              "styledComponentId": "StyledNativeComponent",
-                              "target": [Function],
-                              "withComponent": [Function],
-                            },
-                            "data": [
-                              {
-                                "_geoloc": {
-                                  "lat": 47.8898,
-                                  "lng": -2.83593,
-                                },
-                                "objectID": "223342",
-                                "offer": {
-                                  "dates": [
-                                    1629312300,
-                                    1629485100,
-                                    1629657900,
-                                  ],
-                                  "isDigital": false,
-                                  "isDuo": true,
-                                  "name": "Titane - VF",
-                                  "prices": [
-                                    0,
-                                    0,
-                                    0,
-                                  ],
-                                  "subcategoryId": "CINE_PLEIN_AIR",
-                                  "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
-                                },
-                                "venue": {},
-                              },
-                              {
-                                "_geoloc": {
-                                  "lat": 47.8898,
-                                  "lng": -2.83593,
-                                },
-                                "objectID": "223338",
-                                "offer": {
-                                  "dates": [
-                                    1629312300,
-                                    1629485100,
-                                    1629657900,
-                                  ],
-                                  "isDigital": false,
-                                  "isDuo": true,
-                                  "name": "Bac Nord - VF",
-                                  "prices": [
-                                    0,
-                                    0,
-                                    0,
-                                  ],
-                                  "subcategoryId": "CINE_PLEIN_AIR",
-                                  "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
-                                },
-                                "venue": {},
-                              },
-                              {
-                                "_geoloc": {
-                                  "lat": 47.8898,
-                                  "lng": -2.83593,
-                                },
-                                "objectID": "223339",
-                                "offer": {
-                                  "dates": [
-                                    1629312300,
-                                    1629485100,
-                                    1629657900,
-                                  ],
-                                  "isDigital": false,
-                                  "isDuo": true,
-                                  "name": "Black Widow - VF",
-                                  "prices": [
-                                    0,
-                                    0,
-                                    0,
-                                  ],
-                                  "subcategoryId": "CINE_PLEIN_AIR",
-                                  "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMA",
-                                },
-                                "venue": {},
-                              },
-                            ],
-                            "drawDistance": 187.5,
-                            "estimatedItemSize": 144,
-                            "horizontal": true,
-                            "keyExtractor": [Function],
-                            "numColumns": 1,
-                            "onContentSizeChange": [Function],
-                            "onEndReached": undefined,
-                            "onEndReachedThreshold": 0.2,
-                            "onScroll": [Function],
-                            "renderItem": [Function],
-                            "scrollEnabled": true,
-                            "scrollEventThrottle": 16,
-                            "showsHorizontalScrollIndicator": false,
-                            "testID": "offersModuleList",
-                          },
-                          "renderWindowInsets": {
-                            "height": 0,
-                            "width": 0,
-                          },
-                          "shouldRefreshWithAnchoring": true,
-                        }
-                      }
-                      maxRenderAhead={562.5}
-                      numColumns={1}
-                      onContentSizeChange={[Function]}
-                      onEndReached={[Function]}
-                      onEndReachedThreshold={0}
-                      onEndReachedThresholdRelative={0.2}
-                      onItemLayout={[Function]}
-                      onLayout={[Function]}
-                      onScroll={[Function]}
-                      onScrollBeginDrag={[Function]}
-                      onSizeChanged={[Function]}
-                      onVisibleIndicesChanged={[Function]}
-                      removeClippedSubviews={false}
-                      renderAheadOffset={0}
-                      renderAheadStep={187.5}
-                      renderContentContainer={[Function]}
-                      renderItem={[Function]}
-                      renderItemContainer={[Function]}
-                      rowRenderer={[Function]}
-                      scrollEnabled={true}
-                      scrollEventThrottle={16}
-                      scrollThrottle={16}
-                      scrollViewProps={
-                        {
-                          "contentContainerStyle": {
-                            "backgroundColor": undefined,
-                            "minHeight": 1,
-                            "minWidth": 1,
-                            "paddingBottom": 0,
-                            "paddingTop": 0,
-                          },
-                          "onLayout": [Function],
-                          "onScrollBeginDrag": [Function],
-                          "refreshControl": undefined,
-                          "style": {
-                            "minHeight": 1,
-                            "minWidth": 1,
-                          },
-                        }
-                      }
-                      showsHorizontalScrollIndicator={false}
-                      style={
-                        {
-                          "minHeight": 1,
-                          "minWidth": 1,
-                        }
-                      }
-                      suppressBoundedSizeException={true}
-                      testID="offersModuleList"
-                      windowCorrectionConfig={
-                        {
-                          "applyToInitialOffset": true,
-                          "applyToItemScroll": true,
-                          "value": {
-                            "endCorrection": 0,
-                            "startCorrection": 0,
-                            "windowShift": -1,
-                          },
-                        }
                       }
                     >
                       <View>
@@ -2393,34 +1664,62 @@ exports[`<Venue /> should match snapshot 1`] = `
                       </View>
                     </RCTScrollView>
                   </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "height": 8,
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    isSelected={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "borderRadius": 4,
+                          "bottom": 0,
+                          "height": 4,
+                          "width": "100%",
+                        },
+                      ]
+                    }
+                  />
                 </View>
+                <View
+                  numberOfSpaces={6}
+                  style={
+                    [
+                      {
+                        "width": 24,
+                      },
+                    ]
+                  }
+                />
               </View>
               <View
+                accessibilityRole="none"
                 style={
                   [
                     {
-                      "position": "relative",
+                      "flexGrow": 1,
+                      "flexShrink": 1,
                     },
                   ]
                 }
               >
                 <View
-                  onChange={[Function]}
-                  onLayout={[Function]}
+                  numberOfSpaces={6}
                   style={
                     [
                       {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": "50%",
+                        "height": 24,
                       },
                     ]
                   }
-                  testID="intersectionObserver"
-                  threshold="50%"
-                  triggerOnce={false}
                 />
                 <View
                   gap={4}
@@ -2467,7 +1766,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                         }
                         testID="playlistTitle"
                       >
-                        Test
+                        Toutes les offres
                       </Text>
                     </View>
                   </View>
@@ -2561,23 +1860,83 @@ exports[`<Venue /> should match snapshot 1`] = `
                           }
                         }
                         contentHeight={250}
-                        contentWidth={192}
+                        contentWidth={432}
                         data={
                           [
                             {
                               "_geoloc": {
-                                "lat": 2,
-                                "lng": 2,
+                                "lat": 47.8898,
+                                "lng": -2.83593,
                               },
-                              "objectID": "12",
+                              "objectID": "223342",
                               "offer": {
-                                "name": "Test",
-                                "subcategoryId": "ABO_BIBLIOTHEQUE",
+                                "dates": [
+                                  1629312300,
+                                  1629485100,
+                                  1629657900,
+                                ],
+                                "isDigital": false,
+                                "isDuo": true,
+                                "name": "Titane - VF",
+                                "prices": [
+                                  0,
+                                  0,
+                                  0,
+                                ],
+                                "subcategoryId": "CINE_PLEIN_AIR",
+                                "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
                               },
-                              "venue": {
-                                "address": "Avenue des Tests",
-                                "city": "Jest",
+                              "venue": {},
+                            },
+                            {
+                              "_geoloc": {
+                                "lat": 47.8898,
+                                "lng": -2.83593,
                               },
+                              "objectID": "223338",
+                              "offer": {
+                                "dates": [
+                                  1629312300,
+                                  1629485100,
+                                  1629657900,
+                                ],
+                                "isDigital": false,
+                                "isDuo": true,
+                                "name": "Bac Nord - VF",
+                                "prices": [
+                                  0,
+                                  0,
+                                  0,
+                                ],
+                                "subcategoryId": "CINE_PLEIN_AIR",
+                                "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
+                              },
+                              "venue": {},
+                            },
+                            {
+                              "_geoloc": {
+                                "lat": 47.8898,
+                                "lng": -2.83593,
+                              },
+                              "objectID": "223339",
+                              "offer": {
+                                "dates": [
+                                  1629312300,
+                                  1629485100,
+                                  1629657900,
+                                ],
+                                "isDigital": false,
+                                "isDuo": true,
+                                "name": "Black Widow - VF",
+                                "prices": [
+                                  0,
+                                  0,
+                                  0,
+                                ],
+                                "subcategoryId": "CINE_PLEIN_AIR",
+                                "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMA",
+                              },
+                              "venue": {},
                             },
                           ]
                         }
@@ -2586,30 +1945,90 @@ exports[`<Venue /> should match snapshot 1`] = `
                             "_data": [
                               {
                                 "_geoloc": {
-                                  "lat": 2,
-                                  "lng": 2,
+                                  "lat": 47.8898,
+                                  "lng": -2.83593,
                                 },
-                                "objectID": "12",
+                                "objectID": "223342",
                                 "offer": {
-                                  "name": "Test",
-                                  "subcategoryId": "ABO_BIBLIOTHEQUE",
+                                  "dates": [
+                                    1629312300,
+                                    1629485100,
+                                    1629657900,
+                                  ],
+                                  "isDigital": false,
+                                  "isDuo": true,
+                                  "name": "Titane - VF",
+                                  "prices": [
+                                    0,
+                                    0,
+                                    0,
+                                  ],
+                                  "subcategoryId": "CINE_PLEIN_AIR",
+                                  "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
                                 },
-                                "venue": {
-                                  "address": "Avenue des Tests",
-                                  "city": "Jest",
+                                "venue": {},
+                              },
+                              {
+                                "_geoloc": {
+                                  "lat": 47.8898,
+                                  "lng": -2.83593,
                                 },
+                                "objectID": "223338",
+                                "offer": {
+                                  "dates": [
+                                    1629312300,
+                                    1629485100,
+                                    1629657900,
+                                  ],
+                                  "isDigital": false,
+                                  "isDuo": true,
+                                  "name": "Bac Nord - VF",
+                                  "prices": [
+                                    0,
+                                    0,
+                                    0,
+                                  ],
+                                  "subcategoryId": "CINE_PLEIN_AIR",
+                                  "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
+                                },
+                                "venue": {},
+                              },
+                              {
+                                "_geoloc": {
+                                  "lat": 47.8898,
+                                  "lng": -2.83593,
+                                },
+                                "objectID": "223339",
+                                "offer": {
+                                  "dates": [
+                                    1629312300,
+                                    1629485100,
+                                    1629657900,
+                                  ],
+                                  "isDigital": false,
+                                  "isDuo": true,
+                                  "name": "Black Widow - VF",
+                                  "prices": [
+                                    0,
+                                    0,
+                                    0,
+                                  ],
+                                  "subcategoryId": "CINE_PLEIN_AIR",
+                                  "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMA",
+                                },
+                                "venue": {},
                               },
                             ],
                             "_firstIndexToProcess": 0,
                             "_hasStableIds": true,
                             "_requiresDataChangeHandling": false,
-                            "_size": 1,
+                            "_size": 3,
                             "getStableId": [Function],
                             "rowHasChanged": [Function],
                           }
                         }
                         disableRecycling={false}
-                        estimatedItemSize={192}
+                        estimatedItemSize={144}
                         extendedState={{}}
                         externalScrollView={[Function]}
                         finalRenderAheadOffset={187.5}
@@ -2637,8 +2056,22 @@ exports[`<Venue /> should match snapshot 1`] = `
                                 {
                                   "height": 250,
                                   "type": 0,
-                                  "width": 192,
+                                  "width": 144,
                                   "x": 0,
+                                  "y": 0,
+                                },
+                                {
+                                  "height": 250,
+                                  "type": 0,
+                                  "width": 144,
+                                  "x": 144,
+                                  "y": 0,
+                                },
+                                {
+                                  "height": 250,
+                                  "type": 0,
+                                  "width": 144,
+                                  "x": 288,
                                   "y": 0,
                                 },
                               ],
@@ -2648,7 +2081,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                 "width": 800,
                               },
                               "_totalHeight": 250,
-                              "_totalWidth": 192,
+                              "_totalWidth": 432,
                               "_window": {
                                 "height": 250,
                                 "width": 800,
@@ -2665,10 +2098,14 @@ exports[`<Venue /> should match snapshot 1`] = `
                               "width": 0,
                             },
                             "averageWindow": AverageWindow {
-                              "currentAverage": 192,
+                              "currentAverage": 144,
                               "currentCount": 1,
                               "inputValues": [
-                                192,
+                                144,
+                                ,
+                                ,
+                                ,
+                                ,
                                 ,
                                 ,
                                 ,
@@ -2745,27 +2182,87 @@ exports[`<Venue /> should match snapshot 1`] = `
                               "data": [
                                 {
                                   "_geoloc": {
-                                    "lat": 2,
-                                    "lng": 2,
+                                    "lat": 47.8898,
+                                    "lng": -2.83593,
                                   },
-                                  "objectID": "12",
+                                  "objectID": "223342",
                                   "offer": {
-                                    "name": "Test",
-                                    "subcategoryId": "ABO_BIBLIOTHEQUE",
+                                    "dates": [
+                                      1629312300,
+                                      1629485100,
+                                      1629657900,
+                                    ],
+                                    "isDigital": false,
+                                    "isDuo": true,
+                                    "name": "Titane - VF",
+                                    "prices": [
+                                      0,
+                                      0,
+                                      0,
+                                    ],
+                                    "subcategoryId": "CINE_PLEIN_AIR",
+                                    "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
                                   },
-                                  "venue": {
-                                    "address": "Avenue des Tests",
-                                    "city": "Jest",
+                                  "venue": {},
+                                },
+                                {
+                                  "_geoloc": {
+                                    "lat": 47.8898,
+                                    "lng": -2.83593,
                                   },
+                                  "objectID": "223338",
+                                  "offer": {
+                                    "dates": [
+                                      1629312300,
+                                      1629485100,
+                                      1629657900,
+                                    ],
+                                    "isDigital": false,
+                                    "isDuo": true,
+                                    "name": "Bac Nord - VF",
+                                    "prices": [
+                                      0,
+                                      0,
+                                      0,
+                                    ],
+                                    "subcategoryId": "CINE_PLEIN_AIR",
+                                    "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
+                                  },
+                                  "venue": {},
+                                },
+                                {
+                                  "_geoloc": {
+                                    "lat": 47.8898,
+                                    "lng": -2.83593,
+                                  },
+                                  "objectID": "223339",
+                                  "offer": {
+                                    "dates": [
+                                      1629312300,
+                                      1629485100,
+                                      1629657900,
+                                    ],
+                                    "isDigital": false,
+                                    "isDuo": true,
+                                    "name": "Black Widow - VF",
+                                    "prices": [
+                                      0,
+                                      0,
+                                      0,
+                                    ],
+                                    "subcategoryId": "CINE_PLEIN_AIR",
+                                    "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMA",
+                                  },
+                                  "venue": {},
                                 },
                               ],
                               "drawDistance": 187.5,
-                              "estimatedItemSize": 192,
+                              "estimatedItemSize": 144,
                               "horizontal": true,
                               "keyExtractor": [Function],
                               "numColumns": 1,
                               "onContentSizeChange": [Function],
-                              "onEndReached": [Function],
+                              "onEndReached": undefined,
                               "onEndReachedThreshold": 0.2,
                               "onScroll": [Function],
                               "renderItem": [Function],
@@ -2887,20 +2384,20 @@ exports[`<Venue /> should match snapshot 1`] = `
                               style={
                                 {
                                   "height": 250,
-                                  "width": 192,
+                                  "width": 432,
                                 }
                               }
                               windowSize={800}
                             >
                               <CellContainer
-                                index={0}
+                                index={1}
                                 onLayout={[Function]}
                                 style={
                                   {
                                     "alignItems": "stretch",
                                     "flexDirection": "row",
                                     "height": 250,
-                                    "left": 0,
+                                    "left": 144,
                                     "position": "absolute",
                                     "top": 0,
                                   }
@@ -2915,7 +2412,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                 >
                                   <View>
                                     <View
-                                      accessibilityLabel="Offre Test de la catégorie Livre,   prix . "
+                                      accessibilityLabel="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                                       accessibilityRole="link"
                                       accessibilityValue={
                                         {
@@ -2948,7 +2445,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                           },
                                         ]
                                       }
-                                      testID="Offre Test de la catégorie Livre,   prix . "
+                                      testID="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                                     >
                                       <View
                                         gap={2}
@@ -3034,19 +2531,24 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                   "height": 288,
                                                   "width": 192,
                                                 },
+                                                [
+                                                  {
+                                                    "backgroundColor": "#F1F1F4",
+                                                  },
+                                                  {
+                                                    "borderTopLeftRadius": 8,
+                                                    "borderTopRightRadius": 8,
+                                                    "height": 192,
+                                                    "width": 144,
+                                                  },
+                                                ],
                                               ]
                                             }
-                                            width={192}
                                           >
-                                            <BVLinearGradient
-                                              borderRadius={8}
-                                              colors={
-                                                [
-                                                  4294046196,
-                                                  4291546578,
-                                                ]
-                                              }
-                                              endPoint={
+                                            <FastImageView
+                                              defaultSource={null}
+                                              resizeMode="cover"
+                                              source={
                                                 {
                                                   "x": 0.5,
                                                   "y": 1,
@@ -3077,24 +2579,582 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                   },
                                                 ]
                                               }
-                                              testID="imagePlaceholder"
-                                            >
-                                              <View
-                                                height={64}
-                                                testID="categoryIcon"
-                                                width={64}
-                                              >
-                                                <Text>
-                                                  categoryIcon-SVG-Mock
-                                                </Text>
-                                              </View>
-                                            </BVLinearGradient>
+                                              testID="tileImage"
+                                            />
                                           </View>
                                         </View>
                                       </View>
                                     </View>
                                   </View>
                                 </View>
+                                <View
+                                  leadingItem={
+                                    {
+                                      "_geoloc": {
+                                        "lat": 47.8898,
+                                        "lng": -2.83593,
+                                      },
+                                      "objectID": "223338",
+                                      "offer": {
+                                        "dates": [
+                                          1629312300,
+                                          1629485100,
+                                          1629657900,
+                                        ],
+                                        "isDigital": false,
+                                        "isDuo": true,
+                                        "name": "Bac Nord - VF",
+                                        "prices": [
+                                          0,
+                                          0,
+                                          0,
+                                        ],
+                                        "subcategoryId": "CINE_PLEIN_AIR",
+                                        "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
+                                      },
+                                      "venue": {},
+                                    }
+                                  }
+                                  style={
+                                    [
+                                      {
+                                        "width": 16,
+                                      },
+                                    ]
+                                  }
+                                  trailingItem={
+                                    {
+                                      "_geoloc": {
+                                        "lat": 47.8898,
+                                        "lng": -2.83593,
+                                      },
+                                      "objectID": "223339",
+                                      "offer": {
+                                        "dates": [
+                                          1629312300,
+                                          1629485100,
+                                          1629657900,
+                                        ],
+                                        "isDigital": false,
+                                        "isDuo": true,
+                                        "name": "Black Widow - VF",
+                                        "prices": [
+                                          0,
+                                          0,
+                                          0,
+                                        ],
+                                        "subcategoryId": "CINE_PLEIN_AIR",
+                                        "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMA",
+                                      },
+                                      "venue": {},
+                                    }
+                                  }
+                                  width={16}
+                                />
+                              </CellContainer>
+                              <CellContainer
+                                index={2}
+                                onLayout={[Function]}
+                                style={
+                                  {
+                                    "alignItems": "stretch",
+                                    "flexDirection": "row",
+                                    "height": 250,
+                                    "left": 288,
+                                    "position": "absolute",
+                                    "top": 0,
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "flexDirection": "column",
+                                    }
+                                  }
+                                >
+                                  <View>
+                                    <View
+                                      accessibilityLabel="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
+                                      accessibilityRole="link"
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      focusable={true}
+                                      onClick={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "textDecorationColor": "black",
+                                            "textDecorationLine": "none",
+                                            "textDecorationStyle": "solid",
+                                          },
+                                          {
+                                            "borderRadius": 8,
+                                            "height": 288,
+                                            "marginVertical": 4,
+                                          },
+                                        ]
+                                      }
+                                      testID="Offre Black Widow - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
+                                    >
+                                      <View
+                                        style={
+                                          [
+                                            {
+                                              "flexDirection": "column-reverse",
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        <View
+                                          imageWidth={144}
+                                          style={
+                                            [
+                                              {
+                                                "marginTop": 8,
+                                                "maxWidth": 144,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          <Text
+                                            numberOfLines={2}
+                                            style={
+                                              [
+                                                {
+                                                  "color": "#161617",
+                                                  "fontFamily": "Montserrat-SemiBold",
+                                                  "fontSize": 12,
+                                                  "lineHeight": 19.2,
+                                                },
+                                              ]
+                                            }
+                                          >
+                                            Black Widow - VF
+                                          </Text>
+                                          <Text
+                                            numberOfLines={1}
+                                            style={
+                                              [
+                                                {
+                                                  "color": "#696A6F",
+                                                  "fontFamily": "Montserrat-SemiBold",
+                                                  "fontSize": 12,
+                                                  "lineHeight": 19.2,
+                                                },
+                                              ]
+                                            }
+                                          >
+                                            Dès le 18 août 2021
+                                          </Text>
+                                          <Text
+                                            style={
+                                              [
+                                                {
+                                                  "color": "#696A6F",
+                                                  "fontFamily": "Montserrat-SemiBold",
+                                                  "fontSize": 12,
+                                                  "lineHeight": 19.2,
+                                                },
+                                              ]
+                                            }
+                                            testID="priceIsDuo"
+                                          >
+                                            Gratuit
+                                          </Text>
+                                        </View>
+                                        <View>
+                                          <View
+                                            style={
+                                              [
+                                                {
+                                                  "overflow": "hidden",
+                                                },
+                                                [
+                                                  {
+                                                    "backgroundColor": "#F1F1F4",
+                                                  },
+                                                  {
+                                                    "borderTopLeftRadius": 8,
+                                                    "borderTopRightRadius": 8,
+                                                    "height": 192,
+                                                    "width": 144,
+                                                  },
+                                                ],
+                                              ]
+                                            }
+                                          >
+                                            <FastImageView
+                                              defaultSource={null}
+                                              resizeMode="cover"
+                                              source={
+                                                {
+                                                  "uri": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMA",
+                                                }
+                                              }
+                                              style={
+                                                {
+                                                  "bottom": 0,
+                                                  "left": 0,
+                                                  "position": "absolute",
+                                                  "right": 0,
+                                                  "top": 0,
+                                                }
+                                              }
+                                              testID="tileImage"
+                                            />
+                                          </View>
+                                          <View
+                                            height={24}
+                                            style={
+                                              [
+                                                {
+                                                  "alignItems": "center",
+                                                  "backgroundColor": "#161617",
+                                                  "borderBottomLeftRadius": 8,
+                                                  "borderBottomRightRadius": 8,
+                                                  "flexDirection": "row",
+                                                  "height": 24,
+                                                  "width": 144,
+                                                },
+                                              ]
+                                            }
+                                            width={144}
+                                          >
+                                            <View
+                                              style={
+                                                [
+                                                  {
+                                                    "alignItems": "center",
+                                                    "flexBasis": 0,
+                                                    "flexGrow": 1,
+                                                    "flexShrink": 1,
+                                                    "justifyContent": "center",
+                                                    "paddingHorizontal": 2,
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              <Text
+                                                numberOfLines={1}
+                                                style={
+                                                  [
+                                                    {
+                                                      "color": "#ffffff",
+                                                      "fontFamily": "Montserrat-SemiBold",
+                                                      "fontSize": 12,
+                                                      "lineHeight": 19.2,
+                                                    },
+                                                  ]
+                                                }
+                                                testID="categoryImageCaption"
+                                              >
+                                                Cinéma
+                                              </Text>
+                                            </View>
+                                          </View>
+                                        </View>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </CellContainer>
+                              <CellContainer
+                                index={0}
+                                onLayout={[Function]}
+                                style={
+                                  {
+                                    "alignItems": "stretch",
+                                    "flexDirection": "row",
+                                    "height": 250,
+                                    "left": 0,
+                                    "position": "absolute",
+                                    "top": 0,
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "flexDirection": "column",
+                                    }
+                                  }
+                                >
+                                  <View>
+                                    <View
+                                      accessibilityLabel="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
+                                      accessibilityRole="link"
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      focusable={true}
+                                      onClick={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
+                                      style={
+                                        [
+                                          {
+                                            "textDecorationColor": "black",
+                                            "textDecorationLine": "none",
+                                            "textDecorationStyle": "solid",
+                                          },
+                                          {
+                                            "borderRadius": 8,
+                                            "height": 288,
+                                            "marginVertical": 4,
+                                          },
+                                        ]
+                                      }
+                                      testID="Offre Titane - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
+                                    >
+                                      <View
+                                        style={
+                                          [
+                                            {
+                                              "flexDirection": "column-reverse",
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        <View
+                                          imageWidth={144}
+                                          style={
+                                            [
+                                              {
+                                                "marginTop": 8,
+                                                "maxWidth": 144,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          <Text
+                                            numberOfLines={2}
+                                            style={
+                                              [
+                                                {
+                                                  "color": "#161617",
+                                                  "fontFamily": "Montserrat-SemiBold",
+                                                  "fontSize": 12,
+                                                  "lineHeight": 19.2,
+                                                },
+                                              ]
+                                            }
+                                          >
+                                            Titane - VF
+                                          </Text>
+                                          <Text
+                                            numberOfLines={1}
+                                            style={
+                                              [
+                                                {
+                                                  "color": "#696A6F",
+                                                  "fontFamily": "Montserrat-SemiBold",
+                                                  "fontSize": 12,
+                                                  "lineHeight": 19.2,
+                                                },
+                                              ]
+                                            }
+                                          >
+                                            Dès le 18 août 2021
+                                          </Text>
+                                          <Text
+                                            style={
+                                              [
+                                                {
+                                                  "color": "#696A6F",
+                                                  "fontFamily": "Montserrat-SemiBold",
+                                                  "fontSize": 12,
+                                                  "lineHeight": 19.2,
+                                                },
+                                              ]
+                                            }
+                                            testID="priceIsDuo"
+                                          >
+                                            Gratuit
+                                          </Text>
+                                        </View>
+                                        <View>
+                                          <View
+                                            style={
+                                              [
+                                                {
+                                                  "overflow": "hidden",
+                                                },
+                                                [
+                                                  {
+                                                    "backgroundColor": "#F1F1F4",
+                                                  },
+                                                  {
+                                                    "borderTopLeftRadius": 8,
+                                                    "borderTopRightRadius": 8,
+                                                    "height": 192,
+                                                    "width": 144,
+                                                  },
+                                                ],
+                                              ]
+                                            }
+                                          >
+                                            <FastImageView
+                                              defaultSource={null}
+                                              resizeMode="cover"
+                                              source={
+                                                {
+                                                  "uri": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
+                                                }
+                                              }
+                                              style={
+                                                {
+                                                  "bottom": 0,
+                                                  "left": 0,
+                                                  "position": "absolute",
+                                                  "right": 0,
+                                                  "top": 0,
+                                                }
+                                              }
+                                              testID="tileImage"
+                                            />
+                                          </View>
+                                          <View
+                                            height={24}
+                                            style={
+                                              [
+                                                {
+                                                  "alignItems": "center",
+                                                  "backgroundColor": "#161617",
+                                                  "borderBottomLeftRadius": 8,
+                                                  "borderBottomRightRadius": 8,
+                                                  "flexDirection": "row",
+                                                  "height": 24,
+                                                  "width": 144,
+                                                },
+                                              ]
+                                            }
+                                            width={144}
+                                          >
+                                            <View
+                                              style={
+                                                [
+                                                  {
+                                                    "alignItems": "center",
+                                                    "flexBasis": 0,
+                                                    "flexGrow": 1,
+                                                    "flexShrink": 1,
+                                                    "justifyContent": "center",
+                                                    "paddingHorizontal": 2,
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              <Text
+                                                numberOfLines={1}
+                                                style={
+                                                  [
+                                                    {
+                                                      "color": "#ffffff",
+                                                      "fontFamily": "Montserrat-SemiBold",
+                                                      "fontSize": 12,
+                                                      "lineHeight": 19.2,
+                                                    },
+                                                  ]
+                                                }
+                                                testID="categoryImageCaption"
+                                              >
+                                                Cinéma
+                                              </Text>
+                                            </View>
+                                          </View>
+                                        </View>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                                <View
+                                  leadingItem={
+                                    {
+                                      "_geoloc": {
+                                        "lat": 47.8898,
+                                        "lng": -2.83593,
+                                      },
+                                      "objectID": "223342",
+                                      "offer": {
+                                        "dates": [
+                                          1629312300,
+                                          1629485100,
+                                          1629657900,
+                                        ],
+                                        "isDigital": false,
+                                        "isDuo": true,
+                                        "name": "Titane - VF",
+                                        "prices": [
+                                          0,
+                                          0,
+                                          0,
+                                        ],
+                                        "subcategoryId": "CINE_PLEIN_AIR",
+                                        "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
+                                      },
+                                      "venue": {},
+                                    }
+                                  }
+                                  style={
+                                    [
+                                      {
+                                        "width": 16,
+                                      },
+                                    ]
+                                  }
+                                  trailingItem={
+                                    {
+                                      "_geoloc": {
+                                        "lat": 47.8898,
+                                        "lng": -2.83593,
+                                      },
+                                      "objectID": "223338",
+                                      "offer": {
+                                        "dates": [
+                                          1629312300,
+                                          1629485100,
+                                          1629657900,
+                                        ],
+                                        "isDigital": false,
+                                        "isDuo": true,
+                                        "name": "Bac Nord - VF",
+                                        "prices": [
+                                          0,
+                                          0,
+                                          0,
+                                        ],
+                                        "subcategoryId": "CINE_PLEIN_AIR",
+                                        "thumbUrl": "https://storage.googleapis.com/passculture-metier-ehp-testing-assets/thumbs/products/FARMG",
+                                      },
+                                      "venue": {},
+                                    }
+                                  }
+                                  width={16}
+                                />
                               </CellContainer>
                             </AutoLayoutView>
                             <CellContainer
@@ -3135,7 +3195,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                             >
                               <View>
                                 <View
-                                  accessibilityLabel="Offre Test de la catégorie Livre,   prix . "
+                                  accessibilityLabel="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                                   accessibilityRole="link"
                                   accessibilityValue={
                                     {
@@ -3168,7 +3228,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                       },
                                     ]
                                   }
-                                  testID="Offre Test de la catégorie Livre,   prix . "
+                                  testID="Offre Bac Nord - VF de la catégorie Cinéma,   Dès le 18 août 2021, Gratuit. Possibilité de réserver 2 places."
                                 >
                                   <View
                                     gap={2}
@@ -3254,19 +3314,24 @@ exports[`<Venue /> should match snapshot 1`] = `
                                               "height": 288,
                                               "width": 192,
                                             },
+                                            [
+                                              {
+                                                "backgroundColor": "#F1F1F4",
+                                              },
+                                              {
+                                                "borderTopLeftRadius": 8,
+                                                "borderTopRightRadius": 8,
+                                                "height": 192,
+                                                "width": 144,
+                                              },
+                                            ],
                                           ]
                                         }
-                                        width={192}
                                       >
-                                        <BVLinearGradient
-                                          borderRadius={8}
-                                          colors={
-                                            [
-                                              4294046196,
-                                              4291546578,
-                                            ]
-                                          }
-                                          endPoint={
+                                        <FastImageView
+                                          defaultSource={null}
+                                          resizeMode="cover"
+                                          source={
                                             {
                                               "x": 0.5,
                                               "y": 1,
@@ -3297,18 +3362,8 @@ exports[`<Venue /> should match snapshot 1`] = `
                                               },
                                             ]
                                           }
-                                          testID="imagePlaceholder"
-                                        >
-                                          <View
-                                            height={64}
-                                            testID="categoryIcon"
-                                            width={64}
-                                          >
-                                            <Text>
-                                              categoryIcon-SVG-Mock
-                                            </Text>
-                                          </View>
-                                        </BVLinearGradient>
+                                          testID="tileImage"
+                                        />
                                       </View>
                                     </View>
                                   </View>
@@ -3321,233 +3376,1099 @@ exports[`<Venue /> should match snapshot 1`] = `
                     </View>
                   </View>
                 </View>
-              </View>
-            </View>
-          </View>
-        </View>
-        <View
-          numberOfSpaces={6}
-          style={
-            [
-              {
-                "height": 24,
-              },
-            ]
-          }
-        />
-        <View
-          gap={0}
-          style={
-            [
-              {
-                "gap": 0,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              [
-                {
-                  "backgroundColor": "#F1F1F4",
-                  "height": 8,
-                },
-              ]
-            }
-          />
-          <View
-            style={
-              [
-                {
-                  "flexDirection": "row",
-                  "gap": 16,
-                  "marginHorizontal": 16,
-                  "marginVertical": 24,
-                },
-              ]
-            }
-          >
-            <View
-              size="medium"
-              style={
-                [
-                  {
-                    "borderRadius": 8,
-                    "height": 48,
-                    "overflow": "hidden",
-                    "width": 48,
-                  },
-                ]
-              }
-            >
-              <BVLinearGradient
-                colors={
-                  [
-                    4294614806,
-                    4290271489,
-                  ]
-                }
-                endPoint={
-                  {
-                    "x": 0.5,
-                    "y": 1,
-                  }
-                }
-                locations={null}
-                startPoint={
-                  {
-                    "x": 0.5,
-                    "y": 0,
-                  }
-                }
-                style={
-                  [
-                    {
-                      "flexBasis": 0,
-                      "flexGrow": 1,
-                      "flexShrink": 1,
-                    },
-                  ]
-                }
-              >
                 <View
-                  size="medium"
                   style={
                     [
                       {
-                        "position": "absolute",
-                        "top": -20,
+                        "position": "relative",
                       },
                     ]
                   }
                 >
                   <View
-                    fill="none"
-                    height={92}
-                    width={82}
+                    onChange={[Function]}
+                    onLayout={[Function]}
+                    style={
+                      [
+                        {
+                          "bottom": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": "50%",
+                        },
+                      ]
+                    }
+                    testID="intersectionObserver"
+                    threshold="50%"
+                    triggerOnce={false}
+                  />
+                  <View
+                    gap={4}
+                    style={
+                      [
+                        {
+                          "gap": 16,
+                          "paddingBottom": 24,
+                        },
+                      ]
+                    }
                   >
-                    <Text>
-                      undefined-SVG-Mock
-                    </Text>
+                    <View>
+                      <View
+                        style={
+                          [
+                            {
+                              "flexDirection": "row",
+                            },
+                          ]
+                        }
+                      >
+                        <Text
+                          numberOfLines={2}
+                          style={
+                            [
+                              {
+                                "color": "#161617",
+                                "fontFamily": "Montserrat-Bold",
+                                "fontSize": 19,
+                                "lineHeight": 30.4,
+                                "marginHorizontal": 24,
+                              },
+                            ]
+                          }
+                          testID="playlistTitle"
+                        >
+                          Test
+                        </Text>
+                      </View>
+                    </View>
+                    <View
+                      onLayout={[Function]}
+                      style={
+                        [
+                          {
+                            "position": "relative",
+                            "width": "100%",
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        style={{}}
+                      >
+                        <RCTScrollView
+                          ItemSeparatorComponent={
+                            {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": [
+                                {
+                                  "width": 16,
+                                },
+                              ],
+                              "inlineStyle": InlineStyle {
+                                "rules": [
+                                  [Function],
+                                  "",
+                                ],
+                              },
+                              "render": [Function],
+                              "shouldForwardProp": undefined,
+                              "styledComponentId": "StyledNativeComponent",
+                              "target": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          ListFooterComponent={
+                            {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": [
+                                {
+                                  "width": 24,
+                                },
+                              ],
+                              "inlineStyle": InlineStyle {
+                                "rules": [
+                                  [Function],
+                                  "",
+                                ],
+                              },
+                              "render": [Function],
+                              "shouldForwardProp": undefined,
+                              "styledComponentId": "StyledNativeComponent",
+                              "target": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          ListHeaderComponent={
+                            {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": [
+                                {
+                                  "width": 24,
+                                },
+                              ],
+                              "inlineStyle": InlineStyle {
+                                "rules": [
+                                  [Function],
+                                  "",
+                                ],
+                              },
+                              "render": [Function],
+                              "shouldForwardProp": undefined,
+                              "styledComponentId": "StyledNativeComponent",
+                              "target": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          applyWindowCorrection={[Function]}
+                          canChangeSize={true}
+                          contentContainerStyle={
+                            {
+                              "backgroundColor": undefined,
+                              "minHeight": 1,
+                              "minWidth": 1,
+                              "paddingBottom": 0,
+                              "paddingTop": 0,
+                            }
+                          }
+                          contentHeight={250}
+                          contentWidth={192}
+                          data={
+                            [
+                              {
+                                "_geoloc": {
+                                  "lat": 2,
+                                  "lng": 2,
+                                },
+                                "objectID": "12",
+                                "offer": {
+                                  "name": "Test",
+                                  "subcategoryId": "ABO_BIBLIOTHEQUE",
+                                },
+                                "venue": {
+                                  "address": "Avenue des Tests",
+                                  "city": "Jest",
+                                },
+                              },
+                            ]
+                          }
+                          dataProvider={
+                            DataProvider {
+                              "_data": [
+                                {
+                                  "_geoloc": {
+                                    "lat": 2,
+                                    "lng": 2,
+                                  },
+                                  "objectID": "12",
+                                  "offer": {
+                                    "name": "Test",
+                                    "subcategoryId": "ABO_BIBLIOTHEQUE",
+                                  },
+                                  "venue": {
+                                    "address": "Avenue des Tests",
+                                    "city": "Jest",
+                                  },
+                                },
+                              ],
+                              "_firstIndexToProcess": 0,
+                              "_hasStableIds": true,
+                              "_requiresDataChangeHandling": false,
+                              "_size": 1,
+                              "getStableId": [Function],
+                              "rowHasChanged": [Function],
+                            }
+                          }
+                          disableRecycling={false}
+                          estimatedItemSize={192}
+                          extendedState={{}}
+                          externalScrollView={[Function]}
+                          finalRenderAheadOffset={187.5}
+                          forceNonDeterministicRendering={true}
+                          horizontal={true}
+                          initialOffset={0}
+                          initialRenderIndex={0}
+                          isHorizontal={true}
+                          keyExtractor={[Function]}
+                          layoutProvider={
+                            GridLayoutProviderWithProps {
+                              "_acceptableRelayoutDelta": 1,
+                              "_getHeightOrWidth": [Function],
+                              "_getLayoutTypeForIndex": [Function],
+                              "_getSpan": [Function],
+                              "_hasExpired": false,
+                              "_isHorizontal": true,
+                              "_lastLayoutManager": GridLayoutManager {
+                                "_acceptableRelayoutDelta": 1,
+                                "_getSpan": [Function],
+                                "_isGridHorizontal": true,
+                                "_isHorizontal": true,
+                                "_layoutProvider": [Circular],
+                                "_layouts": [
+                                  {
+                                    "height": 250,
+                                    "type": 0,
+                                    "width": 192,
+                                    "x": 0,
+                                    "y": 0,
+                                  },
+                                ],
+                                "_maxSpan": 1,
+                                "_renderWindowSize": {
+                                  "height": 250,
+                                  "width": 800,
+                                },
+                                "_totalHeight": 250,
+                                "_totalWidth": 192,
+                                "_window": {
+                                  "height": 250,
+                                  "width": 800,
+                                },
+                              },
+                              "_maxSpan": 1,
+                              "_renderWindowSize": {
+                                "height": 250,
+                                "width": 800,
+                              },
+                              "_setLayoutForType": [Function],
+                              "_tempDim": {
+                                "height": 0,
+                                "width": 0,
+                              },
+                              "averageWindow": AverageWindow {
+                                "currentAverage": 192,
+                                "currentCount": 1,
+                                "inputValues": [
+                                  192,
+                                  ,
+                                  ,
+                                  ,
+                                  ,
+                                  ,
+                                  ,
+                                  ,
+                                ],
+                                "nextIndex": 1,
+                              },
+                              "defaultEstimatedItemSize": 100,
+                              "layoutObject": {
+                                "size": undefined,
+                                "span": undefined,
+                              },
+                              "props": {
+                                "ItemSeparatorComponent": {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": [
+                                    {
+                                      "width": 16,
+                                    },
+                                  ],
+                                  "inlineStyle": InlineStyle {
+                                    "rules": [
+                                      [Function],
+                                      "",
+                                    ],
+                                  },
+                                  "render": [Function],
+                                  "shouldForwardProp": undefined,
+                                  "styledComponentId": "StyledNativeComponent",
+                                  "target": [Function],
+                                  "withComponent": [Function],
+                                },
+                                "ListFooterComponent": {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": [
+                                    {
+                                      "width": 24,
+                                    },
+                                  ],
+                                  "inlineStyle": InlineStyle {
+                                    "rules": [
+                                      [Function],
+                                      "",
+                                    ],
+                                  },
+                                  "render": [Function],
+                                  "shouldForwardProp": undefined,
+                                  "styledComponentId": "StyledNativeComponent",
+                                  "target": [Function],
+                                  "withComponent": [Function],
+                                },
+                                "ListHeaderComponent": {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": [
+                                    {
+                                      "width": 24,
+                                    },
+                                  ],
+                                  "inlineStyle": InlineStyle {
+                                    "rules": [
+                                      [Function],
+                                      "",
+                                    ],
+                                  },
+                                  "render": [Function],
+                                  "shouldForwardProp": undefined,
+                                  "styledComponentId": "StyledNativeComponent",
+                                  "target": [Function],
+                                  "withComponent": [Function],
+                                },
+                                "data": [
+                                  {
+                                    "_geoloc": {
+                                      "lat": 2,
+                                      "lng": 2,
+                                    },
+                                    "objectID": "12",
+                                    "offer": {
+                                      "name": "Test",
+                                      "subcategoryId": "ABO_BIBLIOTHEQUE",
+                                    },
+                                    "venue": {
+                                      "address": "Avenue des Tests",
+                                      "city": "Jest",
+                                    },
+                                  },
+                                ],
+                                "drawDistance": 187.5,
+                                "estimatedItemSize": 192,
+                                "horizontal": true,
+                                "keyExtractor": [Function],
+                                "numColumns": 1,
+                                "onContentSizeChange": [Function],
+                                "onEndReached": [Function],
+                                "onEndReachedThreshold": 0.2,
+                                "onScroll": [Function],
+                                "renderItem": [Function],
+                                "scrollEnabled": true,
+                                "scrollEventThrottle": 16,
+                                "showsHorizontalScrollIndicator": false,
+                                "testID": "offersModuleList",
+                              },
+                              "renderWindowInsets": {
+                                "height": 0,
+                                "width": 0,
+                              },
+                              "shouldRefreshWithAnchoring": true,
+                            }
+                          }
+                          maxRenderAhead={562.5}
+                          numColumns={1}
+                          onContentSizeChange={[Function]}
+                          onEndReached={[Function]}
+                          onEndReachedThreshold={0}
+                          onEndReachedThresholdRelative={0.2}
+                          onItemLayout={[Function]}
+                          onLayout={[Function]}
+                          onScroll={[Function]}
+                          onScrollBeginDrag={[Function]}
+                          onSizeChanged={[Function]}
+                          onVisibleIndicesChanged={[Function]}
+                          removeClippedSubviews={false}
+                          renderAheadOffset={0}
+                          renderAheadStep={187.5}
+                          renderContentContainer={[Function]}
+                          renderItem={[Function]}
+                          renderItemContainer={[Function]}
+                          rowRenderer={[Function]}
+                          scrollEnabled={true}
+                          scrollEventThrottle={16}
+                          scrollThrottle={16}
+                          scrollViewProps={
+                            {
+                              "contentContainerStyle": {
+                                "backgroundColor": undefined,
+                                "minHeight": 1,
+                                "minWidth": 1,
+                                "paddingBottom": 0,
+                                "paddingTop": 0,
+                              },
+                              "onLayout": [Function],
+                              "onScrollBeginDrag": [Function],
+                              "refreshControl": undefined,
+                              "style": {
+                                "minHeight": 1,
+                                "minWidth": 1,
+                              },
+                            }
+                          }
+                          showsHorizontalScrollIndicator={false}
+                          style={
+                            {
+                              "minHeight": 1,
+                              "minWidth": 1,
+                            }
+                          }
+                          suppressBoundedSizeException={true}
+                          testID="offersModuleList"
+                          windowCorrectionConfig={
+                            {
+                              "applyToInitialOffset": true,
+                              "applyToItemScroll": true,
+                              "value": {
+                                "endCorrection": 0,
+                                "startCorrection": 0,
+                                "windowShift": -1,
+                              },
+                            }
+                          }
+                        >
+                          <View>
+                            <View
+                              style={
+                                {
+                                  "flexDirection": "row",
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "paddingLeft": 0,
+                                    "paddingTop": 0,
+                                  }
+                                }
+                              />
+                              <View
+                                style={
+                                  [
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "width": 24,
+                                      },
+                                    ]
+                                  }
+                                  width={24}
+                                />
+                              </View>
+                              <AutoLayoutView
+                                enableInstrumentation={false}
+                                horizontal={true}
+                                onBlankAreaEvent={[Function]}
+                                onLayout={[Function]}
+                                renderAheadOffset={0}
+                                scrollOffset={0}
+                                style={
+                                  {
+                                    "height": 250,
+                                    "width": 192,
+                                  }
+                                }
+                                windowSize={800}
+                              >
+                                <CellContainer
+                                  index={0}
+                                  onLayout={[Function]}
+                                  style={
+                                    {
+                                      "alignItems": "stretch",
+                                      "flexDirection": "row",
+                                      "height": 250,
+                                      "left": 0,
+                                      "position": "absolute",
+                                      "top": 0,
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      {
+                                        "flexDirection": "column",
+                                      }
+                                    }
+                                  >
+                                    <View>
+                                      <View
+                                        accessibilityLabel="Offre Test de la catégorie Livre,   prix . "
+                                        accessibilityRole="link"
+                                        accessibilityValue={
+                                          {
+                                            "max": undefined,
+                                            "min": undefined,
+                                            "now": undefined,
+                                            "text": undefined,
+                                          }
+                                        }
+                                        accessible={true}
+                                        focusable={true}
+                                        onClick={[Function]}
+                                        onResponderGrant={[Function]}
+                                        onResponderMove={[Function]}
+                                        onResponderRelease={[Function]}
+                                        onResponderTerminate={[Function]}
+                                        onResponderTerminationRequest={[Function]}
+                                        onStartShouldSetResponder={[Function]}
+                                        style={
+                                          [
+                                            {
+                                              "textDecorationColor": "black",
+                                              "textDecorationLine": "none",
+                                              "textDecorationStyle": "solid",
+                                            },
+                                            {
+                                              "borderRadius": 8,
+                                              "height": 360,
+                                              "marginVertical": 4,
+                                            },
+                                          ]
+                                        }
+                                        testID="Offre Test de la catégorie Livre,   prix . "
+                                      >
+                                        <View
+                                          style={
+                                            [
+                                              {
+                                                "flexDirection": "column-reverse",
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          <View
+                                            imageWidth={192}
+                                            style={
+                                              [
+                                                {
+                                                  "marginTop": 8,
+                                                  "maxWidth": 192,
+                                                },
+                                              ]
+                                            }
+                                          >
+                                            <Text
+                                              numberOfLines={2}
+                                              style={
+                                                [
+                                                  {
+                                                    "color": "#161617",
+                                                    "fontFamily": "Montserrat-SemiBold",
+                                                    "fontSize": 12,
+                                                    "lineHeight": 19.2,
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              Test
+                                            </Text>
+                                            <Text
+                                              style={
+                                                [
+                                                  {
+                                                    "color": "#696A6F",
+                                                    "fontFamily": "Montserrat-SemiBold",
+                                                    "fontSize": 12,
+                                                    "lineHeight": 19.2,
+                                                  },
+                                                ]
+                                              }
+                                              testID="priceIsDuo"
+                                            />
+                                          </View>
+                                          <View>
+                                            <View
+                                              height={264}
+                                              style={
+                                                [
+                                                  {
+                                                    "height": 264,
+                                                    "width": 192,
+                                                  },
+                                                ]
+                                              }
+                                              width={192}
+                                            >
+                                              <BVLinearGradient
+                                                borderRadius={8}
+                                                colors={
+                                                  [
+                                                    4294046196,
+                                                    4291546578,
+                                                  ]
+                                                }
+                                                endPoint={
+                                                  {
+                                                    "x": 0.5,
+                                                    "y": 1,
+                                                  }
+                                                }
+                                                locations={null}
+                                                onlyTopBorderRadius={true}
+                                                startPoint={
+                                                  {
+                                                    "x": 0.5,
+                                                    "y": 0,
+                                                  }
+                                                }
+                                                style={
+                                                  [
+                                                    {
+                                                      "alignItems": "center",
+                                                      "backgroundColor": "#F1F1F4",
+                                                      "borderRadius": 8,
+                                                      "height": "100%",
+                                                      "justifyContent": "center",
+                                                      "width": "100%",
+                                                    },
+                                                    {
+                                                      "borderRadius": 0,
+                                                      "borderTopLeftRadius": 8,
+                                                      "borderTopRightRadius": 8,
+                                                    },
+                                                  ]
+                                                }
+                                                testID="imagePlaceholder"
+                                              >
+                                                <View
+                                                  height={64}
+                                                  testID="categoryIcon"
+                                                  width={64}
+                                                >
+                                                  <Text>
+                                                    categoryIcon-SVG-Mock
+                                                  </Text>
+                                                </View>
+                                              </BVLinearGradient>
+                                            </View>
+                                            <View
+                                              height={24}
+                                              style={
+                                                [
+                                                  {
+                                                    "alignItems": "center",
+                                                    "backgroundColor": "#161617",
+                                                    "borderBottomLeftRadius": 8,
+                                                    "borderBottomRightRadius": 8,
+                                                    "flexDirection": "row",
+                                                    "height": 24,
+                                                    "width": 192,
+                                                  },
+                                                ]
+                                              }
+                                              width={192}
+                                            >
+                                              <View
+                                                style={
+                                                  [
+                                                    {
+                                                      "alignItems": "center",
+                                                      "flexBasis": 0,
+                                                      "flexGrow": 1,
+                                                      "flexShrink": 1,
+                                                      "justifyContent": "center",
+                                                      "paddingHorizontal": 2,
+                                                    },
+                                                  ]
+                                                }
+                                              >
+                                                <Text
+                                                  numberOfLines={1}
+                                                  style={
+                                                    [
+                                                      {
+                                                        "color": "#ffffff",
+                                                        "fontFamily": "Montserrat-SemiBold",
+                                                        "fontSize": 12,
+                                                        "lineHeight": 19.2,
+                                                      },
+                                                    ]
+                                                  }
+                                                  testID="categoryImageCaption"
+                                                >
+                                                  Livre
+                                                </Text>
+                                              </View>
+                                            </View>
+                                          </View>
+                                        </View>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </CellContainer>
+                              </AutoLayoutView>
+                              <CellContainer
+                                index={-1}
+                                style={
+                                  [
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "width": 24,
+                                      },
+                                    ]
+                                  }
+                                  width={24}
+                                />
+                              </CellContainer>
+                              <View
+                                style={
+                                  {
+                                    "paddingBottom": 0,
+                                    "paddingRight": 0,
+                                  }
+                                }
+                              />
+                              <View
+                                pointerEvents="none"
+                                style={
+                                  {
+                                    "opacity": 0,
+                                  }
+                                }
+                              >
+                                <View>
+                                  <View
+                                    accessibilityLabel="Offre Test de la catégorie Livre,   prix . "
+                                    accessibilityRole="link"
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    focusable={true}
+                                    onClick={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "textDecorationColor": "black",
+                                          "textDecorationLine": "none",
+                                          "textDecorationStyle": "solid",
+                                        },
+                                        {
+                                          "borderRadius": 8,
+                                          "height": 360,
+                                          "marginVertical": 4,
+                                        },
+                                      ]
+                                    }
+                                    testID="Offre Test de la catégorie Livre,   prix . "
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "flexDirection": "column-reverse",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <View
+                                        imageWidth={192}
+                                        style={
+                                          [
+                                            {
+                                              "marginTop": 8,
+                                              "maxWidth": 192,
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        <Text
+                                          numberOfLines={2}
+                                          style={
+                                            [
+                                              {
+                                                "color": "#161617",
+                                                "fontFamily": "Montserrat-SemiBold",
+                                                "fontSize": 12,
+                                                "lineHeight": 19.2,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Test
+                                        </Text>
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "color": "#696A6F",
+                                                "fontFamily": "Montserrat-SemiBold",
+                                                "fontSize": 12,
+                                                "lineHeight": 19.2,
+                                              },
+                                            ]
+                                          }
+                                          testID="priceIsDuo"
+                                        />
+                                      </View>
+                                      <View>
+                                        <View
+                                          height={264}
+                                          style={
+                                            [
+                                              {
+                                                "height": 264,
+                                                "width": 192,
+                                              },
+                                            ]
+                                          }
+                                          width={192}
+                                        >
+                                          <BVLinearGradient
+                                            borderRadius={8}
+                                            colors={
+                                              [
+                                                4294046196,
+                                                4291546578,
+                                              ]
+                                            }
+                                            endPoint={
+                                              {
+                                                "x": 0.5,
+                                                "y": 1,
+                                              }
+                                            }
+                                            locations={null}
+                                            onlyTopBorderRadius={true}
+                                            startPoint={
+                                              {
+                                                "x": 0.5,
+                                                "y": 0,
+                                              }
+                                            }
+                                            style={
+                                              [
+                                                {
+                                                  "alignItems": "center",
+                                                  "backgroundColor": "#F1F1F4",
+                                                  "borderRadius": 8,
+                                                  "height": "100%",
+                                                  "justifyContent": "center",
+                                                  "width": "100%",
+                                                },
+                                                {
+                                                  "borderRadius": 0,
+                                                  "borderTopLeftRadius": 8,
+                                                  "borderTopRightRadius": 8,
+                                                },
+                                              ]
+                                            }
+                                            testID="imagePlaceholder"
+                                          >
+                                            <View
+                                              height={64}
+                                              testID="categoryIcon"
+                                              width={64}
+                                            >
+                                              <Text>
+                                                categoryIcon-SVG-Mock
+                                              </Text>
+                                            </View>
+                                          </BVLinearGradient>
+                                        </View>
+                                        <View
+                                          height={24}
+                                          style={
+                                            [
+                                              {
+                                                "alignItems": "center",
+                                                "backgroundColor": "#161617",
+                                                "borderBottomLeftRadius": 8,
+                                                "borderBottomRightRadius": 8,
+                                                "flexDirection": "row",
+                                                "height": 24,
+                                                "width": 192,
+                                              },
+                                            ]
+                                          }
+                                          width={192}
+                                        >
+                                          <View
+                                            style={
+                                              [
+                                                {
+                                                  "alignItems": "center",
+                                                  "flexBasis": 0,
+                                                  "flexGrow": 1,
+                                                  "flexShrink": 1,
+                                                  "justifyContent": "center",
+                                                  "paddingHorizontal": 2,
+                                                },
+                                              ]
+                                            }
+                                          >
+                                            <Text
+                                              numberOfLines={1}
+                                              style={
+                                                [
+                                                  {
+                                                    "color": "#ffffff",
+                                                    "fontFamily": "Montserrat-SemiBold",
+                                                    "fontSize": 12,
+                                                    "lineHeight": 19.2,
+                                                  },
+                                                ]
+                                              }
+                                              testID="categoryImageCaption"
+                                            >
+                                              Livre
+                                            </Text>
+                                          </View>
+                                        </View>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </RCTScrollView>
+                      </View>
+                    </View>
                   </View>
                 </View>
-              </BVLinearGradient>
+              </View>
             </View>
+          </View>
+          <View
+            gap={6}
+            style={
+              [
+                {
+                  "gap": 24,
+                },
+              ]
+            }
+          >
             <View
               style={
                 [
                   {
-                    "flexShrink": 1,
+                    "backgroundColor": "#F1F1F4",
+                    "height": 8,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "flexDirection": "row",
+                    "gap": 16,
+                    "marginHorizontal": 16,
+                    "marginVertical": 24,
                   },
                 ]
               }
             >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 16,
-                      "lineHeight": 25.6,
-                    },
-                  ]
-                }
-              >
-                Fan de lecture ?
-              </Text>
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#696A6F",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 12,
-                      "lineHeight": 19.2,
-                    },
-                  ]
-                }
-              >
-                Reçois nos recos lecture, nos jeux-concours et le meilleur de l’actu littéraire !
-              </Text>
               <View
-                numberOfSpaces={2}
+                size="medium"
                 style={
                   [
                     {
-                      "height": 8,
+                      "borderRadius": 8,
+                      "height": 48,
+                      "overflow": "hidden",
+                      "width": 48,
                     },
                   ]
                 }
-              />
-              <View
-                accessibilityLabel="Suivre le thème"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "alignItems": "center",
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "#ffffff",
-                    "borderColor": "#90949D",
-                    "borderRadius": 24,
-                    "borderWidth": 1,
-                    "flexDirection": "row",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "paddingHorizontal": 12,
-                    "paddingVertical": 4,
-                    "userSelect": "auto",
-                    "width": "auto",
-                  }
-                }
-                testID="Suivre le thème"
               >
-                <View>
-                  undefined-Lottie-Mock
-                </View>
-                <View
-                  numberOfSpaces={2}
+                <BVLinearGradient
+                  colors={
+                    [
+                      4294614806,
+                      4290271489,
+                    ]
+                  }
+                  endPoint={
+                    {
+                      "x": 0.5,
+                      "y": 1,
+                    }
+                  }
+                  locations={null}
+                  startPoint={
+                    {
+                      "x": 0.5,
+                      "y": 0,
+                    }
+                  }
                   style={
                     [
                       {
-                        "width": 8,
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
                       },
                     ]
                   }
-                />
+                >
+                  <View
+                    size="medium"
+                    style={
+                      [
+                        {
+                          "position": "absolute",
+                          "top": -20,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      fill="none"
+                      height={92}
+                      width={82}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </BVLinearGradient>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "flexShrink": 1,
+                    },
+                  ]
+                }
+              >
                 <Text
                   style={
                     [
                       {
                         "color": "#161617",
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                      },
+                    ]
+                  }
+                >
+                  Fan de lecture ?
+                </Text>
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#696A6F",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
                         "lineHeight": 19.2,
@@ -3555,113 +4476,191 @@ exports[`<Venue /> should match snapshot 1`] = `
                     ]
                   }
                 >
-                  Suivre le thème
+                  Reçois nos recos lecture, nos jeux-concours et le meilleur de l’actu littéraire !
                 </Text>
+                <View
+                  numberOfSpaces={2}
+                  style={
+                    [
+                      {
+                        "height": 8,
+                      },
+                    ]
+                  }
+                />
+                <View
+                  accessibilityLabel="Suivre le thème"
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "alignSelf": "flex-start",
+                      "backgroundColor": "#ffffff",
+                      "borderColor": "#90949D",
+                      "borderRadius": 24,
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "height": "auto",
+                      "justifyContent": "center",
+                      "opacity": 1,
+                      "paddingHorizontal": 12,
+                      "paddingVertical": 4,
+                      "userSelect": "auto",
+                      "width": "auto",
+                    }
+                  }
+                  testID="Suivre le thème"
+                >
+                  <View>
+                    undefined-Lottie-Mock
+                  </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        },
+                      ]
+                    }
+                  >
+                    Suivre le thème
+                  </Text>
+                </View>
               </View>
             </View>
+            <Modal
+              accessibilityLabelledBy="testUuidV4"
+              accessibilityModal={true}
+              animationType="none"
+              deviceHeight={1334}
+              deviceWidth={750}
+              hardwareAccelerated={false}
+              hideModalContentWhileAnimating={false}
+              onBackdropPress={[Function]}
+              onModalHide={[Function]}
+              onModalWillHide={[Function]}
+              onModalWillShow={[Function]}
+              onRequestClose={[Function]}
+              panResponderThreshold={4}
+              scrollHorizontal={false}
+              scrollOffset={0}
+              scrollOffsetMax={0}
+              scrollTo={null}
+              statusBarTranslucent={true}
+              supportedOrientations={
+                [
+                  "portrait",
+                  "landscape",
+                ]
+              }
+              swipeThreshold={100}
+              testID="modal"
+              transparent={true}
+              visible={false}
+            />
+            <Modal
+              accessibilityLabelledBy="testUuidV4"
+              accessibilityModal={true}
+              animationType="none"
+              deviceHeight={1334}
+              deviceWidth={750}
+              hardwareAccelerated={false}
+              hideModalContentWhileAnimating={false}
+              onBackdropPress={[Function]}
+              onModalHide={[Function]}
+              onModalWillHide={[Function]}
+              onModalWillShow={[Function]}
+              onRequestClose={[Function]}
+              panResponderThreshold={4}
+              scrollHorizontal={false}
+              scrollOffset={0}
+              scrollOffsetMax={0}
+              scrollTo={null}
+              statusBarTranslucent={true}
+              supportedOrientations={
+                [
+                  "portrait",
+                  "landscape",
+                ]
+              }
+              swipeThreshold={100}
+              testID="modal"
+              transparent={true}
+              visible={false}
+            />
+            <Modal
+              accessibilityLabelledBy="testUuidV4"
+              accessibilityModal={true}
+              animationType="none"
+              deviceHeight={1334}
+              deviceWidth={750}
+              hardwareAccelerated={false}
+              hideModalContentWhileAnimating={false}
+              onBackdropPress={[Function]}
+              onModalHide={[Function]}
+              onModalWillHide={[Function]}
+              onModalWillShow={[Function]}
+              onRequestClose={[Function]}
+              panResponderThreshold={4}
+              scrollHorizontal={false}
+              scrollOffset={0}
+              scrollOffsetMax={0}
+              scrollTo={null}
+              statusBarTranslucent={true}
+              supportedOrientations={
+                [
+                  "portrait",
+                  "landscape",
+                ]
+              }
+              swipeThreshold={100}
+              testID="modal"
+              transparent={true}
+              visible={false}
+            />
           </View>
-          <Modal
-            accessibilityLabelledBy="testUuidV4"
-            accessibilityModal={true}
-            animationType="none"
-            deviceHeight={1334}
-            deviceWidth={750}
-            hardwareAccelerated={false}
-            hideModalContentWhileAnimating={false}
-            onBackdropPress={[Function]}
-            onModalHide={[Function]}
-            onModalWillHide={[Function]}
-            onModalWillShow={[Function]}
-            onRequestClose={[Function]}
-            panResponderThreshold={4}
-            scrollHorizontal={false}
-            scrollOffset={0}
-            scrollOffsetMax={0}
-            scrollTo={null}
-            statusBarTranslucent={true}
-            supportedOrientations={
-              [
-                "portrait",
-                "landscape",
-              ]
-            }
-            swipeThreshold={100}
-            testID="modal"
-            transparent={true}
-            visible={false}
-          />
-          <Modal
-            accessibilityLabelledBy="testUuidV4"
-            accessibilityModal={true}
-            animationType="none"
-            deviceHeight={1334}
-            deviceWidth={750}
-            hardwareAccelerated={false}
-            hideModalContentWhileAnimating={false}
-            onBackdropPress={[Function]}
-            onModalHide={[Function]}
-            onModalWillHide={[Function]}
-            onModalWillShow={[Function]}
-            onRequestClose={[Function]}
-            panResponderThreshold={4}
-            scrollHorizontal={false}
-            scrollOffset={0}
-            scrollOffsetMax={0}
-            scrollTo={null}
-            statusBarTranslucent={true}
-            supportedOrientations={
-              [
-                "portrait",
-                "landscape",
-              ]
-            }
-            swipeThreshold={100}
-            testID="modal"
-            transparent={true}
-            visible={false}
-          />
-          <Modal
-            accessibilityLabelledBy="testUuidV4"
-            accessibilityModal={true}
-            animationType="none"
-            deviceHeight={1334}
-            deviceWidth={750}
-            hardwareAccelerated={false}
-            hideModalContentWhileAnimating={false}
-            onBackdropPress={[Function]}
-            onModalHide={[Function]}
-            onModalWillHide={[Function]}
-            onModalWillShow={[Function]}
-            onRequestClose={[Function]}
-            panResponderThreshold={4}
-            scrollHorizontal={false}
-            scrollOffset={0}
-            scrollOffsetMax={0}
-            scrollTo={null}
-            statusBarTranslucent={true}
-            supportedOrientations={
-              [
-                "portrait",
-                "landscape",
-              ]
-            }
-            swipeThreshold={100}
-            testID="modal"
-            transparent={true}
-            visible={false}
-          />
-        </View>
-        <View
-          gap={6}
-          style={
-            [
-              {
-                "gap": 24,
-              },
-            ]
-          }
-        >
           <View
+            gap={6}
             style={
               [
                 {
@@ -3681,491 +4680,138 @@ exports[`<Venue /> should match snapshot 1`] = `
             }
           >
             <View
-              gap={4}
               style={
                 [
                   {
-                    "gap": 16,
+                    "backgroundColor": "#F1F1F4",
+                    "height": 8,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "marginHorizontal": 24,
                   },
                 ]
               }
             >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 19,
-                      "lineHeight": 30.4,
-                    },
-                  ]
-                }
-              >
-                Passe le bon plan !
-              </Text>
               <View
                 style={
                   [
                     {
-                      "flexDirection": "row",
-                      "maxWidth": 500,
-                      "width": "100%",
+                      "marginBottom": 16,
                     },
                   ]
                 }
               >
                 <View
-                  accessibilityRole="list"
+                  gap={4}
                   style={
                     [
                       {
-                        "flexBasis": 0,
-                        "flexDirection": "row",
-                        "flexGrow": 1,
-                        "flexShrink": 1,
-                        "flexWrap": "wrap",
-                        "justifyContent": "flex-start",
-                        "paddingLeft": 0,
+                        "gap": 16,
                       },
                     ]
                   }
                 >
-                  <View
-                    accessibilityRole="none"
+                  <Text
                     style={
                       [
                         {
-                          "alignItems": "center",
-                          "display": "flex",
-                          "flexBasis": "8.333333333333334%",
-                          "flexGrow": 1,
-                          "flexShrink": 0,
-                          "marginBottom": 20,
-                          "marginHorizontal": 4,
-                          "maxWidth": 76,
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Bold",
+                          "fontSize": 19,
+                          "lineHeight": 30.4,
+                        },
+                      ]
+                    }
+                  >
+                    Passe le bon plan !
+                  </Text>
+                  <View
+                    style={
+                      [
+                        {
+                          "flexDirection": "row",
+                          "maxWidth": 500,
+                          "width": "100%",
                         },
                       ]
                     }
                   >
                     <View
-                      accessibilityRole="button"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
-                      }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={false}
-                      collapsable={false}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
+                      accessibilityRole="list"
                       style={
-                        {
-                          "alignItems": "center",
-                          "height": 96,
-                          "opacity": 1,
-                          "userSelect": "auto",
-                          "width": 76,
-                        }
+                        [
+                          {
+                            "flexBasis": 0,
+                            "flexDirection": "row",
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                            "flexWrap": "wrap",
+                            "justifyContent": "flex-start",
+                            "paddingLeft": 0,
+                          },
+                        ]
                       }
                     >
                       <View
+                        accessibilityRole="none"
                         style={
                           [
                             {
                               "alignItems": "center",
-                              "flexBasis": 0,
+                              "display": "flex",
+                              "flexBasis": "8.333333333333334%",
                               "flexGrow": 1,
-                              "flexShrink": 1,
+                              "flexShrink": 0,
+                              "marginBottom": 20,
+                              "marginHorizontal": 4,
+                              "maxWidth": 76,
                             },
                           ]
                         }
                       >
                         <View
-                          style={
-                            [
-                              {
-                                "paddingBottom": 4,
-                                "paddingLeft": 4,
-                                "paddingRight": 4,
-                                "paddingTop": 4,
-                              },
-                            ]
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
                           }
-                        >
-                          <View
-                            height={48}
-                            width={48}
-                          >
-                            <Text>
-                              undefined-SVG-Mock
-                            </Text>
-                          </View>
-                        </View>
-                        <View
-                          numberOfSpaces={2}
-                          style={
-                            [
-                              {
-                                "height": 8,
-                              },
-                            ]
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
                           }
-                        />
-                        <Text
-                          disabled={false}
+                          accessible={false}
+                          collapsable={false}
+                          focusable={true}
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
                           style={
-                            [
-                              {
-                                "color": "#161617",
-                                "fontFamily": "Montserrat-SemiBold",
-                                "fontSize": 12,
-                                "lineHeight": 19.2,
-                                "textAlign": "center",
-                              },
-                            ]
-                          }
-                        >
-                          Envoyer sur
-Instagram
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
-                  <View
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "alignItems": "center",
-                          "display": "flex",
-                          "flexBasis": "8.333333333333334%",
-                          "flexGrow": 1,
-                          "flexShrink": 0,
-                          "marginBottom": 20,
-                          "marginHorizontal": 4,
-                          "maxWidth": 76,
-                        },
-                      ]
-                    }
-                  >
-                    <View
-                      accessibilityRole="button"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
-                      }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={false}
-                      collapsable={false}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        {
-                          "alignItems": "center",
-                          "height": 96,
-                          "opacity": 1,
-                          "userSelect": "auto",
-                          "width": 76,
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          [
                             {
                               "alignItems": "center",
-                              "flexBasis": 0,
-                              "flexGrow": 1,
-                              "flexShrink": 1,
-                            },
-                          ]
-                        }
-                      >
-                        <View
-                          style={
-                            [
-                              {
-                                "paddingBottom": 4,
-                                "paddingLeft": 4,
-                                "paddingRight": 4,
-                                "paddingTop": 4,
-                              },
-                            ]
-                          }
-                        >
-                          <View
-                            height={48}
-                            width={48}
-                          >
-                            <Text>
-                              undefined-SVG-Mock
-                            </Text>
-                          </View>
-                        </View>
-                        <View
-                          numberOfSpaces={2}
-                          style={
-                            [
-                              {
-                                "height": 8,
-                              },
-                            ]
-                          }
-                        />
-                        <Text
-                          disabled={false}
-                          style={
-                            [
-                              {
-                                "color": "#161617",
-                                "fontFamily": "Montserrat-SemiBold",
-                                "fontSize": 12,
-                                "lineHeight": 19.2,
-                                "textAlign": "center",
-                              },
-                            ]
-                          }
-                        >
-                          Envoyer sur
-WhatsApp
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
-                  <View
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "alignItems": "center",
-                          "display": "flex",
-                          "flexBasis": "8.333333333333334%",
-                          "flexGrow": 1,
-                          "flexShrink": 0,
-                          "marginBottom": 20,
-                          "marginHorizontal": 4,
-                          "maxWidth": 76,
-                        },
-                      ]
-                    }
-                  >
-                    <View
-                      accessibilityRole="button"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
-                      }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={false}
-                      collapsable={false}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        {
-                          "alignItems": "center",
-                          "height": 96,
-                          "opacity": 1,
-                          "userSelect": "auto",
-                          "width": 76,
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          [
-                            {
-                              "alignItems": "center",
-                              "flexBasis": 0,
-                              "flexGrow": 1,
-                              "flexShrink": 1,
-                            },
-                          ]
-                        }
-                      >
-                        <View
-                          style={
-                            [
-                              {
-                                "paddingBottom": 4,
-                                "paddingLeft": 4,
-                                "paddingRight": 4,
-                                "paddingTop": 4,
-                              },
-                            ]
-                          }
-                        >
-                          <View
-                            height={48}
-                            width={48}
-                          >
-                            <Text>
-                              undefined-SVG-Mock
-                            </Text>
-                          </View>
-                        </View>
-                        <View
-                          numberOfSpaces={2}
-                          style={
-                            [
-                              {
-                                "height": 8,
-                              },
-                            ]
-                          }
-                        />
-                        <Text
-                          disabled={false}
-                          style={
-                            [
-                              {
-                                "color": "#161617",
-                                "fontFamily": "Montserrat-SemiBold",
-                                "fontSize": 12,
-                                "lineHeight": 19.2,
-                                "textAlign": "center",
-                              },
-                            ]
-                          }
-                        >
-                          Envoyer sur
-iMessage
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
-                  <View
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "alignItems": "center",
-                          "display": "flex",
-                          "flexBasis": "8.333333333333334%",
-                          "flexGrow": 1,
-                          "flexShrink": 0,
-                          "marginBottom": 20,
-                          "marginHorizontal": 4,
-                          "maxWidth": 76,
-                        },
-                      ]
-                    }
-                  >
-                    <View
-                      accessibilityRole="button"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
-                      }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={false}
-                      collapsable={false}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        {
-                          "alignItems": "center",
-                          "height": 96,
-                          "opacity": 1,
-                          "userSelect": "auto",
-                          "width": 76,
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          [
-                            {
-                              "alignItems": "center",
-                              "flexBasis": 0,
-                              "flexGrow": 1,
-                              "flexShrink": 1,
-                            },
-                          ]
-                        }
-                      >
-                        <View
-                          style={
-                            [
-                              {
-                                "paddingBottom": 4,
-                                "paddingLeft": 4,
-                                "paddingRight": 4,
-                                "paddingTop": 4,
-                              },
-                            ]
+                              "height": 96,
+                              "opacity": 1,
+                              "userSelect": "auto",
+                              "width": 76,
+                            }
                           }
                         >
                           <View
@@ -4173,101 +4819,473 @@ iMessage
                               [
                                 {
                                   "alignItems": "center",
-                                  "borderColor": "#CBCDD2",
-                                  "borderRadius": 24,
-                                  "borderWidth": 1,
-                                  "height": 48,
-                                  "justifyContent": "center",
-                                  "width": 48,
+                                  "flexBasis": 0,
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
                                 },
                               ]
                             }
                           >
                             <View
-                              height={28}
-                              width={28}
+                              style={
+                                [
+                                  {
+                                    "paddingBottom": 4,
+                                    "paddingLeft": 4,
+                                    "paddingRight": 4,
+                                    "paddingTop": 4,
+                                  },
+                                ]
+                              }
                             >
-                              <Text>
-                                undefined-SVG-Mock
-                              </Text>
+                              <View
+                                height={48}
+                                width={48}
+                              >
+                                <Text>
+                                  undefined-SVG-Mock
+                                </Text>
+                              </View>
                             </View>
+                            <View
+                              numberOfSpaces={2}
+                              style={
+                                [
+                                  {
+                                    "height": 8,
+                                  },
+                                ]
+                              }
+                            />
+                            <Text
+                              disabled={false}
+                              style={
+                                [
+                                  {
+                                    "color": "#161617",
+                                    "fontFamily": "Montserrat-SemiBold",
+                                    "fontSize": 12,
+                                    "lineHeight": 19.2,
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Envoyer sur
+Instagram
+                            </Text>
                           </View>
                         </View>
+                      </View>
+                      <View
+                        accessibilityRole="none"
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                              "display": "flex",
+                              "flexBasis": "8.333333333333334%",
+                              "flexGrow": 1,
+                              "flexShrink": 0,
+                              "marginBottom": 20,
+                              "marginHorizontal": 4,
+                              "maxWidth": 76,
+                            },
+                          ]
+                        }
+                      >
                         <View
-                          numberOfSpaces={2}
-                          style={
-                            [
-                              {
-                                "height": 8,
-                              },
-                            ]
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
                           }
-                        />
-                        <Text
-                          disabled={false}
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={false}
+                          collapsable={false}
+                          focusable={true}
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
                           style={
-                            [
-                              {
-                                "color": "#161617",
-                                "fontFamily": "Montserrat-SemiBold",
-                                "fontSize": 12,
-                                "lineHeight": 19.2,
-                                "textAlign": "center",
-                              },
-                            ]
+                            {
+                              "alignItems": "center",
+                              "height": 96,
+                              "opacity": 1,
+                              "userSelect": "auto",
+                              "width": 76,
+                            }
                           }
                         >
-                          Plus
+                          <View
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "flexBasis": 0,
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "paddingBottom": 4,
+                                    "paddingLeft": 4,
+                                    "paddingRight": 4,
+                                    "paddingTop": 4,
+                                  },
+                                ]
+                              }
+                            >
+                              <View
+                                height={48}
+                                width={48}
+                              >
+                                <Text>
+                                  undefined-SVG-Mock
+                                </Text>
+                              </View>
+                            </View>
+                            <View
+                              numberOfSpaces={2}
+                              style={
+                                [
+                                  {
+                                    "height": 8,
+                                  },
+                                ]
+                              }
+                            />
+                            <Text
+                              disabled={false}
+                              style={
+                                [
+                                  {
+                                    "color": "#161617",
+                                    "fontFamily": "Montserrat-SemiBold",
+                                    "fontSize": 12,
+                                    "lineHeight": 19.2,
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Envoyer sur
+WhatsApp
+                            </Text>
+                          </View>
+                        </View>
+                      </View>
+                      <View
+                        accessibilityRole="none"
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                              "display": "flex",
+                              "flexBasis": "8.333333333333334%",
+                              "flexGrow": 1,
+                              "flexShrink": 0,
+                              "marginBottom": 20,
+                              "marginHorizontal": 4,
+                              "maxWidth": 76,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={false}
+                          collapsable={false}
+                          focusable={true}
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "height": 96,
+                              "opacity": 1,
+                              "userSelect": "auto",
+                              "width": 76,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "flexBasis": 0,
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "paddingBottom": 4,
+                                    "paddingLeft": 4,
+                                    "paddingRight": 4,
+                                    "paddingTop": 4,
+                                  },
+                                ]
+                              }
+                            >
+                              <View
+                                height={48}
+                                width={48}
+                              >
+                                <Text>
+                                  undefined-SVG-Mock
+                                </Text>
+                              </View>
+                            </View>
+                            <View
+                              numberOfSpaces={2}
+                              style={
+                                [
+                                  {
+                                    "height": 8,
+                                  },
+                                ]
+                              }
+                            />
+                            <Text
+                              disabled={false}
+                              style={
+                                [
+                                  {
+                                    "color": "#161617",
+                                    "fontFamily": "Montserrat-SemiBold",
+                                    "fontSize": 12,
+                                    "lineHeight": 19.2,
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Envoyer sur
+iMessage
+                            </Text>
+                          </View>
+                        </View>
+                      </View>
+                      <View
+                        accessibilityRole="none"
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                              "display": "flex",
+                              "flexBasis": "8.333333333333334%",
+                              "flexGrow": 1,
+                              "flexShrink": 0,
+                              "marginBottom": 20,
+                              "marginHorizontal": 4,
+                              "maxWidth": 76,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={false}
+                          collapsable={false}
+                          focusable={true}
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "height": 96,
+                              "opacity": 1,
+                              "userSelect": "auto",
+                              "width": 76,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "flexBasis": 0,
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "paddingBottom": 4,
+                                    "paddingLeft": 4,
+                                    "paddingRight": 4,
+                                    "paddingTop": 4,
+                                  },
+                                ]
+                              }
+                            >
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "borderColor": "#CBCDD2",
+                                      "borderRadius": 24,
+                                      "borderWidth": 1,
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "width": 48,
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  height={28}
+                                  width={28}
+                                >
+                                  <Text>
+                                    undefined-SVG-Mock
+                                  </Text>
+                                </View>
+                              </View>
+                            </View>
+                            <View
+                              numberOfSpaces={2}
+                              style={
+                                [
+                                  {
+                                    "height": 8,
+                                  },
+                                ]
+                              }
+                            />
+                            <Text
+                              disabled={false}
+                              style={
+                                [
+                                  {
+                                    "color": "#161617",
+                                    "fontFamily": "Montserrat-SemiBold",
+                                    "fontSize": 12,
+                                    "lineHeight": 19.2,
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Plus
 d’options
-                        </Text>
+                            </Text>
+                          </View>
+                        </View>
                       </View>
                     </View>
                   </View>
                 </View>
               </View>
             </View>
+          </View>
+          <View
+            gap={22}
+            style={
+              [
+                {
+                  "gap": 88,
+                },
+              ]
+            }
+          >
             <View
-              numberOfSpaces={4}
               style={
                 [
                   {
-                    "height": 16,
+                    "backgroundColor": "#F1F1F4",
+                    "height": 8,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "marginBottom": 24,
                   },
                 ]
               }
             />
           </View>
-        </View>
-        <View
-          gap={22}
-          style={
-            [
-              {
-                "gap": 88,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              [
-                {
-                  "backgroundColor": "#F1F1F4",
-                  "height": 8,
-                },
-              ]
-            }
-          />
-          <View
-            numberOfSpaces={6}
-            style={
-              [
-                {
-                  "height": 24,
-                },
-              ]
-            }
-          />
         </View>
       </View>
     </View>
@@ -4878,7 +5896,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
           }
         >
           <View
-            maxHeight={56}
+            gap={4}
             style={
               [
                 {
@@ -7060,188 +8078,39 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                 {
                   "flexDirection": "row",
                   "gap": 16,
-                  "marginHorizontal": 16,
-                  "marginVertical": 24,
                 },
               ]
             }
           >
             <View
-              size="medium"
+              maxHeight={56}
               style={
                 [
                   {
-                    "borderRadius": 8,
-                    "height": 48,
-                    "overflow": "hidden",
-                    "width": 48,
-                  },
-                ]
-              }
-            >
-              <BVLinearGradient
-                colors={
-                  [
-                    4294614806,
-                    4290271489,
-                  ]
-                }
-                endPoint={
-                  {
-                    "x": 0.5,
-                    "y": 1,
-                  }
-                }
-                locations={null}
-                startPoint={
-                  {
-                    "x": 0.5,
-                    "y": 0,
-                  }
-                }
-                style={
-                  [
-                    {
-                      "flexBasis": 0,
-                      "flexGrow": 1,
-                      "flexShrink": 1,
-                    },
-                  ]
-                }
-              >
-                <View
-                  size="medium"
-                  style={
-                    [
-                      {
-                        "position": "absolute",
-                        "top": -20,
-                      },
-                    ]
-                  }
-                >
-                  <View
-                    fill="none"
-                    height={92}
-                    width={82}
-                  >
-                    <Text>
-                      undefined-SVG-Mock
-                    </Text>
-                  </View>
-                </View>
-              </BVLinearGradient>
-            </View>
-            <View
-              style={
-                [
-                  {
-                    "flexShrink": 1,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#161617",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 16,
-                      "lineHeight": 25.6,
-                    },
-                  ]
-                }
-              >
-                Fan de lecture ?
-              </Text>
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#696A6F",
-                      "fontFamily": "Montserrat-SemiBold",
-                      "fontSize": 12,
-                      "lineHeight": 19.2,
-                    },
-                  ]
-                }
-              >
-                Reçois nos recos lecture, nos jeux-concours et le meilleur de l’actu littéraire !
-              </Text>
-              <View
-                numberOfSpaces={2}
-                style={
-                  [
-                    {
-                      "height": 8,
-                    },
-                  ]
-                }
-              />
-              <View
-                accessibilityLabel="Suivre le thème"
-                accessibilityRole="button"
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": undefined,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  {
-                    "alignItems": "center",
-                    "alignSelf": "flex-start",
-                    "backgroundColor": "#ffffff",
-                    "borderColor": "#90949D",
-                    "borderRadius": 24,
-                    "borderWidth": 1,
                     "flexDirection": "row",
-                    "height": "auto",
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "paddingHorizontal": 12,
-                    "paddingVertical": 4,
-                    "userSelect": "auto",
-                    "width": "auto",
-                  }
+                    "flexWrap": "wrap",
+                    "gap": 8,
+                    "maxHeight": 56,
+                    "overflow": "hidden",
+                  },
+                ]
+              }
+              testID="tagsContainer"
+            >
+              <View
+                style={
+                  [
+                    {
+                      "alignSelf": "baseline",
+                      "backgroundColor": "#F1F1F4",
+                      "borderRadius": 6,
+                      "flexDirection": "row",
+                      "paddingHorizontal": 8,
+                      "paddingVertical": 4,
+                    },
+                  ]
                 }
-                testID="Suivre le thème"
               >
-                <View>
-                  undefined-Lottie-Mock
-                </View>
-                <View
-                  numberOfSpaces={2}
-                  style={
-                    [
-                      {
-                        "width": 8,
-                      },
-                    ]
-                  }
-                />
                 <Text
                   style={
                     [
@@ -7249,12 +8118,12 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                         "color": "#161617",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 19.2,
+                        "lineHeight": 16,
                       },
                     ]
                   }
                 >
-                  Suivre le thème
+                  Librairie
                 </Text>
               </View>
             </View>
@@ -7380,16 +8249,18 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
             }
           >
             <View
-              gap={4}
+              gap={1}
               style={
                 [
                   {
-                    "gap": 16,
+                    "gap": 4,
                   },
                 ]
               }
             >
               <Text
+                accessibilityLabel="Nom du lieu : Le Petit Rintintin 1"
+                adjustsFontSizeToFit={true}
                 style={
                   [
                     {
@@ -7401,468 +8272,1231 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                   ]
                 }
               >
-                Passe le bon plan !
+                Le Petit Rintintin 1
               </Text>
               <View
+                gap={3}
                 style={
                   [
                     {
-                      "flexDirection": "row",
-                      "maxWidth": 500,
-                      "width": "100%",
+                      "gap": 12,
                     },
                   ]
                 }
               >
+                <View>
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        },
+                      ]
+                    }
+                  >
+                    Adresse
+                  </Text>
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
+                        },
+                      ]
+                    }
+                  >
+                    1 boulevard Poissonnière, 75000 Paris
+                  </Text>
+                </View>
                 <View
-                  accessibilityRole="list"
                   style={
                     [
                       {
-                        "flexBasis": 0,
-                        "flexDirection": "row",
-                        "flexGrow": 1,
-                        "flexShrink": 1,
-                        "flexWrap": "wrap",
-                        "justifyContent": "flex-start",
-                        "paddingLeft": 0,
+                        "backgroundColor": "#F1F1F4",
+                        "height": 1,
+                        "width": "100%",
+                      },
+                    ]
+                  }
+                />
+                <View
+                  accessibilityLabel="Copier l’adresse"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "backgroundColor": "transparent",
+                      "borderRadius": 24,
+                      "flexDirection": "row",
+                      "justifyContent": "flex-start",
+                      "maxWidth": 500,
+                      "minHeight": 40,
+                      "opacity": 1,
+                      "paddingBottom": 2,
+                      "paddingLeft": 2,
+                      "paddingRight": 2,
+                      "paddingTop": 2,
+                      "userSelect": "auto",
+                      "width": "100%",
+                    }
+                  }
+                  testID="Copier l’adresse"
+                >
+                  <View
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "flexDirection": "row",
+                            "flexShrink": 0,
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        height={20}
+                        testID="button-icon-left"
+                        width={20}
+                      >
+                        <Text>
+                          button-icon-left-SVG-Mock
+                        </Text>
+                      </View>
+                      <View
+                        numberOfSpaces={2}
+                        style={
+                          [
+                            {
+                              "width": 8,
+                            },
+                          ]
+                        }
+                      />
+                    </View>
+                    <Text
+                      adjustsFontSizeToFit={false}
+                      numberOfLines={1}
+                      style={
+                        [
+                          {
+                            "color": "#161617",
+                            "fontFamily": "Montserrat-Bold",
+                            "fontSize": 15,
+                            "lineHeight": 20,
+                            "maxWidth": "100%",
+                          },
+                        ]
+                      }
+                    >
+                      Copier l’adresse
+                    </Text>
+                  </View>
+                </View>
+                <View
+                  style={
+                    [
+                      {
+                        "alignItems": "flex-start",
                       },
                     ]
                   }
                 >
                   <View
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "alignItems": "center",
-                          "display": "flex",
-                          "flexBasis": "8.333333333333334%",
-                          "flexGrow": 1,
-                          "flexShrink": 0,
-                          "marginBottom": 20,
-                          "marginHorizontal": 4,
-                          "maxWidth": 76,
-                        },
-                      ]
+                    accessibilityLabel="Voir l’itinéraire"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
                     }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "transparent",
+                        "borderRadius": 0,
+                        "borderWidth": 0,
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                        "marginTop": 0,
+                        "maxWidth": 500,
+                        "minHeight": 20,
+                        "opacity": 1,
+                        "paddingBottom": 0,
+                        "paddingLeft": 0,
+                        "paddingRight": 0,
+                        "paddingTop": 0,
+                        "userSelect": "auto",
+                        "width": "auto",
+                      }
+                    }
+                    testID="Voir l’itinéraire"
                   >
                     <View
-                      accessibilityRole="button"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
-                      }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={false}
-                      collapsable={false}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
                       style={
-                        {
-                          "alignItems": "center",
-                          "height": 96,
-                          "opacity": 1,
-                          "userSelect": "auto",
-                          "width": 76,
-                        }
+                        [
+                          {
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                          },
+                        ]
                       }
                     >
                       <View
                         style={
                           [
                             {
-                              "alignItems": "center",
-                              "flexBasis": 0,
-                              "flexGrow": 1,
-                              "flexShrink": 1,
+                              "flexDirection": "row",
+                              "flexShrink": 0,
                             },
                           ]
                         }
                       >
                         <View
-                          style={
-                            [
-                              {
-                                "paddingBottom": 4,
-                                "paddingLeft": 4,
-                                "paddingRight": 4,
-                                "paddingTop": 4,
-                              },
-                            ]
-                          }
+                          accessibilityLabel="Nouvelle fenêtre"
+                          height={20}
+                          testID="button-icon-left"
+                          width={20}
                         >
-                          <View
-                            height={48}
-                            width={48}
-                          >
-                            <Text>
-                              undefined-SVG-Mock
-                            </Text>
-                          </View>
+                          <Text>
+                            button-icon-left-SVG-Mock
+                          </Text>
                         </View>
                         <View
                           numberOfSpaces={2}
                           style={
                             [
                               {
-                                "height": 8,
+                                "width": 8,
                               },
                             ]
                           }
                         />
-                        <Text
-                          disabled={false}
-                          style={
-                            [
-                              {
-                                "color": "#161617",
-                                "fontFamily": "Montserrat-SemiBold",
-                                "fontSize": 12,
-                                "lineHeight": 19.2,
-                                "textAlign": "center",
-                              },
-                            ]
-                          }
-                        >
-                          Envoyer sur
-Instagram
-                        </Text>
                       </View>
+                      <Text
+                        adjustsFontSizeToFit={false}
+                        numberOfLines={1}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Bold",
+                              "fontSize": 15,
+                              "lineHeight": 20,
+                              "maxWidth": "100%",
+                            },
+                          ]
+                        }
+                      >
+                        Voir l’itinéraire
+                      </Text>
                     </View>
                   </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        gap={6}
+        style={
+          [
+            {
+              "gap": 24,
+            },
+          ]
+        }
+      >
+        <View
+          animatedStyle={
+            {
+              "value": {},
+            }
+          }
+          collapsable={false}
+          layout={
+            LinearTransition {
+              "build": [Function],
+              "callbackV": undefined,
+              "dampingV": undefined,
+              "delayV": undefined,
+              "durationV": 200,
+              "easingV": undefined,
+              "initialValues": undefined,
+              "massV": undefined,
+              "overshootClampingV": undefined,
+              "randomizeDelay": false,
+              "restDisplacementThresholdV": undefined,
+              "restSpeedThresholdV": undefined,
+              "rotateV": undefined,
+              "stiffnessV": undefined,
+              "type": undefined,
+            }
+          }
+        >
+          <View
+            gap={6}
+            style={
+              [
+                {
+                  "gap": 24,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "backgroundColor": "#F1F1F4",
+                    "height": 8,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                    "width": "100%",
+                  },
+                ]
+              }
+            >
+              <View
+                accessibilityRole="tablist"
+                style={
+                  [
+                    {
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "backgroundColor": "#F1F1F4",
+                        "bottom": 0,
+                        "height": 4,
+                        "position": "absolute",
+                        "width": "100%",
+                      },
+                    ]
+                  }
+                />
+                <View
+                  numberOfSpaces={6}
+                  style={
+                    [
+                      {
+                        "width": 24,
+                      },
+                    ]
+                  }
+                />
+                <View
+                  accessibilityRole="tab"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": false,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "flexBasis": 0,
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                      "maxWidth": 180,
+                      "opacity": 1,
+                      "userSelect": "auto",
+                    }
+                  }
+                >
                   <View
-                    accessibilityRole="none"
+                    gap={2}
                     style={
                       [
                         {
                           "alignItems": "center",
-                          "display": "flex",
-                          "flexBasis": "8.333333333333334%",
+                          "flexDirection": "row",
                           "flexGrow": 1,
-                          "flexShrink": 0,
-                          "marginBottom": 20,
-                          "marginHorizontal": 4,
-                          "maxWidth": 76,
+                          "gap": 8,
+                          "justifyContent": "center",
                         },
                       ]
                     }
                   >
-                    <View
-                      accessibilityRole="button"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
-                      }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={false}
-                      collapsable={false}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
+                    <Text
+                      isHover={false}
+                      isSelected={false}
                       style={
+                        [
+                          {
+                            "color": "#696A6F",
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
+                            "textAlign": "center",
+                          },
+                        ]
+                      }
+                    >
+                      Offres disponibles
+                    </Text>
+                  </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "height": 8,
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    isSelected={false}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "borderRadius": 4,
+                          "bottom": 0,
+                          "height": 4,
+                          "width": "100%",
+                        },
+                      ]
+                    }
+                  />
+                </View>
+                <View
+                  accessibilityRole="tab"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": true,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={false}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "flexBasis": 0,
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                      "maxWidth": 180,
+                      "opacity": 0.7,
+                      "userSelect": "auto",
+                    }
+                  }
+                >
+                  <View
+                    gap={2}
+                    style={
+                      [
                         {
                           "alignItems": "center",
-                          "height": 96,
-                          "opacity": 1,
-                          "userSelect": "auto",
-                          "width": 76,
-                        }
+                          "flexDirection": "row",
+                          "flexGrow": 1,
+                          "gap": 8,
+                          "justifyContent": "center",
+                        },
+                      ]
+                    }
+                  >
+                    <Text
+                      isHover={false}
+                      isSelected={true}
+                      style={
+                        [
+                          {
+                            "color": "#eb0055",
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
+                            "textAlign": "center",
+                          },
+                        ]
+                      }
+                    >
+                      Infos pratiques
+                    </Text>
+                  </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "height": 8,
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    isSelected={true}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#eb0055",
+                          "borderRadius": 4,
+                          "bottom": 0,
+                          "height": 4,
+                          "width": "100%",
+                        },
+                      ]
+                    }
+                  />
+                </View>
+                <View
+                  numberOfSpaces={6}
+                  style={
+                    [
+                      {
+                        "width": 24,
+                      },
+                    ]
+                  }
+                />
+              </View>
+              <View
+                accessibilityRole="none"
+                style={
+                  [
+                    {
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "marginHorizontal": 24,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "height": 8,
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    numberOfSpaces={4}
+                    style={
+                      [
+                        {
+                          "height": 16,
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        },
+                      ]
+                    }
+                  >
+                    Modalités de retrait
+                  </Text>
+                  <View
+                    numberOfSpaces={4}
+                    style={
+                      [
+                        {
+                          "height": 16,
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
+                        },
+                      ]
+                    }
+                  >
+                    How to withdraw, https://test.com
+                  </Text>
+                  <View
+                    numberOfSpaces={4}
+                    style={
+                      [
+                        {
+                          "height": 16,
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#F1F1F4",
+                          "height": 1,
+                          "width": "100%",
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    numberOfSpaces={4}
+                    style={
+                      [
+                        {
+                          "height": 16,
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        },
+                      ]
+                    }
+                  >
+                    Description
+                  </Text>
+                  <View
+                    numberOfSpaces={4}
+                    style={
+                      [
+                        {
+                          "height": 16,
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
+                        },
+                      ]
+                    }
+                  >
+                    https://pass.culture.fr/ lorem ipsum consectetur adipisicing elit. Debitis officiis maiores quia unde, hic quisquam odit ea quo ipsam possimus, labore nesciunt numquam. Id itaque in sed sapiente blanditiis necessitatibus. consectetur adipisicing elit. Debitis officiis maiores quia unde, hic quisquam odit ea quo ipsam possimus, consectetur adipisicing elit. Debitis officiis maiores quia unde, hic quisquam odit ea quo ipsam possimus,
+                  </Text>
+                  <View
+                    numberOfSpaces={4}
+                    style={
+                      [
+                        {
+                          "height": 16,
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#F1F1F4",
+                          "height": 1,
+                          "width": "100%",
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    numberOfSpaces={4}
+                    style={
+                      [
+                        {
+                          "height": 16,
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        },
+                      ]
+                    }
+                  >
+                    Contact
+                  </Text>
+                  <View
+                    numberOfSpaces={4}
+                    style={
+                      [
+                        {
+                          "height": 16,
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    accessibilityLabel="contact@venue.com"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "transparent",
+                        "borderRadius": 24,
+                        "flexDirection": "row",
+                        "justifyContent": "flex-start",
+                        "maxWidth": 500,
+                        "minHeight": 40,
+                        "opacity": 1,
+                        "paddingBottom": 2,
+                        "paddingLeft": 2,
+                        "paddingRight": 2,
+                        "paddingTop": 2,
+                        "userSelect": "auto",
+                        "width": "100%",
+                      }
+                    }
+                    testID="contact@venue.com"
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                          },
+                        ]
                       }
                     >
                       <View
                         style={
                           [
                             {
-                              "alignItems": "center",
-                              "flexBasis": 0,
-                              "flexGrow": 1,
-                              "flexShrink": 1,
+                              "flexDirection": "row",
+                              "flexShrink": 0,
                             },
                           ]
                         }
                       >
                         <View
-                          style={
-                            [
-                              {
-                                "paddingBottom": 4,
-                                "paddingLeft": 4,
-                                "paddingRight": 4,
-                                "paddingTop": 4,
-                              },
-                            ]
-                          }
+                          height={20}
+                          testID="button-icon-left"
+                          width={20}
                         >
-                          <View
-                            height={48}
-                            width={48}
-                          >
-                            <Text>
-                              undefined-SVG-Mock
-                            </Text>
-                          </View>
+                          <Text>
+                            button-icon-left-SVG-Mock
+                          </Text>
                         </View>
                         <View
                           numberOfSpaces={2}
                           style={
                             [
                               {
-                                "height": 8,
+                                "width": 8,
                               },
                             ]
                           }
                         />
-                        <Text
-                          disabled={false}
-                          style={
-                            [
-                              {
-                                "color": "#161617",
-                                "fontFamily": "Montserrat-SemiBold",
-                                "fontSize": 12,
-                                "lineHeight": 19.2,
-                                "textAlign": "center",
-                              },
-                            ]
-                          }
-                        >
-                          Envoyer sur
-WhatsApp
-                        </Text>
                       </View>
+                      <Text
+                        adjustsFontSizeToFit={false}
+                        numberOfLines={1}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Bold",
+                              "fontSize": 15,
+                              "lineHeight": 20,
+                              "maxWidth": "100%",
+                            },
+                          ]
+                        }
+                      >
+                        contact@venue.com
+                      </Text>
                     </View>
                   </View>
                   <View
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "alignItems": "center",
-                          "display": "flex",
-                          "flexBasis": "8.333333333333334%",
-                          "flexGrow": 1,
-                          "flexShrink": 0,
-                          "marginBottom": 20,
-                          "marginHorizontal": 4,
-                          "maxWidth": 76,
-                        },
-                      ]
+                    accessibilityLabel="+33102030405"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
                     }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "transparent",
+                        "borderRadius": 24,
+                        "flexDirection": "row",
+                        "justifyContent": "flex-start",
+                        "maxWidth": 500,
+                        "minHeight": 40,
+                        "opacity": 1,
+                        "paddingBottom": 2,
+                        "paddingLeft": 2,
+                        "paddingRight": 2,
+                        "paddingTop": 2,
+                        "userSelect": "auto",
+                        "width": "100%",
+                      }
+                    }
+                    testID="+33102030405"
                   >
                     <View
-                      accessibilityRole="button"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
-                      }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={false}
-                      collapsable={false}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
                       style={
-                        {
-                          "alignItems": "center",
-                          "height": 96,
-                          "opacity": 1,
-                          "userSelect": "auto",
-                          "width": 76,
-                        }
+                        [
+                          {
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                          },
+                        ]
                       }
                     >
                       <View
                         style={
                           [
                             {
-                              "alignItems": "center",
-                              "flexBasis": 0,
-                              "flexGrow": 1,
-                              "flexShrink": 1,
+                              "flexDirection": "row",
+                              "flexShrink": 0,
                             },
                           ]
                         }
                       >
                         <View
-                          style={
-                            [
-                              {
-                                "paddingBottom": 4,
-                                "paddingLeft": 4,
-                                "paddingRight": 4,
-                                "paddingTop": 4,
-                              },
-                            ]
-                          }
+                          height={20}
+                          testID="button-icon-left"
+                          width={20}
                         >
-                          <View
-                            height={48}
-                            width={48}
-                          >
-                            <Text>
-                              undefined-SVG-Mock
-                            </Text>
-                          </View>
+                          <Text>
+                            button-icon-left-SVG-Mock
+                          </Text>
                         </View>
                         <View
                           numberOfSpaces={2}
                           style={
                             [
                               {
-                                "height": 8,
+                                "width": 8,
                               },
                             ]
                           }
                         />
-                        <Text
-                          disabled={false}
-                          style={
-                            [
-                              {
-                                "color": "#161617",
-                                "fontFamily": "Montserrat-SemiBold",
-                                "fontSize": 12,
-                                "lineHeight": 19.2,
-                                "textAlign": "center",
-                              },
-                            ]
-                          }
-                        >
-                          Envoyer sur
-iMessage
-                        </Text>
                       </View>
+                      <Text
+                        adjustsFontSizeToFit={false}
+                        numberOfLines={1}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Bold",
+                              "fontSize": 15,
+                              "lineHeight": 20,
+                              "maxWidth": "100%",
+                            },
+                          ]
+                        }
+                      >
+                        +33102030405
+                      </Text>
                     </View>
                   </View>
                   <View
-                    accessibilityRole="none"
-                    style={
-                      [
-                        {
-                          "alignItems": "center",
-                          "display": "flex",
-                          "flexBasis": "8.333333333333334%",
-                          "flexGrow": 1,
-                          "flexShrink": 0,
-                          "marginBottom": 20,
-                          "marginHorizontal": 4,
-                          "maxWidth": 76,
-                        },
-                      ]
+                    accessibilityLabel="https://my@website.com"
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
                     }
+                    accessibilityValue={
+                      {
+                        "max": undefined,
+                        "min": undefined,
+                        "now": undefined,
+                        "text": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "transparent",
+                        "borderRadius": 24,
+                        "flexDirection": "row",
+                        "justifyContent": "flex-start",
+                        "maxWidth": 500,
+                        "minHeight": 40,
+                        "opacity": 1,
+                        "paddingBottom": 2,
+                        "paddingLeft": 2,
+                        "paddingRight": 2,
+                        "paddingTop": 2,
+                        "userSelect": "auto",
+                        "width": "100%",
+                      }
+                    }
+                    testID="https://my@website.com"
                   >
                     <View
-                      accessibilityRole="button"
-                      accessibilityState={
-                        {
-                          "busy": undefined,
-                          "checked": undefined,
-                          "disabled": undefined,
-                          "expanded": undefined,
-                          "selected": undefined,
-                        }
-                      }
-                      accessibilityValue={
-                        {
-                          "max": undefined,
-                          "min": undefined,
-                          "now": undefined,
-                          "text": undefined,
-                        }
-                      }
-                      accessible={false}
-                      collapsable={false}
-                      focusable={true}
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
                       style={
-                        {
-                          "alignItems": "center",
-                          "height": 96,
-                          "opacity": 1,
-                          "userSelect": "auto",
-                          "width": 76,
-                        }
+                        [
+                          {
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                          },
+                        ]
                       }
                     >
                       <View
                         style={
                           [
                             {
-                              "alignItems": "center",
-                              "flexBasis": 0,
-                              "flexGrow": 1,
-                              "flexShrink": 1,
+                              "flexDirection": "row",
+                              "flexShrink": 0,
                             },
                           ]
                         }
                       >
                         <View
+                          accessibilityLabel="Nouvelle fenêtre"
+                          height={20}
+                          testID="button-icon-left"
+                          width={20}
+                        >
+                          <Text>
+                            button-icon-left-SVG-Mock
+                          </Text>
+                        </View>
+                        <View
+                          numberOfSpaces={2}
                           style={
                             [
                               {
-                                "paddingBottom": 4,
-                                "paddingLeft": 4,
-                                "paddingRight": 4,
-                                "paddingTop": 4,
+                                "width": 8,
+                              },
+                            ]
+                          }
+                        />
+                      </View>
+                      <Text
+                        adjustsFontSizeToFit={false}
+                        numberOfLines={1}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Bold",
+                              "fontSize": 15,
+                              "lineHeight": 20,
+                              "maxWidth": "100%",
+                            },
+                          ]
+                        }
+                      >
+                        https://my@website.com
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    numberOfSpaces={4}
+                    style={
+                      [
+                        {
+                          "height": 16,
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#F1F1F4",
+                          "height": 1,
+                          "width": "100%",
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    numberOfSpaces={4}
+                    style={
+                      [
+                        {
+                          "height": 16,
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        },
+                      ]
+                    }
+                  >
+                    Accessibilité
+                  </Text>
+                  <View
+                    numberOfSpaces={4}
+                    style={
+                      [
+                        {
+                          "height": 16,
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    accessibilityRole="list"
+                    style={
+                      [
+                        {
+                          "flexDirection": "row",
+                          "gap": 0,
+                          "justifyContent": "space-between",
+                          "overflow": "visible",
+                          "paddingLeft": 0,
+                          "width": "100%",
+                        },
+                      ]
+                    }
+                    testID="BasicAccessibilityInfo"
+                  >
+                    <View
+                      accessibilityRole="none"
+                      style={
+                        [
+                          {
+                            "display": "flex",
+                            "maxWidth": 72,
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        accessibilityLabel="Handicap visuel : Accessible"
+                        accessibilityRole="image"
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                            },
+                          ]
+                        }
+                        testID="accessibilityBadgeContainer"
+                      >
+                        <View
+                          accessibilityHidden={true}
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "borderColor": "#CBCDD2",
+                                "borderRadius": 8,
+                                "borderWidth": 1,
+                                "height": 48,
+                                "width": 48,
                               },
                             ]
                           }
@@ -7871,39 +9505,66 @@ iMessage
                             style={
                               [
                                 {
-                                  "alignItems": "center",
-                                  "borderColor": "#CBCDD2",
-                                  "borderRadius": 24,
-                                  "borderWidth": 1,
-                                  "height": 48,
-                                  "justifyContent": "center",
-                                  "width": 48,
+                                  "flexBasis": 0,
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                              ]
+                            }
+                          />
+                          <View
+                            fill="#161617"
+                            height={24}
+                            width={24}
+                          >
+                            <Text>
+                              undefined-SVG-Mock
+                            </Text>
+                          </View>
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexBasis": 0,
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                              ]
+                            }
+                          />
+                          <View
+                            style={
+                              [
+                                {
+                                  "bottom": -8,
+                                  "position": "absolute",
                                 },
                               ]
                             }
                           >
                             <View
-                              height={28}
-                              width={28}
+                              accessibilityLabel="Accessible"
+                              height={16}
+                              testID="valid-icon"
+                              width={16}
                             >
                               <Text>
-                                undefined-SVG-Mock
+                                valid-icon-SVG-Mock
                               </Text>
                             </View>
                           </View>
                         </View>
                         <View
-                          numberOfSpaces={2}
+                          numberOfSpaces={4}
                           style={
                             [
                               {
-                                "height": 8,
+                                "height": 16,
                               },
                             ]
                           }
                         />
                         <Text
-                          disabled={false}
                           style={
                             [
                               {
@@ -7911,62 +9572,1708 @@ iMessage
                                 "fontFamily": "Montserrat-SemiBold",
                                 "fontSize": 12,
                                 "lineHeight": 19.2,
+                                "paddingHorizontal": 1,
                                 "textAlign": "center",
                               },
                             ]
                           }
                         >
-                          Plus
-d’options
+                          Handicap visuel
                         </Text>
+                      </View>
+                    </View>
+                    <View
+                      accessibilityRole="none"
+                      style={
+                        [
+                          {
+                            "display": "flex",
+                            "maxWidth": 72,
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        accessibilityLabel="Handicap psychique ou cognitif : Non accessible"
+                        accessibilityRole="image"
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                            },
+                          ]
+                        }
+                        testID="accessibilityBadgeContainer"
+                      >
+                        <View
+                          accessibilityHidden={true}
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "borderColor": "#CBCDD2",
+                                "borderRadius": 8,
+                                "borderWidth": 1,
+                                "height": 48,
+                                "width": 48,
+                              },
+                            ]
+                          }
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexBasis": 0,
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                              ]
+                            }
+                          />
+                          <View
+                            fill="#161617"
+                            height={24}
+                            width={24}
+                          >
+                            <Text>
+                              undefined-SVG-Mock
+                            </Text>
+                          </View>
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexBasis": 0,
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                              ]
+                            }
+                          />
+                          <View
+                            style={
+                              [
+                                {
+                                  "bottom": -8,
+                                  "position": "absolute",
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              accessibilityLabel="Non accessible"
+                              fill="#696A6F"
+                              height={16}
+                              testID="invalid-icon"
+                              width={16}
+                            >
+                              <Text>
+                                invalid-icon-SVG-Mock
+                              </Text>
+                            </View>
+                          </View>
+                        </View>
+                        <View
+                          numberOfSpaces={4}
+                          style={
+                            [
+                              {
+                                "height": 16,
+                              },
+                            ]
+                          }
+                        />
+                        <Text
+                          style={
+                            [
+                              {
+                                "color": "#161617",
+                                "fontFamily": "Montserrat-SemiBold",
+                                "fontSize": 12,
+                                "lineHeight": 19.2,
+                                "paddingHorizontal": 1,
+                                "textAlign": "center",
+                              },
+                            ]
+                          }
+                        >
+                          Handicap psychique ou cognitif
+                        </Text>
+                      </View>
+                    </View>
+                    <View
+                      accessibilityRole="none"
+                      style={
+                        [
+                          {
+                            "display": "flex",
+                            "maxWidth": 72,
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        accessibilityLabel="Handicap moteur : Non accessible"
+                        accessibilityRole="image"
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                            },
+                          ]
+                        }
+                        testID="accessibilityBadgeContainer"
+                      >
+                        <View
+                          accessibilityHidden={true}
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "borderColor": "#CBCDD2",
+                                "borderRadius": 8,
+                                "borderWidth": 1,
+                                "height": 48,
+                                "width": 48,
+                              },
+                            ]
+                          }
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexBasis": 0,
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                              ]
+                            }
+                          />
+                          <View
+                            fill="#161617"
+                            height={24}
+                            width={24}
+                          >
+                            <Text>
+                              undefined-SVG-Mock
+                            </Text>
+                          </View>
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexBasis": 0,
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                              ]
+                            }
+                          />
+                          <View
+                            style={
+                              [
+                                {
+                                  "bottom": -8,
+                                  "position": "absolute",
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              accessibilityLabel="Non accessible"
+                              fill="#696A6F"
+                              height={16}
+                              testID="invalid-icon"
+                              width={16}
+                            >
+                              <Text>
+                                invalid-icon-SVG-Mock
+                              </Text>
+                            </View>
+                          </View>
+                        </View>
+                        <View
+                          numberOfSpaces={4}
+                          style={
+                            [
+                              {
+                                "height": 16,
+                              },
+                            ]
+                          }
+                        />
+                        <Text
+                          style={
+                            [
+                              {
+                                "color": "#161617",
+                                "fontFamily": "Montserrat-SemiBold",
+                                "fontSize": 12,
+                                "lineHeight": 19.2,
+                                "paddingHorizontal": 1,
+                                "textAlign": "center",
+                              },
+                            ]
+                          }
+                        >
+                          Handicap moteur
+                        </Text>
+                      </View>
+                    </View>
+                    <View
+                      accessibilityRole="none"
+                      style={
+                        [
+                          {
+                            "display": "flex",
+                            "maxWidth": 72,
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        accessibilityLabel="Handicap auditif : Non accessible"
+                        accessibilityRole="image"
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                            },
+                          ]
+                        }
+                        testID="accessibilityBadgeContainer"
+                      >
+                        <View
+                          accessibilityHidden={true}
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "borderColor": "#CBCDD2",
+                                "borderRadius": 8,
+                                "borderWidth": 1,
+                                "height": 48,
+                                "width": 48,
+                              },
+                            ]
+                          }
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexBasis": 0,
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                              ]
+                            }
+                          />
+                          <View
+                            fill="#161617"
+                            height={24}
+                            width={24}
+                          >
+                            <Text>
+                              undefined-SVG-Mock
+                            </Text>
+                          </View>
+                          <View
+                            style={
+                              [
+                                {
+                                  "flexBasis": 0,
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                              ]
+                            }
+                          />
+                          <View
+                            style={
+                              [
+                                {
+                                  "bottom": -8,
+                                  "position": "absolute",
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              accessibilityLabel="Non accessible"
+                              fill="#696A6F"
+                              height={16}
+                              testID="invalid-icon"
+                              width={16}
+                            >
+                              <Text>
+                                invalid-icon-SVG-Mock
+                              </Text>
+                            </View>
+                          </View>
+                        </View>
+                        <View
+                          numberOfSpaces={4}
+                          style={
+                            [
+                              {
+                                "height": 16,
+                              },
+                            ]
+                          }
+                        />
+                        <Text
+                          style={
+                            [
+                              {
+                                "color": "#161617",
+                                "fontFamily": "Montserrat-SemiBold",
+                                "fontSize": 12,
+                                "lineHeight": 19.2,
+                                "paddingHorizontal": 1,
+                                "textAlign": "center",
+                              },
+                            ]
+                          }
+                        >
+                          Handicap auditif
+                        </Text>
+                      </View>
+                    </View>
+                  </View>
+                  <View
+                    numberOfSpaces={4}
+                    style={
+                      [
+                        {
+                          "height": 16,
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#F1F1F4",
+                          "height": 1,
+                          "width": "100%",
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    numberOfSpaces={4}
+                    style={
+                      [
+                        {
+                          "height": 16,
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        },
+                      ]
+                    }
+                  >
+                    Horaires d’ouverture
+                  </Text>
+                  <View
+                    numberOfSpaces={4}
+                    style={
+                      [
+                        {
+                          "height": 16,
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    accessibilityRole="list"
+                    style={
+                      [
+                        {
+                          "display": "flex",
+                          "flexDirection": "column",
+                          "gap": 8,
+                          "paddingLeft": 0,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      accessibilityLabel="Lundi 09:00 - 19:00"
+                      accessibilityRole="none"
+                      style={
+                        [
+                          {
+                            "display": "flex",
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        accessibilityHidden={true}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Lundi
+                      </Text>
+                      <Text
+                        accessibilityHidden={true}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        09:00 - 19:00
+                      </Text>
+                    </View>
+                    <View
+                      accessibilityLabel="Mardi 09:00 - 12:00  puis  14:00 - 19:00"
+                      accessibilityRole="none"
+                      style={
+                        [
+                          {
+                            "display": "flex",
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        accessibilityHidden={true}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Mardi
+                      </Text>
+                      <Text
+                        accessibilityHidden={true}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        09:00 - 12:00 / 14:00 - 19:00
+                      </Text>
+                    </View>
+                    <View
+                      accessibilityLabel="Mercredi 09:00 - 12:00  puis  14:00 - 19:00"
+                      accessibilityRole="none"
+                      style={
+                        [
+                          {
+                            "display": "flex",
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        accessibilityHidden={true}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Mercredi
+                      </Text>
+                      <Text
+                        accessibilityHidden={true}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        09:00 - 12:00 / 14:00 - 19:00
+                      </Text>
+                    </View>
+                    <View
+                      accessibilityLabel="Jeudi 09:00 - 12:00  puis  14:00 - 19:00"
+                      accessibilityRole="none"
+                      style={
+                        [
+                          {
+                            "display": "flex",
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        accessibilityHidden={true}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Jeudi
+                      </Text>
+                      <Text
+                        accessibilityHidden={true}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        09:00 - 12:00 / 14:00 - 19:00
+                      </Text>
+                    </View>
+                    <View
+                      accessibilityLabel="Vendredi 09:00 - 19:00"
+                      accessibilityRole="none"
+                      style={
+                        [
+                          {
+                            "display": "flex",
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        accessibilityHidden={true}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Vendredi
+                      </Text>
+                      <Text
+                        accessibilityHidden={true}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        09:00 - 19:00
+                      </Text>
+                    </View>
+                    <View
+                      accessibilityLabel="Samedi Fermé"
+                      accessibilityRole="none"
+                      style={
+                        [
+                          {
+                            "display": "flex",
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        accessibilityHidden={true}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Samedi
+                      </Text>
+                      <Text
+                        accessibilityHidden={true}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Fermé
+                      </Text>
+                    </View>
+                    <View
+                      accessibilityLabel="Dimanche Fermé"
+                      accessibilityRole="none"
+                      style={
+                        [
+                          {
+                            "display": "flex",
+                          },
+                        ]
+                      }
+                    >
+                      <Text
+                        accessibilityHidden={true}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Dimanche
+                      </Text>
+                      <Text
+                        accessibilityHidden={true}
+                        style={
+                          [
+                            {
+                              "color": "#161617",
+                              "fontFamily": "Montserrat-Medium",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
+                            },
+                          ]
+                        }
+                      >
+                        Fermé
+                      </Text>
+                    </View>
+                  </View>
+                  <View
+                    numberOfSpaces={4}
+                    style={
+                      [
+                        {
+                          "height": 16,
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    style={
+                      [
+                        {
+                          "backgroundColor": "#F1F1F4",
+                          "height": 1,
+                          "width": "100%",
+                        },
+                      ]
+                    }
+                  />
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "height": 8,
+                        },
+                      ]
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            gap={6}
+            style={
+              [
+                {
+                  "gap": 24,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "backgroundColor": "#F1F1F4",
+                    "height": 8,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "flexDirection": "row",
+                    "gap": 16,
+                    "marginHorizontal": 16,
+                    "marginVertical": 24,
+                  },
+                ]
+              }
+            >
+              <View
+                size="medium"
+                style={
+                  [
+                    {
+                      "borderRadius": 8,
+                      "height": 48,
+                      "overflow": "hidden",
+                      "width": 48,
+                    },
+                  ]
+                }
+              >
+                <BVLinearGradient
+                  colors={
+                    [
+                      4294614806,
+                      4290271489,
+                    ]
+                  }
+                  endPoint={
+                    {
+                      "x": 0.5,
+                      "y": 1,
+                    }
+                  }
+                  locations={null}
+                  startPoint={
+                    {
+                      "x": 0.5,
+                      "y": 0,
+                    }
+                  }
+                  style={
+                    [
+                      {
+                        "flexBasis": 0,
+                        "flexGrow": 1,
+                        "flexShrink": 1,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    size="medium"
+                    style={
+                      [
+                        {
+                          "position": "absolute",
+                          "top": -20,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      fill="none"
+                      height={92}
+                      width={82}
+                    >
+                      <Text>
+                        undefined-SVG-Mock
+                      </Text>
+                    </View>
+                  </View>
+                </BVLinearGradient>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "flexShrink": 1,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#161617",
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
+                      },
+                    ]
+                  }
+                >
+                  Fan de lecture ?
+                </Text>
+                <Text
+                  style={
+                    [
+                      {
+                        "color": "#696A6F",
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 12,
+                        "lineHeight": 19.2,
+                      },
+                    ]
+                  }
+                >
+                  Reçois nos recos lecture, nos jeux-concours et le meilleur de l’actu littéraire !
+                </Text>
+                <View
+                  numberOfSpaces={2}
+                  style={
+                    [
+                      {
+                        "height": 8,
+                      },
+                    ]
+                  }
+                />
+                <View
+                  accessibilityLabel="Suivre le thème"
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "alignSelf": "flex-start",
+                      "backgroundColor": "#ffffff",
+                      "borderColor": "#90949D",
+                      "borderRadius": 24,
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "height": "auto",
+                      "justifyContent": "center",
+                      "opacity": 1,
+                      "paddingHorizontal": 12,
+                      "paddingVertical": 4,
+                      "userSelect": "auto",
+                      "width": "auto",
+                    }
+                  }
+                  testID="Suivre le thème"
+                >
+                  <View>
+                    undefined-Lottie-Mock
+                  </View>
+                  <View
+                    numberOfSpaces={2}
+                    style={
+                      [
+                        {
+                          "width": 8,
+                        },
+                      ]
+                    }
+                  />
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 12,
+                          "lineHeight": 19.2,
+                        },
+                      ]
+                    }
+                  >
+                    Suivre le thème
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <Modal
+              accessibilityLabelledBy="testUuidV4"
+              accessibilityModal={true}
+              animationType="none"
+              deviceHeight={1334}
+              deviceWidth={750}
+              hardwareAccelerated={false}
+              hideModalContentWhileAnimating={false}
+              onBackdropPress={[Function]}
+              onModalHide={[Function]}
+              onModalWillHide={[Function]}
+              onModalWillShow={[Function]}
+              onRequestClose={[Function]}
+              panResponderThreshold={4}
+              scrollHorizontal={false}
+              scrollOffset={0}
+              scrollOffsetMax={0}
+              scrollTo={null}
+              statusBarTranslucent={true}
+              supportedOrientations={
+                [
+                  "portrait",
+                  "landscape",
+                ]
+              }
+              swipeThreshold={100}
+              testID="modal"
+              transparent={true}
+              visible={false}
+            />
+            <Modal
+              accessibilityLabelledBy="testUuidV4"
+              accessibilityModal={true}
+              animationType="none"
+              deviceHeight={1334}
+              deviceWidth={750}
+              hardwareAccelerated={false}
+              hideModalContentWhileAnimating={false}
+              onBackdropPress={[Function]}
+              onModalHide={[Function]}
+              onModalWillHide={[Function]}
+              onModalWillShow={[Function]}
+              onRequestClose={[Function]}
+              panResponderThreshold={4}
+              scrollHorizontal={false}
+              scrollOffset={0}
+              scrollOffsetMax={0}
+              scrollTo={null}
+              statusBarTranslucent={true}
+              supportedOrientations={
+                [
+                  "portrait",
+                  "landscape",
+                ]
+              }
+              swipeThreshold={100}
+              testID="modal"
+              transparent={true}
+              visible={false}
+            />
+            <Modal
+              accessibilityLabelledBy="testUuidV4"
+              accessibilityModal={true}
+              animationType="none"
+              deviceHeight={1334}
+              deviceWidth={750}
+              hardwareAccelerated={false}
+              hideModalContentWhileAnimating={false}
+              onBackdropPress={[Function]}
+              onModalHide={[Function]}
+              onModalWillHide={[Function]}
+              onModalWillShow={[Function]}
+              onRequestClose={[Function]}
+              panResponderThreshold={4}
+              scrollHorizontal={false}
+              scrollOffset={0}
+              scrollOffsetMax={0}
+              scrollTo={null}
+              statusBarTranslucent={true}
+              supportedOrientations={
+                [
+                  "portrait",
+                  "landscape",
+                ]
+              }
+              swipeThreshold={100}
+              testID="modal"
+              transparent={true}
+              visible={false}
+            />
+          </View>
+          <View
+            gap={6}
+            style={
+              [
+                {
+                  "gap": 24,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "backgroundColor": "#F1F1F4",
+                    "height": 8,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "marginHorizontal": 24,
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "marginBottom": 16,
+                    },
+                  ]
+                }
+              >
+                <View
+                  gap={4}
+                  style={
+                    [
+                      {
+                        "gap": 16,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    style={
+                      [
+                        {
+                          "color": "#161617",
+                          "fontFamily": "Montserrat-Bold",
+                          "fontSize": 19,
+                          "lineHeight": 30.4,
+                        },
+                      ]
+                    }
+                  >
+                    Passe le bon plan !
+                  </Text>
+                  <View
+                    style={
+                      [
+                        {
+                          "flexDirection": "row",
+                          "maxWidth": 500,
+                          "width": "100%",
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      accessibilityRole="list"
+                      style={
+                        [
+                          {
+                            "flexBasis": 0,
+                            "flexDirection": "row",
+                            "flexGrow": 1,
+                            "flexShrink": 1,
+                            "flexWrap": "wrap",
+                            "justifyContent": "flex-start",
+                            "paddingLeft": 0,
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        accessibilityRole="none"
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                              "display": "flex",
+                              "flexBasis": "8.333333333333334%",
+                              "flexGrow": 1,
+                              "flexShrink": 0,
+                              "marginBottom": 20,
+                              "marginHorizontal": 4,
+                              "maxWidth": 76,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={false}
+                          collapsable={false}
+                          focusable={true}
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "height": 96,
+                              "opacity": 1,
+                              "userSelect": "auto",
+                              "width": 76,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "flexBasis": 0,
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "paddingBottom": 4,
+                                    "paddingLeft": 4,
+                                    "paddingRight": 4,
+                                    "paddingTop": 4,
+                                  },
+                                ]
+                              }
+                            >
+                              <View
+                                height={48}
+                                width={48}
+                              >
+                                <Text>
+                                  undefined-SVG-Mock
+                                </Text>
+                              </View>
+                            </View>
+                            <View
+                              numberOfSpaces={2}
+                              style={
+                                [
+                                  {
+                                    "height": 8,
+                                  },
+                                ]
+                              }
+                            />
+                            <Text
+                              disabled={false}
+                              style={
+                                [
+                                  {
+                                    "color": "#161617",
+                                    "fontFamily": "Montserrat-SemiBold",
+                                    "fontSize": 12,
+                                    "lineHeight": 19.2,
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Envoyer sur
+Instagram
+                            </Text>
+                          </View>
+                        </View>
+                      </View>
+                      <View
+                        accessibilityRole="none"
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                              "display": "flex",
+                              "flexBasis": "8.333333333333334%",
+                              "flexGrow": 1,
+                              "flexShrink": 0,
+                              "marginBottom": 20,
+                              "marginHorizontal": 4,
+                              "maxWidth": 76,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={false}
+                          collapsable={false}
+                          focusable={true}
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "height": 96,
+                              "opacity": 1,
+                              "userSelect": "auto",
+                              "width": 76,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "flexBasis": 0,
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "paddingBottom": 4,
+                                    "paddingLeft": 4,
+                                    "paddingRight": 4,
+                                    "paddingTop": 4,
+                                  },
+                                ]
+                              }
+                            >
+                              <View
+                                height={48}
+                                width={48}
+                              >
+                                <Text>
+                                  undefined-SVG-Mock
+                                </Text>
+                              </View>
+                            </View>
+                            <View
+                              numberOfSpaces={2}
+                              style={
+                                [
+                                  {
+                                    "height": 8,
+                                  },
+                                ]
+                              }
+                            />
+                            <Text
+                              disabled={false}
+                              style={
+                                [
+                                  {
+                                    "color": "#161617",
+                                    "fontFamily": "Montserrat-SemiBold",
+                                    "fontSize": 12,
+                                    "lineHeight": 19.2,
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Envoyer sur
+WhatsApp
+                            </Text>
+                          </View>
+                        </View>
+                      </View>
+                      <View
+                        accessibilityRole="none"
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                              "display": "flex",
+                              "flexBasis": "8.333333333333334%",
+                              "flexGrow": 1,
+                              "flexShrink": 0,
+                              "marginBottom": 20,
+                              "marginHorizontal": 4,
+                              "maxWidth": 76,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={false}
+                          collapsable={false}
+                          focusable={true}
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "height": 96,
+                              "opacity": 1,
+                              "userSelect": "auto",
+                              "width": 76,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "flexBasis": 0,
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "paddingBottom": 4,
+                                    "paddingLeft": 4,
+                                    "paddingRight": 4,
+                                    "paddingTop": 4,
+                                  },
+                                ]
+                              }
+                            >
+                              <View
+                                height={48}
+                                width={48}
+                              >
+                                <Text>
+                                  undefined-SVG-Mock
+                                </Text>
+                              </View>
+                            </View>
+                            <View
+                              numberOfSpaces={2}
+                              style={
+                                [
+                                  {
+                                    "height": 8,
+                                  },
+                                ]
+                              }
+                            />
+                            <Text
+                              disabled={false}
+                              style={
+                                [
+                                  {
+                                    "color": "#161617",
+                                    "fontFamily": "Montserrat-SemiBold",
+                                    "fontSize": 12,
+                                    "lineHeight": 19.2,
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Envoyer sur
+iMessage
+                            </Text>
+                          </View>
+                        </View>
+                      </View>
+                      <View
+                        accessibilityRole="none"
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                              "display": "flex",
+                              "flexBasis": "8.333333333333334%",
+                              "flexGrow": 1,
+                              "flexShrink": 0,
+                              "marginBottom": 20,
+                              "marginHorizontal": 4,
+                              "maxWidth": 76,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          accessibilityRole="button"
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={false}
+                          collapsable={false}
+                          focusable={true}
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "height": 96,
+                              "opacity": 1,
+                              "userSelect": "auto",
+                              "width": 76,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "flexBasis": 0,
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "paddingBottom": 4,
+                                    "paddingLeft": 4,
+                                    "paddingRight": 4,
+                                    "paddingTop": 4,
+                                  },
+                                ]
+                              }
+                            >
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "borderColor": "#CBCDD2",
+                                      "borderRadius": 24,
+                                      "borderWidth": 1,
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "width": 48,
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  height={28}
+                                  width={28}
+                                >
+                                  <Text>
+                                    undefined-SVG-Mock
+                                  </Text>
+                                </View>
+                              </View>
+                            </View>
+                            <View
+                              numberOfSpaces={2}
+                              style={
+                                [
+                                  {
+                                    "height": 8,
+                                  },
+                                ]
+                              }
+                            />
+                            <Text
+                              disabled={false}
+                              style={
+                                [
+                                  {
+                                    "color": "#161617",
+                                    "fontFamily": "Montserrat-SemiBold",
+                                    "fontSize": 12,
+                                    "lineHeight": 19.2,
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Plus
+d’options
+                            </Text>
+                          </View>
+                        </View>
                       </View>
                     </View>
                   </View>
                 </View>
               </View>
             </View>
+          </View>
+          <View
+            gap={22}
+            style={
+              [
+                {
+                  "gap": 88,
+                },
+              ]
+            }
+          >
             <View
-              numberOfSpaces={4}
               style={
                 [
                   {
-                    "height": 16,
+                    "backgroundColor": "#F1F1F4",
+                    "height": 8,
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                [
+                  {
+                    "marginBottom": 24,
                   },
                 ]
               }
             />
           </View>
-        </View>
-        <View
-          gap={22}
-          style={
-            [
-              {
-                "gap": 88,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              [
-                {
-                  "backgroundColor": "#F1F1F4",
-                  "height": 8,
-                },
-              ]
-            }
-          />
-          <View
-            numberOfSpaces={6}
-            style={
-              [
-                {
-                  "height": 24,
-                },
-              ]
-            }
-          />
         </View>
       </View>
     </View>

--- a/src/features/offer/components/MoviesScreeningCalendar/hook/getVenueMovieOffers.ts
+++ b/src/features/offer/components/MoviesScreeningCalendar/hook/getVenueMovieOffers.ts
@@ -5,7 +5,7 @@ export const getVenueMovieOffers = (
   selectedDate: Date,
   offersWithStocks: OffersStocksResponseV2 | undefined
 ) => {
-  const movieOffers = offersWithStocks?.offers.filter(
+  const movieOffers = offersWithStocks?.offers?.filter(
     (offer) => offer.subcategoryId === SubcategoryIdEnum.SEANCE_CINE
   )
 

--- a/src/features/venue/components/VenueBody/VenueBody.native.test.tsx
+++ b/src/features/venue/components/VenueBody/VenueBody.native.test.tsx
@@ -1,20 +1,16 @@
 import mockdate from 'mockdate'
 import React from 'react'
 import { Linking } from 'react-native'
-import Share, { Social } from 'react-native-share'
-import { UseQueryResult } from 'react-query'
 
 import { useRoute } from '__mocks__/@react-navigation/native'
 import { gtlPlaylistAlgoliaSnapshot } from 'features/gtlPlaylist/fixtures/gtlPlaylistAlgoliaSnapshot'
 import * as useGTLPlaylists from 'features/gtlPlaylist/hooks/useGTLPlaylists'
-import * as useVenueOffers from 'features/venue/api/useVenueOffers'
+import { useVenueOffers } from 'features/venue/api/useVenueOffers'
 import { VenueBody } from 'features/venue/components/VenueBody/VenueBody'
 import { venueDataTest } from 'features/venue/fixtures/venueDataTest'
 import { VenueOffersResponseSnap } from 'features/venue/fixtures/venueOffersResponseSnap'
-import { VenueOffers } from 'features/venue/types'
 import { analytics } from 'libs/analytics/provider'
 import * as useFeatureFlag from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
-import { Network } from 'libs/share/types'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { fireEvent, render, screen } from 'tests/utils'
 
@@ -22,18 +18,17 @@ jest.spyOn(useFeatureFlag, 'useFeatureFlag').mockReturnValue(false)
 
 mockdate.set(new Date('2021-08-15T00:00:00Z'))
 
-jest.mock('features/venue/api/useVenue')
-jest.mock('@react-native-clipboard/clipboard')
-const mockShareSingle = jest.spyOn(Share, 'shareSingle')
 const canOpenURLSpy = jest.spyOn(Linking, 'canOpenURL').mockResolvedValue(false)
 jest
   .spyOn(useGTLPlaylists, 'useGTLPlaylists')
   .mockReturnValue({ isLoading: false, gtlPlaylists: gtlPlaylistAlgoliaSnapshot })
-jest.spyOn(useVenueOffers, 'useVenueOffers').mockReturnValue({
+
+jest.mock('features/venue/api/useVenueOffers')
+const mockUseVenueOffers = useVenueOffers as jest.Mock
+mockUseVenueOffers.mockReturnValue({
   isLoading: false,
   data: { hits: VenueOffersResponseSnap, nbHits: 10 },
-} as unknown as UseQueryResult<VenueOffers, unknown>)
-
+})
 jest.mock('libs/location')
 
 jest.mock('libs/subcategories/useSubcategories')
@@ -50,35 +45,23 @@ describe('<VenueBody />', () => {
     canOpenURLSpy.mockResolvedValueOnce(true)
   })
 
+  it('should display expected tabs', async () => {
+    render(reactQueryProviderHOC(<VenueBody venue={venueDataTest} />))
+
+    expect(await screen.findByText('Offres disponibles')).toBeOnTheScreen()
+    expect(await screen.findByText('Infos pratiques')).toBeOnTheScreen()
+  })
+
   it('should display withdrawal details', async () => {
     render(reactQueryProviderHOC(<VenueBody venue={venueDataTest} />))
-    await waitUntilRendered()
 
     fireEvent.press(screen.getByText('Infos pratiques'))
 
     expect(screen.getByText('How to withdraw, https://test.com')).toBeOnTheScreen()
   })
 
-  it('should share on Instagram', async () => {
-    render(reactQueryProviderHOC(<VenueBody venue={venueDataTest} />))
-
-    const instagramButton = await screen.findByText(`Envoyer sur ${Network.instagram}`)
-
-    fireEvent.press(instagramButton)
-
-    expect(mockShareSingle).toHaveBeenCalledWith({
-      social: Social.Instagram,
-      message: encodeURIComponent(
-        `Retrouve "${venueDataTest.name}" sur le pass Culture\u00a0:\nhttps://webapp-v2.example.com/lieu/5543?utm_gen=product&utm_campaign=share_venue&utm_medium=social_media&utm_source=Instagram`
-      ),
-      type: 'text',
-      url: undefined,
-    })
-  })
-
   it('should log event when pressing on Infos pratiques tab', async () => {
     render(reactQueryProviderHOC(<VenueBody venue={venueDataTest} />))
-    await waitUntilRendered()
 
     fireEvent.press(screen.getByText('Infos pratiques'))
 
@@ -89,16 +72,9 @@ describe('<VenueBody />', () => {
 
   it('should log event when pressing on Offres disponibles tab', async () => {
     render(reactQueryProviderHOC(<VenueBody venue={venueDataTest} />))
-    await waitUntilRendered()
 
     fireEvent.press(screen.getByText('Offres disponibles'))
 
     expect(analytics.logConsultVenueOffers).toHaveBeenCalledWith({ venueId: venueDataTest.id })
   })
 })
-
-const waitUntilRendered = async () => {
-  // We wait until the full render is done
-  // This is due to asynchronous calls to check the media on the phone
-  await screen.findByText(`Envoyer sur ${Network.instagram}`)
-}

--- a/src/features/venue/components/VenueBody/VenueBody.tsx
+++ b/src/features/venue/components/VenueBody/VenueBody.tsx
@@ -6,22 +6,17 @@ import { VenueResponse } from 'api/gen'
 import { GtlPlaylistData } from 'features/gtlPlaylist/types'
 import { PracticalInformation } from 'features/venue/components/PracticalInformation/PracticalInformation'
 import { TabLayout } from 'features/venue/components/TabLayout/TabLayout'
-import { VENUE_CTA_HEIGHT_IN_SPACES } from 'features/venue/components/VenueCTA/VenueCTA'
-import { VenueMessagingApps } from 'features/venue/components/VenueMessagingApps/VenueMessagingApps'
 import { VenueOffers } from 'features/venue/components/VenueOffers/VenueOffers'
-import { VenueThematicSection } from 'features/venue/components/VenueThematicSection/VenueThematicSection'
 import type { VenueOffersArtists, VenueOffers as VenueOffersType } from 'features/venue/types'
 import { Tab } from 'features/venue/types'
 import { analytics } from 'libs/analytics/provider'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
-import { Spacer } from 'ui/theme'
 
 interface Props {
   venue: VenueResponse
   venueArtists?: VenueOffersArtists
   venueOffers?: VenueOffersType
   playlists?: GtlPlaylistData[]
-  shouldDisplayCTA?: boolean
 }
 
 export const VenueBody: FunctionComponent<Props> = ({
@@ -29,12 +24,11 @@ export const VenueBody: FunctionComponent<Props> = ({
   venueArtists,
   venueOffers,
   playlists,
-  shouldDisplayCTA,
 }) => {
   const { isDesktopViewport, isTabletViewport } = useTheme()
   const isLargeScreen = isDesktopViewport || isTabletViewport
 
-  const FirstSectionContainer = isLargeScreen ? View : SectionWithDivider
+  const SectionContainer = isLargeScreen ? View : SectionWithDivider
 
   const tabPanels = {
     [Tab.OFFERS]: (
@@ -49,37 +43,22 @@ export const VenueBody: FunctionComponent<Props> = ({
   }
 
   return (
-    <React.Fragment>
-      <FirstSectionContainer visible gap={6}>
-        <TabLayout
-          tabPanels={tabPanels}
-          tabs={[{ key: Tab.OFFERS }, { key: Tab.INFOS }]}
-          defaultTab={Tab.OFFERS}
-          onTabChange={{
-            'Offres disponibles': () =>
-              analytics.logConsultVenueOffers({
-                venueId: venue.id,
-              }),
-            'Infos pratiques': () =>
-              analytics.logConsultPracticalInformations({
-                venueId: venue.id,
-              }),
-          }}
-        />
-      </FirstSectionContainer>
-
-      <Spacer.Column numberOfSpaces={6} />
-
-      <VenueThematicSection venue={venue} />
-
-      <SectionWithDivider visible margin gap={6}>
-        <VenueMessagingApps venue={venue} />
-        <Spacer.Column numberOfSpaces={4} />
-      </SectionWithDivider>
-
-      <SectionWithDivider visible={!!shouldDisplayCTA} gap={VENUE_CTA_HEIGHT_IN_SPACES}>
-        <Spacer.Column numberOfSpaces={6} />
-      </SectionWithDivider>
-    </React.Fragment>
+    <SectionContainer visible gap={6}>
+      <TabLayout
+        tabPanels={tabPanels}
+        tabs={[{ key: Tab.OFFERS }, { key: Tab.INFOS }]}
+        defaultTab={Tab.OFFERS}
+        onTabChange={{
+          'Offres disponibles': () =>
+            analytics.logConsultVenueOffers({
+              venueId: venue.id,
+            }),
+          'Infos pratiques': () =>
+            analytics.logConsultPracticalInformations({
+              venueId: venue.id,
+            }),
+        }}
+      />
+    </SectionContainer>
   )
 }

--- a/src/features/venue/components/VenueCTA/VenueCTA.tsx
+++ b/src/features/venue/components/VenueCTA/VenueCTA.tsx
@@ -1,9 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
-import { VenueResponse } from 'api/gen'
-import { useNavigateToSearchWithVenueOffers } from 'features/venue/helpers/useNavigateToSearchWithVenueOffers'
-import { analytics } from 'libs/analytics/provider'
+import { SearchNavConfig } from 'features/venue/types'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { StickyBottomWrapper } from 'ui/components/StickyBottomWrapper/StickyBottomWrapper'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
@@ -13,18 +11,18 @@ import { Spacer } from 'ui/theme'
 export const VENUE_CTA_HEIGHT_IN_SPACES = 6 + 10 + 6
 
 interface Props {
-  venue: VenueResponse
+  searchNavConfig: SearchNavConfig
+  onBeforeNavigate: () => void
 }
 
-export const VenueCTA: FunctionComponent<Props> = ({ venue }) => {
-  const searchNavConfig = useNavigateToSearchWithVenueOffers(venue)
+export const VenueCTA: FunctionComponent<Props> = ({ searchNavConfig, onBeforeNavigate }) => {
   return (
     <StickyBottomWrapper>
       <CallToActionContainer>
         <Spacer.Column numberOfSpaces={6} />
         <InternalTouchableLink
           navigateTo={searchNavConfig}
-          onBeforeNavigate={() => analytics.logVenueSeeAllOffersClicked(venue.id)}
+          onBeforeNavigate={onBeforeNavigate}
           as={ButtonPrimary}
           wording="Rechercher une offre"
           icon={SmallMagnifyingGlass}

--- a/src/features/venue/components/VenueContent/VenueContent.tsx
+++ b/src/features/venue/components/VenueContent/VenueContent.tsx
@@ -11,7 +11,8 @@ import { VenueCTA } from 'features/venue/components/VenueCTA/VenueCTA'
 import { VenueHeader } from 'features/venue/components/VenueHeader/VenueHeader'
 import { VenueWebMetaHeader } from 'features/venue/components/VenueWebMetaHeader'
 import { useNavigateToSearchWithVenueOffers } from 'features/venue/helpers/useNavigateToSearchWithVenueOffers'
-import { analytics, isCloseToBottom } from 'libs/analytics'
+import { isCloseToBottom } from 'libs/analytics'
+import { analytics } from 'libs/analytics/provider'
 import { useRemoteConfigContext } from 'libs/firebase/remoteConfig/RemoteConfigProvider'
 import { useFunctionOnce } from 'libs/hooks'
 import { BatchEvent, BatchProfile } from 'libs/react-native-batch'
@@ -95,7 +96,7 @@ export const VenueContent: React.FunctionComponent<Props> = ({
     <AnchorProvider scrollViewRef={scrollViewRef} handleCheckScrollY={handleCheckScrollY}>
       <Container>
         <VenueWebMetaHeader
-          title={venue.publicName || venue.name}
+          title={venue.publicName ?? venue.name}
           description={venue.description}
         />
         <VenueHeaderWrapper

--- a/src/features/venue/components/VenueContent/VenueContent.tsx
+++ b/src/features/venue/components/VenueContent/VenueContent.tsx
@@ -1,44 +1,37 @@
 import React, { useCallback, useEffect, useRef } from 'react'
-import { NativeScrollEvent, NativeSyntheticEvent, Platform, ScrollView } from 'react-native'
+import { NativeScrollEvent, NativeSyntheticEvent, ScrollView } from 'react-native'
 import { IOScrollView as IntersectionObserverScrollView } from 'react-native-intersection-observer'
-import Animated, { Layout } from 'react-native-reanimated'
 import styled, { useTheme } from 'styled-components/native'
 
-import { VenueResponse, VenueTypeCodeKey } from 'api/gen'
-import { GtlPlaylistData } from 'features/gtlPlaylist/types'
+import { VenueResponse } from 'api/gen'
 import { CineContentCTA } from 'features/offer/components/OfferCine/CineContentCTA'
 import { useOfferCTA } from 'features/offer/components/OfferContent/OfferCTAProvider'
-import { VenueBody } from 'features/venue/components/VenueBody/VenueBody'
+import { VenueHeaderWrapper } from 'features/venue/components/VenueContent/VenueHeaderWrapper'
 import { VenueCTA } from 'features/venue/components/VenueCTA/VenueCTA'
 import { VenueHeader } from 'features/venue/components/VenueHeader/VenueHeader'
-import { VenueTopComponent } from 'features/venue/components/VenueTopComponent/VenueTopComponent'
 import { VenueWebMetaHeader } from 'features/venue/components/VenueWebMetaHeader'
-import { VenueOffers, VenueOffersArtists } from 'features/venue/types'
-import { isCloseToBottom } from 'libs/analytics'
+import { useNavigateToSearchWithVenueOffers } from 'features/venue/helpers/useNavigateToSearchWithVenueOffers'
+import { analytics, isCloseToBottom } from 'libs/analytics'
 import { useRemoteConfigContext } from 'libs/firebase/remoteConfig/RemoteConfigProvider'
 import { useFunctionOnce } from 'libs/hooks'
 import { BatchEvent, BatchProfile } from 'libs/react-native-batch'
 import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
 import { AnchorProvider } from 'ui/components/anchor/AnchorContext'
 import { useGetHeaderHeight } from 'ui/components/headers/PageHeaderWithoutPlaceholder'
-import { Spacer } from 'ui/theme'
 
 type Props = {
   venue: VenueResponse
-  gtlPlaylists?: GtlPlaylistData[]
-  venueArtists?: VenueOffersArtists
-  venueOffers?: VenueOffers
+  isCTADisplayed?: boolean
+  children: React.ReactNode
 }
 
 const trackEventHasSeenVenueForSurvey = () =>
   BatchProfile.trackEvent(BatchEvent.hasSeenVenueForSurvey)
-const isWeb = Platform.OS === 'web'
 
 export const VenueContent: React.FunctionComponent<Props> = ({
   venue,
-  gtlPlaylists,
-  venueArtists,
-  venueOffers,
+  isCTADisplayed,
+  children,
 }) => {
   const triggerBatch = useFunctionOnce(trackEventHasSeenVenueForSurvey)
   const scrollViewRef = useRef<ScrollView>(null)
@@ -77,44 +70,45 @@ export const VenueContent: React.FunctionComponent<Props> = ({
   const headerHeight = useGetHeaderHeight()
   const isLargeScreen = isDesktopViewport || isTabletViewport
   const { isButtonVisible, wording } = useOfferCTA()
-
-  const shouldDisplayCTA =
-    venue.venueTypeCode !== VenueTypeCodeKey.MOVIE &&
-    ((venueOffers && venueOffers.hits.length > 0) || (gtlPlaylists && gtlPlaylists.length > 0))
+  const searchNavConfig = useNavigateToSearchWithVenueOffers(venue)
 
   const renderVenueCTA = useCallback(() => {
     if (showAccessScreeningButton && wording.length) {
       return isButtonVisible ? <CineContentCTA /> : null
     }
-    return shouldDisplayCTA ? <VenueCTA venue={venue} /> : null
-  }, [isButtonVisible, shouldDisplayCTA, showAccessScreeningButton, venue, wording.length])
+    return isCTADisplayed ? (
+      <VenueCTA
+        searchNavConfig={searchNavConfig}
+        onBeforeNavigate={() => analytics.logVenueSeeAllOffersClicked(venue.id)}
+      />
+    ) : null
+  }, [
+    isButtonVisible,
+    isCTADisplayed,
+    showAccessScreeningButton,
+    venue.id,
+    wording.length,
+    searchNavConfig,
+  ])
 
   return (
     <AnchorProvider scrollViewRef={scrollViewRef} handleCheckScrollY={handleCheckScrollY}>
       <Container>
-        <VenueWebMetaHeader venue={venue} />
-        {/* On web VenueHeader is called before Body for accessibility navigate order */}
-        {isWeb ? <VenueHeader headerTransition={headerTransition} venue={venue} /> : null}
-        <ContentContainer
-          onScroll={handleScroll}
-          scrollEventThrottle={16}
-          bounces={false}
-          ref={scrollViewRef}>
-          {isLargeScreen ? <Placeholder height={headerHeight} /> : null}
-          <VenueTopComponent venue={venue} />
-          <Spacer.Column numberOfSpaces={isDesktopViewport ? 10 : 6} />
-          <Animated.View layout={Layout.duration(200)}>
-            <VenueBody
-              venue={venue}
-              playlists={gtlPlaylists}
-              venueArtists={venueArtists}
-              venueOffers={venueOffers}
-              shouldDisplayCTA={shouldDisplayCTA}
-            />
-          </Animated.View>
-        </ContentContainer>
-        {/* On native VenueHeader is called after Body to implement the BlurView for iOS */}
-        {isWeb ? null : <VenueHeader headerTransition={headerTransition} venue={venue} />}
+        <VenueWebMetaHeader
+          title={venue.publicName || venue.name}
+          description={venue.description}
+        />
+        <VenueHeaderWrapper
+          header={<VenueHeader headerTransition={headerTransition} venue={venue} />}>
+          <ContentContainer
+            onScroll={handleScroll}
+            scrollEventThrottle={16}
+            bounces={false}
+            ref={scrollViewRef}>
+            {isLargeScreen ? <Placeholder height={headerHeight} /> : null}
+            {children}
+          </ContentContainer>
+        </VenueHeaderWrapper>
         {renderVenueCTA()}
       </Container>
     </AnchorProvider>
@@ -131,7 +125,6 @@ const ContentContainer = styled(IntersectionObserverScrollView).attrs({
 })({
   overflow: 'visible',
 })
-
 const Placeholder = styled.View<{ height: number }>(({ height }) => ({
   height,
 }))

--- a/src/features/venue/components/VenueContent/VenueHeaderWrapper.tsx
+++ b/src/features/venue/components/VenueContent/VenueHeaderWrapper.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+type Props = {
+  children: React.ReactNode
+  header?: React.ReactNode
+}
+
+/* On native VenueHeader is called after Body to implement the BlurView for iOS */
+export const VenueHeaderWrapper = ({ children, header }: Props) => {
+  return (
+    <React.Fragment>
+      {children}
+      {header}
+    </React.Fragment>
+  )
+}

--- a/src/features/venue/components/VenueContent/VenueHeaderWrapper.web.tsx
+++ b/src/features/venue/components/VenueContent/VenueHeaderWrapper.web.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+type Props = {
+  children: React.ReactNode
+  header?: React.ReactNode
+}
+
+/* On web VenueHeader is called before Body for accessibility navigate order */
+export const VenueHeaderWrapper = ({ children, header }: Props) => {
+  return (
+    <React.Fragment>
+      {header}
+      {children}
+    </React.Fragment>
+  )
+}

--- a/src/features/venue/components/VenueMessagingApps/VenueMessagingApps.tsx
+++ b/src/features/venue/components/VenueMessagingApps/VenueMessagingApps.tsx
@@ -1,10 +1,13 @@
 import React, { useCallback } from 'react'
 import { Social } from 'react-native-share'
+import styled from 'styled-components/native'
 
 import { VenueResponse } from 'api/gen'
 import { MessagingApps } from 'features/share/components/MessagingApps/MessagingApps'
 import { getShareVenue } from 'features/share/helpers/getShareVenue'
 import { analytics } from 'libs/analytics/provider'
+import { SectionWithDivider } from 'ui/components/SectionWithDivider'
+import { getSpacing } from 'ui/theme'
 
 type MessagingAppsProps = {
   venue: VenueResponse
@@ -23,10 +26,16 @@ export const VenueMessagingApps = ({ venue }: MessagingAppsProps) => {
   if (!shareContent?.url) return null
 
   return (
-    <MessagingApps
-      shareContent={shareContent}
-      share={share}
-      messagingAppAnalytics={messagingAppAnalytics}
-    />
+    <SectionWithDivider visible margin gap={6}>
+      <Container>
+        <MessagingApps
+          shareContent={shareContent}
+          share={share}
+          messagingAppAnalytics={messagingAppAnalytics}
+        />
+      </Container>
+    </SectionWithDivider>
   )
 }
+
+const Container = styled.View({ marginBottom: getSpacing(4) })

--- a/src/features/venue/components/VenueThematicSection/VenueThematicSection.tsx
+++ b/src/features/venue/components/VenueThematicSection/VenueThematicSection.tsx
@@ -85,7 +85,7 @@ export const VenueThematicSection: FunctionComponent<Props> = ({ venue }: Props)
     return null
 
   return (
-    <SectionWithDivider visible gap={0}>
+    <SectionWithDivider visible gap={6}>
       <ThematicSubscriptionBlock
         thematic={thematic}
         isSubscribeButtonActive={isSubscribeButtonActive}

--- a/src/features/venue/components/VenueTopComponent/VenueTopComponentBase.tsx
+++ b/src/features/venue/components/VenueTopComponent/VenueTopComponentBase.tsx
@@ -18,7 +18,7 @@ import { CopyToClipboardButton } from 'shared/CopyToClipboardButton/CopyToClipbo
 import { Separator } from 'ui/components/Separator'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { InformationTags } from 'ui/InformationTags/InformationTags'
-import { getSpacing, Spacer, TypoDS } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type Props = {
@@ -65,38 +65,39 @@ export const VenueTopComponentBase: React.FunctionComponent<Props> = ({
         handleImagePress={onPressBannerImage}
       />
       <MarginContainer>
-        <InformationTags tags={venueTags} />
-        <Spacer.Column numberOfSpaces={4} />
-        <ViewGap gap={1}>
-          <VenueTitle accessibilityLabel={`Nom du lieu\u00a0: ${venueName}`} adjustsFontSizeToFit>
-            {venueName}
-          </VenueTitle>
-          {isDynamicOpeningHoursDisplayed ? (
-            <OpeningHoursStatus
-              currentDate={currentDate}
-              openingHours={venue.openingHours}
-              timezone={venue.timezone}
-            />
-          ) : null}
-          <ViewGap gap={3}>
-            <View>
-              <TypoDS.BodyAccentXs>Adresse</TypoDS.BodyAccentXs>
-              <TypoDS.Body>{venueFullAddress}</TypoDS.Body>
-            </View>
-            <Separator.Horizontal />
-            <CopyToClipboardButton
-              wording="Copier l’adresse"
-              textToCopy={`${venueName}, ${venueFullAddress}`}
-              onCopy={() => analytics.logCopyAddress({ venueId: venue.id, from: 'venue' })}
-              snackBarMessage="L’adresse a bien été copiée."
-            />
-            <SeeItineraryButton
-              externalNav={{
-                url: getGoogleMapsItineraryUrl(venueFullAddress),
-                address: venueFullAddress,
-              }}
-              onPress={() => analytics.logConsultItinerary({ venueId: venue.id, from: 'venue' })}
-            />
+        <ViewGap gap={4}>
+          <InformationTags tags={venueTags} />
+          <ViewGap gap={1}>
+            <VenueTitle accessibilityLabel={`Nom du lieu\u00a0: ${venueName}`} adjustsFontSizeToFit>
+              {venueName}
+            </VenueTitle>
+            {isDynamicOpeningHoursDisplayed ? (
+              <OpeningHoursStatus
+                currentDate={currentDate}
+                openingHours={venue.openingHours}
+                timezone={venue.timezone}
+              />
+            ) : null}
+            <ViewGap gap={3}>
+              <View>
+                <TypoDS.BodyAccentXs>Adresse</TypoDS.BodyAccentXs>
+                <TypoDS.Body>{venueFullAddress}</TypoDS.Body>
+              </View>
+              <Separator.Horizontal />
+              <CopyToClipboardButton
+                wording="Copier l’adresse"
+                textToCopy={`${venueName}, ${venueFullAddress}`}
+                onCopy={() => analytics.logCopyAddress({ venueId: venue.id, from: 'venue' })}
+                snackBarMessage="L’adresse a bien été copiée."
+              />
+              <SeeItineraryButton
+                externalNav={{
+                  url: getGoogleMapsItineraryUrl(venueFullAddress),
+                  address: venueFullAddress,
+                }}
+                onPress={() => analytics.logConsultItinerary({ venueId: venue.id, from: 'venue' })}
+              />
+            </ViewGap>
           </ViewGap>
         </ViewGap>
       </MarginContainer>

--- a/src/features/venue/components/VenueTopComponent/VenueTopComponentBase.tsx
+++ b/src/features/venue/components/VenueTopComponent/VenueTopComponentBase.tsx
@@ -111,6 +111,7 @@ const TopContainer = styled.View(({ theme }) => {
     flexDirection: isLargeScreen ? 'row' : 'column',
     marginTop: isLargeScreen ? getSpacing(8) : 0,
     marginHorizontal: isLargeScreen ? getSpacing(18) : 0,
+    marginBottom: isLargeScreen ? getSpacing(10) : getSpacing(6),
   }
 })
 

--- a/src/features/venue/components/VenueWebMetaHeader.tsx
+++ b/src/features/venue/components/VenueWebMetaHeader.tsx
@@ -1,18 +1,18 @@
 import React from 'react'
 
-import { VenueResponse } from 'api/gen'
 import { Helmet } from 'libs/react-helmet/Helmet'
 
 import { description } from '../../../../package.json'
 
 interface Props {
-  venue: VenueResponse
+  title: string
+  description?: string | null
 }
 
-export const VenueWebMetaHeader = ({ venue }: Props) => (
+export const VenueWebMetaHeader = (props: Props) => (
   <Helmet>
-    <title>{(venue.publicName || venue.name) + ' | pass Culture'}</title>
-    <meta name="title" content={venue.publicName || venue.name} />
-    <meta name="description" content={venue.description || description} />
+    <title>{props.title + ' | pass Culture'}</title>
+    <meta name="title" content={props.title} />
+    <meta name="description" content={props.description || description} />
   </Helmet>
 )

--- a/src/features/venue/pages/Venue/Venue.tsx
+++ b/src/features/venue/pages/Venue/Venue.tsx
@@ -1,14 +1,25 @@
 import { useRoute } from '@react-navigation/native'
 import React, { FunctionComponent, useEffect } from 'react'
+import Animated, { Layout } from 'react-native-reanimated'
+import styled, { useTheme } from 'styled-components/native'
 
+import { VenueTypeCodeKey } from 'api/gen'
 import { useGTLPlaylists } from 'features/gtlPlaylist/hooks/useGTLPlaylists'
 import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { OfferCTAProvider } from 'features/offer/components/OfferContent/OfferCTAProvider'
 import { useVenue } from 'features/venue/api/useVenue'
 import { useVenueOffers } from 'features/venue/api/useVenueOffers'
 import { useVenueOffersArtists } from 'features/venue/api/useVenueOffersArtists/useVenueOffersArtists'
+import { VenueBody } from 'features/venue/components/VenueBody/VenueBody'
 import { VenueContent } from 'features/venue/components/VenueContent/VenueContent'
+import { VENUE_CTA_HEIGHT_IN_SPACES } from 'features/venue/components/VenueCTA/VenueCTA'
+import { VenueMessagingApps } from 'features/venue/components/VenueMessagingApps/VenueMessagingApps'
+import { VenueThematicSection } from 'features/venue/components/VenueThematicSection/VenueThematicSection'
+import { VenueTopComponent } from 'features/venue/components/VenueTopComponent/VenueTopComponent'
 import { analytics } from 'libs/analytics/provider'
+import { SectionWithDivider } from 'ui/components/SectionWithDivider'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { getSpacing } from 'ui/theme'
 
 export const Venue: FunctionComponent = () => {
   const { params } = useRoute<UseRouteType<'Venue'>>()
@@ -16,6 +27,7 @@ export const Venue: FunctionComponent = () => {
   const { gtlPlaylists } = useGTLPlaylists({ venue, queryKey: 'VENUE_GTL_PLAYLISTS' })
   const { data: venueOffers } = useVenueOffers(venue)
   const { data: venueArtists } = useVenueOffersArtists(venue)
+  const { isDesktopViewport } = useTheme()
 
   useEffect(() => {
     if ((params.from === 'deeplink' || params.from === 'venueMap') && venue?.id) {
@@ -23,14 +35,41 @@ export const Venue: FunctionComponent = () => {
     }
   }, [params.from, venue?.id])
 
+  const isCTADisplayed =
+    venue?.venueTypeCode !== VenueTypeCodeKey.MOVIE &&
+    ((venueOffers && venueOffers.hits.length > 0) || (gtlPlaylists && gtlPlaylists.length > 0))
+
   return venue ? (
     <OfferCTAProvider>
-      <VenueContent
-        venue={venue}
-        gtlPlaylists={gtlPlaylists}
-        venueArtists={venueArtists}
-        venueOffers={venueOffers}
-      />
+      <VenueContent venue={venue} isCTADisplayed={isCTADisplayed}>
+        <VenueTopComponent venue={venue} />
+        <ViewGap gap={isDesktopViewport ? 10 : 6}>
+          <Animated.View layout={Layout.duration(200)}>
+            <VenueBody
+              venue={venue}
+              playlists={gtlPlaylists}
+              venueOffers={venueOffers}
+              venueArtists={venueArtists}
+            />
+
+            <VenueThematicSection venue={venue} />
+
+            <VenueMessagingApps venue={venue} />
+
+            <EmptyBottomSection isVisible={!!isCTADisplayed} />
+          </Animated.View>
+        </ViewGap>
+      </VenueContent>
     </OfferCTAProvider>
   ) : null
 }
+
+const EmptyBottomSection = ({ isVisible }: { isVisible: boolean }) => {
+  return (
+    <SectionWithDivider visible={isVisible} gap={VENUE_CTA_HEIGHT_IN_SPACES}>
+      <EmptySectionContainer />
+    </SectionWithDivider>
+  )
+}
+
+const EmptySectionContainer = styled.View({ marginBottom: getSpacing(6) })

--- a/src/features/venue/types.ts
+++ b/src/features/venue/types.ts
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
 
+import { RootNavigateParams } from 'features/navigation/RootNavigator/types'
 import { Geoloc } from 'libs/algolia/types'
 import { VenueTypeCode } from 'libs/parsers/venueType'
 import { Offer } from 'shared/offer/types'
@@ -68,3 +69,11 @@ export type Artist = {
 }
 
 export type VenueOffersArtists = { artists: Artist[] }
+
+export type SearchNavConfig = {
+  screen: RootNavigateParams[0]
+  params?: RootNavigateParams[1]
+  withPush?: boolean
+  withReset?: boolean
+  fromRef?: boolean
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33463

Testé sur mobile & web. Pas de regressions constatées.


## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [x] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
