### PR TITLE
(PC-33473) feat(tutorial): add age value in storage when user choose …

### DIFF
--- a/src/features/tutorial/pages/AgeSelectionFork.native.test.tsx
+++ b/src/features/tutorial/pages/AgeSelectionFork.native.test.tsx
@@ -4,8 +4,9 @@ import React from 'react'
 import { navigate, useRoute } from '__mocks__/@react-navigation/native'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { TutorialRootStackParamList } from 'features/navigation/RootNavigator/types'
-import { TutorialTypes } from 'features/tutorial/enums'
+import { TutorialTypes, NonEligible } from 'features/tutorial/enums'
 import { AgeSelectionFork } from 'features/tutorial/pages/AgeSelectionFork'
+import { storage } from 'libs/storage'
 import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('libs/firebase/analytics/analytics')
@@ -15,6 +16,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('AgeSelectionFork', () => {
+  beforeEach(async () => {
+    await storage.clear('user_age')
+  })
+
   it('should render correctly', () => {
     renderAgeSelectionFork({ type: TutorialTypes.ONBOARDING })
 
@@ -37,6 +42,17 @@ describe('AgeSelectionFork', () => {
       })
     })
 
+    it('should save user age to local storage when pressing "J’ai 14 ans ou moins"', async () => {
+      renderAgeSelectionFork({ type: TutorialTypes.ONBOARDING })
+
+      const button = screen.getByLabelText('J’ai 14 ans ou moins')
+      await user.press(button)
+
+      const userAge = await storage.readObject('user_age')
+
+      expect(userAge).toBe(NonEligible.UNDER_15)
+    })
+
     it('should navigate to EligibleUserAgeSelection page when pressing "J’ai entre 15 et 18 ans"', async () => {
       renderAgeSelectionFork({ type: TutorialTypes.ONBOARDING })
 
@@ -57,6 +73,17 @@ describe('AgeSelectionFork', () => {
       expect(navigate).toHaveBeenCalledWith('OnboardingGeneralPublicWelcome', {
         type: TutorialTypes.ONBOARDING,
       })
+    })
+
+    it('should save user age to local storage when pressing "J’ai 19 ans ou plus"', async () => {
+      renderAgeSelectionFork({ type: TutorialTypes.ONBOARDING })
+
+      const button = screen.getByLabelText('J’ai 19 ans ou plus')
+      await user.press(button)
+
+      const userAge = await storage.readObject('user_age')
+
+      expect(userAge).toBe(NonEligible.OVER_18)
     })
   })
 

--- a/src/features/tutorial/pages/AgeSelectionFork.tsx
+++ b/src/features/tutorial/pages/AgeSelectionFork.tsx
@@ -1,13 +1,14 @@
 import { StackScreenProps } from '@react-navigation/stack'
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useCallback } from 'react'
 import styled from 'styled-components/native'
 
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { TutorialRootStackParamList } from 'features/navigation/RootNavigator/types'
 import { AgeButton } from 'features/tutorial/components/AgeButton'
 import { useOnboardingContext } from 'features/tutorial/context/OnboardingWrapper'
-import { NonEligible } from 'features/tutorial/enums'
+import { NonEligible, TutorialTypes } from 'features/tutorial/enums'
 import { TutorialPage } from 'features/tutorial/pages/TutorialPage'
+import { storage } from 'libs/storage'
 import { AccessibleUnorderedList } from 'ui/components/accessibility/AccessibleUnorderedList'
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { Spacer, TypoDS } from 'ui/theme'
@@ -18,13 +19,26 @@ type AgeButtonProps = {
   age: string
   endButtonTitle: string
   navigateTo: InternalNavigationProps['navigateTo']
-  onBeforeNavigate?: () => void
+  onBeforeNavigate?: () => Promise<void>
 }
 
 type Props = StackScreenProps<TutorialRootStackParamList, 'AgeSelectionFork'>
 
 export const AgeSelectionFork: FunctionComponent<Props> = ({ route }: Props) => {
   const type = route.params.type
+  const isOnboarding = type === TutorialTypes.ONBOARDING
+
+  const { showNonEligibleModal } = useOnboardingContext()
+
+  const onUnder15Press = useCallback(async () => {
+    showNonEligibleModal(NonEligible.UNDER_15, type)
+    if (isOnboarding) await storage.saveObject('user_age', NonEligible.UNDER_15)
+  }, [type, isOnboarding, showNonEligibleModal])
+
+  const onOver18Press = useCallback(async () => {
+    showNonEligibleModal(NonEligible.OVER_18, type)
+    if (isOnboarding) await storage.saveObject('user_age', NonEligible.OVER_18)
+  }, [type, isOnboarding, showNonEligibleModal])
 
   const ageButtons: AgeButtonProps[] = [
     {
@@ -32,7 +46,7 @@ export const AgeSelectionFork: FunctionComponent<Props> = ({ route }: Props) => 
       age: '14 ans',
       endButtonTitle: ' ou moins',
       navigateTo: navigateToHomeConfig,
-      onBeforeNavigate: () => showNonEligibleModal(NonEligible.UNDER_15, type),
+      onBeforeNavigate: onUnder15Press,
     },
     {
       startButtonTitle: 'J’ai entre ',
@@ -45,10 +59,9 @@ export const AgeSelectionFork: FunctionComponent<Props> = ({ route }: Props) => 
       age: '19 ans',
       endButtonTitle: ' ou plus',
       navigateTo: { screen: 'OnboardingGeneralPublicWelcome' },
+      onBeforeNavigate: onOver18Press,
     },
   ]
-
-  const { showNonEligibleModal } = useOnboardingContext()
 
   return (
     <TutorialPage title="Pour commencer, peux-tu nous dire ton âge&nbsp;?">


### PR DESCRIPTION
…under 15 or over 18 years in AgeSelectionFork

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33473

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |  ![Capture d’écran 2024-12-31 à 15 53 55](https://github.com/user-attachments/assets/55fe25e4-3247-4263-ab5a-e6c12e371da6)  |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4