### PR TITLE
(PC-33888) feat(ChronicleCardList): add chronicle card list for mobile and web

### DIFF
--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -1688,7 +1688,16 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                 ]
               }
             >
-              <View>
+              <View
+                gap={1}
+                style={
+                  [
+                    {
+                      "gap": 4,
+                    },
+                  ]
+                }
+              >
                 <View
                   style={
                     [

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -805,7 +805,16 @@ exports[`<Venue /> should match snapshot 1`] = `
                   ]
                 }
               >
-                <View>
+                <View
+                  gap={1}
+                  style={
+                    [
+                      {
+                        "gap": 4,
+                      },
+                    ]
+                  }
+                >
                   <View
                     style={
                       [
@@ -2520,7 +2529,16 @@ exports[`<Venue /> should match snapshot 1`] = `
                     ]
                   }
                 >
-                  <View>
+                  <View
+                    gap={1}
+                    style={
+                      [
+                        {
+                          "gap": 4,
+                        },
+                      ]
+                    }
+                  >
                     <View
                       style={
                         [

--- a/scripts/dead_code_snapshot.txt
+++ b/scripts/dead_code_snapshot.txt
@@ -4,4 +4,3 @@ src/features/venueMap/constant.ts:22 - Record
 src/ui/theme/constants.ts:25 - AVATAR_MEDIUM
 src/features/auth/helpers/contactSupport.ts:38 - satisfies
 src/features/auth/helpers/contactSupport.ts:38 - ContactSupport (used in module)
-src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx:19 - ChronicleCard

--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
@@ -1,6 +1,8 @@
 import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
+import { CHRONICLE_ITEM_WIDTH } from 'features/chronicle/constant'
+import { ChronicleCardData } from 'features/chronicle/type'
 import { InfoHeader } from 'ui/components/InfoHeader/InfoHeader'
 import { Separator } from 'ui/components/Separator'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
@@ -8,17 +10,8 @@ import { BookClubCertification } from 'ui/svg/BookClubCertification'
 import { TypoDS, getShadow, getSpacing } from 'ui/theme'
 
 const CHRONICLE_THUMBNAIL_SIZE = getSpacing(14)
-export const CHRONICLE_ITEM_WIDTH = 327
 
-export type ChronicleCardProps = {
-  id: number
-  title: string
-  subtitle: string
-  description: string
-  date: string
-}
-
-export const ChronicleCard: FunctionComponent<ChronicleCardProps> = ({
+export const ChronicleCard: FunctionComponent<ChronicleCardData> = ({
   id,
   title,
   subtitle,
@@ -26,7 +19,7 @@ export const ChronicleCard: FunctionComponent<ChronicleCardProps> = ({
   date,
 }) => {
   return (
-    <Container gap={3} key={id}>
+    <Container gap={3} testID={`chronicle-${id.toString()}`}>
       <InfoHeader
         title={title}
         subtitle={subtitle}

--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
@@ -8,8 +8,10 @@ import { BookClubCertification } from 'ui/svg/BookClubCertification'
 import { TypoDS, getShadow, getSpacing } from 'ui/theme'
 
 const CHRONICLE_THUMBNAIL_SIZE = getSpacing(14)
+export const CHRONICLE_ITEM_WIDTH = 327
 
-type ChronicleCardProps = {
+export type ChronicleCardProps = {
+  id: number
   title: string
   subtitle: string
   description: string
@@ -42,9 +44,11 @@ const Container = styled(ViewGap)(({ theme }) => ({
   borderRadius: getSpacing(2),
   border: 1,
   borderColor: theme.colors.greyMedium,
+  maxWidth: CHRONICLE_ITEM_WIDTH,
+  backgroundColor: theme.colors.white,
   ...getShadow({
-    shadowOffset: { width: 0, height: getSpacing(3) },
-    shadowRadius: getSpacing(12),
+    shadowOffset: { width: 0, height: getSpacing(1) },
+    shadowRadius: getSpacing(6),
     shadowColor: theme.colors.black,
     shadowOpacity: 0.15,
   }),

--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
@@ -19,13 +19,14 @@ export type ChronicleCardProps = {
 }
 
 export const ChronicleCard: FunctionComponent<ChronicleCardProps> = ({
+  id,
   title,
   subtitle,
   description,
   date,
 }) => {
   return (
-    <Container gap={3}>
+    <Container gap={3} key={id}>
       <InfoHeader
         title={title}
         subtitle={subtitle}

--- a/src/features/chronicle/components/ChronicleCardList/ChronicleCardList.tsx
+++ b/src/features/chronicle/components/ChronicleCardList/ChronicleCardList.tsx
@@ -1,0 +1,3 @@
+import { ChronicleCardListBase } from 'features/chronicle/components/ChronicleCardListBase/ChronicleCardListBase'
+
+export const ChronicleCardList = ChronicleCardListBase

--- a/src/features/chronicle/components/ChronicleCardList/ChronicleCardList.web.test.tsx
+++ b/src/features/chronicle/components/ChronicleCardList/ChronicleCardList.web.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+
+import { ChronicleCardList } from 'features/chronicle/components/ChronicleCardList/ChronicleCardList.web'
+import { chroniclesSnap } from 'features/chronicle/fixtures/chroniclesSnap'
+import { fireEvent, render, screen } from 'tests/utils/web'
+
+describe('ChronicleCardList', () => {
+  it('should render the ChronicleCardList correctly with horizontal mode', () => {
+    render(<ChronicleCardList data={chroniclesSnap} />)
+
+    expect(screen.getByText('Le Voyage Extraordinaire')).toBeInTheDocument()
+    expect(screen.getByText('L’Art de la Cuisine')).toBeInTheDocument()
+
+    expect(screen.getByTestId('chronicle-list-right-arrow')).toBeInTheDocument()
+  })
+
+  it('should render the ChronicleCardList correctly with vertical mode', () => {
+    render(<ChronicleCardList data={chroniclesSnap} horizontal={false} />)
+
+    expect(screen.getByText('Le Voyage Extraordinaire')).toBeInTheDocument()
+
+    expect(screen.queryByTestId('chronicle-list-left-arrow')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('chronicle-list-right-arrow')).not.toBeInTheDocument()
+  })
+
+  it('should go to next page when right arrow is pressed', () => {
+    render(<ChronicleCardList data={chroniclesSnap} horizontal />)
+
+    fireEvent.click(screen.getByTestId('chronicle-list-right-arrow'))
+
+    // 2 item
+    expect(screen.getByText('L’Art de la Cuisine')).toBeInTheDocument()
+    // 11 item
+    expect(screen.queryByText('L’Odyssée des Espèces')).not.toBeInTheDocument()
+  })
+
+  it('should go to previous page when left arrow is pressed', () => {
+    render(<ChronicleCardList data={chroniclesSnap} horizontal />)
+
+    fireEvent.click(screen.getByTestId('chronicle-list-right-arrow'))
+
+    fireEvent.click(screen.getByTestId('chronicle-list-left-arrow'))
+
+    expect(screen.getByText('Le Voyage Extraordinaire')).toBeInTheDocument()
+    expect(screen.getByText('Explorateur du monde')).toBeInTheDocument()
+  })
+
+  it('should disable the left arrow when on the first item', () => {
+    render(<ChronicleCardList data={chroniclesSnap} horizontal />)
+
+    // Ensure that the left arrow is not clickable on the first item
+    expect(screen.queryByTestId('chronicle-list-left-arrow')).not.toBeInTheDocument()
+  })
+
+  it('should disable the right arrow when on the last item', () => {
+    render(<ChronicleCardList data={chroniclesSnap} horizontal />)
+
+    const rightArrow = screen.getByTestId('chronicle-list-right-arrow')
+
+    // Simulate clicks until the right arrow button is no longer visible
+    while (rightArrow && rightArrow.isConnected) {
+      fireEvent.click(rightArrow)
+    }
+
+    expect(screen.queryByTestId('chronicle-list-right-arrow')).not.toBeInTheDocument()
+  })
+})

--- a/src/features/chronicle/components/ChronicleCardList/ChronicleCardList.web.test.tsx
+++ b/src/features/chronicle/components/ChronicleCardList/ChronicleCardList.web.test.tsx
@@ -5,19 +5,21 @@ import { chroniclesSnap } from 'features/chronicle/fixtures/chroniclesSnap'
 import { fireEvent, render, screen } from 'tests/utils/web'
 
 describe('ChronicleCardList', () => {
-  it('should render the ChronicleCardList correctly with horizontal mode', () => {
+  it('should render the ChronicleCardList correctly', () => {
     render(<ChronicleCardList data={chroniclesSnap} />)
 
     expect(screen.getByText('Le Voyage Extraordinaire')).toBeInTheDocument()
     expect(screen.getByText('L’Art de la Cuisine')).toBeInTheDocument()
+  })
+
+  it('should render the ChronicleCardList with horizontal mode', () => {
+    render(<ChronicleCardList data={chroniclesSnap} />)
 
     expect(screen.getByTestId('chronicle-list-right-arrow')).toBeInTheDocument()
   })
 
-  it('should render the ChronicleCardList correctly with vertical mode', () => {
+  it('should render the ChronicleCardList with vertical mode', () => {
     render(<ChronicleCardList data={chroniclesSnap} horizontal={false} />)
-
-    expect(screen.getByText('Le Voyage Extraordinaire')).toBeInTheDocument()
 
     expect(screen.queryByTestId('chronicle-list-left-arrow')).not.toBeInTheDocument()
     expect(screen.queryByTestId('chronicle-list-right-arrow')).not.toBeInTheDocument()

--- a/src/features/chronicle/components/ChronicleCardList/ChronicleCardList.web.tsx
+++ b/src/features/chronicle/components/ChronicleCardList/ChronicleCardList.web.tsx
@@ -1,12 +1,12 @@
 import React, { FunctionComponent, useState } from 'react'
 import styled from 'styled-components/native'
 
-import { ChronicleCardProps } from 'features/chronicle/components/ChronicleCard/ChronicleCard'
 import { ChronicleCardListBase } from 'features/chronicle/components/ChronicleCardListBase/ChronicleCardListBase'
+import { ChronicleCardData } from 'features/chronicle/type'
 import { PlaylistArrowButton } from 'ui/Playlist/PlaylistArrowButton'
 
 type ChronicleCardListProps = {
-  data: ChronicleCardProps[]
+  data: ChronicleCardData[]
   horizontal?: boolean
 }
 

--- a/src/features/chronicle/components/ChronicleCardList/ChronicleCardList.web.tsx
+++ b/src/features/chronicle/components/ChronicleCardList/ChronicleCardList.web.tsx
@@ -1,0 +1,51 @@
+import React, { FunctionComponent, useState } from 'react'
+import styled from 'styled-components/native'
+
+import { ChronicleCardProps } from 'features/chronicle/components/ChronicleCard/ChronicleCard'
+import { ChronicleCardListBase } from 'features/chronicle/components/ChronicleCardListBase/ChronicleCardListBase'
+import { PlaylistArrowButton } from 'ui/Playlist/PlaylistArrowButton'
+
+type ChronicleCardListProps = {
+  data: ChronicleCardProps[]
+  horizontal?: boolean
+}
+
+export const ChronicleCardList: FunctionComponent<ChronicleCardListProps> = ({
+  data,
+  horizontal = true,
+}) => {
+  const [indexItem, setIndexItem] = useState(0)
+
+  const goToPreviousPage = () => setIndexItem((prev) => Math.max(prev - 1, 0))
+  const goToNextPage = () => setIndexItem((prev) => Math.min(prev + 1, data.length - 1))
+
+  return (
+    <FlatListContainer>
+      {horizontal ? (
+        <React.Fragment>
+          {indexItem > 0 ? (
+            <PlaylistArrowButton
+              direction="left"
+              onPress={goToPreviousPage}
+              testID="chronicle-list-left-arrow"
+            />
+          ) : null}
+
+          {indexItem < data.length - 1 ? (
+            <PlaylistArrowButton
+              direction="right"
+              onPress={goToNextPage}
+              testID="chronicle-list-right-arrow"
+            />
+          ) : null}
+        </React.Fragment>
+      ) : null}
+      <ChronicleCardListBase data={data} indexItem={indexItem} horizontal={horizontal} />
+    </FlatListContainer>
+  )
+}
+
+const FlatListContainer = styled.View<{ minHeight?: number }>({
+  position: 'relative',
+  width: '100%',
+})

--- a/src/features/chronicle/components/ChronicleCardListBase/ChronicleCardListBase.native.test.tsx
+++ b/src/features/chronicle/components/ChronicleCardListBase/ChronicleCardListBase.native.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import { ChronicleCardListBase } from 'features/chronicle/components/ChronicleCardListBase/ChronicleCardListBase'
+import { chroniclesSnap } from 'features/chronicle/fixtures/chroniclesSnap'
+import { render, screen } from 'tests/utils'
+
+describe('ChronicleCardListBase', () => {
+  it('should display all chronicle cards in the list', () => {
+    render(<ChronicleCardListBase data={chroniclesSnap} horizontal />)
+
+    expect(screen.getByText('Le Voyage Extraordinaire')).toBeOnTheScreen()
+  })
+
+  it('should scroll to the correct page when indexItem is provided', () => {
+    const indexItem = 3
+    render(<ChronicleCardListBase data={chroniclesSnap} indexItem={indexItem} horizontal />)
+
+    expect(screen.getByText('La Nature Sauvage')).toBeOnTheScreen()
+  })
+
+  it('should display vertical separators when horizontal is false', () => {
+    render(<ChronicleCardListBase data={chroniclesSnap} horizontal={false} />)
+
+    expect(screen.getAllByTestId('column-separator')).toHaveLength(10)
+  })
+
+  it('should display horizontal separators when horizontal is true', () => {
+    render(<ChronicleCardListBase data={chroniclesSnap} horizontal />)
+
+    expect(screen.getAllByTestId('row-separator')).toHaveLength(10)
+  })
+})

--- a/src/features/chronicle/components/ChronicleCardListBase/ChronicleCardListBase.tsx
+++ b/src/features/chronicle/components/ChronicleCardListBase/ChronicleCardListBase.tsx
@@ -1,0 +1,75 @@
+import React, { FunctionComponent, useEffect, useRef } from 'react'
+import { FlatList } from 'react-native'
+
+import {
+  CHRONICLE_ITEM_WIDTH,
+  ChronicleCard,
+  ChronicleCardProps,
+} from 'features/chronicle/components/ChronicleCard/ChronicleCard'
+import { Spacer, getSpacing } from 'ui/theme'
+
+const SEPARATOR_VALUE = 2
+const keyExtractor = (item: ChronicleCardProps) => item.id.toString()
+
+type ChronicleCardListProps = {
+  data: ChronicleCardProps[]
+  indexItem?: number
+  horizontal?: boolean
+}
+
+const renderItem = ({ item }: { item: ChronicleCardProps }) => {
+  return (
+    <ChronicleCard
+      id={item.id}
+      title={item.title}
+      subtitle={item.subtitle}
+      description={item.description}
+      date={item.date}
+    />
+  )
+}
+
+export const ChronicleCardListBase: FunctionComponent<ChronicleCardListProps> = ({
+  data,
+  indexItem = 0,
+  horizontal = true,
+}) => {
+  const listRef = useRef<FlatList>(null)
+
+  const snapToOffsets = data.map((_, index) => CHRONICLE_ITEM_WIDTH * (index + 1))
+
+  useEffect(() => {
+    if (listRef.current && indexItem >= 0 && indexItem < data.length) {
+      listRef.current.scrollToIndex({ index: indexItem, animated: true })
+    }
+  }, [data.length, indexItem])
+
+  return (
+    <FlatList
+      ref={listRef}
+      data={data}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      ItemSeparatorComponent={horizontal ? RowSeparator : ColumnSeparator}
+      contentContainerStyle={contentContainerStyle}
+      showsHorizontalScrollIndicator={false}
+      horizontal={horizontal}
+      decelerationRate="fast"
+      snapToOffsets={snapToOffsets}
+      getItemLayout={(_, index) => ({
+        length: CHRONICLE_ITEM_WIDTH,
+        offset: CHRONICLE_ITEM_WIDTH * index,
+        index,
+      })}
+    />
+  )
+}
+
+const contentContainerStyle = {
+  paddingVertical: getSpacing(12),
+}
+
+const RowSeparator = () => <Spacer.Row numberOfSpaces={SEPARATOR_VALUE} testID="row-separator" />
+const ColumnSeparator = () => (
+  <Spacer.Column numberOfSpaces={SEPARATOR_VALUE} testID="column-separator" />
+)

--- a/src/features/chronicle/components/ChronicleCardListBase/ChronicleCardListBase.tsx
+++ b/src/features/chronicle/components/ChronicleCardListBase/ChronicleCardListBase.tsx
@@ -1,23 +1,21 @@
 import React, { FunctionComponent, useEffect, useRef } from 'react'
 import { FlatList } from 'react-native'
 
-import {
-  CHRONICLE_ITEM_WIDTH,
-  ChronicleCard,
-  ChronicleCardProps,
-} from 'features/chronicle/components/ChronicleCard/ChronicleCard'
+import { ChronicleCard } from 'features/chronicle/components/ChronicleCard/ChronicleCard'
+import { CHRONICLE_ITEM_WIDTH } from 'features/chronicle/constant'
+import { ChronicleCardData } from 'features/chronicle/type'
 import { Spacer, getSpacing } from 'ui/theme'
 
 const SEPARATOR_VALUE = 2
-const keyExtractor = (item: ChronicleCardProps) => item.id.toString()
+const keyExtractor = (item: ChronicleCardData) => item.id.toString()
 
 type ChronicleCardListProps = {
-  data: ChronicleCardProps[]
+  data: ChronicleCardData[]
   indexItem?: number
   horizontal?: boolean
 }
 
-const renderItem = ({ item }: { item: ChronicleCardProps }) => {
+const renderItem = ({ item }: { item: ChronicleCardData }) => {
   return (
     <ChronicleCard
       id={item.id}

--- a/src/features/chronicle/constant.ts
+++ b/src/features/chronicle/constant.ts
@@ -1,0 +1,1 @@
+export const CHRONICLE_ITEM_WIDTH = 327

--- a/src/features/chronicle/fixtures/chroniclesSnap.ts
+++ b/src/features/chronicle/fixtures/chroniclesSnap.ts
@@ -1,0 +1,128 @@
+import type { ReadonlyDeep } from 'type-fest'
+
+import { ChronicleCardProps } from 'features/chronicle/components/ChronicleCard/ChronicleCard'
+import { toMutable } from 'shared/types/toMutable'
+
+export const chroniclesSnap = toMutable([
+  {
+    id: 1,
+    title: 'Le Voyage Extraordinaire',
+    subtitle: 'Explorateur du monde',
+    description:
+      'Découvrez l’histoire fascinante d’un homme qui a parcouru les coins les plus reculés de la planète.',
+    date: 'Janvier 2024',
+  },
+  {
+    id: 2,
+    title: 'L’Art de la Cuisine',
+    subtitle: 'Chef étoilé',
+    description:
+      'Plongez dans les secrets de la gastronomie avec un chef qui transforme chaque repas en œuvre d’art.',
+    date: 'Février 2024',
+  },
+  {
+    id: 3,
+    title: 'Le Futur de la Technologie',
+    subtitle: 'Visionnaire du digital',
+    description:
+      'Une analyse approfondie des innovations qui changeront notre quotidien dans les années à venir.',
+    date: 'Mars 2024',
+  },
+  {
+    id: 4,
+    title: 'Aventures sous-marines',
+    subtitle: 'Plongeur passionné',
+    description:
+      'Une plongée captivante dans les mystères des océans, révélant une faune et une flore extraordinaires.',
+    date: 'Avril 2024',
+  },
+  {
+    id: 5,
+    title: 'La Magie des Étoiles',
+    subtitle: 'Astrophysicien',
+    description:
+      'Explorez les confins de l’univers à travers le regard d’un scientifique fasciné par les étoiles.',
+    date: 'Mai 2024',
+  },
+  {
+    id: 6,
+    title: 'L’Histoire des Civilisations',
+    subtitle: 'Historien renommé',
+    description:
+      'Un voyage dans le temps pour découvrir les grandes civilisations qui ont marqué notre histoire.',
+    date: 'Juin 2024',
+  },
+  {
+    id: 7,
+    title: 'La Nature Sauvage',
+    subtitle: 'Photographe animalier',
+    description:
+      'Un album photo spectaculaire montrant la beauté brute de la faune et de la flore sauvage.',
+    date: 'Juillet 2024',
+  },
+  {
+    id: 8,
+    title: 'Les Secrets de l’Univers',
+    subtitle: 'Physicien théoricien',
+    description:
+      'Une exploration des théories qui tentent d’expliquer les origines et le fonctionnement de l’univers.',
+    date: 'Août 2024',
+  },
+  {
+    id: 9,
+    title: 'Voyage au Centre de la Terre',
+    subtitle: 'Géologue explorateur',
+    description: 'Une aventure palpitante qui révèle les secrets cachés sous nos pieds.',
+    date: 'Septembre 2024',
+  },
+  {
+    id: 10,
+    title: 'La Renaissance Artistique',
+    subtitle: 'Critique d’art',
+    description: 'Un voyage captivant à travers les œuvres emblématiques de la Renaissance.',
+    date: 'Octobre 2024',
+  },
+  {
+    id: 11,
+    title: 'L’Odyssée des Espèces',
+    subtitle: 'Biologiste marin',
+    description: 'Un regard fascinant sur l’évolution des espèces marines au fil des âges.',
+    date: 'Novembre 2024',
+  },
+  {
+    id: 12,
+    title: 'La Quête des Énergies Renouvelables',
+    subtitle: 'Ingénieur en énergie',
+    description:
+      'Un guide pratique pour comprendre les défis et les opportunités des énergies vertes.',
+    date: 'Décembre 2024',
+  },
+  {
+    id: 13,
+    title: 'Les Mystères de l’Esprit Humain',
+    subtitle: 'Psychologue renommé',
+    description: 'Une plongée dans les complexités du cerveau et du comportement humain.',
+    date: 'Janvier 2025',
+  },
+  {
+    id: 14,
+    title: 'Au-Delà des Frontières',
+    subtitle: 'Journaliste d’investigation',
+    description: 'Un récit poignant sur les luttes et les espoirs des réfugiés à travers le monde.',
+    date: 'Février 2025',
+  },
+  {
+    id: 15,
+    title: 'L’Énigme des Civilisations Perdues',
+    subtitle: 'Archéologue',
+    description: 'Une enquête sur les sociétés disparues et leurs traces laissées dans l’histoire.',
+    date: 'Mars 2025',
+  },
+  {
+    id: 16,
+    title: 'Les Gardiens de la Forêt',
+    subtitle: 'Écologiste',
+    description: 'Un hommage aux protecteurs des écosystèmes forestiers à travers le globe.',
+    date: 'Avril 2025',
+  },
+] as const satisfies ReadonlyDeep<ChronicleCardProps[]>)

--- a/src/features/chronicle/fixtures/chroniclesSnap.ts
+++ b/src/features/chronicle/fixtures/chroniclesSnap.ts
@@ -1,6 +1,6 @@
 import type { ReadonlyDeep } from 'type-fest'
 
-import { ChronicleCardProps } from 'features/chronicle/components/ChronicleCard/ChronicleCard'
+import { ChronicleCardData } from 'features/chronicle/type'
 import { toMutable } from 'shared/types/toMutable'
 
 export const chroniclesSnap = toMutable([
@@ -125,4 +125,4 @@ export const chroniclesSnap = toMutable([
     description: 'Un hommage aux protecteurs des écosystèmes forestiers à travers le globe.',
     date: 'Avril 2025',
   },
-] as const satisfies ReadonlyDeep<ChronicleCardProps[]>)
+] as const satisfies ReadonlyDeep<ChronicleCardData[]>)

--- a/src/features/chronicle/type.ts
+++ b/src/features/chronicle/type.ts
@@ -1,0 +1,7 @@
+export type ChronicleCardData = {
+  id: number
+  title: string
+  subtitle: string
+  description: string
+  date: string
+}

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -5,6 +5,8 @@ import styled, { useTheme } from 'styled-components/native'
 
 import { CategoryIdEnum, OfferResponseV2 } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
+import { ChronicleCardList } from 'features/chronicle/components/ChronicleCardList/ChronicleCardList'
+import { chroniclesSnap } from 'features/chronicle/fixtures/chroniclesSnap'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { OfferAbout } from 'features/offer/components/OfferAbout/OfferAbout'
 import { OfferArtists } from 'features/offer/components/OfferArtists/OfferArtists'
@@ -164,6 +166,8 @@ export const OfferBody: FunctionComponent<Props> = ({
 
       {hasOfferChronicleSection && !isDesktopViewport ? (
         <SectionWithDivider visible margin gap={8}>
+          {/* To remove with the data from the back */}
+          <ChronicleCardList data={chroniclesSnap} />
           <InternalTouchableLink
             as={ButtonSecondaryBlack}
             wording="Voir tous les avis"

--- a/src/ui/components/PassPlaylist.tsx
+++ b/src/ui/components/PassPlaylist.tsx
@@ -1,12 +1,11 @@
 import React, { ComponentProps, ComponentType, useCallback } from 'react'
-import { View } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 
 import { Playlist, RenderFooterItem } from 'ui/components/Playlist'
 import { SeeMore } from 'ui/components/SeeMore'
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
-import { Spacer, TypoDS } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 import { SeeMoreWithEye } from './SeeMoreWithEye'
@@ -83,18 +82,13 @@ export const PassPlaylist = ({
   }
   return (
     <Container gap={4} {...props}>
-      <View>
+      <ViewGap gap={1}>
         <StyledView>
           <StyledTitleComponent testID="playlistTitle">{title}</StyledTitleComponent>
           {renderTitleSeeMore()}
         </StyledView>
-        {subtitle ? (
-          <React.Fragment>
-            <Spacer.Column numberOfSpaces={1} />
-            <StyledSubtitle>{subtitle}</StyledSubtitle>
-          </React.Fragment>
-        ) : null}
-      </View>
+        {subtitle ? <StyledSubtitle>{subtitle}</StyledSubtitle> : null}
+      </ViewGap>
       <Playlist
         testID="offersModuleList"
         data={data}

--- a/src/ui/svg/BookClubCertification.tsx
+++ b/src/ui/svg/BookClubCertification.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
-import { Defs, Path, Stop } from 'react-native-svg'
+import { Defs, LinearGradient, Path, Stop } from 'react-native-svg'
 import styled from 'styled-components/native'
 
 import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
 import { AccessibleIcon } from 'ui/svg/icons/types'
+import { svgIdentifier } from 'ui/svg/utils'
 
 const BookClubCertificationSvg: React.FunctionComponent<AccessibleIcon> = ({
   size,
@@ -12,6 +13,7 @@ const BookClubCertificationSvg: React.FunctionComponent<AccessibleIcon> = ({
   accessibilityLabel,
   testID,
 }) => {
+  const { id: gradientId, fill: gradientFill } = svgIdentifier()
   return (
     <AccessibleSvg
       width={size}
@@ -24,15 +26,15 @@ const BookClubCertificationSvg: React.FunctionComponent<AccessibleIcon> = ({
         fillRule="evenodd"
         clipRule="evenodd"
         d="M8.8125 24.0314C8.8125 15.6049 15.6875 8.80127 24.0625 8.80127C32.4375 8.80127 39.3125 15.6049 39.3125 24.0314C39.3125 32.458 32.4375 39.2616 24.0625 39.2616C15.6875 39.2616 8.8125 32.458 8.8125 24.0314ZM16.25 30.9352V16.2293C16.25 15.3097 16.9958 14.5648 17.9167 14.5648H18.75V24.5518V26.6324V30.7937H16.875C16.65 30.7937 16.4375 30.8436 16.25 30.9352ZM29.525 32.7577H16.9625C16.5708 32.7577 16.25 32.4789 16.25 32.1335C16.25 31.7882 16.5708 31.5094 16.9625 31.5094H29.9958V32.4872C29.9958 32.5746 29.9792 32.6204 29.9667 32.6412C29.9542 32.662 29.9417 32.6787 29.9167 32.6912C29.8542 32.7286 29.7292 32.7577 29.525 32.7577ZM31.2502 16.9201V15.8132C31.2502 15.1266 30.6877 14.5648 30.0002 14.5648H19.6627V27.4647V30.7937H30.0002V30.7354C30.7168 30.5482 31.2502 29.9073 31.2502 29.1292V19.1422V16.9201ZM26.2502 22.4712H22.9168C22.6877 22.4712 22.5002 22.2839 22.5002 22.0551C22.5002 21.8262 22.6877 21.6389 22.9168 21.6389H26.2502C26.4793 21.6389 26.6668 21.8262 26.6668 22.0551C26.6668 22.2839 26.4793 22.4712 26.2502 22.4712ZM27.9168 20.3906H22.9168C22.6877 20.3906 22.5002 20.2033 22.5002 19.9744C22.5002 19.7456 22.6877 19.5583 22.9168 19.5583H27.9168C28.146 19.5583 28.3335 19.7456 28.3335 19.9744C28.3335 20.2033 28.146 20.3906 27.9168 20.3906Z"
-        fill="url(#paint0_linear_4303_7887)"
+        fill={gradientFill}
       />
       <Path
         d="M45.6875 20.5982L46.9375 16.6034L43.5625 14.1066V9.92458L39.5625 8.61378L38.25 4.61899H34.0625L31.5625 1.24837L27.5625 2.49675L24.0625 0L20.625 2.43433L16.625 1.18596L14.125 4.55657H9.9375L8.625 8.55137L4.625 9.86216V14.0442L1.25 16.541L2.5 20.5358L0 24.0312L2.4375 27.4642L1.1875 31.459L4.5625 33.9558V38.1378L8.5625 39.4486L9.875 43.4434H14.0625L16.5625 46.814L20.5625 45.5657L24 48L27.4375 45.5657L31.4375 46.814L33.9375 43.4434H38.125L39.4375 39.4486L43.4375 38.1378V33.9558L46.8125 31.459L45.5625 27.4642L48 24.0312L45.6875 20.5982ZM24.0625 41.2588C14.5625 41.2588 6.8125 33.5189 6.8125 24.0312C6.8125 14.5436 14.5625 6.80364 24.0625 6.80364C33.5625 6.80364 41.3125 14.5436 41.3125 24.0312C41.3125 33.5189 33.5625 41.2588 24.0625 41.2588Z"
-        fill="url(#paint1_linear_4303_7887)"
+        fill={gradientFill}
       />
       <Defs>
-        <linearGradient
-          id="paint0_linear_4303_7887"
+        <LinearGradient
+          id={gradientId}
           x1="24.0625"
           y1="8.80127"
           x2="24.0625"
@@ -40,9 +42,9 @@ const BookClubCertificationSvg: React.FunctionComponent<AccessibleIcon> = ({
           gradientUnits="userSpaceOnUse">
           <Stop stopColor={color} />
           <Stop offset="1" stopColor={color2} />
-        </linearGradient>
-        <linearGradient
-          id="paint1_linear_4303_7887"
+        </LinearGradient>
+        <LinearGradient
+          id={gradientId}
           x1="24"
           y1="0"
           x2="24"
@@ -50,7 +52,7 @@ const BookClubCertificationSvg: React.FunctionComponent<AccessibleIcon> = ({
           gradientUnits="userSpaceOnUse">
           <Stop stopColor={color} />
           <Stop offset="1" stopColor={color2} />
-        </linearGradient>
+        </LinearGradient>
       </Defs>
     </AccessibleSvg>
   )


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33888

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
