### PR TITLE
(PC-33804) feat(TypoDS): update typo body by typo DS

### DIFF
--- a/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
@@ -244,9 +244,9 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }

--- a/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -257,9 +257,9 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }
@@ -271,9 +271,9 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }
@@ -295,9 +295,9 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }
@@ -340,9 +340,9 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }

--- a/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
@@ -1055,9 +1055,9 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
             [
               {
                 "color": "#161617",
-                "fontFamily": "Montserrat-Regular",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "textAlign": "center",
               },
             ]

--- a/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
@@ -133,9 +133,9 @@ exports[`<AccountCreated /> should render correctly 1`] = `
           [
             {
               "color": "#ffffff",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "textAlign": "center",
             },
           ]

--- a/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
@@ -137,9 +137,9 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
@@ -153,9 +153,9 @@ exports[`QuitSignupModal should render correctly 1`] = `
           [
             {
               "color": "#ffffff",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "textAlign": "center",
             },
           ]

--- a/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
@@ -202,9 +202,9 @@ exports[`<SetBirthday /> should render correctly 1`] = `
             [
               {
                 "color": "#161617",
-                "fontFamily": "Montserrat-Regular",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 16,
+                "lineHeight": 25.6,
               },
             ]
           }
@@ -407,9 +407,9 @@ exports[`<SetBirthday /> should render correctly when account creation token and
       [
         {
           "color": "#161617",
-          "fontFamily": "Montserrat-Regular",
-          "fontSize": 15,
-          "lineHeight": 20,
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 16,
+          "lineHeight": 25.6,
         },
       ]
     }
@@ -595,9 +595,9 @@ exports[`<SetBirthday /> should render correctly when account creation token and
             [
               {
                 "color": "#161617",
-                "fontFamily": "Montserrat-Regular",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 16,
+                "lineHeight": 25.6,
               },
             ]
           }

--- a/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.web.test.tsx.web-snap
@@ -1596,7 +1596,7 @@ exports[`<SetBirthday /> touch device should render correctly 1`] = `
           data-testid="styled-input-container"
         >
           <div
-            class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe"
+            class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
             dir="ltr"
             id="testUuidV4"
           >

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
@@ -356,9 +356,9 @@ exports[`<EmailResendModal /> should render correctly 1`] = `
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
@@ -267,9 +267,9 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }
@@ -281,9 +281,9 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }
@@ -305,9 +305,9 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }
@@ -350,9 +350,9 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -1537,9 +1537,9 @@ exports[`Signup Form should render correctly for SetBirthday 1`] = `
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                     },
                   ]
                 }
@@ -2384,9 +2384,9 @@ exports[`Signup Form should render correctly for SetEmail 1`] = `
               [
                 {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "textAlign": "center",
                 },
               ]

--- a/__snapshots__/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.native.test.tsx.native-snap
@@ -168,9 +168,9 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
           [
             {
               "color": "#696A6F",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }

--- a/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
@@ -90,9 +90,9 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
       [
         {
           "color": "#161617",
-          "fontFamily": "Montserrat-Regular",
-          "fontSize": 15,
-          "lineHeight": 20,
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 16,
+          "lineHeight": 25.6,
           "textAlign": "center",
         },
       ]
@@ -105,9 +105,9 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
       [
         {
           "color": "#161617",
-          "fontFamily": "Montserrat-Regular",
-          "fontSize": 15,
-          "lineHeight": 20,
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 16,
+          "lineHeight": 25.6,
           "textAlign": "center",
         },
       ]

--- a/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
@@ -146,9 +146,9 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
           [
             {
               "color": "#ffffff",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }
@@ -170,9 +170,9 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
           [
             {
               "color": "#ffffff",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }

--- a/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
@@ -137,9 +137,9 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]
@@ -164,9 +164,9 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
@@ -82,9 +82,9 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
       [
         {
           "color": "#161617",
-          "fontFamily": "Montserrat-Regular",
-          "fontSize": 15,
-          "lineHeight": 20,
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 16,
+          "lineHeight": 25.6,
           "textAlign": "center",
         },
       ]
@@ -97,9 +97,9 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
       [
         {
           "color": "#161617",
-          "fontFamily": "Montserrat-Regular",
-          "fontSize": 15,
-          "lineHeight": 20,
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 16,
+          "lineHeight": 25.6,
           "textAlign": "center",
         },
       ]

--- a/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
@@ -619,9 +619,9 @@ exports[`BookingDetails should render correctly 1`] = `
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Regular",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -736,9 +736,9 @@ exports[`BookingDetails should render correctly 1`] = `
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Regular",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -748,9 +748,9 @@ exports[`BookingDetails should render correctly 1`] = `
                         [
                           {
                             "color": "#161617",
-                            "fontFamily": "Montserrat-Regular",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-Medium",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -763,9 +763,9 @@ exports[`BookingDetails should render correctly 1`] = `
                         [
                           {
                             "color": "#161617",
-                            "fontFamily": "Montserrat-Regular",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-Medium",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -782,9 +782,9 @@ exports[`BookingDetails should render correctly 1`] = `
                         [
                           {
                             "color": "#161617",
-                            "fontFamily": "Montserrat-Regular",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-Medium",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -798,9 +798,9 @@ exports[`BookingDetails should render correctly 1`] = `
                         [
                           {
                             "color": "#161617",
-                            "fontFamily": "Montserrat-Regular",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-Medium",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -1305,9 +1305,9 @@ exports[`BookingDetails should render correctly 1`] = `
             [
               {
                 "color": "#161617",
-                "fontFamily": "Montserrat-Regular",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 16,
+                "lineHeight": 25.6,
               },
             ]
           }

--- a/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
@@ -137,9 +137,9 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/bookings/pages/Bookings/Bookings.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/Bookings/Bookings.native.test.tsx.native-snap
@@ -438,9 +438,9 @@ exports[`Bookings should render correctly 1`] = `
                   [
                     {
                       "color": "#696A6F",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                     },
                   ]
                 }
@@ -741,9 +741,9 @@ exports[`Bookings should render correctly 1`] = `
                   [
                     {
                       "color": "#696A6F",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                     },
                   ]
                 }

--- a/__snapshots__/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx.native-snap
@@ -372,9 +372,9 @@ exports[`EndedBookings should render correctly 1`] = `
             [
               {
                 "color": "#696A6F",
-                "fontFamily": "Montserrat-Regular",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "paddingBottom": 22,
               },
             ]

--- a/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
@@ -291,9 +291,9 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
               [
                 {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }
@@ -315,9 +315,9 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
               [
                 {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }

--- a/__snapshots__/features/cookies/pages/CookiesDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesDetails.native.test.tsx.native-snap
@@ -186,9 +186,9 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
             [
               {
                 "color": "#161617",
-                "fontFamily": "Montserrat-Regular",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 16,
+                "lineHeight": 25.6,
               },
             ]
           }
@@ -643,9 +643,9 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
               [
                 {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }
@@ -724,9 +724,9 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }
@@ -1029,9 +1029,9 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
               [
                 {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }
@@ -1110,9 +1110,9 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }
@@ -1415,9 +1415,9 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
               [
                 {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }
@@ -1496,9 +1496,9 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }
@@ -1804,9 +1804,9 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
               [
                 {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }
@@ -1885,9 +1885,9 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }
@@ -2000,9 +2000,9 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
       [
         {
           "color": "#161617",
-          "fontFamily": "Montserrat-Regular",
-          "fontSize": 15,
-          "lineHeight": 20,
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 16,
+          "lineHeight": 25.6,
         },
       ]
     }
@@ -2024,9 +2024,9 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
       [
         {
           "color": "#161617",
-          "fontFamily": "Montserrat-Regular",
-          "fontSize": 15,
-          "lineHeight": 20,
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 16,
+          "lineHeight": 25.6,
         },
       ]
     }

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
@@ -105,9 +105,9 @@ exports[`CulturalSurveyThanksPage page When FF is disabled should render the pag
       [
         {
           "color": "#161617",
-          "fontFamily": "Montserrat-Regular",
-          "fontSize": 15,
-          "lineHeight": 20,
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 16,
+          "lineHeight": 25.6,
           "textAlign": "center",
         },
       ]
@@ -343,9 +343,9 @@ exports[`CulturalSurveyThanksPage page When FF is enabled should render the page
       [
         {
           "color": "#161617",
-          "fontFamily": "Montserrat-Regular",
-          "fontSize": 15,
-          "lineHeight": 20,
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 16,
+          "lineHeight": 25.6,
           "textAlign": "center",
         },
       ]

--- a/__snapshots__/features/errors/pages/AsyncErrorBoundary.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/AsyncErrorBoundary.native.test.tsx.native-snap
@@ -194,9 +194,9 @@ exports[`AsyncErrorBoundary component should render 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/errors/pages/AsyncErrorBoundary.web.test.tsx.web-snap
+++ b/__snapshots__/features/errors/pages/AsyncErrorBoundary.web.test.tsx.web-snap
@@ -172,7 +172,7 @@ exports[`AsyncErrorBoundary component should render correctly 1`] = `
         class="css-view-175oi2r r-height-z80fyv"
       />
       <div
-        class="css-text-1rynq56 r-color-jwli3a r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe r-textAlign-q4m81j"
+        class="css-text-1rynq56 r-color-jwli3a r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm r-textAlign-q4m81j"
         dir="ltr"
       >
         Une erreur s’est produite pendant le chargement.

--- a/__snapshots__/features/errors/pages/BannedCountryError.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/BannedCountryError.native.test.tsx.native-snap
@@ -110,9 +110,9 @@ exports[`BannedCountryError should render correctly 1`] = `
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/favorites/pages/NotConnectedFavorites.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/NotConnectedFavorites.native.test.tsx.native-snap
@@ -71,9 +71,9 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
       [
         {
           "color": "#161617",
-          "fontFamily": "Montserrat-Regular",
-          "fontSize": 15,
-          "lineHeight": 20,
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 16,
+          "lineHeight": 25.6,
           "textAlign": "center",
         },
       ]
@@ -228,9 +228,9 @@ exports[`NotConnectedFavorites component should render not connected favorites 1
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "textAlign": "center",
             },
           ]

--- a/__snapshots__/features/forceUpdate/pages/ForceUpdate.native.test.tsx.native-snap
+++ b/__snapshots__/features/forceUpdate/pages/ForceUpdate.native.test.tsx.native-snap
@@ -137,9 +137,9 @@ exports[`<ForceUpdate/> should match snapshot 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
@@ -420,9 +420,9 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
                 [
                   {
                     "color": "#696A6F",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                   },
                 ]
               }

--- a/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
@@ -526,9 +526,9 @@ exports[`Home page should render correctly 1`] = `
                                 [
                                   {
                                     "color": "#ffffff",
-                                    "fontFamily": "Montserrat-Regular",
-                                    "fontSize": 15,
-                                    "lineHeight": 20,
+                                    "fontFamily": "Montserrat-Medium",
+                                    "fontSize": 16,
+                                    "lineHeight": 25.6,
                                   },
                                 ]
                               }

--- a/__snapshots__/features/home/pages/NoContentError.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/NoContentError.native.test.tsx.native-snap
@@ -136,9 +136,9 @@ exports[`NoContentError should render correctly 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
@@ -567,9 +567,9 @@ exports[`ThematicHome should render correctly 1`] = `
             [
               {
                 "color": "#161617",
-                "fontFamily": "Montserrat-Regular",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 16,
+                "lineHeight": 25.6,
               },
             ]
           }

--- a/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
@@ -346,9 +346,9 @@ exports[`<DMSModal/> should render correctly 1`] = `
                 [
                   {
                     "color": "#696A6F",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                   },
                 ]
               }

--- a/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
@@ -154,9 +154,9 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
           [
             {
               "color": "#ffffff",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "textAlign": "center",
             },
           ]

--- a/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
@@ -79,9 +79,9 @@ exports[`Stepper navigation should render correctly 1`] = `
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
           },
         ]
       }

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
@@ -237,9 +237,9 @@ exports[`<BeneficiaryAccountCreated/> should render correctly for 18 year-old be
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]
@@ -615,9 +615,9 @@ exports[`<BeneficiaryAccountCreated/> should render correctly for underage benef
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
@@ -137,9 +137,9 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]
@@ -152,9 +152,9 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
@@ -137,9 +137,9 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]
@@ -162,9 +162,9 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
@@ -144,9 +144,9 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "marginBottom": 20,
             "textAlign": "center",
           },
@@ -212,9 +212,9 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }
@@ -279,9 +279,9 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }
@@ -346,9 +346,9 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }
@@ -415,9 +415,9 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }
@@ -751,9 +751,9 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "marginBottom": 20,
             "textAlign": "center",
           },
@@ -819,9 +819,9 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }
@@ -886,9 +886,9 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }
@@ -955,9 +955,9 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
                   "flexBasis": 0,
                   "flexGrow": 1,
                   "flexShrink": 1,
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }

--- a/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
@@ -336,9 +336,9 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                   [
                     {
                       "color": "#696A6F",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.test.tsx.web-snap
@@ -215,7 +215,7 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
               class="css-view-175oi2r r-height-10ptun7"
             />
             <div
-              class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe r-textAlign-q4m81j"
+              class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm r-textAlign-q4m81j"
               dir="ltr"
             >
               Pour t’identifier, nous allons te demander de te connecter à EduConnect. Munis-toi de ton identifiant et ton mot de passe EduConnect ! Si tu ne les as pas, contacte ton établissement pour les récupérer.

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx.native-snap
@@ -300,9 +300,9 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
                   [
                     {
                       "color": "#696A6F",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                     },
                   ]
                 }
@@ -349,9 +349,9 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
                   [
                     {
                       "color": "#696A6F",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                     },
                   ]
                 }
@@ -398,9 +398,9 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
                   [
                     {
                       "color": "#696A6F",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                     },
                   ]
                 }

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.web.test.tsx.web-snap
@@ -210,7 +210,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
                 class="css-view-175oi2r r-height-1472mwg"
               />
               <div
-                class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
                 dir="ltr"
               >
                 Ton prénom
@@ -229,7 +229,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
                 class="css-view-175oi2r r-height-z80fyv"
               />
               <div
-                class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
                 dir="ltr"
               >
                 Ton nom de famille
@@ -248,7 +248,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
                 class="css-view-175oi2r r-height-z80fyv"
               />
               <div
-                class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
                 dir="ltr"
               >
                 Ta date de naissance

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
@@ -143,9 +143,9 @@ exports[`ComeBackLater should render correctly 1`] = `
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "marginBottom": 24,
             "textAlign": "center",
           },
@@ -157,9 +157,9 @@ exports[`ComeBackLater should render correctly 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }
@@ -186,9 +186,9 @@ exports[`ComeBackLater should render correctly 1`] = `
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "marginBottom": 24,
             "textAlign": "center",
           },

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
@@ -143,9 +143,9 @@ exports[`ExpiredOrLostID should render correctly 1`] = `
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "marginBottom": 20,
             "textAlign": "center",
           },
@@ -169,9 +169,9 @@ exports[`ExpiredOrLostID should render correctly 1`] = `
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "marginBottom": 20,
             "textAlign": "center",
           },
@@ -195,9 +195,9 @@ exports[`ExpiredOrLostID should render correctly 1`] = `
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "marginBottom": 20,
             "textAlign": "center",
           },

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
@@ -138,9 +138,9 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]
@@ -163,9 +163,9 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDOrigin.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDOrigin.native.test.tsx.native-snap
@@ -325,9 +325,9 @@ exports[`SelectIDOrigin should render correctly 1`] = `
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]
@@ -453,9 +453,9 @@ exports[`SelectIDOrigin should render correctly 1`] = `
                             [
                               {
                                 "color": "#161617",
-                                "fontFamily": "Montserrat-Regular",
-                                "fontSize": 15,
-                                "lineHeight": 20,
+                                "fontFamily": "Montserrat-Medium",
+                                "fontSize": 16,
+                                "lineHeight": 25.6,
                               },
                             ]
                           }

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
@@ -315,9 +315,9 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Regular",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-Medium",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }
@@ -343,9 +343,9 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Regular",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-Medium",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }
@@ -371,9 +371,9 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Regular",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-Medium",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectPhoneStatus.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectPhoneStatus.web.test.tsx.web-snap
@@ -165,7 +165,7 @@ exports[`SelectPhoneStatus should render correctly 1`] = `
                 class="css-view-175oi2r r-height-10ptun7"
               />
               <div
-                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe r-textAlign-q4m81j"
+                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm r-textAlign-q4m81j"
                 dir="ltr"
               >
                 Gagne du temps en vérifiant ton identité sur un smartphone ! Tu peux aussi passer par le site demarches-simplifiees.fr mais le traitement sera plus long.
@@ -212,7 +212,7 @@ exports[`SelectPhoneStatus should render correctly 1`] = `
                           class="css-view-175oi2r r-justifyContent-1777fci r-minHeight-mipnz4"
                         >
                           <div
-                            class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                            class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
                             dir="ltr"
                           >
                             J’ai un smartphone à proximité
@@ -273,7 +273,7 @@ exports[`SelectPhoneStatus should render correctly 1`] = `
                           class="css-view-175oi2r r-justifyContent-1777fci r-minHeight-mipnz4"
                         >
                           <div
-                            class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                            class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
                             dir="ltr"
                           >
                             Je n’ai pas de smartphone à proximité

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/CodeNotReceivedModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/CodeNotReceivedModal.native.test.tsx.native-snap
@@ -346,9 +346,9 @@ exports[`<CodeNotReceivedModal /> should have a different color if one attempt r
                 [
                   {
                     "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "textAlign": "center",
                   },
                 ]
@@ -865,9 +865,9 @@ exports[`<CodeNotReceivedModal /> should match snapshot 1`] = `
                 [
                   {
                     "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "textAlign": "center",
                   },
                 ]

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
@@ -356,9 +356,9 @@ exports[`<PhoneValidationTipsModal /> should match snapshot 1`] = `
                 [
                   {
                     "color": "#696A6F",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "textAlign": "center",
                   },
                 ]
@@ -423,9 +423,9 @@ exports[`<PhoneValidationTipsModal /> should match snapshot 1`] = `
                         "flexBasis": 0,
                         "flexGrow": 1,
                         "flexShrink": 1,
-                        "fontFamily": "Montserrat-Regular",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-Medium",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }
@@ -508,9 +508,9 @@ exports[`<PhoneValidationTipsModal /> should match snapshot 1`] = `
                         "flexBasis": 0,
                         "flexGrow": 1,
                         "flexShrink": 1,
-                        "fontFamily": "Montserrat-Regular",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-Medium",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
@@ -321,9 +321,9 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
                     [
                       {
                         "color": "#696A6F",
-                        "fontFamily": "Montserrat-Regular",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-Medium",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "textAlign": "center",
                       },
                     ]
@@ -483,9 +483,9 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
                             [
                               {
                                 "color": "#161617",
-                                "fontFamily": "Montserrat-Regular",
-                                "fontSize": 15,
-                                "lineHeight": 20,
+                                "fontFamily": "Montserrat-Medium",
+                                "fontSize": 16,
+                                "lineHeight": 25.6,
                                 "marginLeft": -4,
                                 "marginRight": 4,
                               },

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
@@ -492,9 +492,9 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
                             [
                               {
                                 "color": "#161617",
-                                "fontFamily": "Montserrat-Regular",
-                                "fontSize": 15,
-                                "lineHeight": 20,
+                                "fontFamily": "Montserrat-Medium",
+                                "fontSize": 16,
+                                "lineHeight": 25.6,
                                 "marginLeft": -4,
                                 "marginRight": 4,
                               },

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
@@ -311,9 +311,9 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
                     [
                       {
                         "color": "#696A6F",
-                        "fontFamily": "Montserrat-Regular",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-Medium",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "textAlign": "center",
                       },
                     ]

--- a/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
@@ -3274,9 +3274,9 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                         [
                           {
                             "color": "#161617",
-                            "fontFamily": "Montserrat-Regular",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-Medium",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }

--- a/__snapshots__/features/maintenance/pages/Maintenance.native.test.tsx.native-snap
+++ b/__snapshots__/features/maintenance/pages/Maintenance.native.test.tsx.native-snap
@@ -147,9 +147,9 @@ exports[`<Maintenance /> should match snapshot with custom message 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]
@@ -360,9 +360,9 @@ exports[`<Maintenance /> should match snapshot with default message 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
@@ -137,9 +137,9 @@ exports[`<PageNotFound/> should render correctly 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/offer/components/SignUpSignInChoiceOfferModal/SignUpSignInChoiceOfferModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/SignUpSignInChoiceOfferModal/SignUpSignInChoiceOfferModal.native.test.tsx.native-snap
@@ -375,9 +375,9 @@ retrouver tes favoris
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]
@@ -527,9 +527,9 @@ retrouver tes favoris
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Regular",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-Medium",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "textAlign": "center",
                       },
                     ]

--- a/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
@@ -137,9 +137,9 @@ exports[`<OfferNotFound /> should render correctly 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/profile/components/Modals/ExpiredCreditModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/components/Modals/ExpiredCreditModal.native.test.tsx.native-snap
@@ -259,9 +259,9 @@ exports[`<ExpiredCreditModal/> should render correctly 1`] = `
             [
               {
                 "color": "#161617",
-                "fontFamily": "Montserrat-Regular",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 16,
+                "lineHeight": 25.6,
               },
             ]
           }

--- a/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
@@ -691,9 +691,9 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                     },
                   ]
                 }
@@ -772,9 +772,9 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
               [
                 {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }
@@ -1077,9 +1077,9 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                     },
                   ]
                 }
@@ -1158,9 +1158,9 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
               [
                 {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }
@@ -1463,9 +1463,9 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                     },
                   ]
                 }
@@ -1544,9 +1544,9 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
               [
                 {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }
@@ -1852,9 +1852,9 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                     },
                   ]
                 }
@@ -1933,9 +1933,9 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
               [
                 {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                 },
               ]
             }

--- a/__snapshots__/features/profile/pages/Profile.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/Profile.web.test.tsx.web-snap
@@ -236,7 +236,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
                 class="css-view-175oi2r r-height-hdaws3"
               />
               <div
-                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
                 dir="ltr"
               >
                 Tu as entre 15 et 18 ans ?
@@ -246,7 +246,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
               class="css-view-175oi2r r-backgroundColor-14a9t8x r-borderRadius-1xfd6ze r-marginBottom-5oul0u r-marginHorizontal-1hy1u7s r-minWidth-68jxh1 r-paddingBottom-qn3fzs r-paddingLeft-puj83k r-paddingRight-11g3r6m r-paddingTop-1ygmrgt r-width-7xmw5f"
             >
               <div
-                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
                 dir="ltr"
               >
                 Identifie-toi pour bénéficier de ton crédit pass Culture
@@ -281,7 +281,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
                   class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-9aw3ui r-justifyContent-1777fci"
                 >
                   <div
-                    class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe r-textAlign-q4m81j"
+                    class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm r-textAlign-q4m81j"
                     dir="ltr"
                   >
                     Déjà un compte ?
@@ -1394,7 +1394,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
                 class="css-view-175oi2r r-height-hdaws3"
               />
               <div
-                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
                 dir="ltr"
               >
                 Tu as entre 15 et 18 ans ?
@@ -1404,7 +1404,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
               class="css-view-175oi2r r-backgroundColor-14a9t8x r-borderRadius-1xfd6ze r-marginBottom-5oul0u r-marginHorizontal-1hy1u7s r-paddingBottom-qn3fzs r-paddingLeft-puj83k r-paddingRight-11g3r6m r-paddingTop-1ygmrgt"
             >
               <div
-                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe"
+                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
                 dir="ltr"
               >
                 Identifie-toi pour bénéficier de ton crédit pass Culture
@@ -1439,7 +1439,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
                   class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz r-gap-9aw3ui r-justifyContent-1777fci"
                 >
                   <div
-                    class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-yv33h5 r-fontSize-a023e6 r-lineHeight-rjixqe r-textAlign-q4m81j"
+                    class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm r-textAlign-q4m81j"
                     dir="ltr"
                   >
                     Déjà un compte ?

--- a/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
@@ -1041,9 +1041,9 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
               [
                 {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "marginTop": 24,
                   "textAlign": "center",
                 },
@@ -1056,9 +1056,9 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                 [
                   {
                     "color": "#696A6F",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                   },
                 ]
               }

--- a/__snapshots__/features/share/pages/ShareAppModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModal.native.test.tsx.native-snap
@@ -244,9 +244,9 @@ exports[`ShareAppModal should match snapshot 1`] = `
                 [
                   {
                     "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "textAlign": "center",
                   },
                 ]

--- a/__snapshots__/features/subscription/NotificationsLoggedOutModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/NotificationsLoggedOutModal.native.test.tsx.native-snap
@@ -374,9 +374,9 @@ exports[`<NotificationsLoggedOutModal /> should render correctly 1`] = `
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]
@@ -525,9 +525,9 @@ exports[`<NotificationsLoggedOutModal /> should render correctly 1`] = `
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Regular",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "textAlign": "center",
                         },
                       ]

--- a/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
@@ -355,9 +355,9 @@ exports[`<NotificationsSettingsModal /> should render correctly 1`] = `
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                     },
                   ]
                 }

--- a/__snapshots__/features/subscription/components/modals/OnboardingSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/OnboardingSubscriptionModal.native.test.tsx.native-snap
@@ -374,9 +374,9 @@ exports[`<OnboardingSubscriptionModal /> should display correctly 1`] = `
                   [
                     {
                       "color": "#696A6F",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]

--- a/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
@@ -374,9 +374,9 @@ exports[`<SubscriptionSuccessModal /> should render correctly for activites_crea
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]
@@ -1036,9 +1036,9 @@ exports[`<SubscriptionSuccessModal /> should render correctly for cinema 1`] = `
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]
@@ -1698,9 +1698,9 @@ exports[`<SubscriptionSuccessModal /> should render correctly for lecture 1`] = 
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]
@@ -2360,9 +2360,9 @@ exports[`<SubscriptionSuccessModal /> should render correctly for musique 1`] = 
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]
@@ -3022,9 +3022,9 @@ exports[`<SubscriptionSuccessModal /> should render correctly for spectacles 1`]
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]
@@ -3684,9 +3684,9 @@ exports[`<SubscriptionSuccessModal /> should render correctly for visites 1`] = 
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]

--- a/__snapshots__/features/subscription/components/modals/UnsubscribingConfirmationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/UnsubscribingConfirmationModal.native.test.tsx.native-snap
@@ -374,9 +374,9 @@ exports[`<UnsubscribingConfirmationModal /> should render correctly 1`] = `
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]

--- a/__snapshots__/features/subscription/page/OnboardingSubscription.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/page/OnboardingSubscription.native.test.tsx.native-snap
@@ -220,9 +220,9 @@ exports[`OnboardingSubscription should render correctly 1`] = `
             [
               {
                 "color": "#161617",
-                "fontFamily": "Montserrat-Regular",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 16,
+                "lineHeight": 25.6,
               },
             ]
           }

--- a/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
@@ -82,9 +82,9 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
       [
         {
           "color": "#161617",
-          "fontFamily": "Montserrat-Regular",
-          "fontSize": 15,
-          "lineHeight": 20,
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 16,
+          "lineHeight": 25.6,
         },
       ]
     }
@@ -259,9 +259,9 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
       [
         {
           "color": "#161617",
-          "fontFamily": "Montserrat-Regular",
-          "fontSize": 15,
-          "lineHeight": 20,
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 16,
+          "lineHeight": 25.6,
         },
       ]
     }
@@ -705,9 +705,9 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
       [
         {
           "color": "#161617",
-          "fontFamily": "Montserrat-Regular",
-          "fontSize": 15,
-          "lineHeight": 20,
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 16,
+          "lineHeight": 25.6,
         },
       ]
     }
@@ -882,9 +882,9 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
       [
         {
           "color": "#161617",
-          "fontFamily": "Montserrat-Regular",
-          "fontSize": 15,
-          "lineHeight": 20,
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 16,
+          "lineHeight": 25.6,
         },
       ]
     }
@@ -1228,9 +1228,9 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
       [
         {
           "color": "#161617",
-          "fontFamily": "Montserrat-Regular",
-          "fontSize": 15,
-          "lineHeight": 20,
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 16,
+          "lineHeight": 25.6,
         },
       ]
     }
@@ -1405,9 +1405,9 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
       [
         {
           "color": "#161617",
-          "fontFamily": "Montserrat-Regular",
-          "fontSize": 15,
-          "lineHeight": 20,
+          "fontFamily": "Montserrat-Medium",
+          "fontSize": 16,
+          "lineHeight": 25.6,
         },
       ]
     }

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
@@ -225,9 +225,9 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
                 [
                   {
                     "color": "#161617",
-                    "fontFamily": "Montserrat-Regular",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontFamily": "Montserrat-Medium",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                   },
                 ]
               }
@@ -490,9 +490,9 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
           },
         ]
       }

--- a/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
@@ -146,9 +146,9 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
           [
             {
               "color": "#ffffff",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }
@@ -170,9 +170,9 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
           [
             {
               "color": "#ffffff",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }

--- a/__snapshots__/features/tutorial/pages/NonEligibleModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/NonEligibleModal.native.test.tsx.native-snap
@@ -278,9 +278,9 @@ exports[`NonEligibleModal should render correctly for onboarding non-eligible ov
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "textAlign": "center",
             },
           ]
@@ -303,9 +303,9 @@ exports[`NonEligibleModal should render correctly for onboarding non-eligible ov
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "textAlign": "center",
             },
           ]
@@ -703,9 +703,9 @@ exports[`NonEligibleModal should render correctly for onboarding non-eligible un
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "textAlign": "center",
             },
           ]
@@ -856,9 +856,9 @@ exports[`NonEligibleModal should render correctly for onboarding non-eligible un
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "textAlign": "center",
             },
           ]
@@ -1257,9 +1257,9 @@ exports[`NonEligibleModal should render correctly for profile tutorial non-eligi
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "textAlign": "center",
             },
           ]
@@ -1282,9 +1282,9 @@ exports[`NonEligibleModal should render correctly for profile tutorial non-eligi
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "textAlign": "center",
             },
           ]
@@ -1682,9 +1682,9 @@ exports[`NonEligibleModal should render correctly for profile tutorial non-eligi
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "textAlign": "center",
             },
           ]
@@ -1707,9 +1707,9 @@ exports[`NonEligibleModal should render correctly for profile tutorial non-eligi
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "textAlign": "center",
             },
           ]

--- a/__snapshots__/features/tutorial/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
@@ -371,9 +371,9 @@ exports[`OnboardingAgeInformation should render correctly for 15-year-old 1`] = 
                       [
                         {
                           "color": "#320096",
-                          "fontFamily": "Montserrat-Regular",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -1092,10 +1092,10 @@ exports[`OnboardingAgeInformation should render correctly for 15-year-old 1`] = 
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
                       "justifyContent": "center",
-                      "lineHeight": 20,
+                      "lineHeight": 25.6,
                       "marginLeft": 6,
                       "marginVertical": 8,
                     },
@@ -2258,9 +2258,9 @@ exports[`OnboardingAgeInformation should render correctly for 16-year-old 1`] = 
                       [
                         {
                           "color": "#320096",
-                          "fontFamily": "Montserrat-Regular",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -2726,10 +2726,10 @@ exports[`OnboardingAgeInformation should render correctly for 16-year-old 1`] = 
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
                       "justifyContent": "center",
-                      "lineHeight": 20,
+                      "lineHeight": 25.6,
                       "marginLeft": 6,
                       "marginVertical": 8,
                     },
@@ -4132,9 +4132,9 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                       [
                         {
                           "color": "#320096",
-                          "fontFamily": "Montserrat-Regular",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -4347,10 +4347,10 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
                       "justifyContent": "center",
-                      "lineHeight": 20,
+                      "lineHeight": 25.6,
                       "marginLeft": 6,
                       "marginVertical": 8,
                     },
@@ -5984,9 +5984,9 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                       [
                         {
                           "color": "#320096",
-                          "fontFamily": "Montserrat-Regular",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-Medium",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }

--- a/__snapshots__/features/tutorial/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
@@ -183,9 +183,9 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/tutorial/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
@@ -192,9 +192,9 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/tutorial/pages/onboarding/OnboardingWelcome.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/onboarding/OnboardingWelcome.native.test.tsx.native-snap
@@ -139,9 +139,9 @@ exports[`OnboardingWelcome should render correctly 1`] = `
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]
@@ -290,9 +290,9 @@ exports[`OnboardingWelcome should render correctly 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "textAlign": "center",
             },
           ]

--- a/__snapshots__/features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation.native.test.tsx.native-snap
@@ -229,9 +229,9 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                     [
                       {
                         "color": "#320096",
-                        "fontFamily": "Montserrat-Regular",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-Medium",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }
@@ -2364,9 +2364,9 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
             [
               {
                 "color": "#161617",
-                "fontFamily": "Montserrat-Regular",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "textAlign": "center",
               },
             ]
@@ -2499,9 +2499,9 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
               [
                 {
                   "color": "#161617",
-                  "fontFamily": "Montserrat-Regular",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "textAlign": "center",
                 },
               ]
@@ -2848,9 +2848,9 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
             [
               {
                 "color": "#161617",
-                "fontFamily": "Montserrat-Regular",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 16,
+                "lineHeight": 25.6,
               },
             ]
           }
@@ -3123,9 +3123,9 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                     [
                       {
                         "color": "#320096",
-                        "fontFamily": "Montserrat-Regular",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-Medium",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }
@@ -5483,9 +5483,9 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
             [
               {
                 "color": "#161617",
-                "fontFamily": "Montserrat-Regular",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 16,
+                "lineHeight": 25.6,
               },
             ]
           }

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -4634,9 +4634,9 @@ d’options
             [
               {
                 "color": "#161617",
-                "fontFamily": "Montserrat-Regular",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 16,
+                "lineHeight": 25.6,
               },
             ]
           }
@@ -8390,9 +8390,9 @@ d’options
             [
               {
                 "color": "#161617",
-                "fontFamily": "Montserrat-Regular",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontFamily": "Montserrat-Medium",
+                "fontSize": 16,
+                "lineHeight": 25.6,
               },
             ]
           }

--- a/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
@@ -137,9 +137,9 @@ exports[`<VenueNotFound /> should render correctly 1`] = `
         [
           {
             "color": "#ffffff",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/libs/location/geolocation/components/GeolocationActivationModal.native.test.tsx.native-snap
+++ b/__snapshots__/libs/location/geolocation/components/GeolocationActivationModal.native.test.tsx.native-snap
@@ -269,9 +269,9 @@ exports[`GeolocationActivationModal should render properly 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "textAlign": "center",
             },
           ]
@@ -294,9 +294,9 @@ exports[`GeolocationActivationModal should render properly 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Regular",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-Medium",
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "textAlign": "center",
             },
           ]

--- a/__snapshots__/libs/network/OfflinePage.native.test.tsx.native-snap
+++ b/__snapshots__/libs/network/OfflinePage.native.test.tsx.native-snap
@@ -99,9 +99,9 @@ exports[`<OfflinePage /> should match snapshot with default message 1`] = `
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Regular",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-Medium",
+            "fontSize": 16,
+            "lineHeight": 25.6,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.native.test.tsx.native-snap
@@ -374,9 +374,9 @@ exports[`<ApplicationProcessingModal /> should match previous snapshot 1`] = `
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]

--- a/__snapshots__/shared/offer/components/AuthenticationModal/AuthenticationModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/AuthenticationModal/AuthenticationModal.native.test.tsx.native-snap
@@ -399,9 +399,9 @@ pour réserver l’offre
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]
@@ -551,9 +551,9 @@ pour réserver l’offre
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Regular",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-Medium",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "textAlign": "center",
                       },
                     ]

--- a/__snapshots__/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx.native-snap
@@ -375,9 +375,9 @@ ton crédit
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]

--- a/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
@@ -376,9 +376,9 @@ pour réserver cette offre
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]
@@ -390,9 +390,9 @@ pour réserver cette offre
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Regular",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-Medium",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "textAlign": "center",
                       },
                     ]
@@ -899,9 +899,9 @@ pour réserver cette offre
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]
@@ -913,9 +913,9 @@ pour réserver cette offre
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Regular",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-Medium",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "textAlign": "center",
                       },
                     ]
@@ -1448,9 +1448,9 @@ pour réserver cette offre
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]
@@ -1462,9 +1462,9 @@ pour réserver cette offre
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Regular",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-Medium",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "textAlign": "center",
                       },
                     ]
@@ -1971,9 +1971,9 @@ pour réserver cette offre
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Regular",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-Medium",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "textAlign": "center",
                     },
                   ]

--- a/eslint-custom-rules/no-raw-text.test.js
+++ b/eslint-custom-rules/no-raw-text.test.js
@@ -18,7 +18,7 @@ const tests = {
     { code: '<Typo.ButtonTextNeutralInfo>toto</Typo.ButtonTextNeutralInfo>' },
     { code: '<Typo.ButtonTextPrimary>toto</Typo.ButtonTextPrimary>' },
     { code: '<Typo.ButtonTextSecondary>toto</Typo.ButtonTextSecondary>' },
-    { code: '<Typo.Body>toto</Typo.Body>' },
+    { code: '<TypoDS.Body>toto</TypoDS.Body>' },
     { code: '<Typo.Caption>toto</Typo.Caption>' },
     { code: '<Typo.CaptionPrimary>toto</Typo.CaptionPrimary>' },
     { code: '<Typo.CaptionSecondary>toto</Typo.CaptionSecondary>' },

--- a/src/cheatcodes/pages/others/CheatcodesScreenAccesLibre.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenAccesLibre.tsx
@@ -50,7 +50,7 @@ export const CheatcodesScreenAccesLibre = () => {
                 {Object.entries(detail.description).map(([key, value]) => (
                   <View key={key}>
                     <Typo.ButtonText>{key}</Typo.ButtonText>
-                    <Typo.Body>{value}</Typo.Body>
+                    <TypoDS.Body>{value}</TypoDS.Body>
                   </View>
                 ))}
                 <Spacer.Column numberOfSpaces={2} />

--- a/src/cheatcodes/pages/others/CheatcodesScreenDebugInformations.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenDebugInformations.tsx
@@ -12,7 +12,7 @@ import { BatchUser } from 'libs/react-native-batch'
 import { storage } from 'libs/storage'
 import { getErrorMessage } from 'shared/getErrorMessage/getErrorMessage'
 import { SecondaryPageWithBlurHeader } from 'ui/pages/SecondaryPageWithBlurHeader'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 const oldAccesstoken =
   'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2MDc1OTE1MzUsIm5iZiI6MTYwNzU5MTUzNSwianRpIjoiNjM' +
@@ -77,9 +77,9 @@ export const CheatcodesScreenDebugInformations: FunctionComponent = function () 
       <Text>Batch installation ID: {batchInstallationId}</Text>
       <Text>User ID: {userId}</Text>
       <Spacer.Flex />
-      <Typo.Body>{someOfferDescription}</Typo.Body>
+      <TypoDS.Body>{someOfferDescription}</TypoDS.Body>
       <Spacer.Flex />
-      <Typo.Body>{ParsedDescription}</Typo.Body>
+      <TypoDS.Body>{ParsedDescription}</TypoDS.Body>
       <Spacer.Flex />
       {env.ENV === 'testing' ? <CodePushButton /> : null}
     </SecondaryPageWithBlurHeader>

--- a/src/features/achievements/components/AchievementBanner.tsx
+++ b/src/features/achievements/components/AchievementBanner.tsx
@@ -4,7 +4,7 @@ import { theme } from 'theme'
 import { GenericBanner } from 'ui/components/ModuleBanner/GenericBanner'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { BicolorTrophy } from 'ui/svg/icons/BicolorTrophy'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, Typo, TypoDS } from 'ui/theme'
 
 export const AchievementBanner: React.FC = () => {
   return (
@@ -16,7 +16,7 @@ export const AchievementBanner: React.FC = () => {
       <GenericBanner LeftIcon={<BicolorTrophy size={theme.icons.sizes.standard} />}>
         <Typo.ButtonText>Mes succès</Typo.ButtonText>
         <Spacer.Column numberOfSpaces={1} />
-        <Typo.Body numberOfLines={2}>Consulte tes exploits</Typo.Body>
+        <TypoDS.Body numberOfLines={2}>Consulte tes exploits</TypoDS.Body>
       </GenericBanner>
     </InternalTouchableLink>
   )

--- a/src/features/auth/components/AuthenticationButton/AuthenticationButton.tsx
+++ b/src/features/auth/components/AuthenticationButton/AuthenticationButton.tsx
@@ -9,7 +9,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { Connect } from 'ui/svg/icons/Connect'
 import { Profile } from 'ui/svg/icons/Profile'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 // eslint-disable-next-line no-restricted-imports
 import { ColorsEnum } from 'ui/theme/colors'
 
@@ -94,6 +94,6 @@ const AuthenticationContainer = styled.View({
   gap: getSpacing(1),
 })
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/features/auth/components/EmailSentGeneric.tsx
+++ b/src/features/auth/components/EmailSentGeneric.tsx
@@ -9,7 +9,7 @@ import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouch
 import { ExternalTouchableLinkProps } from 'ui/components/touchableLink/types'
 import { BicolorEmailSent } from 'ui/svg/icons/BicolorEmailSent'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type Props = {
@@ -39,14 +39,14 @@ export const EmailSentGeneric: FunctionComponent<Props> = ({
       <Spacer.Column numberOfSpaces={4} />
       <TypoDS.Title3 {...getHeadingAttrs(2)}>{title}</TypoDS.Title3>
       <Spacer.Column numberOfSpaces={4} />
-      <Typo.Body>Tu as reçu un lien à l’adresse&nbsp;:</Typo.Body>
-      <Typo.Body>{email}</Typo.Body>
+      <TypoDS.Body>Tu as reçu un lien à l’adresse&nbsp;:</TypoDS.Body>
+      <TypoDS.Body>{email}</TypoDS.Body>
       <Spacer.Column numberOfSpaces={4} />
-      <Typo.Body>L’e-mail peut prendre quelques minutes pour arriver.</Typo.Body>
+      <TypoDS.Body>L’e-mail peut prendre quelques minutes pour arriver.</TypoDS.Body>
       <Spacer.Column numberOfSpaces={4} />
       <Separator.Horizontal />
       <Spacer.Column numberOfSpaces={4} />
-      <Typo.Body>Tu n‘as pas reçu de lien&nbsp;? Tu peux&nbsp;:</Typo.Body>
+      <TypoDS.Body>Tu n‘as pas reçu de lien&nbsp;? Tu peux&nbsp;:</TypoDS.Body>
       <Spacer.Column numberOfSpaces={4} />
       <ExternalTouchableLink
         as={ButtonTertiaryBlack}

--- a/src/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
+++ b/src/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.tsx
@@ -19,7 +19,7 @@ import { Form } from 'ui/components/Form'
 import { isEmailValid } from 'ui/components/inputs/emailCheck'
 import { isValueEmpty } from 'ui/components/inputs/helpers'
 import { SecondaryPageWithBlurHeader } from 'ui/pages/SecondaryPageWithBlurHeader'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type FormValues = {
@@ -63,10 +63,10 @@ export const ForgottenPassword = () => {
       ) : null}
       <TypoDS.Title3 {...getHeadingAttrs(2)}>Mot de passe oublié&nbsp;?</TypoDS.Title3>
       <Spacer.Column numberOfSpaces={2} />
-      <Typo.Body>
+      <TypoDS.Body>
         Saisis ton adresse e-mail pour recevoir un lien qui te permettra de réinitialiser ton mot de
         passe&nbsp;!
-      </Typo.Body>
+      </TypoDS.Body>
       <Spacer.Column numberOfSpaces={8} />
       <Form.MaxWidth>
         <EmailInputController control={control} name="email" autoFocus />

--- a/src/features/auth/pages/signup/AccountCreated/AccountCreated.tsx
+++ b/src/features/auth/pages/signup/AccountCreated/AccountCreated.tsx
@@ -12,7 +12,7 @@ import IlluminatedSmileyAnimation from 'ui/animations/lottie_illuminated_smiley.
 import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export function AccountCreated() {
   const { user } = useAuthContext()
@@ -54,7 +54,7 @@ export function AccountCreated() {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.tsx
+++ b/src/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.tsx
@@ -9,7 +9,7 @@ import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { CalendarIllustration } from 'ui/svg/icons/CalendarIllustration'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 type Props = StackScreenProps<RootStackParamList, 'NotYetUnderageEligibility'>
 
@@ -33,7 +33,7 @@ export const NotYetUnderageEligibility: FunctionComponent<Props> = (props) => {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   textAlign: 'center',
   color: theme.colors.white,
 }))

--- a/src/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.tsx
+++ b/src/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.tsx
@@ -11,7 +11,7 @@ import { Spacer } from 'ui/components/spacer/Spacer'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { BicolorError } from 'ui/svg/icons/BicolorError'
 import { Clear } from 'ui/svg/icons/Clear'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 interface Props {
   visible: boolean
@@ -62,7 +62,7 @@ export const QuitSignupModal: FunctionComponent<Props> = ({
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/auth/pages/signup/SetBirthday/SetBirthday.tsx
+++ b/src/features/auth/pages/signup/SetBirthday/SetBirthday.tsx
@@ -17,7 +17,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { Form } from 'ui/components/Form'
 import { DateInput } from 'ui/components/inputs/DateInput/DateInput'
 import { BicolorIdCard } from 'ui/svg/icons/BicolorIdCard'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type BirthdayForm = {
@@ -90,10 +90,10 @@ export const SetBirthday: FunctionComponent<PreValidationSignupNormalStepProps> 
       {isSSOSubscriptionFromLogin ? (
         <React.Fragment>
           <Spacer.Column numberOfSpaces={4} />
-          <Typo.Body>
+          <TypoDS.Body>
             Ton compte Google “{params?.email ?? ''}” n’est pas lié à un compte existant. Pour
             continuer, tu peux créer un compte.
-          </Typo.Body>
+          </TypoDS.Body>
         </React.Fragment>
       ) : null}
       <Spacer.Column numberOfSpaces={4} />

--- a/src/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.tsx
+++ b/src/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.tsx
@@ -16,7 +16,7 @@ import { AlertBanner } from 'ui/components/banners/AlertBanner'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { Close } from 'ui/svg/icons/Close'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, Typo, TypoDS } from 'ui/theme'
 
 interface Props {
   email: string
@@ -127,7 +127,7 @@ const ModalContent = styled.View({
   alignItems: 'center',
 })
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })
 

--- a/src/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.tsx
+++ b/src/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.tsx
@@ -9,7 +9,7 @@ import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { GenericOfficialPage } from 'ui/pages/GenericOfficialPage'
 import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, Typo, TypoDS } from 'ui/theme'
 
 export const VerifyEligibility: FunctionComponent = () => {
   return (
@@ -45,6 +45,6 @@ export const VerifyEligibility: FunctionComponent = () => {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))

--- a/src/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.tsx
+++ b/src/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.tsx
@@ -6,7 +6,7 @@ import QpiThanks from 'ui/animations/qpi_thanks.json'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const AccountReactivationSuccess = () => (
   <GenericInfoPageWhite
@@ -30,6 +30,6 @@ const ButtonContainer = styled.View({
   paddingBottom: getSpacing(10),
 })
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.tsx
+++ b/src/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { GenericSuspendedAccount } from 'features/auth/pages/suspendedAccount/GenericSuspendedAccount/GenericSuspendedAccount'
 import { analytics } from 'libs/analytics'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export const FraudulentSuspendedAccount = () => (
   <GenericSuspendedAccount onBeforeNavigateContactFraudTeam={onBeforeNavigateContactFraudTeam}>
@@ -19,6 +19,6 @@ const onBeforeNavigateContactFraudTeam = () => {
   analytics.logContactFraudTeam({ from: 'fraudulentsuspendedaccount' })
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
 }))

--- a/src/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.tsx
+++ b/src/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.tsx
@@ -17,7 +17,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
 import { ProfileDeletion } from 'ui/svg/icons/ProfileDeletion'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000
 const addDaysToDate = (date: Date, days: number) => {
@@ -90,7 +90,7 @@ export const SuspendedAccountUponUserRequest = () => {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.tsx
+++ b/src/features/birthdayNotifications/pages/RecreditBirthdayNotification.tsx
@@ -19,7 +19,7 @@ import { useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { Spacer } from 'ui/components/spacer/Spacer'
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
 import { categoriesIcons } from 'ui/svg/icons/bicolor/exports/categoriesIcons'
-import { getSpacing, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 import { getNoHeadingAttrs } from 'ui/theme/typographyAttrs/getNoHeadingAttrs'
 
 export const RecreditBirthdayNotification = () => {
@@ -108,7 +108,7 @@ const StyledSubtitle = styled(TypoDS.Title4).attrs(getNoHeadingAttrs())({
   textAlign: 'center',
 })
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })
 

--- a/src/features/bookOffer/components/AlreadyBooked.tsx
+++ b/src/features/bookOffer/components/AlreadyBooked.tsx
@@ -11,7 +11,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ExternalLink } from 'ui/components/buttons/externalLink/ExternalLink'
 import { Spacer } from 'ui/components/spacer/Spacer'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 export function AlreadyBooked({ offer }: { offer: OfferResponseV2 }) {
   const { bookingState, dismissModal, dispatch } = useBookingContext()
@@ -54,10 +54,10 @@ const Container = styled.View({
   alignItems: 'center',
 })
 
-const Bold = styled(Typo.Body)(({ theme }) => ({
+const Bold = styled(TypoDS.Body)(({ theme }) => ({
   fontFamily: theme.fontFamily.bold,
 }))
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/features/bookOffer/components/BookingCloseInformation.tsx
+++ b/src/features/bookOffer/components/BookingCloseInformation.tsx
@@ -4,7 +4,7 @@ import styled, { useTheme } from 'styled-components/native'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { AppInformationModal } from 'ui/components/modals/AppInformationModal'
 import { BicolorInfo } from 'ui/svg/icons/BicolorInfo'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { LINE_BREAK } from 'ui/theme/constants'
 
 interface Props {
@@ -40,6 +40,6 @@ export const BookingCloseInformation = ({ visible, hideModal }: Props) => {
   )
 }
 
-const ModalBodyText = styled(Typo.Body)({
+const ModalBodyText = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/features/bookOffer/components/BookingImpossible.tsx
+++ b/src/features/bookOffer/components/BookingImpossible.tsx
@@ -13,7 +13,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ButtonTertiaryPrimary } from 'ui/components/buttons/ButtonTertiaryPrimary'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
 import { SadFace } from 'ui/svg/icons/SadFace'
-import { Spacer, Typo, getSpacing } from 'ui/theme'
+import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 
 export const BookingImpossible: React.FC = () => {
   const { bookingState, dismissModal, dispatch } = useBookingContext()
@@ -106,4 +106,4 @@ const Container = styled.View({
   alignContent: 'center',
   alignItems: 'center',
 })
-const StyledBody = styled(Typo.Body)({ textAlign: 'center', paddingHorizontal: getSpacing(6) })
+const StyledBody = styled(TypoDS.Body)({ textAlign: 'center', paddingHorizontal: getSpacing(6) })

--- a/src/features/bookOffer/components/Calendar/DayComponent.tsx
+++ b/src/features/bookOffer/components/Calendar/DayComponent.tsx
@@ -6,7 +6,7 @@ import styled, { DefaultTheme } from 'styled-components/native'
 import { DiagonalStripe } from 'features/bookOffer/components/Calendar/DiagonalStripe'
 import { useBookingContext } from 'features/bookOffer/context/useBookingContext'
 import { OfferStatus } from 'features/bookOffer/helpers/utils'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, Typo, TypoDS } from 'ui/theme'
 
 interface Props {
   status: OfferStatus
@@ -78,7 +78,7 @@ function getStatusColor({ colors }: DefaultTheme, status: OfferStatus) {
   return colors.greyDark
 }
 
-const Body = styled(Typo.Body)(({ theme }) => ({
+const Body = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 

--- a/src/features/bookOffer/components/Calendar/MonthHeader.tsx
+++ b/src/features/bookOffer/components/Calendar/MonthHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { CAPITALIZED_MONTHS } from 'shared/date/months'
-import { Typo } from 'ui/theme/typography'
+import { TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type Props = {
@@ -11,8 +11,8 @@ type Props = {
 export const MonthHeader: React.FC<Props> = ({ date }) => {
   const month = `${CAPITALIZED_MONTHS[date.getMonth()]} ${date.getFullYear()}`
   return (
-    <Typo.Body {...getHeadingAttrs(2)} accessibilityLiveRegion="polite">
+    <TypoDS.Body {...getHeadingAttrs(2)} accessibilityLiveRegion="polite">
       {month}
-    </Typo.Body>
+    </TypoDS.Body>
   )
 }

--- a/src/features/bookOffer/components/PriceLine.tsx
+++ b/src/features/bookOffer/components/PriceLine.tsx
@@ -4,7 +4,7 @@ import { OfferStockResponse } from 'api/gen'
 import { useGetPacificFrancToEuroRate } from 'libs/firebase/firestore/exchangeRates/useGetPacificFrancToEuroRate'
 import { formatCurrencyFromCents } from 'shared/currency/formatCurrencyFromCents'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
-import { Typo } from 'ui/theme'
+import { Typo, TypoDS } from 'ui/theme'
 
 interface PriceLineProps {
   quantity?: number
@@ -26,13 +26,13 @@ export function PriceLine({
   const totalPrice = formatCurrencyFromCents(quantity * unitPrice, currency, euroToPacificFrancRate)
   const price = formatCurrencyFromCents(unitPrice, currency, euroToPacificFrancRate)
 
-  const MainText = shouldDisabledStyles ? Typo.Body : Typo.Caption
-  const SecondaryText = shouldDisabledStyles ? Typo.Body : Typo.CaptionNeutralInfo
+  const MainText = shouldDisabledStyles ? TypoDS.Body : Typo.Caption
+  const SecondaryText = shouldDisabledStyles ? TypoDS.Body : Typo.CaptionNeutralInfo
 
   const shouldDisplayAttributes = attributes?.length
 
   return (
-    <Typo.Body>
+    <TypoDS.Body>
       <MainText>{totalPrice} </MainText>
 
       {quantity > 1 ? (
@@ -46,6 +46,6 @@ export function PriceLine({
       {shouldDisplayAttributes ? (
         <MainText testID="price-line-attributes"> - {attributes.join(' ')}</MainText>
       ) : null}
-    </Typo.Body>
+    </TypoDS.Body>
   )
 }

--- a/src/features/bookOffer/pages/BookingConfirmation.tsx
+++ b/src/features/bookOffer/pages/BookingConfirmation.tsx
@@ -22,7 +22,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
 import { BicolorTicketBooked } from 'ui/svg/icons/BicolorTicketBooked'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export function BookingConfirmation() {
   const { params } = useRoute<UseRouteType<'BookingConfirmation'>>()
@@ -111,7 +111,7 @@ export function BookingConfirmation() {
   )
 }
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })
 

--- a/src/features/bookings/components/ArchiveBookingModal.tsx
+++ b/src/features/bookings/components/ArchiveBookingModal.tsx
@@ -11,7 +11,7 @@ import { AppModal } from 'ui/components/modals/AppModal'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { Close } from 'ui/svg/icons/Close'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
 
 export interface ArchiveBookingModalProps {
   bookingId: number
@@ -81,7 +81,7 @@ const ModalContent = styled.View({
 const Title = styled(Typo.ButtonText)({
   textAlign: 'center',
 })
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
   marginTop: getSpacing(2),
 })

--- a/src/features/bookings/components/BookingPropertiesSection.tsx
+++ b/src/features/bookings/components/BookingPropertiesSection.tsx
@@ -14,7 +14,7 @@ import { Calendar as DefaultCalendar } from 'ui/svg/icons/Calendar'
 import { Duo } from 'ui/svg/icons/Duo'
 import { LocationBuilding as DefaultLocationBuilding } from 'ui/svg/icons/LocationBuilding'
 import { OrderPrice as DefaultOrderPrice } from 'ui/svg/icons/OrderPrice'
-import { Spacer, Typo, TypoDS, getSpacing } from 'ui/theme'
+import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type BookingPropertiesSectionProps = {
@@ -113,7 +113,7 @@ const IconDuoContainer = styled.View({
   marginVertical: -getSpacing(1.5),
 })
 
-const Title = styled(Typo.Body)``
+const Title = styled(TypoDS.Body)``
 
 const Calendar = styled(DefaultCalendar).attrs(({ theme }) => ({
   size: theme.icons.sizes.smaller,

--- a/src/features/bookings/components/CancelBookingModal.tsx
+++ b/src/features/bookings/components/CancelBookingModal.tsx
@@ -23,7 +23,7 @@ import { AppModal } from 'ui/components/modals/AppModal'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { Close } from 'ui/svg/icons/Close'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
 
 interface Props {
   visible: boolean
@@ -117,7 +117,7 @@ const OfferName = styled(Typo.ButtonText)({
   textAlign: 'center',
 })
 
-const Refund = styled(Typo.Body)({
+const Refund = styled(TypoDS.Body)({
   textAlign: 'center',
 })
 

--- a/src/features/bookings/components/OnGoingBookingItem.tsx
+++ b/src/features/bookings/components/OnGoingBookingItem.tsx
@@ -22,7 +22,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { BicolorClock as DefaultClock } from 'ui/svg/icons/BicolorClock'
 import { Duo } from 'ui/svg/icons/Duo'
 import { OfferEvent as DefaultOfferEvent } from 'ui/svg/icons/OfferEvent'
-import { Spacer, Typo, getSpacing } from 'ui/theme'
+import { Spacer, Typo, TypoDS, getSpacing } from 'ui/theme'
 
 type Props = {
   booking: Booking
@@ -145,7 +145,7 @@ const WithdrawContainer = styled.View(({ theme }) => ({
   color: theme.colors.primary,
 }))
 
-const DateLabel = styled(Typo.Body)(({ theme }) => ({
+const DateLabel = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 

--- a/src/features/bookings/components/TicketBody/EmailSent/EmailSent.tsx
+++ b/src/features/bookings/components/TicketBody/EmailSent/EmailSent.tsx
@@ -6,7 +6,7 @@ import { useIsMailAppAvailable } from 'features/auth/helpers/useIsMailAppAvailab
 import { getEmailMessage } from 'features/bookings/components/TicketBody/ticketBodyMessages'
 import { ButtonWithLinearGradient } from 'ui/components/buttons/buttonWithLinearGradient/ButtonWithLinearGradient'
 import { Email } from 'ui/svg/icons/Email'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 type Props = {
   offerDate: Date
@@ -36,7 +36,7 @@ const TicketContainer = styled.View({
   width: '100%',
 })
 
-const WithDrawalContainer = styled(Typo.Body)({
+const WithDrawalContainer = styled(TypoDS.Body)({
   textAlign: 'center',
   maxWidth: '100%',
   paddingBottom: getSpacing(6),

--- a/src/features/bookings/components/TicketBody/NoTicket/NoTicket.tsx
+++ b/src/features/bookings/components/TicketBody/NoTicket/NoTicket.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
 import { BicolorCircledCheck as InitialBicolorCircledCheck } from 'ui/svg/icons/BicolorCircledCheck'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 export const NoTicket: FunctionComponent = () => (
   <TicketContainer testID="withdrawal-info-no-ticket">
@@ -19,7 +19,7 @@ const TicketContainer = styled.View({
   width: '100%',
 })
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
   maxWidth: '100%',
 })

--- a/src/features/bookings/components/TicketBody/SeatWithQrCode/SeatWithQrCode.tsx
+++ b/src/features/bookings/components/TicketBody/SeatWithQrCode/SeatWithQrCode.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
 import { QrCode } from 'features/bookings/components/TicketBody/QrCode/QrCode'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, Typo, TypoDS } from 'ui/theme'
 
 export type SeatWithQrCodeProps = {
   seatIndex?: string
@@ -29,13 +29,13 @@ export const SeatWithQrCode: FunctionComponent<SeatWithQrCodeProps> = ({
   )
 }
 
-const SeatContainer = styled(Typo.Body)({
+const SeatContainer = styled(TypoDS.Body)({
   textAlign: 'center',
   maxWidth: '100%',
   paddingHorizontal: getSpacing(2),
   marginBottom: getSpacing(3),
 })
 
-const Seat = styled(Typo.Body)({
+const Seat = styled(TypoDS.Body)({
   marginLeft: getSpacing(1),
 })

--- a/src/features/bookings/components/TicketBody/TicketWithdrawal/TicketWithdrawal.tsx
+++ b/src/features/bookings/components/TicketBody/TicketWithdrawal/TicketWithdrawal.tsx
@@ -7,7 +7,7 @@ import {
   getStartMessage,
 } from 'features/bookings/components/TicketBody/ticketBodyMessages'
 import { BicolorEmailSent as InitialBicolorEmailSent } from 'ui/svg/icons/BicolorEmailSent'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 type Props = {
   withdrawalType: Exclude<WithdrawalTypeEnum, WithdrawalTypeEnum.no_ticket>
@@ -52,12 +52,12 @@ const BicolorEmailSent = styled(InitialBicolorEmailSent).attrs(({ theme }) => ({
   color2: theme.colors.secondary,
 }))``
 
-const WithDrawalContainer = styled(Typo.Body)({
+const WithDrawalContainer = styled(TypoDS.Body)({
   textAlign: 'center',
   maxWidth: '100%',
   paddingBottom: getSpacing(6),
 })
 
-const TicketWithdrawalDelay = styled(Typo.Body)(({ theme }) => ({
+const TicketWithdrawalDelay = styled(TypoDS.Body)(({ theme }) => ({
   fontFamily: theme.fontFamily.bold,
 }))

--- a/src/features/bookings/pages/BookingDetails/BookingDetails.tsx
+++ b/src/features/bookings/pages/BookingDetails/BookingDetails.tsx
@@ -249,7 +249,7 @@ export function BookingDetails() {
             <SectionWithDivider visible={!!offer.withdrawalDetails} gap={8}>
               <InfoContainer gap={4}>
                 <TypoDS.Title4 {...getHeadingAttrs(2)}>Modalités de retrait</TypoDS.Title4>
-                <Typo.Body testID="withdrawalDetails">{offer.withdrawalDetails}</Typo.Body>
+                <TypoDS.Body testID="withdrawalDetails">{offer.withdrawalDetails}</TypoDS.Body>
               </InfoContainer>
             </SectionWithDivider>
           ) : null}

--- a/src/features/bookings/pages/BookingNotFound/BookingNotFound.tsx
+++ b/src/features/bookings/pages/BookingNotFound/BookingNotFound.tsx
@@ -11,7 +11,7 @@ import { ButtonTertiaryWhite } from 'ui/components/buttons/ButtonTertiaryWhite'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { NoBookings } from 'ui/svg/icons/NoBookings'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export const BookingNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
   const timer = useRef<NodeJS.Timeout>()
@@ -67,7 +67,7 @@ export const BookingNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/bookings/pages/EndedBookings/EndedBookings.tsx
+++ b/src/features/bookings/pages/EndedBookings/EndedBookings.tsx
@@ -30,7 +30,7 @@ import {
 } from 'ui/components/headers/PageHeaderWithoutPlaceholder'
 import { useModal } from 'ui/components/modals/useModal'
 import { Separator } from 'ui/components/Separator'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { TAB_BAR_COMP_HEIGHT_V2 } from 'ui/theme/constants'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
@@ -203,7 +203,7 @@ const Placeholder = styled.View<{ height: number }>(({ height }) => ({
   height,
 }))
 
-const EndedBookingsCount = styled(Typo.Body).attrs(getHeadingAttrs(2))(({ theme }) => ({
+const EndedBookingsCount = styled(TypoDS.Body).attrs(getHeadingAttrs(2))(({ theme }) => ({
   color: theme.colors.greyDark,
   paddingBottom: getSpacing(5.5),
 }))

--- a/src/features/cookies/components/CookiesAccordion.tsx
+++ b/src/features/cookies/components/CookiesAccordion.tsx
@@ -11,7 +11,7 @@ import { Accordion } from 'ui/components/Accordion'
 import FilterSwitch from 'ui/components/FilterSwitch'
 import { Separator } from 'ui/components/Separator'
 import { InfoPlain } from 'ui/svg/icons/InfoPlain'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
 
 export const CookiesAccordion = ({
   cookie,
@@ -33,7 +33,7 @@ export const CookiesAccordion = ({
   return (
     <React.Fragment>
       <StyledAccordionItem
-        title={<Typo.Body>{info.title}</Typo.Body>}
+        title={<TypoDS.Body>{info.title}</TypoDS.Body>}
         onOpenOnce={() => analytics.logHasOpenedCookiesAccordion(cookie)}
         labelId={accordionLabelId}
         leftComponent={
@@ -46,7 +46,7 @@ export const CookiesAccordion = ({
           />
         }>
         <React.Fragment>
-          <Typo.Body>{info.description}</Typo.Body>
+          <TypoDS.Body>{info.description}</TypoDS.Body>
           {info.caption ? (
             <React.Fragment>
               <Spacer.Column numberOfSpaces={4} />

--- a/src/features/cookies/components/CookiesConsentExplanations.tsx
+++ b/src/features/cookies/components/CookiesConsentExplanations.tsx
@@ -1,19 +1,19 @@
 import React from 'react'
 
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, Typo, TypoDS } from 'ui/theme'
 
 export const CookiesConsentExplanations = () => (
   <React.Fragment>
-    <Typo.Body>
+    <TypoDS.Body>
       Les cookies sont des petits fichiers stockés sur ton appareil lorsque tu navigues. Nous
       utilisons les données collectées par ces cookies et traceurs pour t’offrir la meilleure
       expérience possible.
-    </Typo.Body>
+    </TypoDS.Body>
     <Spacer.Column numberOfSpaces={4} />
-    <Typo.Body>
+    <TypoDS.Body>
       Tu peux accéder aux réglages des cookies pour faire un choix éclairé et découvrir notre
       politique de gestion des cookies.
-    </Typo.Body>
+    </TypoDS.Body>
     <Spacer.Column numberOfSpaces={4} />
     <Typo.CaptionNeutralInfo>
       Ton choix est conservé pendant 6 mois et tu pourras le modifier dans les paramètres de

--- a/src/features/cookies/pages/CookiesDetails.tsx
+++ b/src/features/cookies/pages/CookiesDetails.tsx
@@ -17,11 +17,11 @@ export const CookiesDetails = (props: CookiesChoiceSettings) => {
     <React.Fragment>
       <AccordionContainer>
         <StyledAccordionItem>
-          <Typo.Body>
+          <TypoDS.Body>
             Les cookies sont des petits fichiers stockés sur ton appareil lorsque tu navigues. Tu
             peux choisir d’accepter ou non l’activation de leur suivi. Nous utilisons les données
             collectées par ces cookies et traceurs pour t’offrir la meilleure expérience possible.
-          </Typo.Body>
+          </TypoDS.Body>
         </StyledAccordionItem>
       </AccordionContainer>
       <Spacer.Column numberOfSpaces={8} />
@@ -29,12 +29,14 @@ export const CookiesDetails = (props: CookiesChoiceSettings) => {
       <Spacer.Column numberOfSpaces={8} />
       <TypoDS.Title4 {...getHeadingAttrs(2)}>Tu as la main dessus</TypoDS.Title4>
       <Spacer.Column numberOfSpaces={4} />
-      <Typo.Body>
+      <TypoDS.Body>
         Ton choix est conservé pendant 6 mois et tu pourras le modifier dans les paramètres de
         confidentialité de ton profil à tout moment.
-      </Typo.Body>
+      </TypoDS.Body>
       <Spacer.Column numberOfSpaces={4} />
-      <Typo.Body>On te redemandera bien sûr ton consentement si notre politique évolue.</Typo.Body>
+      <TypoDS.Body>
+        On te redemandera bien sûr ton consentement si notre politique évolue.
+      </TypoDS.Body>
       <Spacer.Column numberOfSpaces={4} />
       <Typo.CaptionNeutralInfo>
         {buttonText}

--- a/src/features/culturalSurvey/pages/CulturalSurveyThanks.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyThanks.tsx
@@ -7,7 +7,7 @@ import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import QpiThanks from 'ui/animations/qpi_thanks.json'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const CulturalSurveyThanks: React.FC = () => {
   const enableCulturalSurveyMandatory = useFeatureFlag(
@@ -35,6 +35,6 @@ const ButtonContainer = styled.View({
   paddingBottom: getSpacing(10),
 })
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/features/errors/pages/AsyncErrorBoundary.tsx
+++ b/src/features/errors/pages/AsyncErrorBoundary.tsx
@@ -17,7 +17,7 @@ import { Touchable } from 'ui/components/touchable/Touchable'
 import { GenericErrorPage } from 'ui/pages/GenericErrorPage'
 import { BicolorBrokenConnection } from 'ui/svg/BicolorBrokenConnection'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 interface AsyncFallbackProps extends FallbackProps {
@@ -129,7 +129,7 @@ const HeaderContainer = styledButton(Touchable)<{ top: number }>(({ theme, top }
   zIndex: theme.zIndex.floatingButton,
 }))
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/errors/pages/BannedCountryError.tsx
+++ b/src/features/errors/pages/BannedCountryError.tsx
@@ -7,7 +7,7 @@ import { pushFromRef } from 'features/navigation/navigationRef'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { GenericErrorPage } from 'ui/pages/GenericErrorPage'
 import { BicolorBrokenConnection } from 'ui/svg/BicolorBrokenConnection'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export const BannedCountryError = () => {
@@ -34,6 +34,6 @@ export const BannedCountryError = () => {
   )
 }
 
-const StyledBody = styled(Typo.Body).attrs(() => getHeadingAttrs(2))({
+const StyledBody = styled(TypoDS.Body).attrs(() => getHeadingAttrs(2))({
   textAlign: 'center',
 })

--- a/src/features/favorites/components/Favorite.tsx
+++ b/src/features/favorites/components/Favorite.tsx
@@ -29,7 +29,7 @@ import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouch
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { useLayout } from 'ui/hooks/useLayout'
 import { ExternalSite } from 'ui/svg/icons/ExternalSite'
-import { Spacer, Typo, getSpacing } from 'ui/theme'
+import { Spacer, Typo, TypoDS, getSpacing } from 'ui/theme'
 
 interface Props {
   favorite: FavoriteResponse
@@ -303,12 +303,12 @@ export const FavoriteButtonsContainer = styled.View(({ theme }) => {
   }
 })
 
-const Distance = styled(Typo.Body)(({ theme }) => ({
+const Distance = styled(TypoDS.Body)(({ theme }) => ({
   textAlign: 'right',
   color: theme.colors.greyDark,
 }))
 
-const Body = styled(Typo.Body)(({ theme }) => ({
+const Body = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 

--- a/src/features/favorites/pages/NotConnectedFavorites.tsx
+++ b/src/features/favorites/pages/NotConnectedFavorites.tsx
@@ -8,7 +8,7 @@ import { ButtonWithLinearGradient } from 'ui/components/buttons/buttonWithLinear
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
 import { BicolorUserFavorite } from 'ui/svg/icons/BicolorUserFavorite'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 const onBeforeSignupNavigate = () => {
   analytics.logSignUpFromFavorite()
@@ -54,7 +54,7 @@ const ButtonContainer = styled.View({
   minHeight: getSpacing(31), // To avoid button getting smashed on "square" screens
 })
 
-const CenteredText = styled(Typo.Body)({
+const CenteredText = styled(TypoDS.Body)({
   textAlign: 'center',
 })
 

--- a/src/features/forceUpdate/pages/ForceUpdate.tsx
+++ b/src/features/forceUpdate/pages/ForceUpdate.tsx
@@ -15,7 +15,7 @@ import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouch
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { AgainIllustration } from 'ui/svg/icons/AgainIllustration'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 type ForceUpdateProps = {
   resetErrorBoundary: () => void
@@ -78,7 +78,7 @@ export const ForceUpdate = ({ resetErrorBoundary }: ForceUpdateProps) => {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   textAlign: 'center',
   color: theme.colors.white,
 }))

--- a/src/features/home/components/banners/ActivationBanner.tsx
+++ b/src/features/home/components/banners/ActivationBanner.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
 import { BannerWithBackground } from 'ui/components/ModuleBanner/BannerWithBackground'
 import { AccessibleIcon } from 'ui/svg/icons/types'
-import { Typo } from 'ui/theme'
+import { Typo, TypoDS } from 'ui/theme'
 
 type ActivationBannerProps = {
   title: string
@@ -33,6 +33,6 @@ const StyledButtonText = styled(Typo.ButtonText)(({ theme }) => ({
   color: theme.colors.white,
 }))
 
-const StyledBodyText = styled(Typo.Body)(({ theme }) => ({
+const StyledBodyText = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
 }))

--- a/src/features/home/components/banners/SignupBanner.tsx
+++ b/src/features/home/components/banners/SignupBanner.tsx
@@ -7,7 +7,7 @@ import { analytics } from 'libs/analytics'
 import { BannerWithBackground } from 'ui/components/ModuleBanner/BannerWithBackground'
 import { SystemBanner } from 'ui/components/ModuleBanner/SystemBanner'
 import { BicolorUnlock } from 'ui/svg/icons/BicolorUnlock'
-import { Typo } from 'ui/theme'
+import { Typo, TypoDS } from 'ui/theme'
 
 const onBeforeNavigate = () => analytics.logSignUpClicked({ from: 'home' })
 
@@ -60,6 +60,6 @@ const StyledButtonText = styled(Typo.ButtonText)(({ theme }) => ({
   color: theme.colors.white,
 }))
 
-const StyledBodyText = styled(Typo.Body)(({ theme }) => ({
+const StyledBodyText = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
 }))

--- a/src/features/home/components/headers/DefaultThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/DefaultThematicHomeHeader.tsx
@@ -3,7 +3,7 @@ import { Platform } from 'react-native'
 import styled from 'styled-components/native'
 
 import { useGetThematicHeaderHeight } from 'features/home/api/helpers/useGetThematicHeaderHeight'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 interface DefaultThematicHomeHeaderProps {
   headerTitle?: string
@@ -25,7 +25,7 @@ export const DefaultThematicHomeHeader: FunctionComponent<DefaultThematicHomeHea
           {headerSubtitle ? (
             <React.Fragment>
               <Spacer.Column numberOfSpaces={2} />
-              <Typo.Body numberOfLines={2}>{headerSubtitle}</Typo.Body>
+              <TypoDS.Body numberOfLines={2}>{headerSubtitle}</TypoDS.Body>
             </React.Fragment>
           ) : null}
           <Spacer.Column numberOfSpaces={6} />

--- a/src/features/home/components/headers/highlightThematic/Introduction.tsx
+++ b/src/features/home/components/headers/highlightThematic/Introduction.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 type IntroductionProps = {
   title: string
@@ -13,7 +13,7 @@ export const Introduction = ({ title, paragraph }: IntroductionProps) => (
     <IntroductionContainer>
       <TypoDS.Title4 numberOfLines={3}>{title}</TypoDS.Title4>
       <Spacer.Column numberOfSpaces={4} />
-      <Typo.Body>{paragraph}</Typo.Body>
+      <TypoDS.Body>{paragraph}</TypoDS.Body>
     </IntroductionContainer>
     <Spacer.Column numberOfSpaces={6} />
     <Divider />

--- a/src/features/home/components/modules/ThematicHighlightModule.tsx
+++ b/src/features/home/components/modules/ThematicHighlightModule.tsx
@@ -167,7 +167,7 @@ const Title = styled(TypoDS.Title3)(({ theme }) => ({
   flexShrink: 1,
 }))
 
-const Subtitle = styled(Typo.Body)(({ theme }) => ({
+const Subtitle = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
 }))
 

--- a/src/features/home/components/modules/business/NewBusinessModule.tsx
+++ b/src/features/home/components/modules/business/NewBusinessModule.tsx
@@ -249,7 +249,7 @@ const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
   color: theme.colors.white,
 }))
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
 }))
 const StyledTitle4 = styled(TypoDS.Title4)(({ theme }) => ({

--- a/src/features/home/components/modules/business/OldBusinessModule.tsx
+++ b/src/features/home/components/modules/business/OldBusinessModule.tsx
@@ -14,7 +14,7 @@ import { useHandleFocus } from 'libs/hooks/useHandleFocus'
 import { ImageBackground } from 'libs/resizing-image-on-demand/ImageBackground'
 import { SNACK_BAR_TIME_OUT_LONG, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { ArrowNext } from 'ui/svg/icons/ArrowNext'
-import { LENGTH_XS, MARGIN_DP, RATIO_BUSINESS, Typo, getSpacing } from 'ui/theme'
+import { LENGTH_XS, MARGIN_DP, RATIO_BUSINESS, Typo, TypoDS, getSpacing } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 
 const UnmemoizedBusinessModule = (props: BusinessModuleProps) => {
@@ -184,7 +184,7 @@ const ButtonText = styled(Typo.ButtonText)(({ theme }) => ({
   color: theme.colors.white,
 }))
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
 }))
 

--- a/src/features/home/components/modules/video/VerticalVideoErrorView.tsx
+++ b/src/features/home/components/modules/video/VerticalVideoErrorView.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/native'
 import { theme } from 'theme'
 import { BackgroundWithDefaultStatusBar } from 'ui/svg/Background'
 import { BicolorBrokenConnection } from 'ui/svg/BicolorBrokenConnection'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 const ERROR_TITLE = 'Oups\u00a0!'
 const ERROR_MESSAGE = 'Une erreur s’est produite pendant le chargement de la vidéo'
@@ -57,7 +57,7 @@ const StyledErrorTitle = styled(TypoDS.Title2)(({ theme }) => ({
   textAlign: 'center',
 }))
 
-const StyledErrorMessage = styled(Typo.Body)(({ theme }) => ({
+const StyledErrorMessage = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/home/components/modules/video/VideoErrorView.tsx
+++ b/src/features/home/components/modules/video/VideoErrorView.tsx
@@ -3,7 +3,7 @@ import { StyleProp, View, ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
 
 import { HeaderBackground } from 'ui/svg/HeaderBackground'
-import { Spacer, Typo, TypoDS, getSpacing } from 'ui/theme'
+import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 
 export const VideoErrorView: React.FC<{
   style: StyleProp<ViewStyle>
@@ -41,7 +41,7 @@ const StyledTitle = styled(TypoDS.Title2)(({ theme }) => ({
   textAlign: 'center',
 }))
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/home/components/modules/video/VideoModal.tsx
+++ b/src/features/home/components/modules/video/VideoModal.tsx
@@ -155,7 +155,7 @@ const StyledCaptionDate = styled(Typo.Caption)(({ theme }) => ({
   color: theme.colors.greySemiDark,
 }))
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 

--- a/src/features/home/components/modules/video/VideoModal.web.tsx
+++ b/src/features/home/components/modules/video/VideoModal.web.tsx
@@ -153,7 +153,7 @@ const StyledCaptionDate = styled(Typo.Caption)(({ theme }) => ({
   color: theme.colors.greySemiDark,
 }))
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 

--- a/src/features/home/pages/NoContentError.tsx
+++ b/src/features/home/pages/NoContentError.tsx
@@ -9,7 +9,7 @@ import { ButtonSecondaryWhite } from 'ui/components/buttons/ButtonSecondaryWhite
 import { GenericErrorPage } from 'ui/pages/GenericErrorPage'
 import { BicolorBrokenConnection } from 'ui/svg/BicolorBrokenConnection'
 import { MagnifyingGlass } from 'ui/svg/icons/MagnifyingGlass'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export const NoContentError = () => {
   const { navigate } = useNavigation<UseNavigationType>()
@@ -46,7 +46,7 @@ export const NoContentError = () => {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/identityCheck/components/countryPicker/CountryPicker.tsx
+++ b/src/features/identityCheck/components/countryPicker/CountryPicker.tsx
@@ -13,7 +13,7 @@ import { useModal } from 'ui/components/modals/useModal'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { ArrowDown as DefaultArrowDown } from 'ui/svg/icons/ArrowDown'
 import { Close } from 'ui/svg/icons/Close'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   selectedCountry: Country
@@ -85,7 +85,7 @@ const VerticalSeparator = styled.View(({ theme }) => ({
   borderRightColor: theme.colors.greyDark,
 }))
 
-const CallingCodeText = styled(Typo.Body)({
+const CallingCodeText = styled(TypoDS.Body)({
   marginLeft: -getSpacing(1), // To compensate for the Flag component right margin
   marginRight: getSpacing(1),
 })

--- a/src/features/identityCheck/components/modals/DMSModal.tsx
+++ b/src/features/identityCheck/components/modals/DMSModal.tsx
@@ -8,7 +8,7 @@ import { AppModal } from 'ui/components/modals/AppModal'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { Close } from 'ui/svg/icons/Close'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, Typo, TypoDS } from 'ui/theme'
 
 interface Props {
   visible: boolean
@@ -60,6 +60,6 @@ export const DMSModal: FunctionComponent<Props> = ({ visible, hideModal }) => (
   </AppModal>
 )
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))

--- a/src/features/identityCheck/components/modals/QuitIdentityCheckModal.tsx
+++ b/src/features/identityCheck/components/modals/QuitIdentityCheckModal.tsx
@@ -10,7 +10,7 @@ import { AppFullPageModal } from 'ui/components/modals/AppFullPageModal'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { BicolorError } from 'ui/svg/icons/BicolorError'
 import { Clear } from 'ui/svg/icons/Clear'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 interface Props {
   visible: boolean
@@ -64,7 +64,7 @@ export const QuitIdentityCheckModal: FunctionComponent<Props> = ({
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/identityCheck/pages/Stepper.tsx
+++ b/src/features/identityCheck/pages/Stepper.tsx
@@ -20,7 +20,7 @@ import { StepButton } from 'ui/components/StepButton/StepButton'
 import { StepButtonState } from 'ui/components/StepButton/types'
 import { StepList } from 'ui/components/StepList/StepList'
 import { Invalidate } from 'ui/svg/icons/Invalidate'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export const Stepper = () => {
@@ -161,7 +161,7 @@ const QuitButtonContainer = styled.View({
 const StyledSubtitle = ({ subtitle }: { subtitle: string }) => (
   <React.Fragment>
     <Spacer.Column numberOfSpaces={2} />
-    <Typo.Body>{subtitle}</Typo.Body>
+    <TypoDS.Body>{subtitle}</TypoDS.Body>
     <Spacer.Column numberOfSpaces={8} />
   </React.Fragment>
 )

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.tsx
@@ -20,7 +20,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
 import { categoriesIcons } from 'ui/svg/icons/bicolor/exports/categoriesIcons'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { getNoHeadingAttrs } from 'ui/theme/typographyAttrs/getNoHeadingAttrs'
 
 export function BeneficiaryAccountCreated() {
@@ -87,7 +87,7 @@ const StyledSubtitle = styled(TypoDS.Title4).attrs(getNoHeadingAttrs())({
   textAlign: 'center',
 })
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })
 

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.tsx
@@ -8,7 +8,7 @@ import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { RequestSent } from 'ui/svg/icons/RequestSent'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export function BeneficiaryRequestSent() {
   const { user } = useAuthContext()
@@ -46,7 +46,7 @@ export function BeneficiaryRequestSent() {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/identityCheck/pages/identification/IdentityCheckUnavailable.tsx
+++ b/src/features/identityCheck/pages/identification/IdentityCheckUnavailable.tsx
@@ -14,7 +14,7 @@ import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { ExternalSite } from 'ui/svg/icons/ExternalSite'
 import { HappyFace } from 'ui/svg/icons/HappyFace'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export function IdentityCheckUnavailable() {
   const { params } = useRoute<UseRouteType<'IdentityCheckUnavailable'>>()
@@ -64,7 +64,7 @@ export function IdentityCheckUnavailable() {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/identityCheck/pages/identification/dms/DMSIntroduction.tsx
+++ b/src/features/identityCheck/pages/identification/dms/DMSIntroduction.tsx
@@ -85,7 +85,7 @@ export const DMSIntroduction = (): React.JSX.Element => {
   )
 }
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
   marginBottom: getSpacing(5),
 })

--- a/src/features/identityCheck/pages/identification/dms/IdentityCheckDMS.tsx
+++ b/src/features/identityCheck/pages/identification/dms/IdentityCheckDMS.tsx
@@ -10,7 +10,7 @@ import { SeparatorWithText } from 'ui/components/SeparatorWithText'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { BicolorIdCardWithMagnifyingGlass } from 'ui/svg/icons/BicolorIdCardWithMagnifyingGlass'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
 
 export const IdentityCheckDMS = () => {
   const theme = useTheme()
@@ -74,7 +74,7 @@ const StyledBicolorIdCardWithMagnifyingGlass = styled(BicolorIdCardWithMagnifyin
 
 const Container = styled.View({ height: '100%', alignItems: 'center' })
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   textAlign: 'center',
   color: theme.colors.greyDark,
 }))

--- a/src/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.tsx
+++ b/src/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.tsx
@@ -11,7 +11,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { BicolorIdCardWithMagnifyingGlass } from 'ui/svg/icons/BicolorIdCardWithMagnifyingGlass'
 import { ExternalSite } from 'ui/svg/icons/ExternalSite'
 import { Info } from 'ui/svg/icons/Info'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
 
 export const EduConnectForm = () => {
   const { error, openEduConnectTab } = useEduConnectLogin()
@@ -79,7 +79,7 @@ const Center = styled.View({
   padding: getSpacing(7),
 })
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   textAlign: 'center',
   color: theme.colors.greyDark,
 }))

--- a/src/features/identityCheck/pages/identification/educonnect/EduConnectValidation.tsx
+++ b/src/features/identityCheck/pages/identification/educonnect/EduConnectValidation.tsx
@@ -10,7 +10,7 @@ import { useSaveStep } from 'features/identityCheck/pages/helpers/useSaveStep'
 import { IdentityCheckStep } from 'features/identityCheck/types'
 import { analytics } from 'libs/analytics'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export function EduConnectValidation() {
   const { identification } = useSubscriptionContext()
@@ -59,7 +59,7 @@ export function EduConnectValidation() {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 

--- a/src/features/identityCheck/pages/identification/educonnect/EduConnectValidation.web.tsx
+++ b/src/features/identityCheck/pages/identification/educonnect/EduConnectValidation.web.tsx
@@ -13,7 +13,7 @@ import { DeprecatedIdentityCheckStep } from 'features/identityCheck/types'
 import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { getNoHeadingAttrs } from 'ui/theme/typographyAttrs/getNoHeadingAttrs'
 
 export function EduConnectValidation() {
@@ -92,7 +92,7 @@ const BodyContainer = styled.View({
   alignItems: 'center',
 })
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
@@ -11,7 +11,7 @@ import { ButtonTertiaryWhite } from 'ui/components/buttons/ButtonTertiaryWhite'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 import { useNotEligibleEduConnectErrorData } from '../hooks/useNotEligibleEduConnectErrorData'
 
@@ -79,7 +79,7 @@ export const NotEligibleEduConnect = ({
 type TextBodyProps = TextProps & {
   textAlign?: Exclude<TextStyle['textAlign'], 'auto'>
 }
-const Body = styled(Typo.Body).attrs<TextBodyProps>((props) => props)<TextBodyProps>(
+const Body = styled(TypoDS.Body).attrs<TextBodyProps>((props) => props)<TextBodyProps>(
   ({ theme, textAlign }) => ({
     ...theme.typography.body,
     textAlign,

--- a/src/features/identityCheck/pages/identification/ubble/ComeBackLater.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/ComeBackLater.tsx
@@ -25,7 +25,7 @@ export const ComeBackLater: FunctionComponent = () => {
       headerGoBack
       mobileBottomFlex={0.5}>
       <StyledText>
-        <Typo.Body>Pour profiter du pass Culture, tu dois avoir </Typo.Body>
+        <TypoDS.Body>Pour profiter du pass Culture, tu dois avoir </TypoDS.Body>
         <Typo.ButtonText>
           ta pièce d’identité originale et en cours de validité avec toi.
         </Typo.ButtonText>
@@ -44,7 +44,7 @@ export const ComeBackLater: FunctionComponent = () => {
   )
 }
 
-const StyledText = styled(Typo.Body)({
+const StyledText = styled(TypoDS.Body)({
   textAlign: 'center',
   marginBottom: getSpacing(6),
 })

--- a/src/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.tsx
@@ -9,7 +9,7 @@ import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouch
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
 import { BicolorIdCardError } from 'ui/svg/icons/BicolorIdCardError'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const ExpiredOrLostID = (): React.JSX.Element => {
   useEffect(() => {
@@ -55,7 +55,7 @@ const StyledBicolorIdCardError = styled(BicolorIdCardError).attrs(({ theme }) =>
   color2: theme.colors.primary,
 }))``
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
   marginBottom: getSpacing(5),
 })

--- a/src/features/identityCheck/pages/identification/ubble/IdentityCheckPending.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/IdentityCheckPending.tsx
@@ -7,7 +7,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { BicolorIdCardError } from 'ui/svg/icons/BicolorIdCardError'
 import { AccessibleIcon } from 'ui/svg/icons/types'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export function IdentityCheckPending() {
   return (
@@ -36,7 +36,7 @@ export function IdentityCheckPending() {
 
 const IdCardError: React.FC<AccessibleIcon> = (props) => <BicolorIdCardError {...props} />
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/identityCheck/pages/identification/ubble/SelectIDOrigin.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/SelectIDOrigin.tsx
@@ -36,7 +36,7 @@ const SelectIDOriginContent: FunctionComponent = () => {
       <HeroButtonList
         Title={
           <Text>
-            <Typo.Body>J’ai une carte d’identité ou un passeport </Typo.Body>
+            <TypoDS.Body>J’ai une carte d’identité ou un passeport </TypoDS.Body>
             <Typo.ButtonText>français</Typo.ButtonText>
           </Text>
         }
@@ -80,6 +80,6 @@ const StyledBicolorIdCardWithMagnifyingGlass = styled(BicolorIdCardWithMagnifyin
 const StyledTitle4 = styled(TypoDS.Title4).attrs(getHeadingAttrs(2))({
   textAlign: 'center',
 })
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/features/identityCheck/pages/identification/ubble/SelectIDStatus.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/SelectIDStatus.tsx
@@ -65,11 +65,11 @@ const SelectIDStatusContent: FunctionComponent = () => {
       <StyledTitle4>As-tu ta pièce d’identité avec toi&nbsp;?</StyledTitle4>
       <Spacer.Column numberOfSpaces={4} />
       <StyledText>
-        <Typo.Body>Tu dois avoir ta pièce d’identité </Typo.Body>
+        <TypoDS.Body>Tu dois avoir ta pièce d’identité </TypoDS.Body>
         <Typo.ButtonText>originale </Typo.ButtonText>
-        <Typo.Body>et </Typo.Body>
+        <TypoDS.Body>et </TypoDS.Body>
         <Typo.ButtonText>en cours de validité </Typo.ButtonText>
-        <Typo.Body>avec toi.</Typo.Body>
+        <TypoDS.Body>avec toi.</TypoDS.Body>
       </StyledText>
       <Spacer.Column numberOfSpaces={12} />
       {MainOptionButton}

--- a/src/features/identityCheck/pages/identification/ubble/SelectPhoneStatus.web.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/SelectPhoneStatus.web.tsx
@@ -7,7 +7,7 @@ import { HeroButtonList } from 'ui/components/buttons/HeroButtonList'
 import { BicolorNoPhone } from 'ui/svg/icons/BicolorNoPhone'
 import { BicolorPhonePending } from 'ui/svg/icons/BicolorPhonePending'
 import { BicolorSmartphone } from 'ui/svg/icons/BicolorSmartphone'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export const SelectPhoneStatus: FunctionComponent = () => {
@@ -16,13 +16,13 @@ export const SelectPhoneStatus: FunctionComponent = () => {
 
 const buttonList = [
   <HeroButtonList
-    Title={<Typo.Body>J’ai un smartphone à proximité</Typo.Body>}
+    Title={<TypoDS.Body>J’ai un smartphone à proximité</TypoDS.Body>}
     Icon={<BicolorSmartphone />}
     navigateTo={{ screen: 'SelectIDStatus' }}
     key={1}
   />,
   <HeroButtonList
-    Title={<Typo.Body>Je n’ai pas de smartphone à proximité</Typo.Body>}
+    Title={<TypoDS.Body>Je n’ai pas de smartphone à proximité</TypoDS.Body>}
     Icon={<BicolorNoPhone />}
     navigateTo={{ screen: 'DMSIntroduction', params: { isForeignDMSInformation: false } }}
     key={2}
@@ -62,6 +62,6 @@ const StyledBicolorPhonePending = styled(BicolorPhonePending).attrs(({ theme }) 
 const StyledTitle4 = styled(TypoDS.Title4).attrs(getHeadingAttrs(2))({
   textAlign: 'center',
 })
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/features/identityCheck/pages/phoneValidation/CodeNotReceivedModal.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/CodeNotReceivedModal.tsx
@@ -16,7 +16,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { Close } from 'ui/svg/icons/Close'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, Typo, TypoDS } from 'ui/theme'
 
 export interface CodeNotReceivedModalProps {
   isVisible: boolean
@@ -96,7 +96,7 @@ export const CodeNotReceivedModal: FunctionComponent<CodeNotReceivedModalProps> 
   )
 }
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })
 

--- a/src/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.tsx
@@ -7,7 +7,7 @@ import { AppModal } from 'ui/components/modals/AppModal'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { BicolorSignal } from 'ui/svg/icons/BicolorSignal'
 import { BicolorSmartphone } from 'ui/svg/icons/BicolorSmartphone'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   isVisible: boolean
@@ -46,7 +46,7 @@ export const PhoneValidationTipsModal: FunctionComponent<Props> = (props) => {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
   textAlign: 'center',
 }))

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.tsx
@@ -31,7 +31,7 @@ import { Form } from 'ui/components/Form'
 import { InputError } from 'ui/components/inputs/InputError'
 import { TextInput } from 'ui/components/inputs/TextInput'
 import { useModal } from 'ui/components/modals/useModal'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, Typo, TypoDS } from 'ui/theme'
 
 const INITIAL_COUNTRY = METROPOLITAN_FRANCE
 
@@ -187,7 +187,7 @@ const RemainingAttemptsContainer = styled.View({
   flexDirection: 'row',
 })
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
   textAlign: 'center',
 }))

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.tsx
@@ -24,7 +24,7 @@ import { InputError } from 'ui/components/inputs/InputError'
 import { TextInput } from 'ui/components/inputs/TextInput'
 import { useModal } from 'ui/components/modals/useModal'
 import { Again } from 'ui/svg/icons/Again'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export const SetPhoneValidationCode = () => {
   const { phoneValidation } = useSubscriptionContext()
@@ -177,7 +177,7 @@ export const hasCodeCorrectFormat = (code: string) => {
   return !!code.match(/^\d{6}$/)
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
   textAlign: 'center',
 }))

--- a/src/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManyAttempts.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManyAttempts.tsx
@@ -10,7 +10,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 import { UserBlocked } from 'ui/svg/icons/UserBlocked'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export function PhoneValidationTooManyAttempts() {
   return (
@@ -41,7 +41,7 @@ export function PhoneValidationTooManyAttempts() {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManySMSSent.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/errors/PhoneValidationTooManySMSSent.tsx
@@ -11,7 +11,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
 import { UserBlocked } from 'ui/svg/icons/UserBlocked'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export function PhoneValidationTooManySMSSent() {
   const { counterResetDatetime } = usePhoneValidationRemainingAttempts()
@@ -49,7 +49,7 @@ export function PhoneValidationTooManySMSSent() {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/internal/components/DeeplinksResult.tsx
+++ b/src/features/internal/components/DeeplinksResult.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { DeeplinkItem } from 'features/internal/atoms/DeeplinkItem'
 import { GeneratedDeeplink } from 'features/internal/components/DeeplinksGeneratorForm'
-import { getSpacing, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 interface Props {
   result?: GeneratedDeeplink
@@ -19,7 +19,7 @@ export const DeeplinksResult = ({ result }: Props) => {
             <DeeplinkItem deeplink={result} />
           ) : (
             <CenteredContainer>
-              <Typo.Body>Vous devez d’abord générer un lien</Typo.Body>
+              <TypoDS.Body>Vous devez d’abord générer un lien</TypoDS.Body>
             </CenteredContainer>
           )}
         </ResultContainer>

--- a/src/features/maintenance/pages/Maintenance.tsx
+++ b/src/features/maintenance/pages/Maintenance.tsx
@@ -5,7 +5,7 @@ import { Helmet } from 'libs/react-helmet/Helmet'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { LogoPassCulture as LogoPassCultureOriginal } from 'ui/svg/icons/LogoPassCulture'
 import { MaintenanceCone } from 'ui/svg/icons/MaintenanceCone'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 type MaintenanceProps = {
   message?: string
@@ -32,7 +32,7 @@ export const Maintenance: React.FC<MaintenanceProps> = (props) => {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/navigation/pages/PageNotFound.tsx
+++ b/src/features/navigation/pages/PageNotFound.tsx
@@ -7,7 +7,7 @@ import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { PageNotFound as PageNotFoundIcon } from 'ui/svg/icons/PageNotFound'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export const PageNotFound: React.FC = () => {
   const helmetTitle = 'Page introuvable | pass Culture'
@@ -33,7 +33,7 @@ export const PageNotFound: React.FC = () => {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/offer/components/SelectableListItem/SelectableListItem.stories.tsx
+++ b/src/features/offer/components/SelectableListItem/SelectableListItem.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 import { theme } from 'theme'
 import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storybook/VariantsTemplate'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 import { SelectableListItem } from './SelectableListItem'
 
@@ -22,7 +22,7 @@ const variantConfig: Variants<typeof SelectableListItem> = [
   {
     label: 'SelectableListItem default',
     props: {
-      render: () => <Typo.Body>Hello World</Typo.Body>,
+      render: () => <TypoDS.Body>Hello World</TypoDS.Body>,
       isSelected: false,
       onSelect: action('select'),
     },
@@ -30,7 +30,7 @@ const variantConfig: Variants<typeof SelectableListItem> = [
   {
     label: 'SelectableListItem selected',
     props: {
-      render: () => <Typo.Body>Hello World</Typo.Body>,
+      render: () => <TypoDS.Body>Hello World</TypoDS.Body>,
       isSelected: true,
       onSelect: action('select'),
     },
@@ -39,14 +39,14 @@ const variantConfig: Variants<typeof SelectableListItem> = [
     label: 'SelectableListItem funky content based on state',
     props: {
       render: () => (
-        <Typo.Body
+        <TypoDS.Body
           // eslint-disable-next-line react-native/no-inline-styles
           style={{
             color: theme.colors.primary,
             fontSize: 24,
           }}>
           Hello World
-        </Typo.Body>
+        </TypoDS.Body>
       ),
       isSelected: true,
       onSelect: action('select'),

--- a/src/features/offer/components/SignUpSignInChoiceOfferModal/SignUpSignInChoiceOfferModal.tsx
+++ b/src/features/offer/components/SignUpSignInChoiceOfferModal/SignUpSignInChoiceOfferModal.tsx
@@ -8,7 +8,7 @@ import { ButtonWithLinearGradient } from 'ui/components/buttons/buttonWithLinear
 import { AppModalWithIllustration } from 'ui/components/modals/AppModalWithIllustration'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { BicolorUserFavorite } from 'ui/svg/icons/BicolorUserFavorite'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { LINE_BREAK } from 'ui/theme/constants'
 
 interface Props {
@@ -77,6 +77,6 @@ const StyledButtonContainer = styled.View({
   width: '100%',
 })
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/features/offer/pages/OfferNotFound/OfferNotFound.tsx
+++ b/src/features/offer/pages/OfferNotFound/OfferNotFound.tsx
@@ -8,7 +8,7 @@ import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { NoOffer } from 'ui/svg/icons/NoOffer'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export const OfferNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
   const timer = useRef<NodeJS.Timeout>()
@@ -51,7 +51,7 @@ export const OfferNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/profile/components/BeneficiaryCeilings/BeneficiaryCeilings.tsx
+++ b/src/features/profile/components/BeneficiaryCeilings/BeneficiaryCeilings.tsx
@@ -6,7 +6,7 @@ import { useIsUserUnderageBeneficiary } from 'features/profile/helpers/useIsUser
 import { useGetPacificFrancToEuroRate } from 'libs/firebase/firestore/exchangeRates/useGetPacificFrancToEuroRate'
 import { formatCurrencyFromCents } from 'shared/currency/formatCurrencyFromCents'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { SPACE } from 'ui/theme/constants'
 
 type BeneficiaryCeilingsProps = {
@@ -24,7 +24,7 @@ export function BeneficiaryCeilings({ domainsCredit }: BeneficiaryCeilingsProps)
       {domainsCredit.digital ? (
         <React.Fragment>
           <Spacer.Column numberOfSpaces={6} />
-          <Typo.Body testID="domains-credit-digital">
+          <TypoDS.Body testID="domains-credit-digital">
             dont
             {SPACE}
             <BodySecondary>
@@ -36,11 +36,11 @@ export function BeneficiaryCeilings({ domainsCredit }: BeneficiaryCeilingsProps)
             </BodySecondary>
             {SPACE}
             en offres numériques.
-          </Typo.Body>
+          </TypoDS.Body>
         </React.Fragment>
       ) : null}
       {domainsCredit.physical ? (
-        <Typo.Body testID="domains-credit-physical">
+        <TypoDS.Body testID="domains-credit-physical">
           dont
           {SPACE}
           <BodySecondary>
@@ -52,12 +52,12 @@ export function BeneficiaryCeilings({ domainsCredit }: BeneficiaryCeilingsProps)
           </BodySecondary>
           {SPACE}
           en offres physiques.
-        </Typo.Body>
+        </TypoDS.Body>
       ) : null}
     </React.Fragment>
   )
 }
 
-const BodySecondary = styled(Typo.Body)(({ theme }) => ({
+const BodySecondary = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.secondary,
 }))

--- a/src/features/profile/components/EmptyCredit/EmptyCredit.tsx
+++ b/src/features/profile/components/EmptyCredit/EmptyCredit.tsx
@@ -6,7 +6,7 @@ import { useDepositAmountsByAge } from 'shared/user/useDepositAmountsByAge'
 import { ButtonWithLinearGradient } from 'ui/components/buttons/buttonWithLinearGradient/ButtonWithLinearGradient'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { Offers } from 'ui/svg/icons/Offers'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export const EmptyCredit = ({ age }: { age: number }) => {
   const { homeEntryIdFreeOffers } = useRemoteConfigContext()
@@ -23,10 +23,10 @@ export const EmptyCredit = ({ age }: { age: number }) => {
 
   return (
     <React.Fragment>
-      <Typo.Body>
+      <TypoDS.Body>
         Ton prochain crédit de <HighlightedBody>{incomingCreditMap[age]}</HighlightedBody> sera
         débloqué à {age + 1} ans. En attendant…
-      </Typo.Body>
+      </TypoDS.Body>
       <Spacer.Column numberOfSpaces={4} />
       <InternalTouchableLink
         as={ButtonWithLinearGradient}
@@ -41,7 +41,7 @@ export const EmptyCredit = ({ age }: { age: number }) => {
   )
 }
 
-const HighlightedBody = styled(Typo.Body)(({ theme }) => ({
+const HighlightedBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.secondary,
 }))
 

--- a/src/features/profile/components/Header/CreditHeader/CreditHeader.tsx
+++ b/src/features/profile/components/Header/CreditHeader/CreditHeader.tsx
@@ -17,7 +17,7 @@ import { useDepositAmountsByAge } from 'shared/user/useDepositAmountsByAge'
 import { GenericBanner } from 'ui/components/ModuleBanner/GenericBanner'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { BicolorOffers } from 'ui/svg/icons/BicolorOffers'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, Typo, TypoDS } from 'ui/theme'
 
 export type CreditHeaderProps = {
   firstName?: string | null
@@ -107,14 +107,14 @@ export function CreditHeader({
           {incomingCreditLabelsMap[age] && !isCreditEmpty ? (
             <React.Fragment>
               <Spacer.Column numberOfSpaces={6} />
-              <Typo.Body>
+              <TypoDS.Body>
                 {
                   /* @ts-expect-error: because of noUncheckedIndexedAccess */
                   incomingCreditLabelsMap[age].label
                 }
                 {/* @ts-expect-error: because of noUncheckedIndexedAccess */}
                 <HighlightedBody>{incomingCreditLabelsMap[age].highlightedLabel}</HighlightedBody>
-              </Typo.Body>
+              </TypoDS.Body>
             </React.Fragment>
           ) : null}
           {isCreditEmpty ? <EmptyCredit age={age} /> : null}
@@ -126,10 +126,10 @@ export function CreditHeader({
   )
 }
 
-const HighlightedBody = styled(Typo.Body)(({ theme }) => ({
+const HighlightedBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.secondary,
 }))
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))

--- a/src/features/profile/components/Header/HeaderWithGreyContainer/HeaderWithGreyContainer.stories.tsx
+++ b/src/features/profile/components/Header/HeaderWithGreyContainer/HeaderWithGreyContainer.stories.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/native'
 
 import { formatToSlashedFrenchDate } from 'libs/dates'
 import { theme } from 'theme'
-import { Typo } from 'ui/theme'
+import { Typo, TypoDS } from 'ui/theme'
 
 import { HeaderWithGreyContainer } from './HeaderWithGreyContainer'
 
@@ -47,7 +47,7 @@ WithComponentAsSubtitle.args = {
   title: 'Jean Dubois',
   subtitle: (
     <Row>
-      <Typo.Body>Profite de ton crédit jusqu’au&nbsp;</Typo.Body>
+      <TypoDS.Body>Profite de ton crédit jusqu’au&nbsp;</TypoDS.Body>
       <Typo.ButtonText>{formatToSlashedFrenchDate('2023-02-16T17:16:04.735235')}</Typo.ButtonText>
     </Row>
   ),
@@ -64,11 +64,11 @@ WithLargeContent.args = {
   title: 'Jean Dubois',
   subtitle: 'Tu as entre 15 et 18 ans\u00a0?',
   children: (
-    <Typo.Body>
+    <TypoDS.Body>
       Lorem ipsum dolor, sit amet consectetur adipisicing elit. Porro molestiae laudantium
       voluptatibus accusamus aperiam maiores culpa sint repellendus nobis quisquam minus totam esse
       neque eum soluta, illum, labore, distinctio asperiores?
-    </Typo.Body>
+    </TypoDS.Body>
   ),
 }
 
@@ -76,7 +76,7 @@ export const WithSmallContent = Template.bind({})
 WithSmallContent.args = {
   title: 'Jean Dubois',
   subtitle: 'Tu as entre 15 et 18 ans\u00a0?',
-  children: <Typo.Body>Lorem ipsum dolor, sit amet consectetur</Typo.Body>,
+  children: <TypoDS.Body>Lorem ipsum dolor, sit amet consectetur</TypoDS.Body>,
 }
 WithSmallContent.parameters = {
   chromatic: {

--- a/src/features/profile/components/Header/HeaderWithGreyContainer/HeaderWithGreyContainer.tsx
+++ b/src/features/profile/components/Header/HeaderWithGreyContainer/HeaderWithGreyContainer.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 import { InfoBanner } from 'ui/components/banners/InfoBanner'
 import { PageHeader } from 'ui/components/headers/PageHeader'
 import { Info } from 'ui/svg/icons/Info'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 type PropsWithChildren = {
   title: string
@@ -27,7 +27,7 @@ export const HeaderWithGreyContainer: FunctionComponent<PropsWithChildren> = ({
       {subtitle ? (
         <SubtitleContainer>
           <Spacer.Column numberOfSpaces={1} />
-          {typeof subtitle === 'string' ? <Typo.Body>{subtitle}</Typo.Body> : subtitle}
+          {typeof subtitle === 'string' ? <TypoDS.Body>{subtitle}</TypoDS.Body> : subtitle}
         </SubtitleContainer>
       ) : null}
       {bannerText ? (

--- a/src/features/profile/components/Header/LoggedOutHeader/LoggedOutHeader.tsx
+++ b/src/features/profile/components/Header/LoggedOutHeader/LoggedOutHeader.tsx
@@ -7,7 +7,7 @@ import { HeaderWithGreyContainer } from 'features/profile/components/Header/Head
 import { analytics } from 'libs/analytics'
 import { ButtonWithLinearGradient } from 'ui/components/buttons/buttonWithLinearGradient/ButtonWithLinearGradient'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 const onBeforeNavigate = () => {
   analytics.logProfilSignUp()
@@ -19,7 +19,7 @@ export function LoggedOutHeader() {
 
   return (
     <HeaderWithGreyContainer title="Mon profil" subtitle="Tu as entre 15 et 18 ans&nbsp;?">
-      <Typo.Body>Identifie-toi pour bénéficier de ton crédit pass Culture</Typo.Body>
+      <TypoDS.Body>Identifie-toi pour bénéficier de ton crédit pass Culture</TypoDS.Body>
       <Spacer.Column numberOfSpaces={5} />
       <Container>
         <InternalTouchableLink

--- a/src/features/profile/components/Modals/ExpiredOrExhaustedCreditModalContent.tsx
+++ b/src/features/profile/components/Modals/ExpiredOrExhaustedCreditModalContent.tsx
@@ -1,17 +1,17 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 import { DOUBLE_LINE_BREAK as LINE_BREAK } from 'ui/theme/constants'
 
 export function ExpiredOrExhaustedCreditModalContent() {
   return (
     <ModalChildrenContainer>
-      <Typo.Body>
+      <TypoDS.Body>
         {`Pas de panique, l’aventure continue\u00a0!`}
         {LINE_BREAK}
         {`Tu peux toujours bénéficier des offres gratuites et exclusives sur le pass Culture.`}
-      </Typo.Body>
+      </TypoDS.Body>
     </ModalChildrenContainer>
   )
 }

--- a/src/features/profile/components/Subtitle/Subtitle.tsx
+++ b/src/features/profile/components/Subtitle/Subtitle.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { Typo } from 'ui/theme'
+import { Typo, TypoDS } from 'ui/theme'
 
 type Props = {
   startSubtitle: string
@@ -11,7 +11,7 @@ type Props = {
 export const Subtitle = ({ startSubtitle, boldEndSubtitle }: Props) => {
   return (
     <Row>
-      <Typo.Body>{startSubtitle}</Typo.Body>
+      <TypoDS.Body>{startSubtitle}</TypoDS.Body>
       {boldEndSubtitle ? <Typo.ButtonText>&nbsp;{boldEndSubtitle}</Typo.ButtonText> : null}
     </Row>
   )

--- a/src/features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation.tsx
+++ b/src/features/profile/pages/SuspendAccountConfirmation/SuspendAccountConfirmation.tsx
@@ -14,7 +14,7 @@ import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/S
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
 import { BicolorUserError } from 'ui/svg/BicolorUserError'
 import { Clear } from 'ui/svg/icons/Clear'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { DOUBLE_LINE_BREAK } from 'ui/theme/constants'
 
 type SuspendAccountConfirmationProps = NativeStackScreenProps<
@@ -109,10 +109,10 @@ const StyledBicolorUserError = styled(BicolorUserError).attrs(({ theme }) => ({
   color2: theme.colors.secondary,
 }))``
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })
 
-const BoldText = styled(Typo.Body)(({ theme }) => ({
+const BoldText = styled(TypoDS.Body)(({ theme }) => ({
   fontFamily: theme.fontFamily.bold,
 }))

--- a/src/features/profile/pages/ValidateEmailChange/SubtitleComponent.tsx
+++ b/src/features/profile/pages/ValidateEmailChange/SubtitleComponent.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { Separator } from 'ui/components/Separator'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
 import { TextProps } from 'ui/theme/typography'
 
 export function ValidateEmailChangeSubtitleComponent(props: TextProps) {
   return (
     <Wrapper>
-      <Typo.Body>Nouvelle adresse e-mail&nbsp;:</Typo.Body>
+      <TypoDS.Body>Nouvelle adresse e-mail&nbsp;:</TypoDS.Body>
       <Typo.ButtonText {...props} />
       <Spacer.Column numberOfSpaces={4} />
       <Separator.Horizontal />

--- a/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
+++ b/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
@@ -23,7 +23,7 @@ import { env } from 'libs/environment'
 import { useSearchGroupLabel } from 'libs/subcategories'
 import { useSubcategories } from 'libs/subcategories/useSubcategories'
 import { MagnifyingGlassFilled } from 'ui/svg/icons/MagnifyingGlassFilled'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, Typo, TypoDS } from 'ui/theme'
 
 type AutocompleteOfferItemProps = {
   hit: AlgoliaSuggestionHit
@@ -232,7 +232,7 @@ const SuggestionContainer: FunctionComponent<{
 
 const Suggestion: FunctionComponent<{ categoryToDisplay: string }> = ({ categoryToDisplay }) => (
   <React.Fragment>
-    <Typo.Body> dans </Typo.Body>
+    <TypoDS.Body> dans </TypoDS.Body>
     <Typo.ButtonTextPrimary>{categoryToDisplay}</Typo.ButtonTextPrimary>
   </React.Fragment>
 )

--- a/src/features/search/components/AutocompleteVenueItem/AutocompleteVenueItem.tsx
+++ b/src/features/search/components/AutocompleteVenueItem/AutocompleteVenueItem.tsx
@@ -7,7 +7,7 @@ import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { Highlight } from 'features/search/components/Highlight/Highlight'
 import { AlgoliaVenue } from 'libs/algolia/types'
 import { LocationBuildingFilled } from 'ui/svg/icons/LocationBuildingFilled'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 type AutocompleteVenueItemProps = {
   hit: AlgoliaVenue
@@ -32,7 +32,7 @@ export function AutocompleteVenueItem({ hit, onPress }: AutocompleteVenueItemPro
       </LocationBuildingIconContainer>
       <StyledText numberOfLines={2} ellipsizeMode="tail">
         <Highlight venueHit={hit} attribute="name" />
-        <Typo.Body>{city}</Typo.Body>
+        <TypoDS.Body>{city}</TypoDS.Body>
       </StyledText>
     </AutocompleteItemTouchable>
   )

--- a/src/features/search/components/HoursSlider/HoursSlider.tsx
+++ b/src/features/search/components/HoursSlider/HoursSlider.tsx
@@ -7,7 +7,7 @@ import { Hour, hoursSchema } from 'features/search/helpers/schema/datesHoursSche
 import { useGetFullscreenModalSliderLength } from 'features/search/helpers/useGetFullscreenModalSliderLength'
 import { DEFAULT_TIME_VALUE } from 'features/search/pages/modals/DatesHoursModal/DatesHoursModal'
 import { Slider, ValuesType } from 'ui/components/inputs/Slider'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, Typo, TypoDS } from 'ui/theme'
 
 type HoursSliderProps = {
   value?: [Hour, Hour]
@@ -32,7 +32,7 @@ export function HoursSlider({ field }: Readonly<{ field: HoursSliderProps }>) {
     <View>
       <Spacer.Column numberOfSpaces={3} />
       <LabelHoursContainer nativeID={hoursLabelId}>
-        <Typo.Body>Sortir entre</Typo.Body>
+        <TypoDS.Body>Sortir entre</TypoDS.Body>
         <Typo.ButtonText>{`${minHour}\u00a0h et ${maxHour}\u00a0h`}</Typo.ButtonText>
       </LabelHoursContainer>
       <Spacer.Column numberOfSpaces={2} />

--- a/src/features/search/components/NoSearchResults/NoSearchResult.tsx
+++ b/src/features/search/components/NoSearchResults/NoSearchResult.tsx
@@ -7,7 +7,7 @@ import { useNavigateToSearchFilter } from 'features/search/helpers/useNavigateTo
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { NoOffer } from 'ui/svg/icons/NoOffer'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export function NoSearchResult() {
@@ -83,15 +83,15 @@ const MainTitle = styled(TypoDS.Title4).attrs({
   marginTop: getSpacing(4),
 }))
 
-const MainTitleComplement = styled(Typo.Body)(({ theme }) => ({
+const MainTitleComplement = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.black,
 }))
 
-const DescriptionErrorText = styled(Typo.Body)(({ theme }) => ({
+const DescriptionErrorText = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 
-const DescriptionErrorTextContainer = styled(Typo.Body)({
+const DescriptionErrorTextContainer = styled(TypoDS.Body)({
   marginTop: getSpacing(6),
   textAlign: 'center',
 })

--- a/src/features/search/components/Suggestion/Suggestion.tsx
+++ b/src/features/search/components/Suggestion/Suggestion.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { Again } from 'ui/svg/icons/Again'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 type SuggestionProps = {
   suggestion: string
@@ -32,6 +32,6 @@ const AgainIcon = styled(Again).attrs(({ theme }) => ({
   size: theme.icons.sizes.extraSmall,
 }))``
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   marginLeft: getSpacing(2),
 })

--- a/src/features/search/pages/SuggestedPlacesOrVenues/SuggestedVenues.tsx
+++ b/src/features/search/pages/SuggestedPlacesOrVenues/SuggestedVenues.tsx
@@ -11,7 +11,7 @@ import { Li } from 'ui/components/Li'
 import { Spinner } from 'ui/components/Spinner'
 import { VerticalUl } from 'ui/components/Ul'
 import { LocationBuildingFilled } from 'ui/svg/icons/LocationBuildingFilled'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 const keyExtractor = (venue: Venue) => {
   const { label, info } = venue
@@ -80,12 +80,12 @@ const NoSuggestedVenues = ({ show }: { show: boolean }) =>
     </DescriptionErrorTextContainer>
   ) : null
 
-const DescriptionErrorTextContainer = styled(Typo.Body)({
+const DescriptionErrorTextContainer = styled(TypoDS.Body)({
   marginTop: getSpacing(6),
   textAlign: 'center',
 })
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({ color: theme.colors.greyDark }))
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({ color: theme.colors.greyDark }))
 
 const BuildingIcon = styled(LocationBuildingFilled).attrs(({ theme }) => ({
   size: theme.icons.sizes.smaller,

--- a/src/features/share/pages/ShareAppModal.tsx
+++ b/src/features/share/pages/ShareAppModal.tsx
@@ -8,7 +8,7 @@ import { MarketingModal } from 'ui/components/modals/MarketingModal'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Share } from 'ui/svg/icons/BicolorShare'
 import { Invalidate } from 'ui/svg/icons/Invalidate'
-import { Typo } from 'ui/theme'
+import { Typo, TypoDS } from 'ui/theme'
 import { LINE_BREAK } from 'ui/theme/constants'
 
 type Props = {
@@ -46,6 +46,6 @@ export const ShareAppModal: FunctionComponent<Props> = ({ visible, close, share 
   )
 }
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/features/subscription/NotificationsLoggedOutModal.tsx
+++ b/src/features/subscription/NotificationsLoggedOutModal.tsx
@@ -8,7 +8,7 @@ import { ButtonWithLinearGradient } from 'ui/components/buttons/buttonWithLinear
 import { AppModalWithIllustration } from 'ui/components/modals/AppModalWithIllustration'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { BicolorUserNotification } from 'ui/svg/icons/BicolorUserNotification'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   visible: boolean
@@ -65,7 +65,7 @@ const StyledAuthenticationButton = styled(AuthenticationButton).attrs(({ theme }
   linkColor: theme.colors.secondary,
 }))``
 
-const InformationText = styled(Typo.Body)({
+const InformationText = styled(TypoDS.Body)({
   textAlign: 'center',
 })
 

--- a/src/features/subscription/NotificationsSettingsModal.tsx
+++ b/src/features/subscription/NotificationsSettingsModal.tsx
@@ -13,7 +13,7 @@ import { BellFilled } from 'ui/svg/icons/BellFilled'
 import { Close } from 'ui/svg/icons/Close'
 import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 import { Invalidate } from 'ui/svg/icons/Invalidate'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, Typo, TypoDS } from 'ui/theme'
 
 interface Props {
   visible: boolean
@@ -74,7 +74,7 @@ export const NotificationsSettingsModal: FunctionComponent<Props> = ({
       rightIcon={Close}
       onRightIconPress={onDismiss}>
       <ModalContent>
-        <Typo.Body>{description}</Typo.Body>
+        <TypoDS.Body>{description}</TypoDS.Body>
 
         <Spacer.Column numberOfSpaces={6} />
 

--- a/src/features/subscription/components/modals/OnboardingSubscriptionModal.tsx
+++ b/src/features/subscription/components/modals/OnboardingSubscriptionModal.tsx
@@ -7,7 +7,7 @@ import { AppModalWithIllustration } from 'ui/components/modals/AppModalWithIllus
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { BicolorRingingBell } from 'ui/svg/BicolorRingingBell'
 import { Invalidate } from 'ui/svg/icons/Invalidate'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 type Props = {
   visible: boolean
@@ -47,7 +47,7 @@ const StyledIcon = styled(BicolorRingingBell).attrs(({ theme }) => ({
   size: theme.illustrations.sizes.fullPage,
 }))``
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
   textAlign: 'center',
 }))

--- a/src/features/subscription/components/modals/SubscriptionSuccessModal.tsx
+++ b/src/features/subscription/components/modals/SubscriptionSuccessModal.tsx
@@ -10,7 +10,7 @@ import { AppModalWithIllustration } from 'ui/components/modals/AppModalWithIllus
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { BicolorRingingBell } from 'ui/svg/BicolorRingingBell'
 import { Parameters } from 'ui/svg/icons/Parameters'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, Typo, TypoDS } from 'ui/theme'
 
 interface Props {
   visible: boolean
@@ -53,7 +53,7 @@ const StyledButtonContainer = styled.View({
   width: '100%',
 })
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })
 const StyledCaption = styled(Typo.Caption)(({ theme }) => ({

--- a/src/features/subscription/components/modals/UnsubscribingConfirmationModal.tsx
+++ b/src/features/subscription/components/modals/UnsubscribingConfirmationModal.tsx
@@ -8,7 +8,7 @@ import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
 import { AppModalWithIllustration } from 'ui/components/modals/AppModalWithIllustration'
 import { BicolorRingingBellOff } from 'ui/svg/BicolorRingingBellOff'
 import { Invalidate } from 'ui/svg/icons/Invalidate'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   visible: boolean
@@ -47,7 +47,7 @@ const StyledButtonContainer = styled.View({
   width: '100%',
 })
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })
 

--- a/src/features/subscription/page/OnboardingSubscription.tsx
+++ b/src/features/subscription/page/OnboardingSubscription.tsx
@@ -25,7 +25,7 @@ import { EmptyHeader } from 'ui/components/headers/EmptyHeader'
 import { useModal } from 'ui/components/modals/useModal'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { Invalidate } from 'ui/svg/icons/Invalidate'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 const GRADIENT_HEIGHT = getSpacing(30)
@@ -154,10 +154,10 @@ export const OnboardingSubscription = () => {
           <React.Fragment>
             <StyledTitle3>Choisis des thèmes à suivre</StyledTitle3>
             <Spacer.Column numberOfSpaces={4} />
-            <Typo.Body>
+            <TypoDS.Body>
               Tu recevras des notifs et/ou des mails pour ne rien rater des dernières sorties et
               actus&nbsp;!
-            </Typo.Body>
+            </TypoDS.Body>
             <Spacer.Column numberOfSpaces={6} />
           </React.Fragment>
         }

--- a/src/features/trustedDevice/pages/AccountSecurity.tsx
+++ b/src/features/trustedDevice/pages/AccountSecurity.tsx
@@ -36,10 +36,10 @@ export const AccountSecurity = () => {
       titleComponent={TypoDS.Title3}
       icon={BicolorUserBlocked}
       separateIconFromTitle={false}>
-      <Typo.Body>
+      <TypoDS.Body>
         Tu as indiqué <Typo.ButtonText>ne pas être à l’origine</Typo.ButtonText> de cette
         connexion&nbsp;:
-      </Typo.Body>
+      </TypoDS.Body>
       <Spacer.Column numberOfSpaces={4} />
       <DeviceInformationsBanner
         osAndSource={osAndSource}
@@ -47,12 +47,12 @@ export const AccountSecurity = () => {
         loginDate={loginDate}
       />
       <Spacer.Column numberOfSpaces={4} />
-      <Typo.Body>
+      <TypoDS.Body>
         Pour des raisons de <Typo.ButtonText>sécurité,</Typo.ButtonText> nous te conseillons de
         {isLoggedOutOrHasPassword
           ? ' modifier ton mot de passe ou de suspendre ton compte temporairement.'
           : ' sécuriser l’accès à ta boîte mail et de suspendre ton compte pass Culture temporairement.'}
-      </Typo.Body>
+      </TypoDS.Body>
       {isLoggedOutOrHasPassword ? (
         <React.Fragment>
           <Spacer.Column numberOfSpaces={6} />

--- a/src/features/trustedDevice/pages/SuspensionChoice.tsx
+++ b/src/features/trustedDevice/pages/SuspensionChoice.tsx
@@ -65,7 +65,7 @@ export const SuspensionChoice = () => {
       <Typo.ButtonText>Les conséquences&nbsp;:</Typo.ButtonText>
       <VerticalUl>
         <BulletListItem>
-          <Typo.Body>
+          <TypoDS.Body>
             tes réservations seront annulées sauf pour certains cas précisés dans les{SPACE}
             <ExternalTouchableLink
               as={StyledButtonInsideText}
@@ -73,17 +73,17 @@ export const SuspensionChoice = () => {
               icon={ExternalSiteFilled}
               externalNav={{ url: env.CGU_LINK }}
             />
-          </Typo.Body>
+          </TypoDS.Body>
         </BulletListItem>
         <BulletListItem text="si tu as un dossier en cours, tu ne pourras pas en déposer un nouveau." />
         <BulletListItem text="tu n’auras plus accès au catalogue." />
       </VerticalUl>
       <Spacer.Column numberOfSpaces={4} />
       <Typo.ButtonText>Les données que nous conservons&nbsp;:</Typo.ButtonText>
-      <Typo.Body>
+      <TypoDS.Body>
         Nous gardons toutes les informations personnelles que tu nous as transmises lors de la
         vérification de ton identité.
-      </Typo.Body>
+      </TypoDS.Body>
       <Spacer.Column numberOfSpaces={4} />
       <ButtonContainer>
         <ButtonPrimary

--- a/src/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.tsx
+++ b/src/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { GenericSuspendedAccount } from 'features/auth/pages/suspendedAccount/GenericSuspendedAccount/GenericSuspendedAccount'
 import { analytics } from 'libs/analytics'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export const SuspiciousLoginSuspendedAccount = () => {
   const onBeforeNavigateContactFraudTeam = () => {
@@ -21,6 +21,6 @@ export const SuspiciousLoginSuspendedAccount = () => {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.white,
 }))

--- a/src/features/tutorial/components/AgeButton.stories.tsx
+++ b/src/features/tutorial/components/AgeButton.stories.tsx
@@ -7,7 +7,7 @@ import { TutorialTypes } from 'features/tutorial/enums'
 import { selectArgTypeFromObject } from 'libs/storybook/selectArgTypeFromObject'
 import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storybook/VariantsTemplate'
 import { All } from 'ui/svg/icons/bicolor/All'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, Typo, TypoDS } from 'ui/theme'
 
 import { AgeButton } from './AgeButton'
 
@@ -17,7 +17,7 @@ const BicolorAll = styled(All).attrs(({ theme }) => ({
   size: theme.icons.sizes.small,
 }))``
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.secondary,
 }))
 

--- a/src/features/tutorial/components/AgeCreditBlock.stories.tsx
+++ b/src/features/tutorial/components/AgeCreditBlock.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { CreditStatus } from 'features/tutorial/enums'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 import { AgeCreditBlock } from './AgeCreditBlock'
 
@@ -57,7 +57,7 @@ withDescription.args = {
     <React.Fragment>
       <TypoDS.Title3>300&nbsp;€</TypoDS.Title3>
       <Spacer.Column numberOfSpaces={2} />
-      <Typo.Body>Tu auras 2 ans pour utiliser tes 300&nbsp;€</Typo.Body>
+      <TypoDS.Body>Tu auras 2 ans pour utiliser tes 300&nbsp;€</TypoDS.Body>
     </React.Fragment>
   ),
   age: 18,

--- a/src/features/tutorial/components/AgeCreditBlock.tsx
+++ b/src/features/tutorial/components/AgeCreditBlock.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { CreditBlock } from 'features/tutorial/components/CreditBlock'
 import { CreditStatus } from 'features/tutorial/enums'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, Typo, TypoDS } from 'ui/theme'
 
 type Props = {
   age: number
@@ -31,6 +31,6 @@ export const AgeCreditBlock: FunctionComponent<Props> = ({
   )
 }
 
-const BodySecondary = styled(Typo.Body)(({ theme }) => ({
+const BodySecondary = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.secondary,
 }))

--- a/src/features/tutorial/components/onboarding/OnboardingTimeline.tsx
+++ b/src/features/tutorial/components/onboarding/OnboardingTimeline.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 import { CreditComponentProps, CreditTimeline } from 'features/tutorial/components/CreditTimeline'
 import { TutorialTypes } from 'features/tutorial/enums'
 import { useDepositAmountsByAge } from 'shared/user/useDepositAmountsByAge'
-import { Spacer, Typo, getSpacing, getSpacingString } from 'ui/theme'
+import { Spacer, Typo, TypoDS, getSpacing, getSpacingString } from 'ui/theme'
 
 interface Props {
   age: 15 | 16 | 17 | 18
@@ -35,7 +35,7 @@ const CreditBlockContent = () => {
 
 const CreditResetBlock = () => <StyledBody>Remise à 0 du crédit</StyledBody>
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   marginVertical: getSpacing(2),
   marginLeft: getSpacing(1.5),
   justifyContent: 'center',

--- a/src/features/tutorial/components/profileTutorial/EligibleFooter.tsx
+++ b/src/features/tutorial/components/profileTutorial/EligibleFooter.tsx
@@ -6,7 +6,7 @@ import { EligibleAges } from 'features/tutorial/types'
 import { useDepositAmountsByAge } from 'shared/user/useDepositAmountsByAge'
 import { ButtonWithLinearGradient } from 'ui/components/buttons/buttonWithLinearGradient/ButtonWithLinearGradient'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   age: EligibleAges
@@ -43,6 +43,6 @@ export const EligibleFooter: FunctionComponent<Props> = ({ age }) => {
   )
 }
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/features/tutorial/pages/NonEligibleModal.tsx
+++ b/src/features/tutorial/pages/NonEligibleModal.tsx
@@ -10,7 +10,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
 import { AppInformationModal } from 'ui/components/modals/AppInformationModal'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 type Props = {
   visible: boolean
@@ -60,6 +60,6 @@ export const NonEligibleModal = ({ visible, hideModal, userStatus, type }: Props
   )
 }
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/features/tutorial/pages/onboarding/OnboardingGeneralPublicWelcome.tsx
+++ b/src/features/tutorial/pages/onboarding/OnboardingGeneralPublicWelcome.tsx
@@ -9,7 +9,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { ButtonSecondary } from 'ui/components/buttons/ButtonSecondary'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const OnboardingGeneralPublicWelcome = () => {
   const { reset } = useNavigation<UseNavigationType>()
@@ -53,6 +53,6 @@ const ButtonContainer = styled.View({
   paddingBottom: getSpacing(10),
 })
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/features/tutorial/pages/onboarding/OnboardingGeolocation.tsx
+++ b/src/features/tutorial/pages/onboarding/OnboardingGeolocation.tsx
@@ -11,7 +11,7 @@ import { useLocation } from 'libs/location'
 import GeolocationAnimation from 'ui/animations/geolocalisation.json'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const OnboardingGeolocation = () => {
   const isPassForAllEnabled = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_PASS_FOR_ALL)
@@ -58,6 +58,6 @@ const ButtonContainer = styled.View({
   paddingBottom: getSpacing(10),
 })
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/features/tutorial/pages/onboarding/OnboardingWelcome.tsx
+++ b/src/features/tutorial/pages/onboarding/OnboardingWelcome.tsx
@@ -11,7 +11,7 @@ import { storage } from 'libs/storage'
 import { ButtonWithLinearGradient } from 'ui/components/buttons/buttonWithLinearGradient/ButtonWithLinearGradient'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 const setHasSeenTutorials = () => storage.saveObject('has_seen_tutorials', true)
 
@@ -90,7 +90,7 @@ const StyledTitle1 = styled(TypoDS.Title1)({
   textAlign: 'center',
 })
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })
 

--- a/src/features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation.tsx
+++ b/src/features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation.tsx
@@ -24,7 +24,7 @@ import { ButtonWithLinearGradient } from 'ui/components/buttons/buttonWithLinear
 import { ContentHeader } from 'ui/components/headers/ContentHeader'
 import { useGetHeaderHeight } from 'ui/components/headers/PageHeaderWithoutPlaceholder'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
-import { Spacer, Typo, TypoDS, getSpacing } from 'ui/theme'
+import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type Props = StackScreenProps<TutorialRootStackParamList, 'ProfileTutorialAgeInformation'>
@@ -139,6 +139,6 @@ const Placeholder = styled.View<{ height: number }>(({ height }) => ({
   height,
 }))
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/features/venue/components/TabLayout/TabLayout.native.test.tsx
+++ b/src/features/venue/components/TabLayout/TabLayout.native.test.tsx
@@ -5,9 +5,9 @@ import { TabLayout } from 'features/venue/components/TabLayout/TabLayout'
 import { Tab } from 'features/venue/types'
 import { fireEvent, render, screen } from 'tests/utils'
 import { Map } from 'ui/svg/icons/Map'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
-const ExampleText = styled(Typo.Body)``
+const ExampleText = styled(TypoDS.Body)``
 const tabPanels = {
   [Tab.OFFERS]: <ExampleText>Offres disponibles content</ExampleText>,
   [Tab.INFOS]: <ExampleText>Infos pratiques content</ExampleText>,

--- a/src/features/venue/components/TabLayout/TabLayout.web.test.tsx
+++ b/src/features/venue/components/TabLayout/TabLayout.web.test.tsx
@@ -7,11 +7,11 @@ import { Tab } from 'features/venue/types'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole.web'
 import { fireEvent, render, screen } from 'tests/utils/web'
 import { theme } from 'theme'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 const tabPanels = {
-  [Tab.OFFERS]: <Typo.Body>Offres disponibles content</Typo.Body>,
-  [Tab.INFOS]: <Typo.Body>Infos pratiques content</Typo.Body>,
+  [Tab.OFFERS]: <TypoDS.Body>Offres disponibles content</TypoDS.Body>,
+  [Tab.INFOS]: <TypoDS.Body>Infos pratiques content</TypoDS.Body>,
 }
 
 describe('TabLayout', () => {

--- a/src/features/venue/pages/VenueNotFound/VenueNotFound.tsx
+++ b/src/features/venue/pages/VenueNotFound/VenueNotFound.tsx
@@ -8,7 +8,7 @@ import { ButtonPrimaryWhite } from 'ui/components/buttons/ButtonPrimaryWhite'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { GenericInfoPage } from 'ui/pages/GenericInfoPage'
 import { NoOffer } from 'ui/svg/icons/NoOffer'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export const VenueNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
   const timer = useRef<NodeJS.Timeout>()
@@ -54,7 +54,7 @@ export const VenueNotFound = ({ resetErrorBoundary }: ScreenErrorProps) => {
   )
 }
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   textAlign: 'center',
   color: theme.colors.white,
 }))

--- a/src/libs/firebase/remoteConfig/ABTestingPOC.tsx
+++ b/src/libs/firebase/remoteConfig/ABTestingPOC.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { useRemoteConfigContext } from 'libs/firebase/remoteConfig/RemoteConfigProvider'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const ABTestingPOC: React.FC = () => {
   const { test_param } = useRemoteConfigContext()
@@ -14,7 +14,7 @@ export const ABTestingPOC: React.FC = () => {
     <StyledView>
       <TypoDS.Title2>{message}</TypoDS.Title2>
       <Spacer.Column numberOfSpaces={5} />
-      <Typo.Body>{instructionsText}</Typo.Body>
+      <TypoDS.Body>{instructionsText}</TypoDS.Body>
     </StyledView>
   )
 }

--- a/src/libs/location/components/WhereSection.tsx
+++ b/src/libs/location/components/WhereSection.tsx
@@ -101,7 +101,7 @@ export const WhereSection: React.FC<Props> = ({
           <Spacer.Column numberOfSpaces={4} />
           <Typo.Caption>Distance</Typo.Caption>
           <Spacer.Column numberOfSpaces={1} />
-          <Typo.Body>{distanceToLocation}</Typo.Body>
+          <TypoDS.Body>{distanceToLocation}</TypoDS.Body>
         </React.Fragment>
       ) : null}
       {venueFullAddress ? (
@@ -128,7 +128,7 @@ const VenueNameContainer = styled(InternalTouchableLink)({
   alignItems: 'center',
 })
 
-const StyledAddress = styled(Typo.Body)({
+const StyledAddress = styled(TypoDS.Body)({
   textTransform: 'capitalize',
 })
 

--- a/src/libs/location/geolocation/components/GeolocationActivationModal.tsx
+++ b/src/libs/location/geolocation/components/GeolocationActivationModal.tsx
@@ -8,7 +8,7 @@ import { useLocation } from 'libs/location/LocationWrapper'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { AppInformationModal } from 'ui/components/modals/AppInformationModal'
 import { BicolorLocationPointer } from 'ui/svg/icons/BicolorLocationPointer'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 type Props = {
   hideGeolocPermissionModal: () => void
@@ -65,6 +65,6 @@ export const GeolocationActivationModal: React.FC<Props> = ({
   )
 }
 
-const InformationText = styled(Typo.Body)({
+const InformationText = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/libs/network/OfflinePage.tsx
+++ b/src/libs/network/OfflinePage.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { BicolorBrokenConnection } from 'ui/svg/BicolorBrokenConnection'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export const OfflinePage = () => {
@@ -33,7 +33,7 @@ const StyledTitle2 = styled(TypoDS.Title2).attrs(() => getHeadingAttrs(1))({
   textAlign: 'center',
 })
 
-const StyledBody = styled(Typo.Body).attrs(() => getHeadingAttrs(2))({
+const StyledBody = styled(TypoDS.Body).attrs(() => getHeadingAttrs(2))({
   textAlign: 'center',
 })
 

--- a/src/shared/Banners/GeolocationBanner.tsx
+++ b/src/shared/Banners/GeolocationBanner.tsx
@@ -9,7 +9,7 @@ import { SystemBanner } from 'ui/components/ModuleBanner/SystemBanner'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { BicolorEverywhere as Everywhere } from 'ui/svg/icons/BicolorEverywhere'
-import { Typo } from 'ui/theme'
+import { Typo, TypoDS } from 'ui/theme'
 
 type Props = {
   title: string
@@ -53,7 +53,7 @@ export const GeolocationBanner: FunctionComponent<Props> = ({
       <GenericBanner LeftIcon={<LocationIcon />} testID="genericBanner">
         <ViewGap gap={1}>
           <Typo.ButtonText>{title}</Typo.ButtonText>
-          <Typo.Body numberOfLines={2}>{subtitle}</Typo.Body>
+          <TypoDS.Body numberOfLines={2}>{subtitle}</TypoDS.Body>
         </ViewGap>
       </GenericBanner>
     </Touchable>

--- a/src/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.tsx
+++ b/src/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.tsx
@@ -8,7 +8,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { AppModalWithIllustration } from 'ui/components/modals/AppModalWithIllustration'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { BicolorBookingHold } from 'ui/svg/BicolorBookingHold'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { DOUBLE_LINE_BREAK } from 'ui/theme/constants'
 
 interface Props {
@@ -60,6 +60,6 @@ export const ApplicationProcessingModal: FunctionComponent<Props> = ({
   )
 }
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/shared/offer/components/AuthenticationModal/AuthenticationModal.tsx
+++ b/src/shared/offer/components/AuthenticationModal/AuthenticationModal.tsx
@@ -8,7 +8,7 @@ import { ButtonWithLinearGradient } from 'ui/components/buttons/buttonWithLinear
 import { AppModalWithIllustration } from 'ui/components/modals/AppModalWithIllustration'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { BicolorUserIdentification } from 'ui/svg/BicolorUserIdentification'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, Typo, TypoDS } from 'ui/theme'
 import { LINE_BREAK } from 'ui/theme/constants'
 
 type Props = {
@@ -81,6 +81,6 @@ const StyledAuthenticationButton = styled(AuthenticationButton).attrs(({ theme }
 const StyledButtonContainer = styled.View({
   width: '100%',
 })
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.tsx
+++ b/src/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.tsx
@@ -9,7 +9,7 @@ import { analytics } from 'libs/analytics'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { AppModalWithIllustration } from 'ui/components/modals/AppModalWithIllustration'
 import { BicolorUserError } from 'ui/svg/BicolorUserError'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { DOUBLE_LINE_BREAK, LINE_BREAK } from 'ui/theme/constants'
 
 type Props = {
@@ -61,6 +61,6 @@ export const ErrorApplicationModal: FunctionComponent<Props> = ({
   )
 }
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.tsx
+++ b/src/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.tsx
@@ -13,7 +13,7 @@ import { useGetDepositAmountsByAge } from 'shared/user/useGetDepositAmountsByAge
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { AppModalWithIllustration } from 'ui/components/modals/AppModalWithIllustration'
 import { BicolorIdCardWithMagnifyingGlass } from 'ui/svg/icons/BicolorIdCardWithMagnifyingGlass'
-import { Typo, Spacer } from 'ui/theme'
+import { Typo, Spacer, TypoDS } from 'ui/theme'
 import { LINE_BREAK, SPACE } from 'ui/theme/constants'
 
 type Props = {
@@ -91,6 +91,6 @@ const Deposit = ({ depositAmountByAge }: { depositAmountByAge: string }) => (
   </StyledBody>
 )
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })

--- a/src/ui/components/Accordion.stories.tsx
+++ b/src/ui/components/Accordion.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 import FilterSwitch from 'ui/components/FilterSwitch'
 import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storybook/VariantsTemplate'
-import { Typo } from 'ui/theme'
+import { Typo, TypoDS } from 'ui/theme'
 
 import { Accordion } from './Accordion'
 
@@ -25,7 +25,7 @@ const children = 'children'
 
 const baseProps = {
   title: 'My accordion',
-  children: <Typo.Body>{children}</Typo.Body>,
+  children: <TypoDS.Body>{children}</TypoDS.Body>,
 }
 
 const variantConfig: Variants<typeof Accordion> = [

--- a/src/ui/components/InformationWithIcon.tsx
+++ b/src/ui/components/InformationWithIcon.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
 import { AccessibleBicolorIcon } from 'ui/svg/icons/types'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, Typo, TypoDS } from 'ui/theme'
 
 export const InformationWithIcon: FunctionComponent<{
   Icon: React.FC<AccessibleBicolorIcon>
@@ -34,7 +34,7 @@ const InfoContainer = styled.View({
   alignItems: 'center',
 })
 
-const Info = styled(Typo.Body)({
+const Info = styled(TypoDS.Body)({
   flex: 1,
 })
 

--- a/src/ui/components/InternalStep/InternalStep.stories.tsx
+++ b/src/ui/components/InternalStep/InternalStep.stories.tsx
@@ -7,7 +7,7 @@ import { StepCard } from 'features/profile/components/StepCard/StepCard'
 import { StepButtonState } from 'ui/components/StepButton/types'
 import { BicolorAroundMe } from 'ui/svg/icons/BicolorAroundMe'
 import { Email } from 'ui/svg/icons/Email'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 import { StepVariant } from '../VerticalStepper/types'
 
@@ -32,10 +32,10 @@ Complete.args = {
   variant: StepVariant.complete,
   children: (
     <View style={styles.exampleWrapper}>
-      <Typo.Body>Example text</Typo.Body>
-      <Typo.Body>Example text</Typo.Body>
-      <Typo.Body>Example text</Typo.Body>
-      <Typo.Body>Example text</Typo.Body>
+      <TypoDS.Body>Example text</TypoDS.Body>
+      <TypoDS.Body>Example text</TypoDS.Body>
+      <TypoDS.Body>Example text</TypoDS.Body>
+      <TypoDS.Body>Example text</TypoDS.Body>
     </View>
   ),
 }

--- a/src/ui/components/LoadingPage.tsx
+++ b/src/ui/components/LoadingPage.tsx
@@ -5,7 +5,7 @@ import { useWhiteStatusBarWithoutReactNavigation } from 'libs/hooks/useWhiteStat
 import LottieView from 'libs/lottie'
 import LoadingAnimation from 'ui/animations/lottie_loading.json'
 import { BackgroundWithDefaultStatusBar } from 'ui/svg/Background'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 const UnmemoizedLoadingPage: FunctionComponent = () => {
   useWhiteStatusBarWithoutReactNavigation()
@@ -41,7 +41,7 @@ const StyledLottieView = styled(LottieView)({
   height: 150,
 })
 
-const LoadingText = styled(Typo.Body)(({ theme }) => ({
+const LoadingText = styled(TypoDS.Body)(({ theme }) => ({
   top: -16,
   textAlign: 'center',
   color: theme.colors.white,

--- a/src/ui/components/Markdown/Markdown.native.test.tsx
+++ b/src/ui/components/Markdown/Markdown.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { render, screen } from 'tests/utils'
 import { Markdown } from 'ui/components/Markdown/Markdown'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 const TEXT =
   'Lorem **ipsum dolor** sit amet, consectetur _adipiscing_ elit. Maecenas nec tellus in magna convallis egestas eget **_id justo_**. Donec lorem ante, tempor eu diam quis, laoreet rhoncus tortor.'
@@ -24,7 +24,7 @@ describe('Markdown', () => {
   it('should not render text when children is not a string', () => {
     render(
       <Markdown>
-        <Typo.Body>Lorem</Typo.Body>
+        <TypoDS.Body>Lorem</TypoDS.Body>
       </Markdown>
     )
 

--- a/src/ui/components/ModuleBanner/SystemBanner.tsx
+++ b/src/ui/components/ModuleBanner/SystemBanner.tsx
@@ -8,7 +8,7 @@ import { styledButton } from 'ui/components/buttons/styledButton'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { ArrowRight } from 'ui/svg/icons/ArrowRight'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, Typo, TypoDS } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 
 type Props = {
@@ -43,7 +43,7 @@ export const SystemBanner: FunctionComponent<Props> = ({
         {LeftIcon ? <IconContainer>{LeftIcon}</IconContainer> : null}
         <DescriptionContainer gap={1}>
           <Typo.ButtonText>{title}</Typo.ButtonText>
-          <Typo.Body numberOfLines={2}>{subtitle}</Typo.Body>
+          <TypoDS.Body numberOfLines={2}>{subtitle}</TypoDS.Body>
         </DescriptionContainer>
         <View>
           <StyledArrowRightIcon />

--- a/src/ui/components/NoResultsView.tsx
+++ b/src/ui/components/NoResultsView.tsx
@@ -7,7 +7,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { MagnifyingGlass } from 'ui/svg/icons/MagnifyingGlass'
 import { AccessibleIcon } from 'ui/svg/icons/types'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
 
 type Props = {
   explanations: string
@@ -80,7 +80,7 @@ const CaptionTitle = styled(Typo.Caption)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 
-const StyledBody = styled(Typo.Body)(({ theme }) => ({
+const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   maxWidth: theme.contentPage.maxWidth,
   textAlign: 'center',
 }))

--- a/src/ui/components/SectionWithDivider.stories.tsx
+++ b/src/ui/components/SectionWithDivider.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { View } from 'react-native'
 
 import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storybook/VariantsTemplate'
-import { Typo, TypoDS } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 import { SectionWithDivider } from './SectionWithDivider'
 
@@ -16,11 +16,11 @@ export default meta
 const SectionContent: React.JSX.Element = (
   <View>
     <TypoDS.Title4>Section with divider</TypoDS.Title4>
-    <Typo.Body>
+    <TypoDS.Body>
       Lorem ipsum dolor sit amet consectetur adipisicing elit. Cupiditate quas aut laborum, dolor
       sapiente quos doloribus sequi reprehenderit ullam porro rem corrupti libero repellendus nam
       vel suscipit consequuntur blanditiis omnis.
-    </Typo.Body>
+    </TypoDS.Body>
   </View>
 )
 

--- a/src/ui/components/StepList/StepList.native.test.tsx
+++ b/src/ui/components/StepList/StepList.native.test.tsx
@@ -3,24 +3,24 @@ import { View } from 'react-native'
 
 import { render, screen } from 'tests/utils'
 import { Step } from 'ui/components/Step/Step'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 import { StepList } from './StepList'
 
 const children = [
   <Step key={0}>
     <View>
-      <Typo.Body>Past</Typo.Body>
+      <TypoDS.Body>Past</TypoDS.Body>
     </View>
   </Step>,
   <Step key={1}>
     <View>
-      <Typo.Body>Current</Typo.Body>
+      <TypoDS.Body>Current</TypoDS.Body>
     </View>
   </Step>,
   <Step key={2}>
     <View>
-      <Typo.Body>Future</Typo.Body>
+      <TypoDS.Body>Future</TypoDS.Body>
     </View>
   </Step>,
 ]

--- a/src/ui/components/StepList/StepList.stories.tsx
+++ b/src/ui/components/StepList/StepList.stories.tsx
@@ -8,7 +8,7 @@ import { theme } from 'theme'
 import { StepButtonState } from 'ui/components/StepButton/types'
 import { BicolorAroundMe } from 'ui/svg/icons/BicolorAroundMe'
 import { Email } from 'ui/svg/icons/Email'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 import { Step } from '../Step/Step'
 
@@ -46,17 +46,17 @@ export function UsageExample({ currentStepIndex = 0 }) {
     <StepList currentStepIndex={currentStepIndex}>
       <Step>
         <View style={[styles.content, currentStepIndex === 0 && styles.contentActive]}>
-          <Typo.Body>Play with</Typo.Body>
+          <TypoDS.Body>Play with</TypoDS.Body>
         </View>
       </Step>
       <Step>
         <View style={[styles.content, currentStepIndex === 1 && styles.contentActive]}>
-          <Typo.Body>`currentStepIndex` control</Typo.Body>
+          <TypoDS.Body>`currentStepIndex` control</TypoDS.Body>
         </View>
       </Step>
       <Step>
         <View style={[styles.content, currentStepIndex === 2 && styles.contentActive]}>
-          <Typo.Body>on Storybook</Typo.Body>
+          <TypoDS.Body>on Storybook</TypoDS.Body>
         </View>
       </Step>
     </StepList>

--- a/src/ui/components/accessibility/AccessibleUnorderedList.native.test.tsx
+++ b/src/ui/components/accessibility/AccessibleUnorderedList.native.test.tsx
@@ -2,14 +2,14 @@ import React from 'react'
 
 import { render, screen } from 'tests/utils'
 import { AccessibleUnorderedList } from 'ui/components/accessibility/AccessibleUnorderedList'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 describe('accessibilityList', () => {
   it.each`
-    itemList                                                                      | numberOfSeparator
-    ${[]}                                                                         | ${0}
-    ${[<Typo.Body key={1}>Item</Typo.Body>]}                                      | ${0}
-    ${[<Typo.Body key={1}>Item</Typo.Body>, <Typo.Body key={2}>Item</Typo.Body>]} | ${1}
+    itemList                                                                              | numberOfSeparator
+    ${[]}                                                                                 | ${0}
+    ${[<TypoDS.Body key={1}>Item</TypoDS.Body>]}                                          | ${0}
+    ${[<TypoDS.Body key={1}>Item</TypoDS.Body>, <TypoDS.Body key={2}>Item</TypoDS.Body>]} | ${1}
   `(
     'should render $itemList.length items and $numberOfSeparator separators',
     ({ itemList, numberOfSeparator }) => {

--- a/src/ui/components/buttons/HeroButtonList.stories.tsx
+++ b/src/ui/components/buttons/HeroButtonList.stories.tsx
@@ -8,7 +8,7 @@ import { Emoji } from 'ui/components/Emoji'
 import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storybook/VariantsTemplate'
 import { BicolorSmartphone } from 'ui/svg/icons/BicolorSmartphone'
 import { LocationPointer } from 'ui/svg/icons/LocationPointer'
-import { Typo } from 'ui/theme'
+import { Typo, TypoDS } from 'ui/theme'
 // eslint-disable-next-line no-restricted-imports
 import { ColorsEnum } from 'ui/theme/colors'
 import { iconSizes } from 'ui/theme/iconSizes'
@@ -28,14 +28,14 @@ export default meta
 
 const description = (
   <Text>
-    <Typo.Body>J’ai une carte d’identité, un passeport </Typo.Body>
+    <TypoDS.Body>J’ai une carte d’identité, un passeport </TypoDS.Body>
     <Typo.ButtonText>étranger</Typo.ButtonText>
-    <Typo.Body> ou un titre séjour français</Typo.Body>
+    <TypoDS.Body> ou un titre séjour français</TypoDS.Body>
   </Text>
 )
 const description2 = (
   <Text>
-    <Typo.Body>J’ai ma pièce d’identité </Typo.Body>
+    <TypoDS.Body>J’ai ma pièce d’identité </TypoDS.Body>
     <Typo.ButtonText>en cours de validité avec moi</Typo.ButtonText>
   </Text>
 )

--- a/src/ui/components/headers/ContentHeader.tsx
+++ b/src/ui/components/headers/ContentHeader.tsx
@@ -6,7 +6,7 @@ import styled, { useTheme } from 'styled-components/native'
 import { getAnimationState } from 'ui/animations/helpers/getAnimationState'
 import { BlurView } from 'ui/components/BlurView'
 import { RoundedButton } from 'ui/components/buttons/RoundedButton'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 type AnimatedBlurHeaderFullProps = {
   headerTitle?: string
@@ -117,7 +117,7 @@ const Title = styled(Animated.Text).attrs({
   ...(Platform.OS === 'web' ? { whiteSpace: 'pre-wrap' } : {}),
 }))
 
-const Body = styled(Typo.Body)(({ theme }) => ({
+const Body = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.black,
 }))
 

--- a/src/ui/components/inputs/DateInput/atoms/DateInputDisplay.tsx
+++ b/src/ui/components/inputs/DateInput/atoms/DateInputDisplay.tsx
@@ -6,7 +6,7 @@ import { InputLabel } from 'ui/components/InputLabel/InputLabel'
 import { ContainerWithMaxWidth } from 'ui/components/inputs/ContainerWithMaxWidth'
 import { InputContainer } from 'ui/components/inputs/InputContainer'
 import { LabelContainer } from 'ui/components/inputs/LabelContainer'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   date: Date
@@ -23,7 +23,7 @@ export function DateInputDisplay({ date, isError }: Props) {
       </LabelContainer>
       <Spacer.Column numberOfSpaces={2} />
       <InputContainer isError={isError}>
-        <Typo.Body nativeID={dateInputID}>{formatToFrenchDate(date)}</Typo.Body>
+        <TypoDS.Body nativeID={dateInputID}>{formatToFrenchDate(date)}</TypoDS.Body>
       </InputContainer>
     </ContainerWithMaxWidth>
   )

--- a/src/ui/components/snackBar/SnackBar.tsx
+++ b/src/ui/components/snackBar/SnackBar.tsx
@@ -9,7 +9,7 @@ import { SnackBarProgressBar } from 'ui/components/snackBar/SnackBarProgressBar'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { Close as DefaultClose } from 'ui/svg/icons/Close'
 import { AccessibleIcon } from 'ui/svg/icons/types'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 // eslint-disable-next-line no-restricted-imports
 import { ColorsEnum } from 'ui/theme/colors'
 
@@ -169,7 +169,7 @@ const SnackBarContainer = styled.View<{ isVisible: boolean; marginTop: number }>
   })
 )
 
-const StyledBody = styled(Typo.Body)<{ color: string }>((props) => ({
+const StyledBody = styled(TypoDS.Body)<{ color: string }>((props) => ({
   color: props.color,
   marginHorizontal: getSpacing(3),
   flexGrow: 0,

--- a/src/ui/components/tiles/HorizontalTile.stories.tsx
+++ b/src/ui/components/tiles/HorizontalTile.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { CategoryIdEnum } from 'api/gen'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 import { HorizontalTile } from './HorizontalTile'
 
@@ -20,7 +20,7 @@ const Container = styled.View({
   gap: getSpacing(4),
 })
 
-const Body = styled(Typo.Body)(({ theme }) => ({
+const Body = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 

--- a/src/ui/web/displayOnFocus/displayOnFocus.stories.tsx
+++ b/src/ui/web/displayOnFocus/displayOnFocus.stories.tsx
@@ -3,7 +3,7 @@ import { userEvent, screen } from '@storybook/testing-library'
 import React, { Fragment, FunctionComponent, PropsWithChildren } from 'react'
 import styled from 'styled-components'
 
-import { Typo } from 'ui/theme'
+import { Typo, TypoDS } from 'ui/theme'
 
 import { displayOnFocus } from './displayOnFocus'
 
@@ -33,11 +33,11 @@ const SomeComponentThatDisplayOnFocus: React.FC<PropsWithChildren> =
 
 const Template: ComponentStory<FunctionComponent> = () => (
   <Fragment>
-    <Typo.Body>
+    <TypoDS.Body>
       {body1}
       <Typo.Caption>{caption}</Typo.Caption>
       {body2}
-    </Typo.Body>
+    </TypoDS.Body>
     <RelativeWrapper>
       <SomeComponentThatDisplayOnFocus>{buttonText}</SomeComponentThatDisplayOnFocus>
     </RelativeWrapper>

--- a/src/ui/web/link/QuickAccess.stories.tsx
+++ b/src/ui/web/link/QuickAccess.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { userEvent, screen } from '@storybook/testing-library'
 import React, { Fragment } from 'react'
 
-import { Typo } from 'ui/theme'
+import { Typo, TypoDS } from 'ui/theme'
 
 import { QuickAccess } from './QuickAccess'
 
@@ -17,10 +17,10 @@ const body = ' is a component that should be visible only when giving focus'
 
 const Template: ComponentStory<typeof QuickAccess> = (args) => (
   <Fragment>
-    <Typo.Body>
+    <TypoDS.Body>
       <Typo.Caption>{caption}</Typo.Caption>
       {body}
-    </Typo.Body>
+    </TypoDS.Body>
     <QuickAccess {...args} />
   </Fragment>
 )

--- a/src/web/SupportedBrowsersGate.tsx
+++ b/src/web/SupportedBrowsersGate.tsx
@@ -60,14 +60,14 @@ export const BrowserNotSupportedPage: React.FC<{
       <Container>
         <Title>{title}</Title>
         <Spacer.Column numberOfSpaces={5} />
-        <Typo.Body>
+        <TypoDS.Body>
           Nous ne supportons pas certaines versions et/ou navigateurs qui ne permettraient pas une
           expérience optimale.
-        </Typo.Body>
+        </TypoDS.Body>
         <Spacer.Column numberOfSpaces={5} />
-        <Typo.Body>
+        <TypoDS.Body>
           Voici ceux que nous te conseillons pour profiter pleinement du pass Culture&nbsp;:
-        </Typo.Body>
+        </TypoDS.Body>
         <VerticalUl>
           {supportedBrowsers.map(({ browser, version }) => {
             let displayedMessage = `- ${browser}`
@@ -113,6 +113,6 @@ const Title = styled(TypoDS.Title3)({
   textAlign: 'center',
 })
 
-const StyledBody = styled(Typo.Body)({
+const StyledBody = styled(TypoDS.Body)({
   padding: getSpacing(5),
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33804

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
