### PR TITLE
(PC-33428) feat(NC): use formatCurrencyFromCents instead useFormatCurrencyFromCents

### DIFF
--- a/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
@@ -769,7 +769,7 @@ exports[`BookingDetails should render correctly 1`] = `
                           },
                         ]
                       }
-                      testID="price-line__price-detail"
+                      testID="price-line-price-detail"
                     >
                       (
                       4 €
@@ -788,7 +788,7 @@ exports[`BookingDetails should render correctly 1`] = `
                           },
                         ]
                       }
-                      testID="price-line__label"
+                      testID="price-line-label"
                     >
                        - 
                       Cat 4
@@ -804,7 +804,7 @@ exports[`BookingDetails should render correctly 1`] = `
                           },
                         ]
                       }
-                      testID="price-line__attributes"
+                      testID="price-line-attributes"
                     >
                        - 
                       VOSTFR 3D IMAX

--- a/src/features/birthdayNotifications/pages/EighteenBirthday.tsx
+++ b/src/features/birthdayNotifications/pages/EighteenBirthday.tsx
@@ -2,8 +2,10 @@ import React, { useEffect } from 'react'
 import styled from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
-import { useFormatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
+import { useGetPacificFrancToEuroRate } from 'libs/firebase/firestore/exchangeRates/useGetPacificFrancToEuroRate'
+import { formatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
 import { storage } from 'libs/storage'
+import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { useDepositAmountsByAge } from 'shared/user/useDepositAmountsByAge'
 import TutorialPassLogo from 'ui/animations/eighteen_birthday.json'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
@@ -32,6 +34,9 @@ const useGetPageWording = (userRequiresIdCheck?: boolean) => {
 export function EighteenBirthday() {
   const { user } = useAuthContext()
   const pageWording = useGetPageWording(user?.requiresIdCheck)
+  const currency = useGetCurrencyToDisplay()
+  const euroToPacificFrancRate = useGetPacificFrancToEuroRate()
+  const zero = formatCurrencyFromCents(0, currency, euroToPacificFrancRate)
 
   useEffect(() => {
     storage.saveObject('has_seen_eligible_card', true)
@@ -42,7 +47,7 @@ export function EighteenBirthday() {
       <StyledTitle>{pageWording.text}</StyledTitle>
       <Spacer.Column numberOfSpaces={4} />
       <StyledCaptionNeutralInfo>
-        Ton crédit précédent a été remis à {useFormatCurrencyFromCents(0)}.
+        Ton crédit précédent a été remis à {zero}.
       </StyledCaptionNeutralInfo>
       <Spacer.Column numberOfSpaces={8} />
       <InternalTouchableLink

--- a/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.tsx
+++ b/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.tsx
@@ -5,9 +5,11 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
 import { useResetRecreditAmountToShow } from 'features/profile/api/useResetRecreditAmountToShow'
 import { useAppStateChange } from 'libs/appState'
+import { useGetPacificFrancToEuroRate } from 'libs/firebase/firestore/exchangeRates/useGetPacificFrancToEuroRate'
 import LottieView from 'libs/lottie'
-import { useFormatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
+import { formatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
 import { storage } from 'libs/storage'
+import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { getAge } from 'shared/user/getAge'
 import { useAvailableCredit } from 'shared/user/useAvailableCredit'
 import TutorialPassLogo from 'ui/animations/eighteen_birthday.json'
@@ -28,8 +30,18 @@ export const RecreditBirthdayNotification = () => {
 
   const animationRef = React.useRef<LottieView>(null)
   const credit = useAvailableCredit()
-  const creditedAmount = useFormatCurrencyFromCents(user?.recreditAmountToShow ?? 3000)
-  const remainingCredit = useFormatCurrencyFromCents(credit?.amount ?? 3000)
+  const currency = useGetCurrencyToDisplay()
+  const euroToPacificFrancRate = useGetPacificFrancToEuroRate()
+  const creditedAmount = formatCurrencyFromCents(
+    user?.recreditAmountToShow ?? 3000,
+    currency,
+    euroToPacificFrancRate
+  )
+  const remainingCredit = formatCurrencyFromCents(
+    credit?.amount ?? 3000,
+    currency,
+    euroToPacificFrancRate
+  )
   const { showErrorSnackBar } = useSnackBarContext()
 
   const { mutate: resetRecreditAmountToShow, isLoading: isResetRecreditAmountToShowLoading } =

--- a/src/features/bookOffer/components/BookingInformations.native.test.tsx
+++ b/src/features/bookOffer/components/BookingInformations.native.test.tsx
@@ -115,7 +115,7 @@ describe('<BookingInformations />', () => {
 
     render(<BookingInformations />)
 
-    expect(screen.getByTestId('price-line__label')).toBeOnTheScreen()
+    expect(screen.getByTestId('price-line-label')).toBeOnTheScreen()
   })
 
   it("shouldn't display stock label when the offer hasn't any", () => {
@@ -130,7 +130,7 @@ describe('<BookingInformations />', () => {
 
     render(<BookingInformations />)
 
-    expect(screen.queryByTestId('price-line__label')).not.toBeOnTheScreen()
+    expect(screen.queryByTestId('price-line-label')).not.toBeOnTheScreen()
   })
 
   it('should display stock attributes when the offer has it', () => {
@@ -145,7 +145,7 @@ describe('<BookingInformations />', () => {
 
     render(<BookingInformations />)
 
-    expect(screen.getByTestId('price-line__attributes')).toBeOnTheScreen()
+    expect(screen.getByTestId('price-line-attributes')).toBeOnTheScreen()
   })
 
   it("shouldn't display stock attributes when the offer hasn't any", () => {
@@ -160,7 +160,7 @@ describe('<BookingInformations />', () => {
 
     render(<BookingInformations />)
 
-    expect(screen.queryByTestId('price-line__attributes')).not.toBeOnTheScreen()
+    expect(screen.queryByTestId('price-line-attributes')).not.toBeOnTheScreen()
   })
 
   it('should display expirationDate section when offer is digital and has expirationDate', async () => {

--- a/src/features/bookOffer/components/PriceLine.native.test.tsx
+++ b/src/features/bookOffer/components/PriceLine.native.test.tsx
@@ -26,20 +26,20 @@ describe('<PriceLine />', () => {
     render(<PriceLine unitPrice={500} quantity={2} attributes={attributes} />)
 
     expect(screen.getByText('- VOSTFR 3D IMAX')).toBeOnTheScreen()
-    expect(screen.getByTestId('price-line__price-detail')).toBeOnTheScreen()
-    expect(screen.getByTestId('price-line__attributes')).toBeOnTheScreen()
+    expect(screen.getByTestId('price-line-price-detail')).toBeOnTheScreen()
+    expect(screen.getByTestId('price-line-attributes')).toBeOnTheScreen()
   })
 
   it("should not show cinema's attributes when offer has not attributes", () => {
     render(<PriceLine unitPrice={500} quantity={2} attributes={[]} />)
 
-    expect(screen.queryByTestId('price-line__attributes')).not.toBeOnTheScreen()
+    expect(screen.queryByTestId('price-line-attributes')).not.toBeOnTheScreen()
   })
 
   it('should set default quantity to 1', () => {
     render(<PriceLine unitPrice={500} />)
 
     expect(screen.getByText('5\u00a0€')).toBeOnTheScreen()
-    expect(screen.queryByTestId('price-line__price-detail')).not.toBeOnTheScreen()
+    expect(screen.queryByTestId('price-line-price-detail')).not.toBeOnTheScreen()
   })
 })

--- a/src/features/bookOffer/components/PriceLine.tsx
+++ b/src/features/bookOffer/components/PriceLine.tsx
@@ -1,41 +1,17 @@
 import React from 'react'
 
 import { OfferStockResponse } from 'api/gen'
-import { useFormatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
+import { useGetPacificFrancToEuroRate } from 'libs/firebase/firestore/exchangeRates/useGetPacificFrancToEuroRate'
+import { formatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
+import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { Typo } from 'ui/theme'
 
 interface PriceLineProps {
-  /**
-   * Ordered quantity.
-   * @default 1
-   */
   quantity?: number
-  /**
-   * Offer stock unit price.
-   */
   unitPrice: number
-  /**
-   * Offer stock price category label.
-   */
   label?: OfferStockResponse['priceCategoryLabel']
-  /**
-   * By default, this component displays information in `Typo` components in order to get
-   * correct styling for `<BookingInformations />` component.
-   *
-   * By setting this to `true` you can disable the styling.
-   *
-   * @default false
-   */
   shouldDisabledStyles?: boolean
-  /**
-   * Offer stock features refers to cinema's attributes
-   */
   attributes?: OfferStockResponse['features']
-}
-
-const testIDPrefix = 'price-line'
-function getTestID(str: string) {
-  return `${testIDPrefix}__${str}`
 }
 
 export function PriceLine({
@@ -45,8 +21,10 @@ export function PriceLine({
   shouldDisabledStyles = false,
   attributes,
 }: PriceLineProps) {
-  const totalPrice = useFormatCurrencyFromCents(quantity * unitPrice)
-  const price = useFormatCurrencyFromCents(unitPrice)
+  const currency = useGetCurrencyToDisplay()
+  const euroToPacificFrancRate = useGetPacificFrancToEuroRate()
+  const totalPrice = formatCurrencyFromCents(quantity * unitPrice, currency, euroToPacificFrancRate)
+  const price = formatCurrencyFromCents(unitPrice, currency, euroToPacificFrancRate)
 
   const MainText = shouldDisabledStyles ? Typo.Body : Typo.Caption
   const SecondaryText = shouldDisabledStyles ? Typo.Body : Typo.CaptionNeutralInfo
@@ -58,15 +36,15 @@ export function PriceLine({
       <MainText>{totalPrice} </MainText>
 
       {quantity > 1 ? (
-        <SecondaryText testID={getTestID('price-detail')}>
+        <SecondaryText testID="price-line-price-detail">
           ({price} x {quantity} places)
         </SecondaryText>
       ) : null}
 
-      {label ? <MainText testID={getTestID('label')}> - {label}</MainText> : null}
+      {label ? <MainText testID="price-line-label"> - {label}</MainText> : null}
 
       {shouldDisplayAttributes ? (
-        <MainText testID={getTestID('attributes')}> - {attributes.join(' ')}</MainText>
+        <MainText testID="price-line-attributes"> - {attributes.join(' ')}</MainText>
       ) : null}
     </Typo.Body>
   )

--- a/src/features/bookOffer/pages/BookingConfirmation.tsx
+++ b/src/features/bookOffer/pages/BookingConfirmation.tsx
@@ -8,9 +8,11 @@ import { useOffer } from 'features/offer/api/useOffer'
 import { getShareOffer } from 'features/share/helpers/getShareOffer'
 import { WebShareModal } from 'features/share/pages/WebShareModal'
 import { analytics } from 'libs/analytics'
+import { useGetPacificFrancToEuroRate } from 'libs/firebase/firestore/exchangeRates/useGetPacificFrancToEuroRate'
 import { useShowReview } from 'libs/hooks/useShowReview'
-import { useFormatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
+import { formatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
 import { BatchEvent, BatchProfile } from 'libs/react-native-batch'
+import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { useAvailableCredit } from 'shared/user/useAvailableCredit'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ButtonSecondary } from 'ui/components/buttons/ButtonSecondary'
@@ -41,19 +43,8 @@ export function BookingConfirmation() {
     reset({
       index: 1,
       routes: [
-        {
-          name: 'TabNavigator',
-          state: {
-            routes: [{ name: 'Bookings' }],
-            index: 0,
-          },
-        },
-        {
-          name: 'BookingDetails',
-          params: {
-            id: params.bookingId,
-          },
-        },
+        { name: 'TabNavigator', state: { routes: [{ name: 'Bookings' }], index: 0 } },
+        { name: 'BookingDetails', params: { id: params.bookingId } },
       ],
     })
   }, [params.bookingId, params.offerId, reset, trackBooking])
@@ -72,9 +63,14 @@ export function BookingConfirmation() {
 
   useShowReview()
 
-  const amountLeftText = `Il te reste encore ${useFormatCurrencyFromCents(
-    amountLeft
-  )} à dépenser sur le pass Culture.`
+  const currency = useGetCurrencyToDisplay()
+  const euroToPacificFrancRate = useGetPacificFrancToEuroRate()
+  const amountLeftWithCurrency = formatCurrencyFromCents(
+    amountLeft,
+    currency,
+    euroToPacificFrancRate
+  )
+  const amountLeftText = `Il te reste encore ${amountLeftWithCurrency} à dépenser sur le pass Culture.`
 
   return (
     <React.Fragment>

--- a/src/features/bookings/components/BookingPropertiesSection.native.test.tsx
+++ b/src/features/bookings/components/BookingPropertiesSection.native.test.tsx
@@ -78,14 +78,14 @@ describe('<BookingPropertiesSection />', () => {
     renderBookingProperties(booking)
 
     expect(screen.getByText('- VOSTFR 3D IMAX')).toBeOnTheScreen()
-    expect(screen.getByTestId('price-line__price-detail')).toBeOnTheScreen()
-    expect(screen.getByTestId('price-line__attributes')).toBeOnTheScreen()
+    expect(screen.getByTestId('price-line-price-detail')).toBeOnTheScreen()
+    expect(screen.getByTestId('price-line-attributes')).toBeOnTheScreen()
   })
 
   it("should not show cinema's attributes when booked offer has not attributes", () => {
     renderBookingProperties({ ...booking, stock: { ...booking.stock, features: [] } })
 
-    expect(screen.queryByTestId('price-line__attributes')).not.toBeOnTheScreen()
+    expect(screen.queryByTestId('price-line-attributes')).not.toBeOnTheScreen()
   })
 })
 

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.tsx
@@ -8,9 +8,11 @@ import { isUserUnderageBeneficiary } from 'features/profile/helpers/isUserUndera
 import { useMaxPrice } from 'features/search/helpers/useMaxPrice/useMaxPrice'
 import { useShareAppContext } from 'features/share/context/ShareAppWrapper'
 import { ShareAppModalType } from 'features/share/types'
-import { useFormatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
+import { useGetPacificFrancToEuroRate } from 'libs/firebase/firestore/exchangeRates/useGetPacificFrancToEuroRate'
+import { formatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
 import { BatchEvent, BatchProfile } from 'libs/react-native-batch'
 import { useShouldShowCulturalSurveyForBeneficiaryUser } from 'shared/culturalSurvey/useShouldShowCulturalSurveyForBeneficiaryUser'
+import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import TutorialPassLogo from 'ui/animations/tutorial_pass_logo.json'
 import { AnimatedProgressBar } from 'ui/components/bars/AnimatedProgressBar'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
@@ -31,7 +33,11 @@ export function BeneficiaryAccountCreated() {
   const { showShareAppModal } = useShareAppContext()
   const { actions } = useCreditStore()
 
-  const subtitle = `${useFormatCurrencyFromCents(maxPriceInCents)} viennent d’être crédités sur ton compte pass Culture`
+  const currency = useGetCurrencyToDisplay()
+  const euroToPacificFrancRate = useGetPacificFrancToEuroRate()
+  const maxPrice = formatCurrencyFromCents(maxPriceInCents, currency, euroToPacificFrancRate)
+  const subtitle = `${maxPrice} viennent d’être crédités sur ton compte pass Culture`
+
   const text = isUnderageBeneficiary
     ? 'Tu as jusqu’à la veille de tes 18 ans pour profiter de ton budget.'
     : 'Tu as deux ans pour profiter de ton budget.'
@@ -56,7 +62,7 @@ export function BeneficiaryAccountCreated() {
           icon={categoriesIcons.Show}
           isAnimated
         />
-        <Amount>{useFormatCurrencyFromCents(maxPriceInCents)}</Amount>
+        <Amount>{maxPrice}</Amount>
       </ProgressBarContainer>
       <Spacer.Column numberOfSpaces={4} />
       <StyledBody>{text}</StyledBody>

--- a/src/features/profile/components/CreditInfo/CreditInfo.tsx
+++ b/src/features/profile/components/CreditInfo/CreditInfo.tsx
@@ -4,7 +4,9 @@ import styled from 'styled-components/native'
 
 import { DomainsCredit } from 'api/gen'
 import { CreditProgressBar } from 'features/profile/components/CreditInfo/CreditProgressBar'
-import { useFormatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
+import { useGetPacificFrancToEuroRate } from 'libs/firebase/firestore/exchangeRates/useGetPacificFrancToEuroRate'
+import { formatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
+import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { Spacer } from 'ui/theme'
 import { TypoDS } from 'ui/theme/designSystemTypographie'
 
@@ -13,9 +15,17 @@ type CreditInfoProps = {
 }
 
 export function CreditInfo({ totalCredit }: PropsWithChildren<CreditInfoProps>) {
+  const currency = useGetCurrencyToDisplay()
+  const euroToPacificFrancRate = useGetPacificFrancToEuroRate()
+  const totalCreditWithCurrency = formatCurrencyFromCents(
+    totalCredit.remaining,
+    currency,
+    euroToPacificFrancRate
+  )
+
   return (
     <View testID="credit-info">
-      <Title>{useFormatCurrencyFromCents(totalCredit.remaining)}</Title>
+      <Title>{totalCreditWithCurrency}</Title>
       <Spacer.Column numberOfSpaces={3} />
       <CreditProgressBar progress={totalCredit.remaining / totalCredit.initial} />
     </View>

--- a/src/features/tutorial/components/profileTutorial/EighteenBlockDescription.tsx
+++ b/src/features/tutorial/components/profileTutorial/EighteenBlockDescription.tsx
@@ -5,7 +5,9 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { CreditProgressBar } from 'features/profile/components/CreditInfo/CreditProgressBar'
 import { isUserBeneficiary18 } from 'features/profile/helpers/isUserBeneficiary18'
 import { BlockDescriptionItem } from 'features/tutorial/components/profileTutorial/BlockDescriptionItem'
-import { useFormatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
+import { useGetPacificFrancToEuroRate } from 'libs/firebase/firestore/exchangeRates/useGetPacificFrancToEuroRate'
+import { formatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
+import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { AccessibleUnorderedList } from 'ui/components/accessibility/AccessibleUnorderedList'
 import { BicolorNumeric } from 'ui/svg/icons/bicolor/Numeric'
 import { BicolorClock } from 'ui/svg/icons/BicolorClock'
@@ -18,7 +20,9 @@ type Props = {
 
 export const EighteenBlockDescription: FunctionComponent<Props> = ({ ongoingCredit = false }) => {
   const { isLoggedIn, user } = useAuthContext()
-  const oneHundredEuros = useFormatCurrencyFromCents(100_00)
+  const currency = useGetCurrencyToDisplay()
+  const euroToPacificFrancRate = useGetPacificFrancToEuroRate()
+  const oneHundredEuros = formatCurrencyFromCents(100_00, currency, euroToPacificFrancRate)
 
   const defaultItems = [
     <BlockDescriptionItem

--- a/src/libs/parsers/formatCurrencyFromCents.ts
+++ b/src/libs/parsers/formatCurrencyFromCents.ts
@@ -1,7 +1,6 @@
-import { useGetPacificFrancToEuroRate } from 'libs/firebase/firestore/exchangeRates/useGetPacificFrancToEuroRate'
 import { convertCentsToEuros } from 'libs/parsers/pricesConversion'
 import { RoundUnit, convertEuroToPacificFranc } from 'shared/currency/convertEuroToPacificFranc'
-import { Currency, useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
+import { Currency } from 'shared/currency/useGetCurrencyToDisplay'
 
 import { FormatPriceOptions } from './getDisplayedPrice'
 
@@ -39,10 +38,4 @@ export const formatCurrencyFromCents = (
     })
     return EURformatter.format(priceInEuro)
   }
-}
-
-export const useFormatCurrencyFromCents = (priceInCents: number, options?: FormatPriceOptions) => {
-  const currency = useGetCurrencyToDisplay()
-  const euroToPacificFrancRate = useGetPacificFrancToEuroRate()
-  return formatCurrencyFromCents(priceInCents, currency, euroToPacificFrancRate, options)
 }

--- a/src/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.tsx
+++ b/src/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.tsx
@@ -5,7 +5,9 @@ import styled from 'styled-components/native'
 import { DepositType } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { StepperOrigin, UseNavigationType } from 'features/navigation/RootNavigator/types'
-import { useFormatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
+import { useGetPacificFrancToEuroRate } from 'libs/firebase/firestore/exchangeRates/useGetPacificFrancToEuroRate'
+import { formatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
+import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { getAge } from 'shared/user/getAge'
 import { useGetDepositAmountsByAge } from 'shared/user/useGetDepositAmountsByAge'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
@@ -24,7 +26,9 @@ type Props = {
 export const FinishSubscriptionModal: FunctionComponent<Props> = ({ visible, hideModal, from }) => {
   const { user } = useAuthContext()
   const { navigate } = useNavigation<UseNavigationType>()
-  const zero = useFormatCurrencyFromCents(0)
+  const currency = useGetCurrencyToDisplay()
+  const euroToPacificFrancRate = useGetPacificFrancToEuroRate()
+  const zero = formatCurrencyFromCents(0, currency, euroToPacificFrancRate)
 
   const navigateToStepper = useCallback(() => {
     hideModal()

--- a/src/shared/user/useDepositAmountsByAge.ts
+++ b/src/shared/user/useDepositAmountsByAge.ts
@@ -1,18 +1,39 @@
 import { useSettingsContext } from 'features/auth/context/SettingsContext'
-import { useFormatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
+import { useGetPacificFrancToEuroRate } from 'libs/firebase/firestore/exchangeRates/useGetPacificFrancToEuroRate'
+import { formatCurrencyFromCents } from 'libs/parsers/formatCurrencyFromCents'
+import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 
 export function useDepositAmountsByAge() {
   const { data: settings } = useSettingsContext()
+  const currency = useGetCurrencyToDisplay()
+  const euroToPacificFrancRate = useGetPacificFrancToEuroRate()
+
   const fifteenYearsOldAmount = settings?.depositAmountsByAge?.age_15 ?? 2000
   const sixteenYearsOldAmount = settings?.depositAmountsByAge?.age_16 ?? 3000
   const seventeenYearsOldAmount = settings?.depositAmountsByAge?.age_17 ?? 3000
   const eighteenYearsOldAmount = settings?.depositAmountsByAge?.age_18 ?? 30000
 
   const amountsByAge = {
-    fifteenYearsOldDeposit: useFormatCurrencyFromCents(fifteenYearsOldAmount),
-    sixteenYearsOldDeposit: useFormatCurrencyFromCents(sixteenYearsOldAmount),
-    seventeenYearsOldDeposit: useFormatCurrencyFromCents(seventeenYearsOldAmount),
-    eighteenYearsOldDeposit: useFormatCurrencyFromCents(eighteenYearsOldAmount),
+    fifteenYearsOldDeposit: formatCurrencyFromCents(
+      fifteenYearsOldAmount,
+      currency,
+      euroToPacificFrancRate
+    ),
+    sixteenYearsOldDeposit: formatCurrencyFromCents(
+      sixteenYearsOldAmount,
+      currency,
+      euroToPacificFrancRate
+    ),
+    seventeenYearsOldDeposit: formatCurrencyFromCents(
+      seventeenYearsOldAmount,
+      currency,
+      euroToPacificFrancRate
+    ),
+    eighteenYearsOldDeposit: formatCurrencyFromCents(
+      eighteenYearsOldAmount,
+      currency,
+      euroToPacificFrancRate
+    ),
   }
   return { ...amountsByAge }
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33428

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
