### PR TITLE
(PC-33887) feat(ChronicleCard): add new component ChronicleCard

### DIFF
--- a/scripts/dead_code_snapshot.txt
+++ b/scripts/dead_code_snapshot.txt
@@ -4,3 +4,4 @@ src/features/venueMap/constant.ts:22 - Record
 src/ui/theme/constants.ts:25 - AVATAR_MEDIUM
 src/features/auth/helpers/contactSupport.ts:38 - satisfies
 src/features/auth/helpers/contactSupport.ts:38 - ContactSupport (used in module)
+src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx:19 - ChronicleCard

--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.stories.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.stories.tsx
@@ -1,0 +1,33 @@
+import { ComponentMeta } from '@storybook/react'
+import React from 'react'
+
+import { ChronicleCard } from 'features/chronicle/components/ChronicleCard/ChronicleCard'
+import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storybook/VariantsTemplate'
+
+const meta: ComponentMeta<typeof ChronicleCard> = {
+  title: 'ui/ChronicleCard',
+  component: ChronicleCard,
+}
+export default meta
+
+const baseProps = {
+  title: 'Olivier, 15 ans',
+  subtitle: 'Membre du book club',
+  description:
+    'Pour moi, cette biographie n’est pas comme une autre. Cela concerne le créateur de Star Wars, le premier film...',
+  date: 'Juin 2024',
+}
+
+const variantConfig: Variants<typeof ChronicleCard> = [
+  {
+    label: 'ChronicleCard default',
+    props: { ...baseProps },
+  },
+]
+
+const Template: VariantsStory<typeof ChronicleCard> = (args) => (
+  <VariantsTemplate variants={variantConfig} Component={ChronicleCard} defaultProps={args} />
+)
+
+export const AllVariants = Template.bind({})
+AllVariants.storyName = 'ChronicleCard'

--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
@@ -55,5 +55,5 @@ const Description = styled(TypoDS.BodyAccentS)(({ theme }) => ({
 }))
 
 const PublicationDate = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
-  color: theme.colors.greySemiDark,
+  color: theme.colors.greyDark,
 }))

--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
@@ -1,0 +1,59 @@
+import React, { FunctionComponent } from 'react'
+import styled from 'styled-components/native'
+
+import { InfoHeader } from 'ui/components/InfoHeader/InfoHeader'
+import { Separator } from 'ui/components/Separator'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { BookClubCertification } from 'ui/svg/BookClubCertification'
+import { TypoDS, getShadow, getSpacing } from 'ui/theme'
+
+const CHRONICLE_THUMBNAIL_SIZE = getSpacing(14)
+
+type ChronicleCardProps = {
+  title: string
+  subtitle: string
+  description: string
+  date: string
+}
+
+export const ChronicleCard: FunctionComponent<ChronicleCardProps> = ({
+  title,
+  subtitle,
+  description,
+  date,
+}) => {
+  return (
+    <Container gap={3}>
+      <InfoHeader
+        title={title}
+        subtitle={subtitle}
+        defaultThumbnailSize={CHRONICLE_THUMBNAIL_SIZE}
+        thumbnailComponent={<BookClubCertification />}
+      />
+      <Separator.Horizontal />
+      <Description>{description}</Description>
+      <PublicationDate>{date}</PublicationDate>
+    </Container>
+  )
+}
+
+const Container = styled(ViewGap)(({ theme }) => ({
+  padding: getSpacing(6),
+  borderRadius: getSpacing(2),
+  border: 1,
+  borderColor: theme.colors.greyMedium,
+  ...getShadow({
+    shadowOffset: { width: 0, height: getSpacing(3) },
+    shadowRadius: getSpacing(12),
+    shadowColor: theme.colors.black,
+    shadowOpacity: 0.15,
+  }),
+}))
+
+const Description = styled(TypoDS.BodyAccentS)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))
+
+const PublicationDate = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greySemiDark,
+}))

--- a/src/ui/components/InfoHeader/InfoHeader.tsx
+++ b/src/ui/components/InfoHeader/InfoHeader.tsx
@@ -42,6 +42,7 @@ export const InfoHeader: FunctionComponent<InfoHeaderProps> = ({
 const StyledView = styled.View({
   flexShrink: 1,
   flexDirection: 'row',
+  alignItems: 'center',
   columnGap: getSpacing(2),
 })
 

--- a/src/ui/svg/BookClubCertification.tsx
+++ b/src/ui/svg/BookClubCertification.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react'
+import { Defs, Path, Stop } from 'react-native-svg'
+import styled from 'styled-components/native'
+
+import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
+import { AccessibleIcon } from 'ui/svg/icons/types'
+
+const BookClubCertificationSvg: React.FunctionComponent<AccessibleIcon> = ({
+  size,
+  color,
+  color2,
+  accessibilityLabel,
+  testID,
+}) => {
+  return (
+    <AccessibleSvg
+      width={size}
+      height={size}
+      viewBox="0 0 48 48"
+      fill="none"
+      accessibilityLabel={accessibilityLabel}
+      testID={testID}>
+      <Path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8.8125 24.0314C8.8125 15.6049 15.6875 8.80127 24.0625 8.80127C32.4375 8.80127 39.3125 15.6049 39.3125 24.0314C39.3125 32.458 32.4375 39.2616 24.0625 39.2616C15.6875 39.2616 8.8125 32.458 8.8125 24.0314ZM16.25 30.9352V16.2293C16.25 15.3097 16.9958 14.5648 17.9167 14.5648H18.75V24.5518V26.6324V30.7937H16.875C16.65 30.7937 16.4375 30.8436 16.25 30.9352ZM29.525 32.7577H16.9625C16.5708 32.7577 16.25 32.4789 16.25 32.1335C16.25 31.7882 16.5708 31.5094 16.9625 31.5094H29.9958V32.4872C29.9958 32.5746 29.9792 32.6204 29.9667 32.6412C29.9542 32.662 29.9417 32.6787 29.9167 32.6912C29.8542 32.7286 29.7292 32.7577 29.525 32.7577ZM31.2502 16.9201V15.8132C31.2502 15.1266 30.6877 14.5648 30.0002 14.5648H19.6627V27.4647V30.7937H30.0002V30.7354C30.7168 30.5482 31.2502 29.9073 31.2502 29.1292V19.1422V16.9201ZM26.2502 22.4712H22.9168C22.6877 22.4712 22.5002 22.2839 22.5002 22.0551C22.5002 21.8262 22.6877 21.6389 22.9168 21.6389H26.2502C26.4793 21.6389 26.6668 21.8262 26.6668 22.0551C26.6668 22.2839 26.4793 22.4712 26.2502 22.4712ZM27.9168 20.3906H22.9168C22.6877 20.3906 22.5002 20.2033 22.5002 19.9744C22.5002 19.7456 22.6877 19.5583 22.9168 19.5583H27.9168C28.146 19.5583 28.3335 19.7456 28.3335 19.9744C28.3335 20.2033 28.146 20.3906 27.9168 20.3906Z"
+        fill="url(#paint0_linear_4303_7887)"
+      />
+      <Path
+        d="M45.6875 20.5982L46.9375 16.6034L43.5625 14.1066V9.92458L39.5625 8.61378L38.25 4.61899H34.0625L31.5625 1.24837L27.5625 2.49675L24.0625 0L20.625 2.43433L16.625 1.18596L14.125 4.55657H9.9375L8.625 8.55137L4.625 9.86216V14.0442L1.25 16.541L2.5 20.5358L0 24.0312L2.4375 27.4642L1.1875 31.459L4.5625 33.9558V38.1378L8.5625 39.4486L9.875 43.4434H14.0625L16.5625 46.814L20.5625 45.5657L24 48L27.4375 45.5657L31.4375 46.814L33.9375 43.4434H38.125L39.4375 39.4486L43.4375 38.1378V33.9558L46.8125 31.459L45.5625 27.4642L48 24.0312L45.6875 20.5982ZM24.0625 41.2588C14.5625 41.2588 6.8125 33.5189 6.8125 24.0312C6.8125 14.5436 14.5625 6.80364 24.0625 6.80364C33.5625 6.80364 41.3125 14.5436 41.3125 24.0312C41.3125 33.5189 33.5625 41.2588 24.0625 41.2588Z"
+        fill="url(#paint1_linear_4303_7887)"
+      />
+      <Defs>
+        <linearGradient
+          id="paint0_linear_4303_7887"
+          x1="24.0625"
+          y1="8.80127"
+          x2="24.0625"
+          y2="39.2616"
+          gradientUnits="userSpaceOnUse">
+          <Stop stopColor={color} />
+          <Stop offset="1" stopColor={color2} />
+        </linearGradient>
+        <linearGradient
+          id="paint1_linear_4303_7887"
+          x1="24"
+          y1="0"
+          x2="24"
+          y2="48"
+          gradientUnits="userSpaceOnUse">
+          <Stop stopColor={color} />
+          <Stop offset="1" stopColor={color2} />
+        </linearGradient>
+      </Defs>
+    </AccessibleSvg>
+  )
+}
+
+export const BookClubCertification = styled(BookClubCertificationSvg).attrs(
+  ({ color, color2, size, theme }) => ({
+    color: color ?? theme.colors.skyBlue,
+    color2: color2 ?? theme.colors.skyBlueDark,
+    size: size ?? theme.icons.sizes.standard,
+  })
+)``


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33887

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

![Capture d’écran 2025-01-13 à 16 58 51](https://github.com/user-attachments/assets/4fb74d06-3bbb-4c60-87d3-51827bee779f)



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
