### PR TITLE
(PC-33008) chore(config): tested browsers and updated list

### DIFF
--- a/doc/development/general-info-web.md
+++ b/doc/development/general-info-web.md
@@ -121,14 +121,15 @@ yarn vite preview
 
 Keep in mind to [do the following change to not run into CORS errors](./general-info-web.md#requests-blocked-by-cors-policy).
 
+## Browser compatibility
+
+We currently tested/support the browsers specified in `src/web/SupportedBrowsersGate.tsx`.
+
+If needed, increase compatibility with `@vitejs/plugin-legacy` (you will need to install `terser` for the plugin to work)
+
 ## TODO list
 
 There are certain number of optimizations/improvements and things that were done in webpack that we didn't think were immediately necessary:
-
-MUST HAVE:
-
-- Test older browsers
-- If needed, increase compatibility with `@vitejs/plugin-legacy` (you will need to install `terser` for the plugin to work)
 
 SHOULD HAVE:
 

--- a/package.json
+++ b/package.json
@@ -14,23 +14,6 @@
     "node": ">=20.10"
   },
   "homepage": ".",
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all",
-      "ie 11",
-      "ie 9",
-      "not op_mob >=1"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version",
-      "ie 11",
-      "ie 9"
-    ]
-  },
   "scripts": {
     "preandroid": "./scripts/start_android_emulator_with_certificate.sh",
     "android": "react-native run-android",

--- a/src/web/SupportedBrowsersGate.tsx
+++ b/src/web/SupportedBrowsersGate.tsx
@@ -15,29 +15,13 @@ type SupportedBrowsers = Array<{
   version: number
 }>
 
-// To check if browser is in-app Facebook Messenger browser, we check if FBAV or FBAN is in user agent
-// https://stackoverflow.com/a/32348687
-const messengerBrowserRegex = new RegExp(/FBA[VN]/i)
-const isFacebookMessenger = !!messengerBrowserRegex.exec(navigator?.userAgent)
-
 export const SupportedBrowsersGate: React.FC<PropsWithChildren> = ({ children }) => {
   const browserVersion = Number(DeviceDetect.browserVersion)
   const supportedBrowsers: SupportedBrowsers = [
-    { browser: 'Facebook Messenger', active: isFacebookMessenger, version: 1 },
-    { browser: 'Chrome', active: DeviceDetect.isChrome, version: 50 },
-    { browser: 'Safari sur iOS', active: DeviceDetect.isMobileSafari, version: 12 },
-    { browser: 'Safari sur macOS', active: DeviceDetect.isSafari, version: 10 },
-    { browser: 'Firefox', active: DeviceDetect.isFirefox, version: 55 },
-    { browser: 'Edge sur Windows', active: DeviceDetect.isEdge, version: 79 },
-    { browser: 'Opera', active: DeviceDetect.isOpera && DeviceDetect.isDesktop, version: 80 },
-    { browser: 'Samsung', active: DeviceDetect.isSamsungBrowser, version: 5 },
-    { browser: 'Instagram', active: DeviceDetect.browserName === 'Instagram', version: 200 },
-    { browser: 'Brave', active: DeviceDetect.browserName === 'Brave', version: 98 },
-    {
-      browser: 'Les navigateurs basés sur Chromium (autre que Chrome et Brave)',
-      active: DeviceDetect.isChromium,
-      version: 0,
-    },
+    { browser: 'Chrome', active: DeviceDetect.isChrome, version: 80 },
+    { browser: 'Firefox', active: DeviceDetect.isFirefox, version: 80 },
+    { browser: 'Edge sur Windows', active: DeviceDetect.isEdge, version: 80 },
+    { browser: 'Safari sur macOS', active: DeviceDetect.isSafari, version: 14 },
   ]
 
   const [shouldDisplayApp, setShouldDisplayApp] = React.useState(() =>

--- a/src/web/SupportedBrowsersGate.web.test.tsx
+++ b/src/web/SupportedBrowsersGate.web.test.tsx
@@ -7,16 +7,11 @@ import { SupportedBrowsersGate } from 'web/SupportedBrowsersGate'
 
 describe('SupportedBrowsersGate', () => {
   describe.each`
-    browserProperty       | browserName        | minimalSupportedVersion
-    ${'isChrome'}         | ${'Chrome'}        | ${50}
-    ${'isMobileSafari'}   | ${'Mobile Safari'} | ${12}
-    ${'isSafari'}         | ${'Safari'}        | ${10}
-    ${'isFirefox'}        | ${'Firefox'}       | ${55}
-    ${'isEdge'}           | ${'Edge'}          | ${79}
-    ${'isSamsungBrowser'} | ${'Samsung'}       | ${5}
-    ${'isInstagram'}      | ${'Instagram'}     | ${200}
-    ${'isBrave'}          | ${'Brave'}         | ${98}
-    ${'isChromium'}       | ${'Chromium'}      | ${0}
+    browserProperty | browserName  | minimalSupportedVersion
+    ${'isChrome'}   | ${'Chrome'}  | ${80}
+    ${'isFirefox'}  | ${'Firefox'} | ${80}
+    ${'isEdge'}     | ${'Edge'}    | ${80}
+    ${'isSafari'}   | ${'Safari'}  | ${14}
   `(
     '$browserName v$minimalSupportedVersion',
     ({ browserProperty, browserName, minimalSupportedVersion }) => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33008

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
