### PR TITLE
(PC-33849) refactor(TypoDS): missing typo body update and refacto 

### DIFF
--- a/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.web.test.tsx.web-snap
@@ -92,9 +92,9 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
 }
 
 .c3 {
-  font-family: Montserrat-Regular;
-  font-size: 15px;
-  line-height: 20px;
+  font-family: Montserrat-Medium;
+  font-size: 1rempx;
+  line-height: 1.6rem;
   color: #161617;
   width: 100%;
   padding-right: 16px;
@@ -118,9 +118,9 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
 }
 
 .c6 {
-  font-family: Montserrat-Regular;
-  font-size: 15px;
-  line-height: 20px;
+  font-family: Montserrat-Medium;
+  font-size: 1rempx;
+  line-height: 1.6rem;
   color: #161617;
   width: 100%;
   padding-right: 16px;
@@ -144,9 +144,9 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
 }
 
 .c7 {
-  font-family: Montserrat-Regular;
-  font-size: 15px;
-  line-height: 20px;
+  font-family: Montserrat-Medium;
+  font-size: 1rempx;
+  line-height: 1.6rem;
   color: #161617;
   width: 100%;
   padding-right: 16px;

--- a/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
+++ b/src/features/identityCheck/pages/identification/errors/eduConnect/NotEligibleEduConnect.tsx
@@ -81,7 +81,6 @@ type TextBodyProps = TextProps & {
 }
 const Body = styled(TypoDS.Body).attrs<TextBodyProps>((props) => props)<TextBodyProps>(
   ({ theme, textAlign }) => ({
-    ...theme.typography.body,
     textAlign,
     color: theme.colors.white,
   })

--- a/src/features/search/pages/SuggestedPlacesOrVenues/SuggestedPlaces.tsx
+++ b/src/features/search/pages/SuggestedPlacesOrVenues/SuggestedPlaces.tsx
@@ -91,10 +91,9 @@ const NotLongEnough = ({ show }: { show: boolean }) =>
     </StyledBody>
   ) : null
 
-const ListIconWrapper = styled.View(({ theme }) => ({
-  marginTop: (theme.typography.body.fontSize * 15) / 100,
+const ListIconWrapper = styled.View({
   marginRight: getSpacing(0.5),
-}))
+})
 
 const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,

--- a/src/ui/components/BulletListItem.tsx
+++ b/src/ui/components/BulletListItem.tsx
@@ -5,6 +5,7 @@ import { Li } from 'ui/components/Li'
 import { VerticalUl } from 'ui/components/Ul'
 import { Dot } from 'ui/svg/icons/Dot'
 import { getSpacing, TypoDS } from 'ui/theme'
+import { REM_TO_PX } from 'ui/theme/constants'
 
 // Use with Ul or VerticalUl to be accessible in web
 export const BulletListItem: React.FC<{
@@ -70,7 +71,9 @@ const NestedBullet = styled(Dot).attrs(({ theme }) => ({
 }))``
 
 const BulletContainer = styled.View(({ theme }) => ({
-  height: theme.designSystem.typography.body.lineHeight,
+  height: theme.isDesktopViewport
+    ? parseFloat(theme.designSystem.typography.body.lineHeight) * REM_TO_PX
+    : parseFloat(theme.designSystem.typography.body.lineHeight),
   justifyContent: 'center',
 }))
 

--- a/src/ui/components/CollapsibleText/useIsTextEllipsis.ts
+++ b/src/ui/components/CollapsibleText/useIsTextEllipsis.ts
@@ -1,9 +1,9 @@
 import { useCallback, useState } from 'react'
 import { useTheme } from 'styled-components/native'
 
-import { IsTextEllipsisOutput } from './types'
+import { REM_TO_PX } from 'ui/theme/constants'
 
-const REM_TO_PX = 16
+import { IsTextEllipsisOutput } from './types'
 
 // React Native Web doesn't support onTextLayout
 // https://github.com/necolas/react-native-web/issues/1685
@@ -11,7 +11,7 @@ export const useIsTextEllipsis = (numberOfLines: number): IsTextEllipsisOutput =
   const [isTextEllipsis, setIsTextEllipsis] = useState(false)
   const theme = useTheme()
 
-  const lineHeight = Number(theme.designSystem.typography.body.lineHeight.slice(0, -3)) * REM_TO_PX
+  const lineHeight = parseFloat(theme.designSystem.typography.body.lineHeight) * REM_TO_PX
 
   const onLayout: Required<IsTextEllipsisOutput>['onLayout'] = useCallback(
     (event) => {

--- a/src/ui/components/CollapsibleText/useIsTextEllipsis.web.test.tsx
+++ b/src/ui/components/CollapsibleText/useIsTextEllipsis.web.test.tsx
@@ -5,8 +5,9 @@ import { ThemeProvider } from 'styled-components/native'
 import { computedTheme } from 'tests/computedTheme'
 import { act, renderHook } from 'tests/utils/web'
 import { useIsTextEllipsis } from 'ui/components/CollapsibleText/useIsTextEllipsis'
+import { REM_TO_PX } from 'ui/theme/constants'
 
-const LINE_HEIGHT = Number(computedTheme.typography.body.lineHeight.slice(0, -2))
+const LINE_HEIGHT = parseFloat(computedTheme.designSystem.typography.body.lineHeight) * REM_TO_PX
 
 describe('useIsTextEllipsis', () => {
   it('should return the text ends with ellipsis when the text takes more lines than the max', async () => {

--- a/src/ui/components/inputs/DropDown/DropDown.web.tsx
+++ b/src/ui/components/inputs/DropDown/DropDown.web.tsx
@@ -105,7 +105,7 @@ const StyledSelect = styled.select<SelectProps>`
       : `${theme.borderRadius.button}px`
     const { fontFamily, fontSize, color, lineHeight } = isEmpty
       ? theme.typography.placeholder
-      : theme.typography.body
+      : theme.designSystem.typography.body
     return `
     font-family: ${fontFamily};
     font-size: ${fontSize}px;

--- a/src/ui/theme/constants.ts
+++ b/src/ui/theme/constants.ts
@@ -39,3 +39,5 @@ export const ILLUSTRATION_ICON_SIZE = getSpacing(35) // 140
 export const FULLPAGE_ILLUSTRATION_ICON_SIZE = getSpacing(50)
 // small illustrations should be imported with ILLUSTRATION_SMALL_SIZE
 export const ILLUSTRATION_SMALL_SIZE = getSpacing(25)
+
+export const REM_TO_PX = 16


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33849

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
