### PR TITLE
(PC-33742) feat(SearchBox): add tracker HasSearchCinemaQuery

### DIFF
--- a/src/features/search/components/SearchBox/SearchBox.native.test.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.native.test.tsx
@@ -165,8 +165,6 @@ describe('SearchBox component', () => {
       type: 'tab',
       stale: false,
     })
-
-    setFeatureFlags()
   })
 
   afterEach(() => {
@@ -210,7 +208,7 @@ describe('SearchBox component', () => {
 
         await user.type(searchInput, queryText, { submitEditing: true })
 
-        expect(analytics.logSearchedCinema).toHaveBeenCalledTimes(1)
+        expect(analytics.logHasSearchedCinemaQuery).toHaveBeenCalledTimes(1)
       }
     )
 
@@ -270,10 +268,6 @@ describe('SearchBox component', () => {
         mockSettings.mockReturnValue({ data: { appEnableAutocomplete: false } })
       })
 
-      beforeEach(() => {
-        setFeatureFlags()
-      })
-
       it('should stay on the current view when focusing search input and being on the %s view', async () => {
         useRoute.mockReturnValueOnce({ name: SearchView.Results })
 
@@ -294,7 +288,6 @@ describe('SearchBox component', () => {
           ...mockSearchState,
           query: 'Some text',
         }
-        mockQuery = 'Some text'
         renderSearchBox()
 
         const resetIcon = screen.getByTestId('Réinitialiser la recherche')
@@ -317,7 +310,6 @@ describe('SearchBox component', () => {
         }
         useRoute.mockReturnValueOnce({ name: SearchView.Results })
 
-        mockQuery = 'Some text'
         renderSearchBox(true)
 
         const resetIcon = screen.getByTestId('Réinitialiser la recherche')
@@ -598,7 +590,7 @@ describe('SearchBox component', () => {
 
       await user.type(searchInput, 'cinéma', { submitEditing: true })
 
-      expect(analytics.logSearchedCinema).toHaveBeenCalledTimes(0)
+      expect(analytics.logHasSearchedCinemaQuery).toHaveBeenCalledTimes(0)
     })
 
     it('should reset searchState when user go goBack to Landing', async () => {
@@ -702,9 +694,7 @@ describe('SearchBox component', () => {
       mockPosition = DEFAULT_POSITION
       renderSearchBox()
 
-      await act(async () => {})
-
-      expect(screen.getByText(LocationLabel.everywhereLabel)).toBeOnTheScreen()
+      expect(await screen.findByText(LocationLabel.everywhereLabel)).toBeOnTheScreen()
     })
 
     jest.mock('libs/firebase/analytics/analytics')
@@ -720,7 +710,6 @@ describe('SearchBox component', () => {
           stale: false,
         })
         useRoute.mockReturnValueOnce({ name: SearchView.Results })
-        setFeatureFlags()
       })
 
       it('should unselect the venue and set the view to Landing when current route is search and previous route is Venue when the user press the back button', async () => {
@@ -793,7 +782,6 @@ describe('SearchBox component', () => {
           stale: false,
         })
         useRoute.mockReturnValueOnce({ name: SearchView.Thematic })
-        setFeatureFlags()
       })
 
       it('should execute go back when current route is search and previous route is ThematicSearch', async () => {

--- a/src/features/search/components/SearchBox/SearchBox.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.tsx
@@ -265,7 +265,7 @@ export const SearchBox: React.FunctionComponent<Props> = ({
               .trim()
           )
         ) {
-          analytics.logSearchedCinema()
+          analytics.logHasSearchedCinemaQuery()
         }
       }
 

--- a/src/libs/analytics/__mocks__/logEventAnalytics.ts
+++ b/src/libs/analytics/__mocks__/logEventAnalytics.ts
@@ -194,5 +194,5 @@ export const logEventAnalytics: typeof actualLogEventAnalytics = {
   logDisplayAchievements: jest.fn(),
   logConsultAchievementModal: jest.fn(),
   logViewedBookingPage: jest.fn(),
-  logSearchedCinema: jest.fn(),
+  logHasSearchedCinemaQuery: jest.fn(),
 }

--- a/src/libs/analytics/__mocks__/logEventAnalytics.ts
+++ b/src/libs/analytics/__mocks__/logEventAnalytics.ts
@@ -194,4 +194,5 @@ export const logEventAnalytics: typeof actualLogEventAnalytics = {
   logDisplayAchievements: jest.fn(),
   logConsultAchievementModal: jest.fn(),
   logViewedBookingPage: jest.fn(),
+  logSearchedCinema: jest.fn(),
 }

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -576,6 +576,8 @@ export const logEventAnalytics = {
     analytics.logEvent({ firebase: AnalyticsEvent.SCREENSHOT }, params),
   logSearchScrollToPage: (page: number, searchId?: string) =>
     analytics.logEvent({ firebase: AnalyticsEvent.SEARCH_SCROLL_TO_PAGE }, { page, searchId }),
+  logSearchedCinema: () =>
+    analytics.logEvent({ firebase: AnalyticsEvent.HAS_SEARCHED_CINEMA_QUERY }),
   logSeeMyBooking: (offerId: number) =>
     analytics.logEvent({ firebase: AnalyticsEvent.SEE_MY_BOOKING }, { offerId }),
   logSelectAge: ({ age, from }: { age: number | string; from: TutorialTypes }) =>

--- a/src/libs/analytics/logEventAnalytics.ts
+++ b/src/libs/analytics/logEventAnalytics.ts
@@ -377,6 +377,8 @@ export const logEventAnalytics = {
     analytics.logEvent({ firebase: AnalyticsEvent.HAS_OPENED_COOKIES_ACCORDION }, { type }),
   logHasRefusedCookie: () => analytics.logEvent({ firebase: AnalyticsEvent.HAS_REFUSED_COOKIE }),
   logHasRequestedCode: () => analytics.logEvent({ firebase: AnalyticsEvent.HAS_REQUESTED_CODE }),
+  logHasSearchedCinemaQuery: () =>
+    analytics.logEvent({ firebase: AnalyticsEvent.HAS_SEARCHED_CINEMA_QUERY }),
   logHasSeenAllVideo: (params: {
     moduleId: string
     seenDuration?: number
@@ -576,8 +578,6 @@ export const logEventAnalytics = {
     analytics.logEvent({ firebase: AnalyticsEvent.SCREENSHOT }, params),
   logSearchScrollToPage: (page: number, searchId?: string) =>
     analytics.logEvent({ firebase: AnalyticsEvent.SEARCH_SCROLL_TO_PAGE }, { page, searchId }),
-  logSearchedCinema: () =>
-    analytics.logEvent({ firebase: AnalyticsEvent.HAS_SEARCHED_CINEMA_QUERY }),
   logSeeMyBooking: (offerId: number) =>
     analytics.logEvent({ firebase: AnalyticsEvent.SEE_MY_BOOKING }, { offerId }),
   logSelectAge: ({ age, from }: { age: number | string; from: TutorialTypes }) =>

--- a/src/libs/firebase/analytics/events.ts
+++ b/src/libs/firebase/analytics/events.ts
@@ -97,6 +97,7 @@ export enum AnalyticsEvent {
   HAS_OPENED_COOKIES_ACCORDION = 'HasOpenedCookiesAccordion',
   HAS_REFUSED_COOKIE = 'HasRefusedCookie',
   HAS_REQUESTED_CODE = 'HasRequestedCode',
+  HAS_SEARCHED_CINEMA_QUERY = 'HasSearchedCinemaQuery',
   HAS_SEEN_ALL_VIDEO = 'HasSeenAllVideo',
   HAS_SHARED_APP = 'HasSharedApp',
   HAS_SKIPPED_CULTURAL_SURVEY = 'hasSkippedCulturalSurvey',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33742

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [x] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
