### PR TITLE
(PC-34012) fix(ui): 2 lines title on iOS in ContentHeader + improvements

### DIFF
--- a/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
@@ -1134,38 +1134,19 @@ exports[`BookingDetails should render correctly 1`] = `
       />
     </View>
     <View
-      numberOfSpaces={2}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
-    <View
+      marginRight={64}
       style={
         [
           {
             "alignItems": "center",
-            "flexBasis": 0,
             "flexDirection": "row",
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "marginLeft": 24,
+            "marginRight": 64,
+            "marginVertical": 8,
           },
         ]
       }
     >
-      <View
-        numberOfSpaces={6}
-        style={
-          [
-            {
-              "width": 24,
-            },
-          ]
-        }
-      />
       <View
         accessibilityLabel="Revenir en arrière"
         accessibilityRole="button"
@@ -1328,27 +1309,7 @@ exports[`BookingDetails should render correctly 1`] = `
           ]
         }
       />
-      <View
-        numberOfSpaces={16}
-        style={
-          [
-            {
-              "width": 64,
-            },
-          ]
-        }
-      />
     </View>
-    <View
-      numberOfSpaces={2}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
   </View>
   <Modal
     accessibilityLabelledBy="testUuidV4"

--- a/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
@@ -1130,6 +1130,7 @@ exports[`BookingDetails should render correctly 1`] = `
           {
             "alignItems": "center",
             "flexDirection": "row",
+            "justifyContent": "space-between",
             "marginBottom": 8,
             "marginLeft": 24,
             "marginRight": 64,
@@ -1260,46 +1261,36 @@ exports[`BookingDetails should render correctly 1`] = `
             },
           ]
         }
-      />
-      <Text
-        accessibilityHidden={true}
-        collapsable={false}
-        numberOfLines={2}
-        style={
-          {
-            "color": "#ffffff",
-            "flexShrink": 1,
-            "opacity": 0,
-            "textAlign": "center",
-          }
-        }
       >
         <Text
+          accessibilityHidden={true}
+          collapsable={false}
+          numberOfLines={2}
           style={
-            [
-              {
-                "color": "#161617",
-                "fontFamily": "Montserrat-Medium",
-                "fontSize": 16,
-                "lineHeight": 25.6,
-              },
-            ]
+            {
+              "color": "#ffffff",
+              "flexShrink": 1,
+              "opacity": 0,
+              "textAlign": "center",
+            }
           }
         >
-          Avez-vous déjà vu ?
+          <Text
+            style={
+              [
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
+                },
+              ]
+            }
+          >
+            Avez-vous déjà vu ?
+          </Text>
         </Text>
-      </Text>
-      <View
-        style={
-          [
-            {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-          ]
-        }
-      />
+      </View>
     </View>
   </View>
   <Modal

--- a/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
@@ -1089,17 +1089,6 @@ exports[`BookingDetails should render correctly 1`] = `
     }
   >
     <View
-      customHeight={16}
-      enable={true}
-      style={
-        [
-          {
-            "height": 16,
-          },
-        ]
-      }
-    />
-    <View
       collapsable={false}
       height={80}
       style={
@@ -1135,14 +1124,16 @@ exports[`BookingDetails should render correctly 1`] = `
     </View>
     <View
       marginRight={64}
+      marginTop={16}
       style={
         [
           {
             "alignItems": "center",
             "flexDirection": "row",
+            "marginBottom": 8,
             "marginLeft": 24,
             "marginRight": 64,
-            "marginVertical": 8,
+            "marginTop": 16,
           },
         ]
       }

--- a/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
@@ -349,17 +349,6 @@ exports[`ThematicHome should render correctly 1`] = `
     }
   >
     <View
-      customHeight={16}
-      enable={true}
-      style={
-        [
-          {
-            "height": 16,
-          },
-        ]
-      }
-    />
-    <View
       collapsable={false}
       height={80}
       style={
@@ -395,14 +384,16 @@ exports[`ThematicHome should render correctly 1`] = `
     </View>
     <View
       marginRight={24}
+      marginTop={16}
       style={
         [
           {
             "alignItems": "center",
             "flexDirection": "row",
+            "marginBottom": 8,
             "marginLeft": 24,
             "marginRight": 24,
-            "marginVertical": 8,
+            "marginTop": 16,
           },
         ]
       }

--- a/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
@@ -390,6 +390,7 @@ exports[`ThematicHome should render correctly 1`] = `
           {
             "alignItems": "center",
             "flexDirection": "row",
+            "justifyContent": "space-between",
             "marginBottom": 8,
             "marginLeft": 24,
             "marginRight": 24,
@@ -520,46 +521,36 @@ exports[`ThematicHome should render correctly 1`] = `
             },
           ]
         }
-      />
-      <Text
-        accessibilityHidden={true}
-        collapsable={false}
-        numberOfLines={2}
-        style={
-          {
-            "color": "#ffffff",
-            "flexShrink": 1,
-            "opacity": 0,
-            "textAlign": "center",
-          }
-        }
       >
         <Text
+          accessibilityHidden={true}
+          collapsable={false}
+          numberOfLines={2}
           style={
-            [
-              {
-                "color": "#161617",
-                "fontFamily": "Montserrat-Medium",
-                "fontSize": 16,
-                "lineHeight": 25.6,
-              },
-            ]
+            {
+              "color": "#ffffff",
+              "flexShrink": 1,
+              "opacity": 0,
+              "textAlign": "center",
+            }
           }
         >
-          HeaderTitle
+          <Text
+            style={
+              [
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
+                },
+              ]
+            }
+          >
+            HeaderTitle
+          </Text>
         </Text>
-      </Text>
-      <View
-        style={
-          [
-            {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-          ]
-        }
-      />
+      </View>
       <View
         collapsable={false}
         style={

--- a/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/ThematicHome.native.test.tsx.native-snap
@@ -394,38 +394,19 @@ exports[`ThematicHome should render correctly 1`] = `
       />
     </View>
     <View
-      numberOfSpaces={2}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
-    <View
+      marginRight={24}
       style={
         [
           {
             "alignItems": "center",
-            "flexBasis": 0,
             "flexDirection": "row",
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "marginLeft": 24,
+            "marginRight": 24,
+            "marginVertical": 8,
           },
         ]
       }
     >
-      <View
-        numberOfSpaces={6}
-        style={
-          [
-            {
-              "width": 24,
-            },
-          ]
-        }
-      />
       <View
         accessibilityLabel="Revenir en arrière"
         accessibilityRole="button"
@@ -797,27 +778,7 @@ exports[`ThematicHome should render correctly 1`] = `
           />
         </View>
       </View>
-      <View
-        numberOfSpaces={6}
-        style={
-          [
-            {
-              "width": 24,
-            },
-          ]
-        }
-      />
     </View>
-    <View
-      numberOfSpaces={2}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
   </View>
   <View
     collapsable={false}

--- a/__snapshots__/features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation.native.test.tsx.native-snap
@@ -2671,6 +2671,7 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
           {
             "alignItems": "center",
             "flexDirection": "row",
+            "justifyContent": "space-between",
             "marginBottom": 8,
             "marginLeft": 24,
             "marginRight": 64,
@@ -2801,46 +2802,36 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
             },
           ]
         }
-      />
-      <Text
-        accessibilityHidden={true}
-        collapsable={false}
-        numberOfLines={2}
-        style={
-          {
-            "color": "#ffffff",
-            "flexShrink": 1,
-            "opacity": 0,
-            "textAlign": "center",
-          }
-        }
       >
         <Text
+          accessibilityHidden={true}
+          collapsable={false}
+          numberOfLines={2}
           style={
-            [
-              {
-                "color": "#161617",
-                "fontFamily": "Montserrat-Medium",
-                "fontSize": 16,
-                "lineHeight": 25.6,
-              },
-            ]
+            {
+              "color": "#ffffff",
+              "flexShrink": 1,
+              "opacity": 0,
+              "textAlign": "center",
+            }
           }
         >
-          Le pass Culture à 15 ans
+          <Text
+            style={
+              [
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
+                },
+              ]
+            }
+          >
+            Le pass Culture à 15 ans
+          </Text>
         </Text>
-      </Text>
-      <View
-        style={
-          [
-            {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-          ]
-        }
-      />
+      </View>
     </View>
   </View>,
 ]
@@ -5258,6 +5249,7 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
           {
             "alignItems": "center",
             "flexDirection": "row",
+            "justifyContent": "space-between",
             "marginBottom": 8,
             "marginLeft": 24,
             "marginRight": 64,
@@ -5388,46 +5380,36 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
             },
           ]
         }
-      />
-      <Text
-        accessibilityHidden={true}
-        collapsable={false}
-        numberOfLines={2}
-        style={
-          {
-            "color": "#ffffff",
-            "flexShrink": 1,
-            "opacity": 0,
-            "textAlign": "center",
-          }
-        }
       >
         <Text
+          accessibilityHidden={true}
+          collapsable={false}
+          numberOfLines={2}
           style={
-            [
-              {
-                "color": "#161617",
-                "fontFamily": "Montserrat-Medium",
-                "fontSize": 16,
-                "lineHeight": 25.6,
-              },
-            ]
+            {
+              "color": "#ffffff",
+              "flexShrink": 1,
+              "opacity": 0,
+              "textAlign": "center",
+            }
           }
         >
-          Comment ça marche ?
+          <Text
+            style={
+              [
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
+                },
+              ]
+            }
+          >
+            Comment ça marche ?
+          </Text>
         </Text>
-      </Text>
-      <View
-        style={
-          [
-            {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-          ]
-        }
-      />
+      </View>
     </View>
   </View>,
 ]

--- a/__snapshots__/features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation.native.test.tsx.native-snap
@@ -2630,17 +2630,6 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
     }
   >
     <View
-      customHeight={16}
-      enable={true}
-      style={
-        [
-          {
-            "height": 16,
-          },
-        ]
-      }
-    />
-    <View
       collapsable={false}
       height={80}
       style={
@@ -2676,14 +2665,16 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
     </View>
     <View
       marginRight={64}
+      marginTop={16}
       style={
         [
           {
             "alignItems": "center",
             "flexDirection": "row",
+            "marginBottom": 8,
             "marginLeft": 24,
             "marginRight": 64,
-            "marginVertical": 8,
+            "marginTop": 16,
           },
         ]
       }
@@ -5226,17 +5217,6 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
     }
   >
     <View
-      customHeight={16}
-      enable={true}
-      style={
-        [
-          {
-            "height": 16,
-          },
-        ]
-      }
-    />
-    <View
       collapsable={false}
       height={80}
       style={
@@ -5272,14 +5252,16 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
     </View>
     <View
       marginRight={64}
+      marginTop={16}
       style={
         [
           {
             "alignItems": "center",
             "flexDirection": "row",
+            "marginBottom": 8,
             "marginLeft": 24,
             "marginRight": 64,
-            "marginVertical": 8,
+            "marginTop": 16,
           },
         ]
       }

--- a/__snapshots__/features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation.native.test.tsx.native-snap
@@ -2675,38 +2675,19 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
       />
     </View>
     <View
-      numberOfSpaces={2}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
-    <View
+      marginRight={64}
       style={
         [
           {
             "alignItems": "center",
-            "flexBasis": 0,
             "flexDirection": "row",
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "marginLeft": 24,
+            "marginRight": 64,
+            "marginVertical": 8,
           },
         ]
       }
     >
-      <View
-        numberOfSpaces={6}
-        style={
-          [
-            {
-              "width": 24,
-            },
-          ]
-        }
-      />
       <View
         accessibilityLabel="Revenir en arrière"
         accessibilityRole="button"
@@ -2869,27 +2850,7 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
           ]
         }
       />
-      <View
-        numberOfSpaces={16}
-        style={
-          [
-            {
-              "width": 64,
-            },
-          ]
-        }
-      />
     </View>
-    <View
-      numberOfSpaces={2}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
   </View>,
 ]
 `;
@@ -5310,38 +5271,19 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
       />
     </View>
     <View
-      numberOfSpaces={2}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
-    <View
+      marginRight={64}
       style={
         [
           {
             "alignItems": "center",
-            "flexBasis": 0,
             "flexDirection": "row",
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "marginLeft": 24,
+            "marginRight": 64,
+            "marginVertical": 8,
           },
         ]
       }
     >
-      <View
-        numberOfSpaces={6}
-        style={
-          [
-            {
-              "width": 24,
-            },
-          ]
-        }
-      />
       <View
         accessibilityLabel="Revenir en arrière"
         accessibilityRole="button"
@@ -5504,27 +5446,7 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
           ]
         }
       />
-      <View
-        numberOfSpaces={16}
-        style={
-          [
-            {
-              "width": 64,
-            },
-          ]
-        }
-      />
     </View>
-    <View
-      numberOfSpaces={2}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
   </View>,
 ]
 `;

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -4456,6 +4456,7 @@ d’options
           {
             "alignItems": "center",
             "flexDirection": "row",
+            "justifyContent": "space-between",
             "marginBottom": 8,
             "marginLeft": 24,
             "marginRight": 24,
@@ -4586,47 +4587,37 @@ d’options
             },
           ]
         }
-      />
-      <Text
-        accessibilityHidden={true}
-        collapsable={false}
-        numberOfLines={2}
-        style={
-          {
-            "color": "#ffffff",
-            "flexShrink": 1,
-            "opacity": 0,
-            "textAlign": "center",
-          }
-        }
-        testID="venueHeaderName"
       >
         <Text
+          accessibilityHidden={true}
+          collapsable={false}
+          numberOfLines={2}
           style={
-            [
-              {
-                "color": "#161617",
-                "fontFamily": "Montserrat-Medium",
-                "fontSize": 16,
-                "lineHeight": 25.6,
-              },
-            ]
-          }
-        >
-          Le Petit Rintintin 1
-        </Text>
-      </Text>
-      <View
-        style={
-          [
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
+              "color": "#ffffff",
               "flexShrink": 1,
-            },
-          ]
-        }
-      />
+              "opacity": 0,
+              "textAlign": "center",
+            }
+          }
+          testID="venueHeaderName"
+        >
+          <Text
+            style={
+              [
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
+                },
+              ]
+            }
+          >
+            Le Petit Rintintin 1
+          </Text>
+        </Text>
+      </View>
       <View
         accessibilityLabel="Partager"
         accessibilityRole="button"
@@ -8164,6 +8155,7 @@ d’options
           {
             "alignItems": "center",
             "flexDirection": "row",
+            "justifyContent": "space-between",
             "marginBottom": 8,
             "marginLeft": 24,
             "marginRight": 24,
@@ -8294,47 +8286,37 @@ d’options
             },
           ]
         }
-      />
-      <Text
-        accessibilityHidden={true}
-        collapsable={false}
-        numberOfLines={2}
-        style={
-          {
-            "color": "#ffffff",
-            "flexShrink": 1,
-            "opacity": 0,
-            "textAlign": "center",
-          }
-        }
-        testID="venueHeaderName"
       >
         <Text
+          accessibilityHidden={true}
+          collapsable={false}
+          numberOfLines={2}
           style={
-            [
-              {
-                "color": "#161617",
-                "fontFamily": "Montserrat-Medium",
-                "fontSize": 16,
-                "lineHeight": 25.6,
-              },
-            ]
-          }
-        >
-          Le Petit Rintintin 1
-        </Text>
-      </Text>
-      <View
-        style={
-          [
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
+              "color": "#ffffff",
               "flexShrink": 1,
-            },
-          ]
-        }
-      />
+              "opacity": 0,
+              "textAlign": "center",
+            }
+          }
+          testID="venueHeaderName"
+        >
+          <Text
+            style={
+              [
+                {
+                  "color": "#161617",
+                  "fontFamily": "Montserrat-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
+                },
+              ]
+            }
+          >
+            Le Petit Rintintin 1
+          </Text>
+        </Text>
+      </View>
       <View
         accessibilityLabel="Partager"
         accessibilityRole="button"

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -4415,17 +4415,6 @@ d’options
     }
   >
     <View
-      customHeight={16}
-      enable={true}
-      style={
-        [
-          {
-            "height": 16,
-          },
-        ]
-      }
-    />
-    <View
       collapsable={false}
       height={80}
       style={
@@ -4461,14 +4450,16 @@ d’options
     </View>
     <View
       marginRight={24}
+      marginTop={16}
       style={
         [
           {
             "alignItems": "center",
             "flexDirection": "row",
+            "marginBottom": 8,
             "marginLeft": 24,
             "marginRight": 24,
-            "marginVertical": 8,
+            "marginTop": 16,
           },
         ]
       }
@@ -8132,17 +8123,6 @@ d’options
     }
   >
     <View
-      customHeight={16}
-      enable={true}
-      style={
-        [
-          {
-            "height": 16,
-          },
-        ]
-      }
-    />
-    <View
       collapsable={false}
       height={80}
       style={
@@ -8178,14 +8158,16 @@ d’options
     </View>
     <View
       marginRight={24}
+      marginTop={16}
       style={
         [
           {
             "alignItems": "center",
             "flexDirection": "row",
+            "marginBottom": 8,
             "marginLeft": 24,
             "marginRight": 24,
-            "marginVertical": 8,
+            "marginTop": 16,
           },
         ]
       }

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -4460,38 +4460,19 @@ d’options
       />
     </View>
     <View
-      numberOfSpaces={2}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
-    <View
+      marginRight={24}
       style={
         [
           {
             "alignItems": "center",
-            "flexBasis": 0,
             "flexDirection": "row",
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "marginLeft": 24,
+            "marginRight": 24,
+            "marginVertical": 8,
           },
         ]
       }
     >
-      <View
-        numberOfSpaces={6}
-        style={
-          [
-            {
-              "width": 24,
-            },
-          ]
-        }
-      />
       <View
         accessibilityLabel="Revenir en arrière"
         accessibilityRole="button"
@@ -4767,27 +4748,7 @@ d’options
           </View>
         </View>
       </View>
-      <View
-        numberOfSpaces={6}
-        style={
-          [
-            {
-              "width": 24,
-            },
-          ]
-        }
-      />
     </View>
-    <View
-      numberOfSpaces={2}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
   </View>
   <View
     style={
@@ -8216,38 +8177,19 @@ d’options
       />
     </View>
     <View
-      numberOfSpaces={2}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
-    <View
+      marginRight={24}
       style={
         [
           {
             "alignItems": "center",
-            "flexBasis": 0,
             "flexDirection": "row",
-            "flexGrow": 1,
-            "flexShrink": 1,
+            "marginLeft": 24,
+            "marginRight": 24,
+            "marginVertical": 8,
           },
         ]
       }
     >
-      <View
-        numberOfSpaces={6}
-        style={
-          [
-            {
-              "width": 24,
-            },
-          ]
-        }
-      />
       <View
         accessibilityLabel="Revenir en arrière"
         accessibilityRole="button"
@@ -8523,27 +8465,7 @@ d’options
           </View>
         </View>
       </View>
-      <View
-        numberOfSpaces={6}
-        style={
-          [
-            {
-              "width": 24,
-            },
-          ]
-        }
-      />
     </View>
-    <View
-      numberOfSpaces={2}
-      style={
-        [
-          {
-            "height": 8,
-          },
-        ]
-      }
-    />
   </View>
   <View
     style={

--- a/src/features/offer/components/OfferHeader/OfferHeader.tsx
+++ b/src/features/offer/components/OfferHeader/OfferHeader.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 import { Animated } from 'react-native'
-import { useTheme } from 'styled-components/native'
+import styled, { useTheme } from 'styled-components/native'
 
 import { OfferResponseV2 } from 'api/gen'
 import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/helpers'
@@ -13,6 +13,7 @@ import { FavoriteButton } from 'ui/components/buttons/FavoriteButton'
 import { RoundedButton } from 'ui/components/buttons/RoundedButton'
 import { ContentHeader } from 'ui/components/headers/ContentHeader'
 import { useModal } from 'ui/components/modals/useModal'
+import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Spacer } from 'ui/theme'
 
 interface Props {
@@ -57,7 +58,7 @@ export function OfferHeader({ headerTransition, title, offer }: Readonly<Props>)
         onBackPress={goBack}
         LeftElement={<Spacer.Row numberOfSpaces={13} />}
         RightElement={
-          <React.Fragment>
+          <ButtonsWrapper gap={3}>
             <RoundedButton
               animationState={animationState}
               iconName="share"
@@ -65,9 +66,8 @@ export function OfferHeader({ headerTransition, title, offer }: Readonly<Props>)
               accessibilityLabel="Partager"
               finalColor={theme.colors.black}
             />
-            <Spacer.Row numberOfSpaces={3} />
             <FavoriteButton animationState={animationState} offerId={offer.id} />
-          </React.Fragment>
+          </ButtonsWrapper>
         }
       />
       {shareContent ? (
@@ -81,3 +81,8 @@ export function OfferHeader({ headerTransition, title, offer }: Readonly<Props>)
     </React.Fragment>
   )
 }
+
+const ButtonsWrapper = styled(ViewGap)({
+  flexDirection: 'row',
+  alignItems: 'center',
+})

--- a/src/ui/components/headers/ContentHeader.tsx
+++ b/src/ui/components/headers/ContentHeader.tsx
@@ -6,7 +6,7 @@ import styled, { useTheme } from 'styled-components/native'
 import { getAnimationState } from 'ui/animations/helpers/getAnimationState'
 import { BlurView } from 'ui/components/BlurView'
 import { RoundedButton } from 'ui/components/buttons/RoundedButton'
-import { Spacer, TypoDS, getSpacing } from 'ui/theme'
+import { TypoDS, getSpacing } from 'ui/theme'
 
 type AnimatedBlurHeaderFullProps = {
   headerTitle?: string
@@ -61,14 +61,14 @@ export const ContentHeader = ({
           initialColor={theme.colors.black}
         />
         {LeftElement}
-        <Spacer.Flex />
-        <Title
-          testID={titleTestID}
-          style={{ opacity: customHeaderTitleTransition ?? headerTransition }} // Utilisation de l'interpolation effective
-          accessibilityHidden={ariaHiddenTitle}>
-          <Body>{headerTitle}</Body>
-        </Title>
-        <Spacer.Flex />
+        <TitleContainer>
+          <Title
+            testID={titleTestID}
+            style={{ opacity: customHeaderTitleTransition ?? headerTransition }} // Utilisation de l'interpolation effective
+            accessibilityHidden={ariaHiddenTitle}>
+            <Body>{headerTitle}</Body>
+          </Title>
+        </TitleContainer>
         {RightElement}
       </Row>
     </HeaderContainer>
@@ -99,6 +99,10 @@ const HeaderContainer = styled(Animated.View)<{ height: number }>(({ theme, heig
   borderBottomWidth: 1,
 }))
 
+const TitleContainer = styled.View({
+  flex: 1,
+})
+
 const Title = styled(Animated.Text).attrs({
   numberOfLines: 2,
 })(({ theme }) => ({
@@ -117,6 +121,7 @@ const Row = styled.View<{ marginRight: number; marginTop: number }>(
     ...(Platform.OS === 'web' ? { flex: 1 } : {}),
     flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'space-between',
     marginTop,
     marginBottom: getSpacing(2),
     marginLeft: getSpacing(6),

--- a/src/ui/components/headers/ContentHeader.tsx
+++ b/src/ui/components/headers/ContentHeader.tsx
@@ -122,7 +122,7 @@ const Body = styled(TypoDS.Body)(({ theme }) => ({
 }))
 
 const Row = styled.View({
-  flex: 1,
+  ...(Platform.OS === 'web' ? { flex: 1 } : {}),
   flexDirection: 'row',
   alignItems: 'center',
 })

--- a/src/ui/components/headers/ContentHeader.tsx
+++ b/src/ui/components/headers/ContentHeader.tsx
@@ -38,9 +38,10 @@ export const ContentHeader = ({
   const [ariaHiddenTitle, setAriaHiddenTitle] = useState(true)
   headerTransition.addListener((opacity) => setAriaHiddenTitle(opacity.value !== 1))
 
+  const marginTopHeader = Platform.OS === 'ios' ? top : top + getSpacing(2)
+
   return (
     <HeaderContainer style={containerStyle} height={headerHeight}>
-      <Spacer.TopScreen />
       {
         // There is an issue with the blur on Android: we chose not to render it and use a white background
         // https://github.com/Kureev/react-native-blur/issues/511
@@ -50,7 +51,7 @@ export const ContentHeader = ({
           </BlurNativeContainer>
         )
       }
-      <Row marginRight={RightElement ? getSpacing(6) : getSpacing(16)}>
+      <Row marginRight={RightElement ? getSpacing(6) : getSpacing(16)} marginTop={marginTopHeader}>
         <RoundedButton
           animationState={animationState}
           iconName="back"
@@ -111,11 +112,14 @@ const Body = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.black,
 }))
 
-const Row = styled.View<{ marginRight: number }>(({ marginRight }) => ({
-  ...(Platform.OS === 'web' ? { flex: 1 } : {}),
-  flexDirection: 'row',
-  alignItems: 'center',
-  marginVertical: getSpacing(2),
-  marginLeft: getSpacing(6),
-  marginRight,
-}))
+const Row = styled.View<{ marginRight: number; marginTop: number }>(
+  ({ marginRight, marginTop }) => ({
+    ...(Platform.OS === 'web' ? { flex: 1 } : {}),
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop,
+    marginBottom: getSpacing(2),
+    marginLeft: getSpacing(6),
+    marginRight,
+  })
+)

--- a/src/ui/components/headers/ContentHeader.tsx
+++ b/src/ui/components/headers/ContentHeader.tsx
@@ -59,7 +59,7 @@ export const ContentHeader = ({
           finalColor={theme.colors.black}
           initialColor={theme.colors.black}
         />
-        {LeftElement ? <React.Fragment>{LeftElement}</React.Fragment> : null}
+        {LeftElement}
         <Spacer.Flex />
         <Title
           testID={titleTestID}
@@ -68,7 +68,7 @@ export const ContentHeader = ({
           <Body>{headerTitle}</Body>
         </Title>
         <Spacer.Flex />
-        {RightElement ? <React.Fragment>{RightElement}</React.Fragment> : null}
+        {RightElement}
       </Row>
     </HeaderContainer>
   )

--- a/src/ui/components/headers/ContentHeader.tsx
+++ b/src/ui/components/headers/ContentHeader.tsx
@@ -6,7 +6,7 @@ import styled, { useTheme } from 'styled-components/native'
 import { getAnimationState } from 'ui/animations/helpers/getAnimationState'
 import { BlurView } from 'ui/components/BlurView'
 import { RoundedButton } from 'ui/components/buttons/RoundedButton'
-import { Spacer, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 
 type AnimatedBlurHeaderFullProps = {
   headerTitle?: string
@@ -50,9 +50,7 @@ export const ContentHeader = ({
           </BlurNativeContainer>
         )
       }
-      <Spacer.Column numberOfSpaces={2} />
-      <Row>
-        <Spacer.Row numberOfSpaces={6} />
+      <Row marginRight={RightElement ? getSpacing(6) : getSpacing(16)}>
         <RoundedButton
           animationState={animationState}
           iconName="back"
@@ -70,16 +68,8 @@ export const ContentHeader = ({
           <Body>{headerTitle}</Body>
         </Title>
         <Spacer.Flex />
-        {RightElement ? (
-          <React.Fragment>
-            {RightElement}
-            <Spacer.Row numberOfSpaces={6} />
-          </React.Fragment>
-        ) : (
-          <Spacer.Row numberOfSpaces={16} />
-        )}
+        {RightElement ? <React.Fragment>{RightElement}</React.Fragment> : null}
       </Row>
-      <Spacer.Column numberOfSpaces={2} />
     </HeaderContainer>
   )
 }
@@ -121,8 +111,11 @@ const Body = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.black,
 }))
 
-const Row = styled.View({
+const Row = styled.View<{ marginRight: number }>(({ marginRight }) => ({
   ...(Platform.OS === 'web' ? { flex: 1 } : {}),
   flexDirection: 'row',
   alignItems: 'center',
-})
+  marginVertical: getSpacing(2),
+  marginLeft: getSpacing(6),
+  marginRight,
+}))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34012

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="453" alt="Capture d’écran 2025-01-15 à 16 55 20" src="https://github.com/user-attachments/assets/59bcfaa2-67b2-4f9a-9935-f00676933b18" /> <img width="443" alt="Capture d’écran 2025-01-15 à 16 55 41" src="https://github.com/user-attachments/assets/5d956195-af09-42f5-afd8-2d1f949146a7" />|![Capture d’écran 2025-01-15 à 17 05 42](https://github.com/user-attachments/assets/1d39fbde-fb1b-452a-9185-1e564b117ec4) ![Capture d’écran 2025-01-15 à 17 05 26](https://github.com/user-attachments/assets/d74a057a-b39c-48ec-abb3-ef0338db47fa)|
| Android          |<img width="409" alt="Capture d’écran 2025-01-15 à 16 55 26" src="https://github.com/user-attachments/assets/28296741-1436-44ce-ac33-ffc1a2d32538" /> <img width="407" alt="Capture d’écran 2025-01-15 à 16 55 59" src="https://github.com/user-attachments/assets/82f5b7d8-1260-4ce1-9bd7-4cb8aaf4aa72" />|<img width="412" alt="Capture d’écran 2025-01-15 à 17 06 44" src="https://github.com/user-attachments/assets/7c59fb13-c483-4b7f-90e9-cebcc7bd299d" /> <img width="412" alt="Capture d’écran 2025-01-15 à 17 07 01" src="https://github.com/user-attachments/assets/1e425ca7-0a80-4bfe-bcf8-89a0c628e8f9" />|
| Phone - Chrome   |![Capture d’écran 2025-01-15 à 16 54 40](https://github.com/user-attachments/assets/2109f060-dfcf-491e-ba1e-258cb4c3f4d8) ![Capture d’écran 2025-01-15 à 16 54 58](https://github.com/user-attachments/assets/e9090b46-a5e1-4288-bdcb-246785511f2f)|![Capture d’écran 2025-01-15 à 17 08 38](https://github.com/user-attachments/assets/e177c9b5-535f-49a4-9a26-b922255c6e67) ![Capture d’écran 2025-01-15 à 17 08 26](https://github.com/user-attachments/assets/febe6054-e759-4a82-80ba-99bb94bb8cb6)|
| Desktop - Chrome |![Capture d’écran 2025-01-15 à 16 54 17](https://github.com/user-attachments/assets/9a722c64-d86c-4b3b-85e0-087029316f5b) ![Capture d’écran 2025-01-15 à 16 55 12](https://github.com/user-attachments/assets/a3cb9db8-ddcc-4758-8b7f-dc091dcba9ad)|![Capture d’écran 2025-01-15 à 17 08 57](https://github.com/user-attachments/assets/35ea3be5-5532-4171-aa0e-4880f7f3bb3b) ![Capture d’écran 2025-01-15 à 17 09 22](https://github.com/user-attachments/assets/c66fb76e-4eb4-4205-a0f7-56eeed2d7e00)|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
