### PR TITLE
(BSR) feat(Zustand): Simplify selectors

### DIFF
--- a/src/features/identityCheck/pages/profile/store/addressStore.ts
+++ b/src/features/identityCheck/pages/profile/store/addressStore.ts
@@ -13,9 +13,12 @@ const addressStore = createStore({
     setAddress: (address: string) => set({ address }),
     resetAddress: () => set(defaultState),
   }),
+  selectors: {
+    selectAddress: () => (state) => state.address,
+  },
   options: { persist: true },
 })
 
 export const addressActions = addressStore.actions
 
-export const useAddress = () => addressStore.useStore((state) => state.address)
+export const { useAddress } = addressStore.hooks

--- a/src/features/identityCheck/pages/profile/store/cityStore.ts
+++ b/src/features/identityCheck/pages/profile/store/cityStore.ts
@@ -12,12 +12,13 @@ const cityStore = createStore({
     setCity: (city: SuggestedCity) => set({ city }),
     resetCity: () => set(defaultState),
   }),
+  selectors: {
+    selectCity: () => (state) => state.city,
+  },
   options: {
     persist: true,
   },
 })
 
-const useCityStore = cityStore.useStore
 export const cityActions = cityStore.actions
-
-export const useCity = () => useCityStore((state) => state.city)
+export const { useCity } = cityStore.hooks

--- a/src/features/identityCheck/pages/profile/store/nameStore.ts
+++ b/src/features/identityCheck/pages/profile/store/nameStore.ts
@@ -16,8 +16,11 @@ const nameStore = createStore({
     setName: (name: Name) => set({ name }),
     resetName: () => set(defaultState),
   }),
+  selectors: {
+    selectName: () => (state) => state.name,
+  },
   options: { persist: true },
 })
 
 export const nameActions = nameStore.actions
-export const useName = () => nameStore.useStore((state) => state.name)
+export const { useName } = nameStore.hooks

--- a/src/features/venueMap/store/initialVenuesStore.ts
+++ b/src/features/venueMap/store/initialVenuesStore.ts
@@ -13,10 +13,12 @@ const initialVenuesStore = createStore({
   actions: (set) => ({
     setInitialVenues: (initialVenues: Venue[]) => set({ initialVenues }),
   }),
+  selectors: {
+    selectInitialVenues: () => (state) => state.initialVenues,
+  },
   options: { persist: true },
 })
 
-const useInitialVenuesStore = initialVenuesStore.useStore
 export const initialVenuesActions = initialVenuesStore.actions
 
-export const useInitialVenues = () => useInitialVenuesStore((state) => state.initialVenues)
+export const { useInitialVenues } = initialVenuesStore.hooks

--- a/src/features/venueMap/store/selectedVenueStore.ts
+++ b/src/features/venueMap/store/selectedVenueStore.ts
@@ -14,8 +14,11 @@ const selectedVenueStore = createStore({
     setSelectedVenue: (selectedVenue: GeolocatedVenue) => set({ selectedVenue }),
     removeSelectedVenue: () => set(defaultState),
   }),
+  selectors: {
+    selectSelectedVenue: () => (state) => state.selectedVenue,
+  },
 })
 
 export const selectedVenueActions = selectedVenueStore.actions
 
-export const useSelectedVenue = () => selectedVenueStore.useStore((state) => state.selectedVenue)
+export const { useSelectedVenue } = selectedVenueStore.hooks

--- a/src/features/venueMap/store/venueTypeCodeStore.ts
+++ b/src/features/venueMap/store/venueTypeCodeStore.ts
@@ -13,7 +13,10 @@ const venueTypeCodeStore = createStore({
   actions: (set) => ({
     setVenueTypeCode: (venueTypeCode: VenueTypeCode | null) => set({ venueTypeCode }),
   }),
+  selectors: {
+    selectVenueTypeCode: () => (state) => state.venueTypeCode,
+  },
 })
 
 export const venueTypeCodeActions = venueTypeCodeStore.actions
-export const useVenueTypeCode = () => venueTypeCodeStore.useStore((state) => state.venueTypeCode)
+export const { useVenueTypeCode } = venueTypeCodeStore.hooks

--- a/src/features/venueMap/store/venuesFilterStore.ts
+++ b/src/features/venueMap/store/venuesFilterStore.ts
@@ -26,8 +26,11 @@ const venuesFilterStore = createStore({
       })),
     reset: () => set((_) => ({ venuesFilters: [] })),
   }),
+  selectors: {
+    selectVenuesFilter: () => (state) => state.venuesFilters,
+  },
 })
 
 export const venuesFilterActions = venuesFilterStore.actions
 
-export const useVenuesFilter = () => venuesFilterStore.useStore((state) => state.venuesFilters)
+export const { useVenuesFilter } = venuesFilterStore.hooks

--- a/src/features/venueMap/store/venuesStore.ts
+++ b/src/features/venueMap/store/venuesStore.ts
@@ -13,7 +13,10 @@ const venuesStore = createStore({
   actions: (set) => ({
     setVenues: (venues: Venue[]) => set({ venues }),
   }),
+  selectors: {
+    selectVenues: () => (state) => state.venues,
+  },
 })
 
 export const venuesActions = venuesStore.actions
-export const useVenues = () => venuesStore.useStore((state) => state.venues)
+export const { useVenues } = venuesStore.hooks

--- a/src/libs/store/createStore.ts
+++ b/src/libs/store/createStore.ts
@@ -35,11 +35,6 @@ export function createStore<
 
   const actions = createActions(store.setState)
 
-  const select = <T>(selector: (state: State) => T): T => {
-    const state = store.getState()
-    return selector(state)
-  }
-
   const selectorsWithState = Object.entries(selectors).reduce(
     (acc, [key, selector]) => ({
       ...acc,
@@ -72,7 +67,6 @@ export function createStore<
     useStore: store,
     actions,
     selectors: selectorsWithState,
-    select,
     hooks,
   }
 }

--- a/src/libs/store/createStore.ts
+++ b/src/libs/store/createStore.ts
@@ -64,10 +64,10 @@ export function createStore<
   )
 
   return {
-    useStore: store,
+    store,
     actions,
     selectors: selectorsWithState,
-    hooks,
+    hooks: { useStore: store, ...hooks },
   }
 }
 

--- a/src/libs/store/createStore.ts
+++ b/src/libs/store/createStore.ts
@@ -34,10 +34,25 @@ export function createStore<
     return selector(state)
   }
 
+  const selectorsWithState = Object.entries(selectors).reduce(
+    (acc, [key, selector]) => ({
+      ...acc,
+      [key]: (...args: Parameters<typeof selector>) => {
+        const state = store.getState()
+        return selector(...args)(state)
+      },
+    }),
+    {} as {
+      [K in keyof Selectors]: (
+        ...args: Parameters<Selectors[K]>
+      ) => ReturnType<ReturnType<Selectors[K]>>
+    }
+  )
+
   return {
     useStore: store,
     actions,
-    selectors,
+    selectors: selectorsWithState,
     select,
   }
 }

--- a/src/libs/store/store.types.ts
+++ b/src/libs/store/store.types.ts
@@ -5,6 +5,7 @@ export type CurriedAnyFunction<State> = (...args: never[]) => (state: State) => 
 type Options = {
   persist?: boolean
 }
+export type ReplaceSelectByUse<T extends string> = T extends `select${infer U}` ? `use${U}` : never
 type StoreType<State> = UseBoundStore<StoreApi<State>>
 export type StoreConfig<
   State,
@@ -32,6 +33,15 @@ export type Store<
 > = {
   useStore: UseBoundStore<StoreApi<State>>
   actions: Actions
-  selectors: SelectorsWithState<State, Selectors>
+  selectors: {
+    [K in keyof Selectors]: (
+      ...args: Parameters<Selectors[K]>
+    ) => ReturnType<ReturnType<Selectors[K]>>
+  }
   select: <T>(selector: (state: State) => T) => T
+  hooks: {
+    [K in keyof Selectors as ReplaceSelectByUse<string & K>]: (
+      ...args: Parameters<Selectors[K]>
+    ) => ReturnType<ReturnType<Selectors[K]>>
+  }
 }

--- a/src/libs/store/store.types.ts
+++ b/src/libs/store/store.types.ts
@@ -1,7 +1,7 @@
 import { StoreApi, UseBoundStore } from 'zustand'
 
-export type AnyFunction = (...args: never) => unknown
-export type CurriedAnyFunction<State> = (...args: never) => (state: State) => unknown
+export type AnyFunction = (...args: never[]) => unknown
+export type CurriedAnyFunction<State> = (...args: never[]) => (state: State) => unknown
 type Options = {
   persist?: boolean
 }
@@ -17,6 +17,14 @@ export type StoreConfig<
   selectors?: Selectors
   options?: Options
 }
+export type SelectorsWithState<
+  State,
+  Selectors extends Record<string, CurriedAnyFunction<State>>,
+> = {
+  [K in keyof Selectors]: (
+    ...args: Parameters<Selectors[K]>
+  ) => ReturnType<ReturnType<Selectors[K]>>
+}
 export type Store<
   State,
   Actions extends Record<string, AnyFunction>,
@@ -24,6 +32,6 @@ export type Store<
 > = {
   useStore: UseBoundStore<StoreApi<State>>
   actions: Actions
-  selectors: Selectors
+  selectors: SelectorsWithState<State, Selectors>
   select: <T>(selector: (state: State) => T) => T
 }

--- a/src/libs/store/store.types.ts
+++ b/src/libs/store/store.types.ts
@@ -38,7 +38,6 @@ export type Store<
       ...args: Parameters<Selectors[K]>
     ) => ReturnType<ReturnType<Selectors[K]>>
   }
-  select: <T>(selector: (state: State) => T) => T
   hooks: {
     [K in keyof Selectors as ReplaceSelectByUse<string & K>]: (
       ...args: Parameters<Selectors[K]>

--- a/src/libs/store/store.types.ts
+++ b/src/libs/store/store.types.ts
@@ -6,7 +6,7 @@ export type CurriedAnyFunction<State> = (...args: never[]) => (state: State) => 
 type Options = {
   persist?: boolean
 }
-export type ReplaceSelectByUse<T extends string> = T extends `select${infer U}` ? `use${U}` : never
+type ReplaceSelectByUse<T extends string> = T extends `select${infer U}` ? `use${U}` : never
 type StoreType<State> = UseBoundStore<StoreApi<State>>
 
 export type StoreConfig<
@@ -16,18 +16,21 @@ export type StoreConfig<
 > = {
   name: string
   defaultState: State
-  actions?: (setState: StoreType<State>['setState']) => Actions
+  actions: (setState: StoreType<State>['setState']) => Actions
   selectors?: Selectors
   options?: Options
 }
 
-type SelectorsWithState<State, Selectors extends Record<string, CurriedAnyFunction<State>>> = {
+export type SelectorsWithState<
+  State,
+  Selectors extends Record<string, CurriedAnyFunction<State>>,
+> = {
   [K in keyof Selectors]: (
     ...args: Parameters<Selectors[K]>
   ) => ReturnType<ReturnType<Selectors[K]>>
 }
 
-type HookSelectors<State, Selectors extends Record<string, CurriedAnyFunction<State>>> = {
+export type HookSelectors<State, Selectors extends Record<string, CurriedAnyFunction<State>>> = {
   [K in keyof Selectors as ReplaceSelectByUse<string & K>]: (
     ...args: Parameters<Selectors[K]>
   ) => ReturnType<ReturnType<Selectors[K]>>

--- a/src/libs/store/store.types.ts
+++ b/src/libs/store/store.types.ts
@@ -10,7 +10,7 @@ type StoreType<State> = UseBoundStore<StoreApi<State>>
 export type StoreConfig<
   State,
   Actions extends Record<string, AnyFunction>,
-  Selectors extends Record<string, CurriedAnyFunction<State>>,
+  Selectors extends Record<`select${string}`, CurriedAnyFunction<State>>,
 > = {
   name: string
   defaultState: State

--- a/src/libs/store/store.types.ts
+++ b/src/libs/store/store.types.ts
@@ -1,12 +1,14 @@
 import { StoreApi, UseBoundStore } from 'zustand'
 
 export type AnyFunction = (...args: never[]) => unknown
+
 export type CurriedAnyFunction<State> = (...args: never[]) => (state: State) => unknown
 type Options = {
   persist?: boolean
 }
 export type ReplaceSelectByUse<T extends string> = T extends `select${infer U}` ? `use${U}` : never
 type StoreType<State> = UseBoundStore<StoreApi<State>>
+
 export type StoreConfig<
   State,
   Actions extends Record<string, AnyFunction>,
@@ -18,29 +20,26 @@ export type StoreConfig<
   selectors?: Selectors
   options?: Options
 }
-export type SelectorsWithState<
-  State,
-  Selectors extends Record<string, CurriedAnyFunction<State>>,
-> = {
+
+type SelectorsWithState<State, Selectors extends Record<string, CurriedAnyFunction<State>>> = {
   [K in keyof Selectors]: (
     ...args: Parameters<Selectors[K]>
   ) => ReturnType<ReturnType<Selectors[K]>>
 }
+
+type HookSelectors<State, Selectors extends Record<string, CurriedAnyFunction<State>>> = {
+  [K in keyof Selectors as ReplaceSelectByUse<string & K>]: (
+    ...args: Parameters<Selectors[K]>
+  ) => ReturnType<ReturnType<Selectors[K]>>
+}
+
 export type Store<
   State,
   Actions extends Record<string, AnyFunction>,
   Selectors extends Record<string, CurriedAnyFunction<State>>,
 > = {
-  useStore: UseBoundStore<StoreApi<State>>
+  store: StoreType<State>
   actions: Actions
-  selectors: {
-    [K in keyof Selectors]: (
-      ...args: Parameters<Selectors[K]>
-    ) => ReturnType<ReturnType<Selectors[K]>>
-  }
-  hooks: {
-    [K in keyof Selectors as ReplaceSelectByUse<string & K>]: (
-      ...args: Parameters<Selectors[K]>
-    ) => ReturnType<ReturnType<Selectors[K]>>
-  }
+  selectors: SelectorsWithState<State, Selectors>
+  hooks: { useStore: StoreType<State> } & HookSelectors<State, Selectors>
 }


### PR DESCRIPTION
L'objectif de cette PR est de simplifier l'utilisation des selecteurs

Dans une fonction typescript:
```diff
const { select, selectors } = cityStore

- select(selectors.selectCity())
+ selectors.selectCity()
```

Dans un hook:
```diff
const { selectors, useStore, hooks } = cityStore

- useStore(selectors.selectCity())
+ hooks.useCity()
```

Ainsi nous pouvons écrire des tests métiers complètement découplés de React quand cela est possible et avoir des hooks auto-générés à partir des selecteurs côté React

