### PR TITLE
(PC-33893) feat(chronicle): add chronicle page + see all chronicles button on offer page

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,7 @@ src/features/auth/                                   @pass-culture/jeunes-activa
 src/features/birthdayNotifications/                  @pass-culture/jeunes-conversion
 src/features/bookings/                               @pass-culture/jeunes-conversion
 src/features/bookOffer/                              @pass-culture/jeunes-conversion
+src/features/chronicle/                              @pass-culture/jeunes-decouverte
 src/features/cookies/                                @pass-culture/jeunes-activation
 src/features/culturalSurvey/                         @pass-culture/jeunes-activation
 src/features/deeplinks/                              @pass-culture/jeunes-decouverte

--- a/src/features/chronicle/components/ChroniclesHeader/ChroniclesHeader.native.test.tsx
+++ b/src/features/chronicle/components/ChroniclesHeader/ChroniclesHeader.native.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { Animated } from 'react-native'
+
+import { ChroniclesHeader } from 'features/chronicle/components/ChroniclesHeader/ChroniclesHeader'
+import * as useGoBack from 'features/navigation/useGoBack'
+import { act, render, screen, userEvent } from 'tests/utils'
+
+jest.unmock('react-native/Libraries/Animated/createAnimatedComponent')
+
+const mockGoBack = jest.fn()
+jest.spyOn(useGoBack, 'useGoBack').mockReturnValue({
+  goBack: mockGoBack,
+  canGoBack: jest.fn(() => true),
+})
+
+const user = userEvent.setup()
+
+jest.useFakeTimers()
+
+describe('<ChroniclesHeader />', () => {
+  it('should goBack when we press on the back button', async () => {
+    renderChroniclesHeader()
+
+    await user.press(screen.getByTestId('animated-icon-back'))
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1)
+  })
+
+  it('should fully display the title at the end of the animation', () => {
+    const { animatedValue } = renderChroniclesHeader()
+
+    expect(screen.getByTestId('chroniclesHeaderName').props.accessibilityHidden).toBeTruthy()
+    expect(screen.getByTestId('chroniclesHeaderName').props.style.opacity).toBe(0)
+
+    act(() => {
+      Animated.timing(animatedValue, { duration: 100, toValue: 1, useNativeDriver: false }).start()
+      jest.advanceTimersByTime(100)
+    })
+
+    expect(screen.getByTestId('chroniclesHeaderName').props.accessibilityHidden).toBe(false)
+    expect(screen.getByTestId('chroniclesHeaderName').props.style.opacity).toBe(1)
+  })
+})
+
+function renderChroniclesHeader() {
+  const animatedValue = new Animated.Value(0)
+  render(
+    <ChroniclesHeader
+      title='Tous les avis de "Mon oeuvre incroyable"'
+      headerTransition={animatedValue}
+    />
+  )
+  return { animatedValue }
+}

--- a/src/features/chronicle/components/ChroniclesHeader/ChroniclesHeader.tsx
+++ b/src/features/chronicle/components/ChroniclesHeader/ChroniclesHeader.tsx
@@ -1,0 +1,27 @@
+import React, { FunctionComponent } from 'react'
+import { Animated } from 'react-native'
+
+import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/helpers'
+import { useGoBack } from 'features/navigation/useGoBack'
+import { ContentHeader } from 'ui/components/headers/ContentHeader'
+import { Spacer } from 'ui/theme'
+
+type Props = {
+  headerTransition: Animated.AnimatedInterpolation<string | number>
+  title: string
+}
+
+export const ChroniclesHeader: FunctionComponent<Props> = ({ headerTransition, title }) => {
+  const { goBack } = useGoBack(...getSearchStackConfig('SearchLanding'))
+
+  return (
+    <ContentHeader
+      headerTitle={title}
+      headerTransition={headerTransition}
+      titleTestID="chroniclesHeaderName"
+      onBackPress={goBack}
+      LeftElement={<Spacer.Row numberOfSpaces={13} />}
+      RightElement={<Spacer.Row numberOfSpaces={13} />}
+    />
+  )
+}

--- a/src/features/chronicle/components/ChroniclesHeader/ChroniclesHeader.tsx
+++ b/src/features/chronicle/components/ChroniclesHeader/ChroniclesHeader.tsx
@@ -4,7 +4,6 @@ import { Animated } from 'react-native'
 import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { ContentHeader } from 'ui/components/headers/ContentHeader'
-import { Spacer } from 'ui/theme'
 
 type Props = {
   headerTransition: Animated.AnimatedInterpolation<string | number>
@@ -20,8 +19,6 @@ export const ChroniclesHeader: FunctionComponent<Props> = ({ headerTransition, t
       headerTransition={headerTransition}
       titleTestID="chroniclesHeaderName"
       onBackPress={goBack}
-      LeftElement={<Spacer.Row numberOfSpaces={13} />}
-      RightElement={<Spacer.Row numberOfSpaces={13} />}
     />
   )
 }

--- a/src/features/chronicle/components/ChroniclesWebMetaHeader/ChroniclesWebMetaHeader.tsx
+++ b/src/features/chronicle/components/ChroniclesWebMetaHeader/ChroniclesWebMetaHeader.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+import { Helmet } from 'libs/react-helmet/Helmet'
+
+import { description } from '../../../../../package.json'
+
+interface Props {
+  title: string
+}
+
+export const ChroniclesWebMetaHeader = ({ title }: Props) => {
+  return (
+    <Helmet>
+      <title>{title + ' | pass Culture'}</title>
+      <meta name="title" content={title} />
+      <meta name="description" content={description} />
+    </Helmet>
+  )
+}

--- a/src/features/chronicle/pages/Chronicles/Chronicles.native.test.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.native.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+import { Chronicles } from 'features/chronicle/pages/Chronicles/Chronicles'
+import { render, screen } from 'tests/utils'
+
+describe('Chronicles', () => {
+  it('should render correctly', () => {
+    render(<Chronicles />)
+
+    expect(screen.getByText('Tous les avis')).toBeOnTheScreen()
+  })
+})

--- a/src/features/chronicle/pages/Chronicles/Chronicles.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.tsx
@@ -1,0 +1,48 @@
+import React, { FunctionComponent, useRef } from 'react'
+import { ScrollView } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import styled, { useTheme } from 'styled-components/native'
+
+import { ChroniclesHeader } from 'features/chronicle/components/ChroniclesHeader/ChroniclesHeader'
+import { ChroniclesWebMetaHeader } from 'features/chronicle/components/ChroniclesWebMetaHeader/ChroniclesWebMetaHeader'
+import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
+import { TypoDS, getSpacing } from 'ui/theme'
+
+export const Chronicles: FunctionComponent = () => {
+  const { headerTransition, onScroll } = useOpacityTransition()
+  const { appBarHeight } = useTheme()
+  const { top } = useSafeAreaInsets()
+  const headerHeight = appBarHeight + top
+
+  const scrollViewRef = useRef<ScrollView>(null)
+
+  const title = 'Tous les avis sur "Mon offre incroyable"'
+
+  return (
+    <React.Fragment>
+      <ChroniclesWebMetaHeader title={title} />
+      <ChroniclesHeader headerTransition={headerTransition} title={title} />
+      <ScrollView
+        scrollEventThrottle={16}
+        bounces={false}
+        ref={scrollViewRef}
+        onScroll={onScroll}
+        contentContainerStyle={{ paddingTop: headerHeight, paddingBottom: getSpacing(10) }}>
+        <ChroniclesContainer gap={6}>
+          <TypoDS.Title2>Tous les avis</TypoDS.Title2>
+          <StyledView />
+        </ChroniclesContainer>
+      </ScrollView>
+    </React.Fragment>
+  )
+}
+
+const ChroniclesContainer = styled(ViewGap)(({ theme }) => ({
+  marginTop: getSpacing(4),
+  marginHorizontal: theme.contentPage.marginHorizontal,
+}))
+
+const StyledView = styled.View({
+  height: 800,
+})

--- a/src/features/navigation/RootNavigator/routes.ts
+++ b/src/features/navigation/RootNavigator/routes.ts
@@ -21,6 +21,7 @@ import { RecreditBirthdayNotification } from 'features/birthdayNotifications/pag
 import { BookingDetails } from 'features/bookings/pages/BookingDetails/BookingDetails'
 import { EndedBookings } from 'features/bookings/pages/EndedBookings/EndedBookings'
 import { BookingConfirmation } from 'features/bookOffer/pages/BookingConfirmation'
+import { Chronicles } from 'features/chronicle/pages/Chronicles/Chronicles'
 import { withAsyncErrorBoundary } from 'features/errors/hocs/withAsyncErrorBoundary'
 import { BannedCountryError } from 'features/errors/pages/BannedCountryError'
 import { FavoritesSorts } from 'features/favorites/pages/FavoritesSorts'
@@ -535,5 +536,15 @@ export const routes: RootRoute[] = [
     name: 'Achievements',
     component: Achievements,
     path: 'profile/achievements',
+  },
+  {
+    name: 'Chronicles',
+    component: Chronicles,
+    pathConfig: {
+      path: 'avis-du-book-club/:offerId/:chronicleId',
+      deeplinkPaths: ['chronicles/:offerId/:chronicleId'],
+      parse: screenParamsParser['Chronicles'],
+    },
+    options: { title: 'Avis du book club' },
   },
 ]

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -205,6 +205,7 @@ export type RootStackParamList = {
   ConfirmChangeEmail: { token: string; expiration_timestamp: number }
   ConfirmDeleteProfile: undefined
   ConsentSettings: { onGoBack?: () => void } | undefined
+  Chronicles: { offerId: number; chronicleId?: number }
   CulturalSurvey: undefined
   DeactivateProfileSuccess: undefined
   DeeplinksGenerator: undefined

--- a/src/features/navigation/screenParamsUtils.ts
+++ b/src/features/navigation/screenParamsUtils.ts
@@ -7,6 +7,7 @@ type ScreensRequiringParsing = Extract<
   | 'AfterSignupEmailValidationBuffer'
   | 'BookingDetails'
   | 'BookingConfirmation'
+  | 'Chronicles'
   | 'Home'
   | 'Login'
   | 'Offer'
@@ -94,7 +95,10 @@ export const screenParamsParser: ParamsParsers = {
     bookingId: Number,
     apiRecoParams: identityFn,
   },
-
+  Chronicles: {
+    offerId: Number,
+    chronicleId: Number,
+  },
   Login: {
     displayForcedLoginHelpMessage: parseObject,
     offerId: identityFn,

--- a/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.native.test.tsx
@@ -80,6 +80,7 @@ describe('<OfferBody />', () => {
       RemoteStoreFeatureFlags.WIP_REACTION_FEATURE,
       RemoteStoreFeatureFlags.WIP_REACTION_FAKE_DOOR,
       RemoteStoreFeatureFlags.WIP_CINEMA_OFFER_VENUE_BLOCK,
+      RemoteStoreFeatureFlags.WIP_OFFER_CHRONICLE_SECTION,
     ])
   })
 
@@ -606,6 +607,40 @@ describe('<OfferBody />', () => {
     await user.press(await screen.findByText('Stephen King'))
 
     expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  describe('Chronicles section', () => {
+    it('should display "Voir tous les avis" button when wipOfferChronicleSection feature flag activated and viewport is not desktop', async () => {
+      renderOfferBody({})
+
+      expect(await screen.findByText('Voir tous les avis')).toBeOnTheScreen()
+    })
+
+    it('should not display "Voir tous les avis" button when wipOfferChronicleSection feature flag activated and viewport is desktop', async () => {
+      renderOfferBody({ isDesktopViewport: true })
+
+      await screen.findByText(offerResponseSnap.name)
+
+      expect(screen.queryByText('Voir tous les avis')).not.toBeOnTheScreen()
+    })
+
+    it('should not display "Voir tous les avis" button when wipOfferChronicleSection feature flag deactivated', async () => {
+      setFeatureFlags()
+
+      renderOfferBody({})
+
+      await screen.findByText(offerResponseSnap.name)
+
+      expect(screen.queryByText('Voir tous les avis')).not.toBeOnTheScreen()
+    })
+
+    it('should navigate to chronicles page when pressing "Voir tous les avis" button', async () => {
+      renderOfferBody({})
+
+      await user.press(await screen.findByText('Voir tous les avis'))
+
+      expect(mockNavigate).toHaveBeenNthCalledWith(1, 'Chronicles', { offerId: 116656 })
+    })
   })
 })
 

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -30,6 +30,7 @@ import { getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
 import { Subcategory } from 'libs/subcategories/types'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { isNullOrUndefined } from 'shared/isNullOrUndefined/isNullOrUndefined'
+import { ButtonSecondaryBlack } from 'ui/components/buttons/ButtonSecondaryBlack'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
 import { Separator } from 'ui/components/Separator'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
@@ -52,6 +53,9 @@ export const OfferBody: FunctionComponent<Props> = ({
   const { navigate } = useNavigation<UseNavigationType>()
 
   const hasArtistPage = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ARTIST_PAGE)
+  const hasOfferChronicleSection = useFeatureFlag(
+    RemoteStoreFeatureFlags.WIP_OFFER_CHRONICLE_SECTION
+  )
 
   const { user } = useAuthContext()
   const currency = useGetCurrencyToDisplay()
@@ -106,6 +110,10 @@ export const OfferBody: FunctionComponent<Props> = ({
     navigate('Artist', { fromOfferId: offer.id })
   }
 
+  const handleSeeChroniclesPress = () => {
+    navigate('Chronicles', { offerId: offer.id })
+  }
+
   return (
     <Container>
       <MarginContainer gap={6}>
@@ -156,6 +164,12 @@ export const OfferBody: FunctionComponent<Props> = ({
       ) : null}
 
       <OfferPlace offer={offer} subcategory={subcategory} />
+
+      {hasOfferChronicleSection && !isDesktopViewport ? (
+        <SectionWithDivider visible margin gap={8}>
+          <ButtonSecondaryBlack wording="Voir tous les avis" onPress={handleSeeChroniclesPress} />
+        </SectionWithDivider>
+      ) : null}
 
       {isDesktopViewport ? (
         <View testID="messagingApp-container-without-divider">

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -33,6 +33,7 @@ import { isNullOrUndefined } from 'shared/isNullOrUndefined/isNullOrUndefined'
 import { ButtonSecondaryBlack } from 'ui/components/buttons/ButtonSecondaryBlack'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
 import { Separator } from 'ui/components/Separator'
+import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { InformationTags } from 'ui/InformationTags/InformationTags'
 import { getSpacing, Spacer, TypoDS } from 'ui/theme'
@@ -110,10 +111,6 @@ export const OfferBody: FunctionComponent<Props> = ({
     navigate('Artist', { fromOfferId: offer.id })
   }
 
-  const handleSeeChroniclesPress = () => {
-    navigate('Chronicles', { offerId: offer.id })
-  }
-
   return (
     <Container>
       <MarginContainer gap={6}>
@@ -167,7 +164,11 @@ export const OfferBody: FunctionComponent<Props> = ({
 
       {hasOfferChronicleSection && !isDesktopViewport ? (
         <SectionWithDivider visible margin gap={8}>
-          <ButtonSecondaryBlack wording="Voir tous les avis" onPress={handleSeeChroniclesPress} />
+          <InternalTouchableLink
+            as={ButtonSecondaryBlack}
+            wording="Voir tous les avis"
+            navigateTo={{ screen: 'Chronicles', params: { offerId: offer.id } }}
+          />
         </SectionWithDivider>
       ) : null}
 

--- a/src/libs/firebase/firestore/types.ts
+++ b/src/libs/firebase/firestore/types.ts
@@ -64,6 +64,7 @@ export enum RemoteStoreFeatureFlags {
   WIP_NEW_HIGHLIGHT_THEMATIC_MODULE = 'wipNewHighlightThematicModule',
   WIP_NEW_HOME_MODULE_SIZES = 'wipNewHomeModuleSizes',
   WIP_NEW_OFFER_TILE = 'wipNewOfferTile',
+  WIP_OFFER_CHRONICLE_SECTION = 'wipOfferChronicleSection',
   WIP_OFFERS_IN_BOTTOM_SHEET = 'wipOffersInBottomSheet',
   WIP_PAGE_SEARCH_N1 = 'wipPageSearchN1',
   WIP_REACTION_FAKE_DOOR = 'wipReactionFakeDoor',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33893

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |![Capture d’écran 2025-01-15 à 11 02 56](https://github.com/user-attachments/assets/ca173897-8caa-453e-9566-e12094fa7fa0)|![Capture d’écran 2025-01-15 à 11 05 20](https://github.com/user-attachments/assets/d11a1604-4e30-4b6c-97ee-acc2ce48897d) ![Capture d’écran 2025-01-15 à 11 05 25](https://github.com/user-attachments/assets/98939730-7195-4a63-8b08-11c2a7f78dea) ![Capture d’écran 2025-01-15 à 11 05 33](https://github.com/user-attachments/assets/7dc2e72a-d684-4f2f-88e9-199c098fb6d1)|
| Android          |               |![Capture d’écran 2025-01-15 à 10 00 48](https://github.com/user-attachments/assets/40a82c4d-d018-4019-b1b2-0556451c174c) ![Capture d’écran 2025-01-15 à 10 00 56](https://github.com/user-attachments/assets/02e55a81-4a70-4adb-9cee-1f0c67bcceb3) ![Capture d’écran 2025-01-15 à 10 01 07](https://github.com/user-attachments/assets/fd8fb2fd-e982-4e08-bd96-6ddf6555db00)|
| Phone - Chrome   |               |![Capture d’écran 2025-01-15 à 11 08 23](https://github.com/user-attachments/assets/3d2ca5bf-1439-4397-a518-d93f78cf5ee6) ![Capture d’écran 2025-01-15 à 11 08 29](https://github.com/user-attachments/assets/02abfe85-9685-4d52-aba4-1d3c162d1cff) ![Capture d’écran 2025-01-15 à 11 08 37](https://github.com/user-attachments/assets/e0fadfdf-d773-4306-845c-a5a6ce426fbf)|
| Desktop - Chrome |               |<img width="1722" alt="Capture d’écran 2025-01-15 à 12 15 35" src="https://github.com/user-attachments/assets/8e26eef2-4894-4af9-aece-58a8ad704dc2" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
