### PR TITLE
(PC-33369) feat(NC): add enable: isLoggedIn in useGetStepperInfo

### DIFF
--- a/src/features/home/api/useActivationBanner.native.test.ts
+++ b/src/features/home/api/useActivationBanner.native.test.ts
@@ -78,7 +78,11 @@ describe('useActivationBanner', () => {
 
       await act(async () => {})
 
-      expect(result.current.banner.title).toEqual('Débloque tes 300\u00a0€')
+      expect(result.current.banner).toEqual({
+        title: 'Débloque tes 300\u00a0€',
+        text: 'API - Bénéficie de ton crédit maintenant !',
+        name: BannerName.activation_banner,
+      })
     })
 
     it('isEligibleForBeneficiaryUpgrade', async () => {

--- a/src/features/identityCheck/api/useGetStepperInfo.native.test.ts
+++ b/src/features/identityCheck/api/useGetStepperInfo.native.test.ts
@@ -9,6 +9,9 @@ import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, renderHook } from 'tests/utils'
 
 jest.mock('libs/jwt/jwt')
+jest.mock('features/auth/context/AuthContext', () => ({
+  useAuthContext: jest.fn(() => ({ isLoggedIn: true })),
+}))
 
 describe('useGetStepperInfo', () => {
   it('should get stepsToDisplay from the back', async () => {

--- a/src/features/identityCheck/api/useGetStepperInfo.ts
+++ b/src/features/identityCheck/api/useGetStepperInfo.ts
@@ -2,10 +2,15 @@ import { UseQueryResult, useQuery } from 'react-query'
 
 import { api } from 'api/api'
 import { SubscriptionStepperResponseV2 } from 'api/gen'
+import { useAuthContext } from 'features/auth/context/AuthContext'
 import { QueryKeys } from 'libs/queryKeys'
 
 export const useGetStepperInfo = (): UseQueryResult<SubscriptionStepperResponseV2, unknown> => {
-  return useQuery<SubscriptionStepperResponseV2>([QueryKeys.STEPPER_INFO], () =>
-    api.getNativeV2SubscriptionStepper()
+  const { isLoggedIn } = useAuthContext()
+
+  return useQuery<SubscriptionStepperResponseV2>(
+    [QueryKeys.STEPPER_INFO],
+    () => api.getNativeV2SubscriptionStepper(),
+    { enabled: isLoggedIn }
   )
 }

--- a/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.native.test.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/IdentityCheckEnd.native.test.tsx
@@ -13,6 +13,9 @@ import { render, screen, waitFor } from 'tests/utils'
 
 jest.mock('features/navigation/helpers/navigateToHome')
 jest.mock('libs/jwt/jwt')
+jest.mock('features/auth/context/AuthContext', () => ({
+  useAuthContext: jest.fn(() => ({ isLoggedIn: true })),
+}))
 
 const mockDispatch = jest.fn()
 jest.mock('features/identityCheck/context/SubscriptionContextProvider', () => ({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33369

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |   <img width="1728" alt="Capture d’écran 2024-12-18 à 12 03 04" src="https://github.com/user-attachments/assets/4c854c15-cffd-461f-9679-4d6b4ab97901" /> |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
