### PR TITLE
(PC-34034) build(reanimated): bump reanimated to 3.6.3

### DIFF
--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -488,6 +488,7 @@ exports[`<Venue /> should match snapshot 1`] = `
           LinearTransition {
             "build": [Function],
             "callbackV": undefined,
+            "dampingRatioV": undefined,
             "dampingV": undefined,
             "delayV": undefined,
             "durationV": 200,
@@ -496,6 +497,7 @@ exports[`<Venue /> should match snapshot 1`] = `
             "massV": undefined,
             "overshootClampingV": undefined,
             "randomizeDelay": false,
+            "reduceMotionV": "system",
             "restDisplacementThresholdV": undefined,
             "restSpeedThresholdV": undefined,
             "rotateV": undefined,
@@ -5387,6 +5389,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
           LinearTransition {
             "build": [Function],
             "callbackV": undefined,
+            "dampingRatioV": undefined,
             "dampingV": undefined,
             "delayV": undefined,
             "durationV": 200,
@@ -5395,6 +5398,7 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
             "massV": undefined,
             "overshootClampingV": undefined,
             "randomizeDelay": false,
+            "reduceMotionV": "system",
             "restDisplacementThresholdV": undefined,
             "restSpeedThresholdV": undefined,
             "rotateV": undefined,

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -767,35 +767,10 @@ PODS:
     - React
   - RNPermissions (3.8.0):
     - React-Core
-  - RNReanimated (3.3.0):
-    - DoubleConversion
-    - FBLazyVector
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React-callinvoker
+  - RNReanimated (3.6.3):
+    - RCT-Folly (= 2021.07.22.00)
     - React-Core
-    - React-Core/DevSupport
-    - React-Core/RCTWebSocket
-    - React-CoreModules
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-RCTActionSheet
-    - React-RCTAnimation
-    - React-RCTAppDelegate
-    - React-RCTBlob
-    - React-RCTImage
-    - React-RCTLinking
-    - React-RCTNetwork
-    - React-RCTSettings
-    - React-RCTText
     - ReactCommon/turbomodule/core
-    - Yoga
   - RNScreens (3.32.0):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
@@ -1277,7 +1252,7 @@ SPEC CHECKSUMS:
   RNKeychain: 4f63aada75ebafd26f4bc2c670199461eab85d94
   RNLaunchNavigator: d855643e1f842f13c6cc65575e0755975667032c
   RNPermissions: 215c54462104b3925b412b0fb3c9c497b21c358b
-  RNReanimated: 9f7068e43b9358a46a688d94a5a3adb258139457
+  RNReanimated: 548e621fe2e12b6bdccbc48ed5e5361d9822c775
   RNScreens: ad1c105ac9107cf1a613bf80889485458eb20bd7
   RNSentry: 221d8c3f0bf0d951e9ecc89d3e42ee97aab9d7c0
   RNShare: d82e10f6b7677f4b0048c23709bd04098d5aee6c

--- a/jest/jest.web.setup.ts
+++ b/jest/jest.web.setup.ts
@@ -11,6 +11,20 @@ jest.mock('libs/firebase/firestore/client.web', () => {
   }
 })
 
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+})
+
 window.open = jest.fn()
 
 export {}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "homepage": ".",
   "scripts": {
     "preandroid": "./scripts/start_android_emulator_with_certificate.sh",
-    "android": "yarn preandroid && react-native run-android",
+    "android": "react-native run-android",
     "android:prod": "yarn android --variant=productionDebug --appId=app.passculture.webapp",
     "android:staging": "yarn android --variant=stagingDebug --appId=app.passculture.staging",
     "android:testing": "yarn android --variant=apptestingDebug --appId=app.passculture.testing",
@@ -173,8 +173,8 @@
     "react-native-modal": "^13.0.0",
     "react-native-permissions": "^3.8.0",
     "react-native-qrcode-svg": "^6.1.2",
-    "react-native-reanimated": "3.3.0",
-    "react-native-reanimated-carousel": "^3.5.1",
+    "react-native-reanimated": "3.6.3",
+    "react-native-reanimated-carousel": "4.0.0-canary.22",
     "react-native-safe-area-context": "3.4.1",
     "react-native-screens": "^3.32.0",
     "react-native-share": "^8.2.2",
@@ -329,6 +329,9 @@
     "vite-plugin-html": "^3.2.2"
   },
   "resolutions": {
+    "@babel/plugin-transform-typescript": "^7.23.6",
+    "@babel/plugin-syntax-typescript": "^7.23.3",
+    "@babel/types": "^7.23.6",
     "@react-navigation/core": "6.2.2",
     "@sentry/cli": "^2.33.1",
     "@sentry/core": "7.62.0",

--- a/src/features/home/components/modules/video/VideoCarouselModule.tsx
+++ b/src/features/home/components/modules/video/VideoCarouselModule.tsx
@@ -191,7 +191,9 @@ export const VideoCarouselModule: FunctionComponent<VideoCarouselModuleBaseProps
               testID="videoCarousel"
               vertical={false}
               height={CAROUSEL_HEIGHT}
-              panGestureHandlerProps={{ activeOffsetX: [-5, 5] }}
+              onConfigurePanGesture={(gestureChain) => {
+                gestureChain.activeOffsetX([-5, 5])
+              }}
               width={windowWidth}
               loop={false}
               scrollAnimationDuration={CAROUSEL_ANIMATION_DURATION}

--- a/src/features/offer/components/OfferImageCarouselPagination/OfferImageCarouselPagination.native.test.tsx
+++ b/src/features/offer/components/OfferImageCarouselPagination/OfferImageCarouselPagination.native.test.tsx
@@ -1,13 +1,16 @@
 import React from 'react'
+import { SharedValue } from 'react-native-reanimated'
 
 import { OfferImageCarouselPagination } from 'features/offer/components/OfferImageCarouselPagination/OfferImageCarouselPagination'
 import { render, screen } from 'tests/utils'
+
+const PROGRESS_VALUE = { value: 0 } as SharedValue<number>
 
 describe('<OfferImageCarouselPagination />', () => {
   it('should display pagination with only dots', () => {
     render(
       <OfferImageCarouselPagination
-        progressValue={{ value: 0 }}
+        progressValue={PROGRESS_VALUE}
         offerImages={['image1', 'image2']}
         handlePressButton={jest.fn()}
       />
@@ -19,7 +22,7 @@ describe('<OfferImageCarouselPagination />', () => {
   it('should not display pagination with dots and buttons', () => {
     render(
       <OfferImageCarouselPagination
-        progressValue={{ value: 0 }}
+        progressValue={PROGRESS_VALUE}
         offerImages={['image1', 'image2']}
         handlePressButton={jest.fn()}
       />

--- a/src/features/offer/components/OfferImageCarouselPagination/OfferImageCarouselPagination.web.test.tsx
+++ b/src/features/offer/components/OfferImageCarouselPagination/OfferImageCarouselPagination.web.test.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
+import { SharedValue } from 'react-native-reanimated'
 
 import { OfferImageCarouselPagination } from 'features/offer/components/OfferImageCarouselPagination/OfferImageCarouselPagination.web'
 import { render, screen, userEvent } from 'tests/utils/web'
 
 const mockHandlePressButton = jest.fn()
+
+const PROGRESS_VALUE = { value: 0 } as SharedValue<number>
 
 describe('<OfferImageCarouselPagination />', () => {
   const user = userEvent.setup()
@@ -11,7 +14,7 @@ describe('<OfferImageCarouselPagination />', () => {
   it('should display pagination with dots and buttons', () => {
     render(
       <OfferImageCarouselPagination
-        progressValue={{ value: 0 }}
+        progressValue={PROGRESS_VALUE}
         offerImages={['image1', 'image2']}
         handlePressButton={mockHandlePressButton}
       />
@@ -23,7 +26,7 @@ describe('<OfferImageCarouselPagination />', () => {
   it('should not display pagination with only dots', () => {
     render(
       <OfferImageCarouselPagination
-        progressValue={{ value: 0 }}
+        progressValue={PROGRESS_VALUE}
         offerImages={['image1', 'image2']}
         handlePressButton={mockHandlePressButton}
       />
@@ -35,7 +38,7 @@ describe('<OfferImageCarouselPagination />', () => {
   it('should handle previous button clicking', async () => {
     render(
       <OfferImageCarouselPagination
-        progressValue={{ value: 0 }}
+        progressValue={PROGRESS_VALUE}
         offerImages={['image1', 'image2']}
         handlePressButton={mockHandlePressButton}
       />
@@ -50,7 +53,7 @@ describe('<OfferImageCarouselPagination />', () => {
   it('should handle next button clicking', async () => {
     render(
       <OfferImageCarouselPagination
-        progressValue={{ value: 0 }}
+        progressValue={PROGRESS_VALUE}
         offerImages={['image1', 'image2']}
         handlePressButton={mockHandlePressButton}
       />

--- a/src/ui/CarouselBar/CarouselBar.native.test.tsx
+++ b/src/ui/CarouselBar/CarouselBar.native.test.tsx
@@ -1,19 +1,22 @@
 import React from 'react'
+import { SharedValue } from 'react-native-reanimated'
 
 import { render, screen } from 'tests/utils'
 import { CarouselBar } from 'ui/CarouselBar/CarouselBar'
 
 jest.useFakeTimers()
 
+const PROGRESS_VALUE = { value: 3 } as SharedValue<number>
+
 describe('<CarouselBar/>', () => {
   it('should render the component', () => {
-    render(<CarouselBar index={0} animValue={{ value: 3 }} />)
+    render(<CarouselBar index={0} animValue={PROGRESS_VALUE} />)
 
     expect(screen.getByTestId('carousel-bar')).toBeOnTheScreen()
   })
 
   it('should render with correct styles', () => {
-    render(<CarouselBar index={0} animValue={{ value: 3 }} />)
+    render(<CarouselBar index={0} animValue={PROGRESS_VALUE} />)
     const greyMedium = 'rgba(203, 205, 210, 1)'
 
     expect(screen.getByTestId('carousel-bar')).toHaveStyle({

--- a/src/ui/CarouselBar/CarouselBar.tsx
+++ b/src/ui/CarouselBar/CarouselBar.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import Animated, { interpolateColor, useAnimatedStyle } from 'react-native-reanimated'
+import Animated, { SharedValue, interpolateColor, useAnimatedStyle } from 'react-native-reanimated'
 import styled, { useTheme } from 'styled-components/native'
 
 import { getSpacing } from 'ui/theme'
 
 type Props = {
   index: number
-  animValue: Animated.SharedValue<number>
+  animValue: SharedValue<number>
 }
 
 export const CarouselBar: React.FunctionComponent<Props> = ({ animValue, index }) => {

--- a/src/ui/CarouselDot/CarouselDot.native.test.tsx
+++ b/src/ui/CarouselDot/CarouselDot.native.test.tsx
@@ -1,19 +1,22 @@
 import React from 'react'
+import { SharedValue } from 'react-native-reanimated'
 
 import { render, screen } from 'tests/utils'
 import { CarouselDot } from 'ui/CarouselDot/CarouselDot'
 
 jest.useFakeTimers()
 
+const PROGRESS_VALUE = { value: 3 } as SharedValue<number>
+
 describe('<CarouselDot/>', () => {
   it('should render carousel dot', () => {
-    render(<CarouselDot index={0} animValue={{ value: 3 }} />)
+    render(<CarouselDot index={0} animValue={PROGRESS_VALUE} />)
 
     expect(screen.getByTestId('carousel-dot')).toBeOnTheScreen()
   })
 
   it('should render with correct styles', () => {
-    render(<CarouselDot index={0} animValue={{ value: 3 }} />)
+    render(<CarouselDot index={0} animValue={PROGRESS_VALUE} />)
 
     expect(screen.getByTestId('carousel-dot')).toHaveStyle({
       backgroundColor: 'rgba(105, 106, 111, 1)',

--- a/src/ui/CarouselDot/CarouselDot.tsx
+++ b/src/ui/CarouselDot/CarouselDot.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Animated, {
   Extrapolation,
+  SharedValue,
   interpolate,
   interpolateColor,
   useAnimatedStyle,
@@ -9,7 +10,7 @@ import styled, { useTheme } from 'styled-components/native'
 
 type Props = {
   index: number
-  animValue: Animated.SharedValue<number>
+  animValue: SharedValue<number>
 }
 
 const SMALL_DOT_SIZE = 6

--- a/yarn.lock
+++ b/yarn.lock
@@ -898,7 +898,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-create-class-features-plugin@npm:^7.21.0":
+"@babel/helper-create-class-features-plugin@npm:^7.21.0, @babel/helper-create-class-features-plugin@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-create-class-features-plugin@npm:7.25.9"
   dependencies:
@@ -1529,13 +1529,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.19.0":
-  version: 7.20.2
-  resolution: "@babel/helper-plugin-utils@npm:7.20.2"
-  checksum: f6cae53b7fdb1bf3abd50fa61b10b4470985b400cc794d92635da1e7077bb19729f626adc0741b69403d9b6e411cddddb9c0157a709cc7c4eeb41e663be5d74b
-  languageName: node
-  linkType: hard
-
 "@babel/helper-plugin-utils@npm:^7.20.2":
   version: 7.21.5
   resolution: "@babel/helper-plugin-utils@npm:7.21.5"
@@ -1554,6 +1547,13 @@ __metadata:
   version: 7.24.8
   resolution: "@babel/helper-plugin-utils@npm:7.24.8"
   checksum: 73b1a83ba8bcee21dc94de2eb7323207391715e4369fd55844bb15cf13e3df6f3d13a40786d990e6370bf0f571d94fc31f70dec96c1d1002058258c35ca3767a
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.25.9, @babel/helper-plugin-utils@npm:^7.26.5":
+  version: 7.26.5
+  resolution: "@babel/helper-plugin-utils@npm:7.26.5"
+  checksum: 4771fbb1711c624c62d12deabc2ed7435a6e6994b6ce09d5ede1bc1bf19be59c3775461a1e693bdd596af865685e87bb2abc778f62ceadc1b2095a8e2aa74180
   languageName: node
   linkType: hard
 
@@ -1810,34 +1810,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-string-parser@npm:^7.18.10, @babel/helper-string-parser@npm:^7.23.4":
-  version: 7.24.1
-  resolution: "@babel/helper-string-parser@npm:7.24.1"
-  checksum: 8404e865b06013979a12406aab4c0e8d2e377199deec09dfe9f57b833b0c9ce7b6e8c1c553f2da8d0bcd240c5005bd7a269f4fef0d628aeb7d5fe035c436fb67
-  languageName: node
-  linkType: hard
-
-"@babel/helper-string-parser@npm:^7.19.4":
-  version: 7.19.4
-  resolution: "@babel/helper-string-parser@npm:7.19.4"
-  checksum: b2f8a3920b30dfac81ec282ac4ad9598ea170648f8254b10f475abe6d944808fb006aab325d3eb5a8ad3bea8dfa888cfa6ef471050dae5748497c110ec060943
-  languageName: node
-  linkType: hard
-
-"@babel/helper-string-parser@npm:^7.22.5":
-  version: 7.22.5
-  resolution: "@babel/helper-string-parser@npm:7.22.5"
-  checksum: 836851ca5ec813077bbb303acc992d75a360267aa3b5de7134d220411c852a6f17de7c0d0b8c8dcc0f567f67874c00f4528672b2a4f1bc978a3ada64c8c78467
-  languageName: node
-  linkType: hard
-
-"@babel/helper-string-parser@npm:^7.24.8":
-  version: 7.24.8
-  resolution: "@babel/helper-string-parser@npm:7.24.8"
-  checksum: 39b03c5119216883878655b149148dc4d2e284791e969b19467a9411fccaa33f7a713add98f4db5ed519535f70ad273cdadfd2eb54d47ebbdeac5083351328ce
-  languageName: node
-  linkType: hard
-
 "@babel/helper-string-parser@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-string-parser@npm:7.25.9"
@@ -1863,13 +1835,6 @@ __metadata:
   version: 7.22.20
   resolution: "@babel/helper-validator-identifier@npm:7.22.20"
   checksum: 136412784d9428266bcdd4d91c32bcf9ff0e8d25534a9d94b044f77fe76bc50f941a90319b05aafd1ec04f7d127cd57a179a3716009ff7f3412ef835ada95bdc
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-identifier@npm:^7.19.1":
-  version: 7.19.1
-  resolution: "@babel/helper-validator-identifier@npm:7.19.1"
-  checksum: 0eca5e86a729162af569b46c6c41a63e18b43dbe09fda1d2a3c8924f7d617116af39cac5e4cd5d431bb760b4dca3c0970e0c444789b1db42bcf1fa41fbad0a3a
   languageName: node
   linkType: hard
 
@@ -3340,25 +3305,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-typescript@npm:^7.24.1":
-  version: 7.24.1
-  resolution: "@babel/plugin-syntax-typescript@npm:7.24.1"
+"@babel/plugin-syntax-typescript@npm:^7.23.3":
+  version: 7.25.9
+  resolution: "@babel/plugin-syntax-typescript@npm:7.25.9"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.24.0
+    "@babel/helper-plugin-utils": ^7.25.9
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: bf4bd70788d5456b5f75572e47a2e31435c7c4e43609bd4dffd2cc0c7a6cf90aabcf6cd389e351854de9a64412a07d30effef5373251fe8f6a4c9db0c0163bda
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-typescript@npm:^7.7.2":
-  version: 7.20.0
-  resolution: "@babel/plugin-syntax-typescript@npm:7.20.0"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.19.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 6189c0b5c32ba3c9a80a42338bd50719d783b20ef29b853d4f03929e971913d3cefd80184e924ae98ad6db09080be8fe6f1ffde9a6db8972523234f0274d36f7
+  checksum: 0e9821e8ba7d660c36c919654e4144a70546942ae184e85b8102f2322451eae102cbfadbcadd52ce077a2b44b400ee52394c616feab7b5b9f791b910e933fd33
   languageName: node
   linkType: hard
 
@@ -5212,17 +5166,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-typescript@npm:^7.24.1, @babel/plugin-transform-typescript@npm:^7.5.0":
-  version: 7.24.4
-  resolution: "@babel/plugin-transform-typescript@npm:7.24.4"
+"@babel/plugin-transform-typescript@npm:^7.23.6":
+  version: 7.26.5
+  resolution: "@babel/plugin-transform-typescript@npm:7.26.5"
   dependencies:
-    "@babel/helper-annotate-as-pure": ^7.22.5
-    "@babel/helper-create-class-features-plugin": ^7.24.4
-    "@babel/helper-plugin-utils": ^7.24.0
-    "@babel/plugin-syntax-typescript": ^7.24.1
+    "@babel/helper-annotate-as-pure": ^7.25.9
+    "@babel/helper-create-class-features-plugin": ^7.25.9
+    "@babel/helper-plugin-utils": ^7.26.5
+    "@babel/helper-skip-transparent-expression-wrappers": ^7.25.9
+    "@babel/plugin-syntax-typescript": ^7.25.9
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 57a9a776b1910c706d28972e4b056ced3af8fc59c29b2a6205c2bb2a408141ddb59a8f2f6041f8467a7b260942818767f4ecabb9f63adf7fddf2afa25e774dfc
+  checksum: d022c1ca9ee5a420c374efb209eaca4f94c06851edeea2b3577dad52ea6692b6b33d00217b33a74d91bd62381ace471e26cc6153bbc681b3af1b1436431ff9c0
   languageName: node
   linkType: hard
 
@@ -5926,119 +5881,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.16.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
-  version: 7.16.0
-  resolution: "@babel/types@npm:7.16.0"
-  dependencies:
-    "@babel/helper-validator-identifier": ^7.15.7
-    to-fast-properties: ^2.0.0
-  checksum: 5b483da5c6e6f2394fba7ee1da8787a0c9cddd33491271c4da702e49e6faf95ce41d7c8bf9a4ee47f2ef06bdb35096f4d0f6ae4b5bea35ebefe16309d22344b7
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.12.11, @babel/types@npm:^7.16.8, @babel/types@npm:^7.17.0, @babel/types@npm:^7.2.0":
-  version: 7.17.0
-  resolution: "@babel/types@npm:7.17.0"
-  dependencies:
-    "@babel/helper-validator-identifier": ^7.16.7
-    to-fast-properties: ^2.0.0
-  checksum: 12e5a287986fe557188e87b2c5202223f1dc83d9239a196ab936fdb9f8c1eb0be717ff19f934b5fad4e29a75586d5798f74bed209bccea1c20376b9952056f0e
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.12.7, @babel/types@npm:^7.18.6, @babel/types@npm:^7.22.19, @babel/types@npm:^7.23.4, @babel/types@npm:^7.24.0":
-  version: 7.24.0
-  resolution: "@babel/types@npm:7.24.0"
-  dependencies:
-    "@babel/helper-string-parser": ^7.23.4
-    "@babel/helper-validator-identifier": ^7.22.20
-    to-fast-properties: ^2.0.0
-  checksum: 4b574a37d490f621470ff36a5afaac6deca5546edcb9b5e316d39acbb20998e9c2be42f3fc0bf2b55906fc49ff2a5a6a097e8f5a726ee3f708a0b0ca93aed807
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.16.7":
-  version: 7.16.8
-  resolution: "@babel/types@npm:7.16.8"
-  dependencies:
-    "@babel/helper-validator-identifier": ^7.16.7
-    to-fast-properties: ^2.0.0
-  checksum: 4f6a187b2924df70e21d6e6c0822f91b1b936fe060bc92bb477b93bd8a712c88fe41a73f85c0ec53b033353374fe33e773b04ffc340ad36afd8f647dd05c4ee1
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.18.0":
-  version: 7.18.0
-  resolution: "@babel/types@npm:7.18.0"
-  dependencies:
-    "@babel/helper-validator-identifier": ^7.16.7
-    to-fast-properties: ^2.0.0
-  checksum: 151485f94c929171fd6539430c0ae519e8bb67fbc0d856b285328f5e6ecbaf4237b52d7a581b413f5e7b6268d31a4db6ca9bc01372b284b2966aa473fc902f27
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.18.10, @babel/types@npm:^7.18.9":
-  version: 7.18.10
-  resolution: "@babel/types@npm:7.18.10"
-  dependencies:
-    "@babel/helper-string-parser": ^7.18.10
-    "@babel/helper-validator-identifier": ^7.18.6
-    to-fast-properties: ^2.0.0
-  checksum: 11632c9b106e54021937a6498138014ebc9ad6c327a07b2af3ba8700773945aba4055fd136431cbe3a500d0f363cbf9c68eb4d6d38229897c5de9d06e14c85e8
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.20.0, @babel/types@npm:^7.22.10, @babel/types@npm:^7.22.5":
-  version: 7.22.10
-  resolution: "@babel/types@npm:7.22.10"
-  dependencies:
-    "@babel/helper-string-parser": ^7.22.5
-    "@babel/helper-validator-identifier": ^7.22.5
-    to-fast-properties: ^2.0.0
-  checksum: 095c4f4b7503fa816e4094113f0ec2351ef96ff32012010b771693066ff628c7c664b21c6bd3fb93aeb46fe7c61f6b3a3c9e4ed0034d6a2481201c417371c8af
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.20.7":
-  version: 7.20.7
-  resolution: "@babel/types@npm:7.20.7"
-  dependencies:
-    "@babel/helper-string-parser": ^7.19.4
-    "@babel/helper-validator-identifier": ^7.19.1
-    to-fast-properties: ^2.0.0
-  checksum: b39af241f0b72bba67fd6d0d23914f6faec8c0eba8015c181cbd5ea92e59fc91a52a1ab490d3520c7dbd19ddb9ebb76c476308f6388764f16d8201e37fae6811
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.22.15, @babel/types@npm:^7.23.0":
-  version: 7.23.0
-  resolution: "@babel/types@npm:7.23.0"
-  dependencies:
-    "@babel/helper-string-parser": ^7.22.5
-    "@babel/helper-validator-identifier": ^7.22.20
-    to-fast-properties: ^2.0.0
-  checksum: 215fe04bd7feef79eeb4d33374b39909ce9cad1611c4135a4f7fdf41fe3280594105af6d7094354751514625ea92d0875aba355f53e86a92600f290e77b0e604
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.24.7, @babel/types@npm:^7.24.8, @babel/types@npm:^7.25.0, @babel/types@npm:^7.25.2":
-  version: 7.25.2
-  resolution: "@babel/types@npm:7.25.2"
-  dependencies:
-    "@babel/helper-string-parser": ^7.24.8
-    "@babel/helper-validator-identifier": ^7.24.7
-    to-fast-properties: ^2.0.0
-  checksum: f73f66ba903c6f7e38f519a33d53a67d49c07e208e59ea65250362691dc546c6da7ab90ec66ee79651ef697329872f6f97eb19a6dfcacc026fd05e76a563c5d2
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.25.9, @babel/types@npm:^7.26.3, @babel/types@npm:^7.8.3":
-  version: 7.26.3
-  resolution: "@babel/types@npm:7.26.3"
+"@babel/types@npm:^7.23.6":
+  version: 7.26.5
+  resolution: "@babel/types@npm:7.26.5"
   dependencies:
     "@babel/helper-string-parser": ^7.25.9
     "@babel/helper-validator-identifier": ^7.25.9
-  checksum: 195f428080dcaadbcecc9445df7f91063beeaa91b49ccd78f38a5af6b75a6a58391d0c6614edb1ea322e57889a1684a0aab8e667951f820196901dd341f931e9
+  checksum: 65dc14aa32ace22655c5edadeb99df80776c09cd93c105feaf49cc0583f3116aff0581b7eab630888c39ba61151f251c1399ec982b93585b0d1d1bf4a45b54f9
   languageName: node
   linkType: hard
 
@@ -13059,8 +12908,8 @@ __metadata:
     react-native-modal: ^13.0.0
     react-native-permissions: ^3.8.0
     react-native-qrcode-svg: ^6.1.2
-    react-native-reanimated: 3.3.0
-    react-native-reanimated-carousel: ^3.5.1
+    react-native-reanimated: 3.6.3
+    react-native-reanimated-carousel: 4.0.0-canary.22
     react-native-safe-area-context: 3.4.1
     react-native-screens: ^3.32.0
     react-native-share: ^8.2.2
@@ -29315,21 +29164,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-reanimated-carousel@npm:^3.5.1":
-  version: 3.5.1
-  resolution: "react-native-reanimated-carousel@npm:3.5.1"
+"react-native-reanimated-carousel@npm:4.0.0-canary.22":
+  version: 4.0.0-canary.22
+  resolution: "react-native-reanimated-carousel@npm:4.0.0-canary.22"
   peerDependencies:
-    react: ">=16.8.0"
-    react-native: ">=0.6.0"
-    react-native-gesture-handler: ">=2.0.0"
+    react: ">=18.0.0"
+    react-native: ">=0.70.3"
+    react-native-gesture-handler: ">=2.9.0"
     react-native-reanimated: ">=3.0.0"
-  checksum: a2eb640453fa35f659c1fb5575f903364d513fb7f621104afa14fee2284132674dfaf0d87cb29e8c119f7513094a5967d5193f3dfa24043af167c6f26abcfe73
+  checksum: 52d4f3c66ea46b6309518bb98547b48302d9852d6ffd7db3f470e3edf342cc289d206c015cf9ba0c31b768e1a15b48f5170b4de678bdcb5f7a29791ef948bd0a
   languageName: node
   linkType: hard
 
-"react-native-reanimated@npm:3.3.0":
-  version: 3.3.0
-  resolution: "react-native-reanimated@npm:3.3.0"
+"react-native-reanimated@npm:3.6.3":
+  version: 3.6.3
+  resolution: "react-native-reanimated@npm:3.6.3"
   dependencies:
     "@babel/plugin-transform-object-assign": ^7.16.7
     "@babel/preset-typescript": ^7.16.7
@@ -29344,7 +29193,7 @@ __metadata:
     "@babel/plugin-transform-template-literals": ^7.0.0-0
     react: "*"
     react-native: "*"
-  checksum: 58096b28caef8af261c446eccb91a5a74caa303ba3520b1a2767c5b922b3d19b9a58612ab9b517a959c1b562b2e76e4cf4a8ffb21136960ed63375f6a4c37d1e
+  checksum: 5094beff09bbeaa13101aca9dfb7be7749ccdea72f240751a2a3f23a354cfc6fdf701549fa6c5dff32d03dc1ed4e404a29db3729519c7098d94ae6c8821a32bd
   languageName: node
   linkType: hard
 
@@ -32585,13 +32434,6 @@ __metadata:
   version: 1.0.1
   resolution: "to-arraybuffer@npm:1.0.1"
   checksum: 31433c10b388722729f5da04c6b2a06f40dc84f797bb802a5a171ced1e599454099c6c5bc5118f4b9105e7d049d3ad9d0f71182b77650e4fdb04539695489941
-  languageName: node
-  linkType: hard
-
-"to-fast-properties@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "to-fast-properties@npm:2.0.0"
-  checksum: be2de62fe58ead94e3e592680052683b1ec986c72d589e7b21e5697f8744cdbf48c266fa72f6c15932894c10187b5f54573a3bcf7da0bfd964d5caf23d436168
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34034

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
