### PR TITLE
(BSR) fix(offer): preview image sticky position

### DIFF
--- a/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
@@ -55,6 +55,7 @@ exports[`BookingDetails should render correctly 1`] = `
               {
                 "alignItems": "center",
                 "position": "absolute",
+                "top": 0,
               },
             ]
           }

--- a/src/features/offer/components/OfferImageCarousel/OfferImageCarousel.tsx
+++ b/src/features/offer/components/OfferImageCarousel/OfferImageCarousel.tsx
@@ -1,14 +1,13 @@
 import React, { FunctionComponent, ReactElement, useCallback, useRef } from 'react'
-import { Platform, StyleProp, ViewStyle } from 'react-native'
+import { Platform, StyleProp, View, ViewStyle } from 'react-native'
 import Animated, { FadeIn, SharedValue } from 'react-native-reanimated'
 import Carousel, { ICarouselInstance } from 'react-native-reanimated-carousel'
-import styled, { useTheme } from 'styled-components/native'
+import { useTheme } from 'styled-components/native'
 
 import { OfferImageCarouselItem } from 'features/offer/components/OfferImageCarousel/OfferImageCarouselItem'
 import { OfferImageCarouselPagination } from 'features/offer/components/OfferImageCarouselPagination/OfferImageCarouselPagination'
 import { calculateCarouselIndex } from 'features/offer/helpers/calculateCarouselIndex/calculateCarouselIndex'
 import { useOfferImageContainerDimensions } from 'features/offer/helpers/useOfferImageContainerDimensions'
-import { useGetHeaderHeight } from 'ui/components/headers/PageHeaderWithoutPlaceholder'
 import { Spacer } from 'ui/theme'
 
 type Props = {
@@ -29,13 +28,11 @@ export const OfferImageCarousel: FunctionComponent<Props> = ({
   style,
 }) => {
   const { imageStyle } = useOfferImageContainerDimensions()
-  const headerHeight = useGetHeaderHeight()
   const { borderRadius, isDesktopViewport } = useTheme()
   const carouselRef = useRef<ICarouselInstance>(null)
   const carouselStyle = useRef({
     borderRadius: borderRadius.radius,
   }).current
-  const isSticky = isWeb && isDesktopViewport
   const imagesLoadedCount = useRef(0)
 
   // TODO(PC-000): this method should be excluded in a dedicated .web file
@@ -74,7 +71,7 @@ export const OfferImageCarousel: FunctionComponent<Props> = ({
     )
 
   return (
-    <CarouselContainer style={style} headerHeight={headerHeight} isSticky={isSticky}>
+    <View style={style}>
       <Carousel
         ref={carouselRef}
         testID="offerImageContainerCarousel"
@@ -102,12 +99,6 @@ export const OfferImageCarousel: FunctionComponent<Props> = ({
           />
         </React.Fragment>
       ) : null}
-    </CarouselContainer>
+    </View>
   )
 }
-
-const CarouselContainer = styled(Animated.View)<{ headerHeight: number; isSticky?: boolean }>(
-  ({ headerHeight, isSticky }) => ({
-    ...(isSticky ? { position: 'sticky', top: 48 + headerHeight, zIndex: 1 } : {}),
-  })
-)

--- a/src/features/offer/components/OfferImageContainer/OfferImageContainer.native.test.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageContainer.native.test.tsx
@@ -60,6 +60,7 @@ describe('<OfferImageContainer />', () => {
   it('should display image placeholder outside carousel when image url defined', () => {
     render(
       <OfferImageContainer
+        imageUrls={undefined}
         categoryId={CategoryIdEnum.CINEMA}
         onPress={jest.fn()}
         placeholderImage="placeholder_image"
@@ -67,5 +68,24 @@ describe('<OfferImageContainer />', () => {
     )
 
     expect(screen.getByTestId('placeholderImage')).toBeOnTheScreen()
+  })
+
+  it('should not set sticky position in native', () => {
+    render(
+      <OfferImageContainer
+        categoryId={CategoryIdEnum.CINEMA}
+        onPress={jest.fn()}
+        placeholderImage="placeholder_image"
+      />,
+      {
+        theme: { isNative: true, isDesktopViewport: true },
+      }
+    )
+
+    const container = screen.getByTestId('imageRenderer')
+
+    expect(container).not.toHaveStyle({
+      position: 'sticky',
+    })
   })
 })

--- a/src/features/offer/components/OfferImageContainer/OfferImageContainer.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageContainer.tsx
@@ -1,16 +1,15 @@
-import React, { FunctionComponent, PropsWithChildren, useRef } from 'react'
-import { Platform } from 'react-native'
+import React, { FunctionComponent } from 'react'
 import { useSharedValue } from 'react-native-reanimated'
-import { useTheme } from 'styled-components/native'
 
 import { CategoryIdEnum } from 'api/gen'
-import { OfferImageRenderer } from 'features/offer/components/OfferImageRenderer'
 import {
   offerImageContainerMarginTop,
   useOfferImageContainerDimensions,
 } from 'features/offer/helpers/useOfferImageContainerDimensions'
-import { HeaderWithImage } from 'ui/components/headers/HeaderWithImage'
-import { Spacer } from 'ui/theme'
+import { getSpacing } from 'ui/theme'
+
+import { OfferImageHeaderWrapper } from './OfferImageHeaderWrapper'
+import { OfferImageRenderer } from './OfferImageRenderer'
 
 type Props = {
   categoryId: CategoryIdEnum | null
@@ -19,8 +18,6 @@ type Props = {
   placeholderImage?: string
 }
 
-const isWeb = Platform.OS === 'web'
-
 export const OfferImageContainer: FunctionComponent<Props> = ({
   imageUrls = [],
   onPress,
@@ -28,23 +25,14 @@ export const OfferImageContainer: FunctionComponent<Props> = ({
   placeholderImage,
 }) => {
   const { backgroundHeight } = useOfferImageContainerDimensions()
-  const { isDesktopViewport } = useTheme()
 
   const progressValue = useSharedValue<number>(0)
 
-  const Wrapper = useRef(({ children }: PropsWithChildren) =>
-    isWeb && isDesktopViewport ? (
-      <React.Fragment>{children}</React.Fragment>
-    ) : (
-      <HeaderWithImage imageHeight={backgroundHeight} imageUrl={placeholderImage}>
-        <Spacer.Column numberOfSpaces={offerImageContainerMarginTop} />
-        {children}
-      </HeaderWithImage>
-    )
-  ).current
-
   return (
-    <Wrapper>
+    <OfferImageHeaderWrapper
+      imageHeight={backgroundHeight}
+      imageUrl={placeholderImage}
+      paddingTop={getSpacing(offerImageContainerMarginTop)}>
       <OfferImageRenderer
         offerImages={imageUrls}
         placeholderImage={placeholderImage}
@@ -52,6 +40,6 @@ export const OfferImageContainer: FunctionComponent<Props> = ({
         onPress={onPress}
         categoryId={categoryId}
       />
-    </Wrapper>
+    </OfferImageHeaderWrapper>
   )
 }

--- a/src/features/offer/components/OfferImageContainer/OfferImageContainer.web.test.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageContainer.web.test.tsx
@@ -36,4 +36,38 @@ describe('<OfferImageContainer />', () => {
 
     expect(screen.getByTestId('offerImageContainerCarousel')).toBeInTheDocument()
   })
+
+  it('should apply sticky styles when on desktop', () => {
+    render(
+      <OfferImageContainer
+        imageUrls={['some_url_to_some_resource', 'some_url2_to_some_resource']}
+        categoryId={CategoryIdEnum.CINEMA}
+        onPress={mockOnPress}
+      />,
+      { theme: { isDesktopViewport: true } }
+    )
+
+    const container = screen.getByTestId('imageRenderer')
+
+    expect(container).toHaveStyle({
+      position: 'sticky',
+    })
+  })
+
+  it('should not have sticky position on mobile', () => {
+    render(
+      <OfferImageContainer
+        imageUrls={['some_url_to_some_resource', 'some_url2_to_some_resource']}
+        categoryId={CategoryIdEnum.CINEMA}
+        onPress={mockOnPress}
+      />,
+      { theme: { isDesktopViewport: false } }
+    )
+
+    const container = screen.getByTestId('imageRenderer')
+
+    expect(container).not.toHaveStyle({
+      position: 'sticky',
+    })
+  })
 })

--- a/src/features/offer/components/OfferImageContainer/OfferImageContainer.web.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageContainer.web.tsx
@@ -1,0 +1,68 @@
+import React, { FunctionComponent, PropsWithChildren, useRef } from 'react'
+import { useSharedValue } from 'react-native-reanimated'
+import styled, { useTheme } from 'styled-components/native'
+
+import { CategoryIdEnum } from 'api/gen'
+import { OfferImageRenderer } from 'features/offer/components/OfferImageContainer/OfferImageRenderer'
+import {
+  offerImageContainerMarginTop,
+  useOfferImageContainerDimensions,
+} from 'features/offer/helpers/useOfferImageContainerDimensions'
+import { useGetHeaderHeight } from 'ui/components/headers/PageHeaderWithoutPlaceholder'
+import { getSpacing } from 'ui/theme'
+
+import { OfferImageHeaderWrapper } from './OfferImageHeaderWrapper'
+
+type Props = {
+  categoryId: CategoryIdEnum | null
+  imageUrls?: string[]
+  onPress?: (defaultIndex?: number) => void
+  placeholderImage?: string
+}
+
+export const OfferImageContainer: FunctionComponent<Props> = ({
+  imageUrls = [],
+  onPress,
+  categoryId,
+  placeholderImage,
+}) => {
+  const { backgroundHeight } = useOfferImageContainerDimensions()
+  const { isDesktopViewport } = useTheme()
+  const headerHeight = useGetHeaderHeight()
+
+  const progressValue = useSharedValue<number>(0)
+
+  const Wrapper = useRef(({ children }: PropsWithChildren) =>
+    isDesktopViewport ? (
+      <React.Fragment>{children}</React.Fragment>
+    ) : (
+      <OfferImageHeaderWrapper
+        imageHeight={backgroundHeight}
+        imageUrl={placeholderImage}
+        paddingTop={getSpacing(offerImageContainerMarginTop)}>
+        {children}
+      </OfferImageHeaderWrapper>
+    )
+  ).current
+
+  return (
+    <Wrapper>
+      <StyledOfferImageRenderer
+        offerImages={imageUrls}
+        headerHeight={headerHeight}
+        placeholderImage={placeholderImage}
+        progressValue={progressValue}
+        onPress={onPress}
+        categoryId={categoryId}
+      />
+    </Wrapper>
+  )
+}
+
+const StyledOfferImageRenderer = styled(OfferImageRenderer)<{
+  headerHeight: number
+}>(({ headerHeight, theme }) => ({
+  ...(theme.isDesktopViewport && !theme.isNative
+    ? { position: 'sticky', top: 48 + headerHeight, alignSelf: 'flex-start' }
+    : {}),
+}))

--- a/src/features/offer/components/OfferImageContainer/OfferImageHeaderWrapper.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageHeaderWrapper.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components/native'
+
+import { HeaderWithImage } from 'ui/components/headers/HeaderWithImage'
+
+export const OfferImageHeaderWrapper = styled(HeaderWithImage)<{ paddingTop?: string | number }>(
+  ({ paddingTop }) => ({
+    paddingTop,
+  })
+)

--- a/src/features/offer/components/OfferImageContainer/OfferImageRenderer.tsx
+++ b/src/features/offer/components/OfferImageContainer/OfferImageRenderer.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, useCallback, useState } from 'react'
+import { StyleProp, ViewStyle } from 'react-native'
 import Animated, { FadeIn, FadeOut, SharedValue } from 'react-native-reanimated'
 import styled from 'styled-components/native'
 
@@ -13,6 +14,7 @@ type Props = {
   placeholderImage?: string
   progressValue: SharedValue<number>
   onPress?: (index: number) => void
+  style?: StyleProp<ViewStyle>
 }
 
 export const OfferImageRenderer: FunctionComponent<Props> = ({
@@ -21,6 +23,7 @@ export const OfferImageRenderer: FunctionComponent<Props> = ({
   placeholderImage,
   categoryId,
   onPress,
+  style,
 }) => {
   const [carouselReady, setCarouselReady] = useState(false)
 
@@ -29,7 +32,7 @@ export const OfferImageRenderer: FunctionComponent<Props> = ({
   }, [setCarouselReady])
 
   return (
-    <Animated.View entering={FadeIn}>
+    <Animated.View entering={FadeIn} style={style} testID="imageRenderer">
       <StyledOfferImageCarousel
         progressValue={progressValue}
         offerImages={offerImages}

--- a/src/features/offer/components/OfferImageWrapper/OfferImageWrapper.tsx
+++ b/src/features/offer/components/OfferImageWrapper/OfferImageWrapper.tsx
@@ -1,13 +1,12 @@
 import colorAlpha from 'color-alpha'
 import React, { FunctionComponent } from 'react'
-import { Platform, StyleProp, View, ViewStyle } from 'react-native'
+import { StyleProp, View, ViewStyle } from 'react-native'
 // we import FastImage to get the resizeMode, not to use it as a component
 // eslint-disable-next-line no-restricted-imports
 import LinearGradient from 'react-native-linear-gradient'
-import styled, { useTheme } from 'styled-components/native'
+import styled from 'styled-components/native'
 
 import { useOfferImageContainerDimensions } from 'features/offer/helpers/useOfferImageContainerDimensions'
-import { useGetHeaderHeight } from 'ui/components/headers/PageHeaderWithoutPlaceholder'
 import { getShadow, getSpacing } from 'ui/theme'
 
 type Props = {
@@ -20,8 +19,6 @@ type Props = {
   style?: StyleProp<ViewStyle>
 }
 
-const isWeb = Platform.OS === 'web'
-
 export const OfferImageWrapper: FunctionComponent<Props> = ({
   children,
   imageUrl,
@@ -32,18 +29,9 @@ export const OfferImageWrapper: FunctionComponent<Props> = ({
   style,
 }) => {
   const { imageStyle } = useOfferImageContainerDimensions()
-  const headerHeight = useGetHeaderHeight()
-  const { isDesktopViewport } = useTheme()
-
-  const isSticky = isWeb && isDesktopViewport
 
   return (
-    <Container
-      style={[style, imageStyle]}
-      isSticky={isSticky}
-      headerHeight={headerHeight}
-      withDropShadow={withDropShadow}
-      testID={testID}>
+    <Container style={[style, imageStyle]} withDropShadow={withDropShadow} testID={testID}>
       {imageUrl && shouldDisplayOfferPreview ? (
         <React.Fragment>
           <StyledLinearGradient testID="imageGradient" isInCarousel={isInCarousel} />
@@ -57,10 +45,8 @@ export const OfferImageWrapper: FunctionComponent<Props> = ({
 }
 
 const Container = styled(View)<{
-  headerHeight: number
-  isSticky?: boolean
   withDropShadow?: boolean
-}>(({ headerHeight, isSticky, withDropShadow, theme }) => ({
+}>(({ withDropShadow, theme }) => ({
   backgroundColor: 'transparent',
   bottom: 0,
   ...(withDropShadow
@@ -74,8 +60,6 @@ const Container = styled(View)<{
         shadowOpacity: 0.2,
       })
     : {}),
-  // position sticky only works in web
-  ...(isSticky ? { position: 'sticky', top: 48 + headerHeight, zIndex: 1 } : {}),
 }))
 
 const StyledLinearGradient = styled(LinearGradient).attrs(({ theme }) => ({

--- a/src/features/offer/components/OfferImageWrapper/OfferImageWrapper.web.test.tsx
+++ b/src/features/offer/components/OfferImageWrapper/OfferImageWrapper.web.test.tsx
@@ -6,30 +6,6 @@ import { render, screen, waitFor } from 'tests/utils/web'
 import { theme } from 'theme'
 
 describe('<OfferImageBody />', () => {
-  it('should apply sticky styles when on web and isDesktopViewport is true', () => {
-    renderOfferImageWrapper({ isDesktopViewport: true })
-
-    const container = screen.getByTestId('imageContainer')
-
-    expect(container).toHaveStyle({
-      position: 'sticky',
-      top: '113px',
-      zIndex: 1,
-    })
-  })
-
-  it('should not apply sticky styles when on web and isDesktopViewport is false', () => {
-    renderOfferImageWrapper({ isDesktopViewport: false })
-
-    const container = screen.getByTestId('imageContainer')
-
-    expect(container).not.toHaveStyle({
-      position: 'sticky',
-      top: '113px',
-      zIndex: 1,
-    })
-  })
-
   it('should apply borderRadius when not in carousel', async () => {
     renderOfferImageWrapper({
       isDesktopViewport: false,

--- a/src/ui/components/headers/HeaderWithImage.tsx
+++ b/src/ui/components/headers/HeaderWithImage.tsx
@@ -56,6 +56,7 @@ const Container = styled.View<{ minHeight?: number }>(({ minHeight = 0 }) => ({
 const ImageContainer = styled.View({
   alignItems: 'center',
   position: 'absolute',
+  top: 0,
 })
 
 const DefaultImagePlaceholderOfferV2 = styled.View<{ width: number; height: number }>(


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

Fix sur le placeholder de l'image de preview d'une offre qui ne suit pas au scroll.

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
