### PR TITLE
Pc 33892

### DIFF
--- a/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.native.test.ts
+++ b/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.native.test.ts
@@ -1,6 +1,6 @@
 import { AchievementEnum, AchievementResponse } from 'api/gen'
 import { useShouldShowAchievementSuccessModal } from 'features/achievements/hooks/useShouldShowAchievementSuccessModal'
-import { ModalDisplayState } from 'features/home/components/helpers/useBookingsReactionHelpers'
+import { ModalDisplayState } from 'features/home/components/helpers/useShouldShowReactionModal'
 import { beneficiaryUser } from 'fixtures/user'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'

--- a/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.native.test.ts
+++ b/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.native.test.ts
@@ -98,17 +98,6 @@ describe('useShouldShowAchievementSuccessModal', () => {
       )
     })
 
-    it('should return pending if the achievements are undefined', () => {
-      mockAuthContextWithUser({
-        ...beneficiaryUser,
-        achievements: undefined as unknown as AchievementResponse[],
-      })
-
-      const { result } = renderHook(useShouldShowAchievementSuccessModal)
-
-      expect(result.current.shouldShowAchievementSuccessModal).toEqual(ModalDisplayState.PENDING)
-    })
-
     it('should return an empty array if there are no achievements to show to the user', () => {
       mockAuthContextWithUser({
         ...beneficiaryUser,

--- a/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.native.test.ts
+++ b/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.native.test.ts
@@ -1,6 +1,5 @@
 import { AchievementEnum, AchievementResponse } from 'api/gen'
 import { useShouldShowAchievementSuccessModal } from 'features/achievements/hooks/useShouldShowAchievementSuccessModal'
-import { ModalDisplayState } from 'features/home/components/helpers/useShouldShowReactionModal'
 import { beneficiaryUser } from 'fixtures/user'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
@@ -39,25 +38,21 @@ describe('useShouldShowAchievementSuccessModal', () => {
       useRemoteConfigContextSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
     })
 
-    it('should return shouldNotShow', () => {
-      const { result } = renderHook(useShouldShowAchievementSuccessModal)
+    it('should return false', () => {
+      const { result } = renderHook(() => useShouldShowAchievementSuccessModal())
 
-      expect(result.current.shouldShowAchievementSuccessModal).toEqual(
-        ModalDisplayState.SHOULD_NOT_SHOW
-      )
+      expect(result.current).toEqual(false)
     })
 
-    it('should return shouldNotShow even if there are achievements to show to the user', () => {
+    it('should return false even if there are achievements to show to the user', () => {
       mockAuthContextWithUser({
         ...beneficiaryUser,
         achievements: achievements,
       })
 
-      const { result } = renderHook(useShouldShowAchievementSuccessModal)
+      const { result } = renderHook(() => useShouldShowAchievementSuccessModal())
 
-      expect(result.current.shouldShowAchievementSuccessModal).toEqual(
-        ModalDisplayState.SHOULD_NOT_SHOW
-      )
+      expect(result.current).toEqual(false)
     })
   })
 
@@ -77,66 +72,32 @@ describe('useShouldShowAchievementSuccessModal', () => {
       useRemoteConfigContextSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
     })
 
-    it('should return shouldNotShow', () => {
-      const { result } = renderHook(useShouldShowAchievementSuccessModal)
+    it('should return false by default', () => {
+      const { result } = renderHook(() => useShouldShowAchievementSuccessModal())
 
-      expect(result.current.shouldShowAchievementSuccessModal).toEqual(
-        ModalDisplayState.SHOULD_NOT_SHOW
-      )
+      expect(result.current).toEqual(false)
     })
 
-    it('should return shouldNotShow if there no achievements to show to the user', () => {
+    it('should return false if there no achievements to show to the user', () => {
       mockAuthContextWithUser({
         ...beneficiaryUser,
         achievements: [],
       })
 
-      const { result } = renderHook(useShouldShowAchievementSuccessModal)
+      const { result } = renderHook(() => useShouldShowAchievementSuccessModal())
 
-      expect(result.current.shouldShowAchievementSuccessModal).toEqual(
-        ModalDisplayState.SHOULD_NOT_SHOW
-      )
+      expect(result.current).toEqual(false)
     })
 
-    it('should return an empty array if there are no achievements to show to the user', () => {
-      mockAuthContextWithUser({
-        ...beneficiaryUser,
-        achievements: [],
-      })
-
-      const { result } = renderHook(useShouldShowAchievementSuccessModal)
-
-      expect(result.current.achievementsToShow).toEqual([])
-    })
-
-    it('should return shouldShow if there are achievements to show to the user', () => {
+    it('should return true if there are achievements to show to the user', () => {
       mockAuthContextWithUser({
         ...beneficiaryUser,
         achievements: achievements,
       })
 
-      const { result } = renderHook(useShouldShowAchievementSuccessModal)
+      const { result } = renderHook(() => useShouldShowAchievementSuccessModal())
 
-      expect(result.current.shouldShowAchievementSuccessModal).toEqual(
-        ModalDisplayState.SHOULD_SHOW
-      )
-    })
-
-    it('should return an array with the achievements to show to the user', () => {
-      mockAuthContextWithUser({
-        ...beneficiaryUser,
-        achievements: achievements,
-      })
-
-      const { result } = renderHook(useShouldShowAchievementSuccessModal)
-
-      expect(result.current.achievementsToShow).toEqual([
-        expect.objectContaining({
-          id: 1,
-          name: 'FIRST_ART_LESSON_BOOKING',
-          seenDate: undefined,
-        }),
-      ])
+      expect(result.current).toEqual(true)
     })
   })
 
@@ -149,36 +110,21 @@ describe('useShouldShowAchievementSuccessModal', () => {
       useRemoteConfigContextSpy.mockReturnValue(DEFAULT_REMOTE_CONFIG)
     })
 
-    it('should return shouldNotShow', () => {
-      const { result } = renderHook(useShouldShowAchievementSuccessModal)
+    it('should return false', () => {
+      const { result } = renderHook(() => useShouldShowAchievementSuccessModal())
 
-      expect(result.current.shouldShowAchievementSuccessModal).toEqual(
-        ModalDisplayState.SHOULD_NOT_SHOW
-      )
+      expect(result.current).toEqual(false)
     })
 
-    it('should return shouldNotShow even if there are achievements to show to the user', () => {
+    it('should return false even if there are achievements to show to the user', () => {
       mockAuthContextWithUser({
         ...beneficiaryUser,
         achievements: achievements,
       })
 
-      const { result } = renderHook(useShouldShowAchievementSuccessModal)
+      const { result } = renderHook(() => useShouldShowAchievementSuccessModal())
 
-      expect(result.current.shouldShowAchievementSuccessModal).toEqual(
-        ModalDisplayState.SHOULD_NOT_SHOW
-      )
-    })
-
-    it('should return an array even if there are achievements to show to the user', () => {
-      mockAuthContextWithUser({
-        ...beneficiaryUser,
-        achievements: achievements,
-      })
-
-      const { result } = renderHook(useShouldShowAchievementSuccessModal)
-
-      expect(result.current.achievementsToShow).toEqual([])
+      expect(result.current).toEqual(false)
     })
   })
 })

--- a/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.ts
+++ b/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.ts
@@ -1,16 +1,12 @@
-import { useAuthContext } from 'features/auth/context/AuthContext'
+import { AchievementResponse } from 'api/gen'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { useRemoteConfigContext } from 'libs/firebase/remoteConfig/RemoteConfigProvider'
 
-export const useShouldShowAchievementSuccessModal = () => {
+export const useShouldShowAchievementSuccessModal = (unseenAchievements: AchievementResponse[]) => {
   const areAchievementsEnabled = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_ACHIEVEMENTS)
   const { displayAchievements } = useRemoteConfigContext()
-  const { user } = useAuthContext()
 
-  const unseenAchievements =
-    user?.achievements?.filter((achievement) => !achievement.seenDate) || []
-
-  const isThereAtLeastOneUnseenAchievement = unseenAchievements.length
+  const isThereAtLeastOneUnseenAchievement = !!unseenAchievements.length
   return areAchievementsEnabled && displayAchievements && isThereAtLeastOneUnseenAchievement
 }

--- a/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.ts
+++ b/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.ts
@@ -1,14 +1,10 @@
-import { AchievementResponse } from 'api/gen'
 import { useAuthContext } from 'features/auth/context/AuthContext'
-import { ModalDisplayState } from 'features/home/components/helpers/useBookingsReactionHelpers'
+import { ModalDisplayState } from 'features/home/components/helpers/useShouldShowReactionModal'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { useRemoteConfigContext } from 'libs/firebase/remoteConfig/RemoteConfigProvider'
 
-export const useShouldShowAchievementSuccessModal = (): {
-  shouldShowAchievementSuccessModal: ModalDisplayState
-  achievementsToShow: AchievementResponse[]
-} => {
+export const useShouldShowAchievementSuccessModal = (): ModalDisplayState => {
   const areAchievementsEnabled = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_ACHIEVEMENTS)
   const { displayAchievements } = useRemoteConfigContext()
   const { user, isUserLoading } = useAuthContext()
@@ -18,20 +14,10 @@ export const useShouldShowAchievementSuccessModal = (): {
 
   const isThereAtLeastOneUnseenAchievement = unseenAchievements.length
 
-  if (isUserLoading)
-    return {
-      shouldShowAchievementSuccessModal: ModalDisplayState.PENDING,
-      achievementsToShow: [],
-    }
+  if (isUserLoading) return ModalDisplayState.PENDING
 
   if (areAchievementsEnabled && displayAchievements && isThereAtLeastOneUnseenAchievement)
-    return {
-      shouldShowAchievementSuccessModal: ModalDisplayState.SHOULD_SHOW,
-      achievementsToShow: unseenAchievements,
-    }
+    return ModalDisplayState.SHOULD_SHOW
 
-  return {
-    shouldShowAchievementSuccessModal: ModalDisplayState.SHOULD_NOT_SHOW,
-    achievementsToShow: [],
-  }
+  return ModalDisplayState.SHOULD_NOT_SHOW
 }

--- a/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.ts
+++ b/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.ts
@@ -13,32 +13,25 @@ export const useShouldShowAchievementSuccessModal = (): {
   const { displayAchievements } = useRemoteConfigContext()
   const { user, isUserLoading } = useAuthContext()
 
-  const unseenAchievements = user?.achievements?.filter((achievement) => !achievement.seenDate)
+  const unseenAchievements =
+    user?.achievements?.filter((achievement) => !achievement.seenDate) || []
 
-  const isThereAtLeastOneUnseenAchievement = user?.achievements?.some(
-    (achievement) => !achievement.seenDate
-  )
+  const isThereAtLeastOneUnseenAchievement = unseenAchievements.length
 
-  if (!user || isThereAtLeastOneUnseenAchievement === undefined || isUserLoading)
+  if (isUserLoading)
     return {
       shouldShowAchievementSuccessModal: ModalDisplayState.PENDING,
       achievementsToShow: [],
     }
 
-  if (
-    !areAchievementsEnabled ||
-    !displayAchievements ||
-    user?.achievements.length === 0 ||
-    !isThereAtLeastOneUnseenAchievement
-  )
+  if (areAchievementsEnabled && displayAchievements && isThereAtLeastOneUnseenAchievement)
     return {
-      shouldShowAchievementSuccessModal: ModalDisplayState.SHOULD_NOT_SHOW,
-      achievementsToShow: [],
+      shouldShowAchievementSuccessModal: ModalDisplayState.SHOULD_SHOW,
+      achievementsToShow: unseenAchievements,
     }
 
   return {
-    shouldShowAchievementSuccessModal: ModalDisplayState.SHOULD_SHOW,
-    achievementsToShow:
-      unseenAchievements && unseenAchievements?.length > 0 ? unseenAchievements : [],
+    shouldShowAchievementSuccessModal: ModalDisplayState.SHOULD_NOT_SHOW,
+    achievementsToShow: [],
   }
 }

--- a/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.ts
+++ b/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.ts
@@ -1,10 +1,9 @@
 import { useAuthContext } from 'features/auth/context/AuthContext'
-import { ModalDisplayState } from 'features/home/components/helpers/useShouldShowReactionModal'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { useRemoteConfigContext } from 'libs/firebase/remoteConfig/RemoteConfigProvider'
 
-export const useShouldShowAchievementSuccessModal = (): ModalDisplayState => {
+export const useShouldShowAchievementSuccessModal = () => {
   const areAchievementsEnabled = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_ACHIEVEMENTS)
   const { displayAchievements } = useRemoteConfigContext()
   const { user } = useAuthContext()
@@ -13,8 +12,5 @@ export const useShouldShowAchievementSuccessModal = (): ModalDisplayState => {
     user?.achievements?.filter((achievement) => !achievement.seenDate) || []
 
   const isThereAtLeastOneUnseenAchievement = unseenAchievements.length
-
   return areAchievementsEnabled && displayAchievements && isThereAtLeastOneUnseenAchievement
-    ? ModalDisplayState.SHOULD_SHOW
-    : ModalDisplayState.SHOULD_NOT_SHOW
 }

--- a/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.ts
+++ b/src/features/achievements/hooks/useShouldShowAchievementSuccessModal.ts
@@ -7,17 +7,14 @@ import { useRemoteConfigContext } from 'libs/firebase/remoteConfig/RemoteConfigP
 export const useShouldShowAchievementSuccessModal = (): ModalDisplayState => {
   const areAchievementsEnabled = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_ACHIEVEMENTS)
   const { displayAchievements } = useRemoteConfigContext()
-  const { user, isUserLoading } = useAuthContext()
+  const { user } = useAuthContext()
 
   const unseenAchievements =
     user?.achievements?.filter((achievement) => !achievement.seenDate) || []
 
   const isThereAtLeastOneUnseenAchievement = unseenAchievements.length
 
-  if (isUserLoading) return ModalDisplayState.PENDING
-
-  if (areAchievementsEnabled && displayAchievements && isThereAtLeastOneUnseenAchievement)
-    return ModalDisplayState.SHOULD_SHOW
-
-  return ModalDisplayState.SHOULD_NOT_SHOW
+  return areAchievementsEnabled && displayAchievements && isThereAtLeastOneUnseenAchievement
+    ? ModalDisplayState.SHOULD_SHOW
+    : ModalDisplayState.SHOULD_NOT_SHOW
 }

--- a/src/features/home/components/HomeModals.tsx
+++ b/src/features/home/components/HomeModals.tsx
@@ -1,0 +1,41 @@
+import React, { FC, useEffect } from 'react'
+
+import { AchievementSuccessModal } from 'features/achievements/pages/AchievementSuccessModal'
+import { useBookings } from 'features/bookings/api'
+import { IncomingReactionModalContainer } from 'features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer'
+import { ModalToShow, useWhichModalToShow } from 'features/home/helpers/useWhichModalToShow'
+import { useModal } from 'ui/components/modals/useModal'
+
+export const HomeModals: FC = () => {
+  const { data: bookings, isLoading } = useBookings()
+
+  const { achievementsToShow, bookingsEligibleToReaction, modalToShow } = useWhichModalToShow(
+    bookings,
+    isLoading
+  )
+
+  const {
+    visible: visibleAchievementModal,
+    showModal: showAchievementModal,
+    hideModal: hideAchievementModal,
+  } = useModal(false)
+
+  useEffect(() => {
+    if (modalToShow === ModalToShow.ACHIEVEMENT) {
+      showAchievementModal()
+    }
+  }, [showAchievementModal, modalToShow])
+
+  return (
+    <React.Fragment>
+      {modalToShow === ModalToShow.REACTION ? (
+        <IncomingReactionModalContainer bookingsEligibleToReaction={bookingsEligibleToReaction} />
+      ) : null}
+      <AchievementSuccessModal
+        achievementsToShow={achievementsToShow}
+        visible={visibleAchievementModal}
+        hideModal={hideAchievementModal}
+      />
+    </React.Fragment>
+  )
+}

--- a/src/features/home/components/HomeModals.tsx
+++ b/src/features/home/components/HomeModals.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react'
+import React, { FC, useState } from 'react'
 
 import { useShouldShowAchievementSuccessModal } from 'features/achievements/hooks/useShouldShowAchievementSuccessModal'
 import { AchievementSuccessModal } from 'features/achievements/pages/AchievementSuccessModal'
@@ -9,7 +9,6 @@ import {
   useShouldShowReactionModal,
 } from 'features/home/components/helpers/useShouldShowReactionModal'
 import { IncomingReactionModalContainer } from 'features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer'
-import { useModal } from 'ui/components/modals/useModal'
 
 enum ModalToShow {
   PENDING = 'pending',
@@ -48,18 +47,6 @@ export const HomeModals: FC = () => {
     }
   }
 
-  const {
-    visible: visibleAchievementModal,
-    showModal: showAchievementModal,
-    hideModal: hideAchievementModal,
-  } = useModal(false)
-
-  useEffect(() => {
-    if (modalToShow === ModalToShow.ACHIEVEMENT) {
-      showAchievementModal()
-    }
-  }, [showAchievementModal, modalToShow])
-
   if (isModalContainerReady) {
     return null
   }
@@ -69,11 +56,13 @@ export const HomeModals: FC = () => {
       {modalToShow === ModalToShow.REACTION ? (
         <IncomingReactionModalContainer bookingsEligibleToReaction={bookingsEligibleToReaction} />
       ) : null}
-      <AchievementSuccessModal
-        achievementsToShow={achievementsToShow}
-        visible={visibleAchievementModal}
-        hideModal={hideAchievementModal}
-      />
+      {modalToShow === ModalToShow.ACHIEVEMENT ? (
+        <AchievementSuccessModal
+          achievementsToShow={achievementsToShow}
+          visible
+          hideModal={() => setModalToShow(ModalToShow.NONE)}
+        />
+      ) : null}
     </React.Fragment>
   )
 }

--- a/src/features/home/components/HomeModals.tsx
+++ b/src/features/home/components/HomeModals.tsx
@@ -1,26 +1,19 @@
-import React, { FC, useState } from 'react'
+import React, { FC } from 'react'
 
 import { AchievementSuccessModal } from 'features/achievements/pages/AchievementSuccessModal'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useBookings } from 'features/bookings/api'
-import { ModalDisplayState } from 'features/home/components/helpers/useShouldShowReactionModal'
 import { IncomingReactionModalContainer } from 'features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { useRemoteConfigContext } from 'libs/firebase/remoteConfig/RemoteConfigProvider'
-
-enum ModalToShow {
-  PENDING = 'pending',
-  ACHIEVEMENT = 'achievement',
-  REACTION = 'reaction',
-  NONE = 'none',
-}
+import { useModal } from 'ui/components/modals/useModal'
 
 export const HomeModals: FC = () => {
   const { data: bookings, isLoading: isBookingsLoading } = useBookings()
   const { isUserLoading, user } = useAuthContext()
 
-  const isModalContainerReady = !isUserLoading && !isBookingsLoading
+  const areModalReady = !isUserLoading && !isBookingsLoading
 
   const achievementsToShow =
     user?.achievements?.filter((achievement) => !achievement.seenDate) || []
@@ -30,17 +23,14 @@ export const HomeModals: FC = () => {
       (booking) => booking.enablePopUpReaction && !booking.userReaction
     ) ?? []
 
-  const [modalToShow, setModalToShow] = useState<ModalToShow>(ModalToShow.PENDING)
+  const { visible: visibleAchievementModal, hideModal: hideAchievementModal } = useModal(true)
 
   const isReactionFeatureActive = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
 
   const firstBookingEligibleToReaction = bookingsEligibleToReaction[0]
 
   // There is an issue with !isCookieConsentChecked it goes to true for an instant and disrupts the modal conflict management hook
-  const shouldShowReactionModal =
-    isReactionFeatureActive && firstBookingEligibleToReaction
-      ? ModalDisplayState.SHOULD_SHOW
-      : ModalDisplayState.SHOULD_NOT_SHOW
+  const shouldShowReactionModal = isReactionFeatureActive && firstBookingEligibleToReaction
 
   const areAchievementsEnabled = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_ACHIEVEMENTS)
   const { displayAchievements } = useRemoteConfigContext()
@@ -52,38 +42,26 @@ export const HomeModals: FC = () => {
 
   const shouldShowAchievementSuccessModal =
     areAchievementsEnabled && displayAchievements && isThereAtLeastOneUnseenAchievement
-      ? ModalDisplayState.SHOULD_SHOW
-      : ModalDisplayState.SHOULD_NOT_SHOW
 
-  if (!isBookingsLoading && modalToShow === ModalToShow.PENDING) {
-    if (shouldShowReactionModal === ModalDisplayState.SHOULD_SHOW) {
-      setModalToShow(ModalToShow.REACTION)
-    } else if (shouldShowAchievementSuccessModal === ModalDisplayState.SHOULD_SHOW) {
-      setModalToShow(ModalToShow.ACHIEVEMENT)
-    } else if (
-      shouldShowReactionModal === ModalDisplayState.SHOULD_NOT_SHOW &&
-      shouldShowAchievementSuccessModal === ModalDisplayState.SHOULD_NOT_SHOW
-    ) {
-      setModalToShow(ModalToShow.NONE)
-    }
-  }
-
-  if (isModalContainerReady) {
+  if (areModalReady) {
     return null
   }
 
-  return (
-    <React.Fragment>
-      {modalToShow === ModalToShow.REACTION ? (
-        <IncomingReactionModalContainer bookingsEligibleToReaction={bookingsEligibleToReaction} />
-      ) : null}
-      {modalToShow === ModalToShow.ACHIEVEMENT ? (
-        <AchievementSuccessModal
-          achievementsToShow={achievementsToShow}
-          visible
-          hideModal={() => setModalToShow(ModalToShow.NONE)}
-        />
-      ) : null}
-    </React.Fragment>
-  )
+  if (shouldShowReactionModal) {
+    return (
+      <IncomingReactionModalContainer bookingsEligibleToReaction={bookingsEligibleToReaction} />
+    )
+  }
+
+  if (shouldShowAchievementSuccessModal) {
+    return (
+      <AchievementSuccessModal
+        achievementsToShow={achievementsToShow}
+        visible={visibleAchievementModal}
+        hideModal={hideAchievementModal}
+      />
+    )
+  }
+
+  return null
 }

--- a/src/features/home/components/HomeModals.tsx
+++ b/src/features/home/components/HomeModals.tsx
@@ -9,14 +9,19 @@ import { useModal } from 'ui/components/modals/useModal'
 
 export const HomeModals: FC = () => {
   const { data: bookings, isLoading: isBookingsLoading } = useBookings()
-  const { isUserLoading } = useAuthContext()
+  const { isUserLoading, user } = useAuthContext()
 
   const isModalContainerReady = !isUserLoading && !isBookingsLoading
 
-  const { achievementsToShow, bookingsEligibleToReaction, modalToShow } = useWhichModalToShow(
-    bookings,
-    isBookingsLoading
-  )
+  const { modalToShow } = useWhichModalToShow(bookings, isBookingsLoading)
+
+  const achievementsToShow =
+    user?.achievements?.filter((achievement) => !achievement.seenDate) || []
+
+  const bookingsEligibleToReaction =
+    bookings?.ended_bookings?.filter(
+      (booking) => booking.enablePopUpReaction && !booking.userReaction
+    ) ?? []
 
   const {
     visible: visibleAchievementModal,

--- a/src/features/home/components/HomeModals.tsx
+++ b/src/features/home/components/HomeModals.tsx
@@ -1,17 +1,21 @@
 import React, { FC, useEffect } from 'react'
 
 import { AchievementSuccessModal } from 'features/achievements/pages/AchievementSuccessModal'
+import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useBookings } from 'features/bookings/api'
 import { IncomingReactionModalContainer } from 'features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer'
 import { ModalToShow, useWhichModalToShow } from 'features/home/helpers/useWhichModalToShow'
 import { useModal } from 'ui/components/modals/useModal'
 
 export const HomeModals: FC = () => {
-  const { data: bookings, isLoading } = useBookings()
+  const { data: bookings, isLoading: isBookingsLoading } = useBookings()
+  const { isUserLoading } = useAuthContext()
+
+  const isModalContainerReady = !isUserLoading && !isBookingsLoading
 
   const { achievementsToShow, bookingsEligibleToReaction, modalToShow } = useWhichModalToShow(
     bookings,
-    isLoading
+    isBookingsLoading
   )
 
   const {
@@ -25,6 +29,10 @@ export const HomeModals: FC = () => {
       showAchievementModal()
     }
   }, [showAchievementModal, modalToShow])
+
+  if (isModalContainerReady) {
+    return null
+  }
 
   return (
     <React.Fragment>

--- a/src/features/home/components/HomeModals.tsx
+++ b/src/features/home/components/HomeModals.tsx
@@ -1,12 +1,11 @@
 import React, { FC } from 'react'
 
+import { useShouldShowAchievementSuccessModal } from 'features/achievements/hooks/useShouldShowAchievementSuccessModal'
 import { AchievementSuccessModal } from 'features/achievements/pages/AchievementSuccessModal'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useBookings } from 'features/bookings/api'
+import { useShouldShowReactionModal } from 'features/home/components/helpers/useShouldShowReactionModal'
 import { IncomingReactionModalContainer } from 'features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer'
-import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
-import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import { useRemoteConfigContext } from 'libs/firebase/remoteConfig/RemoteConfigProvider'
 import { useModal } from 'ui/components/modals/useModal'
 
 export const HomeModals: FC = () => {
@@ -25,23 +24,8 @@ export const HomeModals: FC = () => {
 
   const { visible: visibleAchievementModal, hideModal: hideAchievementModal } = useModal(true)
 
-  const isReactionFeatureActive = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
-
-  const firstBookingEligibleToReaction = bookingsEligibleToReaction[0]
-
-  // There is an issue with !isCookieConsentChecked it goes to true for an instant and disrupts the modal conflict management hook
-  const shouldShowReactionModal = isReactionFeatureActive && firstBookingEligibleToReaction
-
-  const areAchievementsEnabled = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_ACHIEVEMENTS)
-  const { displayAchievements } = useRemoteConfigContext()
-
-  const unseenAchievements =
-    user?.achievements?.filter((achievement) => !achievement.seenDate) || []
-
-  const isThereAtLeastOneUnseenAchievement = unseenAchievements.length
-
-  const shouldShowAchievementSuccessModal =
-    areAchievementsEnabled && displayAchievements && isThereAtLeastOneUnseenAchievement
+  const shouldShowReactionModal = useShouldShowReactionModal(bookingsEligibleToReaction)
+  const shouldShowAchievementSuccessModal = useShouldShowAchievementSuccessModal()
 
   if (areModalReady) {
     return null

--- a/src/features/home/components/HomeModals.tsx
+++ b/src/features/home/components/HomeModals.tsx
@@ -12,9 +12,9 @@ export const HomeModals: FC = () => {
   const { data: bookings, isLoading: isBookingsLoading } = useBookings()
   const { isUserLoading, user } = useAuthContext()
 
-  const areModalReady = !isUserLoading && !isBookingsLoading
+  const areModalsReady = !isUserLoading && !isBookingsLoading
 
-  const achievementsToShow =
+  const unseenAchievements =
     user?.achievements?.filter((achievement) => !achievement.seenDate) || []
 
   const bookingsEligibleToReaction =
@@ -25,9 +25,9 @@ export const HomeModals: FC = () => {
   const { visible: visibleAchievementModal, hideModal: hideAchievementModal } = useModal(true)
 
   const shouldShowReactionModal = useShouldShowReactionModal(bookingsEligibleToReaction)
-  const shouldShowAchievementSuccessModal = useShouldShowAchievementSuccessModal()
+  const shouldShowAchievementSuccessModal = useShouldShowAchievementSuccessModal(unseenAchievements)
 
-  if (areModalReady) {
+  if (areModalsReady) {
     return null
   }
 
@@ -40,7 +40,7 @@ export const HomeModals: FC = () => {
   if (shouldShowAchievementSuccessModal) {
     return (
       <AchievementSuccessModal
-        achievementsToShow={achievementsToShow}
+        achievementsToShow={unseenAchievements}
         visible={visibleAchievementModal}
         hideModal={hideAchievementModal}
       />

--- a/src/features/home/components/HomeModals.tsx
+++ b/src/features/home/components/HomeModals.tsx
@@ -1,19 +1,28 @@
-import React, { FC, useEffect } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 
+import { useShouldShowAchievementSuccessModal } from 'features/achievements/hooks/useShouldShowAchievementSuccessModal'
 import { AchievementSuccessModal } from 'features/achievements/pages/AchievementSuccessModal'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useBookings } from 'features/bookings/api'
+import {
+  ModalDisplayState,
+  useShouldShowReactionModal,
+} from 'features/home/components/helpers/useShouldShowReactionModal'
 import { IncomingReactionModalContainer } from 'features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer'
-import { ModalToShow, useWhichModalToShow } from 'features/home/helpers/useWhichModalToShow'
 import { useModal } from 'ui/components/modals/useModal'
+
+enum ModalToShow {
+  PENDING = 'pending',
+  ACHIEVEMENT = 'achievement',
+  REACTION = 'reaction',
+  NONE = 'none',
+}
 
 export const HomeModals: FC = () => {
   const { data: bookings, isLoading: isBookingsLoading } = useBookings()
   const { isUserLoading, user } = useAuthContext()
 
   const isModalContainerReady = !isUserLoading && !isBookingsLoading
-
-  const { modalToShow } = useWhichModalToShow(bookings, isBookingsLoading)
 
   const achievementsToShow =
     user?.achievements?.filter((achievement) => !achievement.seenDate) || []
@@ -22,6 +31,22 @@ export const HomeModals: FC = () => {
     bookings?.ended_bookings?.filter(
       (booking) => booking.enablePopUpReaction && !booking.userReaction
     ) ?? []
+
+  const [modalToShow, setModalToShow] = useState<ModalToShow>(ModalToShow.PENDING)
+  const shouldShowReactionModal = useShouldShowReactionModal(bookings, isBookingsLoading)
+  const shouldShowAchievementSuccessModal = useShouldShowAchievementSuccessModal()
+  if (!isBookingsLoading && modalToShow === ModalToShow.PENDING) {
+    if (shouldShowReactionModal === ModalDisplayState.SHOULD_SHOW) {
+      setModalToShow(ModalToShow.REACTION)
+    } else if (shouldShowAchievementSuccessModal === ModalDisplayState.SHOULD_SHOW) {
+      setModalToShow(ModalToShow.ACHIEVEMENT)
+    } else if (
+      shouldShowReactionModal === ModalDisplayState.SHOULD_NOT_SHOW &&
+      shouldShowAchievementSuccessModal === ModalDisplayState.SHOULD_NOT_SHOW
+    ) {
+      setModalToShow(ModalToShow.NONE)
+    }
+  }
 
   const {
     visible: visibleAchievementModal,

--- a/src/features/home/components/helpers/useBookingsReactionHelpers.ts
+++ b/src/features/home/components/helpers/useBookingsReactionHelpers.ts
@@ -22,7 +22,7 @@ export const useBookingsReactionHelpers = (
       (booking) => booking.enablePopUpReaction && !booking.userReaction
     ) ?? []
 
-  const firstBookingWithoutReaction = bookingsEligibleToReaction[0]
+  const firstBookingEligibleToReaction = bookingsEligibleToReaction[0]
 
   if (isBookingsLoading || bookings === undefined) {
     return {
@@ -31,13 +31,12 @@ export const useBookingsReactionHelpers = (
     }
   }
 
+  if (isReactionFeatureActive && firstBookingEligibleToReaction)
+    return { shouldShowReactionModal: ModalDisplayState.SHOULD_SHOW, bookingsEligibleToReaction }
+
   // There is an issue with !isCookieConsentChecked it goes to true for an instant and disrupts the modal conflict management hook
-
-  if (!isReactionFeatureActive || !firstBookingWithoutReaction)
-    return {
-      shouldShowReactionModal: ModalDisplayState.SHOULD_NOT_SHOW,
-      bookingsEligibleToReaction: [],
-    }
-
-  return { shouldShowReactionModal: ModalDisplayState.SHOULD_SHOW, bookingsEligibleToReaction }
+  return {
+    shouldShowReactionModal: ModalDisplayState.SHOULD_NOT_SHOW,
+    bookingsEligibleToReaction: [],
+  }
 }

--- a/src/features/home/components/helpers/useShouldShowReactionModal.native.test.ts
+++ b/src/features/home/components/helpers/useShouldShowReactionModal.native.test.ts
@@ -1,10 +1,7 @@
-import { BookingsResponse, ReactionTypeEnum, SubcategoriesResponseModelv2 } from 'api/gen'
+import { BookingsResponse, SubcategoriesResponseModelv2 } from 'api/gen'
 import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import * as CookiesUpToDate from 'features/cookies/helpers/useIsCookiesListUpToDate'
-import {
-  ModalDisplayState,
-  useShouldShowReactionModal,
-} from 'features/home/components/helpers/useShouldShowReactionModal'
+import { useShouldShowReactionModal } from 'features/home/components/helpers/useShouldShowReactionModal'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
@@ -34,10 +31,10 @@ describe('useBookingsReactionHelpers', () => {
     setFeatureFlags()
 
     const { result } = renderHook(() =>
-      useShouldShowReactionModal(endedBookingWithoutReaction, false)
+      useShouldShowReactionModal(endedBookingWithoutReaction.ended_bookings)
     )
 
-    expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_NOT_SHOW)
+    expect(result.current).toEqual(false)
   })
 
   describe('when FF wipReactionFeature is true', () => {
@@ -45,34 +42,21 @@ describe('useBookingsReactionHelpers', () => {
       setFeatureFlags([RemoteStoreFeatureFlags.WIP_REACTION_FEATURE])
     })
 
-    it('should return shouldNotShow if the bookings already have reactions', () => {
-      const { result } = renderHook(() =>
-        useShouldShowReactionModal(endedBookingWithReaction, false)
-      )
+    it('should return false if the bookings already have reactions', () => {
+      const { result } = renderHook(() => useShouldShowReactionModal([]))
 
-      expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_NOT_SHOW)
+      expect(result.current).toEqual(false)
     })
 
     // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('should return shouldNotShow if cookies where not accepted', () => {
+    it.skip('should return false if cookies where not accepted', () => {
       cookiesNotAccepted()
 
       const { result } = renderHook(() =>
-        useShouldShowReactionModal(endedBookingWithoutReaction, false)
+        useShouldShowReactionModal(endedBookingWithoutReaction.ended_bookings)
       )
 
-      expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_NOT_SHOW)
-    })
-
-    it('should return true if there are bookings to react to', () => {
-      const { result } = renderHook(() =>
-        useShouldShowReactionModal(endedBookingWithoutReaction, false)
-      )
-
-      expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_SHOW)
-      expect(result.current.bookingsEligibleToReaction).toEqual(
-        endedBookingWithoutReaction.ended_bookings
-      )
+      expect(result.current).toEqual(false)
     })
   })
 })
@@ -89,18 +73,6 @@ const endedBookingWithoutReaction: BookingsResponse = {
     {
       ...bookingsSnap.ended_bookings[0],
       userReaction: null,
-      enablePopUpReaction: true,
-    },
-  ],
-  ongoing_bookings: [],
-  hasBookingsAfter18: false,
-}
-
-const endedBookingWithReaction: BookingsResponse = {
-  ended_bookings: [
-    {
-      ...bookingsSnap.ended_bookings[0],
-      userReaction: ReactionTypeEnum.LIKE,
       enablePopUpReaction: true,
     },
   ],

--- a/src/features/home/components/helpers/useShouldShowReactionModal.native.test.ts
+++ b/src/features/home/components/helpers/useShouldShowReactionModal.native.test.ts
@@ -3,8 +3,8 @@ import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import * as CookiesUpToDate from 'features/cookies/helpers/useIsCookiesListUpToDate'
 import {
   ModalDisplayState,
-  useBookingsReactionHelpers,
-} from 'features/home/components/helpers/useBookingsReactionHelpers'
+  useShouldShowReactionModal,
+} from 'features/home/components/helpers/useShouldShowReactionModal'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
@@ -34,7 +34,7 @@ describe('useBookingsReactionHelpers', () => {
     setFeatureFlags()
 
     const { result } = renderHook(() =>
-      useBookingsReactionHelpers(endedBookingWithoutReaction, false)
+      useShouldShowReactionModal(endedBookingWithoutReaction, false)
     )
 
     expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_NOT_SHOW)
@@ -47,7 +47,7 @@ describe('useBookingsReactionHelpers', () => {
 
     it('should return shouldNotShow if the bookings already have reactions', () => {
       const { result } = renderHook(() =>
-        useBookingsReactionHelpers(endedBookingWithReaction, false)
+        useShouldShowReactionModal(endedBookingWithReaction, false)
       )
 
       expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_NOT_SHOW)
@@ -58,7 +58,7 @@ describe('useBookingsReactionHelpers', () => {
       cookiesNotAccepted()
 
       const { result } = renderHook(() =>
-        useBookingsReactionHelpers(endedBookingWithoutReaction, false)
+        useShouldShowReactionModal(endedBookingWithoutReaction, false)
       )
 
       expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_NOT_SHOW)
@@ -66,7 +66,7 @@ describe('useBookingsReactionHelpers', () => {
 
     it('should return true if there are bookings to react to', () => {
       const { result } = renderHook(() =>
-        useBookingsReactionHelpers(endedBookingWithoutReaction, false)
+        useShouldShowReactionModal(endedBookingWithoutReaction, false)
       )
 
       expect(result.current.shouldShowReactionModal).toEqual(ModalDisplayState.SHOULD_SHOW)

--- a/src/features/home/components/helpers/useShouldShowReactionModal.ts
+++ b/src/features/home/components/helpers/useShouldShowReactionModal.ts
@@ -3,14 +3,12 @@ import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureF
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 
 export enum ModalDisplayState {
-  PENDING = 'pending',
   SHOULD_SHOW = 'shouldShow',
   SHOULD_NOT_SHOW = 'shouldNotShow',
 }
 
 export const useShouldShowReactionModal = (
-  bookings: BookingsResponse | undefined,
-  isBookingsLoading: boolean
+  bookings: BookingsResponse | undefined
 ): ModalDisplayState => {
   const isReactionFeatureActive = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
 
@@ -21,13 +19,8 @@ export const useShouldShowReactionModal = (
 
   const firstBookingEligibleToReaction = bookingsEligibleToReaction[0]
 
-  if (isBookingsLoading || bookings === undefined) {
-    return ModalDisplayState.PENDING
-  }
-
-  if (isReactionFeatureActive && firstBookingEligibleToReaction)
-    return ModalDisplayState.SHOULD_SHOW
-
   // There is an issue with !isCookieConsentChecked it goes to true for an instant and disrupts the modal conflict management hook
-  return ModalDisplayState.SHOULD_NOT_SHOW
+  return isReactionFeatureActive && firstBookingEligibleToReaction
+    ? ModalDisplayState.SHOULD_SHOW
+    : ModalDisplayState.SHOULD_NOT_SHOW
 }

--- a/src/features/home/components/helpers/useShouldShowReactionModal.ts
+++ b/src/features/home/components/helpers/useShouldShowReactionModal.ts
@@ -6,5 +6,5 @@ export const useShouldShowReactionModal = (bookingsEligibleToReaction: BookingRe
   const isReactionFeatureActive = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
   const firstBookingEligibleToReaction = bookingsEligibleToReaction[0]
   // There is an issue with !isCookieConsentChecked it goes to true for an instant and disrupts the modal conflict management hook
-  return isReactionFeatureActive && firstBookingEligibleToReaction
+  return isReactionFeatureActive && !!firstBookingEligibleToReaction
 }

--- a/src/features/home/components/helpers/useShouldShowReactionModal.ts
+++ b/src/features/home/components/helpers/useShouldShowReactionModal.ts
@@ -1,4 +1,4 @@
-import { BookingReponse, BookingsResponse } from 'api/gen'
+import { BookingsResponse } from 'api/gen'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 
@@ -8,13 +8,10 @@ export enum ModalDisplayState {
   SHOULD_NOT_SHOW = 'shouldNotShow',
 }
 
-export const useBookingsReactionHelpers = (
+export const useShouldShowReactionModal = (
   bookings: BookingsResponse | undefined,
   isBookingsLoading: boolean
-): {
-  shouldShowReactionModal: ModalDisplayState
-  bookingsEligibleToReaction: Array<BookingReponse> | undefined
-} => {
+): ModalDisplayState => {
   const isReactionFeatureActive = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
 
   const bookingsEligibleToReaction =
@@ -25,18 +22,12 @@ export const useBookingsReactionHelpers = (
   const firstBookingEligibleToReaction = bookingsEligibleToReaction[0]
 
   if (isBookingsLoading || bookings === undefined) {
-    return {
-      shouldShowReactionModal: ModalDisplayState.PENDING,
-      bookingsEligibleToReaction: [],
-    }
+    return ModalDisplayState.PENDING
   }
 
   if (isReactionFeatureActive && firstBookingEligibleToReaction)
-    return { shouldShowReactionModal: ModalDisplayState.SHOULD_SHOW, bookingsEligibleToReaction }
+    return ModalDisplayState.SHOULD_SHOW
 
   // There is an issue with !isCookieConsentChecked it goes to true for an instant and disrupts the modal conflict management hook
-  return {
-    shouldShowReactionModal: ModalDisplayState.SHOULD_NOT_SHOW,
-    bookingsEligibleToReaction: [],
-  }
+  return ModalDisplayState.SHOULD_NOT_SHOW
 }

--- a/src/features/home/components/helpers/useShouldShowReactionModal.ts
+++ b/src/features/home/components/helpers/useShouldShowReactionModal.ts
@@ -1,26 +1,10 @@
-import { BookingsResponse } from 'api/gen'
+import { BookingReponse } from 'api/gen'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 
-export enum ModalDisplayState {
-  SHOULD_SHOW = 'shouldShow',
-  SHOULD_NOT_SHOW = 'shouldNotShow',
-}
-
-export const useShouldShowReactionModal = (
-  bookings: BookingsResponse | undefined
-): ModalDisplayState => {
+export const useShouldShowReactionModal = (bookingsEligibleToReaction: BookingReponse[]) => {
   const isReactionFeatureActive = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
-
-  const bookingsEligibleToReaction =
-    bookings?.ended_bookings?.filter(
-      (booking) => booking.enablePopUpReaction && !booking.userReaction
-    ) ?? []
-
   const firstBookingEligibleToReaction = bookingsEligibleToReaction[0]
-
   // There is an issue with !isCookieConsentChecked it goes to true for an instant and disrupts the modal conflict management hook
   return isReactionFeatureActive && firstBookingEligibleToReaction
-    ? ModalDisplayState.SHOULD_SHOW
-    : ModalDisplayState.SHOULD_NOT_SHOW
 }

--- a/src/features/home/helpers/useWhichModalToShow.ts
+++ b/src/features/home/helpers/useWhichModalToShow.ts
@@ -19,12 +19,8 @@ export const useWhichModalToShow = (
   isBookingsLoading: boolean
 ) => {
   const [modalToShow, setModalToShow] = useState<ModalToShow>(ModalToShow.PENDING)
-  const { shouldShowReactionModal, bookingsEligibleToReaction } = useBookingsReactionHelpers(
-    bookings,
-    isBookingsLoading
-  )
-  const { shouldShowAchievementSuccessModal, achievementsToShow } =
-    useShouldShowAchievementSuccessModal()
+  const { shouldShowReactionModal } = useBookingsReactionHelpers(bookings, isBookingsLoading)
+  const { shouldShowAchievementSuccessModal } = useShouldShowAchievementSuccessModal()
   if (!isBookingsLoading && modalToShow === ModalToShow.PENDING) {
     if (shouldShowReactionModal === ModalDisplayState.SHOULD_SHOW) {
       setModalToShow(ModalToShow.REACTION)
@@ -38,5 +34,5 @@ export const useWhichModalToShow = (
     }
   }
 
-  return { modalToShow, bookingsEligibleToReaction, achievementsToShow }
+  return { modalToShow }
 }

--- a/src/features/home/helpers/useWhichModalToShow.ts
+++ b/src/features/home/helpers/useWhichModalToShow.ts
@@ -4,8 +4,8 @@ import { BookingsResponse } from 'api/gen'
 import { useShouldShowAchievementSuccessModal } from 'features/achievements/hooks/useShouldShowAchievementSuccessModal'
 import {
   ModalDisplayState,
-  useBookingsReactionHelpers,
-} from 'features/home/components/helpers/useBookingsReactionHelpers'
+  useShouldShowReactionModal,
+} from 'features/home/components/helpers/useShouldShowReactionModal'
 
 export enum ModalToShow {
   PENDING = 'pending',
@@ -19,8 +19,8 @@ export const useWhichModalToShow = (
   isBookingsLoading: boolean
 ) => {
   const [modalToShow, setModalToShow] = useState<ModalToShow>(ModalToShow.PENDING)
-  const { shouldShowReactionModal } = useBookingsReactionHelpers(bookings, isBookingsLoading)
-  const { shouldShowAchievementSuccessModal } = useShouldShowAchievementSuccessModal()
+  const shouldShowReactionModal = useShouldShowReactionModal(bookings, isBookingsLoading)
+  const shouldShowAchievementSuccessModal = useShouldShowAchievementSuccessModal()
   if (!isBookingsLoading && modalToShow === ModalToShow.PENDING) {
     if (shouldShowReactionModal === ModalDisplayState.SHOULD_SHOW) {
       setModalToShow(ModalToShow.REACTION)

--- a/src/features/home/pages/Home.tsx
+++ b/src/features/home/pages/Home.tsx
@@ -3,15 +3,13 @@ import { maxBy } from 'lodash'
 import React, { FunctionComponent, useEffect } from 'react'
 import styled from 'styled-components/native'
 
-import { AchievementSuccessModal } from 'features/achievements/pages/AchievementSuccessModal'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useBookings } from 'features/bookings/api'
 import { useHomepageData } from 'features/home/api/useHomepageData'
 import { HomeHeader } from 'features/home/components/headers/HomeHeader'
-import { IncomingReactionModalContainer } from 'features/home/components/IncomingReactionModalContainer/IncomingReactionModalContainer'
+import { HomeModals } from 'features/home/components/HomeModals'
 import { HomeBanner } from 'features/home/components/modules/banners/HomeBanner'
 import { PERFORMANCE_HOME_CREATION, PERFORMANCE_HOME_LOADING } from 'features/home/constants'
-import { ModalToShow, useWhichModalToShow } from 'features/home/helpers/useWhichModalToShow'
 import { GenericHome } from 'features/home/pages/GenericHome'
 import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { OnboardingSubscriptionModal } from 'features/subscription/components/modals/OnboardingSubscriptionModal'
@@ -56,24 +54,7 @@ export const Home: FunctionComponent = () => {
     userStatus: user?.status?.statusType,
     showOnboardingSubscriptionModal,
   })
-  const { data: bookings, isLoading } = useBookings()
-
-  const { achievementsToShow, bookingsEligibleToReaction, modalToShow } = useWhichModalToShow(
-    bookings,
-    isLoading
-  )
-
-  const {
-    visible: visibleAchievementModal,
-    showModal: showAchievementModal,
-    hideModal: hideAchievementModal,
-  } = useModal(false)
-
-  useEffect(() => {
-    if (modalToShow === ModalToShow.ACHIEVEMENT) {
-      showAchievementModal()
-    }
-  }, [showAchievementModal, modalToShow])
+  const { data: bookings } = useBookings()
 
   useEffect(() => {
     if (id) {
@@ -138,14 +119,7 @@ export const Home: FunctionComponent = () => {
         visible={onboardingSubscriptionModalVisible}
         dismissModal={hideOnboardingSubscriptionModal}
       />
-      {modalToShow === ModalToShow.REACTION ? (
-        <IncomingReactionModalContainer bookingsEligibleToReaction={bookingsEligibleToReaction} />
-      ) : null}
-      <AchievementSuccessModal
-        achievementsToShow={achievementsToShow}
-        visible={visibleAchievementModal}
-        hideModal={hideAchievementModal}
-      />
+      <HomeModals />
     </React.Fragment>
   )
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
