### PR TITLE
(PC-33118) feat(Booking): ViewedBookingPage tracker 

### DIFF
--- a/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
@@ -122,6 +122,7 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
     style={
       [
         {
+          "gap": 16,
           "paddingBottom": 40,
         },
       ]
@@ -214,16 +215,6 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
       </View>
     </View>
     <View
-      numberOfSpaces={4}
-      style={
-        [
-          {
-            "height": 16,
-          },
-        ]
-      }
-    />
-    <View
       accessibilityLabel="Partager l’offre"
       accessibilityState={
         {
@@ -313,16 +304,6 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      numberOfSpaces={4}
-      style={
-        [
-          {
-            "height": 16,
-          },
-        ]
-      }
-    />
     <View
       accessibilityLabel="Retourner à l’accueil"
       accessibilityState={

--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -51,8 +51,7 @@
 ./src/features/offer/components/VenueSelectionListItem/VenueSelectionListItem.web.tsx:81
 ./src/features/offer/components/VenueSelectionListItem/VenueSelectionListItem.web.tsx:83
 ./src/features/offer/components/VenueSelectionListItem/VenueSelectionListItem.web.tsx:85
-./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts:927
-./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts:231
+./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts:935
 ./src/features/profile/components/CreditInfo/CreditProgressBar.tsx:32
 ./src/features/search/components/sections/Accessibility/Accessibility.tsx:33
 ./src/features/search/pages/SuggestedPlacesOrVenues/SuggestedVenues.native.test.tsx:43

--- a/scripts/noUncheckedIndexedAccess_snapshot.txt
+++ b/scripts/noUncheckedIndexedAccess_snapshot.txt
@@ -51,7 +51,6 @@
 ./src/features/offer/components/VenueSelectionListItem/VenueSelectionListItem.web.tsx:81
 ./src/features/offer/components/VenueSelectionListItem/VenueSelectionListItem.web.tsx:83
 ./src/features/offer/components/VenueSelectionListItem/VenueSelectionListItem.web.tsx:85
-./src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts:935
 ./src/features/profile/components/CreditInfo/CreditProgressBar.tsx:32
 ./src/features/search/components/sections/Accessibility/Accessibility.tsx:33
 ./src/features/search/pages/SuggestedPlacesOrVenues/SuggestedVenues.native.test.tsx:43

--- a/src/features/bookOffer/components/BookDateChoice.tsx
+++ b/src/features/bookOffer/components/BookDateChoice.tsx
@@ -1,4 +1,6 @@
 import React, { useMemo } from 'react'
+import { View } from 'react-native'
+import styled from 'styled-components/native'
 
 import { OfferStockResponse } from 'api/gen'
 import { Calendar } from 'features/bookOffer/components/Calendar/Calendar'
@@ -7,7 +9,7 @@ import { useBookingContext } from 'features/bookOffer/context/useBookingContext'
 import { getDistinctPricesFromAllStock } from 'features/bookOffer/helpers/bookingHelpers/bookingHelpers'
 import { formatToCompleteFrenchDate } from 'libs/parsers/formatDates'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, Typo, TypoDS, getSpacing } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 interface Props {
@@ -31,8 +33,7 @@ export const BookDateChoice = ({ stocks, userRemainingCredit }: Props) => {
   const buttonTitle = bookingState.date ? formatToCompleteFrenchDate(bookingState.date) : ''
 
   return (
-    <React.Fragment>
-      <Spacer.Column numberOfSpaces={6} />
+    <StyledView>
       <TypoDS.Title3 {...getHeadingAttrs(3)} testID="DateStep">
         Date
       </TypoDS.Title3>
@@ -50,6 +51,10 @@ export const BookDateChoice = ({ stocks, userRemainingCredit }: Props) => {
           <Typo.ButtonText>{buttonTitle}</Typo.ButtonText>
         </TouchableOpacity>
       )}
-    </React.Fragment>
+    </StyledView>
   )
 }
+
+const StyledView = styled(View)({
+  marginTop: getSpacing(6),
+})

--- a/src/features/bookOffer/pages/BookingConfirmation.native.test.tsx
+++ b/src/features/bookOffer/pages/BookingConfirmation.native.test.tsx
@@ -7,7 +7,7 @@ import { useReviewInAppInformation } from 'features/bookOffer/helpers/useReviewI
 import { analytics } from 'libs/analytics'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { BatchProfile } from 'libs/react-native-batch'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { act, userEvent, render, screen } from 'tests/utils'
 
 import { BookingConfirmation } from './BookingConfirmation'
 
@@ -102,7 +102,7 @@ describe('<BookingConfirmation />', () => {
 
       await act(async () => {
         const shareButton = await screen.findByText('Partager l’offre')
-        fireEvent.press(shareButton)
+        await userEvent.press(shareButton)
       })
 
       expect(share).toHaveBeenCalledTimes(1)
@@ -112,8 +112,8 @@ describe('<BookingConfirmation />', () => {
       render(<BookingConfirmation />)
 
       await act(async () => {
-        const shareButton = screen.getByText('Partager l’offre')
-        fireEvent.press(shareButton)
+        const shareButton = await screen.findByText('Partager l’offre')
+        await userEvent.press(shareButton)
       })
 
       expect(analytics.logShare).toHaveBeenNthCalledWith(1, {
@@ -125,48 +125,42 @@ describe('<BookingConfirmation />', () => {
 
     it('should go to Bookings when click on CTA', async () => {
       render(<BookingConfirmation />)
-      fireEvent.press(screen.getByText('Voir ma réservation'))
+      await userEvent.press(await screen.findByText('Voir ma réservation'))
 
-      await waitFor(() => {
-        expect(reset).toHaveBeenCalledWith({
-          index: 1,
-          routes: [
-            {
-              name: 'TabNavigator',
-              state: {
-                routes: [{ name: 'Bookings' }],
-                index: 0,
-              },
+      expect(reset).toHaveBeenCalledWith({
+        index: 1,
+        routes: [
+          {
+            name: 'TabNavigator',
+            state: {
+              routes: [{ name: 'Bookings' }],
+              index: 0,
             },
-            {
-              name: 'BookingDetails',
-              params: {
-                id: 345,
-              },
+          },
+          {
+            name: 'BookingDetails',
+            params: {
+              id: 345,
             },
-          ],
-        })
+          },
+        ],
       })
     })
 
     it('should log analytic logSeeMyBooking when click on CTA', async () => {
       render(<BookingConfirmation />)
-      fireEvent.press(screen.getByText('Voir ma réservation'))
+      await userEvent.press(await screen.findByText('Voir ma réservation'))
 
-      await waitFor(() => {
-        expect(analytics.logSeeMyBooking).toHaveBeenCalledWith(mockOfferId)
-      })
+      expect(analytics.logSeeMyBooking).toHaveBeenCalledWith(mockOfferId)
     })
 
     it('should log analytic logViewedBookingPage when click on CTA', async () => {
       render(<BookingConfirmation />)
-      fireEvent.press(screen.getByText('Voir ma réservation'))
+      await userEvent.press(await screen.findByText('Voir ma réservation'))
 
-      await waitFor(() => {
-        expect(analytics.logViewedBookingPage).toHaveBeenCalledWith({
-          offerId: mockOfferId,
-          from: 'bookingconfirmation',
-        })
+      expect(analytics.logViewedBookingPage).toHaveBeenCalledWith({
+        offerId: mockOfferId,
+        from: 'bookingconfirmation',
       })
     })
 
@@ -175,7 +169,7 @@ describe('<BookingConfirmation />', () => {
       async (buttonWording) => {
         render(<BookingConfirmation />)
 
-        fireEvent.press(screen.getByText(buttonWording))
+        await userEvent.press(await screen.findByText(buttonWording))
 
         expect(BatchProfile.trackEvent).toHaveBeenCalledWith('has_booked')
       }

--- a/src/features/bookOffer/pages/BookingConfirmation.native.test.tsx
+++ b/src/features/bookOffer/pages/BookingConfirmation.native.test.tsx
@@ -123,12 +123,11 @@ describe('<BookingConfirmation />', () => {
       })
     })
 
-    it('should go to Bookings and log analytics event', async () => {
+    it('should go to Bookings when click on CTA', async () => {
       render(<BookingConfirmation />)
       fireEvent.press(screen.getByText('Voir ma réservation'))
 
       await waitFor(() => {
-        expect(analytics.logSeeMyBooking).toHaveBeenCalledWith(mockOfferId)
         expect(reset).toHaveBeenCalledWith({
           index: 1,
           routes: [
@@ -146,6 +145,27 @@ describe('<BookingConfirmation />', () => {
               },
             },
           ],
+        })
+      })
+    })
+
+    it('should log analytic logSeeMyBooking when click on CTA', async () => {
+      render(<BookingConfirmation />)
+      fireEvent.press(screen.getByText('Voir ma réservation'))
+
+      await waitFor(() => {
+        expect(analytics.logSeeMyBooking).toHaveBeenCalledWith(mockOfferId)
+      })
+    })
+
+    it('should log analytic logViewedBookingPage when click on CTA', async () => {
+      render(<BookingConfirmation />)
+      fireEvent.press(screen.getByText('Voir ma réservation'))
+
+      await waitFor(() => {
+        expect(analytics.logViewedBookingPage).toHaveBeenCalledWith({
+          offerId: mockOfferId,
+          from: 'bookingconfirmation',
         })
       })
     })

--- a/src/features/bookOffer/pages/BookingConfirmation.tsx
+++ b/src/features/bookOffer/pages/BookingConfirmation.tsx
@@ -87,9 +87,7 @@ export function BookingConfirmation() {
         <Spacer.Flex />
         <ButtonContainer>
           <ButtonPrimary key={1} wording="Voir ma réservation" onPress={displayBookingDetails} />
-          <Spacer.Column numberOfSpaces={4} />
           <ButtonSecondary wording="Partager l’offre" onPress={pressShareOffer} />
-          <Spacer.Column numberOfSpaces={4} />
           <InternalTouchableLink
             key={2}
             as={ButtonTertiaryPrimary}
@@ -118,4 +116,5 @@ const StyledBody = styled(Typo.Body)({
 
 const ButtonContainer = styled.View({
   paddingBottom: getSpacing(10),
+  gap: getSpacing(4),
 })

--- a/src/features/bookOffer/pages/BookingConfirmation.tsx
+++ b/src/features/bookOffer/pages/BookingConfirmation.tsx
@@ -39,6 +39,7 @@ export function BookingConfirmation() {
 
   const displayBookingDetails = useCallback(() => {
     analytics.logSeeMyBooking(params.offerId)
+    analytics.logViewedBookingPage({ offerId: params.offerId, from: 'bookingconfirmation' })
     trackBooking()
     reset({
       index: 1,

--- a/src/features/bookings/components/EndedBookingItem.native.test.tsx
+++ b/src/features/bookings/components/EndedBookingItem.native.test.tsx
@@ -127,6 +127,22 @@ describe('EndedBookingItem', () => {
     })
   })
 
+  it('should log logViewedBookingPage when click on offer digital without expiration date and not cancelled', async () => {
+    renderEndedBookingItem({
+      ...bookingsSnap.ended_bookings[0],
+      cancellationDate: null,
+      cancellationReason: null,
+    })
+
+    const item = screen.getByText('Réservation archivée')
+    await user.press(item)
+
+    expect(analytics.logViewedBookingPage).toHaveBeenCalledWith({
+      offerId: bookingsSnap.ended_bookings[0].stock.offer.id,
+      from: 'endedbookings',
+    })
+  })
+
   it('should call share when press share icon', async () => {
     renderEndedBookingItem({
       ...bookingsSnap.ended_bookings[0],

--- a/src/features/bookings/components/EndedBookingItem.tsx
+++ b/src/features/bookings/components/EndedBookingItem.tsx
@@ -55,6 +55,11 @@ export const EndedBookingItem = ({
   function handlePressOffer() {
     const { offer } = stock
     if (!offer.id) return
+    if (shouldRedirectToBooking)
+      analytics.logViewedBookingPage({
+        offerId: stock.offer.id,
+        from: 'endedbookings',
+      })
     if (isEligibleBookingsForArchiveValue) return
     if (netInfo.isConnected) {
       // We pre-populate the query-cache with the data from the search result for a smooth transition

--- a/src/features/bookings/components/OnGoingBookingItem.native.test.tsx
+++ b/src/features/bookings/components/OnGoingBookingItem.native.test.tsx
@@ -9,7 +9,7 @@ import { FREE_OFFER_CATEGORIES_TO_ARCHIVE } from 'features/bookings/constants'
 import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import { Booking } from 'features/bookings/types'
 import { analytics } from 'libs/analytics'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 
 import { OnGoingBookingItem } from './OnGoingBookingItem'
 
@@ -20,6 +20,8 @@ const mockNativeShare = jest.spyOn(Share, 'share').mockResolvedValue({ action: S
 
 jest.mock('libs/firebase/analytics/analytics')
 
+jest.useFakeTimers()
+
 describe('OnGoingBookingItem', () => {
   const bookings = bookingsSnap.ongoing_bookings
 
@@ -28,25 +30,21 @@ describe('OnGoingBookingItem', () => {
   it('should navigate to the booking details page', async () => {
     renderOnGoingBookingItem(initialBooking)
 
-    const item = screen.getByTestId(/Réservation de l’offre/)
-    fireEvent.press(item)
+    const item = await screen.findByTestId(/Réservation de l’offre/)
+    await userEvent.press(item)
 
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('BookingDetails', { id: 123 })
-    })
+    expect(navigate).toHaveBeenCalledWith('BookingDetails', { id: 123 })
   })
 
   it('should log analytic logViewedBookingPage when click on CTA', async () => {
     renderOnGoingBookingItem(initialBooking)
 
-    const item = screen.getByTestId(/Réservation de l’offre/)
-    fireEvent.press(item)
+    const item = await screen.findByTestId(/Réservation de l’offre/)
+    await userEvent.press(item)
 
-    await waitFor(() => {
-      expect(analytics.logViewedBookingPage).toHaveBeenCalledWith({
-        offerId: initialBooking.stock.offer.id,
-        from: 'bookings',
-      })
+    expect(analytics.logViewedBookingPage).toHaveBeenCalledWith({
+      offerId: initialBooking.stock.offer.id,
+      from: 'bookings',
     })
   })
 
@@ -194,7 +192,7 @@ describe('OnGoingBookingItem', () => {
     const shareButton = await screen.findByLabelText(
       `Partager l’offre ${initialBooking.stock.offer.name}`
     )
-    fireEvent.press(shareButton)
+    await userEvent.press(shareButton)
 
     expect(mockNativeShare).toHaveBeenCalledTimes(1)
   })
@@ -205,7 +203,7 @@ describe('OnGoingBookingItem', () => {
     const shareButton = await screen.findByLabelText(
       `Partager l’offre ${initialBooking.stock.offer.name}`
     )
-    fireEvent.press(shareButton)
+    await userEvent.press(shareButton)
 
     expect(analytics.logShare).toHaveBeenNthCalledWith(1, {
       type: 'Offer',

--- a/src/features/bookings/components/OnGoingBookingItem.native.test.tsx
+++ b/src/features/bookings/components/OnGoingBookingItem.native.test.tsx
@@ -9,7 +9,7 @@ import { FREE_OFFER_CATEGORIES_TO_ARCHIVE } from 'features/bookings/constants'
 import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import { Booking } from 'features/bookings/types'
 import { analytics } from 'libs/analytics'
-import { fireEvent, render, screen } from 'tests/utils'
+import { fireEvent, render, screen, waitFor } from 'tests/utils'
 
 import { OnGoingBookingItem } from './OnGoingBookingItem'
 
@@ -25,13 +25,29 @@ describe('OnGoingBookingItem', () => {
 
   const initialBooking: Booking = bookingsSnap.ongoing_bookings[0]
 
-  it('should navigate to the booking details page', () => {
+  it('should navigate to the booking details page', async () => {
     renderOnGoingBookingItem(initialBooking)
 
     const item = screen.getByTestId(/Réservation de l’offre/)
     fireEvent.press(item)
 
-    expect(navigate).toHaveBeenCalledWith('BookingDetails', { id: 123 })
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith('BookingDetails', { id: 123 })
+    })
+  })
+
+  it('should log analytic logViewedBookingPage when click on CTA', async () => {
+    renderOnGoingBookingItem(initialBooking)
+
+    const item = screen.getByTestId(/Réservation de l’offre/)
+    fireEvent.press(item)
+
+    await waitFor(() => {
+      expect(analytics.logViewedBookingPage).toHaveBeenCalledWith({
+        offerId: initialBooking.stock.offer.id,
+        from: 'bookings',
+      })
+    })
   })
 
   describe('should be on site withdrawal ticket event', () => {

--- a/src/features/bookings/components/OnGoingBookingItem.tsx
+++ b/src/features/bookings/components/OnGoingBookingItem.tsx
@@ -69,6 +69,12 @@ export const OnGoingBookingItem = ({ booking, eligibleBookingsForArchive }: Prop
     <React.Fragment>
       <ContentContainer
         navigateTo={{ screen: 'BookingDetails', params: { id: booking.id } }}
+        onBeforeNavigate={() => {
+          analytics.logViewedBookingPage({
+            offerId: stock.offer.id,
+            from: 'bookings',
+          })
+        }}
         accessibilityLabel={accessibilityLabel}>
         <OfferImage imageUrl={stock.offer.image?.url} categoryId={categoryId} size="tall" />
         <AttributesView>

--- a/src/features/bookings/components/OnGoingBookingItem.tsx
+++ b/src/features/bookings/components/OnGoingBookingItem.tsx
@@ -81,7 +81,6 @@ export const OnGoingBookingItem = ({ booking, eligibleBookingsForArchive }: Prop
               {stock.offer.withdrawalType === WithdrawalTypeEnum.on_site ? (
                 <WithdrawContainer testID="on-site-withdrawal-container">
                   <OfferEvent />
-                  <Spacer.Row numberOfSpaces={1} />
                   <OnSiteWithdrawalCaption numberOfLines={2}>
                     {withdrawLabel}
                   </OnSiteWithdrawalCaption>
@@ -89,7 +88,6 @@ export const OnGoingBookingItem = ({ booking, eligibleBookingsForArchive }: Prop
               ) : (
                 <WithdrawContainer testID="withdraw-container">
                   <Clock />
-                  <Spacer.Row numberOfSpaces={1} />
                   <WithdrawCaption numberOfLines={2}>{withdrawLabel}</WithdrawCaption>
                 </WithdrawContainer>
               )}
@@ -98,7 +96,6 @@ export const OnGoingBookingItem = ({ booking, eligibleBookingsForArchive }: Prop
           {canDisplayExpirationMessage ? (
             <ExpirationBookingContainer testID="expiration-booking-container">
               <Clock />
-              <Spacer.Row numberOfSpaces={1} />
               <ExpirationBookingLabel>{correctExpirationMessages}</ExpirationBookingLabel>
             </ExpirationBookingContainer>
           ) : null}
@@ -147,11 +144,13 @@ const DateLabel = styled(Typo.Body)(({ theme }) => ({
 }))
 
 const WithdrawCaption = styled(Typo.Caption)({
+  marginTop: getSpacing(1),
   marginRight: getSpacing(4),
 })
 
 const OnSiteWithdrawalCaption = styled(WithdrawCaption)(({ theme }) => ({
   color: theme.colors.primary,
+  marginTop: getSpacing(1),
 }))
 
 const Clock = styled(DefaultClock).attrs(({ theme }) => ({
@@ -172,6 +171,7 @@ const ExpirationBookingContainer = styled.View(({ theme }) => ({
 }))
 
 const ExpirationBookingLabel = styled(Typo.CaptionPrimary)({
+  marginTop: getSpacing(1),
   marginRight: getSpacing(4),
 })
 

--- a/src/features/bookings/components/OnGoingBookingItem.web.test.tsx
+++ b/src/features/bookings/components/OnGoingBookingItem.web.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { navigate } from '__mocks__/@react-navigation/native'
 import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import { Booking } from 'features/bookings/types'
-import { fireEvent, render, screen } from 'tests/utils/web'
+import { fireEvent, render, screen, waitFor } from 'tests/utils/web'
 
 import { OnGoingBookingItem } from './OnGoingBookingItem'
 
@@ -16,12 +16,14 @@ jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 describe('OnGoingBookingItem', () => {
   const booking: Booking = bookingsSnap.ongoing_bookings[0]
 
-  it('should navigate to the booking details page', () => {
+  it('should navigate to the booking details page', async () => {
     render(<OnGoingBookingItem booking={booking} />)
 
     const item = screen.getByTestId(/Réservation de l’offre/)
     fireEvent.click(item)
 
-    expect(navigate).toHaveBeenCalledWith('BookingDetails', { id: 123 })
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith('BookingDetails', { id: 123 })
+    })
   })
 })

--- a/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts
+++ b/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts
@@ -838,34 +838,42 @@ describe('getCtaWordingAndAction', () => {
       })
     })
 
-    it('should return bottomBannerText and wording if user has already booked this offer', async () => {
-      const result = getCtaWordingAndAction({
-        ...defaultParameters,
-        userStatus: { statusType: YoungStatusType.beneficiary },
-        isBeneficiary: true,
-        offer: CineScreeningOffer,
-        bookedOffers: { [baseOffer.id]: 116656 },
-        subcategory: buildSubcategory({ isEvent: true }),
-        hasEnoughCredit: true,
-      })
+    it.each<{ isEvent: boolean }>([{ isEvent: true }, { isEvent: false }])(
+      'should return bottomBannerText and wording if user has already booked this offer',
+      async (isOfferEvent) => {
+        const result = getCtaWordingAndAction({
+          ...defaultParameters,
+          userStatus: { statusType: YoungStatusType.beneficiary },
+          isBeneficiary: true,
+          offer: CineScreeningOffer,
+          bookedOffers: { [baseOffer.id]: 116656 },
+          subcategory: buildSubcategory(isOfferEvent),
+          hasEnoughCredit: true,
+        })
 
-      expect(result).toEqual({
-        wording: 'Voir ma réservation',
-        bottomBannerText: 'Tu ne peux réserver ce film qu’une seule fois.',
-        isDisabled: false,
-        movieScreeningUserData: {
-          bookings: undefined,
-          hasBookedOffer: true,
-        },
-        navigateTo: {
-          fromRef: true,
-          params: {
-            id: 116656,
-          },
-          screen: 'BookingDetails',
-        },
-      })
-    })
+        expect(JSON.stringify(result)).toEqual(
+          JSON.stringify({
+            wording: 'Voir ma réservation',
+            isDisabled: false,
+            navigateTo: {
+              screen: 'BookingDetails',
+              params: {
+                id: 116656,
+              },
+              fromRef: true,
+            },
+            onPress: () => {
+              analytics.logViewedBookingPage({ offerId: CineScreeningOffer.id, from: 'offer' })
+            },
+            bottomBannerText: 'Tu ne peux réserver ce film qu’une seule fois.',
+            movieScreeningUserData: {
+              bookings: undefined,
+              hasBookedOffer: true,
+            },
+          })
+        )
+      }
+    )
 
     it('should display "Réserver l’offre" wording and modal "authentication" if user is not logged in', () => {
       const result = getCtaWordingAndAction({

--- a/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts
+++ b/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts
@@ -13,6 +13,7 @@ import { analytics } from 'libs/analytics'
 import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
 import { Subcategory } from 'libs/subcategories/types'
 import { OfferModal } from 'shared/offer/enums'
+import { mockBuilder } from 'tests/mockBuilder'
 
 import { getCtaWordingAndAction } from './useCtaWordingAndAction'
 
@@ -646,6 +647,36 @@ describe('getCtaWordingAndAction', () => {
         offerId: baseOffer.id,
         ...defaultApiRecoParams,
         playlistType: defaultPlaylistType,
+      })
+    })
+
+    it('logs event logViewedBookingPage when we click CTA "Réserver l’offre" on free digital event already booked', () => {
+      const offer = baseOffer
+      const subcategory = buildSubcategory({ isEvent: true })
+      const booking = mockBuilder.bookingResponse({ id: offer.id })
+
+      const { onPress } =
+        getCtaWordingAndAction({
+          isLoggedIn: true,
+          userStatus: { statusType: YoungStatusType.beneficiary },
+          isBeneficiary: true,
+          offer,
+          subcategory,
+          hasEnoughCredit: true,
+          bookedOffers: { [offer.id]: offer.id },
+          isUnderageBeneficiary: false,
+          bookOffer: jest.fn(),
+          isBookingLoading: false,
+          booking,
+          apiRecoParams: defaultApiRecoParams,
+          playlistType: defaultPlaylistType,
+        }) || {}
+
+      onPress?.()
+
+      expect(analytics.logViewedBookingPage).toHaveBeenNthCalledWith(1, {
+        from: 'offer',
+        offerId: offer.id,
       })
     })
 

--- a/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts
+++ b/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.native.test.ts
@@ -963,8 +963,8 @@ const buildOffer = (partialOffer: Partial<OfferResponseV2>): OfferResponseV2 => 
 })
 
 const baseSubcategory = subcategoriesDataTest.subcategories[0]
-// @ts-expect-error: because of noUncheckedIndexedAccess
-const buildSubcategory = (partialSubcategory: Partial<Subcategory>): Subcategory => ({
-  ...baseSubcategory,
-  ...partialSubcategory,
-})
+const buildSubcategory = (partialSubcategory: Partial<Subcategory>): Subcategory =>
+  ({
+    ...baseSubcategory,
+    ...partialSubcategory,
+  }) as Subcategory

--- a/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts
+++ b/src/features/offer/helpers/useCtaWordingAndAction/useCtaWordingAndAction.ts
@@ -210,6 +210,9 @@ export const getCtaWordingAndAction = ({
           params: { id: bookedOffers[offer.id] },
           fromRef: true,
         },
+        onPress: () => {
+          analytics.logViewedBookingPage({ offerId: offer.id, from: 'offer' })
+        },
         bottomBannerText: isMovieScreeningOffer ? BottomBannerTextEnum.ALREADY_BOOKED : undefined,
         movieScreeningUserData: {
           hasBookedOffer: true,
@@ -225,12 +228,12 @@ export const getCtaWordingAndAction = ({
           openUrl(booking?.completedUrl ?? '')
           return
         }
-
-        bookOffer({
-          quantity: 1,
-          // @ts-expect-error: because of noUncheckedIndexedAccess
-          stockId: offer.stocks[0].id,
-        })
+        if (offer.stocks[0]?.id) {
+          bookOffer({
+            quantity: 1,
+            stockId: offer.stocks[0].id,
+          })
+        }
       },
     }
   }
@@ -243,6 +246,9 @@ export const getCtaWordingAndAction = ({
         screen: 'BookingDetails',
         params: { id: bookedOffers[offer.id] },
         fromRef: true,
+      },
+      onPress: () => {
+        analytics.logViewedBookingPage({ offerId: offer.id, from: 'offer' })
       },
       bottomBannerText: isMovieScreeningOffer ? BottomBannerTextEnum.ALREADY_BOOKED : undefined,
       movieScreeningUserData: {

--- a/src/features/search/components/SearchSuggestions/SearchSuggestions.tsx
+++ b/src/features/search/components/SearchSuggestions/SearchSuggestions.tsx
@@ -16,7 +16,7 @@ import { buildSearchVenuePosition } from 'libs/algolia/fetchAlgolia/fetchSearchR
 import { getCurrentVenuesIndex } from 'libs/algolia/fetchAlgolia/helpers/getCurrentVenuesIndex'
 import { analytics } from 'libs/analytics'
 import { useLocation } from 'libs/location'
-import { Spacer, getSpacing } from 'ui/theme'
+import { getSpacing } from 'ui/theme'
 
 type SearchSuggestionsParams = {
   queryHistory: string
@@ -100,7 +100,6 @@ export const SearchSuggestions = ({
       keyboardShouldPersistTaps="handled"
       onScroll={Keyboard.dismiss}
       scrollEventThrottle={16}>
-      <Spacer.Column numberOfSpaces={4} />
       <SearchHistory
         history={filteredHistory}
         queryHistory={queryHistory}
@@ -117,12 +116,13 @@ export const SearchSuggestions = ({
         />
         <AutocompleteVenue onItemPress={onVenuePress} />
       </Index>
-      <Spacer.Column numberOfSpaces={3} />
     </StyledScrollView>
   )
 }
 
 const StyledScrollView = styled.ScrollView(({ theme }) => ({
+  paddingTop: getSpacing(4),
+  paddingBottom: getSpacing(3),
   flex: 1,
   paddingLeft: getSpacing(6),
   paddingRight: getSpacing(6),

--- a/src/libs/analytics/__mocks__/logEventAnalytics.ts
+++ b/src/libs/analytics/__mocks__/logEventAnalytics.ts
@@ -193,4 +193,5 @@ export const logEventAnalytics: typeof actualLogEventAnalytics = {
   logVideoPaused: jest.fn(),
   logDisplayAchievements: jest.fn(),
   logConsultAchievementModal: jest.fn(),
+  logViewedBookingPage: jest.fn(),
 }

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -708,4 +708,6 @@ export const logEventAnalytics = {
     homeEntryId: string
     moduleId: string
   }) => analytics.logEvent({ firebase: AnalyticsEvent.VIDEO_PAUSED }, params),
+  logViewedBookingPage: (params: { from: Referrals; offerId: number }) =>
+    analytics.logEvent({ firebase: AnalyticsEvent.VIEWED_BOOKING_PAGE }, params),
 }

--- a/src/libs/firebase/analytics/events.ts
+++ b/src/libs/firebase/analytics/events.ts
@@ -32,6 +32,7 @@ export enum AnalyticsEvent {
   CONFIRM_BOOKING_CANCELLATION = 'ConfirmBookingCancellation',
   CONNECTION_INFO = 'ConnectionInfo',
   CONSULT_ACCESSIBILITY_MODALITIES = 'ConsultAccessibilityModalities',
+  CONSULT_ACHIEVEMENT_MODAL = 'ConsultAchievementModale',
   CONSULT_ACHIEVEMENTS_SUCCESS_MODAL = 'ConsultAchievementsSuccessModal',
   CONSULT_APPLICATION_PROCESSING_MODAL = 'ConsultApplicationProcessingModal',
   CONSULT_ARTICLE_ACCOUNT_DELETION = 'ConsultArticleAccountDeletion',
@@ -72,6 +73,7 @@ export enum AnalyticsEvent {
   DISMISS_ACCOUNT_SECURITY = 'DismissAccountSecurity',
   DISMISS_NOTIFICATIONS = 'DismissNotifications',
   DISMISS_SHARE_APP = 'DismissShareApp',
+  DISPLAY_ACHIEVEMENTS = 'DisplayAchievements',
   DISPLAY_FORCED_LOGIN_HELP_MESSAGE = 'DisplayForcedLoginHelpMessage',
   ERROR_SAVING_NEW_EMAIL = 'ErrorSavingNewMail',
   EXCLUSIVITY_BLOCK_CLICKED = 'ExclusivityBlockClicked',
@@ -179,8 +181,7 @@ export enum AnalyticsEvent {
   VENUE_SEE_ALL_OFFERS_CLICKED = 'VenueSeeAllOffersClicked',
   VENUE_SEE_MORE_CLICKED = 'VenueSeeMoreClicked',
   VIDEO_PAUSED = 'VideoPaused',
-  DISPLAY_ACHIEVEMENTS = 'DisplayAchievements',
-  CONSULT_ACHIEVEMENT_MODAL = 'ConsultAchievementModale',
+  VIEWED_BOOKING_PAGE = 'ViewedBookingPage',
 }
 
 const RESERVED_PREFIXES = ['firebase_', 'google_', 'ga_']

--- a/src/libs/subcategories/fixtures/subcategoriesResponse.ts
+++ b/src/libs/subcategories/fixtures/subcategoriesResponse.ts
@@ -1,6 +1,5 @@
-import { SubcategoriesResponseModelv2 } from 'api/gen'
 import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
 
-export const subcategoriesDataTest: SubcategoriesResponseModelv2 = PLACEHOLDER_DATA
+export const subcategoriesDataTest = PLACEHOLDER_DATA
 
 export const searchGroupsDataTest = PLACEHOLDER_DATA.searchGroups

--- a/src/shared/location/LocationSearchInput.tsx
+++ b/src/shared/location/LocationSearchInput.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { View } from 'react-native'
 import styled from 'styled-components/native'
 
 import { LOCATION_PLACEHOLDER } from 'features/location/constants'
@@ -8,7 +9,7 @@ import { theme } from 'theme'
 import { SearchInput } from 'ui/components/inputs/SearchInput'
 import { useDebounceValue } from 'ui/hooks/useDebounceValue'
 import { MagnifyingGlass } from 'ui/svg/icons/MagnifyingGlass'
-import { Spacer } from 'ui/theme'
+import { getSpacing } from 'ui/theme'
 
 interface LocationSearchInputProps {
   selectedPlace: SuggestedPlace | null
@@ -38,8 +39,7 @@ export const LocationSearchInput = ({
   const shouldShowSuggestedPlaces = isQueryProvided && !selectedPlace
 
   return (
-    <React.Fragment>
-      <Spacer.Column numberOfSpaces={4} />
+    <StyledView>
       <SearchInput
         autoFocus
         LeftIcon={StyledMagnifyingGlass}
@@ -53,15 +53,16 @@ export const LocationSearchInput = ({
         }
       />
       {shouldShowSuggestedPlaces ? (
-        <React.Fragment>
-          <Spacer.Column numberOfSpaces={4} />
+        <StyledView>
           <SuggestedPlaces query={debouncedPlaceQuery} setSelectedPlace={onSetSelectedPlace} />
-        </React.Fragment>
+        </StyledView>
       ) : null}
-    </React.Fragment>
+    </StyledView>
   )
 }
 
 const StyledMagnifyingGlass = styled(MagnifyingGlass).attrs(({ theme }) => ({
   size: theme.icons.sizes.small,
 }))``
+
+const StyledView = styled(View)({ paddingTop: getSpacing(4) })

--- a/src/tests/mockBuilder.ts
+++ b/src/tests/mockBuilder.ts
@@ -3,12 +3,14 @@ import { mergeWith } from 'lodash'
 
 import {
   BookingOfferResponse,
+  BookingReponse,
   BookingVenueResponse,
   OfferResponseV2,
   OfferStockResponse,
   OfferVenueResponse,
   SubcategoryIdEnum,
 } from 'api/gen'
+import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import { createDateBuilder } from 'features/offer/components/MoviesScreeningCalendar/createBuilder'
 import { offersStocksResponseSnap } from 'features/offer/fixtures/offersStocksResponse'
 import { mockedBookingOfferResponse } from 'fixtures/booking'
@@ -82,6 +84,7 @@ export const mockBuilder = {
   searchResponseOffer: createMockBuilder<SearchResponse<Offer>>(searchResponseOffer),
   bookingVenueResponse: createMockBuilder<BookingVenueResponse>(mockedBookingOfferResponse.venue),
   bookingOfferResponse: createMockBuilder<BookingOfferResponse>(mockedBookingOfferResponse),
+  bookingResponse: createMockBuilder<BookingReponse>(bookingsSnap.ongoing_bookings[0]),
 }
 
 export const dateBuilder = createDateBuilder()


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33118

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
