### PR TITLE
(PC-33882) fix(achievements): modals now wait for queries to finish

### DIFF
--- a/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.native.test.ts
+++ b/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.native.test.ts
@@ -98,7 +98,7 @@ describe('useShouldShowAchievementSuccessModal', () => {
       )
     })
 
-    it('should return shouldNotShow if the achievements are undefined', () => {
+    it('should return pending if the achievements are undefined', () => {
       mockAuthContextWithUser({
         ...beneficiaryUser,
         achievements: undefined as unknown as AchievementResponse[],
@@ -106,9 +106,7 @@ describe('useShouldShowAchievementSuccessModal', () => {
 
       const { result } = renderHook(useShouldShowAchievementSuccessModal)
 
-      expect(result.current.shouldShowAchievementSuccessModal).toEqual(
-        ModalDisplayState.SHOULD_NOT_SHOW
-      )
+      expect(result.current.shouldShowAchievementSuccessModal).toEqual(ModalDisplayState.PENDING)
     })
 
     it('should return an empty array if there are no achievements to show to the user', () => {

--- a/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.ts
+++ b/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.ts
@@ -11,7 +11,7 @@ export const useShouldShowAchievementSuccessModal = (): {
 } => {
   const areAchievementsEnabled = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_ACHIEVEMENTS)
   const { displayAchievements } = useRemoteConfigContext()
-  const { user } = useAuthContext()
+  const { user, isUserLoading } = useAuthContext()
 
   const unseenAchievements = user?.achievements?.filter((achievement) => !achievement.seenDate)
 
@@ -19,10 +19,15 @@ export const useShouldShowAchievementSuccessModal = (): {
     (achievement) => !achievement.seenDate
   )
 
+  if (!user || isThereAtLeastOneUnseenAchievement === undefined || isUserLoading)
+    return {
+      shouldShowAchievementSuccessModal: ModalDisplayState.PENDING,
+      achievementsToShow: [],
+    }
+
   if (
     !areAchievementsEnabled ||
     !displayAchievements ||
-    !user?.achievements ||
     user?.achievements.length === 0 ||
     !isThereAtLeastOneUnseenAchievement
   )

--- a/src/features/home/components/helpers/useBookingsReactionHelpers.native.test.ts
+++ b/src/features/home/components/helpers/useBookingsReactionHelpers.native.test.ts
@@ -33,7 +33,9 @@ describe('useBookingsReactionHelpers', () => {
   it('should return false when FF wipReactionFeature is false', () => {
     setFeatureFlags()
 
-    const { result } = renderHook(() => useBookingsReactionHelpers(endedBookingWithoutReaction))
+    const { result } = renderHook(() =>
+      useBookingsReactionHelpers(endedBookingWithoutReaction, false)
+    )
 
     expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_NOT_SHOW)
   })
@@ -44,7 +46,9 @@ describe('useBookingsReactionHelpers', () => {
     })
 
     it('should return shouldNotShow if the bookings already have reactions', () => {
-      const { result } = renderHook(() => useBookingsReactionHelpers(endedBookingWithReaction))
+      const { result } = renderHook(() =>
+        useBookingsReactionHelpers(endedBookingWithReaction, false)
+      )
 
       expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_NOT_SHOW)
     })
@@ -53,13 +57,17 @@ describe('useBookingsReactionHelpers', () => {
     it.skip('should return shouldNotShow if cookies where not accepted', () => {
       cookiesNotAccepted()
 
-      const { result } = renderHook(() => useBookingsReactionHelpers(endedBookingWithoutReaction))
+      const { result } = renderHook(() =>
+        useBookingsReactionHelpers(endedBookingWithoutReaction, false)
+      )
 
       expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_NOT_SHOW)
     })
 
     it('should return true if there are bookings to react to', () => {
-      const { result } = renderHook(() => useBookingsReactionHelpers(endedBookingWithoutReaction))
+      const { result } = renderHook(() =>
+        useBookingsReactionHelpers(endedBookingWithoutReaction, false)
+      )
 
       expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_SHOW)
       expect(result.current.bookingsEligibleToReaction).toEqual(

--- a/src/features/home/components/helpers/useBookingsReactionHelpers.ts
+++ b/src/features/home/components/helpers/useBookingsReactionHelpers.ts
@@ -9,7 +9,8 @@ export enum ModalDisplayState {
 }
 
 export const useBookingsReactionHelpers = (
-  bookings: BookingsResponse | undefined = undefined
+  bookings: BookingsResponse | undefined,
+  isBookingsLoading: boolean
 ): {
   shouldShowReactionModal: ModalDisplayState
   bookingsEligibleToReaction: Array<BookingReponse> | undefined
@@ -23,7 +24,7 @@ export const useBookingsReactionHelpers = (
 
   const firstBookingWithoutReaction = bookingsEligibleToReaction[0]
 
-  if (bookings === undefined) {
+  if (isBookingsLoading || bookings === undefined) {
     return {
       shouldShowReactionModal: ModalDisplayState.PENDING,
       bookingsEligibleToReaction: [],

--- a/src/features/home/helpers/useWhichModalToShow.native.test.ts
+++ b/src/features/home/helpers/useWhichModalToShow.native.test.ts
@@ -44,9 +44,9 @@ describe('useWhichModalToShow', () => {
       achievements: achievements,
     })
 
-    const { result } = renderHook(() => useWhichModalToShow(endedBookingWithReaction))
+    const { result } = renderHook(() => useWhichModalToShow(endedBookingWithReaction, false))
 
-    expect(result.current.showModal).toEqual(ModalToShow.ACHIEVEMENT)
+    expect(result.current.modalToShow).toEqual(ModalToShow.ACHIEVEMENT)
   })
 
   it('should return reaction if the reaction modal should be shown and the achievement modal should not be shown', () => {
@@ -55,9 +55,9 @@ describe('useWhichModalToShow', () => {
       achievements: [],
     })
 
-    const { result } = renderHook(() => useWhichModalToShow(endedBookingWithoutReaction))
+    const { result } = renderHook(() => useWhichModalToShow(endedBookingWithoutReaction, false))
 
-    expect(result.current.showModal).toEqual(ModalToShow.REACTION)
+    expect(result.current.modalToShow).toEqual(ModalToShow.REACTION)
   })
 
   it('should return reaction if the reaction modal should be show, even if the achievement modal should be shown', () => {
@@ -66,9 +66,9 @@ describe('useWhichModalToShow', () => {
       achievements: achievements,
     })
 
-    const { result } = renderHook(() => useWhichModalToShow(endedBookingWithoutReaction))
+    const { result } = renderHook(() => useWhichModalToShow(endedBookingWithoutReaction, false))
 
-    expect(result.current.showModal).toEqual(ModalToShow.REACTION)
+    expect(result.current.modalToShow).toEqual(ModalToShow.REACTION)
   })
 
   it('should return none if the reaction and achievement both should not be shown', () => {
@@ -77,9 +77,9 @@ describe('useWhichModalToShow', () => {
       achievements: [],
     })
 
-    const { result } = renderHook(() => useWhichModalToShow(endedBookingWithReaction))
+    const { result } = renderHook(() => useWhichModalToShow(endedBookingWithReaction, false))
 
-    expect(result.current.showModal).toEqual(ModalToShow.NONE)
+    expect(result.current.modalToShow).toEqual(ModalToShow.NONE)
   })
 })
 

--- a/src/features/home/helpers/useWhichModalToShow.ts
+++ b/src/features/home/helpers/useWhichModalToShow.ts
@@ -14,25 +14,29 @@ export enum ModalToShow {
   NONE = 'none',
 }
 
-export const useWhichModalToShow = (bookings: BookingsResponse | undefined = undefined) => {
-  const [showModal, setShowModal] = useState<ModalToShow>(ModalToShow.PENDING)
-  const { shouldShowReactionModal, bookingsEligibleToReaction } =
-    useBookingsReactionHelpers(bookings)
+export const useWhichModalToShow = (
+  bookings: BookingsResponse | undefined,
+  isBookingsLoading: boolean
+) => {
+  const [modalToShow, setModalToShow] = useState<ModalToShow>(ModalToShow.PENDING)
+  const { shouldShowReactionModal, bookingsEligibleToReaction } = useBookingsReactionHelpers(
+    bookings,
+    isBookingsLoading
+  )
   const { shouldShowAchievementSuccessModal, achievementsToShow } =
     useShouldShowAchievementSuccessModal()
-
-  if (bookings !== undefined && showModal === ModalToShow.PENDING) {
+  if (!isBookingsLoading && modalToShow === ModalToShow.PENDING) {
     if (shouldShowReactionModal === ModalDisplayState.SHOULD_SHOW) {
-      setShowModal(ModalToShow.REACTION)
+      setModalToShow(ModalToShow.REACTION)
     } else if (shouldShowAchievementSuccessModal === ModalDisplayState.SHOULD_SHOW) {
-      setShowModal(ModalToShow.ACHIEVEMENT)
+      setModalToShow(ModalToShow.ACHIEVEMENT)
     } else if (
       shouldShowReactionModal === ModalDisplayState.SHOULD_NOT_SHOW &&
       shouldShowAchievementSuccessModal === ModalDisplayState.SHOULD_NOT_SHOW
     ) {
-      setShowModal(ModalToShow.NONE)
+      setModalToShow(ModalToShow.NONE)
     }
   }
 
-  return { showModal, bookingsEligibleToReaction, achievementsToShow }
+  return { modalToShow, bookingsEligibleToReaction, achievementsToShow }
 }

--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -56,13 +56,12 @@ export const Home: FunctionComponent = () => {
     userStatus: user?.status?.statusType,
     showOnboardingSubscriptionModal,
   })
-  const { data: bookings } = useBookings()
+  const { data: bookings, isLoading } = useBookings()
 
-  const {
-    achievementsToShow,
-    bookingsEligibleToReaction,
-    showModal: modalToShow,
-  } = useWhichModalToShow(bookings)
+  const { achievementsToShow, bookingsEligibleToReaction, modalToShow } = useWhichModalToShow(
+    bookings,
+    isLoading
+  )
 
   const {
     visible: visibleAchievementModal,

--- a/src/features/reactions/api/useAvailableReaction.test.ts
+++ b/src/features/reactions/api/useAvailableReaction.test.ts
@@ -6,6 +6,9 @@ import { act, renderHook } from 'tests/utils'
 
 jest.mock('libs/network/NetInfoWrapper')
 jest.mock('libs/jwt/jwt')
+jest.mock('features/auth/context/AuthContext', () => ({
+  useAuthContext: jest.fn(() => ({ isLoggedIn: true })),
+}))
 
 describe('useAvailableReaction', () => {
   beforeEach(() => {

--- a/src/features/reactions/api/useAvailableReaction.ts
+++ b/src/features/reactions/api/useAvailableReaction.ts
@@ -2,10 +2,17 @@ import { useQuery } from 'react-query'
 
 import { api } from 'api/api'
 import { GetAvailableReactionsResponse } from 'api/gen'
+import { useAuthContext } from 'features/auth/context/AuthContext'
 import { QueryKeys } from 'libs/queryKeys'
 
 export const useAvailableReaction = () => {
-  return useQuery<GetAvailableReactionsResponse>([QueryKeys.AVAILABLE_REACTION], () =>
-    api.getNativeV1ReactionAvailable()
+  const { isLoggedIn } = useAuthContext()
+
+  return useQuery<GetAvailableReactionsResponse>(
+    [QueryKeys.AVAILABLE_REACTION],
+    () => api.getNativeV1ReactionAvailable(),
+    {
+      enabled: isLoggedIn,
+    }
   )
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33882

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
