### PR TITLE
(PC-33484) fix(CategoryButtonsHome): should be an InternalTouchableLink for accessibility

### DIFF
--- a/src/features/home/components/modules/categories/CategoryButton.tsx
+++ b/src/features/home/components/modules/categories/CategoryButton.tsx
@@ -1,0 +1,87 @@
+import React, { FunctionComponent } from 'react'
+import { TouchableOpacityProps } from 'react-native'
+import styled from 'styled-components/native'
+
+import { useHandleFocus } from 'libs/hooks/useHandleFocus'
+import { useHandleHover } from 'libs/hooks/useHandleHover'
+import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
+import { InternalNavigationProps } from 'ui/components/touchableLink/types'
+import { getSpacing, TypoDS } from 'ui/theme'
+// eslint-disable-next-line no-restricted-imports
+import { ColorsEnum } from 'ui/theme/colors'
+import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
+import { getHoverStyle } from 'ui/theme/getHoverStyle/getHoverStyle'
+
+type CategoryButtonProps = {
+  label: string
+  textColor: ColorsEnum
+  fillColor: ColorsEnum
+  borderColor: ColorsEnum
+  height?: number
+  navigateTo: InternalNavigationProps['navigateTo']
+  onBeforeNavigate: () => void
+  style?: TouchableOpacityProps['style']
+  children?: never
+}
+export const CategoryButton: FunctionComponent<CategoryButtonProps> = ({
+  label,
+  fillColor,
+  borderColor,
+  style,
+  navigateTo,
+  onBeforeNavigate,
+  height,
+}) => {
+  const focusProps = useHandleFocus()
+  const hoverProps = useHandleHover()
+
+  return (
+    <TouchableContainer
+      {...focusProps}
+      {...hoverProps}
+      onMouseDown={(e: Event) => e.preventDefault()} // Prevent focus on click
+      navigateTo={navigateTo}
+      onBeforeNavigate={onBeforeNavigate}
+      accessibilityLabel={`Catégorie ${label}`}
+      baseColor={fillColor}
+      borderColor={borderColor}
+      style={style}
+      height={height}>
+      <LabelContainer>
+        <Label>{label.toUpperCase()}</Label>
+      </LabelContainer>
+    </TouchableContainer>
+  )
+}
+
+const TouchableContainer = styled(InternalTouchableLink)<{
+  onMouseDown: (e: Event) => void
+  isFocus: boolean
+  isHover: boolean
+  baseColor: ColorsEnum
+  borderColor: ColorsEnum
+  height?: number
+}>(({ theme, isFocus, isHover, baseColor, borderColor, height }) => ({
+  height,
+  overflow: 'hidden',
+  borderRadius: theme.borderRadius.radius,
+  ...customFocusOutline({ isFocus, color: theme.colors.black }),
+  ...getHoverStyle(theme.colors.black, isHover),
+  backgroundColor: baseColor,
+  borderColor,
+  borderWidth: '1.6px',
+  flexDirection: 'column',
+  display: 'flex',
+  justifyContent: 'flex-end',
+}))
+
+const LabelContainer = styled.View({
+  padding: getSpacing(2),
+  width: '100%',
+  alignItems: 'flex-start',
+})
+
+const Label = styled(TypoDS.BodyAccentS).attrs({ numberOfLines: 3 })(({ theme }) => ({
+  textAlign: 'left',
+  color: theme.colors.black,
+}))

--- a/src/features/home/components/modules/categories/CategoryListModule.tsx
+++ b/src/features/home/components/modules/categories/CategoryListModule.tsx
@@ -1,12 +1,10 @@
-import { useNavigation } from '@react-navigation/native'
 import React, { useEffect } from 'react'
 import styled from 'styled-components/native'
 
+import { CategoryButton } from 'features/home/components/modules/categories/CategoryButton'
 import { CategoryBlock as CategoryBlockData } from 'features/home/types'
-import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { analytics } from 'libs/analytics'
 import { ContentTypes } from 'libs/contentful/types'
-import { CategoryButton } from 'shared/Buttons/CategoryButton'
 import { getSpacing, TypoDS } from 'ui/theme'
 import { newColorMapping } from 'ui/theme/newColorMapping'
 
@@ -30,8 +28,6 @@ export const CategoryListModule = ({
   index,
   homeEntryId,
 }: CategoryListProps) => {
-  const { navigate } = useNavigation<UseNavigationType>()
-
   useEffect(() => {
     analytics.logModuleDisplayedOnHomepage({
       moduleId: id,
@@ -53,19 +49,22 @@ export const CategoryListModule = ({
             textColor={newColorMapping[item.color].text}
             fillColor={newColorMapping[item.color].fill}
             borderColor={newColorMapping[item.color].border}
-            onPress={() => {
+            onBeforeNavigate={() => {
               analytics.logCategoryBlockClicked({
                 moduleId: item.id,
                 moduleListID: id,
                 entryId: homeEntryId,
                 toEntryId: item.homeEntryId,
               })
-              navigate('ThematicHome', {
+            }}
+            navigateTo={{
+              screen: 'ThematicHome',
+              params: {
                 homeId: item.homeEntryId,
                 from: 'category_block',
                 moduleId: item.id,
                 moduleListId: id,
-              })
+              },
             }}
           />
         ))}

--- a/src/features/home/components/modules/categories/CategoryListModule.tsx
+++ b/src/features/home/components/modules/categories/CategoryListModule.tsx
@@ -6,7 +6,7 @@ import { CategoryBlock as CategoryBlockData } from 'features/home/types'
 import { analytics } from 'libs/analytics'
 import { ContentTypes } from 'libs/contentful/types'
 import { getSpacing, TypoDS } from 'ui/theme'
-import { newColorMapping } from 'ui/theme/newColorMapping'
+import { colorMapping } from 'ui/theme/colorMapping'
 
 type CategoryListProps = {
   id: string
@@ -46,9 +46,9 @@ export const CategoryListModule = ({
             key={item.id}
             label={item.title}
             height={BLOCK_HEIGHT}
-            textColor={newColorMapping[item.color].text}
-            fillColor={newColorMapping[item.color].fill}
-            borderColor={newColorMapping[item.color].border}
+            textColor={colorMapping[item.color].text}
+            fillColor={colorMapping[item.color].fill}
+            borderColor={colorMapping[item.color].border}
             onBeforeNavigate={() => {
               analytics.logCategoryBlockClicked({
                 moduleId: item.id,

--- a/src/features/home/components/modules/video/VideoCarouselModule.tsx
+++ b/src/features/home/components/modules/video/VideoCarouselModule.tsx
@@ -25,7 +25,7 @@ import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
 import { CarouselBar } from 'ui/CarouselBar/CarouselBar'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { getShadow, getSpacing } from 'ui/theme'
-import { newColorMapping } from 'ui/theme/newColorMapping'
+import { colorMapping } from 'ui/theme/colorMapping'
 
 const CAROUSEL_HEIGHT = getSpacing(35)
 const CAROUSEL_ANIMATION_DURATION = 500
@@ -223,7 +223,7 @@ const Container = styled.View({
 const ColoredAttachedTileContainer = styled.View<{
   color: Color
 }>(({ color }) => ({
-  backgroundColor: newColorMapping[color].fill,
+  backgroundColor: colorMapping[color].fill,
 }))
 
 const StyledInternalTouchableLink = styled(InternalTouchableLink)(({ theme }) => ({

--- a/src/features/search/components/Buttons/CategoryButton.tsx
+++ b/src/features/search/components/Buttons/CategoryButton.tsx
@@ -21,6 +21,7 @@ type CategoryButtonProps = {
   onPress?: () => void
   children?: never
 }
+//TODO(PC-33718): Fix A11y by using InternalTouchableLink and merge with Home's CategoryButton
 export const CategoryButton: FunctionComponent<CategoryButtonProps> = ({
   label,
   fillColor,

--- a/src/features/search/components/CategoriesListDumb/CategoriesListDumb.tsx
+++ b/src/features/search/components/CategoriesListDumb/CategoriesListDumb.tsx
@@ -2,9 +2,9 @@ import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
 import { VenueMapLocationModal } from 'features/location/components/VenueMapLocationModal'
+import { CategoryButton } from 'features/search/components/Buttons/CategoryButton'
 import { Gradient } from 'features/search/enums'
 import { VenueMapBlock } from 'features/venueMap/components/VenueMapBlock/VenueMapBlock'
-import { CategoryButton } from 'shared/Buttons/CategoryButton'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 import { getSpacing, TypoDS } from 'ui/theme'
 // eslint-disable-next-line no-restricted-imports

--- a/src/ui/theme/colorMapping.ts
+++ b/src/ui/theme/colorMapping.ts
@@ -2,7 +2,7 @@ import { Color } from 'features/home/types'
 // eslint-disable-next-line no-restricted-imports
 import { ColorsEnum } from 'ui/theme/colors'
 
-export const newColorMapping: Record<
+export const colorMapping: Record<
   keyof typeof Color,
   { border: ColorsEnum; text: ColorsEnum; fill: ColorsEnum }
 > = {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33484

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots
<img width="1013" alt="Capture d’écran 2024-12-26 à 11 35 16" src="https://github.com/user-attachments/assets/202f821d-7091-47a0-b81d-73f56e265cf9" />

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
