### PR TITLE
(PC-33973) fix(VideoModal): remove unnecessary test

### DIFF
--- a/src/features/home/components/modules/video/VideoModal.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoModal.native.test.tsx
@@ -10,7 +10,7 @@ import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategories
 import { MODAL_TO_SHOW_TIME } from 'tests/constants'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { act, userEvent, render, screen } from 'tests/utils'
 
 jest.mock('libs/network/NetInfoWrapper')
 
@@ -27,6 +27,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+jest.useFakeTimers()
+const user = userEvent.setup()
 
 describe('VideoModal', () => {
   beforeEach(() => {
@@ -49,9 +52,7 @@ describe('VideoModal', () => {
 
     const closeButton = screen.getByTestId('Fermer la modale vidéo')
 
-    await act(async () => {
-      fireEvent.press(closeButton)
-    })
+    await user.press(closeButton)
 
     expect(analytics.logHasDismissedModal).toHaveBeenNthCalledWith(1, {
       moduleId: 'abcd',
@@ -59,13 +60,6 @@ describe('VideoModal', () => {
       videoDuration: 267,
       seenDuration: 135,
     })
-  })
-
-  it('should render properly with FF on', async () => {
-    // TODO(PC-33973): test passes with no FF on
-    renderVideoModal()
-
-    expect(await screen.findByText('Découvre Lujipeka')).toBeOnTheScreen()
   })
 })
 

--- a/src/features/home/components/modules/video/VideoMonoOfferTile.native.test.tsx
+++ b/src/features/home/components/modules/video/VideoMonoOfferTile.native.test.tsx
@@ -12,7 +12,7 @@ import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategories
 import { Offer } from 'shared/offer/types'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, render, screen, userEvent } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('libs/network/NetInfoWrapper')
 
@@ -28,7 +28,6 @@ const mockAnalyticsParams: OfferAnalyticsParams = {
 const hideModalMock = jest.fn()
 
 const user = userEvent.setup()
-
 jest.useFakeTimers()
 
 describe('VideoMonoOfferTile', () => {
@@ -37,10 +36,16 @@ describe('VideoMonoOfferTile', () => {
     setFeatureFlags()
   })
 
+  it('should render properly', async () => {
+    renderOfferVideoModule()
+
+    expect(await screen.findByText(mockOffer.offer.name)).toBeOnTheScreen()
+  })
+
   it('should redirect to an offer when pressing it', async () => {
     renderOfferVideoModule()
 
-    await user.press(screen.getByText('La nuit des temps'))
+    await user.press(screen.getByText(mockOffer.offer.name))
 
     expect(navigate).toHaveBeenCalledWith('Offer', { id: 102_280 })
   })
@@ -49,7 +54,7 @@ describe('VideoMonoOfferTile', () => {
     const offerWithoutImage = omit(mockOffer, 'offer.thumbUrl')
     renderOfferVideoModule(offerWithoutImage)
 
-    await act(async () => {})
+    await screen.findByText(mockOffer.offer.name)
 
     expect(screen.getByTestId('imagePlaceholder')).toBeOnTheScreen()
   })
@@ -57,21 +62,11 @@ describe('VideoMonoOfferTile', () => {
   it('should log ConsultOffer on when pressing it', async () => {
     renderOfferVideoModule()
 
-    await user.press(screen.getByText('La nuit des temps'))
+    await user.press(screen.getByText(mockOffer.offer.name))
 
     expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {
       offerId: +mockOffer.objectID,
       ...mockAnalyticsParams,
-    })
-  })
-
-  describe('With FF on', () => {
-    it('should render properly', async () => {
-      // TODO(PC-33973): test passes with no FF on
-
-      renderOfferVideoModule()
-
-      expect(await screen.findByText('La nuit des temps')).toBeOnTheScreen()
     })
   })
 })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33973

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
