### PR TITLE
(PC-33665) feat(ThematicSearch): update playlists

### DIFF
--- a/src/features/search/pages/ThematicSearch/api/fetchCinemaOffers.native.test.ts
+++ b/src/features/search/pages/ThematicSearch/api/fetchCinemaOffers.native.test.ts
@@ -32,18 +32,15 @@ function buildQueries(userLocation: Position) {
   return [
     buildQuery({
       ...commonQueryParams,
-      hitsPerPage: 20,
       filters: 'offer.subcategoryId:"SEANCE_CINE"',
     }),
     buildQuery({
       ...commonQueryParams,
-      hitsPerPage: 30,
       filters: 'offer.subcategoryId:"SEANCE_CINE"',
       numericFilters: 'offer.releaseDate: 1743984000 TO 1744588800',
     }),
     buildQuery({
       ...commonQueryParams,
-      hitsPerPage: 30,
       filters:
         'offer.nativeCategoryId:"CARTES_CINEMA" AND (offer.subcategoryId:"CARTE_CINE_MULTISEANCES" OR offer.subcategoryId:"CINE_VENTE_DISTANCE")',
     }),

--- a/src/features/search/pages/ThematicSearch/api/fetchCinemaOffers.ts
+++ b/src/features/search/pages/ThematicSearch/api/fetchCinemaOffers.ts
@@ -21,18 +21,15 @@ export const fetchCinemaOffers = async (userLocation?: Position) => {
   const queries: MultipleQueriesQuery[] = [
     buildQuery({
       ...commonQueryParams,
-      hitsPerPage: 20,
       filters: `offer.subcategoryId:"${SubcategoryIdEnum.SEANCE_CINE}"`,
     }),
     buildQuery({
       ...commonQueryParams,
-      hitsPerPage: 30,
       filters: `offer.subcategoryId:"${SubcategoryIdEnum.SEANCE_CINE}"`,
       numericFilters: `offer.releaseDate: ${sevenDaysAgo} TO ${today}`,
     }),
     buildQuery({
       ...commonQueryParams,
-      hitsPerPage: 30,
       filters: `offer.nativeCategoryId:"${NativeCategoryIdEnumv2.CARTES_CINEMA}" AND (offer.subcategoryId:"${SubcategoryIdEnum.CARTE_CINE_MULTISEANCES}" OR offer.subcategoryId:"${SubcategoryIdEnum.CINE_VENTE_DISTANCE}")`,
     }),
   ]

--- a/src/features/search/pages/ThematicSearch/api/fetchFilmsOffers.native.test.ts
+++ b/src/features/search/pages/ThematicSearch/api/fetchFilmsOffers.native.test.ts
@@ -17,23 +17,16 @@ describe('fetchFilmsOffers', () => {
 })
 
 function buildQueries(userLocation: Position) {
-  const commonQueryParams = {
-    hitsPerPage: 20,
-  }
-
   return [
     buildQuery({
-      ...commonQueryParams,
       indexName: 'algoliaOffersIndexNameB',
       filters: 'offer.subcategoryId:"ABO_PLATEFORME_VIDEO"',
     }),
     buildQuery({
-      ...commonQueryParams,
       indexName: 'algoliaOffersIndexNameB',
       filters: 'offer.subcategoryId:"VOD"',
     }),
     buildQuery({
-      ...commonQueryParams,
       indexName: 'algoliaOffersIndexName',
       filters:
         'offer.nativeCategoryId:"DVD_BLU_RAY" AND offer.subcategoryId:"SUPPORT_PHYSIQUE_FILM" AND NOT offer.last30DaysBookingsRange:"very-low"',

--- a/src/features/search/pages/ThematicSearch/api/fetchFilmsOffers.ts
+++ b/src/features/search/pages/ThematicSearch/api/fetchFilmsOffers.ts
@@ -10,23 +10,16 @@ import { Position } from 'libs/location/types'
 import { Offer } from 'shared/offer/types'
 
 export const fetchFilmsOffers = async (userLocation?: Position) => {
-  const commonQueryParams = {
-    hitsPerPage: 20,
-  }
-
   const queries: MultipleQueriesQuery[] = [
     buildQuery({
-      ...commonQueryParams,
       indexName: env.ALGOLIA_OFFERS_INDEX_NAME_B,
       filters: `offer.subcategoryId:"${SubcategoryIdEnum.ABO_PLATEFORME_VIDEO}"`,
     }),
     buildQuery({
-      ...commonQueryParams,
       indexName: env.ALGOLIA_OFFERS_INDEX_NAME_B,
       filters: `offer.subcategoryId:"${SubcategoryIdEnum.VOD}"`,
     }),
     buildQuery({
-      ...commonQueryParams,
       indexName: env.ALGOLIA_OFFERS_INDEX_NAME,
       userLocation,
       filters: `offer.nativeCategoryId:"${NativeCategoryIdEnumv2.DVD_BLU_RAY}" AND offer.subcategoryId:"${SubcategoryIdEnum.SUPPORT_PHYSIQUE_FILM}" AND NOT offer.last30DaysBookingsRange:"very-low"`,

--- a/src/features/search/pages/ThematicSearch/api/fetchMusicOffers.native.test.ts
+++ b/src/features/search/pages/ThematicSearch/api/fetchMusicOffers.native.test.ts
@@ -19,7 +19,6 @@ function buildQueries(userLocation: Position) {
   const commonQueryParams = {
     indexName: 'algoliaOffersIndexNameB',
     userLocation,
-    hitsPerPage: 20,
   }
 
   return [
@@ -37,6 +36,7 @@ function buildQueries(userLocation: Position) {
       ...commonQueryParams,
       filters:
         'offer.subcategoryId:"FESTIVAL_MUSIQUE" AND NOT offer.last30DaysBookingsRange:"very-low"',
+      withRadius: false,
     }),
     buildQuery({
       ...commonQueryParams,

--- a/src/features/search/pages/ThematicSearch/api/fetchMusicOffers.ts
+++ b/src/features/search/pages/ThematicSearch/api/fetchMusicOffers.ts
@@ -10,7 +10,6 @@ export const fetchMusicOffers = async (userLocation?: Position) => {
   const commonQueryParams = {
     indexName: env.ALGOLIA_OFFERS_INDEX_NAME_B,
     userLocation,
-    hitsPerPage: 20,
   }
 
   const queries: MultipleQueriesQuery[] = [
@@ -26,6 +25,7 @@ export const fetchMusicOffers = async (userLocation?: Position) => {
     buildQuery({
       ...commonQueryParams,
       filters: `offer.subcategoryId:"${SubcategoryIdEnum.FESTIVAL_MUSIQUE}" AND NOT offer.last30DaysBookingsRange:"very-low"`,
+      withRadius: false,
     }),
     buildQuery({
       ...commonQueryParams,

--- a/src/features/search/pages/ThematicSearch/api/utils.ts
+++ b/src/features/search/pages/ThematicSearch/api/utils.ts
@@ -11,6 +11,7 @@ type ThematicSearchQueryParams = {
   numericFilters?: string
   hitsPerPage?: number
   distinct?: boolean
+  withRadius?: boolean
 }
 
 export const buildQuery = ({
@@ -20,6 +21,7 @@ export const buildQuery = ({
   numericFilters,
   hitsPerPage,
   distinct,
+  withRadius = true,
 }: ThematicSearchQueryParams): MultipleQueriesQuery => ({
   indexName,
   query: '',
@@ -29,12 +31,12 @@ export const buildQuery = ({
     ...(userLocation
       ? {
           aroundLatLng: `${userLocation.latitude}, ${userLocation.longitude}`,
-          aroundRadius: DEFAULT_RADIUS * 1000,
+          ...(withRadius && { aroundRadius: DEFAULT_RADIUS * 1000 }),
         }
       : {}),
     ...(filters && { filters }),
     ...(numericFilters && { numericFilters }),
     ...(distinct && { distinct }),
-    ...(hitsPerPage && { hitsPerPage }),
+    hitsPerPage: hitsPerPage ?? 50,
   },
 })

--- a/src/features/search/pages/ThematicSearch/api/utils.ts
+++ b/src/features/search/pages/ThematicSearch/api/utils.ts
@@ -31,7 +31,7 @@ export const buildQuery = ({
     ...(userLocation
       ? {
           aroundLatLng: `${userLocation.latitude}, ${userLocation.longitude}`,
-          ...(withRadius && { aroundRadius: DEFAULT_RADIUS * 1000 }),
+          aroundRadius: withRadius ? DEFAULT_RADIUS * 1000 : 'all',
         }
       : {}),
     ...(filters && { filters }),


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33665

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [X] Made sure my feature is working on web.
- [X] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
