### PR TITLE
(BSR) docs(java): a password is needed

### DIFF
--- a/doc/installation/Android.md
+++ b/doc/installation/Android.md
@@ -27,10 +27,18 @@ Then open the Android Virtual Devices Manager and select (or create) a Virtual D
 
 ### Install
 
+In the `.env.local` file, add
+
+```sh
+KEYTOOL_PASSWORD=THE_PASSWORD # replace THE_PASSWORD with the one from Keeper search for "Android keytool password"
+```
+
 ```sh
 ./scripts/install_certificate_java.sh # this script ask root password
 direnv reload
 ```
+
+If it fails [see troubleshooting](./setup.md#troubleshooting)
 
 ### 🔥 Firebase setup
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
