### PR TITLE
(BSR) fix(ThematicSearch): restore venue playlist after algolia redirect

### DIFF
--- a/src/libs/algolia/doAlgoliaRedirect.native.test.ts
+++ b/src/libs/algolia/doAlgoliaRedirect.native.test.ts
@@ -2,6 +2,7 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { SearchGroupNameEnumv2 } from 'api/gen'
 import { defaultDisabilitiesProperties } from 'features/accessibility/context/AccessibilityFiltersWrapper'
 import { initialSearchState } from 'features/search/context/reducer'
+import { SearchState } from 'features/search/types'
 import { doAlgoliaRedirect } from 'libs/algolia/doAlgoliaRedirect'
 
 const mockSearchstate = { ...initialSearchState, shouldRedirect: true }
@@ -10,16 +11,7 @@ const mockNavigateToThematicSearch = navigate
 
 describe('doAlgoliaRedirect', () => {
   it('should redirect to thematicSearch', async () => {
-    const mockUrl =
-      'http://passculture.app/recherche/resultats?offerCategories=%5B%22CINEMA%22%5D&query=%22%22'
-
-    doAlgoliaRedirect(
-      new URL(mockUrl),
-      mockSearchstate,
-      defaultDisabilitiesProperties,
-      mockDispatch,
-      mockNavigateToThematicSearch
-    )
+    executeDoAlgoliaRedirect(mockSearchstate)
 
     expect(mockDispatch).toHaveBeenNthCalledWith(1, {
       type: 'SET_STATE',
@@ -35,5 +27,54 @@ describe('doAlgoliaRedirect', () => {
       }),
       defaultDisabilitiesProperties
     )
+
+    expect(mockDispatch).toHaveBeenNthCalledWith(1, {
+      type: 'SET_STATE',
+      payload: expect.objectContaining({
+        query: '',
+      }),
+    })
+  })
+
+  it('should reset query after redirection to thematicSearch', async () => {
+    const mockQuery = 'cinema'
+    executeDoAlgoliaRedirect({ ...mockSearchstate, query: mockQuery })
+
+    expect(mockDispatch).toHaveBeenNthCalledWith(1, {
+      type: 'SET_STATE',
+      payload: expect.objectContaining({
+        shouldRedirect: false,
+        query: mockQuery,
+      }),
+    })
+
+    expect(mockNavigateToThematicSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shouldRedirect: false,
+        offerCategories: [SearchGroupNameEnumv2.CINEMA],
+        query: mockQuery,
+      }),
+      defaultDisabilitiesProperties
+    )
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'SET_STATE',
+      payload: expect.objectContaining({
+        query: '',
+      }),
+    })
   })
 })
+
+const executeDoAlgoliaRedirect = (searchState: SearchState) => {
+  const mockUrl =
+    'http://passculture.app/recherche/resultats?offerCategories=%5B%22CINEMA%22%5D&query=%22%22'
+
+  doAlgoliaRedirect(
+    new URL(mockUrl),
+    searchState,
+    defaultDisabilitiesProperties,
+    mockDispatch,
+    mockNavigateToThematicSearch
+  )
+}

--- a/src/libs/algolia/doAlgoliaRedirect.ts
+++ b/src/libs/algolia/doAlgoliaRedirect.ts
@@ -26,5 +26,10 @@ export const doAlgoliaRedirect = (
     payload: newSearchState,
   })
 
-  return navigateToThematicSearch(newSearchState, disabilities)
+  navigateToThematicSearch(newSearchState, disabilities)
+
+  dispatch({
+    type: 'SET_STATE',
+    payload: { ...newSearchState, query: '' },
+  })
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome | <video src="https://github.com/user-attachments/assets/407112b8-7b61-454c-8a1d-dc0621c404f6" /> | <video src="https://github.com/user-attachments/assets/8c8178c7-916a-4535-9a76-518bb3d8ed10" /> |

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
