### PR TITLE
(BSR) feat(cheatcodes): add subscreens in cheatcodes search

### DIFF
--- a/src/cheatcodes/components/CheatcodesButtonList.tsx
+++ b/src/cheatcodes/components/CheatcodesButtonList.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
+import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+
+type Props = {
+  buttons: ButtonsWithSubscreensProps[]
+}
+
+export const CheatcodesButtonList: React.FC<Props> = ({ buttons }) => (
+  <React.Fragment>
+    {buttons.map((button, index) => (
+      <React.Fragment key={index}>
+        <LinkToScreen
+          title={button.title ?? button.screen}
+          screen={button.screen}
+          onPress={button.onPress}
+          navigationParams={button.navigationParams}
+        />
+        {button.subscreens?.map((subscreen, subIndex) => (
+          <LinkToScreen
+            key={`${index}-${subIndex}`}
+            title={`↳ ${subscreen.title ?? subscreen.screen ?? '[sans titre]'}`}
+            screen={subscreen.screen}
+            onPress={subscreen.onPress}
+            navigationParams={subscreen.navigationParams}
+            buttonHeight="extraSmall"
+            isSubscreen
+          />
+        ))}
+      </React.Fragment>
+    ))}
+  </React.Fragment>
+)

--- a/src/cheatcodes/components/CheatcodesButtonList.tsx
+++ b/src/cheatcodes/components/CheatcodesButtonList.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 
 import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
-import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 
 type Props = {
-  buttons: ButtonsWithSubscreensProps[]
+  buttons: CheatcodesButtonsWithSubscreensProps[]
 }
 
 export const CheatcodesButtonList: React.FC<Props> = ({ buttons }) => (

--- a/src/cheatcodes/components/CheatcodesSubscreenButtonList.tsx
+++ b/src/cheatcodes/components/CheatcodesSubscreenButtonList.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 
 import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
-import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 
 interface Props {
-  buttons: ButtonsWithSubscreensProps[]
+  buttons: CheatcodesButtonsWithSubscreensProps[]
 }
 
 export const CheatcodesSubscreensButtonList: React.FC<Props> = ({ buttons }) => (

--- a/src/cheatcodes/components/CheatcodesSubscreenButtonList.tsx
+++ b/src/cheatcodes/components/CheatcodesSubscreenButtonList.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
+import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+
+interface Props {
+  buttons: ButtonsWithSubscreensProps[]
+}
+
+export const CheatcodesSubscreensButtonList: React.FC<Props> = ({ buttons }) => (
+  <React.Fragment>
+    {buttons.map((button, index) =>
+      button.subscreens?.map((subscreen, subIndex) => (
+        <LinkToScreen
+          key={`${index}-${subIndex}`}
+          title={subscreen.title ?? subscreen.screen ?? '[sans titre]'}
+          screen={subscreen.screen}
+          onPress={subscreen.onPress}
+          navigationParams={subscreen.navigationParams}
+        />
+      ))
+    )}
+  </React.Fragment>
+)

--- a/src/cheatcodes/components/LinkToScreen.tsx
+++ b/src/cheatcodes/components/LinkToScreen.tsx
@@ -38,7 +38,7 @@ export const LinkToScreen = ({
         />
       ) : (
         <InternalTouchableLink
-          as={isSubscreen ? ButtonSecondary : ButtonPrimary}
+          as={Button}
           wording={title ?? screen}
           navigateTo={{ screen, params: navigationParams }}
           disabled={disabled}

--- a/src/cheatcodes/components/LinkToScreen.tsx
+++ b/src/cheatcodes/components/LinkToScreen.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components/native'
 
 import { RootScreenNames, RootStackParamList } from 'features/navigation/RootNavigator/types'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
+import { ButtonSecondary } from 'ui/components/buttons/ButtonSecondary'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { padding } from 'ui/theme'
 
@@ -12,6 +13,8 @@ interface Props {
   title?: string
   navigationParams?: RootStackParamList[RootScreenNames]
   disabled?: boolean
+  buttonHeight?: 'extraSmall' | 'small'
+  isSubscreen?: boolean
 }
 
 export const LinkToScreen = ({
@@ -20,20 +23,31 @@ export const LinkToScreen = ({
   title,
   navigationParams,
   disabled = false,
-}: Props) => (
-  <Row>
-    {onPress ? (
-      <ButtonPrimary wording={title ?? screen} onPress={onPress} disabled={disabled} />
-    ) : (
-      <InternalTouchableLink
-        as={ButtonPrimary}
-        wording={title ?? screen}
-        navigateTo={{ screen, params: navigationParams }}
-        disabled={disabled}
-      />
-    )}
-  </Row>
-)
+  buttonHeight = 'small',
+  isSubscreen = false,
+}: Props) => {
+  const Button = isSubscreen ? ButtonSecondary : ButtonPrimary
+  return (
+    <Row>
+      {onPress ? (
+        <Button
+          wording={title ?? screen}
+          onPress={onPress}
+          disabled={disabled}
+          buttonHeight={buttonHeight}
+        />
+      ) : (
+        <InternalTouchableLink
+          as={isSubscreen ? ButtonSecondary : ButtonPrimary}
+          wording={title ?? screen}
+          navigateTo={{ screen, params: navigationParams }}
+          disabled={disabled}
+          buttonHeight={buttonHeight}
+        />
+      )}
+    </Row>
+  )
+}
 
 const Row = styled.View(({ theme }) => ({
   width: theme.appContentWidth > theme.breakpoints.sm ? '50%' : '100%',

--- a/src/cheatcodes/hooks/filterAndSortCheatcodesButtons.ts
+++ b/src/cheatcodes/hooks/filterAndSortCheatcodesButtons.ts
@@ -1,23 +1,26 @@
 import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 
-const isMatching = (filter: string, str?: string): boolean =>
-  (str ?? '').toLowerCase().includes(filter.toLowerCase())
+const isMatching = (searchValue: string, str?: string): boolean =>
+  (str ?? '').toLowerCase().includes(searchValue.toLowerCase())
 
 export const filterAndSortCheatcodesButtons = (
-  filter: string,
+  searchValue: string,
   buttons: CheatcodesButtonsWithSubscreensProps[]
 ): CheatcodesButtonsWithSubscreensProps[] =>
   buttons
     .filter((button) => button.title || button.screen)
     .map((button): CheatcodesButtonsWithSubscreensProps | null => {
       const filteredSubscreens = button.subscreens?.filter(
-        (subscreen) => isMatching(filter, subscreen.title) || isMatching(filter, subscreen.screen)
+        (subscreen) =>
+          isMatching(searchValue, subscreen.title) || isMatching(searchValue, subscreen.screen)
       )
       const isButtonMatching =
-        isMatching(filter, button.title) ||
-        isMatching(filter, button.screen) ||
+        isMatching(searchValue, button.title) ||
+        isMatching(searchValue, button.screen) ||
         (filteredSubscreens && filteredSubscreens.length > 0)
-      return isButtonMatching ? { ...button, subscreens: filter ? filteredSubscreens : [] } : null
+      return isButtonMatching
+        ? { ...button, subscreens: searchValue ? filteredSubscreens : [] }
+        : null
     })
     .filter((button): button is CheatcodesButtonsWithSubscreensProps => button !== null)
     .sort((a, b) =>

--- a/src/cheatcodes/hooks/filterAndSortCheatcodesButtons.ts
+++ b/src/cheatcodes/hooks/filterAndSortCheatcodesButtons.ts
@@ -1,0 +1,25 @@
+import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+
+const isMatching = (filter: string, str?: string): boolean =>
+  (str ?? '').toLowerCase().includes(filter.toLowerCase())
+
+export const filterAndSortCheatcodesButtons = (
+  filter: string,
+  buttons: ButtonsWithSubscreensProps[]
+): ButtonsWithSubscreensProps[] =>
+  buttons
+    .filter((button) => button.title || button.screen)
+    .map((button): ButtonsWithSubscreensProps | null => {
+      const filteredSubscreens = button.subscreens?.filter(
+        (subscreen) => isMatching(filter, subscreen.title) || isMatching(filter, subscreen.screen)
+      )
+      const isButtonMatching =
+        isMatching(filter, button.title) ||
+        isMatching(filter, button.screen) ||
+        (filteredSubscreens && filteredSubscreens.length > 0)
+      return isButtonMatching ? { ...button, subscreens: filter ? filteredSubscreens : [] } : null
+    })
+    .filter((button): button is ButtonsWithSubscreensProps => button !== null)
+    .sort((a, b) =>
+      (a.title || a.screen || 'sans titre').localeCompare(b.title || b.screen || 'sans titre')
+    )

--- a/src/cheatcodes/hooks/filterAndSortCheatcodesButtons.ts
+++ b/src/cheatcodes/hooks/filterAndSortCheatcodesButtons.ts
@@ -1,15 +1,15 @@
-import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 
 const isMatching = (filter: string, str?: string): boolean =>
   (str ?? '').toLowerCase().includes(filter.toLowerCase())
 
 export const filterAndSortCheatcodesButtons = (
   filter: string,
-  buttons: ButtonsWithSubscreensProps[]
-): ButtonsWithSubscreensProps[] =>
+  buttons: CheatcodesButtonsWithSubscreensProps[]
+): CheatcodesButtonsWithSubscreensProps[] =>
   buttons
     .filter((button) => button.title || button.screen)
-    .map((button): ButtonsWithSubscreensProps | null => {
+    .map((button): CheatcodesButtonsWithSubscreensProps | null => {
       const filteredSubscreens = button.subscreens?.filter(
         (subscreen) => isMatching(filter, subscreen.title) || isMatching(filter, subscreen.screen)
       )
@@ -19,7 +19,7 @@ export const filterAndSortCheatcodesButtons = (
         (filteredSubscreens && filteredSubscreens.length > 0)
       return isButtonMatching ? { ...button, subscreens: filter ? filteredSubscreens : [] } : null
     })
-    .filter((button): button is ButtonsWithSubscreensProps => button !== null)
+    .filter((button): button is CheatcodesButtonsWithSubscreensProps => button !== null)
     .sort((a, b) =>
       (a.title || a.screen || 'sans titre').localeCompare(b.title || b.screen || 'sans titre')
     )

--- a/src/cheatcodes/pages/CheatcodesMenu.tsx
+++ b/src/cheatcodes/pages/CheatcodesMenu.tsx
@@ -68,8 +68,8 @@ export function CheatcodesMenu(): React.JSX.Element {
     { title: 'Debug informations 🪲', screen: 'CheatcodesScreenDebugInformations' },
     { title: 'Errors 👾', screen: 'CheatcodesNavigationErrors' },
     { title: 'Pages non écrans ❌', screen: 'CheatcodesNavigationNotScreensPages' },
-    { title: 'AccesLibre 🌈', screen: 'CheatcodesNavigationSignUp' },
-    { title: 'SignUp 🎨', screen: 'CheatcodesScreenAccesLibre' },
+    { title: 'AccesLibre 🌈', screen: 'CheatcodesScreenAccesLibre' },
+    { title: 'SignUp 🎨', screen: 'CheatcodesNavigationSignUp' },
     { title: 'Account Management ⚙️', screen: 'CheatcodesNavigationAccountManagement' },
     { title: 'Envoyer une erreur Sentry 📤', onPress: onPressSentry },
   ]
@@ -82,7 +82,7 @@ export function CheatcodesMenu(): React.JSX.Element {
   return (
     <CheatcodesTemplateScreen title="Cheatcodes">
       <StyledSearchInput
-        placeholder="Rechercher dans cette page..."
+        placeholder="Rechercher..."
         value={filter}
         onChangeText={setFilter}
         onPressRightIcon={resetSearch}

--- a/src/cheatcodes/pages/CheatcodesMenu.tsx
+++ b/src/cheatcodes/pages/CheatcodesMenu.tsx
@@ -15,7 +15,7 @@ import { cheatcodesNavigationProfileButtons } from 'cheatcodes/pages/features/pr
 import { cheatcodesNavigationSubscriptionButtons } from 'cheatcodes/pages/features/subscription/CheatcodesNavigationSubscription'
 import { cheatcodesNavigationTrustedDeviceButtons } from 'cheatcodes/pages/features/trustedDevice/CheatcodesNavigationTrustedDevice'
 import { cheatcodesNavigationTutorialButtons } from 'cheatcodes/pages/features/tutorial/CheatcodesNavigationTutorial'
-import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 import { ForceUpdate } from 'features/forceUpdate/pages/ForceUpdate'
 import { env } from 'libs/environment'
 import { useLogTypeFromRemoteConfig } from 'libs/hooks/useLogTypeFromRemoteConfig'
@@ -46,7 +46,7 @@ export function CheatcodesMenu(): React.JSX.Element {
     setScreenError(new ScreenError('Test force update page', { Screen: ForceUpdate, logType }))
   }
 
-  const featuresButtons: ButtonsWithSubscreensProps[] = [
+  const featuresButtons: CheatcodesButtonsWithSubscreensProps[] = [
     ...cheatcodesNavigationAchievementsButtons,
     ...cheatcodesNavigationBookOfferButtons,
     ...cheatcodesNavigationCulturalSurveyButtons,
@@ -61,7 +61,7 @@ export function CheatcodesMenu(): React.JSX.Element {
     { title: 'Share 🔗', screen: 'CheatcodesNavigationShare' },
   ]
 
-  const otherButtons: ButtonsWithSubscreensProps[] = [
+  const otherButtons: CheatcodesButtonsWithSubscreensProps[] = [
     { title: 'Nouvelle-Calédonie 🇳🇨', screen: 'CheatcodesScreenNewCaledonia' },
     { title: 'Features flags 🏳️', screen: 'CheatcodesScreenFeatureFlags' },
     { title: 'Remote config 📊', screen: 'CheatcodesScreenRemoteConfig' },

--- a/src/cheatcodes/pages/CheatcodesMenu.tsx
+++ b/src/cheatcodes/pages/CheatcodesMenu.tsx
@@ -2,10 +2,21 @@ import React, { useState } from 'react'
 import styled from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
 
+import { CheatcodesButtonList } from 'cheatcodes/components/CheatcodesButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
-import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
+import { filterAndSortCheatcodesButtons } from 'cheatcodes/hooks/filterAndSortCheatcodesButtons'
+import { cheatcodesNavigationAchievementsButtons } from 'cheatcodes/pages/features/achievements/CheatcodesNavigationAchievements'
+import { cheatcodesNavigationBookOfferButtons } from 'cheatcodes/pages/features/bookOffer/CheatcodesNavigationBookOffer'
+import { cheatcodesNavigationCulturalSurveyButtons } from 'cheatcodes/pages/features/culturalSurvey/CheatcodesNavigationCulturalSurvey'
+import { cheatcodesNavigationHomeButtons } from 'cheatcodes/pages/features/home/CheatcodesNavigationHome'
+import { cheatcodesNavigationIdentityCheckButtons } from 'cheatcodes/pages/features/identityCheck/CheatcodesNavigationIdentityCheck'
+import { cheatcodesNavigationInternalButtons } from 'cheatcodes/pages/features/internal/CheatcodesNavigationInternal'
+import { cheatcodesNavigationProfileButtons } from 'cheatcodes/pages/features/profile/CheatcodesNavigationProfile'
+import { cheatcodesNavigationSubscriptionButtons } from 'cheatcodes/pages/features/subscription/CheatcodesNavigationSubscription'
+import { cheatcodesNavigationTrustedDeviceButtons } from 'cheatcodes/pages/features/trustedDevice/CheatcodesNavigationTrustedDevice'
+import { cheatcodesNavigationTutorialButtons } from 'cheatcodes/pages/features/tutorial/CheatcodesNavigationTutorial'
+import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
 import { ForceUpdate } from 'features/forceUpdate/pages/ForceUpdate'
-import { RootScreenNames } from 'features/navigation/RootNavigator/types'
 import { env } from 'libs/environment'
 import { useLogTypeFromRemoteConfig } from 'libs/hooks/useLogTypeFromRemoteConfig'
 import { eventMonitoring } from 'libs/monitoring'
@@ -14,12 +25,6 @@ import { SearchInput } from 'ui/components/inputs/SearchInput'
 import { SeparatorWithText } from 'ui/components/SeparatorWithText'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { getSpacing } from 'ui/theme'
-
-type ButtonProps = {
-  title: string
-  screen?: RootScreenNames
-  onPress?: () => void
-}
 
 export function CheatcodesMenu(): React.JSX.Element {
   const [filter, setFilter] = useState('')
@@ -41,22 +46,22 @@ export function CheatcodesMenu(): React.JSX.Element {
     setScreenError(new ScreenError('Test force update page', { Screen: ForceUpdate, logType }))
   }
 
-  const featuresButtons: ButtonProps[] = [
-    { title: 'Achievements 🏆', screen: 'CheatcodesNavigationAchievements' },
-    { title: 'BookOffer 🎫', screen: 'CheatcodesNavigationBookOffer' },
-    { title: 'Cultural Survey 🎨', screen: 'CheatcodesNavigationCulturalSurvey' },
+  const featuresButtons: ButtonsWithSubscreensProps[] = [
+    ...cheatcodesNavigationAchievementsButtons,
+    ...cheatcodesNavigationBookOfferButtons,
+    ...cheatcodesNavigationCulturalSurveyButtons,
+    ...cheatcodesNavigationHomeButtons,
+    ...cheatcodesNavigationIdentityCheckButtons,
+    ...cheatcodesNavigationInternalButtons,
+    ...cheatcodesNavigationProfileButtons,
+    ...cheatcodesNavigationSubscriptionButtons,
+    ...cheatcodesNavigationTrustedDeviceButtons,
+    ...cheatcodesNavigationTutorialButtons,
     { title: 'ForceUpdate 🆙', onPress: onPressForceUpdate },
-    { title: 'Home 🏠', screen: 'CheatcodesNavigationHome' },
-    { title: 'IdentityCheck 🎨', screen: 'CheatcodesNavigationIdentityCheck' },
-    { title: 'Internal (Marketing) 🎯', screen: 'CheatcodesNavigationInternal' },
-    { title: 'Profile 👤', screen: 'CheatcodesNavigationProfile' },
     { title: 'Share 🔗', screen: 'CheatcodesNavigationShare' },
-    { title: 'Subscription 🔔', screen: 'CheatcodesNavigationSubscription' },
-    { title: 'Trusted device 📱', screen: 'CheatcodesNavigationTrustedDevice' },
-    { title: 'Tutorial ❔', screen: 'CheatcodesNavigationTutorial' },
   ]
 
-  const otherButtons: ButtonProps[] = [
+  const otherButtons: ButtonsWithSubscreensProps[] = [
     { title: 'Nouvelle-Calédonie 🇳🇨', screen: 'CheatcodesScreenNewCaledonia' },
     { title: 'Features flags 🏳️', screen: 'CheatcodesScreenFeatureFlags' },
     { title: 'Remote config 📊', screen: 'CheatcodesScreenRemoteConfig' },
@@ -71,13 +76,8 @@ export function CheatcodesMenu(): React.JSX.Element {
 
   if (screenError) throw screenError
 
-  const filteredFeaturesButtons = featuresButtons
-    .filter((button) => button.title.toLowerCase().includes(filter.toLowerCase()))
-    .sort((a, b) => a.title.localeCompare(b.title))
-
-  const filteredOtherButtons = otherButtons
-    .filter((button) => button.title.toLowerCase().includes(filter.toLowerCase()))
-    .sort((a, b) => a.title.localeCompare(b.title))
+  const filteredFeaturesButtons = filterAndSortCheatcodesButtons(filter, featuresButtons)
+  const filteredOtherButtons = filterAndSortCheatcodesButtons(filter, otherButtons)
 
   return (
     <CheatcodesTemplateScreen title="Cheatcodes">
@@ -87,32 +87,14 @@ export function CheatcodesMenu(): React.JSX.Element {
         onChangeText={setFilter}
         onPressRightIcon={resetSearch}
       />
-
       <StyledView>
         <SeparatorWithText label="FEATURES" />
       </StyledView>
-
-      {filteredFeaturesButtons.map((button, index) => (
-        <LinkToScreen
-          key={index}
-          title={button.title}
-          screen={button.screen}
-          onPress={button.onPress}
-        />
-      ))}
-
+      <CheatcodesButtonList buttons={filteredFeaturesButtons} />
       <StyledView>
         <SeparatorWithText label="AUTRES" />
       </StyledView>
-
-      {filteredOtherButtons.map((button, index) => (
-        <LinkToScreen
-          key={index}
-          title={button.title}
-          screen={button.screen}
-          onPress={button.onPress}
-        />
-      ))}
+      <CheatcodesButtonList buttons={filteredOtherButtons} />
     </CheatcodesTemplateScreen>
   )
 }

--- a/src/cheatcodes/pages/CheatcodesMenu.tsx
+++ b/src/cheatcodes/pages/CheatcodesMenu.tsx
@@ -30,8 +30,8 @@ import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/S
 import { getSpacing } from 'ui/theme'
 
 export function CheatcodesMenu(): React.JSX.Element {
-  const [filter, setFilter] = useState('')
-  const resetSearch = () => setFilter('')
+  const [searchValue, setSearchValue] = useState('')
+  const resetSearch = () => setSearchValue('')
 
   const { showInfoSnackBar } = useSnackBarContext()
   const onPressSentry = () => {
@@ -79,15 +79,15 @@ export function CheatcodesMenu(): React.JSX.Element {
 
   if (screenError) throw screenError
 
-  const filteredFeaturesButtons = filterAndSortCheatcodesButtons(filter, featuresButtons)
-  const filteredOtherButtons = filterAndSortCheatcodesButtons(filter, otherButtons)
+  const filteredFeaturesButtons = filterAndSortCheatcodesButtons(searchValue, featuresButtons)
+  const filteredOtherButtons = filterAndSortCheatcodesButtons(searchValue, otherButtons)
 
   return (
     <CheatcodesTemplateScreen title="Cheatcodes">
       <StyledSearchInput
         placeholder="Rechercher..."
-        value={filter}
-        onChangeText={setFilter}
+        value={searchValue}
+        onChangeText={setSearchValue}
         onPressRightIcon={resetSearch}
       />
       <StyledView>

--- a/src/cheatcodes/pages/CheatcodesMenu.tsx
+++ b/src/cheatcodes/pages/CheatcodesMenu.tsx
@@ -15,6 +15,9 @@ import { cheatcodesNavigationProfileButtons } from 'cheatcodes/pages/features/pr
 import { cheatcodesNavigationSubscriptionButtons } from 'cheatcodes/pages/features/subscription/CheatcodesNavigationSubscription'
 import { cheatcodesNavigationTrustedDeviceButtons } from 'cheatcodes/pages/features/trustedDevice/CheatcodesNavigationTrustedDevice'
 import { cheatcodesNavigationTutorialButtons } from 'cheatcodes/pages/features/tutorial/CheatcodesNavigationTutorial'
+import { cheatcodesNavigationAccountManagementButtons } from 'cheatcodes/pages/others/CheatcodesNavigationAccountManagement'
+import { cheatcodesNavigationErrorsButtons } from 'cheatcodes/pages/others/CheatcodesNavigationErrors'
+import { cheatcodesNavigationSignUpButtons } from 'cheatcodes/pages/others/CheatcodesNavigationSignUp'
 import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 import { ForceUpdate } from 'features/forceUpdate/pages/ForceUpdate'
 import { env } from 'libs/environment'
@@ -62,16 +65,16 @@ export function CheatcodesMenu(): React.JSX.Element {
   ]
 
   const otherButtons: CheatcodesButtonsWithSubscreensProps[] = [
-    { title: 'Nouvelle-Calédonie 🇳🇨', screen: 'CheatcodesScreenNewCaledonia' },
-    { title: 'Features flags 🏳️', screen: 'CheatcodesScreenFeatureFlags' },
-    { title: 'Remote config 📊', screen: 'CheatcodesScreenRemoteConfig' },
-    { title: 'Debug informations 🪲', screen: 'CheatcodesScreenDebugInformations' },
-    { title: 'Errors 👾', screen: 'CheatcodesNavigationErrors' },
-    { title: 'Pages non écrans ❌', screen: 'CheatcodesNavigationNotScreensPages' },
+    ...cheatcodesNavigationAccountManagementButtons,
+    ...cheatcodesNavigationErrorsButtons,
+    ...cheatcodesNavigationSignUpButtons,
     { title: 'AccesLibre 🌈', screen: 'CheatcodesScreenAccesLibre' },
-    { title: 'SignUp 🎨', screen: 'CheatcodesNavigationSignUp' },
-    { title: 'Account Management ⚙️', screen: 'CheatcodesNavigationAccountManagement' },
+    { title: 'Debug informations 🪲', screen: 'CheatcodesScreenDebugInformations' },
     { title: 'Envoyer une erreur Sentry 📤', onPress: onPressSentry },
+    { title: 'Features flags 🏳️', screen: 'CheatcodesScreenFeatureFlags' },
+    { title: 'Nouvelle-Calédonie 🇳🇨', screen: 'CheatcodesScreenNewCaledonia' },
+    { title: 'Pages non écrans ❌', screen: 'CheatcodesNavigationNotScreensPages' },
+    { title: 'Remote config 📊', screen: 'CheatcodesScreenRemoteConfig' },
   ]
 
   if (screenError) throw screenError

--- a/src/cheatcodes/pages/features/achievements/CheatcodesNavigationAchievements.tsx
+++ b/src/cheatcodes/pages/features/achievements/CheatcodesNavigationAchievements.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 
+import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
+import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
 import {
   userCompletedBookBooking,
   userCompletedMovieBooking,
@@ -9,12 +11,21 @@ import {
 import { AchievementSuccessModal } from 'features/achievements/pages/AchievementSuccessModal'
 import { useModal } from 'ui/components/modals/useModal'
 
+export const cheatcodesNavigationAchievementsButtons: [ButtonsWithSubscreensProps] = [
+  {
+    title: 'Achievements 🏆',
+    screen: 'CheatcodesNavigationAchievements',
+    subscreens: [{ screen: 'Achievements', navigationParams: { from: 'cheatcodes' } }],
+  },
+]
+
 export function CheatcodesNavigationAchievements(): React.JSX.Element {
   const {
     visible: visibleOneAchievement,
     showModal: showModalOneAchievement,
     hideModal: hideModalOneAchievement,
   } = useModal(false)
+
   const {
     visible: visibleSeveralAchievements,
     showModal: showModalSeveralAchievements,
@@ -22,8 +33,9 @@ export function CheatcodesNavigationAchievements(): React.JSX.Element {
   } = useModal(false)
 
   return (
-    <CheatcodesTemplateScreen title="Achievements 🏆">
-      <LinkToScreen screen="Achievements" navigationParams={{ from: 'cheatcodes' }} />
+    <CheatcodesTemplateScreen title={cheatcodesNavigationAchievementsButtons[0].title}>
+      <CheatcodesSubscreensButtonList buttons={cheatcodesNavigationAchievementsButtons} />
+
       <LinkToScreen
         title="AchievementSuccessModal (1 unlocked)"
         onPress={showModalOneAchievement}
@@ -33,6 +45,7 @@ export function CheatcodesNavigationAchievements(): React.JSX.Element {
         visible={visibleOneAchievement}
         hideModal={hideModalOneAchievement}
       />
+
       <LinkToScreen
         title="AchievementSuccessModal (2+ unlocked)"
         onPress={showModalSeveralAchievements}

--- a/src/cheatcodes/pages/features/achievements/CheatcodesNavigationAchievements.tsx
+++ b/src/cheatcodes/pages/features/achievements/CheatcodesNavigationAchievements.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
-import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 import {
   userCompletedBookBooking,
   userCompletedMovieBooking,
@@ -11,7 +11,7 @@ import {
 import { AchievementSuccessModal } from 'features/achievements/pages/AchievementSuccessModal'
 import { useModal } from 'ui/components/modals/useModal'
 
-export const cheatcodesNavigationAchievementsButtons: [ButtonsWithSubscreensProps] = [
+export const cheatcodesNavigationAchievementsButtons: [CheatcodesButtonsWithSubscreensProps] = [
   {
     title: 'Achievements 🏆',
     screen: 'CheatcodesNavigationAchievements',

--- a/src/cheatcodes/pages/features/bookOffer/CheatcodesNavigationBookOffer.tsx
+++ b/src/cheatcodes/pages/features/bookOffer/CheatcodesNavigationBookOffer.tsx
@@ -1,15 +1,23 @@
 import React from 'react'
 
+import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
-import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
+import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+
+export const cheatcodesNavigationBookOfferButtons: [ButtonsWithSubscreensProps] = [
+  {
+    title: 'BookOffer 🎫',
+    screen: 'CheatcodesNavigationBookOffer',
+    subscreens: [
+      { screen: 'BookingConfirmation', navigationParams: { offerId: 11224, bookingId: 1240 } },
+    ],
+  },
+]
 
 export function CheatcodesNavigationBookOffer(): React.JSX.Element {
   return (
-    <CheatcodesTemplateScreen title="Internal (Maketing) 🎯">
-      <LinkToScreen
-        screen="BookingConfirmation"
-        navigationParams={{ offerId: 11224, bookingId: 1240 }}
-      />
+    <CheatcodesTemplateScreen title={cheatcodesNavigationBookOfferButtons[0].title}>
+      <CheatcodesSubscreensButtonList buttons={cheatcodesNavigationBookOfferButtons} />
     </CheatcodesTemplateScreen>
   )
 }

--- a/src/cheatcodes/pages/features/bookOffer/CheatcodesNavigationBookOffer.tsx
+++ b/src/cheatcodes/pages/features/bookOffer/CheatcodesNavigationBookOffer.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 
 import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
-import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 
-export const cheatcodesNavigationBookOfferButtons: [ButtonsWithSubscreensProps] = [
+export const cheatcodesNavigationBookOfferButtons: [CheatcodesButtonsWithSubscreensProps] = [
   {
     title: 'BookOffer 🎫',
     screen: 'CheatcodesNavigationBookOffer',

--- a/src/cheatcodes/pages/features/culturalSurvey/CheatcodesNavigationCulturalSurvey.tsx
+++ b/src/cheatcodes/pages/features/culturalSurvey/CheatcodesNavigationCulturalSurvey.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 
 import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
-import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 
-export const cheatcodesNavigationCulturalSurveyButtons: [ButtonsWithSubscreensProps] = [
+export const cheatcodesNavigationCulturalSurveyButtons: [CheatcodesButtonsWithSubscreensProps] = [
   {
     title: 'CulturalSurvey 🎨',
     screen: 'CheatcodesNavigationCulturalSurvey',

--- a/src/cheatcodes/pages/features/culturalSurvey/CheatcodesNavigationCulturalSurvey.tsx
+++ b/src/cheatcodes/pages/features/culturalSurvey/CheatcodesNavigationCulturalSurvey.tsx
@@ -1,14 +1,25 @@
 import React from 'react'
 
+import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
-import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
+import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+
+export const cheatcodesNavigationCulturalSurveyButtons: [ButtonsWithSubscreensProps] = [
+  {
+    title: 'CulturalSurvey 🎨',
+    screen: 'CheatcodesNavigationCulturalSurvey',
+    subscreens: [
+      { screen: 'CulturalSurveyIntro' },
+      { screen: 'CulturalSurveyQuestions' },
+      { screen: 'CulturalSurveyThanks' },
+    ],
+  },
+]
 
 export function CheatcodesNavigationCulturalSurvey(): React.JSX.Element {
   return (
-    <CheatcodesTemplateScreen title="CulturalSurvey 🎨">
-      <LinkToScreen screen="CulturalSurveyIntro" />
-      <LinkToScreen screen="CulturalSurveyQuestions" />
-      <LinkToScreen screen="CulturalSurveyThanks" />
+    <CheatcodesTemplateScreen title={cheatcodesNavigationCulturalSurveyButtons[0].title}>
+      <CheatcodesSubscreensButtonList buttons={cheatcodesNavigationCulturalSurveyButtons} />
     </CheatcodesTemplateScreen>
   )
 }

--- a/src/cheatcodes/pages/features/home/CheatcodesNavigationHome.tsx
+++ b/src/cheatcodes/pages/features/home/CheatcodesNavigationHome.tsx
@@ -1,26 +1,28 @@
-import { useNavigation } from '@react-navigation/native'
 import React from 'react'
 
+import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
-import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
-import { UseNavigationType } from 'features/navigation/RootNavigator/types'
+import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+
+export const cheatcodesNavigationHomeButtons: [ButtonsWithSubscreensProps] = [
+  {
+    title: 'Home 🏠',
+    screen: 'CheatcodesNavigationHome',
+    subscreens: [
+      {
+        title: 'HighlightThematicHomeHeader',
+        screen: 'CheatcodesScreenHighlightThematicHomeHeader',
+      },
+      { title: 'DefaultThematicHomeHeader', screen: 'CheatcodesScreenDefaultThematicHomeHeader' },
+      { title: 'CategoryThematicHomeHeader', screen: 'CheatcodesScreenCategoryThematicHomeHeader' },
+    ],
+  },
+]
 
 export const CheatcodesNavigationHome = () => {
-  const { navigate } = useNavigation<UseNavigationType>()
   return (
-    <CheatcodesTemplateScreen title="Home 🏠">
-      <LinkToScreen
-        title="HighlightThematicHomeHeader"
-        onPress={() => navigate('CheatcodesScreenHighlightThematicHomeHeader')}
-      />
-      <LinkToScreen
-        title="DefaultThematicHomeHeader"
-        onPress={() => navigate('CheatcodesScreenDefaultThematicHomeHeader')}
-      />
-      <LinkToScreen
-        title="CategoryThematicHomeHeader"
-        onPress={() => navigate('CheatcodesScreenCategoryThematicHomeHeader')}
-      />
+    <CheatcodesTemplateScreen title={cheatcodesNavigationHomeButtons[0].title}>
+      <CheatcodesSubscreensButtonList buttons={cheatcodesNavigationHomeButtons} />
     </CheatcodesTemplateScreen>
   )
 }

--- a/src/cheatcodes/pages/features/home/CheatcodesNavigationHome.tsx
+++ b/src/cheatcodes/pages/features/home/CheatcodesNavigationHome.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 
 import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
-import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 
-export const cheatcodesNavigationHomeButtons: [ButtonsWithSubscreensProps] = [
+export const cheatcodesNavigationHomeButtons: [CheatcodesButtonsWithSubscreensProps] = [
   {
     title: 'Home 🏠',
     screen: 'CheatcodesNavigationHome',

--- a/src/cheatcodes/pages/features/identityCheck/CheatcodesNavigationIdentityCheck.tsx
+++ b/src/cheatcodes/pages/features/identityCheck/CheatcodesNavigationIdentityCheck.tsx
@@ -1,8 +1,10 @@
 import { useNavigation } from '@react-navigation/native'
 import React, { useState } from 'react'
 
+import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
+import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
 import { NotEligibleEduConnect } from 'features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect'
 import { EduConnectErrorMessageEnum } from 'features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData'
 import { PhoneValidationTipsModal } from 'features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal'
@@ -10,6 +12,43 @@ import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { useLogTypeFromRemoteConfig } from 'libs/hooks/useLogTypeFromRemoteConfig'
 import { ScreenError } from 'libs/monitoring/errors'
 import { Spacer } from 'ui/theme'
+
+export const cheatcodesNavigationIdentityCheckButtons: [ButtonsWithSubscreensProps] = [
+  {
+    title: 'IdentityCheck 🎨',
+    screen: 'CheatcodesNavigationIdentityCheck',
+    subscreens: [
+      { title: 'NewIdentificationFlow 🎨', screen: 'CheatcodesNavigationNewIdentificationFlow' },
+      { screen: 'Stepper' },
+      { screen: 'PhoneValidationTooManyAttempts' },
+      { screen: 'PhoneValidationTooManySMSSent' },
+      { screen: 'SetPhoneNumber' },
+      { screen: 'SetPhoneNumberWithoutValidation' },
+      { screen: 'SetPhoneValidationCode' },
+      { screen: 'SetStatus' },
+      { screen: 'IdentityCheckUnavailable' },
+      { screen: 'IdentityCheckPending' },
+      { screen: 'SetName' },
+      { screen: 'SetAddress' },
+      { screen: 'SetCity' },
+      { screen: 'IdentityCheckEnd' },
+      { screen: 'IdentityCheckHonor' },
+      { screen: 'EduConnectForm' },
+      { screen: 'IdentityCheckDMS' },
+      { screen: 'VerifyEligibility' },
+      { screen: 'BeneficiaryRequestSent' },
+      { screen: 'IdentificationFork' },
+      {
+        screen: 'EduConnectValidation',
+        navigationParams: {
+          firstName: 'firstName',
+          lastName: 'lastName',
+          dateOfBirth: '2021-12-01',
+        },
+      },
+    ],
+  },
+]
 
 export function CheatcodesNavigationIdentityCheck(): React.JSX.Element {
   const [screenError, setScreenError] = useState<ScreenError | undefined>(undefined)
@@ -29,68 +68,44 @@ export function CheatcodesNavigationIdentityCheck(): React.JSX.Element {
   if (screenError) throw screenError
 
   return (
-    <CheatcodesTemplateScreen title="IdentityCheck 🎨">
-      <LinkToScreen
-        title="NewIdentificationFlow 🎨"
-        screen="CheatcodesNavigationNewIdentificationFlow"
-      />
-      <LinkToScreen screen="Stepper" />
-      <LinkToScreen screen="PhoneValidationTooManyAttempts" />
-      <LinkToScreen screen="PhoneValidationTooManySMSSent" />
-      <LinkToScreen screen="SetPhoneNumber" />
-      <LinkToScreen screen="SetPhoneNumberWithoutValidation" />
+    <CheatcodesTemplateScreen title={cheatcodesNavigationIdentityCheckButtons[0].title}>
+      <CheatcodesSubscreensButtonList buttons={cheatcodesNavigationIdentityCheckButtons} />
+
       <LinkToScreen
         title="PhoneValidation tips Modal"
         onPress={() => setPhoneValidationTipsModalVisible(true)}
       />
-      <LinkToScreen screen="SetPhoneValidationCode" />
-      <LinkToScreen screen="SetStatus" />
-      <LinkToScreen screen="IdentityCheckUnavailable" />
-      <LinkToScreen screen="IdentityCheckPending" />
-      <LinkToScreen screen="SetName" />
-      <LinkToScreen screen="SetAddress" />
-      <LinkToScreen screen="SetCity" />
-      <LinkToScreen screen="IdentityCheckEnd" />
-      <LinkToScreen screen="IdentityCheckHonor" />
-      <LinkToScreen screen="EduConnectForm" />
-      <LinkToScreen screen="IdentityCheckDMS" />
-      <LinkToScreen
-        screen="EduConnectValidation"
-        navigationParams={{
-          firstName: 'firstName',
-          lastName: 'lastName',
-          dateOfBirth: '2021-12-01',
-        }}
-      />
-      <LinkToScreen
-        title="UserAgeNotValid Educonnect Error"
-        onPress={() => trigger(EduConnectErrorMessageEnum.UserAgeNotValid)}
-      />
-      <LinkToScreen
-        title="UserAgeNotValid18YearsOld Error"
-        onPress={() => trigger(EduConnectErrorMessageEnum.UserAgeNotValid18YearsOld)}
-      />
-      <LinkToScreen
-        title="UserTypeNotStudent Error"
-        onPress={() => trigger(EduConnectErrorMessageEnum.UserTypeNotStudent)}
-      />
-      <LinkToScreen
-        title="DuplicateUser Error"
-        onPress={() => trigger(EduConnectErrorMessageEnum.DuplicateUser)}
-      />
-      <LinkToScreen
-        title="Generic Error"
-        onPress={() => trigger(EduConnectErrorMessageEnum.GenericError)}
-      />
-      <LinkToScreen screen="VerifyEligibility" />
-      <LinkToScreen screen="BeneficiaryRequestSent" />
-      <LinkToScreen screen="IdentificationFork" />
-      <Spacer.BottomScreen />
       <PhoneValidationTipsModal
         isVisible={phoneValidationTipsModalVisible}
         dismissModal={() => setPhoneValidationTipsModalVisible(false)}
         onGoBack={() => navigate('CheatcodesNavigationIdentityCheck')}
       />
+
+      <LinkToScreen
+        title="UserAgeNotValid Educonnect Error"
+        onPress={() => trigger(EduConnectErrorMessageEnum.UserAgeNotValid)}
+      />
+
+      <LinkToScreen
+        title="UserAgeNotValid18YearsOld Error"
+        onPress={() => trigger(EduConnectErrorMessageEnum.UserAgeNotValid18YearsOld)}
+      />
+
+      <LinkToScreen
+        title="UserTypeNotStudent Error"
+        onPress={() => trigger(EduConnectErrorMessageEnum.UserTypeNotStudent)}
+      />
+
+      <LinkToScreen
+        title="DuplicateUser Error"
+        onPress={() => trigger(EduConnectErrorMessageEnum.DuplicateUser)}
+      />
+
+      <LinkToScreen
+        title="Generic Error"
+        onPress={() => trigger(EduConnectErrorMessageEnum.GenericError)}
+      />
+      <Spacer.BottomScreen />
     </CheatcodesTemplateScreen>
   )
 }

--- a/src/cheatcodes/pages/features/identityCheck/CheatcodesNavigationIdentityCheck.tsx
+++ b/src/cheatcodes/pages/features/identityCheck/CheatcodesNavigationIdentityCheck.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react'
 import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
-import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 import { NotEligibleEduConnect } from 'features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect'
 import { EduConnectErrorMessageEnum } from 'features/identityCheck/pages/identification/errors/hooks/useNotEligibleEduConnectErrorData'
 import { PhoneValidationTipsModal } from 'features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal'
@@ -13,7 +13,7 @@ import { useLogTypeFromRemoteConfig } from 'libs/hooks/useLogTypeFromRemoteConfi
 import { ScreenError } from 'libs/monitoring/errors'
 import { Spacer } from 'ui/theme'
 
-export const cheatcodesNavigationIdentityCheckButtons: [ButtonsWithSubscreensProps] = [
+export const cheatcodesNavigationIdentityCheckButtons: [CheatcodesButtonsWithSubscreensProps] = [
   {
     title: 'IdentityCheck 🎨',
     screen: 'CheatcodesNavigationIdentityCheck',

--- a/src/cheatcodes/pages/features/internal/CheatcodesNavigationInternal.tsx
+++ b/src/cheatcodes/pages/features/internal/CheatcodesNavigationInternal.tsx
@@ -1,13 +1,21 @@
 import React from 'react'
 
+import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
-import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
+import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+
+export const cheatcodesNavigationInternalButtons: [ButtonsWithSubscreensProps] = [
+  {
+    title: 'Internal (Maketing) 🎯',
+    screen: 'CheatcodesNavigationInternal',
+    subscreens: [{ screen: 'DeeplinksGenerator' }, { screen: 'UTMParameters' }],
+  },
+]
 
 export function CheatcodesNavigationInternal(): React.JSX.Element {
   return (
-    <CheatcodesTemplateScreen title="Internal (Maketing) 🎯">
-      <LinkToScreen screen="DeeplinksGenerator" />
-      <LinkToScreen screen="UTMParameters" />
+    <CheatcodesTemplateScreen title={cheatcodesNavigationInternalButtons[0].title}>
+      <CheatcodesSubscreensButtonList buttons={cheatcodesNavigationInternalButtons} />
     </CheatcodesTemplateScreen>
   )
 }

--- a/src/cheatcodes/pages/features/internal/CheatcodesNavigationInternal.tsx
+++ b/src/cheatcodes/pages/features/internal/CheatcodesNavigationInternal.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 
 import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
-import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 
-export const cheatcodesNavigationInternalButtons: [ButtonsWithSubscreensProps] = [
+export const cheatcodesNavigationInternalButtons: [CheatcodesButtonsWithSubscreensProps] = [
   {
     title: 'Internal (Maketing) 🎯',
     screen: 'CheatcodesNavigationInternal',

--- a/src/cheatcodes/pages/features/profile/CheatcodesNavigationProfile.tsx
+++ b/src/cheatcodes/pages/features/profile/CheatcodesNavigationProfile.tsx
@@ -3,11 +3,11 @@ import React from 'react'
 import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
-import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 import { ExpiredCreditModal } from 'features/profile/components/Modals/ExpiredCreditModal'
 import { useModal } from 'ui/components/modals/useModal'
 
-export const cheatcodesNavigationProfileButtons: [ButtonsWithSubscreensProps] = [
+export const cheatcodesNavigationProfileButtons: [CheatcodesButtonsWithSubscreensProps] = [
   {
     title: 'Profile 🎨',
     screen: 'CheatcodesNavigationProfile',

--- a/src/cheatcodes/pages/features/profile/CheatcodesNavigationProfile.tsx
+++ b/src/cheatcodes/pages/features/profile/CheatcodesNavigationProfile.tsx
@@ -1,9 +1,29 @@
 import React from 'react'
 
+import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
+import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
 import { ExpiredCreditModal } from 'features/profile/components/Modals/ExpiredCreditModal'
 import { useModal } from 'ui/components/modals/useModal'
+
+export const cheatcodesNavigationProfileButtons: [ButtonsWithSubscreensProps] = [
+  {
+    title: 'Profile 🎨',
+    screen: 'CheatcodesNavigationProfile',
+    subscreens: [
+      { screen: 'Login' },
+      { screen: 'FeedbackInApp' },
+      { screen: 'ChangeCity' },
+      { screen: 'ChangeEmail' },
+      { screen: 'ChangeStatus' },
+      { screen: 'ChangeEmailSetPassword', navigationParams: { token: 'token' } },
+      { screen: 'ConsentSettings' },
+      { screen: 'NotificationsSettings' },
+      { screen: 'ChangeEmailExpiredLink' },
+    ],
+  },
+]
 
 export function CheatcodesNavigationProfile(): React.JSX.Element {
   const {
@@ -13,16 +33,9 @@ export function CheatcodesNavigationProfile(): React.JSX.Element {
   } = useModal(false)
 
   return (
-    <CheatcodesTemplateScreen title="Profile 🎨">
-      <LinkToScreen screen="Login" />
-      <LinkToScreen screen="FeedbackInApp" />
-      <LinkToScreen screen="ChangeCity" />
-      <LinkToScreen screen="ChangeEmail" />
-      <LinkToScreen screen="ChangeStatus" />
-      <LinkToScreen screen="ChangeEmailSetPassword" navigationParams={{ token: 'token' }} />
-      <LinkToScreen screen="ConsentSettings" />
-      <LinkToScreen screen="NotificationsSettings" />
-      <LinkToScreen screen="ChangeEmailExpiredLink" />
+    <CheatcodesTemplateScreen title={cheatcodesNavigationProfileButtons[0].title}>
+      <CheatcodesSubscreensButtonList buttons={cheatcodesNavigationProfileButtons} />
+
       <LinkToScreen title="Modal Crédit Expiré" onPress={showExpiredCreditModal} />
       <ExpiredCreditModal visible={expiredCreditModalVisible} hideModal={hideExpiredCreditModal} />
     </CheatcodesTemplateScreen>

--- a/src/cheatcodes/pages/features/subscription/CheatcodesNavigationSubscription.tsx
+++ b/src/cheatcodes/pages/features/subscription/CheatcodesNavigationSubscription.tsx
@@ -1,12 +1,22 @@
 import React from 'react'
 
+import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
+import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
 import { OnboardingSubscriptionModal } from 'features/subscription/components/modals/OnboardingSubscriptionModal'
 import { SubscriptionSuccessModal } from 'features/subscription/components/modals/SubscriptionSuccessModal'
 import { UnsubscribingConfirmationModal } from 'features/subscription/components/modals/UnsubscribingConfirmationModal'
 import { SubscriptionTheme } from 'features/subscription/types'
 import { useModal } from 'ui/components/modals/useModal'
+
+export const cheatcodesNavigationSubscriptionButtons: [ButtonsWithSubscreensProps] = [
+  {
+    title: 'Subscription 🔔',
+    screen: 'CheatcodesNavigationSubscription',
+    subscreens: [{ screen: 'OnboardingSubscription' }],
+  },
+]
 
 export function CheatcodesNavigationSubscription(): React.JSX.Element {
   const {
@@ -51,44 +61,51 @@ export function CheatcodesNavigationSubscription(): React.JSX.Element {
   } = useModal(false)
 
   return (
-    <CheatcodesTemplateScreen title="Subscription 🔔">
-      <LinkToScreen screen="OnboardingSubscription" />
+    <CheatcodesTemplateScreen title={cheatcodesNavigationSubscriptionButtons[0].title}>
+      <CheatcodesSubscreensButtonList buttons={cheatcodesNavigationSubscriptionButtons} />
+
       <LinkToScreen title="Modale Cinéma" onPress={showCinemaModal} />
       <SubscriptionSuccessModal
         theme={SubscriptionTheme.CINEMA}
         visible={cinemaModalVisible}
         dismissModal={hideCinemaModal}
       />
+
       <LinkToScreen title="Modale Lecture" onPress={showLectureModal} />
       <SubscriptionSuccessModal
         theme={SubscriptionTheme.LECTURE}
         visible={lectureModalVisible}
         dismissModal={hideLectureModal}
       />
+
       <LinkToScreen title="Modale Musique" onPress={showMusiqueModal} />
       <SubscriptionSuccessModal
         theme={SubscriptionTheme.MUSIQUE}
         visible={musiqueModalVisible}
         dismissModal={hideMusiqueModal}
       />
+
       <LinkToScreen title="Modale Spectacles" onPress={showSpectaclesModal} />
       <SubscriptionSuccessModal
         theme={SubscriptionTheme.SPECTACLES}
         visible={spectaclesModalVisible}
         dismissModal={hideSpectaclesModal}
       />
+
       <LinkToScreen title="Modale Visites et sorties" onPress={showVisitesModal} />
       <SubscriptionSuccessModal
         theme={SubscriptionTheme.VISITES}
         visible={visitesModalVisible}
         dismissModal={hideVisitesModal}
       />
+
       <LinkToScreen title="Modale Activités créatives" onPress={showActivitesModal} />
       <SubscriptionSuccessModal
         theme={SubscriptionTheme.ACTIVITES}
         visible={activitesModalVisible}
         dismissModal={hideActivitesModal}
       />
+
       <LinkToScreen title="Modale Désinscription" onPress={showUnsubscribingModal} />
       <UnsubscribingConfirmationModal
         theme={SubscriptionTheme.VISITES}
@@ -96,6 +113,7 @@ export function CheatcodesNavigationSubscription(): React.JSX.Element {
         dismissModal={hideUnsubscribingModal}
         onUnsubscribePress={hideUnsubscribingModal}
       />
+
       <LinkToScreen title="Modale Onboarding" onPress={showOnboardingSubModal} />
       <OnboardingSubscriptionModal
         visible={onboardingSubModalVisible}

--- a/src/cheatcodes/pages/features/subscription/CheatcodesNavigationSubscription.tsx
+++ b/src/cheatcodes/pages/features/subscription/CheatcodesNavigationSubscription.tsx
@@ -3,14 +3,14 @@ import React from 'react'
 import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
-import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 import { OnboardingSubscriptionModal } from 'features/subscription/components/modals/OnboardingSubscriptionModal'
 import { SubscriptionSuccessModal } from 'features/subscription/components/modals/SubscriptionSuccessModal'
 import { UnsubscribingConfirmationModal } from 'features/subscription/components/modals/UnsubscribingConfirmationModal'
 import { SubscriptionTheme } from 'features/subscription/types'
 import { useModal } from 'ui/components/modals/useModal'
 
-export const cheatcodesNavigationSubscriptionButtons: [ButtonsWithSubscreensProps] = [
+export const cheatcodesNavigationSubscriptionButtons: [CheatcodesButtonsWithSubscreensProps] = [
   {
     title: 'Subscription 🔔',
     screen: 'CheatcodesNavigationSubscription',

--- a/src/cheatcodes/pages/features/trustedDevice/CheatcodesNavigationTrustedDevice.tsx
+++ b/src/cheatcodes/pages/features/trustedDevice/CheatcodesNavigationTrustedDevice.tsx
@@ -5,14 +5,14 @@ import styled from 'styled-components/native'
 import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
-import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { ROUTE_PARAMS } from 'features/trustedDevice/fixtures/fixtures'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { TextInput } from 'ui/components/inputs/TextInput'
 import { Spacer, getSpacing } from 'ui/theme'
 
-export const cheatcodesNavigationTrustedDeviceButtons: [ButtonsWithSubscreensProps] = [
+export const cheatcodesNavigationTrustedDeviceButtons: [CheatcodesButtonsWithSubscreensProps] = [
   {
     title: 'Trusted device 📱',
     screen: 'CheatcodesNavigationTrustedDevice',

--- a/src/cheatcodes/pages/features/trustedDevice/CheatcodesNavigationTrustedDevice.tsx
+++ b/src/cheatcodes/pages/features/trustedDevice/CheatcodesNavigationTrustedDevice.tsx
@@ -2,13 +2,28 @@ import { useNavigation } from '@react-navigation/native'
 import React, { useState } from 'react'
 import styled from 'styled-components/native'
 
+import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
+import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { ROUTE_PARAMS } from 'features/trustedDevice/fixtures/fixtures'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { TextInput } from 'ui/components/inputs/TextInput'
 import { Spacer, getSpacing } from 'ui/theme'
+
+export const cheatcodesNavigationTrustedDeviceButtons: [ButtonsWithSubscreensProps] = [
+  {
+    title: 'Trusted device 📱',
+    screen: 'CheatcodesNavigationTrustedDevice',
+    subscreens: [
+      { screen: 'CheatcodesScreenTrustedDeviceInfos' },
+      { screen: 'SuspensionChoice' },
+      { screen: 'SuspensionChoiceExpiredLink' },
+      { screen: 'SuspiciousLoginSuspendedAccount' },
+    ],
+  },
+]
 
 export function CheatcodesNavigationTrustedDevice(): React.JSX.Element {
   const [value, setValue] = useState('')
@@ -19,12 +34,11 @@ export function CheatcodesNavigationTrustedDevice(): React.JSX.Element {
   }
 
   return (
-    <CheatcodesTemplateScreen title="Trusted device 📱">
-      <LinkToScreen screen="CheatcodesScreenTrustedDeviceInfos" />
-      <LinkToScreen screen="SuspensionChoice" />
-      <LinkToScreen screen="SuspensionChoiceExpiredLink" />
-      <LinkToScreen screen="SuspiciousLoginSuspendedAccount" />
+    <CheatcodesTemplateScreen title={cheatcodesNavigationTrustedDeviceButtons[0].title}>
+      <CheatcodesSubscreensButtonList buttons={cheatcodesNavigationTrustedDeviceButtons} />
+
       <LinkToScreen screen="AccountSecurity" navigationParams={ROUTE_PARAMS} />
+
       <BufferContainer>
         <ButtonPrimary
           wording="AccountSecurityBuffer"

--- a/src/cheatcodes/pages/features/tutorial/CheatcodesNavigationTutorial.tsx
+++ b/src/cheatcodes/pages/features/tutorial/CheatcodesNavigationTutorial.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 
 import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
-import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 
-export const cheatcodesNavigationTutorialButtons: [ButtonsWithSubscreensProps] = [
+export const cheatcodesNavigationTutorialButtons: [CheatcodesButtonsWithSubscreensProps] = [
   {
     title: 'Tutorial ❔',
     screen: 'CheatcodesNavigationTutorial',

--- a/src/cheatcodes/pages/features/tutorial/CheatcodesNavigationTutorial.tsx
+++ b/src/cheatcodes/pages/features/tutorial/CheatcodesNavigationTutorial.tsx
@@ -1,13 +1,24 @@
 import React from 'react'
 
+import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
-import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
+import { ButtonsWithSubscreensProps } from 'cheatcodes/types'
+
+export const cheatcodesNavigationTutorialButtons: [ButtonsWithSubscreensProps] = [
+  {
+    title: 'Tutorial ❔',
+    screen: 'CheatcodesNavigationTutorial',
+    subscreens: [
+      { title: 'Onboarding  🛶', screen: 'CheatcodesNavigationOnboarding' },
+      { title: 'ProfileTutorial 👤', screen: 'CheatcodesNavigationProfileTutorial' },
+    ],
+  },
+]
 
 export function CheatcodesNavigationTutorial(): React.JSX.Element {
   return (
-    <CheatcodesTemplateScreen title="Tutorial ❔">
-      <LinkToScreen title="Onboarding  🛶" screen="CheatcodesNavigationOnboarding" />
-      <LinkToScreen title="ProfileTutorial 👤" screen="CheatcodesNavigationProfileTutorial" />
+    <CheatcodesTemplateScreen title={cheatcodesNavigationTutorialButtons[0].title}>
+      <CheatcodesSubscreensButtonList buttons={cheatcodesNavigationTutorialButtons} />
     </CheatcodesTemplateScreen>
   )
 }

--- a/src/cheatcodes/pages/others/CheatcodesNavigationAccountManagement.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesNavigationAccountManagement.tsx
@@ -1,26 +1,35 @@
 import React from 'react'
 
+import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
-import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
+
+export const cheatcodesNavigationAccountManagementButtons: [CheatcodesButtonsWithSubscreensProps] =
+  [
+    {
+      title: 'Account Management ⚙️',
+      screen: 'CheatcodesNavigationAccountManagement',
+      subscreens: [
+        { screen: 'FraudulentSuspendedAccount' },
+        { screen: 'SuspendedAccountUponUserRequest' },
+        { screen: 'AccountReactivationSuccess' },
+        { screen: 'DeleteProfileReason' },
+        { screen: 'ConfirmDeleteProfile' },
+        { screen: 'DeactivateProfileSuccess' },
+        { screen: 'DeleteProfileSuccess' },
+        { screen: 'DeleteProfileConfirmation' },
+        { screen: 'ResetPasswordExpiredLink' },
+        { screen: 'DeleteProfileAccountNotDeletable' },
+        { screen: 'DeleteProfileAccountHacked' },
+        { screen: 'ResetPasswordEmailSent', navigationParams: { email: 'jean.dupont@gmail.com' } },
+      ],
+    },
+  ]
 
 export function CheatcodesNavigationAccountManagement(): React.JSX.Element {
   return (
-    <CheatcodesTemplateScreen title="Account Management ⚙️">
-      <LinkToScreen screen="FraudulentSuspendedAccount" />
-      <LinkToScreen screen="SuspendedAccountUponUserRequest" />
-      <LinkToScreen screen="AccountReactivationSuccess" />
-      <LinkToScreen screen="DeleteProfileReason" />
-      <LinkToScreen screen="ConfirmDeleteProfile" />
-      <LinkToScreen screen="DeactivateProfileSuccess" />
-      <LinkToScreen screen="DeleteProfileSuccess" />
-      <LinkToScreen screen="DeleteProfileConfirmation" />
-      <LinkToScreen screen="ResetPasswordExpiredLink" />
-      <LinkToScreen
-        screen="ResetPasswordEmailSent"
-        navigationParams={{ email: 'jean.dupont@gmail.com' }}
-      />
-      <LinkToScreen screen="DeleteProfileAccountNotDeletable" />
-      <LinkToScreen screen="DeleteProfileAccountHacked" />
+    <CheatcodesTemplateScreen title={cheatcodesNavigationAccountManagementButtons[0].title}>
+      <CheatcodesSubscreensButtonList buttons={cheatcodesNavigationAccountManagementButtons} />
     </CheatcodesTemplateScreen>
   )
 }

--- a/src/cheatcodes/pages/others/CheatcodesNavigationErrors.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesNavigationErrors.tsx
@@ -3,8 +3,10 @@ import React, { createElement, FunctionComponent, useState } from 'react'
 import { useQuery } from 'react-query'
 import styled from 'styled-components/native'
 
+import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 import { NoContentError } from 'features/home/pages/NoContentError'
 import { Maintenance } from 'features/maintenance/pages/Maintenance'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
@@ -13,6 +15,14 @@ import { AsyncError, ScreenError } from 'libs/monitoring'
 import { LogTypeEnum } from 'libs/monitoring/errors'
 import { QueryKeys } from 'libs/queryKeys'
 import { Typo } from 'ui/theme'
+
+export const cheatcodesNavigationErrorsButtons: [CheatcodesButtonsWithSubscreensProps] = [
+  {
+    title: 'Errors 👾',
+    screen: 'CheatcodesNavigationErrors',
+    subscreens: [{ screen: 'BannedCountryError' }],
+  },
+]
 
 const MAX_ASYNC_TEST_REQ_COUNT = 3
 
@@ -26,10 +36,7 @@ export const CheatcodesNavigationErrors: FunctionComponent = () => {
   const { refetch: errorAsyncQuery, isFetching } = useQuery(
     [QueryKeys.ERROR_ASYNC],
     () => errorAsync(),
-    {
-      cacheTime: 0,
-      enabled: false,
-    }
+    { cacheTime: 0, enabled: false }
   )
 
   async function errorAsync() {
@@ -48,8 +55,9 @@ export const CheatcodesNavigationErrors: FunctionComponent = () => {
   }
 
   return (
-    <CheatcodesTemplateScreen title="Errors 👾">
-      <LinkToScreen screen="BannedCountryError" />
+    <CheatcodesTemplateScreen title={cheatcodesNavigationErrorsButtons[0].title}>
+      <CheatcodesSubscreensButtonList buttons={cheatcodesNavigationErrorsButtons} />
+
       <LinkToScreen
         title={
           asyncTestReqCount < MAX_ASYNC_TEST_REQ_COUNT
@@ -59,6 +67,7 @@ export const CheatcodesNavigationErrors: FunctionComponent = () => {
         disabled={isFetching || asyncTestReqCount >= MAX_ASYNC_TEST_REQ_COUNT}
         onPress={() => errorAsyncQuery()}
       />
+
       <LinkToScreen
         title="Contentful KO error"
         onPress={() =>
@@ -70,10 +79,12 @@ export const CheatcodesNavigationErrors: FunctionComponent = () => {
           )
         }
       />
+
       <LinkToScreen
         title="Offre inexistante"
         onPress={() => navigate('Offer', { id: 0, from: 'searchresults' })}
       />
+
       <LinkToScreen
         title="Maintenance Page"
         onPress={() =>
@@ -87,6 +98,7 @@ export const CheatcodesNavigationErrors: FunctionComponent = () => {
           )
         }
       />
+
       <LinkToScreen
         title="Erreur rendering"
         onPress={() => {

--- a/src/cheatcodes/pages/others/CheatcodesNavigationSignUp.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesNavigationSignUp.tsx
@@ -1,14 +1,43 @@
 import React from 'react'
 
+import { CheatcodesSubscreensButtonList } from 'cheatcodes/components/CheatcodesSubscreenButtonList'
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { LinkToScreen } from 'cheatcodes/components/LinkToScreen'
 import { useSomeOfferId } from 'cheatcodes/hooks/useSomeOfferId'
+import { CheatcodesButtonsWithSubscreensProps } from 'cheatcodes/types'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
 import { ApplicationProcessingModal } from 'shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal'
 import { AuthenticationModal } from 'shared/offer/components/AuthenticationModal/AuthenticationModal'
 import { ErrorApplicationModal } from 'shared/offer/components/ErrorApplicationModal/ErrorApplicationModal'
 import { FinishSubscriptionModal } from 'shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal'
 import { useModal } from 'ui/components/modals/useModal'
+
+export const cheatcodesNavigationSignUpButtons: [CheatcodesButtonsWithSubscreensProps] = [
+  {
+    title: 'SignUp 🎨',
+    screen: 'CheatcodesNavigationSignUp',
+    subscreens: [
+      { screen: 'AccountCreated' },
+      { screen: 'BeneficiaryAccountCreated' },
+      { screen: 'SignupConfirmationExpiredLink', navigationParams: { email: 'john@wick.com' } },
+      {
+        screen: 'NotYetUnderageEligibility',
+        navigationParams: {
+          eligibilityStartDatetime: new Date('2019-12-01T00:00:00Z').toString(),
+        },
+      },
+
+      {
+        screen: 'AfterSignupEmailValidationBuffer',
+        navigationParams: {
+          token: 'whichTokenDoYouWantReally',
+          expiration_timestamp: 456789123,
+          email: 'john@wick.com',
+        },
+      },
+    ],
+  },
+]
 
 export function CheatcodesNavigationSignUp(): React.JSX.Element {
   const offerId = useSomeOfferId()
@@ -38,33 +67,16 @@ export function CheatcodesNavigationSignUp(): React.JSX.Element {
   } = useModal(false)
 
   return (
-    <CheatcodesTemplateScreen title="SignUp 🎨">
-      <LinkToScreen
-        screen="SignupConfirmationExpiredLink"
-        navigationParams={{ email: 'john@wick.com' }}
-      />
-      <LinkToScreen
-        screen="AfterSignupEmailValidationBuffer"
-        navigationParams={{
-          token: 'whichTokenDoYouWantReally',
-          expiration_timestamp: 456789123,
-          email: 'john@wick.com',
-        }}
-      />
-      <LinkToScreen screen="AccountCreated" />
-      <LinkToScreen screen="BeneficiaryAccountCreated" />
-      <LinkToScreen
-        screen="NotYetUnderageEligibility"
-        navigationParams={{
-          eligibilityStartDatetime: new Date('2019-12-01T00:00:00Z').toString(),
-        }}
-      />
+    <CheatcodesTemplateScreen title={cheatcodesNavigationSignUpButtons[0].title}>
+      <CheatcodesSubscreensButtonList buttons={cheatcodesNavigationSignUpButtons} />
+
       <LinkToScreen title="Finish subscription modal" onPress={showFinishSubscriptionModal} />
       <FinishSubscriptionModal
         visible={finishSubscriptionModalVisible}
         hideModal={hideFinishSubscriptionModal}
         from={StepperOrigin.OFFER}
       />
+
       <LinkToScreen title="Authentication modal from offer" onPress={showAuthenticationModal} />
       <AuthenticationModal
         visible={authenticationModalVisible}
@@ -72,12 +84,14 @@ export function CheatcodesNavigationSignUp(): React.JSX.Element {
         offerId={offerId}
         from={StepperOrigin.FAVORITE}
       />
+
       <LinkToScreen title="Application Processing Modal" onPress={showApplicationProcessingModal} />
       <ApplicationProcessingModal
         visible={applicationProcessingModalVisible}
         hideModal={hideApplicationProcessingModal}
         offerId={offerId}
       />
+
       <LinkToScreen title="Error Application Modal" onPress={showErrorApplicationModal} />
       <ErrorApplicationModal
         visible={errorApplicationModalVisible}

--- a/src/cheatcodes/types.ts
+++ b/src/cheatcodes/types.ts
@@ -1,13 +1,13 @@
 import { RootScreenNames, RootStackParamList } from 'features/navigation/RootNavigator/types'
 
-export type ButtonProps = {
+type CheatcodesButtonProps = {
   title?: string
   screen?: RootScreenNames
   onPress?: () => void
   navigationParams?: RootStackParamList[RootScreenNames]
 }
 
-export type ButtonsWithSubscreensProps = Omit<ButtonProps, 'title'> & {
+export type CheatcodesButtonsWithSubscreensProps = Omit<CheatcodesButtonProps, 'title'> & {
   title: string
-  subscreens?: ButtonProps[]
+  subscreens?: CheatcodesButtonProps[]
 }

--- a/src/cheatcodes/types.ts
+++ b/src/cheatcodes/types.ts
@@ -1,0 +1,12 @@
+import { RootScreenNames, RootStackParamList } from 'features/navigation/RootNavigator/types'
+
+export type ButtonProps = {
+  title?: string
+  screen?: RootScreenNames
+  onPress?: () => void
+  navigationParams?: RootStackParamList[RootScreenNames]
+}
+
+export type ButtonsWithSubscreensProps = ButtonProps & {
+  subscreens?: ButtonProps[]
+}

--- a/src/cheatcodes/types.ts
+++ b/src/cheatcodes/types.ts
@@ -7,6 +7,7 @@ export type ButtonProps = {
   navigationParams?: RootStackParamList[RootScreenNames]
 }
 
-export type ButtonsWithSubscreensProps = ButtonProps & {
+export type ButtonsWithSubscreensProps = Omit<ButtonProps, 'title'> & {
+  title: string
   subscreens?: ButtonProps[]
 }


### PR DESCRIPTION
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |   ![Capture d’écran 2025-01-06 à 17 47 12](https://github.com/user-attachments/assets/e7d8fa40-ebec-4d09-9f01-b931892bad25)   |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |     |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4