### PR TITLE
(PC-33565) fix(HorizontalOfferTile): flaky test

### DIFF
--- a/src/features/favorites/components/Favorite.native.test.tsx
+++ b/src/features/favorites/components/Favorite.native.test.tsx
@@ -19,7 +19,7 @@ import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategories
 import { Credit } from 'shared/user/useAvailableCredit'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, userEvent, render, screen, waitFor } from 'tests/utils'
+import { userEvent, render, screen, waitFor } from 'tests/utils'
 import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
 import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
 
@@ -34,7 +34,7 @@ jest.mock('ui/components/snackBar/SnackBarContext', () => ({
 
 const credit: Credit = { amount: 100, isExpired: false }
 
-const user: UserProfileResponse = {
+const userProfile: UserProfileResponse = {
   isBeneficiary: true,
   bookedOffers: {},
   domainsCredit: { [ExpenseDomain.all]: { initial: 500, remaining: 300 } },
@@ -67,7 +67,7 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
-const userAction = userEvent.setup()
+const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('<Favorite /> component', () => {
@@ -80,9 +80,7 @@ describe('<Favorite /> component', () => {
     renderFavorite()
 
     const offre = screen.getByText(favorite.offer.name)
-    await act(async () => {
-      userAction.press(offre)
-    })
+    await user.press(offre)
 
     expect(navigate).toHaveBeenCalledWith('Offer', {
       from: 'favorites',
@@ -104,7 +102,7 @@ describe('<Favorite /> component', () => {
     mockDistance = '10 km'
     renderFavorite()
 
-    await userAction.press(screen.getByText('Supprimer'))
+    await user.press(screen.getByText('Supprimer'))
 
     await waitFor(() => {
       expect(deleteFavoriteSpy).toHaveBeenNthCalledWith(1, favorite.id)
@@ -121,7 +119,7 @@ describe('<Favorite /> component', () => {
       favorite: { ...favorite, id, offer: { ...favorite.offer, id } },
     })
 
-    await userAction.press(screen.getByText('Supprimer'))
+    await user.press(screen.getByText('Supprimer'))
 
     await waitFor(() => {
       expect(deleteFavoriteSpy).toHaveBeenNthCalledWith(1, id)
@@ -136,9 +134,7 @@ describe('<Favorite /> component', () => {
     renderFavorite()
 
     const shareButton = await screen.findByLabelText(`Partager l’offre ${favorite.offer.name}`)
-    await act(async () => {
-      userAction.press(shareButton)
-    })
+    await user.press(shareButton)
 
     expect(shareSpy).toHaveBeenCalledTimes(1)
   })
@@ -147,9 +143,7 @@ describe('<Favorite /> component', () => {
     renderFavorite()
 
     const shareButton = await screen.findByLabelText(`Partager l’offre ${favorite.offer.name}`)
-    await act(async () => {
-      userAction.press(shareButton)
-    })
+    await user.press(shareButton)
 
     expect(analytics.logShare).toHaveBeenNthCalledWith(1, {
       type: 'Offer',
@@ -182,7 +176,7 @@ function simulateBackend(options: Options = DEFAULT_GET_FAVORITE_OPTIONS) {
 const DEFAULT_PROPS = {
   credit,
   favorite,
-  user,
+  userProfile,
   onInAppBooking,
 }
 
@@ -192,10 +186,10 @@ type RenderFavoriteParams = {
 }
 
 function renderFavorite(props: RenderFavoriteParams = DEFAULT_PROPS) {
-  const { favorite, user } = { ...DEFAULT_PROPS, ...props }
+  const { favorite, userProfile } = { ...DEFAULT_PROPS, ...props }
   return render(
     reactQueryProviderHOC(
-      <Favorite favorite={favorite} user={user} onInAppBooking={onInAppBooking} />
+      <Favorite favorite={favorite} user={userProfile} onInAppBooking={onInAppBooking} />
     )
   )
 }

--- a/src/features/favorites/components/Favorite.native.test.tsx
+++ b/src/features/favorites/components/Favorite.native.test.tsx
@@ -19,7 +19,7 @@ import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategories
 import { Credit } from 'shared/user/useAvailableCredit'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { act, userEvent, render, screen, waitFor } from 'tests/utils'
 import { SNACK_BAR_TIME_OUT } from 'ui/components/snackBar/SnackBarContext'
 import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
 
@@ -67,6 +67,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const userAction = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<Favorite /> component', () => {
   beforeEach(() => {
     mockServer.getApi<SubcategoriesResponseModelv2>(`/v1/subcategories/v2`, subcategoriesDataTest)
@@ -78,7 +81,7 @@ describe('<Favorite /> component', () => {
 
     const offre = screen.getByText(favorite.offer.name)
     await act(async () => {
-      fireEvent.press(offre)
+      userAction.press(offre)
     })
 
     expect(navigate).toHaveBeenCalledWith('Offer', {
@@ -101,7 +104,7 @@ describe('<Favorite /> component', () => {
     mockDistance = '10 km'
     renderFavorite()
 
-    fireEvent.press(screen.getByText('Supprimer'))
+    await userAction.press(screen.getByText('Supprimer'))
 
     await waitFor(() => {
       expect(deleteFavoriteSpy).toHaveBeenNthCalledWith(1, favorite.id)
@@ -118,7 +121,7 @@ describe('<Favorite /> component', () => {
       favorite: { ...favorite, id, offer: { ...favorite.offer, id } },
     })
 
-    fireEvent.press(screen.getByText('Supprimer'))
+    await userAction.press(screen.getByText('Supprimer'))
 
     await waitFor(() => {
       expect(deleteFavoriteSpy).toHaveBeenNthCalledWith(1, id)
@@ -134,7 +137,7 @@ describe('<Favorite /> component', () => {
 
     const shareButton = await screen.findByLabelText(`Partager l’offre ${favorite.offer.name}`)
     await act(async () => {
-      fireEvent.press(shareButton)
+      userAction.press(shareButton)
     })
 
     expect(shareSpy).toHaveBeenCalledTimes(1)
@@ -145,7 +148,7 @@ describe('<Favorite /> component', () => {
 
     const shareButton = await screen.findByLabelText(`Partager l’offre ${favorite.offer.name}`)
     await act(async () => {
-      fireEvent.press(shareButton)
+      userAction.press(shareButton)
     })
 
     expect(analytics.logShare).toHaveBeenNthCalledWith(1, {

--- a/src/features/home/components/AttachedModuleCard/AttachedOfferCard.native.test.tsx
+++ b/src/features/home/components/AttachedModuleCard/AttachedOfferCard.native.test.tsx
@@ -6,7 +6,6 @@ import { SubcategoriesResponseModelv2 } from 'api/gen'
 import { AttachedOfferCard } from 'features/home/components/AttachedModuleCard/AttachedOfferCard'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import { useDistance } from 'libs/location/hooks/useDistance'
 import { ILocationContext, LocationMode } from 'libs/location/types'
 import { PLACEHOLDER_DATA } from 'libs/subcategories/placeholderData'
 import { useSubcategories } from 'libs/subcategories/useSubcategories'
@@ -36,9 +35,10 @@ mockUseSubcategories.mockReturnValue({
 
 mockdate.set(new Date('2019-12-01T00:00:00.000Z'))
 
-jest.mock('libs/location/hooks/useDistance')
-const mockUseDistance = useDistance as jest.Mock
-mockUseDistance.mockReturnValue('10 km')
+const mockDistance: string | null = '10 km'
+jest.mock('libs/location/hooks/useDistance', () => ({
+  useDistance: () => mockDistance,
+}))
 
 describe('AttachedOfferCard', () => {
   beforeEach(() => {

--- a/src/features/home/components/modules/venues/VenueTile.native.test.tsx
+++ b/src/features/home/components/modules/venues/VenueTile.native.test.tsx
@@ -4,7 +4,7 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { venuesSearchFixture } from 'libs/algolia/fixtures/venuesSearchFixture'
 import { analytics } from 'libs/analytics'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 
 import { VenueTile, VenueTileProps } from './VenueTile'
 
@@ -23,21 +23,24 @@ jest.mock('libs/location/hooks/useDistance', () => ({
   useDistance: () => mockDistance,
 }))
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('VenueTile component', () => {
+  afterEach(() => (mockDistance = null))
+
   it('should navigate to the venue when clicking on the venue tile', async () => {
     renderVenueTile()
 
-    fireEvent.press(screen.getByTestId(/Lieu/))
+    await user.press(screen.getByTestId(/Lieu/))
 
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('Venue', { id: venue.id })
-    })
+    expect(navigate).toHaveBeenCalledWith('Venue', { id: venue.id })
   })
 
-  it('should log analytics event ConsultVenue when pressing on the venue tile', () => {
+  it('should log analytics event ConsultVenue when pressing on the venue tile', async () => {
     renderVenueTile()
 
-    fireEvent.press(screen.getByTestId(/Lieu/))
+    await user.press(screen.getByTestId(/Lieu/))
 
     expect(analytics.logConsultVenue).toHaveBeenNthCalledWith(1, {
       venueId: venue.id,
@@ -47,10 +50,10 @@ describe('VenueTile component', () => {
     })
   })
 
-  it('should log analytics event ConsultVenue with homeEntryId when provided', () => {
+  it('should log analytics event ConsultVenue with homeEntryId when provided', async () => {
     renderVenueTile({ homeEntryId: 'abcd' })
 
-    fireEvent.press(screen.getByTestId(/Lieu/))
+    await user.press(screen.getByTestId(/Lieu/))
 
     expect(analytics.logConsultVenue).toHaveBeenNthCalledWith(1, {
       venueId: venue.id,

--- a/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
+++ b/src/features/offer/components/OfferPlace/OfferPlace.native.test.tsx
@@ -8,7 +8,8 @@ import { OfferCTAProvider } from 'features/offer/components/OfferContent/OfferCT
 import { OfferPlace, OfferPlaceProps } from 'features/offer/components/OfferPlace/OfferPlace'
 import { mockSubcategory } from 'features/offer/fixtures/mockSubcategory'
 import { analytics } from 'libs/analytics'
-import * as useFeatureFlag from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { ILocationContext, LocationMode } from 'libs/location/types'
 import { SuggestedPlace } from 'libs/place/types'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -16,7 +17,6 @@ import { act, render, screen, userEvent } from 'tests/utils'
 import { AnchorProvider } from 'ui/components/anchor/AnchorContext'
 import * as useModalAPI from 'ui/components/modals/useModal'
 
-jest.useFakeTimers()
 jest.mock('libs/address/useFormatFullAddress')
 const offerVenues = [
   {
@@ -71,8 +71,6 @@ jest.mock('api/useSearchVenuesOffer/useSearchVenueOffers', () => ({
   useSearchVenueOffers: () => mockUseSearchVenueOffers(),
 }))
 
-const useFeatureFlagSpy = jest.spyOn(useFeatureFlag, 'useFeatureFlag')
-
 const offerPlaceProps: OfferPlaceProps = {
   offer: mockOffer,
   subcategory: mockSubcategory,
@@ -102,13 +100,14 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
 })
 
 const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<OfferPlace />', () => {
   beforeEach(() => {
+    setFeatureFlags()
     mockDistance = null
     mockdate.set(new Date('2021-01-01'))
     mockUseSearchVenueOffers.mockReturnValue(searchVenueOfferWithVenues)
-    useFeatureFlagSpy.mockReturnValue(false) // this value corresponds to TARGET_XP_CINE_FROM_OFFER feature flag
   })
 
   it('should display change venue button when offer subcategory is "Livres audio", offer has an EAN and that there are other venues offering the same offer', () => {
@@ -125,7 +124,8 @@ describe('<OfferPlace />', () => {
   })
 
   it('should display new xp cine block when offer subcategory is "Seance cine" and FF is on', async () => {
-    useFeatureFlagSpy.mockReturnValueOnce(true) // this value corresponds to TARGET_XP_CINE_FROM_OFFER feature flag
+    setFeatureFlags([RemoteStoreFeatureFlags.TARGET_XP_CINE_FROM_OFFER])
+
     renderOfferPlace({
       ...offerPlaceProps,
       offer: {

--- a/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.native.test.tsx
+++ b/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.native.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { ReactTestInstance } from 'react-test-renderer'
 
 import { push } from '__mocks__/@react-navigation/native'
 import { mockOffer } from 'features/bookOffer/fixtures/offer'
@@ -12,7 +11,7 @@ import {
   mockedAlgoliaResponse,
   moreHitsForSimilarOffersPlaylist,
 } from 'libs/algolia/fixtures/algoliaFixtures'
-import * as useFeatureFlag from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { userEvent, render, screen } from 'tests/utils'
 
@@ -22,11 +21,6 @@ const mockDistance: string | null = null
 jest.mock('libs/location/hooks/useDistance', () => ({
   useDistance: () => mockDistance,
 }))
-
-jest
-  .spyOn(useFeatureFlag, 'useFeatureFlag')
-  // this value corresponds to WIP_NEW_OFFER_TILE feature flag
-  .mockReturnValue(false)
 
 const mockSearchHits = [...mockedAlgoliaResponse.hits, ...moreHitsForSimilarOffersPlaylist]
 
@@ -54,6 +48,10 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('<OfferPlaylistList />', () => {
+  beforeEach(() => {
+    setFeatureFlags()
+  })
+
   describe('Similar offers', () => {
     describe('Same category playlist', () => {
       it('should not display same category playlist when offer has not it', () => {
@@ -77,7 +75,7 @@ describe('<OfferPlaylistList />', () => {
           sameCategorySimilarOffers: mockSearchHits,
         })
 
-        await user.press(screen.queryAllByText('La nuit des temps')[0] as ReactTestInstance)
+        await user.press(screen.getByText('La nuit des temps'))
 
         expect(push).toHaveBeenCalledWith('Offer', {
           from: 'offer',
@@ -110,7 +108,7 @@ describe('<OfferPlaylistList />', () => {
           otherCategoriesSimilarOffers: mockSearchHits,
         })
 
-        await user.press(screen.queryAllByText('La nuit des temps')[0] as ReactTestInstance)
+        await user.press(screen.getByText('La nuit des temps'))
 
         expect(push).toHaveBeenCalledWith('Offer', {
           from: 'offer',

--- a/src/features/search/components/SearchVenueItems/SearchVenueItem.native.test.tsx
+++ b/src/features/search/components/SearchVenueItems/SearchVenueItem.native.test.tsx
@@ -5,7 +5,7 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { VenueTypeCodeKey } from 'api/gen'
 import { AlgoliaVenue } from 'libs/algolia/types'
 import { analytics } from 'libs/analytics'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 
 import { SearchVenueItem } from './SearchVenueItem'
 
@@ -45,7 +45,12 @@ const ITEM_HEIGHT = 96
 const ITEM_WIDTH = 144
 const searchId = uuidv4()
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<SearchVenueItem />', () => {
+  afterEach(() => (mockDistance = null))
+
   it('should render venue item correctly', () => {
     render(<SearchVenueItem venue={mockAlgoliaVenue} width={ITEM_WIDTH} height={ITEM_HEIGHT} />)
 
@@ -65,14 +70,12 @@ describe('<SearchVenueItem />', () => {
       />
     )
 
-    fireEvent.press(screen.getByTestId(/Lieu/))
+    await user.press(screen.getByTestId(/Lieu/))
 
-    await waitFor(() => {
-      expect(analytics.logConsultVenue).toHaveBeenCalledWith({
-        venueId: Number(mockAlgoliaVenue.objectID),
-        searchId,
-        from: 'searchVenuePlaylist',
-      })
+    expect(analytics.logConsultVenue).toHaveBeenCalledWith({
+      venueId: Number(mockAlgoliaVenue.objectID),
+      searchId,
+      from: 'searchVenuePlaylist',
     })
   })
 
@@ -103,14 +106,12 @@ describe('<SearchVenueItem />', () => {
       />
     )
 
-    fireEvent.press(screen.getByTestId(/Lieu/))
+    await user.press(screen.getByTestId(/Lieu/))
 
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('Venue', {
-        id: Number(mockAlgoliaVenue.objectID),
-        from: 'venue',
-        searchId: 'testUuidV4',
-      })
+    expect(navigate).toHaveBeenCalledWith('Venue', {
+      id: Number(mockAlgoliaVenue.objectID),
+      from: 'venue',
+      searchId: 'testUuidV4',
     })
   })
 

--- a/src/libs/location/components/WhereSection.native.test.tsx
+++ b/src/libs/location/components/WhereSection.native.test.tsx
@@ -4,7 +4,7 @@ import { offerVenueResponseSnap as venue } from 'features/offer/fixtures/offerVe
 import { mockedFullAddress as address } from 'libs/address/fixtures/mockedFormatFullAddress'
 import { WhereSection } from 'libs/location/components/WhereSection'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, act, screen } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 
 jest.mock('libs/itinerary/useItinerary', () => ({
   useItinerary: jest.fn(() => ({ availableApps: ['waze'], navigateTo: jest.fn() })),
@@ -19,8 +19,11 @@ const beforeNavigateToItinerary = jest.fn()
 
 jest.mock('libs/firebase/analytics/analytics')
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('WhereSection', () => {
-  it('should log ConsultLocationItinerary analytics when clicking on "voir l’itinéraire"', () => {
+  it('should log ConsultLocationItinerary analytics when clicking on "voir l’itinéraire"', async () => {
     render(
       reactQueryProviderHOC(
         <WhereSection
@@ -33,9 +36,7 @@ describe('WhereSection', () => {
       )
     )
 
-    act(() => {
-      fireEvent.press(screen.getByText('Voir l’itinéraire'))
-    })
+    await user.press(screen.getByText('Voir l’itinéraire'))
 
     expect(beforeNavigateToItinerary).toHaveBeenCalledTimes(1)
   })

--- a/src/ui/components/tiles/HorizontalOfferTile.native.test.tsx
+++ b/src/ui/components/tiles/HorizontalOfferTile.native.test.tsx
@@ -9,7 +9,6 @@ import { analytics } from 'libs/analytics'
 import { OfferAnalyticsParams } from 'libs/analytics/types'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import { useDistance } from 'libs/location/hooks/useDistance'
 import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
 import { Offer } from 'shared/offer/types'
 import { mockServer } from 'tests/mswServer'
@@ -27,9 +26,10 @@ const mockAnalyticsParams: OfferAnalyticsParams = {
   searchId: '539b285e',
 }
 
-jest.mock('libs/location/hooks/useDistance')
-const mockUseDistance = useDistance as jest.Mock
-mockUseDistance.mockReturnValue(null)
+let mockDistance: string | null = null
+jest.mock('libs/location/hooks/useDistance', () => ({
+  useDistance: () => mockDistance,
+}))
 
 const spyLogClickOnOffer = jest.fn()
 const mockUseLogClickOnOffer = jest.spyOn(logClickOnProductAPI, 'useLogClickOnOffer')
@@ -105,10 +105,8 @@ describe('HorizontalOfferTile component', () => {
     })
   })
 
-  // TODO(PC-33565): fix flaky tests
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('should show distance if geolocation enabled', async () => {
-    mockUseDistance.mockReturnValueOnce('10 km')
+  it('should show distance if geolocation enabled', async () => {
+    mockDistance = '10 km'
 
     renderHorizontalOfferTile({
       offer: mockOffer,
@@ -119,7 +117,8 @@ describe('HorizontalOfferTile component', () => {
   })
 
   it('should not show distance if user has an unprecise location (type municipality or locality)', async () => {
-    mockUseDistance.mockReturnValueOnce(null)
+    mockDistance = null
+
     renderHorizontalOfferTile({
       offer: mockOffer,
       analyticsParams: mockAnalyticsParams,

--- a/src/ui/components/tiles/HorizontalOfferTile.native.test.tsx
+++ b/src/ui/components/tiles/HorizontalOfferTile.native.test.tsx
@@ -42,14 +42,15 @@ jest.mock('libs/algolia/analytics/SearchAnalyticsWrapper', () => ({
 jest.mock('libs/firebase/analytics/analytics')
 
 const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('HorizontalOfferTile component', () => {
-  jest.useFakeTimers()
-
   beforeEach(() => {
     setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_PACIFIC_FRANC_CURRENCY])
     mockServer.getApi<SubcategoriesResponseModelv2>(`/v1/subcategories/v2`, subcategoriesDataTest)
   })
+
+  afterEach(() => (mockDistance = null))
 
   it('should navigate to the offer when pressing an offer', async () => {
     renderHorizontalOfferTile({


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33565

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
