### PR TITLE
(PC-33886) refactor(VenuePreview): Create a reusable/generic component InfoHeader

### DIFF
--- a/src/features/offer/components/OfferVenueBlock/VenueBlock.tsx
+++ b/src/features/offer/components/OfferVenueBlock/VenueBlock.tsx
@@ -1,15 +1,13 @@
 import React, { ComponentProps, FunctionComponent, useMemo } from 'react'
 import { View } from 'react-native'
-import styled, { useTheme } from 'styled-components/native'
+import styled from 'styled-components/native'
 
 import { OfferResponseV2 } from 'api/gen'
 import { useVenueBlock } from 'features/offer/components/OfferVenueBlock/useVenueBlock'
 import { useDistance } from 'libs/location/hooks/useDistance'
-import { Image } from 'libs/resizing-image-on-demand/Image'
-import { InfoHeader } from 'ui/components/InfoHeader/InfoHeader'
 import { Tag } from 'ui/components/Tag/Tag'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
-import { RightFilled } from 'ui/svg/icons/RightFilled'
+import { VenueInfoHeader } from 'ui/components/VenueInfoHeader/VenueInfoHeader'
 import { getSpacing, Spacer } from 'ui/theme'
 
 const VENUE_THUMBNAIL_SIZE = getSpacing(14)
@@ -25,7 +23,6 @@ export function VenueBlock({ onSeeVenuePress, offer }: Readonly<Props>) {
     venue,
     offerAddress: address,
   })
-  const theme = useTheme()
 
   const { latitude: lat, longitude: lng } = offer.venue.coordinates
   const distance = useDistance({ lat, lng })
@@ -52,33 +49,14 @@ export function VenueBlock({ onSeeVenuePress, offer }: Readonly<Props>) {
       <TouchableContainer
         navigateTo={{ screen: 'Venue', params: { id: venue.id } }}
         onBeforeNavigate={onSeeVenuePress}>
-        <InfoHeader
+        <VenueInfoHeader
           title={venueName}
           subtitle={venueAddress}
-          rightComponent={
-            hasVenuePage ? (
-              <RightFilled size={theme.icons.sizes.extraSmall} testID="RightFilled" />
-            ) : null
-          }
-          thumbnailComponent={
-            venue.bannerUrl ? (
-              <VenueThumbnail
-                url={venue.bannerUrl}
-                height={VENUE_THUMBNAIL_SIZE}
-                width={VENUE_THUMBNAIL_SIZE}
-                testID="VenuePreviewImage"
-              />
-            ) : null
-          }
-          defaultThumbnailSize={VENUE_THUMBNAIL_SIZE}
+          imageSize={VENUE_THUMBNAIL_SIZE}
+          showArrow={hasVenuePage}
+          imageURL={venue.bannerUrl ?? undefined}
         />
       </TouchableContainer>
     </React.Fragment>
   )
 }
-
-const VenueThumbnail = styled(Image)<{ height: number; width: number }>(({ height, width }) => ({
-  borderRadius: 4,
-  height,
-  width,
-}))

--- a/src/features/offer/components/OfferVenueBlock/VenueBlock.tsx
+++ b/src/features/offer/components/OfferVenueBlock/VenueBlock.tsx
@@ -1,13 +1,15 @@
 import React, { ComponentProps, FunctionComponent, useMemo } from 'react'
 import { View } from 'react-native'
-import styled from 'styled-components/native'
+import styled, { useTheme } from 'styled-components/native'
 
 import { OfferResponseV2 } from 'api/gen'
 import { useVenueBlock } from 'features/offer/components/OfferVenueBlock/useVenueBlock'
 import { useDistance } from 'libs/location/hooks/useDistance'
+import { Image } from 'libs/resizing-image-on-demand/Image'
+import { InfoHeader } from 'ui/components/InfoHeader/InfoHeader'
 import { Tag } from 'ui/components/Tag/Tag'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
-import { VenuePreview } from 'ui/components/VenuePreview/VenuePreview'
+import { RightFilled } from 'ui/svg/icons/RightFilled'
 import { getSpacing, Spacer } from 'ui/theme'
 
 const VENUE_THUMBNAIL_SIZE = getSpacing(14)
@@ -23,6 +25,7 @@ export function VenueBlock({ onSeeVenuePress, offer }: Readonly<Props>) {
     venue,
     offerAddress: address,
   })
+  const theme = useTheme()
 
   const { latitude: lat, longitude: lng } = offer.venue.coordinates
   const distance = useDistance({ lat, lng })
@@ -49,15 +52,33 @@ export function VenueBlock({ onSeeVenuePress, offer }: Readonly<Props>) {
       <TouchableContainer
         navigateTo={{ screen: 'Venue', params: { id: venue.id } }}
         onBeforeNavigate={onSeeVenuePress}>
-        <VenuePreview
-          address={venueAddress}
-          bannerUrl={venue.bannerUrl}
-          withRightArrow={hasVenuePage}
-          venueName={venueName}
-          imageWidth={VENUE_THUMBNAIL_SIZE}
-          imageHeight={VENUE_THUMBNAIL_SIZE}
+        <InfoHeader
+          title={venueName}
+          subtitle={venueAddress}
+          rightComponent={
+            hasVenuePage ? (
+              <RightFilled size={theme.icons.sizes.extraSmall} testID="RightFilled" />
+            ) : null
+          }
+          thumbnailComponent={
+            venue.bannerUrl ? (
+              <VenueThumbnail
+                url={venue.bannerUrl}
+                height={VENUE_THUMBNAIL_SIZE}
+                width={VENUE_THUMBNAIL_SIZE}
+                testID="VenuePreviewImage"
+              />
+            ) : null
+          }
+          defaultThumbnailSize={VENUE_THUMBNAIL_SIZE}
         />
       </TouchableContainer>
     </React.Fragment>
   )
 }
+
+const VenueThumbnail = styled(Image)<{ height: number; width: number }>(({ height, width }) => ({
+  borderRadius: 4,
+  height,
+  width,
+}))

--- a/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.tsx
+++ b/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.tsx
@@ -1,13 +1,11 @@
 import React, { ComponentProps, FunctionComponent } from 'react'
-import styled, { useTheme } from 'styled-components/native'
+import styled from 'styled-components/native'
 
-import { Image } from 'libs/resizing-image-on-demand/Image'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { CloseButton } from 'ui/components/headers/CloseButton'
-import { InfoHeader } from 'ui/components/InfoHeader/InfoHeader'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
+import { VenueInfoHeader } from 'ui/components/VenueInfoHeader/VenueInfoHeader'
 import { InformationTags } from 'ui/InformationTags/InformationTags'
-import { RightFilled } from 'ui/svg/icons/RightFilled'
 import { getShadow, getSpacing, Spacer } from 'ui/theme'
 
 type Props = {
@@ -34,7 +32,6 @@ export const VenueMapPreview: FunctionComponent<Props> = ({
   withRightArrow,
   ...touchableProps
 }) => {
-  const theme = useTheme()
   const Wrapper = noBorder ? InternalTouchableLink : Container
   return (
     <Wrapper {...touchableProps}>
@@ -43,25 +40,12 @@ export const VenueMapPreview: FunctionComponent<Props> = ({
         <StyledCloseButton onClose={onClose} size={iconSize} />
       </Row>
       <Spacer.Column numberOfSpaces={2} />
-      <InfoHeader
+      <VenueInfoHeader
         title={venueName}
         subtitle={address}
-        defaultThumbnailSize={VENUE_THUMBNAIL_SIZE}
-        rightComponent={
-          withRightArrow ? (
-            <RightFilled size={theme.icons.sizes.extraSmall} testID="RightFilled" />
-          ) : null
-        }
-        thumbnailComponent={
-          bannerUrl ? (
-            <VenueThumbnail
-              url={bannerUrl}
-              height={VENUE_THUMBNAIL_SIZE}
-              width={VENUE_THUMBNAIL_SIZE}
-              testID="VenuePreviewImage"
-            />
-          ) : null
-        }
+        imageSize={VENUE_THUMBNAIL_SIZE}
+        showArrow={withRightArrow}
+        imageURL={bannerUrl}
       />
     </Wrapper>
   )
@@ -95,9 +79,3 @@ const StyledCloseButton = styledButton(CloseButton)({
 const StyledInformationTags = styled(InformationTags)({
   flexGrow: 1,
 })
-
-const VenueThumbnail = styled(Image)<{ height: number; width: number }>(({ height, width }) => ({
-  borderRadius: 4,
-  height,
-  width,
-}))

--- a/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.tsx
+++ b/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.tsx
@@ -1,11 +1,13 @@
 import React, { ComponentProps, FunctionComponent } from 'react'
-import styled from 'styled-components/native'
+import styled, { useTheme } from 'styled-components/native'
 
+import { Image } from 'libs/resizing-image-on-demand/Image'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { CloseButton } from 'ui/components/headers/CloseButton'
+import { InfoHeader } from 'ui/components/InfoHeader/InfoHeader'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
-import { VenuePreview } from 'ui/components/VenuePreview/VenuePreview'
 import { InformationTags } from 'ui/InformationTags/InformationTags'
+import { RightFilled } from 'ui/svg/icons/RightFilled'
 import { getShadow, getSpacing, Spacer } from 'ui/theme'
 
 type Props = {
@@ -32,6 +34,7 @@ export const VenueMapPreview: FunctionComponent<Props> = ({
   withRightArrow,
   ...touchableProps
 }) => {
+  const theme = useTheme()
   const Wrapper = noBorder ? InternalTouchableLink : Container
   return (
     <Wrapper {...touchableProps}>
@@ -40,13 +43,25 @@ export const VenueMapPreview: FunctionComponent<Props> = ({
         <StyledCloseButton onClose={onClose} size={iconSize} />
       </Row>
       <Spacer.Column numberOfSpaces={2} />
-      <VenuePreview
-        venueName={venueName}
-        address={address}
-        bannerUrl={bannerUrl}
-        imageWidth={VENUE_THUMBNAIL_SIZE}
-        imageHeight={VENUE_THUMBNAIL_SIZE}
-        withRightArrow={withRightArrow}
+      <InfoHeader
+        title={venueName}
+        subtitle={address}
+        defaultThumbnailSize={VENUE_THUMBNAIL_SIZE}
+        rightComponent={
+          withRightArrow ? (
+            <RightFilled size={theme.icons.sizes.extraSmall} testID="RightFilled" />
+          ) : null
+        }
+        thumbnailComponent={
+          bannerUrl ? (
+            <VenueThumbnail
+              url={bannerUrl}
+              height={VENUE_THUMBNAIL_SIZE}
+              width={VENUE_THUMBNAIL_SIZE}
+              testID="VenuePreviewImage"
+            />
+          ) : null
+        }
       />
     </Wrapper>
   )
@@ -80,3 +95,9 @@ const StyledCloseButton = styledButton(CloseButton)({
 const StyledInformationTags = styled(InformationTags)({
   flexGrow: 1,
 })
+
+const VenueThumbnail = styled(Image)<{ height: number; width: number }>(({ height, width }) => ({
+  borderRadius: 4,
+  height,
+  width,
+}))

--- a/src/ui/components/InfoHeader/InfoHeader.stories.tsx
+++ b/src/ui/components/InfoHeader/InfoHeader.stories.tsx
@@ -1,0 +1,69 @@
+import { ComponentMeta } from '@storybook/react'
+import React from 'react'
+import styled from 'styled-components/native'
+
+import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
+import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storybook/VariantsTemplate'
+import { All } from 'ui/svg/icons/bicolor/All'
+import { RightFilled } from 'ui/svg/icons/RightFilled'
+
+import { InfoHeader } from './InfoHeader'
+
+const meta: ComponentMeta<typeof InfoHeader> = {
+  title: 'ui/InfoHeader',
+  component: InfoHeader,
+}
+export default meta
+
+const baseProps = {
+  title: offerResponseSnap.venue.name,
+  subtitle: offerResponseSnap.venue.address ?? '',
+  defaultThumbnailSize: 56,
+}
+
+const RightArrow = () => (
+  <React.Fragment>
+    <RightIcon testID="RightFilled" />
+  </React.Fragment>
+)
+
+const RightIcon = styled(RightFilled).attrs(({ theme }) => ({
+  size: theme.icons.sizes.extraSmall,
+}))({
+  flexShrink: 0,
+})
+
+const variantConfig: Variants<typeof InfoHeader> = [
+  {
+    label: 'InfoHeader default',
+    props: { ...baseProps },
+  },
+  {
+    label: 'InfoHeader with image',
+    props: {
+      ...baseProps,
+      thumbnailComponent: <All size={56} />,
+    },
+  },
+  {
+    label: 'InfoHeader with arrow',
+    props: {
+      ...baseProps,
+      rightComponent: <RightArrow />,
+    },
+  },
+  {
+    label: 'InfoHeader without subtitle',
+    props: {
+      ...baseProps,
+      subtitle: undefined,
+    },
+  },
+]
+
+const Template: VariantsStory<typeof InfoHeader> = (args) => (
+  <VariantsTemplate variants={variantConfig} Component={InfoHeader} defaultProps={args} />
+)
+
+export const AllVariants = Template.bind({})
+AllVariants.storyName = 'InfoHeader'

--- a/src/ui/components/InfoHeader/InfoHeader.tsx
+++ b/src/ui/components/InfoHeader/InfoHeader.tsx
@@ -21,9 +21,7 @@ export const InfoHeader: FunctionComponent<InfoHeaderProps> = ({
   children,
 }) => (
   <StyledView>
-    {thumbnailComponent ? (
-      thumbnailComponent
-    ) : (
+    {thumbnailComponent || (
       <ThumbnailPlaceholder
         width={defaultThumbnailSize}
         height={defaultThumbnailSize}
@@ -34,7 +32,7 @@ export const InfoHeader: FunctionComponent<InfoHeaderProps> = ({
       {children}
       <TitleContainer>
         <Title>{title}</Title>
-        {rightComponent ? rightComponent : null}
+        {rightComponent || null}
       </TitleContainer>
       {subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
     </RightContainer>

--- a/src/ui/components/InfoHeader/InfoHeader.tsx
+++ b/src/ui/components/InfoHeader/InfoHeader.tsx
@@ -1,0 +1,67 @@
+import React, { FunctionComponent, PropsWithChildren, ReactNode } from 'react'
+import styled from 'styled-components/native'
+
+import { ThumbnailPlaceholder } from 'ui/components/InfoHeader/ThumbnailPlaceHolder'
+import { TypoDS, getSpacing } from 'ui/theme'
+
+type InfoHeaderProps = PropsWithChildren<{
+  title: string
+  defaultThumbnailSize: number
+  subtitle?: string
+  thumbnailComponent?: ReactNode
+  rightComponent?: ReactNode
+}>
+
+export const InfoHeader: FunctionComponent<InfoHeaderProps> = ({
+  title,
+  subtitle,
+  rightComponent,
+  defaultThumbnailSize,
+  thumbnailComponent,
+  children,
+}) => (
+  <StyledView>
+    {thumbnailComponent ? (
+      thumbnailComponent
+    ) : (
+      <ThumbnailPlaceholder
+        width={defaultThumbnailSize}
+        height={defaultThumbnailSize}
+        testID="VenuePreviewPlaceholder"
+      />
+    )}
+    <RightContainer>
+      {children}
+      <TitleContainer>
+        <Title>{title}</Title>
+        {rightComponent ? rightComponent : null}
+      </TitleContainer>
+      {subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
+    </RightContainer>
+  </StyledView>
+)
+
+const StyledView = styled.View({
+  flexShrink: 1,
+  flexDirection: 'row',
+  columnGap: getSpacing(2),
+})
+
+const RightContainer = styled.View({
+  flexShrink: 1,
+  justifyContent: 'center',
+})
+
+const TitleContainer = styled.View({
+  flexDirection: 'row',
+  alignItems: 'center',
+  columnGap: getSpacing(1),
+})
+
+const Title = styled(TypoDS.BodyAccent).attrs({ numberOfLines: 1 })({
+  flexShrink: 1,
+})
+
+const Subtitle = styled(TypoDS.BodyAccentXs).attrs({ numberOfLines: 2 })(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/ui/components/InfoHeader/ThumbnailPlaceHolder.tsx
+++ b/src/ui/components/InfoHeader/ThumbnailPlaceHolder.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { ViewProps } from 'react-native'
+import LinearGradient from 'react-native-linear-gradient'
+import styled from 'styled-components/native'
+
+import { All } from 'ui/svg/icons/bicolor/All'
+
+const ThumbnailPlaceholderContainer = styled(LinearGradient).attrs(({ theme }) => ({
+  colors: [theme.colors.greyLight, theme.colors.greyMedium],
+}))<{ height: number; width: number }>(({ theme, height, width }) => ({
+  borderRadius: theme.borderRadius.radius,
+  height,
+  width,
+  alignItems: 'center',
+  justifyContent: 'center',
+}))
+
+const ThumbnailPlaceholderIcon = styled(All).attrs(({ theme }) => ({
+  size: theme.icons.sizes.standard,
+  color: theme.colors.greyMedium,
+}))``
+
+type ThumbnailPlaceholderProps = ViewProps & {
+  height: number
+  width: number
+}
+
+export const ThumbnailPlaceholder = ({ height, width, ...props }: ThumbnailPlaceholderProps) => (
+  <ThumbnailPlaceholderContainer height={height} width={width} {...props}>
+    <ThumbnailPlaceholderIcon />
+  </ThumbnailPlaceholderContainer>
+)

--- a/src/ui/components/VenueInfoHeader/VenueInfoHeader.native.test.tsx
+++ b/src/ui/components/VenueInfoHeader/VenueInfoHeader.native.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react'
+
+import { render, screen } from 'tests/utils'
+import { VenueInfoHeader } from 'ui/components/VenueInfoHeader/VenueInfoHeader'
+
+const VENUE_THUMBNAIL_SIZE = 48
+
+describe('<VenueInfoHeader />', () => {
+  it('should display venue name', () => {
+    render(
+      <VenueInfoHeader
+        title="PATHE BEAUGRENELLE"
+        showArrow={false}
+        imageURL="https://example.com/image.jpg"
+        imageSize={VENUE_THUMBNAIL_SIZE}
+      />
+    )
+
+    expect(screen.getByText('PATHE BEAUGRENELLE')).toBeOnTheScreen()
+  })
+
+  it('should display venue subtitle', () => {
+    render(
+      <VenueInfoHeader
+        title="PATHE BEAUGRENELLE"
+        subtitle="Paris, France"
+        showArrow={false}
+        imageURL="https://example.com/image.jpg"
+        imageSize={VENUE_THUMBNAIL_SIZE}
+      />
+    )
+
+    expect(screen.getByText('Paris, France')).toBeOnTheScreen()
+  })
+
+  it('should display image when imageURL is provided', () => {
+    render(
+      <VenueInfoHeader
+        title="PATHE BEAUGRENELLE"
+        subtitle="Paris, France"
+        showArrow={false}
+        imageURL="https://example.com/image.jpg"
+        imageSize={VENUE_THUMBNAIL_SIZE}
+      />
+    )
+
+    expect(screen.getByTestId('VenuePreviewImage')).toBeOnTheScreen()
+  })
+
+  it('should not display image when imageURL is not provided', () => {
+    render(
+      <VenueInfoHeader
+        title="PATHE BEAUGRENELLE"
+        subtitle="Paris, France"
+        showArrow={false}
+        imageSize={VENUE_THUMBNAIL_SIZE}
+      />
+    )
+
+    expect(screen.queryByTestId('VenuePreviewImage')).not.toBeOnTheScreen()
+    expect(screen.getByTestId('VenuePreviewPlaceholder')).toBeOnTheScreen()
+  })
+
+  it('should display arrow when showArrow is true', () => {
+    render(
+      <VenueInfoHeader
+        title="PATHE BEAUGRENELLE"
+        subtitle="Paris, France"
+        showArrow
+        imageURL="https://example.com/image.jpg"
+        imageSize={VENUE_THUMBNAIL_SIZE}
+      />
+    )
+
+    expect(screen.getByTestId('RightFilled')).toBeOnTheScreen()
+  })
+
+  it('should not display arrow when showArrow is false', () => {
+    render(
+      <VenueInfoHeader
+        title="PATHE BEAUGRENELLE"
+        subtitle="Paris, France"
+        showArrow={false}
+        imageURL="https://example.com/image.jpg"
+        imageSize={VENUE_THUMBNAIL_SIZE}
+      />
+    )
+
+    expect(screen.queryByTestId('RightFilled')).not.toBeOnTheScreen()
+  })
+})

--- a/src/ui/components/VenueInfoHeader/VenueInfoHeader.tsx
+++ b/src/ui/components/VenueInfoHeader/VenueInfoHeader.tsx
@@ -1,0 +1,50 @@
+import React, { FunctionComponent } from 'react'
+import styled, { useTheme } from 'styled-components/native'
+
+import { Image } from 'libs/resizing-image-on-demand/Image'
+import { InfoHeader } from 'ui/components/InfoHeader/InfoHeader'
+import { RightFilled } from 'ui/svg/icons/RightFilled'
+
+type VenueInfoHeaderProps = {
+  title: string
+  imageSize: number
+  subtitle?: string
+  showArrow?: boolean
+  imageURL?: string
+}
+
+export const VenueInfoHeader: FunctionComponent<VenueInfoHeaderProps> = ({
+  title,
+  imageSize,
+  subtitle,
+  showArrow = false,
+  imageURL,
+}) => {
+  const theme = useTheme()
+  return (
+    <InfoHeader
+      title={title}
+      subtitle={subtitle}
+      rightComponent={
+        showArrow ? <RightFilled size={theme.icons.sizes.extraSmall} testID="RightFilled" /> : null
+      }
+      thumbnailComponent={
+        imageURL ? (
+          <VenueThumbnail
+            url={imageURL}
+            height={imageSize}
+            width={imageSize}
+            testID="VenuePreviewImage"
+          />
+        ) : null
+      }
+      defaultThumbnailSize={imageSize}
+    />
+  )
+}
+
+const VenueThumbnail = styled(Image)<{ height: number; width: number }>(({ height, width }) => ({
+  borderRadius: 4,
+  height,
+  width,
+}))

--- a/src/ui/components/VenuePreview/VenuePreview.tsx
+++ b/src/ui/components/VenuePreview/VenuePreview.tsx
@@ -17,6 +17,7 @@ type Props = PropsWithChildren<{
   imageWidth: number
 }>
 
+// TODO(PC-00000): remove with VenueListModule
 export const VenuePreview: FunctionComponent<Props> = ({
   address,
   bannerUrl,


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33886

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

![Capture d’écran 2025-01-10 à 12 10 19](https://github.com/user-attachments/assets/1125a883-2605-46be-8838-bf8170d32422)

![Capture d’écran 2025-01-10 à 12 10 31](https://github.com/user-attachments/assets/d4fb7547-2188-4a71-82de-6f756292a909)

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
