### PR TITLE
(BSR) fix(CI): solve concurrency issue in GHA

### DIFF
--- a/.github/workflows/dev_on_workflow_linter_ts.yml
+++ b/.github/workflows/dev_on_workflow_linter_ts.yml
@@ -13,7 +13,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.ref }}
+  group: linter-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/dev_on_workflow_tester.yml
+++ b/.github/workflows/dev_on_workflow_tester.yml
@@ -13,7 +13,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.ref }}
+  group: tester-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
The yarn-linter would often be canceled by the concurrency as the tester job was first executed, for example https://github.com/pass-culture/pass-culture-app-native/actions/runs/12630587585/job/35190784705