### PR TITLE
(PC-33898) feat(SafeSeatWithQrCode): add FF

### DIFF
--- a/src/features/bookings/components/Ticket/TicketSwiper.native.test.tsx
+++ b/src/features/bookings/components/Ticket/TicketSwiper.native.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import type { BookingsResponse } from 'api/gen'
 import { TicketSwiper } from 'features/bookings/components/Ticket/TicketSwiper'
 import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { render, screen } from 'tests/utils'
 
 jest.mock('libs/subcategories/useCategoryId')
@@ -13,6 +14,8 @@ const booking: BookingsResponse['ongoing_bookings'][number] = bookingsSnap.ongoi
 jest.mock('libs/firebase/analytics/analytics')
 
 describe('<TicketSwiper/>', () => {
+  beforeEach(() => setFeatureFlags())
+
   it('should display ticket without external bookings information if there are no external bookings (externalBookings is null)', () => {
     booking.externalBookings = null
 

--- a/src/features/bookings/components/TicketBody/SafeSeatWithQrCode/SafeSeatWithQrCode.tsx
+++ b/src/features/bookings/components/TicketBody/SafeSeatWithQrCode/SafeSeatWithQrCode.tsx
@@ -36,9 +36,7 @@ export const SafeSeatWithQrCode: FC<SafeSeatWithQrCodeProps> = ({
     categoriesToHide,
   })
 
-  if (!shouldQrCodeBeHidden) {
-    return <SeatWithQrCode {...seatWithQrCodeProps} />
-  }
+  if (!shouldQrCodeBeHidden) return <SeatWithQrCode {...seatWithQrCodeProps} />
 
   return (
     <DashedContainer>

--- a/src/features/bookings/components/TicketBody/SafeSeatWithQrCode/SafeSeatWithQrCode.tsx
+++ b/src/features/bookings/components/TicketBody/SafeSeatWithQrCode/SafeSeatWithQrCode.tsx
@@ -28,7 +28,7 @@ export const SafeSeatWithQrCode: FC<SafeSeatWithQrCodeProps> = ({
   venue,
   ...seatWithQrCodeProps
 }) => {
-  const { day, shouldQrCodeBeHidden } = useSafeSeatWithQrCode({
+  const { day, time, shouldQrCodeBeHidden } = useSafeSeatWithQrCode({
     beginningDatetime,
     qrCodeVisibilityHoursBeforeEvent,
     subcategoryId,
@@ -47,6 +47,7 @@ export const SafeSeatWithQrCode: FC<SafeSeatWithQrCodeProps> = ({
           <View>
             <StyledBody>Ton billet sera disponible ici le</StyledBody>
             <StyledBody>{day}</StyledBody>
+            <StyledBody>à {time}</StyledBody>
           </View>
         </ContentContainer>
       </BlurredQrCodeContainer>

--- a/src/features/bookings/components/TicketBody/SafeSeatWithQrCode/useSafeSeatWithQrCode.native.test.ts
+++ b/src/features/bookings/components/TicketBody/SafeSeatWithQrCode/useSafeSeatWithQrCode.native.test.ts
@@ -88,7 +88,19 @@ describe('useSafeSeatWithQrCode', () => {
             categoriesToHide: [subcategoryId],
           })
 
-          expect(result.current.day).toEqual('14 janvier 2024 à 02h00')
+          expect(result.current.day).toEqual('14 janvier 2024')
+        })
+
+        it('should display the right time', () => {
+          const { result } = renderUseSafeSeatWithQrCode({
+            beginningDatetime: eventDay,
+            qrCodeVisibilityHoursBeforeEvent,
+            venue,
+            subcategoryId,
+            categoriesToHide: [subcategoryId],
+          })
+
+          expect(result.current.time).toEqual('02h00')
         })
       })
 

--- a/src/features/bookings/components/TicketBody/SafeSeatWithQrCode/useSafeSeatWithQrCode.ts
+++ b/src/features/bookings/components/TicketBody/SafeSeatWithQrCode/useSafeSeatWithQrCode.ts
@@ -3,7 +3,11 @@ import { isBefore, subHours } from 'date-fns'
 import { BookingVenueResponse, SubcategoryIdEnum } from 'api/gen'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import { formatToCompleteFrenchDateTime, getTimeZonedDate } from 'libs/parsers/formatDates'
+import {
+  formatToCompleteFrenchDate,
+  formatToHour,
+  getTimeZonedDate,
+} from 'libs/parsers/formatDates'
 
 type Parameters = {
   subcategoryId: SubcategoryIdEnum
@@ -34,7 +38,8 @@ export const useSafeSeatWithQrCode = ({
     subHours(new Date(beginningDatetime), qrCodeVisibilityHoursBeforeEvent),
     venue?.timezone
   )
-  const day = formatToCompleteFrenchDateTime(timezonedDate, false)
+  const day = formatToCompleteFrenchDate(timezonedDate, false)
+  const time = formatToHour(timezonedDate)
 
-  return { shouldQrCodeBeHidden: shouldbeHidden, day }
+  return { shouldQrCodeBeHidden: shouldbeHidden, day, time }
 }

--- a/src/features/bookings/components/TicketBody/SafeSeatWithQrCode/useSafeSeatWithQrCode.ts
+++ b/src/features/bookings/components/TicketBody/SafeSeatWithQrCode/useSafeSeatWithQrCode.ts
@@ -1,6 +1,8 @@
 import { isBefore, subHours } from 'date-fns'
 
 import { BookingVenueResponse, SubcategoryIdEnum } from 'api/gen'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { formatToCompleteFrenchDateTime, getTimeZonedDate } from 'libs/parsers/formatDates'
 
 type Parameters = {
@@ -18,13 +20,15 @@ export const useSafeSeatWithQrCode = ({
   venue,
   categoriesToHide = [],
 }: Parameters) => {
+  const enableHideTicket = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_HIDE_TICKET)
+
   const now = new Date()
   const isAmongCategoriesToHide = categoriesToHide.includes(subcategoryId)
   const isBeforeHoursOffset = isBefore(
     now,
     subHours(new Date(beginningDatetime || ''), qrCodeVisibilityHoursBeforeEvent)
   )
-  const shouldbeHidden = isAmongCategoriesToHide && isBeforeHoursOffset
+  const shouldbeHidden = isAmongCategoriesToHide && isBeforeHoursOffset && enableHideTicket
 
   const timezonedDate = getTimeZonedDate(
     subHours(new Date(beginningDatetime), qrCodeVisibilityHoursBeforeEvent),

--- a/src/features/bookings/components/TicketBody/TicketBody.native.test.tsx
+++ b/src/features/bookings/components/TicketBody/TicketBody.native.test.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 
 import { SubcategoryIdEnum, WithdrawalTypeEnum } from 'api/gen'
 import { TicketBody } from 'features/bookings/components/TicketBody/TicketBody'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { mockBuilder } from 'tests/mockBuilder'
 import { render, screen } from 'tests/utils'
 
@@ -51,31 +53,37 @@ describe('TicketBody', () => {
 
   describe('QrCode for external bookings', () => {
     describe('concert or festival', () => {
-      it('should be hidden until 2 days before the event', () => {
-        render(
-          <TicketBody
-            {...initialProps}
-            subcategoryId={SubcategoryIdEnum.FESTIVAL_MUSIQUE}
-            externalBookings={{ barcode: 'barcode' }}
-            venue={venue}
-          />
-        )
+      describe('when FF enableHideTicket is true', () => {
+        beforeEach(() => {
+          setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_HIDE_TICKET])
+        })
 
-        expect(screen.queryByTestId('qr-code')).not.toBeOnTheScreen()
-      })
+        it('should be hidden until 2 days before the event', () => {
+          render(
+            <TicketBody
+              {...initialProps}
+              subcategoryId={SubcategoryIdEnum.FESTIVAL_MUSIQUE}
+              externalBookings={{ barcode: 'barcode' }}
+              venue={venue}
+            />
+          )
 
-      it('should be displayed 2 days before the event', () => {
-        render(
-          <TicketBody
-            {...initialProps}
-            beginningDatetime="2021-03-11T20:00:00"
-            subcategoryId={SubcategoryIdEnum.FESTIVAL_MUSIQUE}
-            externalBookings={{ barcode: 'barcode' }}
-            venue={venue}
-          />
-        )
+          expect(screen.queryByTestId('qr-code')).not.toBeOnTheScreen()
+        })
 
-        expect(screen.getByTestId('qr-code')).toBeOnTheScreen()
+        it('should be displayed 2 days before the event', () => {
+          render(
+            <TicketBody
+              {...initialProps}
+              beginningDatetime="2021-03-11T20:00:00"
+              subcategoryId={SubcategoryIdEnum.FESTIVAL_MUSIQUE}
+              externalBookings={{ barcode: 'barcode' }}
+              venue={venue}
+            />
+          )
+
+          expect(screen.getByTestId('qr-code')).toBeOnTheScreen()
+        })
       })
 
       it('should display the availability date', () => {
@@ -90,6 +98,25 @@ describe('TicketBody', () => {
         )
 
         expect(screen.getByText('11 mars 2021 à 21h00')).toBeOnTheScreen()
+      })
+
+      describe('when FF enableHideTicket is false', () => {
+        beforeEach(() => {
+          setFeatureFlags()
+        })
+
+        it('should not be hidden even until 2 days before the event', () => {
+          render(
+            <TicketBody
+              {...initialProps}
+              subcategoryId={SubcategoryIdEnum.FESTIVAL_MUSIQUE}
+              externalBookings={{ barcode: 'barcode' }}
+              venue={venue}
+            />
+          )
+
+          expect(screen.getByTestId('qr-code')).toBeOnTheScreen()
+        })
       })
     })
 

--- a/src/features/bookings/components/TicketBody/TicketBody.native.test.tsx
+++ b/src/features/bookings/components/TicketBody/TicketBody.native.test.tsx
@@ -97,7 +97,21 @@ describe('TicketBody', () => {
           />
         )
 
-        expect(screen.getByText('11 mars 2021 à 21h00')).toBeOnTheScreen()
+        expect(screen.getByText('11 mars 2021')).toBeOnTheScreen()
+      })
+
+      it('should display the availability time', () => {
+        render(
+          <TicketBody
+            {...initialProps}
+            beginningDatetime="2021-03-13T20:00:00"
+            subcategoryId={SubcategoryIdEnum.FESTIVAL_MUSIQUE}
+            externalBookings={{ barcode: 'barcode' }}
+            venue={venue}
+          />
+        )
+
+        expect(screen.getByText('à 21h00')).toBeOnTheScreen()
       })
 
       describe('when FF enableHideTicket is false', () => {

--- a/src/libs/firebase/firestore/types.ts
+++ b/src/libs/firebase/firestore/types.ts
@@ -55,6 +55,7 @@ export enum RemoteStoreFeatureFlags {
   ENABLE_ACHIEVEMENTS = 'enableAchievements',
   ENABLE_CREDIT_V3 = 'enableCreditV3',
   ENABLE_CULTURAL_SURVEY_MANDATORY = 'enableCulturalSurveyMandatory',
+  ENABLE_HIDE_TICKET = 'enableHideTicket',
   ENABLE_PACIFIC_FRANC_CURRENCY = 'enablePacificFrancCurrency',
   ENABLE_PASS_FOR_ALL = 'enablePassForAll',
   ENABLE_REPLICA_ALGOLIA_INDEX = 'enableReplicaAlgoliaIndex',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33898

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

| Platform         | Before | After |
| :--------------- | :-----------: | :---: |
| iOS |![Capture d’écran 2025-01-16 à 16 12 45](https://github.com/user-attachments/assets/0f8bd91a-d8c3-4335-b859-f08e5f49bdfc)|![Simulator Screenshot - iPhone SE (3rd generation) - 2025-01-17 at 11 52 17](https://github.com/user-attachments/assets/acd324b2-3f92-4f1d-8eae-9edac3b11f79)|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
