### PR TITLE
(PC-33684) feat(storybook): use local image instead online image for …

### DIFF
--- a/src/features/offer/components/StickyBookingButton/StickyBookingButton.stories.tsx
+++ b/src/features/offer/components/StickyBookingButton/StickyBookingButton.stories.tsx
@@ -1,8 +1,9 @@
 import { ComponentMeta } from '@storybook/react'
 import React from 'react'
-import { StyleSheet, View } from 'react-native'
+import styled from 'styled-components/native'
 
 import { StickyBookingButton } from 'features/offer/components/StickyBookingButton/StickyBookingButton'
+import { SHARE_APP_IMAGE_SOURCE } from 'features/share/components/shareAppImage'
 import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storybook/VariantsTemplate'
 
 const meta: ComponentMeta<typeof StickyBookingButton> = {
@@ -10,17 +11,6 @@ const meta: ComponentMeta<typeof StickyBookingButton> = {
   component: StickyBookingButton,
 }
 export default meta
-
-const styles = StyleSheet.create({
-  container: {
-    width: '100%',
-    height: 200,
-    backgroundImage:
-      'url("https://img.freepik.com/photos-gratuite/peinture-lac-montagne-montagne-arriere-plan_188544-9126.jpg?w=1380&t=st=1701705399~exp=1701705999~hmac=c2bf28443a351fb39a524c2fb4603030acdca56b8d6d165a5dccaf922265f073")',
-    backgroundSize: 'cover',
-    position: 'relative',
-  },
-})
 
 const variantConfig: Variants<typeof StickyBookingButton> = [
   {
@@ -88,10 +78,16 @@ const variantConfig: Variants<typeof StickyBookingButton> = [
 ]
 
 const Template: VariantsStory<typeof StickyBookingButton> = () => (
-  <View style={styles.container}>
+  <ImageBackground source={SHARE_APP_IMAGE_SOURCE}>
     <VariantsTemplate variants={variantConfig} Component={StickyBookingButton} />
-  </View>
+  </ImageBackground>
 )
 
 export const AllVariants = Template.bind({})
 AllVariants.storyName = 'StickyBookingButton'
+
+const ImageBackground = styled.ImageBackground({
+  width: '100%',
+  height: '200px',
+  position: 'relative',
+})

--- a/src/ui/components/BlurryWrapper/BlurryWrapper.stories.tsx
+++ b/src/ui/components/BlurryWrapper/BlurryWrapper.stories.tsx
@@ -2,6 +2,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react'
 import React from 'react'
 import styled from 'styled-components/native'
 
+import { SHARE_APP_IMAGE_SOURCE } from 'features/share/components/shareAppImage'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 
 import { BlurryWrapper } from './BlurryWrapper'
@@ -14,9 +15,9 @@ const meta: ComponentMeta<typeof BlurryWrapper> = {
 export default meta
 
 const Template: ComponentStory<typeof BlurryWrapper> = (props) => (
-  <Background>
+  <ImageBackground source={SHARE_APP_IMAGE_SOURCE}>
     <BlurryWrapper {...props} />
-  </Background>
+  </ImageBackground>
 )
 
 export const Default = Template.bind({})
@@ -25,10 +26,8 @@ Default.args = {
   children: <ButtonPrimary wording="Réserver l’offre" mediumWidth />,
 }
 
-const Background = styled.View({
+const ImageBackground = styled.ImageBackground({
   width: '100%',
   height: '400px',
-  backgroundImage:
-    'url("https://img.freepik.com/photos-gratuite/produit-beaute-explosant-couleurs-vibrantes-ia-generatrice-poudre_188544-9687.jpg?size=626&ext=jpg&ga=GA1.1.953763522.1701356022")',
   justifyContent: 'center',
 })

--- a/src/ui/components/StickyBottomWrapper/StickyBottomWrapper.stories.tsx
+++ b/src/ui/components/StickyBottomWrapper/StickyBottomWrapper.stories.tsx
@@ -2,6 +2,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react'
 import React from 'react'
 import styled from 'styled-components/native'
 
+import { SHARE_APP_IMAGE_SOURCE } from 'features/share/components/shareAppImage'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { InformationWithIcon } from 'ui/components/InformationWithIcon'
 import { BicolorWarning } from 'ui/svg/icons/BicolorWarning'
@@ -20,9 +21,9 @@ const Template: ComponentStory<typeof StickyBottomWrapper> = (props) => (
       Icon={BicolorWarning}
       text="To have a correct layout, the parent of StickyBottomWrapper must be in `position: relative;`"
     />
-    <Background>
+    <ImageBackground source={SHARE_APP_IMAGE_SOURCE}>
       <StickyBottomWrapper {...props} />
-    </Background>
+    </ImageBackground>
   </React.Fragment>
 )
 
@@ -32,11 +33,8 @@ Default.args = {
   children: <ButtonPrimary wording="Réserver l’offre" />,
 }
 
-const Background = styled.View({
+const ImageBackground = styled.ImageBackground({
   width: '400px',
   height: '400px',
-  backgroundImage:
-    'url("https://img.freepik.com/free-photo/painting-mountain-lake-with-mountain-background_188544-9126.jpg?w=2000&t=st=1701356049~exp=1701356649~hmac=6a462a2b6bb330ed3be82c39f0cbbf763fa130a646e4874b0c969352ae2641a1")',
-  backgroundSize: 'cover',
   position: 'relative',
 })


### PR DESCRIPTION
…BlurryWrapper, StickyBookingButton and StickyBottomWrapper stories

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33684

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
