### PR TITLE
(PC-33894) feat(identityCheck): change tests name in DMSModal

### DIFF
--- a/src/features/identityCheck/components/modals/DMSModal.native.test.tsx
+++ b/src/features/identityCheck/components/modals/DMSModal.native.test.tsx
@@ -43,7 +43,7 @@ describe('<DMSModal/>', () => {
     expect(mockedOpenUrl).toHaveBeenCalledWith(env.DMS_FRENCH_CITIZEN_URL, undefined, true)
   })
 
-  it('should open DSM french citizen when clicking on "Je suis de nationalité étrangère" button', async () => {
+  it('should open DSM foreign citizen when clicking on "Je suis de nationalité étrangère" button', async () => {
     render(<DMSModal visible hideModal={hideModalMock} />)
     const foreignCitizenDMSButton = screen.getByText('Je suis de nationalité étrangère')
     await fireEvent.press(foreignCitizenDMSButton)


### PR DESCRIPTION
[PC-33894](https://passculture.atlassian.net/browse/PC-33894)

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

[PC-33894]: https://passculture.atlassian.net/browse/PC-33894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ