### PR TITLE
(PC-33818) fix(achievements): hook to handle bug

### DIFF
--- a/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.native.test.ts
+++ b/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.native.test.ts
@@ -1,5 +1,6 @@
 import { AchievementEnum, AchievementResponse } from 'api/gen'
 import { useShouldShowAchievementSuccessModal } from 'features/achievements/hooks/useShouldShowAchievementSuccessModal'
+import { ModalDisplayState } from 'features/home/components/helpers/useBookingsReactionHelpers'
 import { beneficiaryUser } from 'fixtures/user'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
@@ -9,6 +10,7 @@ import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
 import { renderHook } from 'tests/utils'
 
 jest.mock('features/auth/context/AuthContext')
+jest.mock('libs/firebase/analytics/analytics')
 const useRemoteConfigContextSpy = jest.spyOn(useRemoteConfigContext, 'useRemoteConfigContext')
 
 const achievements: AchievementResponse[] = [
@@ -37,13 +39,15 @@ describe('useShouldShowAchievementSuccessModal', () => {
       useRemoteConfigContextSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
     })
 
-    it('should return false', () => {
+    it('should return shouldNotShow', () => {
       const { result } = renderHook(useShouldShowAchievementSuccessModal)
 
-      expect(result.current.shouldShowAchievementSuccessModal).toBeFalsy()
+      expect(result.current.shouldShowAchievementSuccessModal).toEqual(
+        ModalDisplayState.SHOULD_NOT_SHOW
+      )
     })
 
-    it('should return false even if there are achievements to show to the user', () => {
+    it('should return shouldNotShow even if there are achievements to show to the user', () => {
       mockAuthContextWithUser({
         ...beneficiaryUser,
         achievements: achievements,
@@ -51,7 +55,9 @@ describe('useShouldShowAchievementSuccessModal', () => {
 
       const { result } = renderHook(useShouldShowAchievementSuccessModal)
 
-      expect(result.current.shouldShowAchievementSuccessModal).toBeFalsy()
+      expect(result.current.shouldShowAchievementSuccessModal).toEqual(
+        ModalDisplayState.SHOULD_NOT_SHOW
+      )
     })
   })
 
@@ -71,13 +77,15 @@ describe('useShouldShowAchievementSuccessModal', () => {
       useRemoteConfigContextSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
     })
 
-    it('should return false', () => {
+    it('should return shouldNotShow', () => {
       const { result } = renderHook(useShouldShowAchievementSuccessModal)
 
-      expect(result.current.shouldShowAchievementSuccessModal).toBeFalsy()
+      expect(result.current.shouldShowAchievementSuccessModal).toEqual(
+        ModalDisplayState.SHOULD_NOT_SHOW
+      )
     })
 
-    it('should return false if there no achievements to show to the user', () => {
+    it('should return shouldNotShow if there no achievements to show to the user', () => {
       mockAuthContextWithUser({
         ...beneficiaryUser,
         achievements: [],
@@ -85,10 +93,12 @@ describe('useShouldShowAchievementSuccessModal', () => {
 
       const { result } = renderHook(useShouldShowAchievementSuccessModal)
 
-      expect(result.current.shouldShowAchievementSuccessModal).toBeFalsy()
+      expect(result.current.shouldShowAchievementSuccessModal).toEqual(
+        ModalDisplayState.SHOULD_NOT_SHOW
+      )
     })
 
-    it('should return false if the achievements are undefined', () => {
+    it('should return shouldNotShow if the achievements are undefined', () => {
       mockAuthContextWithUser({
         ...beneficiaryUser,
         achievements: undefined as unknown as AchievementResponse[],
@@ -96,7 +106,9 @@ describe('useShouldShowAchievementSuccessModal', () => {
 
       const { result } = renderHook(useShouldShowAchievementSuccessModal)
 
-      expect(result.current.shouldShowAchievementSuccessModal).toBeFalsy()
+      expect(result.current.shouldShowAchievementSuccessModal).toEqual(
+        ModalDisplayState.SHOULD_NOT_SHOW
+      )
     })
 
     it('should return an empty array if there are no achievements to show to the user', () => {
@@ -110,7 +122,7 @@ describe('useShouldShowAchievementSuccessModal', () => {
       expect(result.current.achievementsToShow).toEqual([])
     })
 
-    it('should return true if there are achievements to show to the user', () => {
+    it('should return shouldShow if there are achievements to show to the user', () => {
       mockAuthContextWithUser({
         ...beneficiaryUser,
         achievements: achievements,
@@ -118,18 +130,9 @@ describe('useShouldShowAchievementSuccessModal', () => {
 
       const { result } = renderHook(useShouldShowAchievementSuccessModal)
 
-      expect(result.current.shouldShowAchievementSuccessModal).toBeTruthy()
-    })
-
-    it('should return false if another modal is open even if there are achievements to show to the user', () => {
-      mockAuthContextWithUser({
-        ...beneficiaryUser,
-        achievements: achievements,
-      })
-
-      const { result } = renderHook(() => useShouldShowAchievementSuccessModal(true))
-
-      expect(result.current.shouldShowAchievementSuccessModal).toBeFalsy()
+      expect(result.current.shouldShowAchievementSuccessModal).toEqual(
+        ModalDisplayState.SHOULD_SHOW
+      )
     })
 
     it('should return an array with the achievements to show to the user', () => {
@@ -159,13 +162,15 @@ describe('useShouldShowAchievementSuccessModal', () => {
       useRemoteConfigContextSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
     })
 
-    it('should return false', () => {
+    it('should return shouldNotShow', () => {
       const { result } = renderHook(useShouldShowAchievementSuccessModal)
 
-      expect(result.current.shouldShowAchievementSuccessModal).toBeFalsy()
+      expect(result.current.shouldShowAchievementSuccessModal).toEqual(
+        ModalDisplayState.SHOULD_NOT_SHOW
+      )
     })
 
-    it('should return false even if there are achievements to show to the user', () => {
+    it('should return shouldNotShow even if there are achievements to show to the user', () => {
       mockAuthContextWithUser({
         ...beneficiaryUser,
         achievements: achievements,
@@ -173,7 +178,9 @@ describe('useShouldShowAchievementSuccessModal', () => {
 
       const { result } = renderHook(useShouldShowAchievementSuccessModal)
 
-      expect(result.current.shouldShowAchievementSuccessModal).toBeFalsy()
+      expect(result.current.shouldShowAchievementSuccessModal).toEqual(
+        ModalDisplayState.SHOULD_NOT_SHOW
+      )
     })
 
     it('should return an array even if there are achievements to show to the user', () => {

--- a/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.ts
+++ b/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.ts
@@ -1,12 +1,14 @@
 import { AchievementResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
+import { ModalDisplayState } from 'features/home/components/helpers/useBookingsReactionHelpers'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { useRemoteConfigContext } from 'libs/firebase/remoteConfig/RemoteConfigProvider'
 
-export const useShouldShowAchievementSuccessModal = (
-  isAnotherModalOpen = false
-): { shouldShowAchievementSuccessModal: boolean; achievementsToShow: AchievementResponse[] } => {
+export const useShouldShowAchievementSuccessModal = (): {
+  shouldShowAchievementSuccessModal: ModalDisplayState
+  achievementsToShow: AchievementResponse[]
+} => {
   const areAchievementsEnabled = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_ACHIEVEMENTS)
   const { displayAchievements } = useRemoteConfigContext()
   const { user } = useAuthContext()
@@ -22,13 +24,15 @@ export const useShouldShowAchievementSuccessModal = (
     !displayAchievements ||
     !user?.achievements ||
     user?.achievements.length === 0 ||
-    !isThereAtLeastOneUnseenAchievement ||
-    isAnotherModalOpen
+    !isThereAtLeastOneUnseenAchievement
   )
-    return { shouldShowAchievementSuccessModal: false, achievementsToShow: [] }
+    return {
+      shouldShowAchievementSuccessModal: ModalDisplayState.SHOULD_NOT_SHOW,
+      achievementsToShow: [],
+    }
 
   return {
-    shouldShowAchievementSuccessModal: isThereAtLeastOneUnseenAchievement,
+    shouldShowAchievementSuccessModal: ModalDisplayState.SHOULD_SHOW,
     achievementsToShow:
       unseenAchievements && unseenAchievements?.length > 0 ? unseenAchievements : [],
   }

--- a/src/features/home/components/helpers/useBookingsReactionHelpers.native.test.ts
+++ b/src/features/home/components/helpers/useBookingsReactionHelpers.native.test.ts
@@ -1,7 +1,10 @@
 import { BookingsResponse, ReactionTypeEnum, SubcategoriesResponseModelv2 } from 'api/gen'
 import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import * as CookiesUpToDate from 'features/cookies/helpers/useIsCookiesListUpToDate'
-import { useBookingsReactionHelpers } from 'features/home/components/helpers/useBookingsReactionHelpers'
+import {
+  ModalDisplayState,
+  useBookingsReactionHelpers,
+} from 'features/home/components/helpers/useBookingsReactionHelpers'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
@@ -32,8 +35,7 @@ describe('useBookingsReactionHelpers', () => {
 
     const { result } = renderHook(() => useBookingsReactionHelpers(endedBookingWithoutReaction))
 
-    expect(result.current.shouldShowReactionModal).toBeFalsy()
-    expect(result.current.bookingsEligibleToReaction).toHaveLength(0)
+    expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_NOT_SHOW)
   })
 
   describe('when FF wipReactionFeature is true', () => {
@@ -41,26 +43,25 @@ describe('useBookingsReactionHelpers', () => {
       setFeatureFlags([RemoteStoreFeatureFlags.WIP_REACTION_FEATURE])
     })
 
-    it('should return false if the bookings already have reactions', () => {
+    it('should return shouldNotShow if the bookings already have reactions', () => {
       const { result } = renderHook(() => useBookingsReactionHelpers(endedBookingWithReaction))
 
-      expect(result.current.shouldShowReactionModal).toBeFalsy()
-      expect(result.current.bookingsEligibleToReaction).toHaveLength(0)
+      expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_NOT_SHOW)
     })
 
-    it('should return false if cookies where not accepted', () => {
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('should return shouldNotShow if cookies where not accepted', () => {
       cookiesNotAccepted()
 
       const { result } = renderHook(() => useBookingsReactionHelpers(endedBookingWithoutReaction))
 
-      expect(result.current.shouldShowReactionModal).toBeFalsy()
-      expect(result.current.bookingsEligibleToReaction).toHaveLength(0)
+      expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_NOT_SHOW)
     })
 
     it('should return true if there are bookings to react to', () => {
       const { result } = renderHook(() => useBookingsReactionHelpers(endedBookingWithoutReaction))
 
-      expect(result.current.shouldShowReactionModal).toBeTruthy()
+      expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_SHOW)
       expect(result.current.bookingsEligibleToReaction).toEqual(
         endedBookingWithoutReaction.ended_bookings
       )

--- a/src/features/home/helpers/useWhichModalToShow.native.test.ts
+++ b/src/features/home/helpers/useWhichModalToShow.native.test.ts
@@ -1,0 +1,117 @@
+import { AchievementEnum, AchievementResponse, BookingsResponse, ReactionTypeEnum } from 'api/gen'
+import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
+import * as CookiesUpToDate from 'features/cookies/helpers/useIsCookiesListUpToDate'
+import { ModalToShow, useWhichModalToShow } from 'features/home/helpers/useWhichModalToShow'
+import { beneficiaryUser } from 'fixtures/user'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.constants'
+import * as useRemoteConfigContext from 'libs/firebase/remoteConfig/RemoteConfigProvider'
+import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
+import { renderHook } from 'tests/utils'
+
+jest.mock('features/auth/context/AuthContext')
+jest.mock('libs/firebase/analytics/analytics')
+const useRemoteConfigContextSpy = jest.spyOn(useRemoteConfigContext, 'useRemoteConfigContext')
+
+jest.spyOn(CookiesUpToDate, 'useIsCookiesListUpToDate').mockReturnValue({
+  isCookiesListUpToDate: true,
+  cookiesLastUpdate: { lastUpdated: new Date('10/12/2022'), lastUpdateBuildVersion: 10208002 },
+})
+
+describe('useWhichModalToShow', () => {
+  beforeEach(() => {
+    setFeatureFlags([
+      RemoteStoreFeatureFlags.ENABLE_ACHIEVEMENTS,
+      RemoteStoreFeatureFlags.WIP_REACTION_FEATURE,
+    ])
+  })
+
+  beforeAll(() => {
+    useRemoteConfigContextSpy.mockReturnValue({
+      ...DEFAULT_REMOTE_CONFIG,
+      displayAchievements: true,
+    })
+  })
+
+  afterAll(() => {
+    useRemoteConfigContextSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
+  })
+
+  it('should return achievement if the achievement modal should be shown and the reaction modal should not be shown', () => {
+    mockAuthContextWithUser({
+      ...beneficiaryUser,
+      achievements: achievements,
+    })
+
+    const { result } = renderHook(() => useWhichModalToShow(endedBookingWithReaction))
+
+    expect(result.current.showModal).toEqual(ModalToShow.ACHIEVEMENT)
+  })
+
+  it('should return reaction if the reaction modal should be shown and the achievement modal should not be shown', () => {
+    mockAuthContextWithUser({
+      ...beneficiaryUser,
+      achievements: [],
+    })
+
+    const { result } = renderHook(() => useWhichModalToShow(endedBookingWithoutReaction))
+
+    expect(result.current.showModal).toEqual(ModalToShow.REACTION)
+  })
+
+  it('should return reaction if the reaction modal should be show, even if the achievement modal should be shown', () => {
+    mockAuthContextWithUser({
+      ...beneficiaryUser,
+      achievements: achievements,
+    })
+
+    const { result } = renderHook(() => useWhichModalToShow(endedBookingWithoutReaction))
+
+    expect(result.current.showModal).toEqual(ModalToShow.REACTION)
+  })
+
+  it('should return none if the reaction and achievement both should not be shown', () => {
+    mockAuthContextWithUser({
+      ...beneficiaryUser,
+      achievements: [],
+    })
+
+    const { result } = renderHook(() => useWhichModalToShow(endedBookingWithReaction))
+
+    expect(result.current.showModal).toEqual(ModalToShow.NONE)
+  })
+})
+
+const endedBookingWithoutReaction: BookingsResponse = {
+  ended_bookings: [
+    {
+      ...bookingsSnap.ended_bookings[0],
+      userReaction: null,
+      enablePopUpReaction: true,
+    },
+  ],
+  ongoing_bookings: [],
+  hasBookingsAfter18: false,
+}
+
+const achievements: AchievementResponse[] = [
+  {
+    id: 1,
+    name: AchievementEnum.FIRST_ART_LESSON_BOOKING,
+    seenDate: undefined,
+    unlockedDate: new Date().toDateString(),
+  },
+]
+
+const endedBookingWithReaction: BookingsResponse = {
+  ended_bookings: [
+    {
+      ...bookingsSnap.ended_bookings[0],
+      userReaction: ReactionTypeEnum.LIKE,
+      enablePopUpReaction: true,
+    },
+  ],
+  ongoing_bookings: [],
+  hasBookingsAfter18: false,
+}

--- a/src/features/home/helpers/useWhichModalToShow.ts
+++ b/src/features/home/helpers/useWhichModalToShow.ts
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+
+import { BookingsResponse } from 'api/gen'
+import { useShouldShowAchievementSuccessModal } from 'features/achievements/hooks/useShouldShowAchievementSuccessModal'
+import {
+  ModalDisplayState,
+  useBookingsReactionHelpers,
+} from 'features/home/components/helpers/useBookingsReactionHelpers'
+
+export enum ModalToShow {
+  PENDING = 'pending',
+  ACHIEVEMENT = 'achievement',
+  REACTION = 'reaction',
+  NONE = 'none',
+}
+
+export const useWhichModalToShow = (bookings: BookingsResponse | undefined = undefined) => {
+  const [showModal, setShowModal] = useState<ModalToShow>(ModalToShow.PENDING)
+  const { shouldShowReactionModal, bookingsEligibleToReaction } =
+    useBookingsReactionHelpers(bookings)
+  const { shouldShowAchievementSuccessModal, achievementsToShow } =
+    useShouldShowAchievementSuccessModal()
+
+  if (bookings !== undefined && showModal === ModalToShow.PENDING) {
+    if (shouldShowReactionModal === ModalDisplayState.SHOULD_SHOW) {
+      setShowModal(ModalToShow.REACTION)
+    } else if (shouldShowAchievementSuccessModal === ModalDisplayState.SHOULD_SHOW) {
+      setShowModal(ModalToShow.ACHIEVEMENT)
+    } else if (
+      shouldShowReactionModal === ModalDisplayState.SHOULD_NOT_SHOW &&
+      shouldShowAchievementSuccessModal === ModalDisplayState.SHOULD_NOT_SHOW
+    ) {
+      setShowModal(ModalToShow.NONE)
+    }
+  }
+
+  return { showModal, bookingsEligibleToReaction, achievementsToShow }
+}

--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -3,16 +3,15 @@ import { maxBy } from 'lodash'
 import React, { FunctionComponent, useEffect } from 'react'
 import styled from 'styled-components/native'
 
-import { useShouldShowAchievementSuccessModal } from 'features/achievements/hooks/useShouldShowAchievementSuccessModal'
 import { AchievementSuccessModal } from 'features/achievements/pages/AchievementSuccessModal'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useBookings } from 'features/bookings/api'
 import { useHomepageData } from 'features/home/api/useHomepageData'
 import { HomeHeader } from 'features/home/components/headers/HomeHeader'
-import { useBookingsReactionHelpers } from 'features/home/components/helpers/useBookingsReactionHelpers'
 import { IncomingReactionModalContainer } from 'features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer'
 import { HomeBanner } from 'features/home/components/modules/banners/HomeBanner'
 import { PERFORMANCE_HOME_CREATION, PERFORMANCE_HOME_LOADING } from 'features/home/constants'
+import { ModalToShow, useWhichModalToShow } from 'features/home/helpers/useWhichModalToShow'
 import { GenericHome } from 'features/home/pages/GenericHome'
 import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { OnboardingSubscriptionModal } from 'features/subscription/components/modals/OnboardingSubscriptionModal'
@@ -59,10 +58,12 @@ export const Home: FunctionComponent = () => {
   })
   const { data: bookings } = useBookings()
 
-  const { shouldShowReactionModal, bookingsEligibleToReaction } =
-    useBookingsReactionHelpers(bookings)
-  const { shouldShowAchievementSuccessModal, achievementsToShow } =
-    useShouldShowAchievementSuccessModal(shouldShowReactionModal)
+  const {
+    achievementsToShow,
+    bookingsEligibleToReaction,
+    showModal: modalToShow,
+  } = useWhichModalToShow(bookings)
+
   const {
     visible: visibleAchievementModal,
     showModal: showAchievementModal,
@@ -70,10 +71,10 @@ export const Home: FunctionComponent = () => {
   } = useModal(false)
 
   useEffect(() => {
-    if (shouldShowAchievementSuccessModal) {
+    if (modalToShow === ModalToShow.ACHIEVEMENT) {
       showAchievementModal()
     }
-  }, [shouldShowAchievementSuccessModal, showAchievementModal])
+  }, [showAchievementModal, modalToShow])
 
   useEffect(() => {
     if (id) {
@@ -138,7 +139,7 @@ export const Home: FunctionComponent = () => {
         visible={onboardingSubscriptionModalVisible}
         dismissModal={hideOnboardingSubscriptionModal}
       />
-      {shouldShowReactionModal ? (
+      {modalToShow === ModalToShow.REACTION ? (
         <IncomingReactionModalContainer bookingsEligibleToReaction={bookingsEligibleToReaction} />
       ) : null}
       <AchievementSuccessModal

--- a/src/features/home/pages/Home.web.test.tsx
+++ b/src/features/home/pages/Home.web.test.tsx
@@ -53,6 +53,10 @@ describe('<Home/>', () => {
         modules: [formattedBusinessModule],
         homeEntryId: 'fakeEntryId',
       }) // Adding useBookingsReactionHelpers to Home.tsx caused an extra render
+      mockUseHomepageData.mockReturnValueOnce({
+        modules: [formattedBusinessModule],
+        homeEntryId: 'fakeEntryId',
+      }) // Adding useWhichModalToShow to Home.tsx caused an extra render
 
       const { container } = render(<Home />, {
         wrapper: ({ children }) => reactQueryProviderHOC(children),


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33818

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
