### PR TITLE
(PC-30293) feat(Algolia): trigger to thematic search on specific query

### DIFF
--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -55,7 +55,6 @@
 ./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts:927
 ./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts:231
 ./src/features/profile/components/CreditInfo/CreditProgressBar.tsx:32
-./src/features/search/api/useSearchResults/useSearchResults.ts:106
 ./src/features/search/components/sections/Accessibility/Accessibility.tsx:33
 ./src/features/search/pages/SuggestedPlacesOrVenues/SuggestedVenues.native.test.tsx:43
 ./src/features/search/pages/modals/CategoriesModal/CategoriesModal.tsx:118

--- a/src/features/navigation/SearchStackNavigator/routes.ts
+++ b/src/features/navigation/SearchStackNavigator/routes.ts
@@ -10,7 +10,7 @@ import { ThematicSearch } from 'features/search/pages/ThematicSearch/ThematicSea
 
 import { SearchStackRoute, SearchStackParamList, SearchStackRouteName } from './types'
 
-export const initialSearchStackRouteName: SearchStackRouteName = 'SearchLanding'
+const initialSearchStackRouteName: SearchStackRouteName = 'SearchLanding'
 
 const routes: SearchStackRoute[] = [
   {

--- a/src/features/navigation/screenParamsUtils.ts
+++ b/src/features/navigation/screenParamsUtils.ts
@@ -63,6 +63,7 @@ const searchParamsParser = {
   venue: JSON.parse,
   accessibilityFilter: JSON.parse,
   gtls: JSON.parse,
+  shouldRedirect: JSON.parse,
 }
 
 export const screenParamsParser: ParamsParsers = {
@@ -226,6 +227,7 @@ const searchParamsStringifier = {
   venue: JSON.stringify,
   accessibilityFilter: JSON.stringify,
   gtls: JSON.stringify,
+  shouldRedirect: JSON.stringify,
 }
 
 export const screenParamsStringifier: ParamsStringifiers = {

--- a/src/features/search/helpers/useNavigateToSearch/useNavigateToSearch.ts
+++ b/src/features/search/helpers/useNavigateToSearch/useNavigateToSearch.ts
@@ -1,17 +1,13 @@
-import { useNavigation } from '@react-navigation/native'
+import { StackActions, useNavigation } from '@react-navigation/native'
 
 import { DisabilitiesProperties } from 'features/accessibility/types'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/helpers'
-import { initialSearchStackRouteName } from 'features/navigation/SearchStackNavigator/routes'
 import { SearchStackRouteName } from 'features/navigation/SearchStackNavigator/types'
 import { SearchState } from 'features/search/types'
 
-export const useNavigateToSearch = (
-  routeName: SearchStackRouteName = initialSearchStackRouteName
-) => {
-  const { navigate } = useNavigation<UseNavigationType>()
-
+export const useNavigateToSearch = (routeName: SearchStackRouteName) => {
+  const { navigate, dispatch } = useNavigation<UseNavigationType>()
   const navigateToSearch = (
     newSearchState: SearchState,
     newAccessibilityFilter: DisabilitiesProperties
@@ -23,5 +19,18 @@ export const useNavigateToSearch = (
       })
     )
   }
-  return { navigateToSearch }
+
+  const replaceToSearch = (
+    newSearchState: SearchState,
+    newAccessibilityFilter: DisabilitiesProperties
+  ): void => {
+    const replaceAction = StackActions.replace(routeName, {
+      ...newSearchState,
+      accessibilityFilter: newAccessibilityFilter,
+    })
+
+    dispatch(replaceAction)
+  }
+
+  return { navigateToSearch, replaceToSearch }
 }

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -62,6 +62,7 @@ export interface SearchState {
   isFromHistory?: boolean
   venue?: Venue
   gtls?: GTL[]
+  shouldRedirect?: boolean
 }
 
 export type UserData = {

--- a/src/libs/algolia/doAlgoliaRedirect.native.test.ts
+++ b/src/libs/algolia/doAlgoliaRedirect.native.test.ts
@@ -28,7 +28,7 @@ describe('doAlgoliaRedirect', () => {
       }),
     })
 
-    expect(navigate).toHaveBeenCalledWith(
+    expect(mockNavigateToThematicSearch).toHaveBeenCalledWith(
       expect.objectContaining({
         shouldRedirect: false,
         offerCategories: [SearchGroupNameEnumv2.CINEMA],

--- a/src/libs/algolia/doAlgoliaRedirect.native.test.ts
+++ b/src/libs/algolia/doAlgoliaRedirect.native.test.ts
@@ -1,0 +1,39 @@
+import { navigate } from '__mocks__/@react-navigation/native'
+import { SearchGroupNameEnumv2 } from 'api/gen'
+import { defaultDisabilitiesProperties } from 'features/accessibility/context/AccessibilityFiltersWrapper'
+import { initialSearchState } from 'features/search/context/reducer'
+import { doAlgoliaRedirect } from 'libs/algolia/doAlgoliaRedirect'
+
+const mockSearchstate = { ...initialSearchState, shouldRedirect: true }
+const mockDispatch = jest.fn()
+const mockNavigateToThematicSearch = navigate
+
+describe('doAlgoliaRedirect', () => {
+  it('should redirect to thematicSearch', async () => {
+    const mockUrl =
+      'http://passculture.app/recherche/resultats?offerCategories=%5B%22CINEMA%22%5D&query=%22%22'
+
+    doAlgoliaRedirect(
+      new URL(mockUrl),
+      mockSearchstate,
+      defaultDisabilitiesProperties,
+      mockDispatch,
+      mockNavigateToThematicSearch
+    )
+
+    expect(mockDispatch).toHaveBeenNthCalledWith(1, {
+      type: 'SET_STATE',
+      payload: expect.objectContaining({
+        shouldRedirect: false,
+      }),
+    })
+
+    expect(navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shouldRedirect: false,
+        offerCategories: [SearchGroupNameEnumv2.CINEMA],
+      }),
+      defaultDisabilitiesProperties
+    )
+  })
+})

--- a/src/libs/algolia/doAlgoliaRedirect.ts
+++ b/src/libs/algolia/doAlgoliaRedirect.ts
@@ -1,0 +1,30 @@
+import { Dispatch } from 'react'
+
+import { DisabilitiesProperties } from 'features/accessibility/types'
+import { Action } from 'features/search/context/reducer'
+import { SearchState } from 'features/search/types'
+
+export const doAlgoliaRedirect = (
+  url: URL,
+  searchState: SearchState,
+  disabilities: DisabilitiesProperties,
+  dispatch: Dispatch<Action>,
+  navigateToThematicSearch: (
+    newSearchState: SearchState,
+    newAccessibilityFilter: DisabilitiesProperties
+  ) => void
+) => {
+  const offerCategories = url.searchParams.get('offerCategories') || ''
+  const newSearchState = {
+    ...searchState,
+    offerCategories: JSON.parse(offerCategories),
+    shouldRedirect: false,
+  }
+
+  dispatch({
+    type: 'SET_STATE',
+    payload: newSearchState,
+  })
+
+  return navigateToThematicSearch(newSearchState, disabilities)
+}

--- a/src/libs/algolia/fetchAlgolia/fetchSearchResults/fetchSearchResults.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchSearchResults/fetchSearchResults.ts
@@ -25,6 +25,12 @@ type FetchOfferAndVenuesArgs = {
   disabilitiesProperties: DisabilitiesProperties
 }
 
+type RenderingContent = {
+  redirect?: {
+    url?: string
+  }
+}
+
 export const fetchSearchResults = async ({
   parameters,
   buildLocationParameterParams,
@@ -137,8 +143,16 @@ export const fetchSearchResults = async ({
       ]
 
     if (storeQueryID) storeQueryID(offersResponse.queryID)
+    const { renderingContent } = offersResponse
+    const redirectUrl = (renderingContent as RenderingContent)?.redirect?.url
 
-    return { offersResponse, venuesResponse, facetsResponse, duplicatedOffersResponse }
+    return {
+      offersResponse,
+      venuesResponse,
+      facetsResponse,
+      duplicatedOffersResponse,
+      redirectUrl,
+    }
   } catch (error) {
     captureAlgoliaError(error)
     return {
@@ -158,6 +172,7 @@ export const fetchSearchResults = async ({
         nbPages: 0,
         userData: null,
       },
+      redirectUrl: undefined,
     }
   }
 }

--- a/src/libs/firebase/remoteConfig/helpers/getRemoteConfigFromConfigValues.ts
+++ b/src/libs/firebase/remoteConfig/helpers/getRemoteConfigFromConfigValues.ts
@@ -41,4 +41,7 @@ export const getRemoteConfigFromConfigValues = (
     parameters.shareAppModalVersion
   ).asString() as CustomRemoteConfig['shareAppModalVersion'],
   showAccessScreeningButton: getConfigValue(parameters.showAccessScreeningButton).asBoolean(),
+  shouldRedirectToThematicSearch: getConfigValue(
+    parameters.shouldRedirectToThematicSearch
+  ).asBoolean(),
 })

--- a/src/libs/firebase/remoteConfig/remoteConfig.constants.ts
+++ b/src/libs/firebase/remoteConfig/remoteConfig.constants.ts
@@ -35,4 +35,5 @@ export const DEFAULT_REMOTE_CONFIG: CustomRemoteConfig = {
   },
   shareAppModalVersion: 'default',
   showAccessScreeningButton: false,
+  shouldRedirectToThematicSearch: false,
 }

--- a/src/libs/firebase/remoteConfig/remoteConfig.types.ts
+++ b/src/libs/firebase/remoteConfig/remoteConfig.types.ts
@@ -23,6 +23,7 @@ export type CustomRemoteConfig = {
   subscriptionHomeEntryIds: Record<SubscriptionTheme, string>
   shareAppModalVersion: 'default' | 'A' | 'B'
   showAccessScreeningButton: boolean
+  shouldRedirectToThematicSearch: boolean
 }
 
 /* The purpose of GenericRemoteConfig is only to resolve type conflicts.


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-30293

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [X] Made sure my feature is working on web.
- [X] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome |               | <video src="https://github.com/user-attachments/assets/72e9a3d3-2e2a-4860-804d-f9e38913029f" /> |

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
