### PR TITLE
(PC-33870) feat(modals): integrate cookie check to reaction/achievement modal display logic

### DIFF
--- a/src/features/cookies/helpers/useIsCookiesListUpToDate.native.test.ts
+++ b/src/features/cookies/helpers/useIsCookiesListUpToDate.native.test.ts
@@ -48,6 +48,7 @@ describe('isCookiesListUpToDate', () => {
       expect(result.current).toEqual({
         cookiesLastUpdate: defaultMockFirestore,
         isCookiesListUpToDate: false,
+        isLoading: false,
       })
     })
   })
@@ -63,6 +64,7 @@ describe('isCookiesListUpToDate', () => {
       expect(result.current).toEqual({
         cookiesLastUpdate: defaultMockFirestore,
         isCookiesListUpToDate: false,
+        isLoading: false,
       })
     })
   })
@@ -81,6 +83,7 @@ describe('isCookiesListUpToDate', () => {
         expect(result.current).toEqual({
           cookiesLastUpdate: defaultMockFirestore,
           isCookiesListUpToDate: false,
+          isLoading: false,
         })
       })
     }
@@ -95,6 +98,7 @@ describe('isCookiesListUpToDate', () => {
       expect(result.current).toEqual({
         cookiesLastUpdate: undefined,
         isCookiesListUpToDate: true,
+        isLoading: false,
       })
     })
   })
@@ -110,6 +114,7 @@ describe('isCookiesListUpToDate', () => {
       expect(result.current).toEqual({
         cookiesLastUpdate: defaultMockFirestore,
         isCookiesListUpToDate: true,
+        isLoading: false,
       })
     })
   })
@@ -133,6 +138,7 @@ describe('isCookiesListUpToDate', () => {
           lastUpdateBuildVersion: buildVersion + 1,
         },
         isCookiesListUpToDate: true,
+        isLoading: false,
       })
     })
   })
@@ -150,6 +156,7 @@ describe('isCookiesListUpToDate', () => {
       expect(result.current).toEqual({
         cookiesLastUpdate: { ...defaultMockFirestore, lastUpdated: TOMORROW },
         isCookiesListUpToDate: true,
+        isLoading: false,
       })
     })
   })
@@ -162,6 +169,7 @@ describe('isCookiesListUpToDate', () => {
       expect(result.current).toEqual({
         cookiesLastUpdate: undefined,
         isCookiesListUpToDate: true,
+        isLoading: false,
       })
     })
   })

--- a/src/features/cookies/helpers/useIsCookiesListUpToDate.ts
+++ b/src/features/cookies/helpers/useIsCookiesListUpToDate.ts
@@ -16,7 +16,7 @@ export const useIsCookiesListUpToDate = () => {
     return { consent, lastUpdate }
   }
 
-  const { data } = useQuery(QueryKeys.COOKIES_DATA, fetchCookiesData, {
+  const { data, isLoading } = useQuery(QueryKeys.COOKIES_DATA, fetchCookiesData, {
     staleTime: 1000 * 30,
     cacheTime: 1000 * 30,
     enabled: onlineManager.isOnline(),
@@ -58,5 +58,6 @@ export const useIsCookiesListUpToDate = () => {
   return {
     isCookiesListUpToDate: isUpToDate(),
     cookiesLastUpdate,
+    isLoading,
   }
 }

--- a/src/features/cookies/pages/PrivacyPolicy.native.test.tsx
+++ b/src/features/cookies/pages/PrivacyPolicy.native.test.tsx
@@ -26,7 +26,7 @@ const mockUseCookies = jest.spyOn(Cookies, 'useCookies').mockReturnValue(default
 
 const mockUseIsCookiesListUpToDate = jest
   .spyOn(CookiesUpToDate, 'useIsCookiesListUpToDate')
-  .mockReturnValue({ isCookiesListUpToDate: true, cookiesLastUpdate: undefined })
+  .mockReturnValue({ isCookiesListUpToDate: true, cookiesLastUpdate: undefined, isLoading: false })
 
 jest.mock('features/navigation/navigationRef')
 
@@ -67,6 +67,7 @@ describe('<PrivacyPolicy />', () => {
     mockUseIsCookiesListUpToDate.mockReturnValueOnce({
       isCookiesListUpToDate: true,
       cookiesLastUpdate: undefined,
+      isLoading: false,
     })
     mockUseCookies.mockReturnValueOnce({
       ...defaultUseCookies,
@@ -86,6 +87,7 @@ describe('<PrivacyPolicy />', () => {
     mockUseIsCookiesListUpToDate.mockReturnValueOnce({
       isCookiesListUpToDate: false,
       cookiesLastUpdate: undefined,
+      isLoading: false,
     })
     mockUseCookies.mockReturnValueOnce({
       ...defaultUseCookies,

--- a/src/features/home/components/helpers/useBookingsReactionHelpers.native.test.ts
+++ b/src/features/home/components/helpers/useBookingsReactionHelpers.native.test.ts
@@ -1,6 +1,5 @@
 import { BookingsResponse, ReactionTypeEnum, SubcategoriesResponseModelv2 } from 'api/gen'
 import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
-import * as CookiesUpToDate from 'features/cookies/helpers/useIsCookiesListUpToDate'
 import {
   ModalDisplayState,
   useBookingsReactionHelpers,
@@ -19,12 +18,6 @@ jest.mock('libs/subcategories/useSubcategories', () => ({
   }),
 }))
 
-const mockUseIsCookiesListUpToDate = jest
-  .spyOn(CookiesUpToDate, 'useIsCookiesListUpToDate')
-  .mockReturnValue({
-    isCookiesListUpToDate: true,
-    cookiesLastUpdate: { lastUpdated: new Date('10/12/2022'), lastUpdateBuildVersion: 10208002 },
-  })
 jest.mock('libs/firebase/analytics/analytics') // mocking analytics used in useIsCookiesListUpToDate
 
 jest.useFakeTimers()
@@ -53,18 +46,7 @@ describe('useBookingsReactionHelpers', () => {
       expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_NOT_SHOW)
     })
 
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('should return shouldNotShow if cookies where not accepted', () => {
-      cookiesNotAccepted()
-
-      const { result } = renderHook(() =>
-        useBookingsReactionHelpers(endedBookingWithoutReaction, false)
-      )
-
-      expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_NOT_SHOW)
-    })
-
-    it('should return true if there are bookings to react to', () => {
+    it('should return shouldShow if there are bookings to react to', () => {
       const { result } = renderHook(() =>
         useBookingsReactionHelpers(endedBookingWithoutReaction, false)
       )
@@ -76,13 +58,6 @@ describe('useBookingsReactionHelpers', () => {
     })
   })
 })
-
-function cookiesNotAccepted() {
-  mockUseIsCookiesListUpToDate.mockReturnValueOnce({
-    isCookiesListUpToDate: true,
-    cookiesLastUpdate: undefined,
-  })
-}
 
 const endedBookingWithoutReaction: BookingsResponse = {
   ended_bookings: [

--- a/src/features/home/components/helpers/useBookingsReactionHelpers.ts
+++ b/src/features/home/components/helpers/useBookingsReactionHelpers.ts
@@ -31,8 +31,6 @@ export const useBookingsReactionHelpers = (
     }
   }
 
-  // There is an issue with !isCookieConsentChecked it goes to true for an instant and disrupts the modal conflict management hook
-
   if (!isReactionFeatureActive || !firstBookingWithoutReaction)
     return {
       shouldShowReactionModal: ModalDisplayState.SHOULD_NOT_SHOW,

--- a/src/features/home/helpers/useWhichModalToShow.native.test.ts
+++ b/src/features/home/helpers/useWhichModalToShow.native.test.ts
@@ -14,10 +14,13 @@ jest.mock('features/auth/context/AuthContext')
 jest.mock('libs/firebase/analytics/analytics')
 const useRemoteConfigContextSpy = jest.spyOn(useRemoteConfigContext, 'useRemoteConfigContext')
 
-jest.spyOn(CookiesUpToDate, 'useIsCookiesListUpToDate').mockReturnValue({
-  isCookiesListUpToDate: true,
-  cookiesLastUpdate: { lastUpdated: new Date('10/12/2022'), lastUpdateBuildVersion: 10208002 },
-})
+const mockUseIsCookiesListUpToDate = jest
+  .spyOn(CookiesUpToDate, 'useIsCookiesListUpToDate')
+  .mockReturnValue({
+    isCookiesListUpToDate: true,
+    cookiesLastUpdate: { lastUpdated: new Date('10/12/2022'), lastUpdateBuildVersion: 10208002 },
+    isLoading: false,
+  })
 
 describe('useWhichModalToShow', () => {
   beforeEach(() => {
@@ -36,6 +39,19 @@ describe('useWhichModalToShow', () => {
 
   afterAll(() => {
     useRemoteConfigContextSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
+  })
+
+  it('should return pending if the cookies modal should show', () => {
+    cookiesNotAccepted()
+
+    mockAuthContextWithUser({
+      ...beneficiaryUser,
+      achievements: achievements,
+    })
+
+    const { result } = renderHook(() => useWhichModalToShow(endedBookingWithoutReaction, false))
+
+    expect(result.current.modalToShow).toEqual(ModalToShow.NONE)
   })
 
   it('should return achievement if the achievement modal should be shown and the reaction modal should not be shown', () => {
@@ -114,4 +130,12 @@ const endedBookingWithReaction: BookingsResponse = {
   ],
   ongoing_bookings: [],
   hasBookingsAfter18: false,
+}
+
+function cookiesNotAccepted() {
+  mockUseIsCookiesListUpToDate.mockReturnValueOnce({
+    isCookiesListUpToDate: false,
+    cookiesLastUpdate: undefined,
+    isLoading: false,
+  })
 }

--- a/src/features/home/helpers/useWhichModalToShow.ts
+++ b/src/features/home/helpers/useWhichModalToShow.ts
@@ -2,6 +2,7 @@ import { useState } from 'react'
 
 import { BookingsResponse } from 'api/gen'
 import { useShouldShowAchievementSuccessModal } from 'features/achievements/hooks/useShouldShowAchievementSuccessModal'
+import { useIsCookiesListUpToDate } from 'features/cookies/helpers/useIsCookiesListUpToDate'
 import {
   ModalDisplayState,
   useBookingsReactionHelpers,
@@ -25,8 +26,14 @@ export const useWhichModalToShow = (
   )
   const { shouldShowAchievementSuccessModal, achievementsToShow } =
     useShouldShowAchievementSuccessModal()
-  if (!isBookingsLoading && modalToShow === ModalToShow.PENDING) {
-    if (shouldShowReactionModal === ModalDisplayState.SHOULD_SHOW) {
+  const { isCookiesListUpToDate, isLoading: isCookiesListUpToDateLoading } =
+    useIsCookiesListUpToDate()
+  const shouldShowCookiesModal = !isCookiesListUpToDate
+
+  if (!isCookiesListUpToDateLoading && !isBookingsLoading && modalToShow === ModalToShow.PENDING) {
+    if (shouldShowCookiesModal) {
+      setModalToShow(ModalToShow.NONE)
+    } else if (shouldShowReactionModal === ModalDisplayState.SHOULD_SHOW) {
       setModalToShow(ModalToShow.REACTION)
     } else if (shouldShowAchievementSuccessModal === ModalDisplayState.SHOULD_SHOW) {
       setModalToShow(ModalToShow.ACHIEVEMENT)

--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -56,11 +56,11 @@ export const Home: FunctionComponent = () => {
     userStatus: user?.status?.statusType,
     showOnboardingSubscriptionModal,
   })
-  const { data: bookings, isLoading } = useBookings()
+  const { data: bookings, isLoading: isBookingsLoading } = useBookings()
 
   const { achievementsToShow, bookingsEligibleToReaction, modalToShow } = useWhichModalToShow(
     bookings,
-    isLoading
+    isBookingsLoading
   )
 
   const {

--- a/src/features/home/pages/Home.web.test.tsx
+++ b/src/features/home/pages/Home.web.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { SubcategoriesResponseModelv2 } from 'api/gen'
-import * as CookiesUpToDate from 'features/cookies/helpers/useIsCookiesListUpToDate'
 import { useHomepageData } from 'features/home/api/useHomepageData'
 import { formattedBusinessModule } from 'features/home/fixtures/homepage.fixture'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
@@ -32,11 +31,6 @@ jest.mock('libs/firebase/firestore/featureFlags/useFeatureFlag')
 jest.mock('libs/firebase/analytics/analytics')
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 
-jest.spyOn(CookiesUpToDate, 'useIsCookiesListUpToDate').mockReturnValue({
-  isCookiesListUpToDate: true,
-  cookiesLastUpdate: { lastUpdated: new Date('10/12/2022'), lastUpdateBuildVersion: 10208002 },
-}) // Cookies hook used in useBookingsReactionHelpers
-
 describe('<Home/>', () => {
   beforeEach(() => {
     setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_PACIFIC_FRANC_CURRENCY])
@@ -49,10 +43,6 @@ describe('<Home/>', () => {
         modules: [formattedBusinessModule],
         homeEntryId: 'fakeEntryId',
       })
-      mockUseHomepageData.mockReturnValueOnce({
-        modules: [formattedBusinessModule],
-        homeEntryId: 'fakeEntryId',
-      }) // Adding useBookingsReactionHelpers to Home.tsx caused an extra render
       mockUseHomepageData.mockReturnValueOnce({
         modules: [formattedBusinessModule],
         homeEntryId: 'fakeEntryId',

--- a/src/features/navigation/RootNavigator/RootNavigator.web.test.tsx
+++ b/src/features/navigation/RootNavigator/RootNavigator.web.test.tsx
@@ -19,7 +19,7 @@ const mockUseCurrentRoute = jest.mocked(useCurrentRoute)
 
 jest
   .spyOn(CookiesUpToDate, 'useIsCookiesListUpToDate')
-  .mockReturnValue({ isCookiesListUpToDate: true, cookiesLastUpdate: undefined })
+  .mockReturnValue({ isCookiesListUpToDate: true, cookiesLastUpdate: undefined, isLoading: false })
 jest.mock('features/forceUpdate/helpers/useMustUpdateApp')
 jest.unmock('@react-navigation/native')
 jest.mock('features/auth/context/AuthContext')


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33870

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
