### PR TITLE
(PC-33859) feat(TypoDS): update typo caption into boddyAccentXs from DS

### DIFF
--- a/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
@@ -956,7 +956,7 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                           "color": "#161617",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
@@ -230,7 +230,7 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }

--- a/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -158,7 +158,7 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }

--- a/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
@@ -245,7 +245,7 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
           "color": "#696A6F",
           "fontFamily": "Montserrat-SemiBold",
           "fontSize": 12,
-          "lineHeight": 16,
+          "lineHeight": 19.2,
         },
       ]
     }
@@ -376,7 +376,7 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
               "color": "#161617",
               "fontFamily": "Montserrat-SemiBold",
               "fontSize": 12,
-              "lineHeight": 16,
+              "lineHeight": 19.2,
               "maxWidth": "100%",
             },
           ]
@@ -495,7 +495,7 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
               "color": "#161617",
               "fontFamily": "Montserrat-SemiBold",
               "fontSize": 12,
-              "lineHeight": 16,
+              "lineHeight": 19.2,
               "maxWidth": "100%",
             },
           ]
@@ -618,7 +618,7 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
           "color": "#696A6F",
           "fontFamily": "Montserrat-SemiBold",
           "fontSize": 12,
-          "lineHeight": 16,
+          "lineHeight": 19.2,
         },
       ]
     }
@@ -1001,7 +1001,7 @@ exports[`<AcceptCgu/> should render correctly for SSO subscription 1`] = `
           "color": "#696A6F",
           "fontFamily": "Montserrat-SemiBold",
           "fontSize": 12,
-          "lineHeight": 16,
+          "lineHeight": 19.2,
         },
       ]
     }
@@ -1132,7 +1132,7 @@ exports[`<AcceptCgu/> should render correctly for SSO subscription 1`] = `
               "color": "#161617",
               "fontFamily": "Montserrat-SemiBold",
               "fontSize": 12,
-              "lineHeight": 16,
+              "lineHeight": 19.2,
               "maxWidth": "100%",
             },
           ]
@@ -1251,7 +1251,7 @@ exports[`<AcceptCgu/> should render correctly for SSO subscription 1`] = `
               "color": "#161617",
               "fontFamily": "Montserrat-SemiBold",
               "fontSize": 12,
-              "lineHeight": 16,
+              "lineHeight": 19.2,
               "maxWidth": "100%",
             },
           ]
@@ -1374,7 +1374,7 @@ exports[`<AcceptCgu/> should render correctly for SSO subscription 1`] = `
           "color": "#696A6F",
           "fontFamily": "Montserrat-SemiBold",
           "fontSize": 12,
-          "lineHeight": 16,
+          "lineHeight": 19.2,
         },
       ]
     }

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
@@ -383,12 +383,13 @@ exports[`<EmailResendModal /> should render correctly 1`] = `
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                     },
                   ]
                 }
               >
-                Attention, il te reste : 
+                Attention, il te reste :
+                 
                 <Text
                   style={
                     [
@@ -396,7 +397,7 @@ exports[`<EmailResendModal /> should render correctly 1`] = `
                         "color": "#161617",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -230,7 +230,7 @@ exports[`Signup Form should render correctly for AcceptCgu 1`] = `
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -571,7 +571,7 @@ exports[`Signup Form should render correctly for AcceptCgu 1`] = `
                 "color": "#696A6F",
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
-                "lineHeight": 16,
+                "lineHeight": 19.2,
               },
             ]
           }
@@ -702,7 +702,7 @@ exports[`Signup Form should render correctly for AcceptCgu 1`] = `
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                     "maxWidth": "100%",
                   },
                 ]
@@ -821,7 +821,7 @@ exports[`Signup Form should render correctly for AcceptCgu 1`] = `
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                     "maxWidth": "100%",
                   },
                 ]
@@ -944,7 +944,7 @@ exports[`Signup Form should render correctly for AcceptCgu 1`] = `
                 "color": "#696A6F",
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
-                "lineHeight": 16,
+                "lineHeight": 19.2,
               },
             ]
           }
@@ -1232,7 +1232,7 @@ exports[`Signup Form should render correctly for SetBirthday 1`] = `
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -2769,7 +2769,7 @@ exports[`Signup Form should render correctly for SetPassword 1`] = `
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }

--- a/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
@@ -493,7 +493,7 @@ exports[`BookingDetails should render correctly 1`] = `
                   "color": "#696A6F",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                   "textAlign": "center",
                 },
               ]
@@ -1055,7 +1055,7 @@ exports[`BookingDetails should render correctly 1`] = `
                     "color": "#696A6F",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                     "marginBottom": 24,
                     "textAlign": "center",
                   },

--- a/__snapshots__/features/bookings/pages/Bookings/Bookings.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/Bookings/Bookings.native.test.tsx.native-snap
@@ -266,7 +266,7 @@ exports[`Bookings should render correctly 1`] = `
                   "color": "#696A6F",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                   "paddingBottom": 16,
                   "paddingHorizontal": 24,
                 },
@@ -994,7 +994,7 @@ exports[`Bookings should render correctly 1`] = `
                               "color": "#ffffff",
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 12,
-                              "lineHeight": 16,
+                              "lineHeight": 19.2,
                               "textAlign": "center",
                             },
                           ]

--- a/__snapshots__/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx.native-snap
@@ -654,7 +654,7 @@ exports[`EndedBookings should render correctly 1`] = `
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -1108,7 +1108,7 @@ exports[`EndedBookings should render correctly 1`] = `
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }

--- a/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
@@ -341,7 +341,7 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
                   "color": "#696A6F",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                 },
               ]
             }

--- a/__snapshots__/features/cookies/pages/CookiesDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesDetails.native.test.tsx.native-snap
@@ -251,7 +251,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
             "flexShrink": 1,
             "fontFamily": "Montserrat-SemiBold",
             "fontSize": 12,
-            "lineHeight": 16,
+            "lineHeight": 19.2,
           },
         ]
       }
@@ -277,7 +277,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
               "color": "#696A6F",
               "fontFamily": "Montserrat-SemiBold",
               "fontSize": 12,
-              "lineHeight": 16,
+              "lineHeight": 19.2,
             },
           ]
         }
@@ -770,7 +770,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
                 "color": "#696A6F",
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
-                "lineHeight": 16,
+                "lineHeight": 19.2,
               },
             ]
           }
@@ -1156,7 +1156,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
                 "color": "#696A6F",
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
-                "lineHeight": 16,
+                "lineHeight": 19.2,
               },
             ]
           }
@@ -1542,7 +1542,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
                 "color": "#696A6F",
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
-                "lineHeight": 16,
+                "lineHeight": 19.2,
               },
             ]
           }
@@ -1923,7 +1923,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
             "color": "#696A6F",
             "fontFamily": "Montserrat-SemiBold",
             "fontSize": 12,
-            "lineHeight": 16,
+            "lineHeight": 19.2,
           },
         ]
       }
@@ -2050,7 +2050,7 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
           "color": "#696A6F",
           "fontFamily": "Montserrat-SemiBold",
           "fontSize": 12,
-          "lineHeight": 16,
+          "lineHeight": 19.2,
         },
       ]
     }

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx.native-snap
@@ -238,7 +238,7 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                       "color": "#161617",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                       "marginLeft": 8,
                     },
                   ]
@@ -327,7 +327,7 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                 "color": "#696A6F",
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
-                "lineHeight": 16,
+                "lineHeight": 19.2,
               },
             ]
           }
@@ -502,7 +502,7 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -669,7 +669,7 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -836,7 +836,7 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -1003,7 +1003,7 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -1476,7 +1476,7 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -1643,7 +1643,7 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -1810,7 +1810,7 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }

--- a/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
@@ -348,7 +348,7 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
                         "color": "#ffffff",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }
@@ -398,7 +398,7 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
                     "color": "#90949D",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -617,7 +617,7 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
                           "color": "#0E8474",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                           "marginBottom": 4,
                         },
                       ]
@@ -648,7 +648,7 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                           "marginBottom": 4,
                         },
                       ]

--- a/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
@@ -207,7 +207,7 @@ exports[`Home page should render correctly 1`] = `
                             "color": "#696A6F",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -298,7 +298,7 @@ exports[`Home page should render correctly 1`] = `
                             "color": "#161617",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                             "maxWidth": 100,
                             "paddingTop": 4,
                           },

--- a/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
@@ -490,7 +490,7 @@ exports[`<DMSModal/> should render correctly 1`] = `
                     "color": "#696A6F",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -632,7 +632,7 @@ exports[`<DMSModal/> should render correctly 1`] = `
                     "color": "#696A6F",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }

--- a/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
@@ -606,7 +606,7 @@ exports[`Stepper navigation should render correctly 1`] = `
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }

--- a/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
@@ -423,7 +423,7 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                                 "color": "#696A6F",
                                 "fontFamily": "Montserrat-SemiBold",
                                 "fontSize": 12,
-                                "lineHeight": 16,
+                                "lineHeight": 19.2,
                               },
                             ]
                           }
@@ -565,7 +565,7 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                             "color": "#161617",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                             "maxWidth": "100%",
                           },
                         ]
@@ -772,7 +772,7 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                                 "color": "#696A6F",
                                 "fontFamily": "Montserrat-SemiBold",
                                 "fontSize": 12,
-                                "lineHeight": 16,
+                                "lineHeight": 19.2,
                               },
                             ]
                           }
@@ -968,7 +968,7 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                               "color": "#320096",
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 12,
-                              "lineHeight": 16,
+                              "lineHeight": 19.2,
                               "maxWidth": "100%",
                             },
                           ]

--- a/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
@@ -444,7 +444,7 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
             "color": "#161617",
             "fontFamily": "Montserrat-SemiBold",
             "fontSize": 12,
-            "lineHeight": 16,
+            "lineHeight": 19.2,
             "textAlign": "center",
           },
         ]
@@ -984,7 +984,7 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
             "color": "#161617",
             "fontFamily": "Montserrat-SemiBold",
             "fontSize": 12,
-            "lineHeight": 16,
+            "lineHeight": 19.2,
             "textAlign": "center",
           },
         ]

--- a/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
@@ -494,7 +494,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                         "textAlign": "center",
                       },
                     ]
@@ -692,7 +692,7 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                         "textAlign": "center",
                       },
                     ]

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDOrigin.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDOrigin.native.test.tsx.native-snap
@@ -659,7 +659,7 @@ exports[`SelectIDOrigin should render correctly 1`] = `
                             "color": "#161617",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
@@ -522,7 +522,7 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
                                 "color": "#161617",
                                 "fontFamily": "Montserrat-SemiBold",
                                 "fontSize": 12,
-                                "lineHeight": 16,
+                                "lineHeight": 19.2,
                               },
                             ]
                           }
@@ -735,7 +735,7 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
                                 "color": "#161617",
                                 "fontFamily": "Montserrat-SemiBold",
                                 "fontSize": 12,
-                                "lineHeight": 16,
+                                "lineHeight": 19.2,
                               },
                             ]
                           }
@@ -878,7 +878,7 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
                                 "color": "#161617",
                                 "fontFamily": "Montserrat-SemiBold",
                                 "fontSize": 12,
-                                "lineHeight": 16,
+                                "lineHeight": 19.2,
                               },
                             ]
                           }

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/CodeNotReceivedModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/CodeNotReceivedModal.native.test.tsx.native-snap
@@ -391,7 +391,7 @@ exports[`<CodeNotReceivedModal /> should have a different color if one attempt r
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }
@@ -406,7 +406,7 @@ exports[`<CodeNotReceivedModal /> should have a different color if one attempt r
                         "color": "#b60025",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }
@@ -910,7 +910,7 @@ exports[`<CodeNotReceivedModal /> should match snapshot 1`] = `
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }
@@ -925,7 +925,7 @@ exports[`<CodeNotReceivedModal /> should match snapshot 1`] = `
                         "color": "#161617",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
@@ -442,7 +442,7 @@ exports[`<PhoneValidationTipsModal /> should match snapshot 1`] = `
                         "flexShrink": 1,
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }
@@ -527,7 +527,7 @@ exports[`<PhoneValidationTipsModal /> should match snapshot 1`] = `
                         "flexShrink": 1,
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
@@ -692,7 +692,7 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                     },
                   ]
                 }
@@ -707,7 +707,7 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
                       "color": "#161617",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                     },
                   ]
                 }
@@ -721,7 +721,7 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                     },
                   ]
                 }

--- a/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
@@ -1994,7 +1994,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           "color": "#CBCDD2",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -2265,7 +2265,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           "color": "#CBCDD2",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -2385,7 +2385,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           "color": "#CBCDD2",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -2505,7 +2505,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           "color": "#CBCDD2",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -2625,7 +2625,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           "color": "#CBCDD2",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -2746,7 +2746,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           "color": "#CBCDD2",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -3017,7 +3017,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                           "color": "#CBCDD2",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -3086,7 +3086,7 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                     "color": "#b60025",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                     "paddingVertical": 6,
                   },
                 ]

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityActionPlan.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityActionPlan.native.test.tsx.native-snap
@@ -2764,7 +2764,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                   "maxWidth": "100%",
                 },
               ]
@@ -2896,7 +2896,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                   "maxWidth": "100%",
                 },
               ]
@@ -3028,7 +3028,7 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
@@ -225,7 +225,7 @@ exports[`<ChangeEmail/> should render correctly 1`] = `
               "color": "#696A6F",
               "fontFamily": "Montserrat-SemiBold",
               "fontSize": 12,
-              "lineHeight": 16,
+              "lineHeight": 19.2,
             },
           ]
         }
@@ -249,7 +249,7 @@ exports[`<ChangeEmail/> should render correctly 1`] = `
               "color": "#696A6F",
               "fontFamily": "Montserrat-SemiBold",
               "fontSize": 12,
-              "lineHeight": 16,
+              "lineHeight": 19.2,
             },
           ]
         }

--- a/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
@@ -299,7 +299,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                 "flexShrink": 1,
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
-                "lineHeight": 16,
+                "lineHeight": 19.2,
               },
             ]
           }
@@ -325,7 +325,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                   "color": "#696A6F",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                 },
               ]
             }
@@ -818,7 +818,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                     "color": "#696A6F",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -1204,7 +1204,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                     "color": "#696A6F",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -1590,7 +1590,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                     "color": "#696A6F",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -1971,7 +1971,7 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                 "color": "#696A6F",
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
-                "lineHeight": 16,
+                "lineHeight": 19.2,
               },
             ]
           }

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
@@ -339,7 +339,7 @@ exports[`DeleteProfileConfirmation should match snapshot 1`] = `
                     "color": "#320096",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
@@ -475,7 +475,7 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }

--- a/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/PersonalData/PersonalData.native.test.tsx.native-snap
@@ -215,7 +215,7 @@ exports[`PersonalData should render personal data success 1`] = `
               "color": "#696A6F",
               "fontFamily": "Montserrat-SemiBold",
               "fontSize": 12,
-              "lineHeight": 16,
+              "lineHeight": 19.2,
             },
           ]
         }
@@ -265,7 +265,7 @@ exports[`PersonalData should render personal data success 1`] = `
               "color": "#696A6F",
               "fontFamily": "Montserrat-SemiBold",
               "fontSize": 12,
-              "lineHeight": 16,
+              "lineHeight": 19.2,
             },
           ]
         }
@@ -418,7 +418,7 @@ exports[`PersonalData should render personal data success 1`] = `
                     "color": "#eb0055",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                     "maxWidth": "100%",
                   },
                 ]
@@ -448,7 +448,7 @@ exports[`PersonalData should render personal data success 1`] = `
               "color": "#696A6F",
               "fontFamily": "Montserrat-SemiBold",
               "fontSize": 12,
-              "lineHeight": 16,
+              "lineHeight": 19.2,
             },
           ]
         }
@@ -498,7 +498,7 @@ exports[`PersonalData should render personal data success 1`] = `
               "color": "#696A6F",
               "fontFamily": "Montserrat-SemiBold",
               "fontSize": 12,
-              "lineHeight": 16,
+              "lineHeight": 19.2,
             },
           ]
         }
@@ -651,7 +651,7 @@ exports[`PersonalData should render personal data success 1`] = `
                     "color": "#eb0055",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                     "maxWidth": "100%",
                   },
                 ]
@@ -681,7 +681,7 @@ exports[`PersonalData should render personal data success 1`] = `
               "color": "#696A6F",
               "fontFamily": "Montserrat-SemiBold",
               "fontSize": 12,
-              "lineHeight": 16,
+              "lineHeight": 19.2,
             },
           ]
         }
@@ -834,7 +834,7 @@ exports[`PersonalData should render personal data success 1`] = `
                     "color": "#eb0055",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                     "maxWidth": "100%",
                   },
                 ]
@@ -864,7 +864,7 @@ exports[`PersonalData should render personal data success 1`] = `
               "color": "#696A6F",
               "fontFamily": "Montserrat-SemiBold",
               "fontSize": 12,
-              "lineHeight": 16,
+              "lineHeight": 19.2,
             },
           ]
         }
@@ -1018,7 +1018,7 @@ exports[`PersonalData should render personal data success 1`] = `
                     "color": "#eb0055",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                     "maxWidth": "100%",
                   },
                 ]
@@ -1205,7 +1205,7 @@ exports[`PersonalData should render personal data success 1`] = `
                       "color": "#320096",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
@@ -237,7 +237,7 @@ exports[`Profile component should render correctly 1`] = `
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                     },
                   ]
                 }
@@ -797,7 +797,7 @@ exports[`Profile component should render correctly 1`] = `
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                     },
                   ]
                 }
@@ -1112,7 +1112,7 @@ exports[`Profile component should render correctly 1`] = `
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                     },
                   ]
                 }
@@ -1722,7 +1722,7 @@ exports[`Profile component should render correctly 1`] = `
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                     },
                   ]
                 }
@@ -1957,7 +1957,7 @@ exports[`Profile component should render correctly 1`] = `
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                     },
                   ]
                 }
@@ -2128,7 +2128,7 @@ exports[`Profile component should render correctly 1`] = `
                                   "color": "#161617",
                                   "fontFamily": "Montserrat-SemiBold",
                                   "fontSize": 12,
-                                  "lineHeight": 16,
+                                  "lineHeight": 19.2,
                                 },
                               ]
                             }
@@ -2241,7 +2241,7 @@ exports[`Profile component should render correctly 1`] = `
                                   "color": "#161617",
                                   "fontFamily": "Montserrat-SemiBold",
                                   "fontSize": 12,
-                                  "lineHeight": 16,
+                                  "lineHeight": 19.2,
                                 },
                               ]
                             }
@@ -2354,7 +2354,7 @@ exports[`Profile component should render correctly 1`] = `
                                   "color": "#161617",
                                   "fontFamily": "Montserrat-SemiBold",
                                   "fontSize": 12,
-                                  "lineHeight": 16,
+                                  "lineHeight": 19.2,
                                 },
                               ]
                             }
@@ -2467,7 +2467,7 @@ exports[`Profile component should render correctly 1`] = `
                                   "color": "#161617",
                                   "fontFamily": "Montserrat-SemiBold",
                                   "fontSize": 12,
-                                  "lineHeight": 16,
+                                  "lineHeight": 19.2,
                                 },
                               ]
                             }

--- a/__snapshots__/features/profile/pages/Profile.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/Profile.web.test.tsx.web-snap
@@ -332,7 +332,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
               >
                 <h2
                   aria-level="2"
-                  class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                  class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                   dir="ltr"
                   role="heading"
                 >
@@ -495,7 +495,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
               >
                 <h2
                   aria-level="2"
-                  class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                  class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                   dir="ltr"
                   role="heading"
                 >
@@ -614,7 +614,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
               >
                 <h2
                   aria-level="2"
-                  class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                  class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                   dir="ltr"
                   role="heading"
                 >
@@ -802,7 +802,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
               >
                 <h2
                   aria-level="2"
-                  class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                  class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                   dir="ltr"
                   role="heading"
                 >
@@ -854,7 +854,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
                               class="css-view-175oi2r r-height-hdaws3"
                             />
                             <div
-                              class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                              class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                               dir="ltr"
                             >
                               Instagram
@@ -892,7 +892,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
                               class="css-view-175oi2r r-height-hdaws3"
                             />
                             <div
-                              class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                              class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                               dir="ltr"
                             >
                               X
@@ -930,7 +930,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
                               class="css-view-175oi2r r-height-hdaws3"
                             />
                             <div
-                              class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                              class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                               dir="ltr"
                             >
                               Tiktok
@@ -968,7 +968,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
                               class="css-view-175oi2r r-height-hdaws3"
                             />
                             <div
-                              class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                              class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                               dir="ltr"
                             >
                               Facebook
@@ -1084,7 +1084,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
                         />
                       </div>
                       <div
-                        class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0 r-maxWidth-dnmrzs"
+                        class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8 r-maxWidth-dnmrzs"
                         dir="ltr"
                       >
                         CGU utilisateurs
@@ -1122,7 +1122,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
                         />
                       </div>
                       <div
-                        class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0 r-maxWidth-dnmrzs"
+                        class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8 r-maxWidth-dnmrzs"
                         dir="ltr"
                       >
                         Charte des données personnelles
@@ -1490,7 +1490,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
               >
                 <h2
                   aria-level="2"
-                  class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                  class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                   dir="ltr"
                   role="heading"
                 >
@@ -1653,7 +1653,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
               >
                 <h2
                   aria-level="2"
-                  class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                  class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                   dir="ltr"
                   role="heading"
                 >
@@ -1772,7 +1772,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
               >
                 <h2
                   aria-level="2"
-                  class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                  class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                   dir="ltr"
                   role="heading"
                 >
@@ -1960,7 +1960,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
               >
                 <h2
                   aria-level="2"
-                  class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                  class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                   dir="ltr"
                   role="heading"
                 >
@@ -2012,7 +2012,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
                               class="css-view-175oi2r r-height-hdaws3"
                             />
                             <div
-                              class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                              class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                               dir="ltr"
                             >
                               Instagram
@@ -2050,7 +2050,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
                               class="css-view-175oi2r r-height-hdaws3"
                             />
                             <div
-                              class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                              class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                               dir="ltr"
                             >
                               X
@@ -2088,7 +2088,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
                               class="css-view-175oi2r r-height-hdaws3"
                             />
                             <div
-                              class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                              class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                               dir="ltr"
                             >
                               Tiktok
@@ -2126,7 +2126,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
                               class="css-view-175oi2r r-height-hdaws3"
                             />
                             <div
-                              class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                              class="css-text-1rynq56 r-WebkitBoxOrient-8akbws r-display-krxsd3 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                               dir="ltr"
                             >
                               Facebook
@@ -2242,7 +2242,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
                         />
                       </div>
                       <div
-                        class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0 r-maxWidth-dnmrzs"
+                        class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8 r-maxWidth-dnmrzs"
                         dir="ltr"
                       >
                         CGU utilisateurs
@@ -2280,7 +2280,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
                         />
                       </div>
                       <div
-                        class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0 r-maxWidth-dnmrzs"
+                        class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8 r-maxWidth-dnmrzs"
                         dir="ltr"
                       >
                         Charte des données personnelles

--- a/__snapshots__/features/profile/pages/TrackEmailChange/TrackEmailChange.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/TrackEmailChange/TrackEmailChange.native.test.tsx.native-snap
@@ -673,7 +673,7 @@ exports[`TrackEmailChange v2 account with password should render correctly when 
                             "color": "#696A6F",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -1383,7 +1383,7 @@ exports[`TrackEmailChange v2 account with password should render correctly when 
                             "color": "#696A6F",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -2797,7 +2797,7 @@ exports[`TrackEmailChange v2 account with password should render correctly when 
                             "color": "#696A6F",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -3731,7 +3731,7 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                             "color": "#696A6F",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -4441,7 +4441,7 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                             "color": "#696A6F",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -5883,7 +5883,7 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                             "color": "#696A6F",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -7529,7 +7529,7 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                             "color": "#696A6F",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }

--- a/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
@@ -1338,7 +1338,7 @@ exports[`<SearchFilter/> should render correctly 1`] = `
                 "color": "#161617",
                 "fontFamily": "Montserrat-SemiBold",
                 "fontSize": 12,
-                "lineHeight": 16,
+                "lineHeight": 19.2,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/search/pages/SearchLanding/SearchLanding.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchLanding/SearchLanding.native.test.tsx.native-snap
@@ -113,7 +113,7 @@ exports[`<SearchLanding /> When wipAppV2SearchLandingHeader feature flag deactiv
                   "color": "#696A6F",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                   "marginTop": 4,
                 },
               ]
@@ -208,7 +208,7 @@ exports[`<SearchLanding /> When wipAppV2SearchLandingHeader feature flag deactiv
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                     "maxWidth": 100,
                     "paddingTop": 4,
                   },

--- a/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
@@ -455,7 +455,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                           "textAlign": "center",
                         },
                       ]

--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -434,7 +434,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                             "color": "#161617",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                             "marginLeft": 4,
                             "maxWidth": 100,
                           },
@@ -614,7 +614,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -698,7 +698,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -782,7 +782,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -866,7 +866,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -950,7 +950,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -1034,7 +1034,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -1118,7 +1118,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -1202,7 +1202,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -1286,7 +1286,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -1370,7 +1370,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -1454,7 +1454,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -1538,7 +1538,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -1622,7 +1622,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                     "color": "#161617",
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                   },
                 ]
               }
@@ -4248,7 +4248,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                               "color": "#161617",
                                               "fontFamily": "Montserrat-SemiBold",
                                               "fontSize": 12,
-                                              "lineHeight": 16,
+                                              "lineHeight": 19.2,
                                             },
                                           ]
                                         }
@@ -4262,7 +4262,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                               "color": "#696A6F",
                                               "fontFamily": "Montserrat-SemiBold",
                                               "fontSize": 12,
-                                              "lineHeight": 16,
+                                              "lineHeight": 19.2,
                                             },
                                           ]
                                         }
@@ -4373,7 +4373,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                                   "color": "#ffffff",
                                                   "fontFamily": "Montserrat-SemiBold",
                                                   "fontSize": 12,
-                                                  "lineHeight": 16,
+                                                  "lineHeight": 19.2,
                                                 },
                                               ]
                                             }
@@ -4715,7 +4715,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                               "color": "#161617",
                                               "fontFamily": "Montserrat-SemiBold",
                                               "fontSize": 12,
-                                              "lineHeight": 16,
+                                              "lineHeight": 19.2,
                                             },
                                           ]
                                         }
@@ -4729,7 +4729,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                               "color": "#696A6F",
                                               "fontFamily": "Montserrat-SemiBold",
                                               "fontSize": 12,
-                                              "lineHeight": 16,
+                                              "lineHeight": 19.2,
                                             },
                                           ]
                                         }
@@ -4840,7 +4840,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                                   "color": "#ffffff",
                                                   "fontFamily": "Montserrat-SemiBold",
                                                   "fontSize": 12,
-                                                  "lineHeight": 16,
+                                                  "lineHeight": 19.2,
                                                 },
                                               ]
                                             }
@@ -5182,7 +5182,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                               "color": "#161617",
                                               "fontFamily": "Montserrat-SemiBold",
                                               "fontSize": 12,
-                                              "lineHeight": 16,
+                                              "lineHeight": 19.2,
                                             },
                                           ]
                                         }
@@ -5196,7 +5196,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                               "color": "#696A6F",
                                               "fontFamily": "Montserrat-SemiBold",
                                               "fontSize": 12,
-                                              "lineHeight": 16,
+                                              "lineHeight": 19.2,
                                             },
                                           ]
                                         }
@@ -5307,7 +5307,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                                   "color": "#ffffff",
                                                   "fontFamily": "Montserrat-SemiBold",
                                                   "fontSize": 12,
-                                                  "lineHeight": 16,
+                                                  "lineHeight": 19.2,
                                                 },
                                               ]
                                             }
@@ -5649,7 +5649,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                               "color": "#161617",
                                               "fontFamily": "Montserrat-SemiBold",
                                               "fontSize": 12,
-                                              "lineHeight": 16,
+                                              "lineHeight": 19.2,
                                             },
                                           ]
                                         }
@@ -5663,7 +5663,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                               "color": "#696A6F",
                                               "fontFamily": "Montserrat-SemiBold",
                                               "fontSize": 12,
-                                              "lineHeight": 16,
+                                              "lineHeight": 19.2,
                                             },
                                           ]
                                         }
@@ -5774,7 +5774,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                                   "color": "#ffffff",
                                                   "fontFamily": "Montserrat-SemiBold",
                                                   "fontSize": 12,
-                                                  "lineHeight": 16,
+                                                  "lineHeight": 19.2,
                                                 },
                                               ]
                                             }
@@ -6116,7 +6116,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                               "color": "#161617",
                                               "fontFamily": "Montserrat-SemiBold",
                                               "fontSize": 12,
-                                              "lineHeight": 16,
+                                              "lineHeight": 19.2,
                                             },
                                           ]
                                         }
@@ -6130,7 +6130,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                               "color": "#696A6F",
                                               "fontFamily": "Montserrat-SemiBold",
                                               "fontSize": 12,
-                                              "lineHeight": 16,
+                                              "lineHeight": 19.2,
                                             },
                                           ]
                                         }
@@ -6241,7 +6241,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                                   "color": "#ffffff",
                                                   "fontFamily": "Montserrat-SemiBold",
                                                   "fontSize": 12,
-                                                  "lineHeight": 16,
+                                                  "lineHeight": 19.2,
                                                 },
                                               ]
                                             }
@@ -6599,7 +6599,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                           "color": "#161617",
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
-                                          "lineHeight": 16,
+                                          "lineHeight": 19.2,
                                         },
                                       ]
                                     }
@@ -6613,7 +6613,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                           "color": "#696A6F",
                                           "fontFamily": "Montserrat-SemiBold",
                                           "fontSize": 12,
-                                          "lineHeight": 16,
+                                          "lineHeight": 19.2,
                                         },
                                       ]
                                     }
@@ -6724,7 +6724,7 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                                               "color": "#ffffff",
                                               "fontFamily": "Montserrat-SemiBold",
                                               "fontSize": 12,
-                                              "lineHeight": 16,
+                                              "lineHeight": 19.2,
                                             },
                                           ]
                                         }

--- a/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
@@ -2591,7 +2591,7 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
                         "color": "#161617",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx.native-snap
@@ -956,7 +956,7 @@ exports[`<DatesHoursModal/> should render modal correctly after animation and wi
                         "color": "#161617",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
@@ -712,7 +712,7 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
                         "color": "#161617",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
@@ -1214,7 +1214,7 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                         "color": "#161617",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
@@ -732,7 +732,7 @@ exports[`VenueModal should render correctly 1`] = `
                         "color": "#161617",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/share/pages/ShareAppModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModal.native.test.tsx.native-snap
@@ -491,7 +491,7 @@ exports[`ShareAppModal should match snapshot 1`] = `
                           "color": "#161617",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
+++ b/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
@@ -444,7 +444,7 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                                 class="css-view-175oi2r r-height-3da1kt"
                               />
                               <div
-                                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                                 dir="ltr"
                               >
                                 Facebook
@@ -474,7 +474,7 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                                 class="css-view-175oi2r r-height-3da1kt"
                               />
                               <div
-                                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                                 dir="ltr"
                               >
                                 X
@@ -504,7 +504,7 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                                 class="css-view-175oi2r r-height-3da1kt"
                               />
                               <div
-                                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                                 dir="ltr"
                               >
                                 WhatsApp
@@ -534,7 +534,7 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                                 class="css-view-175oi2r r-height-3da1kt"
                               />
                               <div
-                                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1enofrn r-lineHeight-1cwl3u0"
+                                class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-aeuvnr r-fontSize-1r11ck1 r-lineHeight-66i6z8"
                                 dir="ltr"
                               >
                                 Telegram

--- a/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
@@ -807,7 +807,7 @@ exports[`<NotificationsSettingsModal /> should render correctly 1`] = `
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                     },
                   ]
                 }

--- a/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
@@ -401,7 +401,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for activites_crea
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                       "textAlign": "center",
                     },
                   ]
@@ -1063,7 +1063,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for cinema 1`] = `
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                       "textAlign": "center",
                     },
                   ]
@@ -1725,7 +1725,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for lecture 1`] = 
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                       "textAlign": "center",
                     },
                   ]
@@ -2387,7 +2387,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for musique 1`] = 
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                       "textAlign": "center",
                     },
                   ]
@@ -3049,7 +3049,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for spectacles 1`]
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                       "textAlign": "center",
                     },
                   ]
@@ -3711,7 +3711,7 @@ exports[`<SubscriptionSuccessModal /> should render correctly for visites 1`] = 
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                       "textAlign": "center",
                     },
                   ]

--- a/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
@@ -183,7 +183,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
                 "color": "#161617",
                 "fontFamily": "Montserrat-Regular",
                 "fontSize": 12,
-                "lineHeight": 16,
+                "lineHeight": 19.2,
               },
             ]
           }
@@ -195,7 +195,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
                   "color": "#161617",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                 },
               ]
             }
@@ -213,7 +213,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
                   "color": "#161617",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                 },
               ]
             }
@@ -231,7 +231,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
                   "color": "#161617",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                 },
               ]
             }
@@ -806,7 +806,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
                 "color": "#161617",
                 "fontFamily": "Montserrat-Regular",
                 "fontSize": 12,
-                "lineHeight": 16,
+                "lineHeight": 19.2,
               },
             ]
           }
@@ -818,7 +818,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
                   "color": "#161617",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                 },
               ]
             }
@@ -836,7 +836,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
                   "color": "#161617",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                 },
               ]
             }
@@ -854,7 +854,7 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
                   "color": "#161617",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                 },
               ]
             }
@@ -1329,7 +1329,7 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
                 "color": "#161617",
                 "fontFamily": "Montserrat-Regular",
                 "fontSize": 12,
-                "lineHeight": 16,
+                "lineHeight": 19.2,
               },
             ]
           }
@@ -1341,7 +1341,7 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
                   "color": "#161617",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                 },
               ]
             }
@@ -1359,7 +1359,7 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
                   "color": "#161617",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                 },
               ]
             }
@@ -1377,7 +1377,7 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
                   "color": "#161617",
                   "fontFamily": "Montserrat-SemiBold",
                   "fontSize": 12,
-                  "lineHeight": 16,
+                  "lineHeight": 19.2,
                 },
               ]
             }

--- a/__snapshots__/features/tutorial/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
@@ -442,7 +442,7 @@ exports[`OnboardingAgeInformation should render correctly for 15-year-old 1`] = 
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -626,7 +626,7 @@ exports[`OnboardingAgeInformation should render correctly for 15-year-old 1`] = 
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -695,7 +695,7 @@ exports[`OnboardingAgeInformation should render correctly for 15-year-old 1`] = 
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -879,7 +879,7 @@ exports[`OnboardingAgeInformation should render correctly for 15-year-old 1`] = 
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -948,7 +948,7 @@ exports[`OnboardingAgeInformation should render correctly for 15-year-old 1`] = 
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -1269,7 +1269,7 @@ exports[`OnboardingAgeInformation should render correctly for 15-year-old 1`] = 
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -1363,7 +1363,7 @@ exports[`OnboardingAgeInformation should render correctly for 15-year-old 1`] = 
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -2008,7 +2008,7 @@ exports[`OnboardingAgeInformation should render correctly for 16-year-old 1`] = 
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -2077,7 +2077,7 @@ exports[`OnboardingAgeInformation should render correctly for 16-year-old 1`] = 
                             "color": "#696A6F",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -2329,7 +2329,7 @@ exports[`OnboardingAgeInformation should render correctly for 16-year-old 1`] = 
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -2513,7 +2513,7 @@ exports[`OnboardingAgeInformation should render correctly for 16-year-old 1`] = 
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -2582,7 +2582,7 @@ exports[`OnboardingAgeInformation should render correctly for 16-year-old 1`] = 
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -2903,7 +2903,7 @@ exports[`OnboardingAgeInformation should render correctly for 16-year-old 1`] = 
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -2997,7 +2997,7 @@ exports[`OnboardingAgeInformation should render correctly for 16-year-old 1`] = 
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -3642,7 +3642,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -3711,7 +3711,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                             "color": "#696A6F",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -3882,7 +3882,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -3951,7 +3951,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                             "color": "#696A6F",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -4203,7 +4203,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -4524,7 +4524,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -4618,7 +4618,7 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -5263,7 +5263,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -5332,7 +5332,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                             "color": "#696A6F",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -5503,7 +5503,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -5572,7 +5572,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                             "color": "#696A6F",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -5743,7 +5743,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -5812,7 +5812,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                             "color": "#696A6F",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }
@@ -6080,7 +6080,7 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-SemiBold",
                             "fontSize": 12,
-                            "lineHeight": 16,
+                            "lineHeight": 19.2,
                           },
                         ]
                       }

--- a/__snapshots__/features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation.native.test.tsx.native-snap
@@ -469,7 +469,7 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                               "flexShrink": 1,
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 12,
-                              "lineHeight": 16,
+                              "lineHeight": 19.2,
                             },
                           ]
                         }
@@ -537,7 +537,7 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                               "flexShrink": 1,
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 12,
-                              "lineHeight": 16,
+                              "lineHeight": 19.2,
                             },
                           ]
                         }
@@ -585,7 +585,7 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -769,7 +769,7 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }
@@ -974,7 +974,7 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -1158,7 +1158,7 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }
@@ -1363,7 +1363,7 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -1547,7 +1547,7 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
                     "justifyContent": "center",
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                     "marginLeft": 6,
                   },
                 ]
@@ -1739,7 +1739,7 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }
@@ -1938,7 +1938,7 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                         "flexShrink": 1,
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }
@@ -2018,7 +2018,7 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                               "flexShrink": 1,
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 12,
-                              "lineHeight": 16,
+                              "lineHeight": 19.2,
                             },
                           ]
                         }
@@ -2086,7 +2086,7 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                               "flexShrink": 1,
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 12,
-                              "lineHeight": 16,
+                              "lineHeight": 19.2,
                             },
                           ]
                         }
@@ -2134,7 +2134,7 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -2309,7 +2309,7 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
                     "justifyContent": "center",
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                     "marginLeft": 6,
                   },
                 ]
@@ -3363,7 +3363,7 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                               "flexShrink": 1,
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 12,
-                              "lineHeight": 16,
+                              "lineHeight": 19.2,
                             },
                           ]
                         }
@@ -3431,7 +3431,7 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                               "flexShrink": 1,
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 12,
-                              "lineHeight": 16,
+                              "lineHeight": 19.2,
                             },
                           ]
                         }
@@ -3479,7 +3479,7 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -3663,7 +3663,7 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }
@@ -3868,7 +3868,7 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -4052,7 +4052,7 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }
@@ -4257,7 +4257,7 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -4441,7 +4441,7 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
                     "justifyContent": "center",
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                     "marginLeft": 6,
                   },
                 ]
@@ -4633,7 +4633,7 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }
@@ -4832,7 +4832,7 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                         "flexShrink": 1,
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                       },
                     ]
                   }
@@ -4912,7 +4912,7 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                               "flexShrink": 1,
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 12,
-                              "lineHeight": 16,
+                              "lineHeight": 19.2,
                             },
                           ]
                         }
@@ -4980,7 +4980,7 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                               "flexShrink": 1,
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 12,
-                              "lineHeight": 16,
+                              "lineHeight": 19.2,
                             },
                           ]
                         }
@@ -5028,7 +5028,7 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 16,
+                          "lineHeight": 19.2,
                         },
                       ]
                     }
@@ -5203,7 +5203,7 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                     "fontFamily": "Montserrat-SemiBold",
                     "fontSize": 12,
                     "justifyContent": "center",
-                    "lineHeight": 16,
+                    "lineHeight": 19.2,
                     "marginLeft": 6,
                   },
                 ]

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -1539,7 +1539,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                 "color": "#161617",
                                                 "fontFamily": "Montserrat-SemiBold",
                                                 "fontSize": 12,
-                                                "lineHeight": 16,
+                                                "lineHeight": 19.2,
                                               },
                                             ]
                                           }
@@ -1554,7 +1554,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                 "color": "#696A6F",
                                                 "fontFamily": "Montserrat-SemiBold",
                                                 "fontSize": 12,
-                                                "lineHeight": 16,
+                                                "lineHeight": 19.2,
                                               },
                                             ]
                                           }
@@ -1568,7 +1568,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                 "color": "#696A6F",
                                                 "fontFamily": "Montserrat-SemiBold",
                                                 "fontSize": 12,
-                                                "lineHeight": 16,
+                                                "lineHeight": 19.2,
                                               },
                                             ]
                                           }
@@ -1657,7 +1657,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                     "color": "#ffffff",
                                                     "fontFamily": "Montserrat-SemiBold",
                                                     "fontSize": 12,
-                                                    "lineHeight": 16,
+                                                    "lineHeight": 19.2,
                                                   },
                                                 ]
                                               }
@@ -1823,7 +1823,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                 "color": "#161617",
                                                 "fontFamily": "Montserrat-SemiBold",
                                                 "fontSize": 12,
-                                                "lineHeight": 16,
+                                                "lineHeight": 19.2,
                                               },
                                             ]
                                           }
@@ -1838,7 +1838,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                 "color": "#696A6F",
                                                 "fontFamily": "Montserrat-SemiBold",
                                                 "fontSize": 12,
-                                                "lineHeight": 16,
+                                                "lineHeight": 19.2,
                                               },
                                             ]
                                           }
@@ -1852,7 +1852,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                 "color": "#696A6F",
                                                 "fontFamily": "Montserrat-SemiBold",
                                                 "fontSize": 12,
-                                                "lineHeight": 16,
+                                                "lineHeight": 19.2,
                                               },
                                             ]
                                           }
@@ -1941,7 +1941,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                     "color": "#ffffff",
                                                     "fontFamily": "Montserrat-SemiBold",
                                                     "fontSize": 12,
-                                                    "lineHeight": 16,
+                                                    "lineHeight": 19.2,
                                                   },
                                                 ]
                                               }
@@ -2043,7 +2043,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                 "color": "#161617",
                                                 "fontFamily": "Montserrat-SemiBold",
                                                 "fontSize": 12,
-                                                "lineHeight": 16,
+                                                "lineHeight": 19.2,
                                               },
                                             ]
                                           }
@@ -2058,7 +2058,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                 "color": "#696A6F",
                                                 "fontFamily": "Montserrat-SemiBold",
                                                 "fontSize": 12,
-                                                "lineHeight": 16,
+                                                "lineHeight": 19.2,
                                               },
                                             ]
                                           }
@@ -2072,7 +2072,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                 "color": "#696A6F",
                                                 "fontFamily": "Montserrat-SemiBold",
                                                 "fontSize": 12,
-                                                "lineHeight": 16,
+                                                "lineHeight": 19.2,
                                               },
                                             ]
                                           }
@@ -2161,7 +2161,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                     "color": "#ffffff",
                                                     "fontFamily": "Montserrat-SemiBold",
                                                     "fontSize": 12,
-                                                    "lineHeight": 16,
+                                                    "lineHeight": 19.2,
                                                   },
                                                 ]
                                               }
@@ -2343,7 +2343,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                             "color": "#161617",
                                             "fontFamily": "Montserrat-SemiBold",
                                             "fontSize": 12,
-                                            "lineHeight": 16,
+                                            "lineHeight": 19.2,
                                           },
                                         ]
                                       }
@@ -2358,7 +2358,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                             "color": "#696A6F",
                                             "fontFamily": "Montserrat-SemiBold",
                                             "fontSize": 12,
-                                            "lineHeight": 16,
+                                            "lineHeight": 19.2,
                                           },
                                         ]
                                       }
@@ -2372,7 +2372,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                             "color": "#696A6F",
                                             "fontFamily": "Montserrat-SemiBold",
                                             "fontSize": 12,
-                                            "lineHeight": 16,
+                                            "lineHeight": 19.2,
                                           },
                                         ]
                                       }
@@ -2461,7 +2461,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                 "color": "#ffffff",
                                                 "fontFamily": "Montserrat-SemiBold",
                                                 "fontSize": 12,
-                                                "lineHeight": 16,
+                                                "lineHeight": 19.2,
                                               },
                                             ]
                                           }
@@ -3056,7 +3056,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                   "color": "#161617",
                                                   "fontFamily": "Montserrat-SemiBold",
                                                   "fontSize": 12,
-                                                  "lineHeight": 16,
+                                                  "lineHeight": 19.2,
                                                 },
                                               ]
                                             }
@@ -3070,7 +3070,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                   "color": "#696A6F",
                                                   "fontFamily": "Montserrat-SemiBold",
                                                   "fontSize": 12,
-                                                  "lineHeight": 16,
+                                                  "lineHeight": 19.2,
                                                 },
                                               ]
                                             }
@@ -3181,7 +3181,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                       "color": "#ffffff",
                                                       "fontFamily": "Montserrat-SemiBold",
                                                       "fontSize": 12,
-                                                      "lineHeight": 16,
+                                                      "lineHeight": 19.2,
                                                     },
                                                   ]
                                                 }
@@ -3299,7 +3299,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                               "color": "#161617",
                                               "fontFamily": "Montserrat-SemiBold",
                                               "fontSize": 12,
-                                              "lineHeight": 16,
+                                              "lineHeight": 19.2,
                                             },
                                           ]
                                         }
@@ -3313,7 +3313,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                               "color": "#696A6F",
                                               "fontFamily": "Montserrat-SemiBold",
                                               "fontSize": 12,
-                                              "lineHeight": 16,
+                                              "lineHeight": 19.2,
                                             },
                                           ]
                                         }
@@ -3424,7 +3424,7 @@ exports[`<Venue /> should match snapshot 1`] = `
                                                   "color": "#ffffff",
                                                   "fontFamily": "Montserrat-SemiBold",
                                                   "fontSize": 12,
-                                                  "lineHeight": 16,
+                                                  "lineHeight": 19.2,
                                                 },
                                               ]
                                             }

--- a/__snapshots__/features/venueMap/pages/modals/VenueTypeModal/VenueTypeModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/venueMap/pages/modals/VenueTypeModal/VenueTypeModal.native.test.tsx.native-snap
@@ -3705,7 +3705,7 @@ exports[`<VenueTypeModal /> When venue type is null should render modal correctl
                         "color": "#161617",
                         "fontFamily": "Montserrat-SemiBold",
                         "fontSize": 12,
-                        "lineHeight": 16,
+                        "lineHeight": 19.2,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
@@ -958,7 +958,7 @@ pour réserver cette offre
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-SemiBold",
                       "fontSize": 12,
-                      "lineHeight": 16,
+                      "lineHeight": 19.2,
                     },
                   ]
                 }

--- a/eslint-custom-rules/no-raw-text.test.js
+++ b/eslint-custom-rules/no-raw-text.test.js
@@ -19,9 +19,7 @@ const tests = {
     { code: '<Typo.ButtonTextPrimary>toto</Typo.ButtonTextPrimary>' },
     { code: '<Typo.ButtonTextSecondary>toto</Typo.ButtonTextSecondary>' },
     { code: '<TypoDS.Body>toto</TypoDS.Body>' },
-    { code: '<Typo.Caption>toto</Typo.Caption>' },
-    { code: '<Typo.CaptionPrimary>toto</Typo.CaptionPrimary>' },
-    { code: '<Typo.CaptionSecondary>toto</Typo.CaptionSecondary>' },
+    { code: '<TypoDS.BodyAccentXs>toto</TypoDS.BodyAccentXs>' },
     // <Styled***>string</Styled***>
     { code: '<StyledTitle1>toto</StyledTitle1>' },
     { code: '<StyledTitle2>toto</StyledTitle2>' },

--- a/src/cheatcodes/pages/others/CheatcodesNavigationErrors.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesNavigationErrors.tsx
@@ -14,7 +14,7 @@ import { useLogTypeFromRemoteConfig } from 'libs/hooks/useLogTypeFromRemoteConfi
 import { AsyncError, ScreenError } from 'libs/monitoring'
 import { LogTypeEnum } from 'libs/monitoring/errors'
 import { QueryKeys } from 'libs/queryKeys'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export const cheatcodesNavigationErrorsButtons: [CheatcodesButtonsWithSubscreensProps] = [
   {
@@ -112,7 +112,7 @@ export const CheatcodesNavigationErrors: FunctionComponent = () => {
   )
 }
 
-const CenteredText = styled(Typo.Caption)({
+const CenteredText = styled(TypoDS.BodyAccentXs)({
   width: '100%',
   textAlign: 'center',
 })

--- a/src/features/auth/pages/signup/AcceptCgu/AcceptCgu.tsx
+++ b/src/features/auth/pages/signup/AcceptCgu/AcceptCgu.tsx
@@ -2,6 +2,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import React, { FunctionComponent, useCallback, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { Text } from 'react-native'
+import styled from 'styled-components/native'
 import { v4 as uuidv4 } from 'uuid'
 
 import { useSettingsContext } from 'features/auth/context/SettingsContext'
@@ -20,7 +21,7 @@ import { InputError } from 'ui/components/inputs/InputError'
 import { Separator } from 'ui/components/Separator'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type FormValues = {
@@ -149,10 +150,10 @@ export const AcceptCgu: FunctionComponent<PreValidationSignupLastStepProps> = ({
         required
       />
       <Spacer.Column numberOfSpaces={6} />
-      <Typo.CaptionNeutralInfo>
+      <CaptionNeutralInfo>
         <Text accessibilityHidden>*obligatoires pour créer ton compte. </Text>
         En cochant ces 2 cases tu assures avoir lu&nbsp;:
-      </Typo.CaptionNeutralInfo>
+      </CaptionNeutralInfo>
       <Spacer.Column numberOfSpaces={2} />
       <ExternalTouchableLink
         as={ButtonQuaternaryBlack}
@@ -188,7 +189,7 @@ export const AcceptCgu: FunctionComponent<PreValidationSignupLastStepProps> = ({
         relatedInputId={checkCGUErrorId}
       />
       <Spacer.Column numberOfSpaces={4} />
-      <Typo.CaptionNeutralInfo>
+      <CaptionNeutralInfo>
         Lors de ton utilisation des services de la société pass Culture, nous sommes amenés à
         collecter et utiliser tes données personnelles pour assurer le bon fonctionnement de
         l’application et des services que nous proposons. Pour en savoir plus sur la gestion de tes
@@ -196,8 +197,12 @@ export const AcceptCgu: FunctionComponent<PreValidationSignupLastStepProps> = ({
         suppression), tu peux te reporter à la charte des données personnelles. Tu peux également
         gérer certaines préférences concernant tes données depuis les paramètres de ton compte,
         comme par exemple le fait de ne plus souhaiter recevoir notre newsletter.
-      </Typo.CaptionNeutralInfo>
+      </CaptionNeutralInfo>
       <Spacer.Column numberOfSpaces={5} />
     </Form.MaxWidth>
   )
 }
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/auth/pages/signup/SignupConfirmationEmailSent/EmailAttemptsLeft.tsx
+++ b/src/features/auth/pages/signup/SignupConfirmationEmailSent/EmailAttemptsLeft.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 interface Props {
   attemptsLeft?: number
@@ -21,15 +21,16 @@ export const EmailAttemptsLeft: FunctionComponent<Props> = ({ attemptsLeft }) =>
   }
   return (
     <StyledCaption>
-      Attention, il te reste&nbsp;: <Typo.Caption>{`${attemptsLeft} demandes`}</Typo.Caption>
+      Attention, il te reste&nbsp;:{' '}
+      <TypoDS.BodyAccentXs>{`${attemptsLeft} demandes`}</TypoDS.BodyAccentXs>
     </StyledCaption>
   )
 }
 
-const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+const StyledCaption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 
-const StyledErrorText = styled(Typo.Caption)(({ theme }) => ({
+const StyledErrorText = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.error,
 }))

--- a/src/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.tsx
+++ b/src/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.tsx
@@ -16,7 +16,7 @@ import { AlertBanner } from 'ui/components/banners/AlertBanner'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { Close } from 'ui/svg/icons/Close'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   email: string
@@ -131,7 +131,7 @@ const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })
 
-const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+const StyledCaption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.error,
   textAlign: 'center',
 }))

--- a/src/features/bookOffer/components/BookingDetails.tsx
+++ b/src/features/bookOffer/components/BookingDetails.tsx
@@ -35,7 +35,7 @@ import { Loader } from 'ui/components/Loader'
 import { useModal } from 'ui/components/modals/useModal'
 import { Error } from 'ui/svg/icons/Error'
 import { LocationBuilding } from 'ui/svg/icons/LocationBuilding'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export interface BookingDetailsProps {
@@ -328,7 +328,7 @@ const VenueTitleText = styled(TypoDS.Title4).attrs(getHeadingAttrs(2))({
   flexShrink: 1,
 })
 
-const VenueAddress = styled(Typo.Hint)(({ theme }) => ({
+const VenueAddress = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 

--- a/src/features/bookOffer/components/BookingDetails.tsx
+++ b/src/features/bookOffer/components/BookingDetails.tsx
@@ -227,7 +227,7 @@ export function BookingDetails({ stocks, onPressBookOffer, isLoading }: BookingD
         Icon={LocationBuilding}
         message={
           <VenueContainer>
-            <Typo.Caption testID="venueName">{venueName}</Typo.Caption>
+            <TypoDS.BodyAccentXs testID="venueName">{venueName}</TypoDS.BodyAccentXs>
             <Spacer.Column numberOfSpaces={1} />
             <VenueAddress testID="venueAddress">{venueFullAddress}</VenueAddress>
           </VenueContainer>
@@ -313,10 +313,11 @@ const Separator = styled.View(({ theme }) => ({
   backgroundColor: theme.colors.greyLight,
 }))
 
-const Caption = styled(Typo.CaptionNeutralInfo)({
+const Caption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   marginTop: getSpacing(1),
   textAlign: 'center',
-})
+  color: theme.colors.greyDark,
+}))
 
 const VenueTitleContainer = styled.View({
   flexDirection: 'row',

--- a/src/features/bookOffer/components/Calendar/Calendar.tsx
+++ b/src/features/bookOffer/components/Calendar/Calendar.tsx
@@ -26,7 +26,7 @@ import { CAPITALIZED_MONTHS, CAPITALIZED_SHORT_MONTHS } from 'shared/date/months
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { ArrowNext as DefaultArrowNext } from 'ui/svg/icons/ArrowNext'
 import { ArrowPrevious as DefaultArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 LocaleConfig.locales['fr'] = {
   monthNames: [...CAPITALIZED_MONTHS],
@@ -175,7 +175,7 @@ export const Calendar: React.FC<Props> = ({
 // Only works for iOS but still useful
 const hitSlop = { top: 8, bottom: 8, left: 8, right: 8 }
 
-const Caption = styled(Typo.Caption)<{ status: OfferStatus }>(({ status, theme }) => ({
+const Caption = styled(TypoDS.BodyAccentXs)<{ status: OfferStatus }>(({ status, theme }) => ({
   color: status === OfferStatus.BOOKABLE ? theme.colors.primary : theme.colors.greyDark,
   textAlign: 'center',
 }))

--- a/src/features/bookOffer/components/CancellationDetails.tsx
+++ b/src/features/bookOffer/components/CancellationDetails.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { useBookingOffer } from 'features/bookOffer/helpers/useBookingOffer'
 import { useBookingStock } from 'features/bookOffer/helpers/useBookingStock'
 import { formatDateTimezone } from 'libs/parsers/formatDates'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 const NOT_CANCELLABLE_MESSAGE =
@@ -33,7 +33,7 @@ export const CancellationDetails: React.FC = () => {
     <React.Fragment>
       <TypoDS.Title4 {...getHeadingAttrs(2)}>Conditions d’annulation</TypoDS.Title4>
       <Spacer.Column numberOfSpaces={2} />
-      <Typo.Caption>{message}</Typo.Caption>
+      <TypoDS.BodyAccentXs>{message}</TypoDS.BodyAccentXs>
     </React.Fragment>
   )
 }

--- a/src/features/bookOffer/components/DuoChoice.tsx
+++ b/src/features/bookOffer/components/DuoChoice.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { ChoiceBloc, getTextColor } from 'features/bookOffer/components/ChoiceBloc'
 import { AccessibleIcon } from 'ui/svg/icons/types'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, Typo, TypoDS } from 'ui/theme'
 
 interface Props {
   title: string
@@ -69,7 +69,7 @@ const ButtonText = styled(Typo.ButtonText)<TypoProps>(({ selected, disabled, the
   color: getTextColor(theme, selected, disabled),
 }))
 
-const Caption = styled(Typo.Caption)<TypoProps>(({ selected, disabled, theme }) => ({
+const Caption = styled(TypoDS.BodyAccentXs)<TypoProps>(({ selected, disabled, theme }) => ({
   color: getTextColor(theme, selected, disabled),
   textAlign: 'center',
 }))

--- a/src/features/bookOffer/components/PriceLine.tsx
+++ b/src/features/bookOffer/components/PriceLine.tsx
@@ -4,7 +4,7 @@ import { OfferStockResponse } from 'api/gen'
 import { useGetPacificFrancToEuroRate } from 'libs/firebase/firestore/exchangeRates/useGetPacificFrancToEuroRate'
 import { formatCurrencyFromCents } from 'shared/currency/formatCurrencyFromCents'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
-import { Typo, TypoDS } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 interface PriceLineProps {
   quantity?: number
@@ -26,8 +26,8 @@ export function PriceLine({
   const totalPrice = formatCurrencyFromCents(quantity * unitPrice, currency, euroToPacificFrancRate)
   const price = formatCurrencyFromCents(unitPrice, currency, euroToPacificFrancRate)
 
-  const MainText = shouldDisabledStyles ? TypoDS.Body : Typo.Caption
-  const SecondaryText = shouldDisabledStyles ? TypoDS.Body : Typo.CaptionNeutralInfo
+  const MainText = shouldDisabledStyles ? TypoDS.Body : TypoDS.BodyAccentXs
+  const SecondaryText = shouldDisabledStyles ? TypoDS.Body : TypoDS.BodyAccentXs
 
   const shouldDisplayAttributes = attributes?.length
 

--- a/src/features/bookings/components/BicolorBookingsCountV2.tsx
+++ b/src/features/bookings/components/BicolorBookingsCountV2.tsx
@@ -6,7 +6,7 @@ import { useScaleAnimation } from 'features/favorites/helpers/useScaleFavoritesA
 import { createLabels } from 'shared/handleTooManyCount/countUtils'
 import { BicolorBookingsV2 } from 'ui/svg/icons/BicolorBookingsV2'
 import { AccessibleBicolorIcon } from 'ui/svg/icons/types'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 export const BicolorBookingsCountV2: React.FC<AccessibleBicolorIcon> = ({
   size,
@@ -50,6 +50,6 @@ const PastilleContainer = styled.View(({ theme }) => ({
   paddingHorizontal: getSpacing(1),
 }))
 
-const Counter = styled(Typo.Hint)(({ theme }) => ({
+const Counter = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.white,
 }))

--- a/src/features/bookings/components/BookingDetailsCancelButton.tsx
+++ b/src/features/bookings/components/BookingDetailsCancelButton.tsx
@@ -13,7 +13,7 @@ import { isUserExBeneficiary } from 'features/profile/helpers/isUserExBeneficiar
 import { formatToCompleteFrenchDate } from 'libs/parsers/formatDates'
 import { useSubcategory } from 'libs/subcategories'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
-import { Typo, getSpacing } from 'ui/theme'
+import { TypoDS, getSpacing } from 'ui/theme'
 import { LINE_BREAK } from 'ui/theme/constants'
 
 export interface BookingDetailsCancelButtonProps {
@@ -92,7 +92,8 @@ export const BookingDetailsCancelButton = (props: BookingDetailsCancelButtonProp
   )
 }
 
-const StyledCaption = styled(Typo.CaptionNeutralInfo)({
+const StyledCaption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   textAlign: 'center',
   marginBottom: getSpacing(6),
-})
+  color: theme.colors.greyDark,
+}))

--- a/src/features/bookings/components/BookingExpiration.tsx
+++ b/src/features/bookings/components/BookingExpiration.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react'
 import styled from 'styled-components/native'
 
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 interface BookingExpirationProps {
   children: ReactNode
@@ -22,6 +22,7 @@ export const BookingExpiration = ({ children, expirationDate }: BookingExpiratio
   )
 }
 
-const StyledCaption = styled(Typo.CaptionNeutralInfo)({
+const StyledCaption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   textAlign: 'center',
-})
+  color: theme.colors.greyDark,
+}))

--- a/src/features/bookings/components/BookingItemWithIcon.tsx
+++ b/src/features/bookings/components/BookingItemWithIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { AccessibleIcon } from 'ui/svg/icons/types'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const Item: React.FC<{
   Icon: React.FC<AccessibleIcon>
@@ -20,9 +20,9 @@ export const Item: React.FC<{
         <StyledIcon />
       </IconWrapper>
       <Spacer.Row numberOfSpaces={3} />
-      {typeof message === 'string' ? <Typo.Caption>{message}</Typo.Caption> : message}
+      {typeof message === 'string' ? <TypoDS.BodyAccentXs>{message}</TypoDS.BodyAccentXs> : message}
       <Spacer.Row numberOfSpaces={2} />
-      <Typo.CaptionNeutralInfo>{subtext}</Typo.CaptionNeutralInfo>
+      <CaptionNeutralInfo>{subtext}</CaptionNeutralInfo>
     </Row>
   )
 }
@@ -37,3 +37,7 @@ const Row = styled.View(({ theme }) => ({
 const IconWrapper = styled.View({
   flexShrink: 0,
 })
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/bookings/components/EndedBookingItem.tsx
+++ b/src/features/bookings/components/EndedBookingItem.tsx
@@ -20,7 +20,7 @@ import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/S
 import { OfferImage } from 'ui/components/tiles/OfferImage'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 type Props = {
   booking: Booking
@@ -111,7 +111,7 @@ export const EndedBookingItem = ({
                 booking={booking}
                 isEligibleBookingsForArchiveValue={isEligibleBookingsForArchiveValue}
               />
-              <Typo.CaptionNeutralInfo>{endedBookingDateLabel}</Typo.CaptionNeutralInfo>
+              <CaptionNeutralInfo>{endedBookingDateLabel}</CaptionNeutralInfo>
             </EndedReasonAndDate>
           </AttributesView>
         </ContentContainerGap>
@@ -151,3 +151,7 @@ const EndedReasonAndDate = styled(ViewGap)({
   alignItems: 'center',
   flexWrap: 'wrap',
 })
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/bookings/components/OnGoingBookingItem.tsx
+++ b/src/features/bookings/components/OnGoingBookingItem.tsx
@@ -22,7 +22,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { BicolorClock as DefaultClock } from 'ui/svg/icons/BicolorClock'
 import { Duo } from 'ui/svg/icons/Duo'
 import { OfferEvent as DefaultOfferEvent } from 'ui/svg/icons/OfferEvent'
-import { Spacer, Typo, TypoDS, getSpacing } from 'ui/theme'
+import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 
 type Props = {
   booking: Booking
@@ -149,7 +149,7 @@ const DateLabel = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 
-const WithdrawCaption = styled(Typo.Caption)({
+const WithdrawCaption = styled(TypoDS.BodyAccentXs)({
   marginTop: getSpacing(1),
   marginRight: getSpacing(4),
 })
@@ -176,7 +176,7 @@ const ExpirationBookingContainer = styled.View(({ theme }) => ({
   color: theme.colors.primary,
 }))
 
-const ExpirationBookingLabel = styled(Typo.CaptionPrimary)({
+const ExpirationBookingLabel = styled(TypoDS.BodyAccentXs)({
   marginTop: getSpacing(1),
   marginRight: getSpacing(4),
 })

--- a/src/features/bookings/components/OnGoingBookingsList.tsx
+++ b/src/features/bookings/components/OnGoingBookingsList.tsx
@@ -20,7 +20,7 @@ import {
 } from 'ui/components/placeholders/Placeholders'
 import { Separator } from 'ui/components/Separator'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { TAB_BAR_COMP_HEIGHT_V2 } from 'ui/theme/constants'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
@@ -154,7 +154,7 @@ const Container = styled.View<{ flex?: number }>(({ flex }) => ({
   height: '100%',
 }))
 
-const BookingsCount = styled(Typo.Caption).attrs(() => getHeadingAttrs(2))(({ theme }) => ({
+const BookingsCount = styled(TypoDS.BodyAccentXs).attrs(() => getHeadingAttrs(2))(({ theme }) => ({
   paddingHorizontal: getSpacing(6),
   paddingBottom: getSpacing(4),
   color: theme.colors.greyDark,

--- a/src/features/bookings/components/TicketBody/BookingComplementaryInfo/BookingComplementaryInfo.tsx
+++ b/src/features/bookings/components/TicketBody/BookingComplementaryInfo/BookingComplementaryInfo.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
-import { Typo, getSpacing } from 'ui/theme'
+import { TypoDS, getSpacing } from 'ui/theme'
 
 type Props = {
   title: string
@@ -10,8 +10,8 @@ type Props = {
 
 export const BookingComplementaryInfo: FunctionComponent<Props> = ({ title, value }) => (
   <Container testID="bookingComplementaryInfo">
-    <Typo.Caption>{title}&nbsp;</Typo.Caption>
-    <Typo.CaptionNeutralInfo>{value}</Typo.CaptionNeutralInfo>
+    <TypoDS.BodyAccentXs>{title}&nbsp;</TypoDS.BodyAccentXs>
+    <CaptionNeutralInfo>{value}</CaptionNeutralInfo>
   </Container>
 )
 
@@ -21,3 +21,7 @@ const Container = styled.View({
   alignItems: 'center',
   justifyContent: 'center',
 })
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/bookings/components/TicketBody/SeatWithQrCode/SeatWithQrCode.tsx
+++ b/src/features/bookings/components/TicketBody/SeatWithQrCode/SeatWithQrCode.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
 import { QrCode } from 'features/bookings/components/TicketBody/QrCode/QrCode'
-import { getSpacing, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 export type SeatWithQrCodeProps = {
   seatIndex?: string
@@ -21,7 +21,7 @@ export const SeatWithQrCode: FunctionComponent<SeatWithQrCodeProps> = ({
   return (
     <React.Fragment>
       <SeatContainer>
-        {seatIndex ? <Typo.Caption>{currentSeatWithIndex}</Typo.Caption> : null}
+        {seatIndex ? <TypoDS.BodyAccentXs>{currentSeatWithIndex}</TypoDS.BodyAccentXs> : null}
         {seat ? <Seat>{currentSeat}</Seat> : null}
       </SeatContainer>
       <QrCode qrCode={barcode} />

--- a/src/features/bookings/pages/BookingDetails/BookingDetails.tsx
+++ b/src/features/bookings/pages/BookingDetails/BookingDetails.tsx
@@ -46,7 +46,7 @@ import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouch
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { EmailFilled } from 'ui/svg/icons/EmailFilled'
-import { getSpacing, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 import { Helmet } from 'ui/web/global/Helmet'
 
@@ -208,9 +208,9 @@ export function BookingDetails() {
                 <ViewGap gap={2.5}>
                   <TypoDS.Title4 {...getHeadingAttrs(2)}>Contact de l’organisateur</TypoDS.Title4>
 
-                  <Typo.CaptionNeutralInfo>
+                  <CaptionNeutralInfo>
                     Si tu n’as pas reçu tes billets, contacte l’organisateur
-                  </Typo.CaptionNeutralInfo>
+                  </CaptionNeutralInfo>
 
                   <SendEmailContainer>
                     <ExternalTouchableLink
@@ -297,9 +297,10 @@ const StyledScrollView = styled.ScrollView.attrs({
   },
 })``
 
-const OfferRules = styled(Typo.CaptionNeutralInfo)({
+const OfferRules = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
   textAlign: 'center',
-})
+}))
 
 const InfoContainer = styled(ViewGap)({
   paddingHorizontal: getSpacing(6),
@@ -317,3 +318,7 @@ const SendEmailContainer = styled.View({
 const StyledHeaderWithImage = styled(HeaderWithImage)({
   marginBottom: getSpacing(offerImageContainerMarginTop),
 })
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/cookies/components/CookiesAccordion.tsx
+++ b/src/features/cookies/components/CookiesAccordion.tsx
@@ -11,7 +11,7 @@ import { Accordion } from 'ui/components/Accordion'
 import FilterSwitch from 'ui/components/FilterSwitch'
 import { Separator } from 'ui/components/Separator'
 import { InfoPlain } from 'ui/svg/icons/InfoPlain'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const CookiesAccordion = ({
   cookie,
@@ -71,10 +71,10 @@ const InfoCaption: React.FC<PropsWithChildren> = ({ children }) => (
     <IconContainer>
       <StyledInfo />
     </IconContainer>
-    <Typo.CaptionNeutralInfo>
+    <CaptionNeutralInfo>
       <IconSpacer />
       {children}
-    </Typo.CaptionNeutralInfo>
+    </CaptionNeutralInfo>
   </View>
 )
 
@@ -102,3 +102,7 @@ const StyledAccordionItem = styled(Accordion).attrs({
     paddingHorizontal: 0,
   },
 })``
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/cookies/components/CookiesConsentExplanations.tsx
+++ b/src/features/cookies/components/CookiesConsentExplanations.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
+import styled from 'styled-components/native'
 
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export const CookiesConsentExplanations = () => (
   <React.Fragment>
@@ -15,10 +16,14 @@ export const CookiesConsentExplanations = () => (
       politique de gestion des cookies.
     </TypoDS.Body>
     <Spacer.Column numberOfSpaces={4} />
-    <Typo.CaptionNeutralInfo>
+    <CaptionNeutralInfo>
       Ton choix est conservé pendant 6 mois et tu pourras le modifier dans les paramètres de
       confidentialité de ton profil à tout moment.
-    </Typo.CaptionNeutralInfo>
+    </CaptionNeutralInfo>
     <Spacer.Column numberOfSpaces={4} />
   </React.Fragment>
 )
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/cookies/components/CookiesSettings.tsx
+++ b/src/features/cookies/components/CookiesSettings.tsx
@@ -12,7 +12,7 @@ import { CookiesChoiceSettings } from 'features/cookies/types'
 import FilterSwitch from 'ui/components/FilterSwitch'
 import { InputLabel } from 'ui/components/InputLabel/InputLabel'
 import { styledInputLabel } from 'ui/components/InputLabel/styledInputLabel'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 const checkboxID = uuidv4()
@@ -59,7 +59,7 @@ export const CookiesSettings = ({
       </TypoDS.Title4>
       <Spacer.Column numberOfSpaces={6} />
       <ChoiceContainer>
-        <StyledCaptionNeutralInfo>Je choisis mes cookies</StyledCaptionNeutralInfo>
+        <CaptionNeutralInfo>Je choisis mes cookies</CaptionNeutralInfo>
         <AcceptAllContainer>
           <StyledInputLabel id={labelID} htmlFor={checkboxID}>
             {inputLabel}
@@ -93,9 +93,10 @@ const ChoiceContainer = styled.View({
   justifyContent: 'space-between',
 })
 
-const StyledCaptionNeutralInfo = styled(Typo.CaptionNeutralInfo)`
-  flex-shrink: 1;
-`
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+  flexShrink: 1,
+}))
 
 const AcceptAllContainer = styled.View({
   flexDirection: 'row',
@@ -103,6 +104,6 @@ const AcceptAllContainer = styled.View({
 })
 
 const StyledInputLabel = styledInputLabel(InputLabel)(({ theme }) => ({
-  ...theme.typography.caption,
+  ...theme.designSystem.typography.bodyAccentXs,
   color: theme.colors.greyDark,
 }))

--- a/src/features/cookies/pages/CookiesDetails.tsx
+++ b/src/features/cookies/pages/CookiesDetails.tsx
@@ -38,7 +38,7 @@ export const CookiesDetails = (props: CookiesChoiceSettings) => {
         On te redemandera bien sûr ton consentement si notre politique évolue.
       </TypoDS.Body>
       <Spacer.Column numberOfSpaces={4} />
-      <Typo.CaptionNeutralInfo>
+      <CaptionNeutralInfo>
         {buttonText}
         <Spacer.Row numberOfSpaces={1} />
         <ExternalTouchableLink
@@ -48,7 +48,7 @@ export const CookiesDetails = (props: CookiesChoiceSettings) => {
           icon={ExternalSiteFilled}
           typography="BodyAccentXs"
         />
-      </Typo.CaptionNeutralInfo>
+      </CaptionNeutralInfo>
       <Spacer.Column numberOfSpaces={8} />
     </React.Fragment>
   )
@@ -71,3 +71,7 @@ const AccordionContainer = styled.View({
   borderRadius: ACCORDION_BORDER_RADIUS,
   overflow: 'hidden',
 })
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/culturalSurvey/components/CulturalSurveyCheckbox.tsx
+++ b/src/features/culturalSurvey/components/CulturalSurveyCheckbox.tsx
@@ -7,7 +7,7 @@ import { theme } from 'theme'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 import { Validate } from 'ui/svg/icons/Validate'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, Typo, TypoDS } from 'ui/theme'
 
 type CulturalSurveyCheckboxProps = {
   title: string
@@ -53,9 +53,7 @@ export const CulturalSurveyCheckbox = (props: CulturalSurveyCheckboxProps) => {
         ) : null}
         <DescriptionContainer>
           <Typo.ButtonText>{props.title}</Typo.ButtonText>
-          {props.subtitle ? (
-            <Typo.CaptionNeutralInfo>{props.subtitle}</Typo.CaptionNeutralInfo>
-          ) : null}
+          {props.subtitle ? <CaptionNeutralInfo>{props.subtitle}</CaptionNeutralInfo> : null}
         </DescriptionContainer>
         {isSelected ? (
           <ValidateIconContainer>
@@ -105,3 +103,7 @@ const ActivityIconContainer = styled.View({
   alignContent: 'center',
   marginLeft: getSpacing(4),
 })
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/culturalSurvey/components/CulturalSurveyProgressBar.tsx
+++ b/src/features/culturalSurvey/components/CulturalSurveyProgressBar.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { ProgressBar } from 'ui/components/bars/ProgressBar'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 type CulturalSurveyProgressBarProps = {
   progress: number
@@ -43,7 +43,7 @@ const PercentageContainer = styled.View({
   alignSelf: 'center',
 })
 
-const SurveyProgressPercentage = styled(Typo.Caption)({
+const SurveyProgressPercentage = styled(TypoDS.BodyAccentXs)({
   marginLeft: getSpacing(2),
 })
 

--- a/src/features/culturalSurvey/pages/CulturalSurveyQuestions.tsx
+++ b/src/features/culturalSurvey/pages/CulturalSurveyQuestions.tsx
@@ -35,7 +35,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { Li } from 'ui/components/Li'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { VerticalUl } from 'ui/components/Ul'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 type CulturalSurveyQuestionsProps = StackScreenProps<
   CulturalSurveyRootStackParamList,
@@ -202,7 +202,7 @@ export function CulturalSurveyQuestions({ route }: CulturalSurveyQuestionsProps)
         testID="cultural-survey-questions-scrollview">
         <TypoDS.Title3>{culturalSurveyQuestion?.title}</TypoDS.Title3>
         <CaptionContainer>
-          <Typo.CaptionNeutralInfo>{pageSubtitle}</Typo.CaptionNeutralInfo>
+          <CaptionNeutralInfo>{pageSubtitle}</CaptionNeutralInfo>
         </CaptionContainer>
         <VerticalUl>
           {culturalSurveyQuestion?.answers.map((answer) => (
@@ -286,3 +286,7 @@ const FixedBottomChildrenView = styled(View)({
   paddingTop: getSpacing(3),
   paddingHorizontal: getSpacing(6),
 })
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/favorites/components/Favorite.tsx
+++ b/src/features/favorites/components/Favorite.tsx
@@ -204,7 +204,7 @@ export const Favorite: React.FC<Props> = (props) => {
                   {displayPrice ? (
                     <React.Fragment>
                       <Spacer.Column numberOfSpaces={1} />
-                      <Typo.Caption>{displayPrice}</Typo.Caption>
+                      <TypoDS.BodyAccentXs>{displayPrice}</TypoDS.BodyAccentXs>
                     </React.Fragment>
                   ) : null}
                 </LeftContent>

--- a/src/features/favorites/components/NumberOfResults.tsx
+++ b/src/features/favorites/components/NumberOfResults.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { plural } from 'libs/plural'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export const NumberOfResults: React.FC<{ nbFavorites: number }> = ({ nbFavorites }) => {
@@ -24,6 +24,6 @@ const Container = styled.View({
   marginBottom: getSpacing(4),
 })
 
-const Caption = styled(Typo.Caption).attrs(() => getHeadingAttrs(2))(({ theme }) => ({
+const Caption = styled(TypoDS.BodyAccentXs).attrs(() => getHeadingAttrs(2))(({ theme }) => ({
   color: theme.colors.greyDark,
 }))

--- a/src/features/home/components/AttachedModuleCard/AttachedCardDisplay.tsx
+++ b/src/features/home/components/AttachedModuleCard/AttachedCardDisplay.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { OfferName } from 'ui/components/tiles/OfferName'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
 
 interface AttachedCardDisplayProps {
   title: string
@@ -37,12 +37,10 @@ export const AttachedCardDisplay: React.FC<AttachedCardDisplayProps> = ({
         </ImageContainer>
       ) : null}
       <CentralColumn>
-        {subtitle ? <Typo.Caption>{subtitle}</Typo.Caption> : null}
+        {subtitle ? <TypoDS.BodyAccentXs>{subtitle}</TypoDS.BodyAccentXs> : null}
         <OfferName title={title} />
         {details
-          ? details?.map((detail) => (
-              <Typo.CaptionNeutralInfo key={detail}>{detail}</Typo.CaptionNeutralInfo>
-            ))
+          ? details?.map((detail) => <CaptionNeutralInfo key={detail}>{detail}</CaptionNeutralInfo>)
           : null}
       </CentralColumn>
       <RightColumn>
@@ -99,4 +97,8 @@ const Container = styled.View<{ shouldFixHeight: boolean }>(({ theme, shouldFixH
   padding: OFFER_CARD_PADDING,
   flexWrap: 'wrap',
   height: shouldFixHeight ? OFFER_CARD_HEIGHT + 2 * OFFER_CARD_PADDING : 'auto',
+}))
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
 }))

--- a/src/features/home/components/AttachedModuleCard/AttachedCardDisplay.tsx
+++ b/src/features/home/components/AttachedModuleCard/AttachedCardDisplay.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { OfferName } from 'ui/components/tiles/OfferName'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 interface AttachedCardDisplayProps {
   title: string
@@ -46,7 +46,7 @@ export const AttachedCardDisplay: React.FC<AttachedCardDisplayProps> = ({
       <RightColumn>
         {rightTagLabel ? (
           <TagWrapper label={rightTagLabel}>
-            <Typo.Hint>{rightTagLabel}</Typo.Hint>
+            <TypoDS.BodyAccentXs>{rightTagLabel}</TypoDS.BodyAccentXs>
           </TagWrapper>
         ) : null}
         <Spacer.Flex />

--- a/src/features/home/components/BlackCaption.tsx
+++ b/src/features/home/components/BlackCaption.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { StyleProp, View, ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
 
-import { Typo, getSpacing } from 'ui/theme'
+import { TypoDS, getSpacing } from 'ui/theme'
 
 // no need to provide inline style property if BlackCaption is used as a styled component
 // const StyledBlackCaption = styled(BlackCaption)({ // add style here })
@@ -23,6 +23,6 @@ const BlackCaptionContainer = styled(View)(({ theme }) => ({
   padding: getSpacing(1),
 }))
 
-const BlackCaptionLabel = styled(Typo.Caption)(({ theme }) => ({
+const BlackCaptionLabel = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.white,
 }))

--- a/src/features/home/components/Trend.tsx
+++ b/src/features/home/components/Trend.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { TrendBlock, TrendNavigationProps } from 'features/home/types'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 type TrendProps = TrendBlock &
   TrendNavigationProps & {
@@ -28,7 +28,7 @@ const Item = styled(InternalTouchableLink)(({ theme }) => ({
   alignItems: 'center',
 }))
 
-const StyledText = styled(Typo.Caption).attrs({
+const StyledText = styled(TypoDS.BodyAccentXs).attrs({
   numberOfLines: 2,
 })(({ theme }) => ({
   textAlign: 'center',

--- a/src/features/home/components/headers/AnimatedHighlightThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/AnimatedHighlightThematicHomeHeader.tsx
@@ -7,7 +7,7 @@ import { HEADER_BLACK_BACKGROUND_HEIGHT } from 'features/home/components/constan
 import { BlackBackground } from 'features/home/components/headers/BlackBackground'
 import { computeDateRangeDisplay } from 'features/home/components/helpers/computeDateRangeDisplay'
 import { HighlightThematicHeader } from 'features/home/types'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 type HighlightThematicHeaderProps = Omit<HighlightThematicHeader, 'type'>
@@ -84,7 +84,7 @@ const DateRangeCaptionContainer = styled.View<{ statusBarHeight: number }>(
   })
 )
 
-const DateRangeCaption = styled(Typo.Caption)(({ theme }) => ({
+const DateRangeCaption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.white,
 }))
 

--- a/src/features/home/components/headers/HighlightThematicHomeHeader.tsx
+++ b/src/features/home/components/headers/HighlightThematicHomeHeader.tsx
@@ -7,7 +7,7 @@ import { BlackBackground } from 'features/home/components/headers/BlackBackgroun
 import { Introduction } from 'features/home/components/headers/highlightThematic/Introduction'
 import { computeDateRangeDisplay } from 'features/home/components/helpers/computeDateRangeDisplay'
 import { HighlightThematicHeader } from 'features/home/types'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { useCustomSafeInsets } from 'ui/theme/useCustomSafeInsets'
 
 type HighligthThematicHeaderProps = Omit<HighlightThematicHeader, 'type'>
@@ -73,7 +73,7 @@ const DateRangeCaptionContainer = styled.View<{ statusBarHeight: number }>(
   })
 )
 
-const DateRangeCaption = styled(Typo.Caption)(({ theme }) => ({
+const DateRangeCaption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.white,
 }))
 

--- a/src/features/home/components/headers/HomeHeader.tsx
+++ b/src/features/home/components/headers/HomeHeader.tsx
@@ -12,7 +12,7 @@ import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay
 import { useAvailableCredit } from 'shared/user/useAvailableCredit'
 import { PageHeader } from 'ui/components/headers/PageHeader'
 import { Separator } from 'ui/components/Separator'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const HomeHeader: FunctionComponent = function () {
   const availableCredit = useAvailableCredit()
@@ -82,7 +82,7 @@ const HeaderContainer = styled.View(({ theme }) => ({
 const TitleContainer = styled.View({
   width: '100%',
 })
-const Subtitle = styled(Typo.Caption)(({ theme }) => ({
+const Subtitle = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 

--- a/src/features/home/components/modules/HighlightOfferModule.tsx
+++ b/src/features/home/components/modules/HighlightOfferModule.tsx
@@ -268,7 +268,7 @@ const OfferDetails = styled.View(({ theme }) => ({
 
 const StyledOfferTitle = styled(Typo.ButtonText)``
 
-const AdditionalDetail = styled(Typo.Caption)(({ theme }) => ({
+const AdditionalDetail = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyDark,
   marginTop: getSpacing(1),
 }))

--- a/src/features/home/components/modules/ThematicHighlightModule.tsx
+++ b/src/features/home/components/modules/ThematicHighlightModule.tsx
@@ -14,7 +14,7 @@ import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { theme } from 'theme'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 const TILE_HEIGHT = 244
 
@@ -150,7 +150,7 @@ const DateRangeCaptionContainer = styled.View(({ theme }) => ({
   paddingHorizontal: getSpacing(2),
 }))
 
-const DateRangeCaption = styled(Typo.Hint)(({ theme }) => ({
+const DateRangeCaption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.white,
 }))
 

--- a/src/features/home/components/modules/VenueListModule.tsx
+++ b/src/features/home/components/modules/VenueListModule.tsx
@@ -16,7 +16,7 @@ import { useModal } from 'ui/components/modals/useModal'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { ArrowRight } from 'ui/svg/icons/ArrowRight'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 type HeaderProps = {
   onPress?: VoidFunction
@@ -45,7 +45,7 @@ const ListHeaderComponent: FunctionComponent<HeaderProps> = ({ onPress }) => {
   return (
     <React.Fragment>
       <Component {...props} {...focusProps}>
-        <Typo.Caption>{'Les lieux culturels à proximité'.toUpperCase()}</Typo.Caption>
+        <TypoDS.BodyAccentXs>{'Les lieux culturels à proximité'.toUpperCase()}</TypoDS.BodyAccentXs>
         <ArrowRightIcon testID="arrow-right" />
       </Component>
       <Spacer.Column numberOfSpaces={4} />

--- a/src/features/home/components/modules/VenueListModule.web.tsx
+++ b/src/features/home/components/modules/VenueListModule.web.tsx
@@ -7,7 +7,7 @@ import { VenueHit } from 'libs/algolia/types'
 import { analytics } from 'libs/analytics'
 import { useHandleFocus } from 'libs/hooks/useHandleFocus'
 import { SeeMoreWithEye } from 'ui/components/SeeMoreWithEye'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 type ModuleProps = {
   moduleId: string
@@ -37,9 +37,9 @@ const ListHeaderComponent: FunctionComponent<ModuleProps> = ({
 
   return (
     <StyledView {...focusProps}>
-      <Typo.Caption numberOfLines={1}>
+      <TypoDS.BodyAccentXs numberOfLines={1}>
         {'Les lieux culturels à proximité'.toUpperCase()}
-      </Typo.Caption>
+      </TypoDS.BodyAccentXs>
       <SeeMoreWithEye
         title="liste des lieux"
         titleSeeMoreLink={{

--- a/src/features/home/components/modules/business/NewBusinessModule.tsx
+++ b/src/features/home/components/modules/business/NewBusinessModule.tsx
@@ -245,7 +245,7 @@ const StyledTitle1 = styled(TypoDS.Title1)(({ theme }) => ({
 const StyledTitle3 = styled(TypoDS.Title3)(({ theme }) => ({
   color: theme.colors.white,
 }))
-const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+const StyledCaption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.white,
 }))
 

--- a/src/features/home/components/modules/venues/VenueDetails.tsx
+++ b/src/features/home/components/modules/venues/VenueDetails.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { PixelRatio } from 'react-native'
 import styled from 'styled-components/native'
 
-import { Typo, GUTTER_DP } from 'ui/theme'
+import { Typo, GUTTER_DP, TypoDS } from 'ui/theme'
 
 interface VenueDetailsProps {
   width: number
@@ -36,6 +36,6 @@ const Row = styled.View({
   flexDirection: 'row',
 })
 
-const TypeLabel = styled(Typo.Caption).attrs({
+const TypeLabel = styled(TypoDS.BodyAccentXs).attrs({
   numberOfLines: 1,
 })(({ theme }) => ({ flexShrink: 1, color: theme.colors.greyDark }))

--- a/src/features/home/components/modules/video/ButtonWithCaption.tsx
+++ b/src/features/home/components/modules/video/ButtonWithCaption.tsx
@@ -6,7 +6,7 @@ import { Touchable } from 'ui/components/touchable/Touchable'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { AccessibleIcon } from 'ui/svg/icons/types'
-import { Spacer, Typo, getSpacing } from 'ui/theme'
+import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 
 type ButtonWithCaptionProps = {
   onPress: () => void
@@ -47,7 +47,7 @@ const ButtonWithCaptionContainer = styled.View({
   alignItems: 'center',
 })
 
-const ButtonCaption = styled(Typo.Caption)(({ theme }) => ({
+const ButtonCaption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/home/components/modules/video/VerticalVideoPlayer.tsx
+++ b/src/features/home/components/modules/video/VerticalVideoPlayer.tsx
@@ -26,7 +26,7 @@ import { Pause } from 'ui/svg/icons/Pause'
 import { PlayV2 } from 'ui/svg/icons/PlayV2'
 import { SoundOff } from 'ui/svg/icons/SoundOff'
 import { SoundOn } from 'ui/svg/icons/SoundOn'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 import { PlayerState } from './types'
 
@@ -328,7 +328,7 @@ const StyledYoutubePlayer = styled(YouTubePlayer).attrs({
   webViewStyle: Platform.OS === 'android' ? { opacity: 0.99 } : undefined,
 })``
 
-const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+const StyledCaption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.white,
   textAlign: 'center',
 }))

--- a/src/features/home/components/modules/video/VideoModal.tsx
+++ b/src/features/home/components/modules/video/VideoModal.tsx
@@ -18,7 +18,7 @@ import { AppModal } from 'ui/components/modals/AppModal'
 import { ModalSwipeDirection } from 'ui/components/modals/types'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { Close } from 'ui/svg/icons/Close'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const VideoModal: React.FC<VideoModalProps> = (props) => {
   const playerRef = useRef<YoutubeIframeRef>(null)
@@ -147,11 +147,11 @@ const StyledTagBackground = styled(View)<{ color: string }>(({ color }) => ({
   borderRadius: theme.borderRadius.checkbox,
 }))
 
-const StyledCaptionTag = styled(Typo.Caption)(({ theme }) => ({
+const StyledCaptionTag = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.white,
 }))
 
-const StyledCaptionDate = styled(Typo.Caption)(({ theme }) => ({
+const StyledCaptionDate = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greySemiDark,
 }))
 

--- a/src/features/home/components/modules/video/VideoModal.web.tsx
+++ b/src/features/home/components/modules/video/VideoModal.web.tsx
@@ -18,7 +18,7 @@ import { styledButton } from 'ui/components/buttons/styledButton'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { Close } from 'ui/svg/icons/Close'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 interface VideoModalProps extends VideoModule {
   offers: Offer[]
@@ -145,11 +145,11 @@ const StyledTagBackground = styled(View)<{ color: string }>(({ color }) => ({
   borderRadius: theme.borderRadius.checkbox,
 }))
 
-const StyledCaptionTag = styled(Typo.Caption)(({ theme }) => ({
+const StyledCaptionTag = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.white,
 }))
 
-const StyledCaptionDate = styled(Typo.Caption)(({ theme }) => ({
+const StyledCaptionDate = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greySemiDark,
 }))
 

--- a/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
@@ -20,7 +20,7 @@ import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
 import { OfferImage } from 'ui/components/tiles/OfferImage'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
-import { Typo, getShadow, getSpacing } from 'ui/theme'
+import { Typo, TypoDS, getShadow, getSpacing } from 'ui/theme'
 
 type Props = {
   offer: Offer
@@ -156,7 +156,7 @@ const ArrowOffer = styled.View({
   right: getSpacing(4),
 })
 
-const CategoryText = styled(Typo.Caption)<{ color: string }>(({ color }) => ({
+const CategoryText = styled(TypoDS.BodyAccentXs)<{ color: string }>(({ color }) => ({
   color: getTagColor(color),
   marginBottom: getSpacing(1),
 }))
@@ -165,7 +165,7 @@ const TitleText = styled(Typo.ButtonText)({
   marginBottom: getSpacing(1),
 })
 
-const AdditionalInfoText = styled(Typo.Caption)(({ theme }) => ({
+const AdditionalInfoText = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyDark,
   marginBottom: getSpacing(1),
 }))

--- a/src/features/home/components/modules/video/VideoMultiOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMultiOfferTile.tsx
@@ -18,7 +18,7 @@ import { Offer } from 'shared/offer/types'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
 import { OfferImage } from 'ui/components/tiles/OfferImage'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
-import { Spacer, Typo, getSpacing } from 'ui/theme'
+import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 
 type Props = {
   offer: Offer
@@ -98,7 +98,7 @@ export const VideoMultiOfferTile: FunctionComponent<Props> = ({
               withStroke
             />
             <Spacer.Column numberOfSpaces={2} />
-            <Typo.Caption numberOfLines={1}>{offer.offer.name}</Typo.Caption>
+            <TypoDS.BodyAccentXs numberOfLines={1}>{offer.offer.name}</TypoDS.BodyAccentXs>
             <AdditionalInfoText>{labelMapping[offer.offer.subcategoryId]}</AdditionalInfoText>
             {displayPrice ? <AdditionalInfoText>{displayPrice}</AdditionalInfoText> : null}
           </React.Fragment>
@@ -117,6 +117,6 @@ const StyledTouchableLink = styled(InternalTouchableLink)(({ theme }) => ({
   width: theme.tiles.sizes['large'].width,
 }))
 
-const AdditionalInfoText = styled(Typo.Caption)(({ theme }) => ({
+const AdditionalInfoText = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))

--- a/src/features/identityCheck/components/SecondButtonList.tsx
+++ b/src/features/identityCheck/components/SecondButtonList.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent } from 'react'
 import { SectionRow } from 'ui/components/SectionRow'
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { AccessibleIcon } from 'ui/svg/icons/types'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 interface SecondButtonListProps {
   leftIcon: FunctionComponent<AccessibleIcon>
@@ -17,7 +17,7 @@ export const SecondButtonList: FunctionComponent<SecondButtonListProps> = ({
   navigateTo,
   onBeforeNavigate,
 }) => {
-  const renderTitle = (title: string) => <Typo.Caption>{title}</Typo.Caption>
+  const renderTitle = (title: string) => <TypoDS.BodyAccentXs>{title}</TypoDS.BodyAccentXs>
 
   return (
     <SectionRow

--- a/src/features/identityCheck/components/modals/DMSModal.tsx
+++ b/src/features/identityCheck/components/modals/DMSModal.tsx
@@ -8,7 +8,7 @@ import { AppModal } from 'ui/components/modals/AppModal'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { Close } from 'ui/svg/icons/Close'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   visible: boolean
@@ -43,7 +43,7 @@ export const DMSModal: FunctionComponent<Props> = ({ visible, hideModal }) => (
       icon={ExternalSiteFilled}
       justifyContent="flex-start"
     />
-    <Typo.CaptionNeutralInfo>Carte d’identité ou passeport.</Typo.CaptionNeutralInfo>
+    <CaptionNeutralInfo>Carte d’identité ou passeport.</CaptionNeutralInfo>
     <Spacer.Column numberOfSpaces={8} />
     <ExternalTouchableLink
       as={ButtonTertiaryBlack}
@@ -53,13 +53,15 @@ export const DMSModal: FunctionComponent<Props> = ({ visible, hideModal }) => (
       icon={ExternalSiteFilled}
       justifyContent="flex-start"
     />
-    <Typo.CaptionNeutralInfo>
-      Titre de séjour, carte d’identité, ou passeport.
-    </Typo.CaptionNeutralInfo>
+    <CaptionNeutralInfo>Titre de séjour, carte d’identité, ou passeport.</CaptionNeutralInfo>
     <Spacer.Column numberOfSpaces={4} />
   </AppModal>
 )
 
 const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))

--- a/src/features/identityCheck/pages/identification/IdentificationFork.tsx
+++ b/src/features/identityCheck/pages/identification/IdentificationFork.tsx
@@ -16,7 +16,7 @@ import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouch
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Marianne } from 'ui/svg/icons/Marianne'
 import { Ubble } from 'ui/svg/icons/Ubble'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
 
 export const IdentificationFork: FunctionComponent = () => {
   return (
@@ -96,6 +96,6 @@ const StyledExternalTouchableLinkContainer = styled.View({
   marginTop: getSpacing(3),
 })
 
-const StyledCaption = styled(Typo.Caption)({
+const StyledCaption = styled(TypoDS.BodyAccentXs)({
   color: theme.colors.greyDark,
 })

--- a/src/features/identityCheck/pages/identification/dms/DMSIntroduction.tsx
+++ b/src/features/identityCheck/pages/identification/dms/DMSIntroduction.tsx
@@ -18,7 +18,7 @@ import { BicolorProfile } from 'ui/svg/icons/BicolorProfile'
 import { ExternalSite } from 'ui/svg/icons/ExternalSite'
 import { AccessibleBicolorIcon } from 'ui/svg/icons/types'
 import { LogoDMS } from 'ui/svg/LogoDMS'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const DMSIntroduction = (): React.JSX.Element => {
   const { params } = useRoute<UseRouteType<'DMSIntroduction'>>()
@@ -90,7 +90,7 @@ const StyledBody = styled(TypoDS.Body)({
   marginBottom: getSpacing(5),
 })
 
-const StyledCaption = styled(Typo.Caption)({
+const StyledCaption = styled(TypoDS.BodyAccentXs)({
   textAlign: 'center',
 })
 

--- a/src/features/identityCheck/pages/identification/dms/IdentityCheckDMS.tsx
+++ b/src/features/identityCheck/pages/identification/dms/IdentityCheckDMS.tsx
@@ -10,7 +10,7 @@ import { SeparatorWithText } from 'ui/components/SeparatorWithText'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { BicolorIdCardWithMagnifyingGlass } from 'ui/svg/icons/BicolorIdCardWithMagnifyingGlass'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const IdentityCheckDMS = () => {
   const theme = useTheme()
@@ -46,7 +46,7 @@ export const IdentityCheckDMS = () => {
               onBeforeNavigate={onDMSFrenchCitizenPress}
               icon={ExternalSiteFilled}
             />
-            <StyledCaption>Carte d’identité ou passeport.</StyledCaption>
+            <CaptionNeutralInfo>Carte d’identité ou passeport.</CaptionNeutralInfo>
             <StyledSeparatorWithText>
               <SeparatorWithText label="ou" />
             </StyledSeparatorWithText>
@@ -57,7 +57,7 @@ export const IdentityCheckDMS = () => {
               onBeforeNavigate={onDMSForeignCitizenPress}
               icon={ExternalSiteFilled}
             />
-            <StyledCaption>Titre de séjour, carte d’identité ou passeport.</StyledCaption>
+            <CaptionNeutralInfo>Titre de séjour, carte d’identité ou passeport.</CaptionNeutralInfo>
           </ButtonContainer>
           <Spacer.BottomScreen />
         </Container>
@@ -85,6 +85,7 @@ const StyledSeparatorWithText = styled.View({
   marginVertical: getSpacing(6),
 })
 
-const StyledCaption = styled(Typo.CaptionNeutralInfo)({
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   textAlign: 'center',
-})
+  color: theme.colors.greyDark,
+}))

--- a/src/features/identityCheck/pages/identification/ubble/SelectIDStatus.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/SelectIDStatus.tsx
@@ -31,7 +31,7 @@ export const SelectIDStatus: FunctionComponent = () => (
 const MainOptionButton = (
   <HeroButtonList
     Title={<Typo.ButtonText>J’ai ma pièce d’identité en cours de validité</Typo.ButtonText>}
-    Subtitle={<Typo.Caption>Les copies ne sont pas acceptées</Typo.Caption>}
+    Subtitle={<TypoDS.BodyAccentXs>Les copies ne sont pas acceptées</TypoDS.BodyAccentXs>}
     Icon={<BicolorIdCard />}
     navigateTo={{ screen: 'UbbleWebview' }}
     onBeforeNavigate={() => logEventSelectIdStatusClicked(IDStatus.ID_OK)}

--- a/src/features/identityCheck/pages/phoneValidation/CodeNotReceivedModal.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/CodeNotReceivedModal.tsx
@@ -16,7 +16,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { AppModal } from 'ui/components/modals/AppModal'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { Close } from 'ui/svg/icons/Close'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export interface CodeNotReceivedModalProps {
   isVisible: boolean
@@ -78,7 +78,7 @@ export const CodeNotReceivedModal: FunctionComponent<CodeNotReceivedModalProps> 
         <Spacer.Column numberOfSpaces={8} />
         <BottomContentContainer>
           <WarningContainer>
-            <Typo.CaptionNeutralInfo>Attention, il te reste&nbsp;: </Typo.CaptionNeutralInfo>
+            <CaptionNeutralInfo>Attention, il te reste&nbsp;: </CaptionNeutralInfo>
             <WarningRemainingAttempts isLastAttempt={isLastAttempt}>
               {requestsWording}
             </WarningRemainingAttempts>
@@ -108,8 +108,12 @@ const WarningContainer = styled.View({
   flexDirection: 'row',
 })
 
-const WarningRemainingAttempts = styled(Typo.Caption)<{ isLastAttempt: boolean }>(
+const WarningRemainingAttempts = styled(TypoDS.BodyAccentXs)<{ isLastAttempt: boolean }>(
   ({ theme, isLastAttempt }) => ({
     color: isLastAttempt ? theme.colors.error : theme.colors.black,
   })
 )
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.tsx
+++ b/src/features/identityCheck/pages/phoneValidation/SetPhoneNumber.tsx
@@ -31,7 +31,7 @@ import { Form } from 'ui/components/Form'
 import { InputError } from 'ui/components/inputs/InputError'
 import { TextInput } from 'ui/components/inputs/TextInput'
 import { useModal } from 'ui/components/modals/useModal'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 const INITIAL_COUNTRY = METROPOLITAN_FRANCE
 
@@ -163,11 +163,11 @@ export const SetPhoneNumber = () => {
       fixedBottomChildren={
         <BottomContentContainer>
           <RemainingAttemptsContainer>
-            <Typo.CaptionNeutralInfo>Il te reste </Typo.CaptionNeutralInfo>
+            <CaptionNeutralInfo>Il te reste </CaptionNeutralInfo>
             <WarningRemainingAttempts isLastAttempt={isLastAttempt}>
               {requestsWording + ' '}
             </WarningRemainingAttempts>
-            <Typo.CaptionNeutralInfo>de code de validation</Typo.CaptionNeutralInfo>
+            <CaptionNeutralInfo>de code de validation</CaptionNeutralInfo>
           </RemainingAttemptsContainer>
           <Spacer.Column numberOfSpaces={2} />
           <ButtonPrimary
@@ -203,8 +203,12 @@ const InputContainer = styled.View(({ theme }) => ({
   marginHorizontal: theme.isMobileViewport ? undefined : 'auto',
 }))
 
-const WarningRemainingAttempts = styled(Typo.Caption)<{ isLastAttempt: boolean }>(
+const WarningRemainingAttempts = styled(TypoDS.BodyAccentXs)<{ isLastAttempt: boolean }>(
   ({ theme, isLastAttempt }) => ({
     color: isLastAttempt ? theme.colors.error : theme.colors.black,
   })
 )
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/internal/atoms/DeeplinkItem.tsx
+++ b/src/features/internal/atoms/DeeplinkItem.tsx
@@ -5,7 +5,7 @@ import { GeneratedDeeplink } from 'features/internal/components/DeeplinksGenerat
 import { useCopyToClipboard } from 'libs/useCopyToClipboard/useCopyToClipboard'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { Share as DefaultShare } from 'ui/svg/icons/BicolorShare'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   deeplink: GeneratedDeeplink
@@ -28,7 +28,7 @@ export const DeeplinkItem = ({ deeplink, before }: Props) => {
         <Spacer.Flex flex={0.85}>
           <ExternalTouchableLink
             externalNav={{ url: deeplink.universalLink, params: { shouldLogEvent: false } }}>
-            <Typo.Caption>{deeplink.universalLink}</Typo.Caption>
+            <TypoDS.BodyAccentXs>{deeplink.universalLink}</TypoDS.BodyAccentXs>
           </ExternalTouchableLink>
         </Spacer.Flex>
 
@@ -45,7 +45,7 @@ export const DeeplinkItem = ({ deeplink, before }: Props) => {
         <Spacer.Flex flex={0.85}>
           <ExternalTouchableLink
             externalNav={{ url: deeplink.firebaseLink, params: { shouldLogEvent: false } }}>
-            <Typo.Caption>{deeplink.firebaseLink}</Typo.Caption>
+            <TypoDS.BodyAccentXs>{deeplink.firebaseLink}</TypoDS.BodyAccentXs>
           </ExternalTouchableLink>
         </Spacer.Flex>
 

--- a/src/features/internal/components/DeeplinksGeneratorForm.tsx
+++ b/src/features/internal/components/DeeplinksGeneratorForm.tsx
@@ -40,7 +40,7 @@ import { Separator } from 'ui/components/Separator'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { useEnterKeyAction } from 'ui/hooks/useEnterKeyAction'
 import { Warning as WarningDefault } from 'ui/svg/icons/BicolorWarning'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export interface GeneratedDeeplink {
   universalLink: string
@@ -418,7 +418,7 @@ const ErrorContainer = styled.View({
   alignItems: 'center',
 })
 
-const ErrorText = styled(Typo.Caption)(({ theme }) => ({
+const ErrorText = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   paddingVertical: getSpacing(1.5),
   color: theme.colors.error,
 }))
@@ -437,7 +437,7 @@ const PaddingContainer = styled.View({
   padding: getSpacing(5),
 })
 
-const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+const StyledCaption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyMedium,
 }))
 

--- a/src/features/internal/components/DeeplinksHistory.tsx
+++ b/src/features/internal/components/DeeplinksHistory.tsx
@@ -8,7 +8,7 @@ import { GeneratedDeeplink } from 'features/internal/components/DeeplinksGenerat
 import { Checkbox } from 'ui/components/inputs/Checkbox/Checkbox'
 import { useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
-import { getSpacing, padding, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, padding, Spacer, TypoDS } from 'ui/theme'
 
 export interface DeeplinksHistoryProps {
   history: Readonly<GeneratedDeeplink[]>
@@ -104,7 +104,9 @@ export const DeeplinksHistory = ({
 
 const renderItem = ({ item, index }: { item: GeneratedDeeplink; index: number }) => {
   const indice = `#${index}`
-  return <DeeplinkItem before={<Typo.Caption>{indice}</Typo.Caption>} deeplink={item} />
+  return (
+    <DeeplinkItem before={<TypoDS.BodyAccentXs>{indice}</TypoDS.BodyAccentXs>} deeplink={item} />
+  )
 }
 
 const flatListStyle = { marginVertical: getSpacing(4) }

--- a/src/features/location/components/LocationSearchWidget.tsx
+++ b/src/features/location/components/LocationSearchWidget.tsx
@@ -11,7 +11,7 @@ import { Separator } from 'ui/components/Separator'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { LocationPointer } from 'ui/svg/icons/LocationPointer'
 import { LocationPointerNotFilled } from 'ui/svg/icons/LocationPointerNotFilled'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 export const LocationSearchWidget = () => {
   const { place, selectedLocationMode } = useLocation()
@@ -59,7 +59,7 @@ const SmallLocationPointerNotFilled = styled(LocationPointerNotFilled).attrs(({ 
   size: theme.icons.sizes.extraSmall,
 }))``
 
-const LocationTitle = styled(Typo.Caption).attrs({
+const LocationTitle = styled(TypoDS.BodyAccentXs).attrs({
   numberOfLines: 1,
 })({
   marginLeft: getSpacing(1),

--- a/src/features/location/components/LocationWidget.tsx
+++ b/src/features/location/components/LocationWidget.tsx
@@ -18,7 +18,7 @@ import { Touchable } from 'ui/components/touchable/Touchable'
 import { BicolorLocationPointer } from 'ui/svg/icons/BicolorLocationPointer'
 import { LocationPointer } from 'ui/svg/icons/LocationPointer'
 import { LocationPointerAppV2 } from 'ui/svg/icons/LocationPointerAppV2'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 export const LOCATION_TITLE_MAX_WIDTH = getSpacing(25)
 const WIDGET_HEIGHT = getSpacing(10 + 1 + 4) // roundedButton + padding + caption
@@ -109,7 +109,7 @@ const StyledTouchable = styledButton(Touchable)({
   marginLeft: getSpacing(2),
 })
 
-const StyledCaption = styled(Typo.Caption)({
+const StyledCaption = styled(TypoDS.BodyAccentXs)({
   paddingTop: getSpacing(1),
   maxWidth: LOCATION_TITLE_MAX_WIDTH,
 })

--- a/src/features/navigation/TabBar/TabBarTitle.tsx
+++ b/src/features/navigation/TabBar/TabBarTitle.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled, { useTheme } from 'styled-components/native'
 
 import { HiddenAccessibleText } from 'ui/components/HiddenAccessibleText'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 interface Props {
   displayName: string
@@ -16,7 +16,7 @@ export const TabBarTitle: React.FC<Props> = ({ selected, displayName }) => {
   return <HiddenAccessibleText>{displayName}</HiddenAccessibleText>
 }
 
-const Title = styled(Typo.Caption)<{ selected?: boolean }>(({ theme, selected }) => ({
+const Title = styled(TypoDS.BodyAccentXs)<{ selected?: boolean }>(({ theme, selected }) => ({
   color: selected ? theme.colors.black : theme.colors.greyDark,
   fontSize: theme.tabBar.fontSize,
   textAlign: 'center',

--- a/src/features/offer/components/BottomBanner/BottomBanner.tsx
+++ b/src/features/offer/components/BottomBanner/BottomBanner.tsx
@@ -3,7 +3,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import styled from 'styled-components/native'
 
 import { BicolorWarning } from 'ui/svg/icons/BicolorWarning'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   text: string
@@ -22,7 +22,7 @@ export const BottomBanner = ({ text, ...props }: Props) => {
       </IconContainer>
       <Spacer.Row numberOfSpaces={4} />
       <TextContainer>
-        <Typo.Caption>{text}</Typo.Caption>
+        <TypoDS.BodyAccentXs>{text}</TypoDS.BodyAccentXs>
       </TextContainer>
     </Container>
   )

--- a/src/features/offer/components/VenueDetails/VenueDetails.tsx
+++ b/src/features/offer/components/VenueDetails/VenueDetails.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 
 import { VenueDetail } from 'features/offer/types'
 import { Tag } from 'ui/components/Tag/Tag'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
 import { getHoverStyle } from 'ui/theme/getHoverStyle/getHoverStyle'
 
 export interface VenueDetailsProps extends VenueDetail, ViewProps {
@@ -62,7 +62,7 @@ const Title = styled(Typo.ButtonText).attrs({
   ...getHoverStyle(theme.colors.black, isHover),
 }))
 
-const VenueAddress = styled(Typo.Caption).attrs({
+const VenueAddress = styled(TypoDS.BodyAccentXs).attrs({
   numberOfLines: 2,
   ellipsizeMode: 'tail',
 })<{ isHover?: boolean }>(({ theme, isHover }) => ({

--- a/src/features/offer/components/VenueSelectionListHeader/VenueSelectionListHeader.tsx
+++ b/src/features/offer/components/VenueSelectionListHeader/VenueSelectionListHeader.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
 import { GeolocationBanner } from 'shared/Banners/GeolocationBanner'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type Props = {
@@ -44,6 +44,6 @@ const ListHeaderContainer = styled.View({
   width: '100%',
 })
 
-const HeaderMessageText = styled(Typo.Caption)(({ theme }) => ({
+const HeaderMessageText = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))

--- a/src/features/profile/components/Disclaimers/AlreadyChangedEmailDisclaimer.tsx
+++ b/src/features/profile/components/Disclaimers/AlreadyChangedEmailDisclaimer.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { analytics } from 'libs/analytics'
 import { BicolorClock } from 'ui/svg/icons/BicolorClock'
-import { getSpacingString, Spacer, Typo } from 'ui/theme'
+import { getSpacingString, Spacer, TypoDS } from 'ui/theme'
 
 export const AlreadyChangedEmailDisclaimer = () => {
   useEffect(() => {
@@ -35,6 +35,6 @@ const StyledClock = styled(BicolorClock).attrs(({ theme }) => ({
   color2: theme.colors.greyDark,
 }))``
 
-const BodyText = styled(Typo.Caption)({
+const BodyText = styled(TypoDS.BodyAccentXs)({
   flexShrink: 1,
 })

--- a/src/features/profile/components/Disclaimers/ChangeEmailDisclaimer.tsx
+++ b/src/features/profile/components/Disclaimers/ChangeEmailDisclaimer.tsx
@@ -1,20 +1,25 @@
 import React from 'react'
+import styled from 'styled-components/native'
 
 import { Separator } from 'ui/components/Separator'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export function ChangeEmailDisclaimer() {
   return (
     <React.Fragment>
-      <Typo.CaptionNeutralInfo>
+      <CaptionNeutralInfo>
         Pour modifier ton adresse e-mail, tu dois d’abord faire une demande de modification.
-      </Typo.CaptionNeutralInfo>
+      </CaptionNeutralInfo>
       <Spacer.Column numberOfSpaces={4} />
-      <Typo.CaptionNeutralInfo>
+      <CaptionNeutralInfo>
         Tu ne peux modifier ton adresse e-mail qu’une fois par jour.
-      </Typo.CaptionNeutralInfo>
+      </CaptionNeutralInfo>
       <Spacer.Column numberOfSpaces={4} />
       <Separator.Horizontal />
     </React.Fragment>
   )
 }
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/profile/components/SectionWithSwitch/SectionWithSwitch.tsx
+++ b/src/features/profile/components/SectionWithSwitch/SectionWithSwitch.tsx
@@ -90,6 +90,6 @@ const FilterSwitchLabelContainer = styled.View({
 })
 
 const ToggleLabel = styledInputLabel(InputLabel)(({ theme }) => ({
-  ...theme.typography.caption,
+  ...theme.designSystem.typography.bodyAccentXs,
   color: theme.colors.greyDark,
 }))

--- a/src/features/profile/components/StepCard/StepCard.tsx
+++ b/src/features/profile/components/StepCard/StepCard.tsx
@@ -3,7 +3,7 @@ import { View, ViewProps } from 'react-native'
 import styled, { DefaultTheme, useTheme } from 'styled-components/native'
 
 import { StepButtonState } from 'ui/components/StepButton/types'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, Typo, TypoDS } from 'ui/theme'
 
 interface StepCardProps extends ViewProps {
   title: string
@@ -36,9 +36,7 @@ export function StepCard({
         </IconContainer>
         <TextContainter>
           <Title type={type}>{title}</Title>
-          {shouldDisplaySubtitle ? (
-            <Typo.CaptionNeutralInfo>{subtitle}</Typo.CaptionNeutralInfo>
-          ) : null}
+          {shouldDisplaySubtitle ? <CaptionNeutralInfo>{subtitle}</CaptionNeutralInfo> : null}
         </TextContainter>
       </Container>
     </Parent>
@@ -74,6 +72,10 @@ const TextContainter = styled.View({
 
 const Title = styled(Typo.ButtonText)<{ type: StepButtonState }>(({ theme, type }) => ({
   color: type === StepButtonState.CURRENT ? theme.colors.black : theme.colors.greyDark,
+}))
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
 }))
 
 function getIconWithColors(icon: ReactElement, type: StepButtonState, theme: DefaultTheme) {

--- a/src/features/profile/pages/PersonalData/PersonalData.tsx
+++ b/src/features/profile/pages/PersonalData/PersonalData.tsx
@@ -16,7 +16,7 @@ import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouch
 import { SecondaryPageWithBlurHeader } from 'ui/pages/SecondaryPageWithBlurHeader'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Trash } from 'ui/svg/icons/Trash'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { SECTION_ROW_ICON_SIZE } from 'ui/theme/constants'
 
 function onEmailChangeClick() {
@@ -52,14 +52,14 @@ export function PersonalData() {
     <SecondaryPageWithBlurHeader title="Informations personnelles">
       {user?.isBeneficiary ? (
         <React.Fragment>
-          <Typo.CaptionNeutralInfo>Prénom et nom</Typo.CaptionNeutralInfo>
+          <CaptionNeutralInfo>Prénom et nom</CaptionNeutralInfo>
           <Spacer.Column numberOfSpaces={2} />
           <TypoDS.Body>{fullname}</TypoDS.Body>
           <StyledSeparator />
         </React.Fragment>
       ) : null}
 
-      <Typo.CaptionNeutralInfo>Adresse e-mail</Typo.CaptionNeutralInfo>
+      <CaptionNeutralInfo>Adresse e-mail</CaptionNeutralInfo>
       <Spacer.Column numberOfSpaces={2} />
       <EditContainer>
         <EditText>{user?.email}</EditText>
@@ -75,7 +75,7 @@ export function PersonalData() {
 
       {user?.isBeneficiary && user?.phoneNumber ? (
         <React.Fragment>
-          <Typo.CaptionNeutralInfo>Numéro de téléphone</Typo.CaptionNeutralInfo>
+          <CaptionNeutralInfo>Numéro de téléphone</CaptionNeutralInfo>
           <Spacer.Column numberOfSpaces={2} />
           <TypoDS.Body>{user?.phoneNumber}</TypoDS.Body>
           <StyledSeparator />
@@ -84,7 +84,7 @@ export function PersonalData() {
 
       {user?.hasPassword ? (
         <React.Fragment>
-          <Typo.CaptionNeutralInfo>Mot de passe</Typo.CaptionNeutralInfo>
+          <CaptionNeutralInfo>Mot de passe</CaptionNeutralInfo>
           <Spacer.Column numberOfSpaces={2} />
           <EditContainer>
             <EditText>{'*'.repeat(12)}</EditText>
@@ -100,7 +100,7 @@ export function PersonalData() {
 
       {user?.isBeneficiary ? (
         <React.Fragment>
-          <Typo.CaptionNeutralInfo>Statut</Typo.CaptionNeutralInfo>
+          <CaptionNeutralInfo>Statut</CaptionNeutralInfo>
           <Spacer.Column numberOfSpaces={2} />
           <EditContainer>
             <EditText>{user?.activityId && ACTIVITIES[user.activityId]}</EditText>
@@ -116,7 +116,7 @@ export function PersonalData() {
 
       {user?.isBeneficiary ? (
         <React.Fragment>
-          <Typo.CaptionNeutralInfo>Ville de résidence</Typo.CaptionNeutralInfo>
+          <CaptionNeutralInfo>Ville de résidence</CaptionNeutralInfo>
           <Spacer.Column numberOfSpaces={2} />
           <EditContainer>
             <EditText numberOfLines={2}>{city}</EditText>
@@ -167,3 +167,7 @@ const EditText = styled(TypoDS.Body)({
   flexShrink: 1,
   marginRight: getSpacing(2),
 })
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/profile/pages/ValidateEmailChange/SubtitleComponent.tsx
+++ b/src/features/profile/pages/ValidateEmailChange/SubtitleComponent.tsx
@@ -26,6 +26,7 @@ const Wrapper = styled.View({
   alignItems: 'center',
 })
 
-const StyledCaption = styled(Typo.CaptionNeutralInfo)({
+const StyledCaption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   textAlign: 'center',
-})
+  color: theme.colors.greyDark,
+}))

--- a/src/features/reactions/components/ReactionChoiceModalBodyWithValidation/ReactionChoiceModalBodyWithValidation.tsx
+++ b/src/features/reactions/components/ReactionChoiceModalBodyWithValidation/ReactionChoiceModalBodyWithValidation.tsx
@@ -8,7 +8,7 @@ import { Separator } from 'ui/components/Separator'
 import { HorizontalTile } from 'ui/components/tiles/HorizontalTile'
 import { ValidationMark } from 'ui/components/ValidationMark'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 type Props = {
   offer: OfferResponse | BookingOfferResponse
@@ -62,11 +62,11 @@ const SubtitleContainer = styled(ViewGap)({
   alignItems: 'center',
 })
 
-const UsedText = styled(Typo.Caption)(({ theme }) => ({
+const UsedText = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greenValid,
 }))
 
-const DateUsedText = styled(Typo.Caption)(({ theme }) => ({
+const DateUsedText = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 

--- a/src/features/search/components/AutocompleteOffer/AutocompleteOffer.tsx
+++ b/src/features/search/components/AutocompleteOffer/AutocompleteOffer.tsx
@@ -8,7 +8,7 @@ import { CreateHistoryItem } from 'features/search/types'
 import { AlgoliaSuggestionHit } from 'libs/algolia/types'
 import { Li } from 'ui/components/Li'
 import { VerticalUl } from 'ui/components/Ul'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type AutocompleteOfferProps = UseInfiniteHitsProps & {
@@ -48,6 +48,8 @@ const StyledVerticalUl = styled(VerticalUl)({
   marginTop: getSpacing(4),
 })
 
-const AutocompleteOfferTitleText = styled(Typo.Caption).attrs(getHeadingAttrs(2))(({ theme }) => ({
-  color: theme.colors.greyDark,
-}))
+const AutocompleteOfferTitleText = styled(TypoDS.BodyAccentXs).attrs(getHeadingAttrs(2))(
+  ({ theme }) => ({
+    color: theme.colors.greyDark,
+  })
+)

--- a/src/features/search/components/AutocompleteVenue/AutocompleteVenue.tsx
+++ b/src/features/search/components/AutocompleteVenue/AutocompleteVenue.tsx
@@ -6,7 +6,7 @@ import { AutocompleteVenueItem } from 'features/search/components/AutocompleteVe
 import { AlgoliaVenue } from 'libs/algolia/types'
 import { Li } from 'ui/components/Li'
 import { VerticalUl } from 'ui/components/Ul'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type AutocompleteVenueProps = UseInfiniteHitsProps & {
@@ -38,6 +38,8 @@ const StyledVerticalUl = styled(VerticalUl)({
   marginTop: getSpacing(4),
 })
 
-const AutocompleteVenueTitleText = styled(Typo.Caption).attrs(getHeadingAttrs(2))(({ theme }) => ({
-  color: theme.colors.greyDark,
-}))
+const AutocompleteVenueTitleText = styled(TypoDS.BodyAccentXs).attrs(getHeadingAttrs(2))(
+  ({ theme }) => ({
+    color: theme.colors.greyDark,
+  })
+)

--- a/src/features/search/components/SearchHistory/SearchHistory.tsx
+++ b/src/features/search/components/SearchHistory/SearchHistory.tsx
@@ -9,7 +9,7 @@ import { styledButton } from 'ui/components/buttons/styledButton'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { VerticalUl } from 'ui/components/Ul'
 import { Close as DefaultClose } from 'ui/svg/icons/Close'
-import { Typo, getSpacing } from 'ui/theme'
+import { TypoDS, getSpacing } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type Props = {
@@ -55,9 +55,11 @@ const StyledVerticalUl = styled(VerticalUl)({
   marginTop: getSpacing(4),
 })
 
-const SearchHistoryTitleText = styled(Typo.Caption).attrs(getHeadingAttrs(2))(({ theme }) => ({
-  color: theme.colors.greyDark,
-}))
+const SearchHistoryTitleText = styled(TypoDS.BodyAccentXs).attrs(getHeadingAttrs(2))(
+  ({ theme }) => ({
+    color: theme.colors.greyDark,
+  })
+)
 
 const Container = styled.View<{ isEmptyQuery: boolean }>(({ isEmptyQuery }) => ({
   flexDirection: 'row',

--- a/src/features/search/components/SearchTitleAndWidget/SearchTitleAndWidget.tsx
+++ b/src/features/search/components/SearchTitleAndWidget/SearchTitleAndWidget.tsx
@@ -7,7 +7,7 @@ import { SearchLocationWidgetDesktopView } from 'features/location/components/Se
 import { ScreenOrigin } from 'features/location/enums'
 import { InputLabel } from 'ui/components/InputLabel/InputLabel'
 import { styledInputLabel } from 'ui/components/InputLabel/styledInputLabel'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type Props = {
@@ -51,7 +51,7 @@ const StyledTitleMainText = styledInputLabel(InputLabel)(({ theme }) => ({
   ...theme.typography.title1,
 }))
 
-const CaptionSubtitle = styled(Typo.Caption)(({ theme }) => ({
+const CaptionSubtitle = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   marginTop: getSpacing(1),
   color: theme.colors.greyDark,
 }))

--- a/src/features/search/components/SearchVenueItemsDetails/SearchVenueItemDetails.tsx
+++ b/src/features/search/components/SearchVenueItemsDetails/SearchVenueItemDetails.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { PixelRatio } from 'react-native'
 import styled from 'styled-components/native'
 
-import { Typo, GUTTER_DP } from 'ui/theme'
+import { Typo, GUTTER_DP, TypoDS } from 'ui/theme'
 
 interface SearchVenueItemDetailsProps {
   width: number
@@ -37,6 +37,6 @@ const VenueName = styled(Typo.ButtonText).attrs({
   numberOfLines: 2,
 })({})
 
-const ShortAddressLabel = styled(Typo.Caption).attrs({
+const ShortAddressLabel = styled(TypoDS.BodyAccentXs).attrs({
   numberOfLines: 2,
 })(({ theme }) => ({ flexShrink: 1, color: theme.colors.greyDark }))

--- a/src/features/subscription/NotificationsSettingsModal.tsx
+++ b/src/features/subscription/NotificationsSettingsModal.tsx
@@ -13,7 +13,7 @@ import { BellFilled } from 'ui/svg/icons/BellFilled'
 import { Close } from 'ui/svg/icons/Close'
 import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 import { Invalidate } from 'ui/svg/icons/Invalidate'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   visible: boolean
@@ -138,7 +138,7 @@ const ModalContent = styled.View({
   width: '100%',
 })
 
-const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+const StyledCaption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 

--- a/src/features/subscription/components/modals/SubscriptionSuccessModal.tsx
+++ b/src/features/subscription/components/modals/SubscriptionSuccessModal.tsx
@@ -10,7 +10,7 @@ import { AppModalWithIllustration } from 'ui/components/modals/AppModalWithIllus
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { BicolorRingingBell } from 'ui/svg/BicolorRingingBell'
 import { Parameters } from 'ui/svg/icons/Parameters'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   visible: boolean
@@ -56,7 +56,7 @@ const StyledButtonContainer = styled.View({
 const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })
-const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+const StyledCaption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyDark,
   textAlign: 'center',
 }))

--- a/src/features/trustedDevice/components/DeviceInformationsBanner.tsx
+++ b/src/features/trustedDevice/components/DeviceInformationsBanner.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { InfoBanner } from 'ui/components/banners/InfoBanner'
 import { Info } from 'ui/svg/icons/Info'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 import { LINE_BREAK } from 'ui/theme/constants'
 
 type DeviceInformationsBanner = {
@@ -20,17 +20,17 @@ export const DeviceInformationsBanner: React.FC<DeviceInformationsBanner> = ({
   <InfoBanner
     message={
       <CaptionRegular>
-        <Typo.Caption>Appareil utilisé&nbsp;: </Typo.Caption> {osAndSource}
+        <TypoDS.BodyAccentXs>Appareil utilisé&nbsp;: </TypoDS.BodyAccentXs> {osAndSource}
         {LINE_BREAK}
-        <Typo.Caption>Lieu&nbsp;: </Typo.Caption> {location}
+        <TypoDS.BodyAccentXs>Lieu&nbsp;: </TypoDS.BodyAccentXs> {location}
         {LINE_BREAK}
-        <Typo.Caption>Date et heure&nbsp;: </Typo.Caption> {loginDate}
+        <TypoDS.BodyAccentXs>Date et heure&nbsp;: </TypoDS.BodyAccentXs> {loginDate}
       </CaptionRegular>
     }
     icon={Info}
   />
 )
 
-const CaptionRegular = styled(Typo.Caption)(({ theme }) => ({
+const CaptionRegular = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   fontFamily: theme.fontFamily.regular,
 }))

--- a/src/features/tutorial/components/AgeButton.stories.tsx
+++ b/src/features/tutorial/components/AgeButton.stories.tsx
@@ -21,6 +21,10 @@ const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.secondary,
 }))
 
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))
+
 const meta: ComponentMeta<typeof AgeButton> = {
   title: 'features/tutorial/AgeButton',
   component: AgeButton,
@@ -48,9 +52,9 @@ const TextExample = ({ withSubtitle = false }) => (
     {withSubtitle ? (
       <React.Fragment>
         <Spacer.Column numberOfSpaces={1} />
-        <Typo.CaptionNeutralInfo numberOfLines={2}>
+        <CaptionNeutralInfo numberOfLines={2}>
           j’ai moins de 15 ans ou plus de 18 ans
-        </Typo.CaptionNeutralInfo>
+        </CaptionNeutralInfo>
       </React.Fragment>
     ) : null}
   </React.Fragment>

--- a/src/features/tutorial/components/AgeCreditBlock.tsx
+++ b/src/features/tutorial/components/AgeCreditBlock.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { CreditBlock } from 'features/tutorial/components/CreditBlock'
 import { CreditStatus } from 'features/tutorial/enums'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 type Props = {
   age: number
@@ -18,7 +18,7 @@ export const AgeCreditBlock: FunctionComponent<Props> = ({
   onPress,
   children,
 }) => {
-  const AgeText = creditStatus === CreditStatus.ONGOING ? BodySecondary : Typo.CaptionNeutralInfo
+  const AgeText = creditStatus === CreditStatus.ONGOING ? BodySecondary : CaptionNeutralInfo
 
   const statusIsOngoing = creditStatus === CreditStatus.ONGOING
 
@@ -33,4 +33,8 @@ export const AgeCreditBlock: FunctionComponent<Props> = ({
 
 const BodySecondary = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.secondary,
+}))
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
 }))

--- a/src/features/tutorial/components/CreditStatusTag.tsx
+++ b/src/features/tutorial/components/CreditStatusTag.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { CreditStatus } from 'features/tutorial/enums'
 import { getTagColor } from 'features/tutorial/helpers/getTagColor'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 interface Props {
   status: CreditStatus
@@ -19,7 +19,7 @@ export const CreditStatusTag: React.FC<Props> = ({ status }) => {
   )
 }
 
-const StyledText = styled(Typo.Caption)<{ status: CreditStatus }>(({ theme, status }) => ({
+const StyledText = styled(TypoDS.BodyAccentXs)<{ status: CreditStatus }>(({ theme, status }) => ({
   color: status === CreditStatus.GONE ? theme.colors.greyDark : theme.colors.white,
 }))
 

--- a/src/features/tutorial/components/onboarding/OnboardingTimeline.tsx
+++ b/src/features/tutorial/components/onboarding/OnboardingTimeline.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 import { CreditComponentProps, CreditTimeline } from 'features/tutorial/components/CreditTimeline'
 import { TutorialTypes } from 'features/tutorial/enums'
 import { useDepositAmountsByAge } from 'shared/user/useDepositAmountsByAge'
-import { Spacer, Typo, TypoDS, getSpacing, getSpacingString } from 'ui/theme'
+import { Spacer, TypoDS, getSpacing, getSpacingString } from 'ui/theme'
 
 interface Props {
   age: 15 | 16 | 17 | 18
@@ -17,7 +17,7 @@ export const OnboardingTimeline: FunctionComponent<Props> = ({ age }) => {
   return <CreditTimeline age={age} stepperProps={stepperProps} type={TutorialTypes.ONBOARDING} />
 }
 
-const DescriptionText = styled(Typo.Caption)(({ theme }) => ({
+const DescriptionText = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   fontSize: theme.tabBar.fontSize,
   lineHeight: getSpacingString(3),
   color: theme.colors.greyDark,

--- a/src/features/tutorial/components/profileTutorial/BlockDescriptionItem.tsx
+++ b/src/features/tutorial/components/profileTutorial/BlockDescriptionItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { Typo, getSpacing } from 'ui/theme'
+import { TypoDS, getSpacing } from 'ui/theme'
 
 type Props = {
   icon: React.ReactElement
@@ -23,7 +23,7 @@ const ItemContainer = styled.View({
   flexShrink: 1,
 })
 
-const StyledCaption = styled(Typo.Caption)({
+const StyledCaption = styled(TypoDS.BodyAccentXs)({
   flexShrink: 1,
 })
 

--- a/src/features/tutorial/components/profileTutorial/EighteenBlockDescription.tsx
+++ b/src/features/tutorial/components/profileTutorial/EighteenBlockDescription.tsx
@@ -12,7 +12,7 @@ import { AccessibleUnorderedList } from 'ui/components/accessibility/AccessibleU
 import { BicolorNumeric } from 'ui/svg/icons/bicolor/Numeric'
 import { BicolorClock } from 'ui/svg/icons/BicolorClock'
 import { BicolorLock } from 'ui/svg/icons/BicolorLock'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 type Props = {
   ongoingCredit?: boolean
@@ -57,7 +57,7 @@ export const EighteenBlockDescription: FunctionComponent<Props> = ({ ongoingCred
   )
 }
 
-const StyledCaption = styled(Typo.Caption)({
+const StyledCaption = styled(TypoDS.BodyAccentXs)({
   flexShrink: 1,
 })
 

--- a/src/features/tutorial/components/profileTutorial/InformationStepContent.tsx
+++ b/src/features/tutorial/components/profileTutorial/InformationStepContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { Spacer, Typo, getSpacing } from 'ui/theme'
+import { Spacer, Typo, TypoDS, getSpacing } from 'ui/theme'
 
 interface Props {
   title: string
@@ -22,7 +22,7 @@ const StyledButtonText = styled(Typo.ButtonText).attrs({ numberOfLines: 3 })({
   marginLeft: getSpacing(1.5),
   justifyContent: 'center',
 })
-const StyledCaption = styled(Typo.Caption)({
+const StyledCaption = styled(TypoDS.BodyAccentXs)({
   marginLeft: getSpacing(1.5),
   justifyContent: 'center',
 })

--- a/src/features/tutorial/components/profileTutorial/Timelines/PastSteps.tsx
+++ b/src/features/tutorial/components/profileTutorial/Timelines/PastSteps.tsx
@@ -3,9 +3,9 @@ import styled from 'styled-components/native'
 
 import { CreditComponentProps } from 'features/tutorial/components/CreditTimeline'
 import { BicolorUnlock } from 'ui/svg/icons/BicolorUnlock'
-import { Spacer, Typo, getSpacing } from 'ui/theme'
+import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 
-const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+const StyledCaption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 

--- a/src/features/tutorial/components/profileTutorial/Timelines/TutorialTimelineSixteen.tsx
+++ b/src/features/tutorial/components/profileTutorial/Timelines/TutorialTimelineSixteen.tsx
@@ -11,7 +11,7 @@ import {
 import { UnderageBlockDescription } from 'features/tutorial/components/profileTutorial/UnderageBlockDescription'
 import { TutorialTypes } from 'features/tutorial/enums'
 import { useDepositAmountsByAge } from 'shared/user/useDepositAmountsByAge'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   activatedAt?: number | null
@@ -38,7 +38,7 @@ export const TutorialTimelineSixteen = ({ activatedAt }: Props) => {
   )
 }
 
-const StyledCaption = styled(Typo.Caption)(({ theme }) => ({
+const StyledCaption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 

--- a/src/features/venue/components/TabLayout/InfoTab.tsx
+++ b/src/features/venue/components/TabLayout/InfoTab.tsx
@@ -6,7 +6,7 @@ import { PastilleType } from 'features/venue/types'
 import { useHandleHover } from 'libs/hooks/useHandleHover'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { AccessibleIcon } from 'ui/svg/icons/types'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 import { TouchableTab } from './TouchableTab'
 
@@ -90,6 +90,6 @@ const PastilleContainer = styled.View(({ theme }) => ({
   paddingHorizontal: getSpacing(1),
 }))
 
-const Counter = styled(Typo.Hint)(({ theme }) => ({
+const Counter = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.white,
 }))

--- a/src/features/venueMap/components/MapPinWithCounter/MapPinWithCounter.tsx
+++ b/src/features/venueMap/components/MapPinWithCounter/MapPinWithCounter.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
 import { MapPin } from 'ui/svg/icons/MapPin'
-import { getShadow, getSpacing, Typo } from 'ui/theme'
+import { getShadow, getSpacing, TypoDS } from 'ui/theme'
 
 type Props = {
   count: number
@@ -20,7 +20,7 @@ export const MapPinWithCounter: FunctionComponent<Props> = ({ count }) => {
       <MapPin />
 
       <NumberContainer testID="numberContainer">
-        <Typo.Caption>{count < 100 ? String(count) : '99+'}</Typo.Caption>
+        <TypoDS.BodyAccentXs>{count < 100 ? String(count) : '99+'}</TypoDS.BodyAccentXs>
       </NumberContainer>
     </Container>
   )

--- a/src/libs/location/components/WhereSection.tsx
+++ b/src/libs/location/components/WhereSection.tsx
@@ -91,7 +91,7 @@ export const WhereSection: React.FC<Props> = ({
       {address ? (
         <React.Fragment>
           <Spacer.Column numberOfSpaces={4} />
-          <Typo.Caption>Adresse</Typo.Caption>
+          <TypoDS.BodyAccentXs>Adresse</TypoDS.BodyAccentXs>
           <Spacer.Column numberOfSpaces={1} />
           <StyledAddress>{address}</StyledAddress>
         </React.Fragment>
@@ -99,7 +99,7 @@ export const WhereSection: React.FC<Props> = ({
       {distanceToLocation ? (
         <React.Fragment>
           <Spacer.Column numberOfSpaces={4} />
-          <Typo.Caption>Distance</Typo.Caption>
+          <TypoDS.BodyAccentXs>Distance</TypoDS.BodyAccentXs>
           <Spacer.Column numberOfSpaces={1} />
           <TypoDS.Body>{distanceToLocation}</TypoDS.Body>
         </React.Fragment>

--- a/src/libs/network/OfflineModeContainer.tsx
+++ b/src/libs/network/OfflineModeContainer.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, useState, useEffect, useRef } from 'react'
 import styled from 'styled-components/native'
 
 import { useNetInfoContext } from 'libs/network/NetInfoWrapper'
-import { getSpacing, Typo, Spacer } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 const THIRTY_SECONDS = 15000
 
@@ -58,6 +58,6 @@ const OfflineModeBanner = styled.View(({ theme }) => ({
   alignItems: 'center',
 }))
 
-const OfflineModeBannerText = styled(Typo.Caption)(({ theme }) => ({
+const OfflineModeBannerText = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.offlineMode.banner.textColor,
 }))

--- a/src/libs/share/SocialButton.tsx
+++ b/src/libs/share/SocialButton.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { ExternalNavigationProps } from 'ui/components/touchableLink/types'
 import { AccessibleIcon } from 'ui/svg/icons/types'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   label: string
@@ -16,7 +16,7 @@ export const SocialButton = ({ label, icon: Icon, externalNav }: Props) => (
   <Container externalNav={externalNav}>
     <Icon />
     <Spacer.Column numberOfSpaces={2} />
-    <Typo.Caption>{label}</Typo.Caption>
+    <TypoDS.BodyAccentXs>{label}</TypoDS.BodyAccentXs>
   </Container>
 )
 

--- a/src/shared/IntersectionObserver/IntersectionObserver.native.test.tsx
+++ b/src/shared/IntersectionObserver/IntersectionObserver.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { IntersectionObserver } from 'shared/IntersectionObserver/IntersectionObserver'
 import { fireEvent, render, screen } from 'tests/utils'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 const onChangeMock = jest.fn()
 
@@ -10,7 +10,7 @@ describe('<IntersectionObserver />', () => {
   it('should call onChange with correct value when intersection changed', () => {
     render(
       <IntersectionObserver onChange={onChangeMock}>
-        <Typo.Caption>Hello world</Typo.Caption>
+        <TypoDS.BodyAccentXs>Hello world</TypoDS.BodyAccentXs>
       </IntersectionObserver>
     )
 
@@ -23,7 +23,7 @@ describe('<IntersectionObserver />', () => {
   it('should use a threshold at 0 by default to execute intersection changed', () => {
     render(
       <IntersectionObserver onChange={onChangeMock}>
-        <Typo.Caption>Hello world</Typo.Caption>
+        <TypoDS.BodyAccentXs>Hello world</TypoDS.BodyAccentXs>
       </IntersectionObserver>
     )
 
@@ -37,7 +37,7 @@ describe('<IntersectionObserver />', () => {
   it('should use a number custom threshold to execute intersection changed', () => {
     render(
       <IntersectionObserver onChange={onChangeMock} threshold={100}>
-        <Typo.Caption>Hello world</Typo.Caption>
+        <TypoDS.BodyAccentXs>Hello world</TypoDS.BodyAccentXs>
       </IntersectionObserver>
     )
 
@@ -51,7 +51,7 @@ describe('<IntersectionObserver />', () => {
   it('should use a percent custom threshold to execute intersection changed', () => {
     render(
       <IntersectionObserver onChange={onChangeMock} threshold="60%">
-        <Typo.Caption>Hello world</Typo.Caption>
+        <TypoDS.BodyAccentXs>Hello world</TypoDS.BodyAccentXs>
       </IntersectionObserver>
     )
 
@@ -65,7 +65,7 @@ describe('<IntersectionObserver />', () => {
   it('should render children correctly', () => {
     render(
       <IntersectionObserver onChange={onChangeMock} threshold="60%">
-        <Typo.Caption>Hello world</Typo.Caption>
+        <TypoDS.BodyAccentXs>Hello world</TypoDS.BodyAccentXs>
       </IntersectionObserver>
     )
 

--- a/src/shared/IntersectionObserver/IntersectionObserver.stories.tsx
+++ b/src/shared/IntersectionObserver/IntersectionObserver.stories.tsx
@@ -5,7 +5,7 @@ import { StyleSheet, View } from 'react-native'
 import { IOScrollView as IntersectionObserverScrollView } from 'react-native-intersection-observer'
 
 import { theme } from 'theme'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 import { IntersectionObserver } from './IntersectionObserver'
 
@@ -32,13 +32,13 @@ const Template: ComponentStory<typeof IntersectionObserver> = (props) => {
   return (
     <IntersectionObserverScrollView style={styles.scrollView}>
       <View style={styles.stateObserverView}>
-        <Typo.Caption>
+        <TypoDS.BodyAccentXs>
           {inView ? 'Observer visible' : 'Observer not visible'} - scroll to test
-        </Typo.Caption>
+        </TypoDS.BodyAccentXs>
       </View>
       <IntersectionObserver onChange={handleChange} threshold={props.threshold}>
         <View style={styles.observerView}>
-          <Typo.Caption>The observer</Typo.Caption>
+          <TypoDS.BodyAccentXs>The observer</TypoDS.BodyAccentXs>
         </View>
       </IntersectionObserver>
     </IntersectionObserverScrollView>

--- a/src/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.tsx
+++ b/src/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.tsx
@@ -68,9 +68,7 @@ export const FinishSubscriptionModal: FunctionComponent<Props> = ({ visible, hid
       <Spacer.Column numberOfSpaces={6} />
       {isUserTransitioningTo18 ? (
         <React.Fragment>
-          <Typo.CaptionNeutralInfo>
-            Ton crédit précédent a été remis à {zero}.
-          </Typo.CaptionNeutralInfo>
+          <CaptionNeutralInfo>Ton crédit précédent a été remis à {zero}.</CaptionNeutralInfo>
           <Spacer.Column numberOfSpaces={6} />
         </React.Fragment>
       ) : null}
@@ -94,3 +92,7 @@ const Deposit = ({ depositAmountByAge }: { depositAmountByAge: string }) => (
 const StyledBody = styled(TypoDS.Body)({
   textAlign: 'center',
 })
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/ui/components/Badge/Badge.tsx
+++ b/src/ui/components/Badge/Badge.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 type Props = {
   value: number
@@ -32,7 +32,7 @@ const Wrapper = styled.View({
   paddingHorizontal: getSpacing(0.5),
 })
 
-const Caption = styled(Typo.Caption)(({ theme }) => ({
+const Caption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   textAlign: 'center',
   color: theme.colors.white,
 }))

--- a/src/ui/components/CheckboxBlock/CheckboxBlock.tsx
+++ b/src/ui/components/CheckboxBlock/CheckboxBlock.tsx
@@ -7,7 +7,7 @@ import { useHandleHover } from 'libs/hooks/useHandleHover'
 import { accessibleCheckboxProps } from 'shared/accessibilityProps/accessibleCheckboxProps'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { CheckboxMark } from 'ui/svg/icons/CheckBoxTMark'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, Typo, TypoDS } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 import { getHoverStyle } from 'ui/theme/getHoverStyle/getHoverStyle'
 
@@ -41,7 +41,7 @@ export const CheckboxBlock = ({
         {LeftIcon ? <LeftIcon /> : null}
         <View>
           <Typo.ButtonText>{label}</Typo.ButtonText>
-          {sublabel ? <Typo.CaptionNeutralInfo>{sublabel}</Typo.CaptionNeutralInfo> : null}
+          {sublabel ? <CaptionNeutralInfo>{sublabel}</CaptionNeutralInfo> : null}
         </View>
       </InnerContainer>
       <Box checked={checked}>{checked ? <CheckboxMark /> : null}</Box>
@@ -84,4 +84,8 @@ const Box = styled.View<{ checked: boolean }>(({ checked, theme }) => ({
   borderWidth: getSpacing(0.25),
   borderColor: checked ? theme.colors.primary : theme.colors.greySemiDark,
   backgroundColor: checked ? theme.colors.primary : theme.colors.white,
+}))
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
 }))

--- a/src/ui/components/ImageCaption.tsx
+++ b/src/ui/components/ImageCaption.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { PixelRatio } from 'react-native'
 import styled from 'styled-components/native'
 
-import { Typo, GUTTER_DP, getSpacing } from 'ui/theme'
+import { GUTTER_DP, getSpacing, TypoDS } from 'ui/theme'
 
 interface ImageCaptionProps {
   categoryLabel: string | null
@@ -31,11 +31,11 @@ export const ImageCaption = ({ categoryLabel, height, width, distance }: ImageCa
   )
 }
 
-const CategoryLabel = styled(Typo.Caption)(({ theme }) => ({
+const CategoryLabel = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.white,
 }))
 
-const Distance = styled(Typo.Caption)(({ theme }) => ({
+const Distance = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.white,
 }))
 

--- a/src/ui/components/InformationWithIcon.tsx
+++ b/src/ui/components/InformationWithIcon.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
 import { AccessibleBicolorIcon } from 'ui/svg/icons/types'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export const InformationWithIcon: FunctionComponent<{
   Icon: React.FC<AccessibleBicolorIcon>
@@ -38,9 +38,10 @@ const Info = styled(TypoDS.Body)({
   flex: 1,
 })
 
-const Subtitle = styled(Typo.CaptionNeutralInfo)({
+const Subtitle = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
   flex: 1,
-})
+}))
 
 const TextContainer = styled.View({
   flexDirection: 'column',

--- a/src/ui/components/NoResultsView.tsx
+++ b/src/ui/components/NoResultsView.tsx
@@ -7,7 +7,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { MagnifyingGlass } from 'ui/svg/icons/MagnifyingGlass'
 import { AccessibleIcon } from 'ui/svg/icons/types'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 type Props = {
   explanations: string
@@ -76,7 +76,7 @@ const ContentContainer = styled.View(({ theme }) => ({
   marginHorizontal: theme.contentPage.marginHorizontal,
 }))
 
-const CaptionTitle = styled(Typo.Caption)(({ theme }) => ({
+const CaptionTitle = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 

--- a/src/ui/components/OfferCaption.tsx
+++ b/src/ui/components/OfferCaption.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { PixelRatio } from 'react-native'
 import styled from 'styled-components/native'
 
-import { Typo, GUTTER_DP } from 'ui/theme'
+import { GUTTER_DP, TypoDS } from 'ui/theme'
 
 interface OfferCaptionProps {
   imageWidth: number
@@ -15,9 +15,9 @@ export const OfferCaption = (props: OfferCaptionProps) => {
   const { imageWidth, name, date, price } = props
   return (
     <CaptionContainer imageWidth={imageWidth}>
-      <Typo.Caption numberOfLines={2}>{name}</Typo.Caption>
-      {date ? <Typo.CaptionNeutralInfo numberOfLines={1}>{date}</Typo.CaptionNeutralInfo> : null}
-      <Typo.CaptionNeutralInfo testID="priceIsDuo">{price}</Typo.CaptionNeutralInfo>
+      <TypoDS.BodyAccentXs numberOfLines={2}>{name}</TypoDS.BodyAccentXs>
+      {date ? <CaptionNeutralInfo numberOfLines={1}>{date}</CaptionNeutralInfo> : null}
+      <CaptionNeutralInfo testID="priceIsDuo">{price}</CaptionNeutralInfo>
     </CaptionContainer>
   )
 }
@@ -25,4 +25,8 @@ export const OfferCaption = (props: OfferCaptionProps) => {
 const CaptionContainer = styled.View<{ imageWidth: number }>(({ imageWidth }) => ({
   maxWidth: imageWidth,
   marginTop: PixelRatio.roundToNearestPixel(GUTTER_DP / 2),
+}))
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
 }))

--- a/src/ui/components/Section.tsx
+++ b/src/ui/components/Section.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren } from 'react'
 import styled from 'styled-components/native'
 
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 import { Separator } from './Separator'
@@ -13,7 +13,7 @@ type SectionProps = PropsWithChildren<{
 export function Section(props: SectionProps) {
   return (
     <Container>
-      {props.title ? <StyledCaption>{props.title}</StyledCaption> : null}
+      {props.title ? <CaptionNeutralInfo>{props.title}</CaptionNeutralInfo> : null}
       <Spacer.Column numberOfSpaces={2} />
       <Separator.Horizontal />
       {props.children}
@@ -25,4 +25,6 @@ const Container = styled.View({
   paddingTop: getSpacing(2),
 })
 
-const StyledCaption = styled(Typo.CaptionNeutralInfo).attrs(getHeadingAttrs(2))``
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs).attrs(getHeadingAttrs(2))(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/ui/components/SocialNetworkCard.tsx
+++ b/src/ui/components/SocialNetworkCard.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { analytics } from 'libs/analytics'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
-import { Typo, getSpacing, Spacer } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 import { SocialNetwork, SocialNetworkIconsMap } from './socials/types'
 
@@ -35,7 +35,7 @@ function SocialNetworkCardComponent(props: SocialNetworkCardProps) {
           <StyledIcon />
         </NetworkIconBox>
         <Spacer.Column numberOfSpaces={1} />
-        <Typo.Caption numberOfLines={2}>{name}</Typo.Caption>
+        <TypoDS.BodyAccentXs numberOfLines={2}>{name}</TypoDS.BodyAccentXs>
       </Container>
     </ExternalTouchableLink>
   )

--- a/src/ui/components/StepButton/StepButton.tsx
+++ b/src/ui/components/StepButton/StepButton.tsx
@@ -8,7 +8,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { AccessibleIcon } from 'ui/svg/icons/types'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, Typo, TypoDS } from 'ui/theme'
 
 interface Props {
   step: StepDetails
@@ -175,7 +175,7 @@ const StyledButtonText = styled(Typo.ButtonText)<{ stepState: StepButtonState }>
   })
 )
 
-const StepSubtitle = styled(Typo.Caption)<{ stepState: StepButtonState }>(
+const StepSubtitle = styled(TypoDS.BodyAccentXs)<{ stepState: StepButtonState }>(
   ({ stepState, theme }) => ({
     color:
       stepState === StepButtonState.CURRENT || stepState === StepButtonState.RETRY

--- a/src/ui/components/Tooltip.tsx
+++ b/src/ui/components/Tooltip.tsx
@@ -9,7 +9,7 @@ import { styledButton } from 'ui/components/buttons/styledButton'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { useEscapeKeyAction } from 'ui/hooks/useEscapeKeyAction'
 import { Clear } from 'ui/svg/icons/Clear'
-import { Typo, getSpacing } from 'ui/theme'
+import { TypoDS, getSpacing } from 'ui/theme'
 
 const FADE_IN_DURATION = 300
 
@@ -104,7 +104,7 @@ const Background = styled.View(({ theme }) => ({
   backgroundColor: theme.uniqueColors.backgroundSurface,
 }))
 
-const StyledText = styled(Typo.Caption)(({ theme }) => ({
+const StyledText = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   flexShrink: 1,
   color: theme.colors.white,
 }))

--- a/src/ui/components/buttons/ButtonPrimary.ts
+++ b/src/ui/components/buttons/ButtonPrimary.ts
@@ -5,7 +5,7 @@ import { AppButton } from 'ui/components/buttons/AppButton/AppButton'
 import { BaseButtonProps } from 'ui/components/buttons/AppButton/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { Typo } from 'ui/theme'
+import { Typo, TypoDS } from 'ui/theme'
 
 export const ButtonPrimary = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ isLoading, disabled, textSize, icon, theme, buttonHeight, ...rest }) => {
@@ -31,7 +31,7 @@ export const ButtonPrimary = styledButton(AppButton).attrs<BaseButtonProps>(
       backgroundColor = theme.buttons.disabled.primary.backgroundColor
     }
 
-    const Title = styled(buttonHeight === 'extraSmall' ? Typo.Caption : Typo.ButtonText)({
+    const Title = styled(buttonHeight === 'extraSmall' ? TypoDS.BodyAccentXs : Typo.ButtonText)({
       maxWidth: '100%',
       color: disabled ? theme.buttons.disabled.primary.textColor : theme.buttons.primary.textColor,
       fontSize: textSize,

--- a/src/ui/components/buttons/ButtonQuaternaryBlack.ts
+++ b/src/ui/components/buttons/ButtonQuaternaryBlack.ts
@@ -4,7 +4,7 @@ import { AppButton } from 'ui/components/buttons/AppButton/AppButton'
 import { BaseButtonProps } from 'ui/components/buttons/AppButton/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 export const ButtonQuaternaryBlack = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ icon, disabled, theme, ...rest }) => {
@@ -24,7 +24,7 @@ export const ButtonQuaternaryBlack = styledButton(AppButton).attrs<BaseButtonPro
       size: theme.buttons.quaternaryBlack.iconSize,
     })``
 
-    const Title = styled(Typo.Caption)({
+    const Title = styled(TypoDS.BodyAccentXs)({
       maxWidth: '100%',
       color: disabled
         ? theme.buttons.disabled.quaternaryBlack.textColor

--- a/src/ui/components/buttons/ButtonQuaternaryGrey.ts
+++ b/src/ui/components/buttons/ButtonQuaternaryGrey.ts
@@ -4,7 +4,7 @@ import { AppButton } from 'ui/components/buttons/AppButton/AppButton'
 import { BaseButtonProps } from 'ui/components/buttons/AppButton/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 export const ButtonQuaternaryGrey = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ icon, disabled, theme, ...rest }) => {
@@ -24,7 +24,7 @@ export const ButtonQuaternaryGrey = styledButton(AppButton).attrs<BaseButtonProp
       size: theme.buttons.quaternaryGrey.iconSize,
     })``
 
-    const Title = styled(Typo.Caption)({
+    const Title = styled(TypoDS.BodyAccentXs)({
       maxWidth: '100%',
       color: disabled
         ? theme.buttons.disabled.quaternaryGrey.textColor

--- a/src/ui/components/buttons/ButtonQuaternaryPrimary.ts
+++ b/src/ui/components/buttons/ButtonQuaternaryPrimary.ts
@@ -4,7 +4,7 @@ import { AppButton } from 'ui/components/buttons/AppButton/AppButton'
 import { BaseButtonProps } from 'ui/components/buttons/AppButton/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 export const ButtonQuaternaryPrimary = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ icon, disabled, theme, ...rest }) => {
@@ -24,7 +24,7 @@ export const ButtonQuaternaryPrimary = styledButton(AppButton).attrs<BaseButtonP
       size: theme.buttons.quaternaryPrimary.iconSize,
     })``
 
-    const Title = styled(Typo.Caption)({
+    const Title = styled(TypoDS.BodyAccentXs)({
       maxWidth: '100%',
       color: disabled
         ? theme.buttons.disabled.quaternaryPrimary.textColor

--- a/src/ui/components/buttons/ButtonQuaternarySecondary.ts
+++ b/src/ui/components/buttons/ButtonQuaternarySecondary.ts
@@ -4,7 +4,7 @@ import { AppButton } from 'ui/components/buttons/AppButton/AppButton'
 import { BaseButtonProps } from 'ui/components/buttons/AppButton/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 export const ButtonQuaternarySecondary = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ icon, disabled, theme, ...rest }) => {
@@ -24,7 +24,7 @@ export const ButtonQuaternarySecondary = styledButton(AppButton).attrs<BaseButto
       size: theme.buttons.quaternarySecondary.iconSize,
     })``
 
-    const Title = styled(Typo.Caption)({
+    const Title = styled(TypoDS.BodyAccentXs)({
       maxWidth: '100%',
       color: disabled
         ? theme.buttons.disabled.quaternarySecondary.textColor

--- a/src/ui/components/buttons/HeroButtonList.stories.tsx
+++ b/src/ui/components/buttons/HeroButtonList.stories.tsx
@@ -43,7 +43,7 @@ const description2 = (
 const caption = (
   <Text>
     <Emoji.Warning withSpaceAfter />
-    <Typo.Caption>Les copies ne sont pas acceptées </Typo.Caption>
+    <TypoDS.BodyAccentXs>Les copies ne sont pas acceptées </TypoDS.BodyAccentXs>
   </Text>
 )
 

--- a/src/ui/components/buttons/SubcategoryButton/SubcategoryButton.tsx
+++ b/src/ui/components/buttons/SubcategoryButton/SubcategoryButton.tsx
@@ -3,7 +3,7 @@ import { Platform, useWindowDimensions } from 'react-native'
 
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Touchable } from 'ui/components/touchable/Touchable'
-import { getShadow, Typo } from 'ui/theme'
+import { getShadow, TypoDS } from 'ui/theme'
 // eslint-disable-next-line no-restricted-imports
 import type { ColorsEnum } from 'ui/theme/colors'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
@@ -72,7 +72,7 @@ const StyledTouchable = styledButton(Touchable)<{
   padding: getSpacing(2),
 }))
 
-const StyledText = styledButton(Typo.Caption).attrs({
+const StyledText = styledButton(TypoDS.BodyAccentXs).attrs({
   ellipsizeMode: 'tail',
   numberOfLines: 2,
   ...(Platform.OS === 'ios' && { paddingRight: getSpacing(4) }),

--- a/src/ui/components/headers/PageHeader.tsx
+++ b/src/ui/components/headers/PageHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 type Props = {
   title: string
@@ -38,6 +38,6 @@ const TitleContainer = styled.View({
   flexShrink: 1,
 })
 
-const CaptionSubtitle = styled(Typo.Caption)(({ theme }) => ({
+const CaptionSubtitle = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))

--- a/src/ui/components/headers/RightButtonText.tsx
+++ b/src/ui/components/headers/RightButtonText.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react'
 
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Touchable } from 'ui/components/touchable/Touchable'
-import { Typo, getSpacing } from 'ui/theme'
+import { TypoDS, getSpacing } from 'ui/theme'
 
 interface HeaderIconProps {
   wording: 'Fermer' | 'Quitter' | 'Annuler'
@@ -12,7 +12,7 @@ interface HeaderIconProps {
 export const RightButtonText: FunctionComponent<HeaderIconProps> = ({ onClose, wording }) => {
   return (
     <StyledTouchable onPress={onClose}>
-      <Typo.Caption>{wording}</Typo.Caption>
+      <TypoDS.BodyAccentXs>{wording}</TypoDS.BodyAccentXs>
     </StyledTouchable>
   )
 }

--- a/src/ui/components/inputs/LargeTextInput/LargeTextInput.tsx
+++ b/src/ui/components/inputs/LargeTextInput/LargeTextInput.tsx
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { InputError } from 'ui/components/inputs/InputError'
 import { TextInput } from 'ui/components/inputs/TextInput'
 import { TextInputProps } from 'ui/components/inputs/types'
-import { getSpacing, Typo } from 'ui/theme'
+import { TypoDS, getSpacing } from 'ui/theme'
 
 interface LargeTextInputProps extends Omit<TextInputProps, 'value' | 'onChangeText'> {
   label: string
@@ -58,9 +58,9 @@ const WithRefLargeTextInput: React.ForwardRefRenderFunction<RNTextInput, LargeTe
           />
         </InputErrorContainer>
         <CountContainer>
-          <Typo.CaptionNeutralInfo>
+          <CaptionNeutralInfo>
             {value ? value.length : 0} / {maxValueLength}
-          </Typo.CaptionNeutralInfo>
+          </CaptionNeutralInfo>
         </CountContainer>
       </FooterContainer>
     </React.Fragment>
@@ -83,3 +83,7 @@ const CountContainer = styled.View({
   textAlign: 'end',
   width: getSpacing(18),
 })
+
+const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/ui/web/displayOnFocus/displayOnFocus.stories.tsx
+++ b/src/ui/web/displayOnFocus/displayOnFocus.stories.tsx
@@ -3,7 +3,7 @@ import { userEvent, screen } from '@storybook/testing-library'
 import React, { Fragment, FunctionComponent, PropsWithChildren } from 'react'
 import styled from 'styled-components'
 
-import { Typo, TypoDS } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 import { displayOnFocus } from './displayOnFocus'
 
@@ -35,7 +35,7 @@ const Template: ComponentStory<FunctionComponent> = () => (
   <Fragment>
     <TypoDS.Body>
       {body1}
-      <Typo.Caption>{caption}</Typo.Caption>
+      <TypoDS.BodyAccentXs>{caption}</TypoDS.BodyAccentXs>
       {body2}
     </TypoDS.Body>
     <RelativeWrapper>

--- a/src/ui/web/link/QuickAccess.stories.tsx
+++ b/src/ui/web/link/QuickAccess.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { userEvent, screen } from '@storybook/testing-library'
 import React, { Fragment } from 'react'
 
-import { Typo, TypoDS } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 import { QuickAccess } from './QuickAccess'
 
@@ -18,7 +18,7 @@ const body = ' is a component that should be visible only when giving focus'
 const Template: ComponentStory<typeof QuickAccess> = (args) => (
   <Fragment>
     <TypoDS.Body>
-      <Typo.Caption>{caption}</Typo.Caption>
+      <TypoDS.BodyAccentXs>{caption}</TypoDS.BodyAccentXs>
       {body}
     </TypoDS.Body>
     <QuickAccess {...args} />

--- a/src/web/SupportedBrowsersGate.tsx
+++ b/src/web/SupportedBrowsersGate.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components/native'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { Li } from 'ui/components/Li'
 import { VerticalUl } from 'ui/components/Ul'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 type SupportedBrowsers = Array<{
   browser: string
@@ -82,7 +82,9 @@ export const BrowserNotSupportedPage: React.FC<{
           })}
         </VerticalUl>
         <Spacer.Column numberOfSpaces={5} />
-        <Typo.Caption>Mets vite à jour ton navigateur en allant dans les paramètres</Typo.Caption>
+        <TypoDS.BodyAccentXs>
+          Mets vite à jour ton navigateur en allant dans les paramètres
+        </TypoDS.BodyAccentXs>
         <Spacer.Column numberOfSpaces={2} />
         <ButtonPrimary
           wording="J’accède au pass Culture sans mettre à jour mon navigateur"


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33859

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
