### PR TITLE
(PC-33906) feat(TypoDS): update typo button

### DIFF
--- a/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/accessibility/components/AccessibilityFiltersModal.native.test.tsx.native-snap
@@ -1054,8 +1054,8 @@ exports[`<AccessibilityFiltersModal /> should render modal correctly 1`] = `
                         {
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword.native.test.tsx.native-snap
@@ -477,8 +477,8 @@ exports[`<ForgottenPassword /> should match snapshot 1`] = `
                   {
                     "color": "#696A6F",
                     "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword.native.test.tsx.native-snap
@@ -1170,8 +1170,8 @@ exports[`ReinitializePassword Page should match snapshot 1`] = `
                   {
                     "color": "#696A6F",
                     "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/forgottenPassword/ResetPasswordEmailSent/ResetPasswordEmailSent.native.test.tsx.native-snap
@@ -467,8 +467,8 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                 {
                   "color": "#161617",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -593,8 +593,8 @@ exports[`<ResetPasswordEmailSent /> should match snapshot 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/login/Login.native.test.tsx.native-snap
@@ -723,8 +723,8 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
                     {
                       "color": "#161617",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]
@@ -820,8 +820,8 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
                   {
                     "color": "#696A6F",
                     "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "maxWidth": "100%",
                   },
                 ]
@@ -1017,8 +1017,8 @@ exports[`<Login/> should render correctly when feature flag is enabled 1`] = `
                   {
                     "color": "#161617",
                     "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AcceptCgu/AcceptCgu.native.test.tsx.native-snap
@@ -590,8 +590,8 @@ exports[`<AcceptCgu/> should render correctly 1`] = `
             {
               "color": "#696A6F",
               "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "maxWidth": "100%",
             },
           ]
@@ -1346,8 +1346,8 @@ exports[`<AcceptCgu/> should render correctly for SSO subscription 1`] = `
             {
               "color": "#696A6F",
               "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "maxWidth": "100%",
             },
           ]

--- a/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/AccountCreated/AccountCreated.native.test.tsx.native-snap
@@ -254,8 +254,8 @@ exports[`<AccountCreated /> should render correctly 1`] = `
                   {
                     "color": "#eb0055",
                     "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/NotYetUnderageEligibility/NotYetUnderageEligibility.native.test.tsx.native-snap
@@ -258,8 +258,8 @@ exports[`<NotYetUnderageEligibility /> should render properly 1`] = `
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/QuitSignupModal/QuitSignupModal.native.test.tsx.native-snap
@@ -284,8 +284,8 @@ exports[`QuitSignupModal should render correctly 1`] = `
                   {
                     "color": "#eb0055",
                     "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "maxWidth": "100%",
                   },
                 ]
@@ -412,8 +412,8 @@ exports[`QuitSignupModal should render correctly 1`] = `
                   {
                     "color": "#ffffff",
                     "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.native.test.tsx.native-snap
@@ -342,8 +342,8 @@ exports[`<SetBirthday /> should render correctly 1`] = `
               {
                 "color": "#696A6F",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -735,8 +735,8 @@ exports[`<SetBirthday /> should render correctly when account creation token and
               {
                 "color": "#696A6F",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.web.test.tsx.web-snap
+++ b/__snapshots__/features/auth/pages/signup/SetBirthday/SetBirthday.web.test.tsx.web-snap
@@ -61,9 +61,9 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
 }
 
 .c1 {
-  font-family: Montserrat-Regular;
-  font-size: 15px;
-  line-height: 20px;
+  font-family: Montserrat-Medium;
+  font-size: 1rem;
+  line-height: 1.6rem;
   color: #161617;
   cursor: pointer;
 }
@@ -1443,7 +1443,7 @@ exports[`<SetBirthday /> no touch device should render correctly 1`] = `
           class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
         >
           <div
-            class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
+            class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-cygvgh r-lineHeight-u6qrkm r-maxWidth-dnmrzs"
             dir="ltr"
           >
             Continuer
@@ -1519,9 +1519,9 @@ exports[`<SetBirthday /> touch device should render correctly 1`] = `
 }
 
 .c1 {
-  font-family: Montserrat-Regular;
-  font-size: 15px;
-  line-height: 20px;
+  font-family: Montserrat-Medium;
+  font-size: 1rem;
+  line-height: 1.6rem;
   color: #161617;
   cursor: pointer;
 }
@@ -2570,7 +2570,7 @@ exports[`<SetBirthday /> touch device should render correctly 1`] = `
           class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
         >
           <div
-            class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
+            class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-cygvgh r-lineHeight-u6qrkm r-maxWidth-dnmrzs"
             dir="ltr"
           >
             Continuer

--- a/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx.native-snap
@@ -678,8 +678,8 @@ exports[`SetPassword Page should render correctly 1`] = `
             {
               "color": "#696A6F",
               "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "maxWidth": "100%",
             },
           ]

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/EmailResendModal.native.test.tsx.native-snap
@@ -490,8 +490,8 @@ exports[`<EmailResendModal /> should render correctly 1`] = `
                         {
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSentPage.native.test.tsx.native-snap
@@ -477,8 +477,8 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
                 {
                   "color": "#161617",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -594,8 +594,8 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
                 {
                   "color": "#161617",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -720,8 +720,8 @@ exports[`<SignupConfirmationEmailSentPage /> should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/SignupForm.native.test.tsx.native-snap
@@ -916,8 +916,8 @@ exports[`Signup Form should render correctly for AcceptCgu 1`] = `
                   {
                     "color": "#696A6F",
                     "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "maxWidth": "100%",
                   },
                 ]
@@ -1677,8 +1677,8 @@ exports[`Signup Form should render correctly for SetBirthday 1`] = `
                     {
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]
@@ -2346,8 +2346,8 @@ exports[`Signup Form should render correctly for SetEmail 1`] = `
                   {
                     "color": "#696A6F",
                     "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "maxWidth": "100%",
                   },
                 ]
@@ -3550,8 +3550,8 @@ exports[`Signup Form should render correctly for SetPassword 1`] = `
                   {
                     "color": "#696A6F",
                     "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.native.test.tsx.native-snap
@@ -192,9 +192,9 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-SemiBold",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }
@@ -329,8 +329,8 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -456,8 +456,8 @@ exports[`<VerifyEligibility /> should show the correct deposit amount 1`] = `
                 {
                   "color": "#161617",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx.native-snap
@@ -211,8 +211,8 @@ exports[`<AccountReactivationSuccess /> should match snapshot 1`] = `
               {
                 "color": "#ffffff",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx.native-snap
@@ -321,8 +321,8 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -448,8 +448,8 @@ exports[`<FraudulentSuspendedAccount /> should match snapshot 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
+++ b/__snapshots__/features/auth/pages/suspendedAccount/SuspendedAccountUponUserRequest/SuspendedAccountUponUserRequest.native.test.tsx.native-snap
@@ -285,8 +285,8 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -412,8 +412,8 @@ exports[`<SuspendedAccountUponUserRequest /> should match snapshot 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
+++ b/__snapshots__/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx.native-snap
@@ -212,8 +212,8 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
             {
               "color": "#ffffff",
               "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "maxWidth": "100%",
             },
           ]
@@ -339,8 +339,8 @@ exports[`<EighteenBirthday /> should render eighteen birthday 1`] = `
             {
               "color": "#161617",
               "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "maxWidth": "100%",
             },
           ]

--- a/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookOffer/pages/BookingConfirmation.native.test.tsx.native-snap
@@ -203,8 +203,8 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
               {
                 "color": "#ffffff",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -293,8 +293,8 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
               {
                 "color": "#eb0055",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -410,8 +410,8 @@ exports[`<BookingConfirmation /> should render correctly 1`] = `
               {
                 "color": "#eb0055",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx.native-snap
@@ -936,8 +936,8 @@ exports[`BookingDetails should render correctly 1`] = `
                       {
                         "color": "#161617",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]
@@ -1027,8 +1027,8 @@ exports[`BookingDetails should render correctly 1`] = `
                     {
                       "color": "#ffffff",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx.native-snap
@@ -258,8 +258,8 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -355,8 +355,8 @@ exports[`<BookingNotFound/> should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/bookings/pages/Bookings/Bookings.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/Bookings/Bookings.native.test.tsx.native-snap
@@ -427,9 +427,9 @@ exports[`Bookings should render correctly 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "flexShrink": 1,
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }
@@ -730,9 +730,9 @@ exports[`Bookings should render correctly 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "flexShrink": 1,
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }

--- a/__snapshots__/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/EndedBookings/EndedBookings.native.test.tsx.native-snap
@@ -563,9 +563,9 @@ exports[`EndedBookings should render correctly 1`] = `
                       [
                         {
                           "color": "#161617",
-                          "flexShrink": 1,
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -1017,9 +1017,9 @@ exports[`EndedBookings should render correctly 1`] = `
                       [
                         {
                           "color": "#161617",
-                          "flexShrink": 1,
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }

--- a/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesConsent.native.test.tsx.native-snap
@@ -478,8 +478,8 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
                         {
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]
@@ -586,8 +586,8 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
                         {
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]
@@ -688,8 +688,8 @@ exports[`<CookiesConsent/> should render correctly 1`] = `
                     {
                       "color": "#eb0055",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/cookies/pages/CookiesDetails.native.test.tsx.native-snap
+++ b/__snapshots__/features/cookies/pages/CookiesDetails.native.test.tsx.native-snap
@@ -105,9 +105,9 @@ exports[`<CookiesDetails/> should render correctly 1`] = `
                 [
                   {
                     "color": "#161617",
-                    "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                   },
                 ]
               }

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyIntro.native.test.tsx.native-snap
@@ -229,8 +229,8 @@ exports[`CulturalSurveyIntro page When FF is disabled should render the page wit
               {
                 "color": "#161617",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -329,8 +329,8 @@ exports[`CulturalSurveyIntro page When FF is disabled should render the page wit
               {
                 "color": "#ffffff",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -456,8 +456,8 @@ exports[`CulturalSurveyIntro page When FF is disabled should render the page wit
               {
                 "color": "#161617",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -702,8 +702,8 @@ exports[`CulturalSurveyIntro page When FF is enabled should render the page with
               {
                 "color": "#ffffff",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -829,8 +829,8 @@ exports[`CulturalSurveyIntro page When FF is enabled should render the page with
               {
                 "color": "#161617",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyQuestions.native.test.tsx.native-snap
@@ -486,9 +486,9 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -653,9 +653,9 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -820,9 +820,9 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -987,9 +987,9 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -1154,9 +1154,9 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -1307,9 +1307,9 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -1460,9 +1460,9 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -1627,9 +1627,9 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -1794,9 +1794,9 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -1942,9 +1942,9 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -2053,8 +2053,8 @@ exports[`CulturalSurveyQuestions page should render the page with correct layout
               {
                 "color": "#ffffff",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
+++ b/__snapshots__/features/culturalSurvey/pages/CulturalSurveyThanks.native.test.tsx.native-snap
@@ -211,8 +211,8 @@ exports[`CulturalSurveyThanksPage page When FF is disabled should render the pag
               {
                 "color": "#ffffff",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -449,8 +449,8 @@ exports[`CulturalSurveyThanksPage page When FF is enabled should render the page
               {
                 "color": "#ffffff",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/errors/pages/AsyncErrorBoundary.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/AsyncErrorBoundary.native.test.tsx.native-snap
@@ -301,8 +301,8 @@ exports[`AsyncErrorBoundary component should render 1`] = `
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/errors/pages/AsyncErrorBoundary.web.test.tsx.web-snap
+++ b/__snapshots__/features/errors/pages/AsyncErrorBoundary.web.test.tsx.web-snap
@@ -194,7 +194,7 @@ exports[`AsyncErrorBoundary component should render correctly 1`] = `
             class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
           >
             <div
-              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-ntw818 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
+              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-ntw818 r-fontFamily-1gknse6 r-fontSize-cygvgh r-lineHeight-u6qrkm r-maxWidth-dnmrzs"
               dir="ltr"
             >
               Réessayer

--- a/__snapshots__/features/errors/pages/BannedCountryError.native.test.tsx.native-snap
+++ b/__snapshots__/features/errors/pages/BannedCountryError.native.test.tsx.native-snap
@@ -217,8 +217,8 @@ exports[`BannedCountryError should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/favorites/pages/Favorites.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/Favorites.native.test.tsx.native-snap
@@ -190,8 +190,8 @@ exports[`<Favorites/> should render correctly 1`] = `
               {
                 "color": "#ffffff",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
               },
             ]
           }

--- a/__snapshots__/features/favorites/pages/FavoritesSorts.native.test.tsx.native-snap
+++ b/__snapshots__/features/favorites/pages/FavoritesSorts.native.test.tsx.native-snap
@@ -748,8 +748,8 @@ exports[`<FavoritesSorts/> should render correctly 1`] = `
                   {
                     "color": "#ffffff",
                     "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/forceUpdate/pages/ForceUpdate.native.test.tsx.native-snap
+++ b/__snapshots__/features/forceUpdate/pages/ForceUpdate.native.test.tsx.native-snap
@@ -259,8 +259,8 @@ exports[`<ForceUpdate/> should match snapshot 1`] = `
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -387,8 +387,8 @@ exports[`<ForceUpdate/> should match snapshot 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
@@ -631,9 +631,9 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "marginBottom": 4,
                         },
                       ]

--- a/__snapshots__/features/home/pages/GenericHome.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/GenericHome.native.test.tsx.native-snap
@@ -132,9 +132,9 @@ exports[`GenericHome With not displayed skeleton by default should display real 
                 [
                   {
                     "color": "#161617",
-                    "fontFamily": "Montserrat-Black",
-                    "fontSize": 26,
-                    "lineHeight": 34,
+                    "fontFamily": "Montserrat-Bold",
+                    "fontSize": 28,
+                    "lineHeight": 44.8,
                   },
                 ]
               }
@@ -330,9 +330,9 @@ exports[`GenericHome With not displayed skeleton by default should display skele
                 [
                   {
                     "color": "#161617",
-                    "fontFamily": "Montserrat-Black",
-                    "fontSize": 26,
-                    "lineHeight": 34,
+                    "fontFamily": "Montserrat-Bold",
+                    "fontSize": 28,
+                    "lineHeight": 44.8,
                   },
                 ]
               }

--- a/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
@@ -512,9 +512,9 @@ exports[`Home page should render correctly 1`] = `
                                 [
                                   {
                                     "color": "#ffffff",
-                                    "fontFamily": "Montserrat-Bold",
-                                    "fontSize": 15,
-                                    "lineHeight": 20,
+                                    "fontFamily": "Montserrat-SemiBold",
+                                    "fontSize": 16,
+                                    "lineHeight": 25.6,
                                   },
                                 ]
                               }

--- a/__snapshots__/features/home/pages/NoContentError.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/NoContentError.native.test.tsx.native-snap
@@ -276,8 +276,8 @@ exports[`NoContentError should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/DMSModal.native.test.tsx.native-snap
@@ -472,8 +472,8 @@ exports[`<DMSModal/> should render correctly 1`] = `
                       {
                         "color": "#161617",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]
@@ -614,8 +614,8 @@ exports[`<DMSModal/> should render correctly 1`] = `
                       {
                         "color": "#161617",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/components/modals/QuitIdentityCheckModal.native.test.tsx.native-snap
@@ -275,8 +275,8 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
                   {
                     "color": "#eb0055",
                     "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "maxWidth": "100%",
                   },
                 ]
@@ -403,8 +403,8 @@ exports[`<QuitIdentityCheckModal/> should render correctly 1`] = `
                   {
                     "color": "#ffffff",
                     "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/Stepper.native.test.tsx.native-snap
@@ -337,9 +337,9 @@ exports[`Stepper navigation should render correctly 1`] = `
                       [
                         {
                           "color": "#696A6F",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -589,9 +589,9 @@ exports[`Stepper navigation should render correctly 1`] = `
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -876,9 +876,9 @@ exports[`Stepper navigation should render correctly 1`] = `
                       [
                         {
                           "color": "#696A6F",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -1129,9 +1129,9 @@ exports[`Stepper navigation should render correctly 1`] = `
                       [
                         {
                           "color": "#696A6F",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -1274,8 +1274,8 @@ exports[`Stepper navigation should render correctly 1`] = `
                 {
                   "color": "#161617",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx.native-snap
@@ -341,8 +341,8 @@ exports[`<BeneficiaryAccountCreated/> should render correctly for 18 year-old be
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -719,8 +719,8 @@ exports[`<BeneficiaryAccountCreated/> should render correctly for underage benef
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/BeneficiaryRequestSent.native.test.tsx.native-snap
@@ -273,8 +273,8 @@ exports[`<BeneficiaryRequestSent /> should render correctly 1`] = `
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/pages/confirmation/IdentityCheckHonor.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/confirmation/IdentityCheckHonor.native.test.tsx.native-snap
@@ -175,8 +175,8 @@ exports[`<IdentityCheckHonor/> should render correctly 1`] = `
               {
                 "color": "#ffffff",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentificationFork.native.test.tsx.native-snap
@@ -398,9 +398,9 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                           [
                             {
                               "color": "#161617",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 15,
-                              "lineHeight": 20,
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
                             },
                           ]
                         }
@@ -747,9 +747,9 @@ exports[`<IdentificationFork /> should render correctly 1`] = `
                           [
                             {
                               "color": "#161617",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 15,
-                              "lineHeight": 20,
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
                             },
                           ]
                         }

--- a/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/IdentityCheckUnavailable.native.test.tsx.native-snap
@@ -354,8 +354,8 @@ exports[`<IdentityCheckUnavailable /> should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/DMSIntroduction.native.test.tsx.native-snap
@@ -579,8 +579,8 @@ exports[`DMSIntroduction foreign version should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -1119,8 +1119,8 @@ exports[`DMSIntroduction french version should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/dms/IdentityCheckDMS.native.test.tsx.native-snap
@@ -476,8 +476,8 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -674,8 +674,8 @@ exports[`<IdentityCheckDMS /> should render correctly 1`] = `
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.test.tsx.web-snap
@@ -206,7 +206,7 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
               </div>
             </div>
             <div
-              class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-textAlign-q4m81j"
+              class="css-text-1rynq56 r-color-v2ubm6 r-fontFamily-aeuvnr r-fontSize-cygvgh r-lineHeight-u6qrkm r-textAlign-q4m81j"
               dir="ltr"
             >
               Identification
@@ -289,7 +289,7 @@ exports[`<EduConnectForm /> should render EduConnectForm 1`] = `
                 />
               </div>
               <div
-                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
+                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-cygvgh r-lineHeight-u6qrkm r-maxWidth-dnmrzs"
                 dir="ltr"
               >
                 Ouvrir un onglet ÉduConnect

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.native.test.tsx.native-snap
@@ -527,8 +527,8 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
                     {
                       "color": "#ffffff",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/educonnect/EduConnectValidation.web.test.tsx.web-snap
@@ -280,7 +280,7 @@ exports[`<EduConnectValidation /> should render EduConnectValidation component c
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
               <div
-                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
+                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-cygvgh r-lineHeight-u6qrkm r-maxWidth-dnmrzs"
                 dir="ltr"
               >
                 Valider mes informations

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ComeBackLater.native.test.tsx.native-snap
@@ -171,9 +171,9 @@ exports[`ComeBackLater should render correctly 1`] = `
           [
             {
               "color": "#161617",
-              "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontFamily": "Montserrat-SemiBold",
+              "fontSize": 16,
+              "lineHeight": 25.6,
             },
           ]
         }
@@ -285,8 +285,8 @@ exports[`ComeBackLater should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/ExpiredOrLostID.native.test.tsx.native-snap
@@ -325,8 +325,8 @@ exports[`ExpiredOrLostID should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/IdentityCheckPending.native.test.tsx.native-snap
@@ -284,8 +284,8 @@ exports[`<IdentityCheckPending/> should render correctly 1`] = `
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDOrigin.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDOrigin.native.test.tsx.native-snap
@@ -467,9 +467,9 @@ exports[`SelectIDOrigin should render correctly 1`] = `
                             [
                               {
                                 "color": "#161617",
-                                "fontFamily": "Montserrat-Bold",
-                                "fontSize": 15,
-                                "lineHeight": 20,
+                                "fontFamily": "Montserrat-SemiBold",
+                                "fontSize": 16,
+                                "lineHeight": 25.6,
                               },
                             ]
                           }

--- a/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/identification/ubble/SelectIDStatus.native.test.tsx.native-snap
@@ -329,9 +329,9 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }
@@ -357,9 +357,9 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }
@@ -497,9 +497,9 @@ exports[`SelectIDStatus should render SelectIDStatus page correctly 1`] = `
                           [
                             {
                               "color": "#161617",
-                              "fontFamily": "Montserrat-Bold",
-                              "fontSize": 15,
-                              "lineHeight": 20,
+                              "fontFamily": "Montserrat-SemiBold",
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
                             },
                           ]
                         }

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/CodeNotReceivedModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/CodeNotReceivedModal.native.test.tsx.native-snap
@@ -499,8 +499,8 @@ exports[`<CodeNotReceivedModal /> should have a different color if one attempt r
                         {
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]
@@ -1018,8 +1018,8 @@ exports[`<CodeNotReceivedModal /> should match snapshot 1`] = `
                         {
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/PhoneValidationTipsModal.native.test.tsx.native-snap
@@ -621,8 +621,8 @@ exports[`<PhoneValidationTipsModal /> should match snapshot 1`] = `
                       {
                         "color": "#ffffff",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumber.native.test.tsx.native-snap
@@ -814,8 +814,8 @@ exports[`SetPhoneNumber should match snapshot without modal appearance 1`] = `
                       {
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneNumberWithoutValidation.native.test.tsx.native-snap
@@ -702,8 +702,8 @@ exports[`SetPhoneNumberWithoutValidation should match snapshot 1`] = `
                     {
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/phoneValidation/SetPhoneValidationCode.native.test.tsx.native-snap
@@ -602,8 +602,8 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
                             {
                               "color": "#161617",
                               "fontFamily": "Montserrat-Bold",
-                              "fontSize": 15,
-                              "lineHeight": 20,
+                              "fontSize": 16,
+                              "lineHeight": 25.6,
                               "maxWidth": "100%",
                             },
                           ]
@@ -740,8 +740,8 @@ exports[`SetPhoneValidationCode should match snapshot 1`] = `
                     {
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/profile/SetAddress.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetAddress.native.test.tsx.native-snap
@@ -528,8 +528,8 @@ exports[`<SetAddress/> should render correctly 1`] = `
                     {
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/profile/SetAddress.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetAddress.web.test.tsx.web-snap
@@ -117,9 +117,9 @@ exports[`<SetAddress/> should render correctly 1`] = `
 }
 
 .c3 {
-  font-family: Montserrat-Regular;
-  font-size: 15px;
-  line-height: 20px;
+  font-family: Montserrat-Medium;
+  font-size: 1rem;
+  line-height: 1.6rem;
   color: #161617;
   cursor: pointer;
 }
@@ -289,7 +289,7 @@ exports[`<SetAddress/> should render correctly 1`] = `
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
               <div
-                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
+                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-cygvgh r-lineHeight-u6qrkm r-maxWidth-dnmrzs"
                 dir="ltr"
               >
                 Continuer

--- a/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetCity.native.test.tsx.native-snap
@@ -541,8 +541,8 @@ exports[`<SetCity/> should render correctly 1`] = `
                     {
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/profile/SetCity.web.test.tsx.web-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetCity.web.test.tsx.web-snap
@@ -63,9 +63,9 @@ exports[`<SetCity/> should render correctly 1`] = `
 }
 
 .c3 {
-  font-family: Montserrat-Regular;
-  font-size: 15px;
-  line-height: 20px;
+  font-family: Montserrat-Medium;
+  font-size: 1rem;
+  line-height: 1.6rem;
   color: #161617;
   cursor: pointer;
 }
@@ -294,7 +294,7 @@ exports[`<SetCity/> should render correctly 1`] = `
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
               <div
-                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
+                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-cygvgh r-lineHeight-u6qrkm r-maxWidth-dnmrzs"
                 dir="ltr"
               >
                 Continuer

--- a/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetName.native.test.tsx.native-snap
@@ -740,8 +740,8 @@ Nous les vérifions et ils ne pourront plus être modifiés par la suite.
                     {
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/identityCheck/pages/profile/SetStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/identityCheck/pages/profile/SetStatus.native.test.tsx.native-snap
@@ -2162,8 +2162,8 @@ exports[`<SetStatus/> should render correctly 1`] = `
               {
                 "color": "#696A6F",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
+++ b/__snapshots__/features/internal/pages/DeeplinksGenerator.native.test.tsx.native-snap
@@ -3170,8 +3170,8 @@ exports[`<DeeplinksGenerator /> should render DeeplinksGenerator 1`] = `
                     {
                       "color": "#ffffff",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/HomeLocationModal.native.test.tsx.native-snap
@@ -805,8 +805,8 @@ exports[`HomeLocationModal should render correctly if modal visible 1`] = `
                       {
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/SearchLocationModal.native.test.tsx.native-snap
@@ -798,8 +798,8 @@ exports[`SearchLocationModal should render correctly if modal visible 1`] = `
                       {
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/location/components/VenueMapLocationModal.native.test.tsx.native-snap
@@ -756,8 +756,8 @@ exports[`VenueMapLocationModal should render correctly if modal visible 1`] = `
                       {
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/navigation/pages/PageNotFound.native.test.tsx.native-snap
@@ -258,8 +258,8 @@ exports[`<PageNotFound/> should render correctly 1`] = `
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/notifications/pages/AskNotificationsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/notifications/pages/AskNotificationsModal.native.test.tsx.native-snap
@@ -376,8 +376,8 @@ exports[`AskNotificationsModal should render properly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/notifications/pages/PushNotificationsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/notifications/pages/PushNotificationsModal.native.test.tsx.native-snap
@@ -388,8 +388,8 @@ exports[`PushNotificationsModal should render properly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/pages/OfferNotFound/OfferNotFound.native.test.tsx.native-snap
@@ -258,8 +258,8 @@ exports[`<OfferNotFound /> should render correctly 1`] = `
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityActionPlan.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityActionPlan.native.test.tsx.native-snap
@@ -2006,8 +2006,8 @@ exports[`AccessibilityActionPlan should render correctly 1`] = `
                 {
                   "color": "#161617",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/Accessibility/AccessibilityEngagement.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Accessibility/AccessibilityEngagement.native.test.tsx.native-snap
@@ -484,8 +484,8 @@ exports[`AccessibilityEngagement should render correctly 1`] = `
                 {
                   "color": "#161617",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.native.test.tsx.native-snap
@@ -529,8 +529,8 @@ exports[`<SetCity/> should render correctly 1`] = `
                     {
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/ChangeCity/ChangeCity.web.test.tsx.web-snap
@@ -63,9 +63,9 @@ exports[`<ChangeCity/> should render correctly 1`] = `
 }
 
 .c3 {
-  font-family: Montserrat-Regular;
-  font-size: 15px;
-  line-height: 20px;
+  font-family: Montserrat-Medium;
+  font-size: 1rem;
+  line-height: 1.6rem;
   color: #161617;
   cursor: pointer;
 }
@@ -290,7 +290,7 @@ exports[`<ChangeCity/> should render correctly 1`] = `
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
               <div
-                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
+                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-cygvgh r-lineHeight-u6qrkm r-maxWidth-dnmrzs"
                 dir="ltr"
               >
                 Valider ma ville de résidence

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmail.native.test.tsx.native-snap
@@ -603,8 +603,8 @@ exports[`<ChangeEmail/> should render correctly 1`] = `
                       {
                         "color": "#ffffff",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmail/ChangeEmailExpiredLink.native.test.tsx.native-snap
@@ -285,8 +285,8 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -412,8 +412,8 @@ Tu peux faire une nouvelle demande de modification dans ton profil.
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -724,8 +724,8 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -851,8 +851,8 @@ Connecte-toi avec ton ancienne adresse e-mail pour faire une nouvelle demande de
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeEmailSetPassword/ChangeEmailSetPassword.native.test.tsx.native-snap
@@ -1168,8 +1168,8 @@ exports[`<ChangeEmailSetPassword /> should match snapshot 1`] = `
                     {
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangePassword/ChangePassword.native.test.tsx.native-snap
@@ -943,8 +943,8 @@ exports[`ChangePassword should render correctly 1`] = `
                     {
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ChangeStatus/ChangeStatus.native.test.tsx.native-snap
@@ -2162,8 +2162,8 @@ exports[`<ChangeStatus/> should render correctly 1`] = `
               {
                 "color": "#696A6F",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -4385,8 +4385,8 @@ exports[`<ChangeStatus/> should show loading component 1`] = `
               {
                 "color": "#696A6F",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConfirmChangeEmail/ConfirmChangeEmail.native.test.tsx.native-snap
@@ -163,8 +163,8 @@ exports[`<ConfirmChangeEmail /> should render correctly 1`] = `
             {
               "color": "#ffffff",
               "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "maxWidth": "100%",
             },
           ]
@@ -291,8 +291,8 @@ exports[`<ConfirmChangeEmail /> should render correctly 1`] = `
             {
               "color": "#161617",
               "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "maxWidth": "100%",
             },
           ]

--- a/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/ConsentSettings/ConsentSettings.native.test.tsx.native-snap
@@ -2299,8 +2299,8 @@ exports[`<ConsentSettings/> should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/ConfirmDeleteProfile.native.test.tsx.native-snap
@@ -590,8 +590,8 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
                   {
                     "color": "#ffffff",
                     "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "maxWidth": "100%",
                   },
                 ]
@@ -718,8 +718,8 @@ exports[`ConfirmDeleteProfile component should render confirm delete profile 1`]
                   {
                     "color": "#161617",
                     "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeactivateProfileSuccess.native.test.tsx.native-snap
@@ -317,8 +317,8 @@ exports[`DeactivateProfileSuccess component should render delete profile success
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -444,8 +444,8 @@ exports[`DeactivateProfileSuccess component should render delete profile success
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountHacked.native.test.tsx.native-snap
@@ -241,8 +241,8 @@ exports[`DeleteProfileAccountHacked should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -361,8 +361,8 @@ exports[`DeleteProfileAccountHacked should render correctly 1`] = `
                 {
                   "color": "#161617",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx.native-snap
@@ -326,8 +326,8 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -443,8 +443,8 @@ exports[`DeleteProfileAccountNotDeletable should render correctly 1`] = `
                 {
                   "color": "#161617",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileConfirmation.native.test.tsx.native-snap
@@ -436,8 +436,8 @@ exports[`DeleteProfileConfirmation should match snapshot 1`] = `
               {
                 "color": "#ffffff",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -564,8 +564,8 @@ exports[`DeleteProfileConfirmation should match snapshot 1`] = `
               {
                 "color": "#161617",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileContactSupport.native.test.tsx.native-snap
@@ -243,8 +243,8 @@ exports[`DeleteProfileContactSupport should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -360,8 +360,8 @@ exports[`DeleteProfileContactSupport should render correctly 1`] = `
                 {
                   "color": "#161617",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx.native-snap
@@ -242,8 +242,8 @@ exports[`DeleteProfileEmailHacked should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -332,8 +332,8 @@ exports[`DeleteProfileEmailHacked should render correctly 1`] = `
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -450,8 +450,8 @@ exports[`DeleteProfileEmailHacked should render correctly 1`] = `
                 {
                   "color": "#161617",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx.native-snap
@@ -290,8 +290,8 @@ exports[`DeleteProfileSuccess component should render delete profile success 1`]
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx.native-snap
@@ -518,8 +518,8 @@ exports[`SuspendAccountConfirmationWithoutAuthentication should render correctly
               {
                 "color": "#ffffff",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -636,8 +636,8 @@ exports[`SuspendAccountConfirmationWithoutAuthentication should render correctly
               {
                 "color": "#161617",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/FeedbackInApp/FeedbackInApp.native.test.tsx.native-snap
@@ -571,8 +571,8 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
                       {
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]
@@ -790,8 +790,8 @@ exports[`<FeedbackInApp/> should match snapshot 1`] = `
                       {
                         "color": "#161617",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NewEmailSelection/NewEmailSelection.native.test.tsx.native-snap
@@ -500,8 +500,8 @@ exports[`<NewEmailSelection /> should match snapshot 1`] = `
                   {
                     "color": "#696A6F",
                     "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "fontSize": 16,
+                    "lineHeight": 25.6,
                     "maxWidth": "100%",
                   },
                 ]

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.native.test.tsx.native-snap
@@ -2293,8 +2293,8 @@ exports[`NotificationsSettings should render correctly when user is logged in 1`
                     {
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]
@@ -4670,8 +4670,8 @@ exports[`NotificationsSettings should render correctly when user is not logged i
                     {
                       "color": "#696A6F",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/NotificationSettings/NotificationsSettings.web.test.tsx.web-snap
@@ -95,9 +95,9 @@ exports[`NotificationsSettings should render correctly 1`] = `
 }
 
 .c3 {
-  font-family: Montserrat-Regular;
-  font-size: 15px;
-  line-height: 20px;
+  font-family: Montserrat-Medium;
+  font-size: 1rem;
+  line-height: 1.6rem;
   color: #161617;
   cursor: pointer;
 }
@@ -928,7 +928,7 @@ exports[`NotificationsSettings should render correctly 1`] = `
               class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
             >
               <div
-                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
+                class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-cygvgh r-lineHeight-u6qrkm r-maxWidth-dnmrzs"
                 dir="ltr"
               >
                 Enregistrer

--- a/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/Profile.native.test.tsx.native-snap
@@ -128,8 +128,8 @@ exports[`Profile component should render correctly 1`] = `
                       {
                         "color": "#696A6F",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/profile/pages/Profile.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/Profile.web.test.tsx.web-snap
@@ -156,9 +156,9 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
 }
 
 .c3 {
-  font-family: Montserrat-Regular;
-  font-size: 15px;
-  line-height: 20px;
+  font-family: Montserrat-Medium;
+  font-size: 1rem;
+  line-height: 1.6rem;
   color: #161617;
   cursor: pointer;
 }
@@ -199,7 +199,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
                   class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
                 >
                   <div
-                    class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
+                    class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-cygvgh r-lineHeight-u6qrkm r-maxWidth-dnmrzs"
                     dir="ltr"
                   >
                     Cheatcodes
@@ -1314,9 +1314,9 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
 }
 
 .c3 {
-  font-family: Montserrat-Regular;
-  font-size: 15px;
-  line-height: 20px;
+  font-family: Montserrat-Medium;
+  font-size: 1rem;
+  line-height: 1.6rem;
   color: #161617;
   cursor: pointer;
 }
@@ -1357,7 +1357,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
                   class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
                 >
                   <div
-                    class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
+                    class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-v2ubm6 r-fontFamily-1gknse6 r-fontSize-cygvgh r-lineHeight-u6qrkm r-maxWidth-dnmrzs"
                     dir="ltr"
                   >
                     Cheatcodes

--- a/__snapshots__/features/profile/pages/TrackEmailChange/TrackEmailChange.native.test.tsx.native-snap
+++ b/__snapshots__/features/profile/pages/TrackEmailChange/TrackEmailChange.native.test.tsx.native-snap
@@ -404,9 +404,9 @@ exports[`TrackEmailChange v2 account with password should render correctly when 
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -656,9 +656,9 @@ exports[`TrackEmailChange v2 account with password should render correctly when 
                         [
                           {
                             "color": "#161617",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -921,9 +921,9 @@ exports[`TrackEmailChange v2 account with password should render correctly when 
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -1366,9 +1366,9 @@ exports[`TrackEmailChange v2 account with password should render correctly when 
                         [
                           {
                             "color": "#161617",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -1641,9 +1641,9 @@ exports[`TrackEmailChange v2 account with password should render correctly when 
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -1881,9 +1881,9 @@ exports[`TrackEmailChange v2 account with password should render correctly when 
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -2306,9 +2306,9 @@ exports[`TrackEmailChange v2 account with password should render correctly when 
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -2538,9 +2538,9 @@ exports[`TrackEmailChange v2 account with password should render correctly when 
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -2780,9 +2780,9 @@ exports[`TrackEmailChange v2 account with password should render correctly when 
                         [
                           {
                             "color": "#161617",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -3230,9 +3230,9 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -3462,9 +3462,9 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -3714,9 +3714,9 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                         [
                           {
                             "color": "#161617",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -3979,9 +3979,9 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -4424,9 +4424,9 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                         [
                           {
                             "color": "#161617",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -4699,9 +4699,9 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -4949,9 +4949,9 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -5189,9 +5189,9 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -5614,9 +5614,9 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -5866,9 +5866,9 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                         [
                           {
                             "color": "#161617",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -6141,9 +6141,9 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -6381,9 +6381,9 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -6806,9 +6806,9 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -7038,9 +7038,9 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -7270,9 +7270,9 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                         [
                           {
                             "color": "#696A6F",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }
@@ -7512,9 +7512,9 @@ exports[`TrackEmailChange v2 account without password (sso) should render correc
                         [
                           {
                             "color": "#161617",
-                            "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontFamily": "Montserrat-SemiBold",
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                           },
                         ]
                       }

--- a/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchFilter/SearchFilter.native.test.tsx.native-snap
@@ -1437,8 +1437,8 @@ exports[`<SearchFilter/> should render correctly 1`] = `
               {
                 "color": "#ffffff",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/search/pages/SearchLanding/SearchLanding.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchLanding/SearchLanding.native.test.tsx.native-snap
@@ -95,9 +95,9 @@ exports[`<SearchLanding /> When wipAppV2SearchLandingHeader feature flag deactiv
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Black",
-                      "fontSize": 26,
-                      "lineHeight": 34,
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 28,
+                      "lineHeight": 44.8,
                     },
                   ]
                 }

--- a/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
@@ -95,9 +95,9 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Black",
-                      "fontSize": 26,
-                      "lineHeight": 34,
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 28,
+                      "lineHeight": 44.8,
                     },
                   ]
                 }
@@ -1153,8 +1153,8 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                     {
                       "color": "#ffffff",
                       "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                       "maxWidth": "100%",
                     },
                   ]

--- a/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/ThematicSearch/ThematicSearch.native.test.tsx.native-snap
@@ -85,9 +85,9 @@ exports[`<ThematicSearch/> book offerCategory should render <ThematicSearch /> 1
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Black",
-                      "fontSize": 26,
-                      "lineHeight": 34,
+                      "fontFamily": "Montserrat-Bold",
+                      "fontSize": 28,
+                      "lineHeight": 44.8,
                     },
                   ]
                 }

--- a/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/CategoriesModal/CategoriesModal.native.test.tsx.native-snap
@@ -2689,8 +2689,8 @@ exports[`<CategoriesModal/> With categories view should render correctly 1`] = `
                       {
                         "color": "#ffffff",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/DatesHoursModal/DatesHoursModal.native.test.tsx.native-snap
@@ -1054,8 +1054,8 @@ exports[`<DatesHoursModal/> should render modal correctly after animation and wi
                       {
                         "color": "#ffffff",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/OfferDuoModal/OfferDuoModal.native.test.tsx.native-snap
@@ -810,8 +810,8 @@ exports[`<OfferDuoModal/> should render modal correctly after animation and with
                       {
                         "color": "#ffffff",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/PriceModal/PriceModal.native.test.tsx.native-snap
@@ -1312,8 +1312,8 @@ exports[`<PriceModal/> should render modal correctly after animation and with en
                       {
                         "color": "#ffffff",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/modals/VenueModal/VenueModal.native.test.tsx.native-snap
@@ -830,8 +830,8 @@ exports[`VenueModal should render correctly 1`] = `
                       {
                         "color": "#ffffff",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/features/share/pages/ShareAppModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModal.native.test.tsx.native-snap
@@ -257,9 +257,9 @@ exports[`ShareAppModal should match snapshot 1`] = `
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-SemiBold",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                     },
                   ]
                 }

--- a/__snapshots__/features/share/pages/ShareAppModalVersionA.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModalVersionA.native.test.tsx.native-snap
@@ -466,8 +466,8 @@ exports[`ShareAppModalVersionA should match snapshot 1`] = `
                           {
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -575,8 +575,8 @@ exports[`ShareAppModalVersionA should match snapshot 1`] = `
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]

--- a/__snapshots__/features/share/pages/ShareAppModalVersionB.native.test.tsx.native-snap
+++ b/__snapshots__/features/share/pages/ShareAppModalVersionB.native.test.tsx.native-snap
@@ -466,8 +466,8 @@ exports[`ShareAppModalVersionB should match snapshot 1`] = `
                           {
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -575,8 +575,8 @@ exports[`ShareAppModalVersionB should match snapshot 1`] = `
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]

--- a/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
+++ b/__snapshots__/features/share/pages/WebShareModal.web.test.tsx.web-snap
@@ -358,7 +358,7 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                                   />
                                 </div>
                                 <div
-                                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
+                                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-cygvgh r-lineHeight-u6qrkm r-maxWidth-dnmrzs"
                                   dir="ltr"
                                 >
                                   Copier
@@ -399,7 +399,7 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                                   />
                                 </div>
                                 <div
-                                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
+                                  class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-1rmcaf9 r-fontFamily-1gknse6 r-fontSize-cygvgh r-lineHeight-u6qrkm r-maxWidth-dnmrzs"
                                   dir="ltr"
                                 >
                                   E-mail
@@ -556,7 +556,7 @@ exports[`<WebShareModal/> should render correctly when shown 1`] = `
                             class="css-view-175oi2r r-alignItems-1awozwy r-flexDirection-18u37iz"
                           >
                             <div
-                              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-a023e6 r-lineHeight-rjixqe r-maxWidth-dnmrzs"
+                              class="css-text-1rynq56 r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-color-jwli3a r-fontFamily-1gknse6 r-fontSize-cygvgh r-lineHeight-u6qrkm r-maxWidth-dnmrzs"
                               dir="ltr"
                             >
                               Annuler

--- a/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/NotificationsSettingsModal.native.test.tsx.native-snap
@@ -899,8 +899,8 @@ exports[`<NotificationsSettingsModal /> should render correctly 1`] = `
                         {
                           "color": "#696A6F",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]
@@ -1029,8 +1029,8 @@ exports[`<NotificationsSettingsModal /> should render correctly 1`] = `
                         {
                           "color": "#161617",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/features/subscription/components/modals/OnboardingSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/OnboardingSubscriptionModal.native.test.tsx.native-snap
@@ -469,8 +469,8 @@ exports[`<OnboardingSubscriptionModal /> should display correctly 1`] = `
                         {
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]
@@ -597,8 +597,8 @@ exports[`<OnboardingSubscriptionModal /> should display correctly 1`] = `
                         {
                           "color": "#161617",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/SubscriptionSuccessModal.native.test.tsx.native-snap
@@ -503,8 +503,8 @@ exports[`<SubscriptionSuccessModal /> should render correctly for activites_crea
                           {
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -631,8 +631,8 @@ exports[`<SubscriptionSuccessModal /> should render correctly for activites_crea
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -1165,8 +1165,8 @@ exports[`<SubscriptionSuccessModal /> should render correctly for cinema 1`] = `
                           {
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -1293,8 +1293,8 @@ exports[`<SubscriptionSuccessModal /> should render correctly for cinema 1`] = `
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -1827,8 +1827,8 @@ exports[`<SubscriptionSuccessModal /> should render correctly for lecture 1`] = 
                           {
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -1955,8 +1955,8 @@ exports[`<SubscriptionSuccessModal /> should render correctly for lecture 1`] = 
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -2489,8 +2489,8 @@ exports[`<SubscriptionSuccessModal /> should render correctly for musique 1`] = 
                           {
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -2617,8 +2617,8 @@ exports[`<SubscriptionSuccessModal /> should render correctly for musique 1`] = 
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -3151,8 +3151,8 @@ exports[`<SubscriptionSuccessModal /> should render correctly for spectacles 1`]
                           {
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -3279,8 +3279,8 @@ exports[`<SubscriptionSuccessModal /> should render correctly for spectacles 1`]
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -3813,8 +3813,8 @@ exports[`<SubscriptionSuccessModal /> should render correctly for visites 1`] = 
                           {
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -3941,8 +3941,8 @@ exports[`<SubscriptionSuccessModal /> should render correctly for visites 1`] = 
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]

--- a/__snapshots__/features/subscription/components/modals/UnsubscribingConfirmationModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/components/modals/UnsubscribingConfirmationModal.native.test.tsx.native-snap
@@ -478,8 +478,8 @@ exports[`<UnsubscribingConfirmationModal /> should render correctly 1`] = `
                           {
                             "color": "#ffffff",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -606,8 +606,8 @@ exports[`<UnsubscribingConfirmationModal /> should render correctly 1`] = `
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]

--- a/__snapshots__/features/subscription/page/OnboardingSubscription.native.test.tsx.native-snap
+++ b/__snapshots__/features/subscription/page/OnboardingSubscription.native.test.tsx.native-snap
@@ -391,9 +391,9 @@ exports[`OnboardingSubscription should render correctly 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }
@@ -577,9 +577,9 @@ exports[`OnboardingSubscription should render correctly 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }
@@ -763,9 +763,9 @@ exports[`OnboardingSubscription should render correctly 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }
@@ -949,9 +949,9 @@ exports[`OnboardingSubscription should render correctly 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }
@@ -1135,9 +1135,9 @@ exports[`OnboardingSubscription should render correctly 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }
@@ -1321,9 +1321,9 @@ exports[`OnboardingSubscription should render correctly 1`] = `
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                       },
                     ]
                   }
@@ -1490,8 +1490,8 @@ exports[`OnboardingSubscription should render correctly 1`] = `
               {
                 "color": "#696A6F",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -1608,8 +1608,8 @@ exports[`OnboardingSubscription should render correctly 1`] = `
               {
                 "color": "#161617",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/AccountSecurity.native.test.tsx.native-snap
@@ -95,9 +95,9 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Bold",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 16,
+            "lineHeight": 25.6,
           },
         ]
       }
@@ -272,9 +272,9 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Bold",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 16,
+            "lineHeight": 25.6,
           },
         ]
       }
@@ -369,8 +369,8 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
             {
               "color": "#ffffff",
               "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "maxWidth": "100%",
             },
           ]
@@ -469,8 +469,8 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
             {
               "color": "#eb0055",
               "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "maxWidth": "100%",
             },
           ]
@@ -597,8 +597,8 @@ exports[`<AccountSecurity/> with route params when user is connected and has a p
             {
               "color": "#161617",
               "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "maxWidth": "100%",
             },
           ]
@@ -718,9 +718,9 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Bold",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 16,
+            "lineHeight": 25.6,
           },
         ]
       }
@@ -895,9 +895,9 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Bold",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 16,
+            "lineHeight": 25.6,
           },
         ]
       }
@@ -992,8 +992,8 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
             {
               "color": "#ffffff",
               "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "maxWidth": "100%",
             },
           ]
@@ -1120,8 +1120,8 @@ exports[`<AccountSecurity/> with route params when user is connected and has no 
             {
               "color": "#161617",
               "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "maxWidth": "100%",
             },
           ]
@@ -1241,9 +1241,9 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Bold",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 16,
+            "lineHeight": 25.6,
           },
         ]
       }
@@ -1418,9 +1418,9 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Bold",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 16,
+            "lineHeight": 25.6,
           },
         ]
       }
@@ -1515,8 +1515,8 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
             {
               "color": "#ffffff",
               "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "maxWidth": "100%",
             },
           ]
@@ -1615,8 +1615,8 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
             {
               "color": "#eb0055",
               "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "maxWidth": "100%",
             },
           ]
@@ -1743,8 +1743,8 @@ exports[`<AccountSecurity/> without route params should match snapshot when no t
             {
               "color": "#161617",
               "fontFamily": "Montserrat-Bold",
-              "fontSize": 15,
-              "lineHeight": 20,
+              "fontSize": 16,
+              "lineHeight": 25.6,
               "maxWidth": "100%",
             },
           ]

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoice.native.test.tsx.native-snap
@@ -142,9 +142,9 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Bold",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 16,
+            "lineHeight": 25.6,
           },
         ]
       }
@@ -476,9 +476,9 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
         [
           {
             "color": "#161617",
-            "fontFamily": "Montserrat-Bold",
-            "fontSize": 15,
-            "lineHeight": 20,
+            "fontFamily": "Montserrat-SemiBold",
+            "fontSize": 16,
+            "lineHeight": 25.6,
           },
         ]
       }
@@ -593,8 +593,8 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -720,8 +720,8 @@ exports[`<SuspensionChoice/> should match snapshot 1`] = `
                 {
                   "color": "#161617",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspensionChoiceExpiredLink.native.test.tsx.native-snap
@@ -315,8 +315,8 @@ Tu peux toujours contacter le service fraude pour sécuriser ton compte.
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -442,8 +442,8 @@ Tu peux toujours contacter le service fraude pour sécuriser ton compte.
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
+++ b/__snapshots__/features/trustedDevice/pages/SuspiciousLoginSuspendedAccount.native.test.tsx.native-snap
@@ -321,8 +321,8 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -448,8 +448,8 @@ exports[`<SuspiciousLoginSuspendedAccount/> should match snapshot 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/tutorial/pages/NonEligibleModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/NonEligibleModal.native.test.tsx.native-snap
@@ -404,8 +404,8 @@ exports[`NonEligibleModal for user under 15 years old should render correctly fo
                 {
                   "color": "#161617",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -525,8 +525,8 @@ exports[`NonEligibleModal for user under 15 years old should render correctly fo
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -950,8 +950,8 @@ exports[`NonEligibleModal for user under 15 years old should render correctly fo
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/tutorial/pages/TutorialPage.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/TutorialPage.native.test.tsx.native-snap
@@ -302,8 +302,8 @@ exports[`TutorialPage should render correctly 1`] = `
               {
                 "color": "#ffffff",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/tutorial/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/onboarding/OnboardingAgeInformation.native.test.tsx.native-snap
@@ -648,9 +648,9 @@ exports[`OnboardingAgeInformation should render correctly for 15-year-old 1`] = 
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -901,9 +901,9 @@ exports[`OnboardingAgeInformation should render correctly for 15-year-old 1`] = 
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -1291,9 +1291,9 @@ exports[`OnboardingAgeInformation should render correctly for 15-year-old 1`] = 
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -1620,8 +1620,8 @@ exports[`OnboardingAgeInformation should render correctly for 15-year-old 1`] = 
               {
                 "color": "#161617",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -2029,9 +2029,9 @@ exports[`OnboardingAgeInformation should render correctly for 16-year-old 1`] = 
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -2534,9 +2534,9 @@ exports[`OnboardingAgeInformation should render correctly for 16-year-old 1`] = 
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -2924,9 +2924,9 @@ exports[`OnboardingAgeInformation should render correctly for 16-year-old 1`] = 
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -3253,8 +3253,8 @@ exports[`OnboardingAgeInformation should render correctly for 16-year-old 1`] = 
               {
                 "color": "#161617",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -3662,9 +3662,9 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -3902,9 +3902,9 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -4544,9 +4544,9 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -4873,8 +4873,8 @@ exports[`OnboardingAgeInformation should render correctly for 17-year-old 1`] = 
               {
                 "color": "#161617",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -5282,9 +5282,9 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -5522,9 +5522,9 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -5762,9 +5762,9 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -6334,8 +6334,8 @@ exports[`OnboardingAgeInformation should render correctly for 18-year-old 1`] = 
               {
                 "color": "#161617",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -6797,8 +6797,8 @@ exports[`OnboardingAgeInformation when enableCreditV3 activated should render co
               {
                 "color": "#161617",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -7260,8 +7260,8 @@ exports[`OnboardingAgeInformation when enableCreditV3 activated should render co
               {
                 "color": "#161617",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -7925,9 +7925,9 @@ exports[`OnboardingAgeInformation when enableCreditV3 activated should render co
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -8254,8 +8254,8 @@ exports[`OnboardingAgeInformation when enableCreditV3 activated should render co
               {
                 "color": "#161617",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -8663,9 +8663,9 @@ exports[`OnboardingAgeInformation when enableCreditV3 activated should render co
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -9235,8 +9235,8 @@ exports[`OnboardingAgeInformation when enableCreditV3 activated should render co
               {
                 "color": "#161617",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]

--- a/__snapshots__/features/tutorial/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/onboarding/OnboardingGeneralPublicWelcome.native.test.tsx.native-snap
@@ -82,8 +82,8 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
               {
                 "color": "#696A6F",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -281,8 +281,8 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -372,8 +372,8 @@ exports[`OnboardingGeneralPublicWelcome should render correctly 1`] = `
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/tutorial/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/onboarding/OnboardingGeolocation.native.test.tsx.native-snap
@@ -91,8 +91,8 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
               {
                 "color": "#696A6F",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -298,8 +298,8 @@ exports[`OnboardingGeolocation should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/profileTutorial/ProfileTutorialAgeInformation.native.test.tsx.native-snap
@@ -791,9 +791,9 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "marginBottom": 8,
                       },
                     ]
@@ -805,9 +805,9 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                       [
                         {
                           "color": "#320096",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -1180,9 +1180,9 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "marginBottom": 8,
                       },
                     ]
@@ -1194,9 +1194,9 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                       [
                         {
                           "color": "#320096",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -1518,10 +1518,10 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                 [
                   {
                     "color": "#161617",
-                    "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 16,
                     "justifyContent": "center",
-                    "lineHeight": 20,
+                    "lineHeight": 25.6,
                     "marginLeft": 6,
                   },
                 ]
@@ -1761,9 +1761,9 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "marginBottom": 8,
                       },
                     ]
@@ -1775,9 +1775,9 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                       [
                         {
                           "color": "#320096",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -2280,10 +2280,10 @@ exports[`<ProfileTutorialAgeInformation /> should display not logged in version 
                 [
                   {
                     "color": "#161617",
-                    "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 16,
                     "justifyContent": "center",
-                    "lineHeight": 20,
+                    "lineHeight": 25.6,
                     "marginLeft": 6,
                   },
                 ]
@@ -3628,9 +3628,9 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "marginBottom": 8,
                       },
                     ]
@@ -3642,9 +3642,9 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                       [
                         {
                           "color": "#320096",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -4017,9 +4017,9 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "marginBottom": 8,
                       },
                     ]
@@ -4031,9 +4031,9 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                       [
                         {
                           "color": "#320096",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -4355,10 +4355,10 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                 [
                   {
                     "color": "#161617",
-                    "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 16,
                     "justifyContent": "center",
-                    "lineHeight": 20,
+                    "lineHeight": 25.6,
                     "marginLeft": 6,
                   },
                 ]
@@ -4598,9 +4598,9 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                     [
                       {
                         "color": "#161617",
-                        "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontFamily": "Montserrat-SemiBold",
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "marginBottom": 8,
                       },
                     ]
@@ -4612,9 +4612,9 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                       [
                         {
                           "color": "#320096",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -5117,10 +5117,10 @@ exports[`<ProfileTutorialAgeInformation /> should render correctly when logged i
                 [
                   {
                     "color": "#161617",
-                    "fontFamily": "Montserrat-Bold",
-                    "fontSize": 15,
+                    "fontFamily": "Montserrat-SemiBold",
+                    "fontSize": 16,
                     "justifyContent": "center",
-                    "lineHeight": 20,
+                    "lineHeight": 25.6,
                     "marginLeft": 6,
                   },
                 ]

--- a/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/Venue/Venue.native.test.tsx.native-snap
@@ -331,8 +331,8 @@ exports[`<Venue /> should match snapshot 1`] = `
                         {
                           "color": "#161617",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]
@@ -451,8 +451,8 @@ exports[`<Venue /> should match snapshot 1`] = `
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -4880,8 +4880,8 @@ d’options
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -5248,8 +5248,8 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                         {
                           "color": "#161617",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]
@@ -5368,8 +5368,8 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -5989,8 +5989,8 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -6097,8 +6097,8 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -6206,8 +6206,8 @@ exports[`<Venue /> should match snapshot with practical information 1`] = `
                           {
                             "color": "#161617",
                             "fontFamily": "Montserrat-Bold",
-                            "fontSize": 15,
-                            "lineHeight": 20,
+                            "fontSize": 16,
+                            "lineHeight": 25.6,
                             "maxWidth": "100%",
                           },
                         ]
@@ -8579,8 +8579,8 @@ d’options
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
+++ b/__snapshots__/features/venue/pages/VenueNotFound/VenueNotFound.native.test.tsx.native-snap
@@ -258,8 +258,8 @@ exports[`<VenueNotFound /> should render correctly 1`] = `
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/features/venueMap/pages/modals/VenueTypeModal/VenueTypeModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/venueMap/pages/modals/VenueTypeModal/VenueTypeModal.native.test.tsx.native-snap
@@ -3803,8 +3803,8 @@ exports[`<VenueTypeModal /> When venue type is null should render modal correctl
                       {
                         "color": "#ffffff",
                         "fontFamily": "Montserrat-Bold",
-                        "fontSize": 15,
-                        "lineHeight": 20,
+                        "fontSize": 16,
+                        "lineHeight": 25.6,
                         "maxWidth": "100%",
                       },
                     ]

--- a/__snapshots__/libs/location/geolocation/components/GeolocationActivationModal.native.test.tsx.native-snap
+++ b/__snapshots__/libs/location/geolocation/components/GeolocationActivationModal.native.test.tsx.native-snap
@@ -389,8 +389,8 @@ exports[`GeolocationActivationModal should render properly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/__snapshots__/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/ApplicationProcessingModal/ApplicationProcessingModal.native.test.tsx.native-snap
@@ -473,8 +473,8 @@ exports[`<ApplicationProcessingModal /> should match previous snapshot 1`] = `
                         {
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]
@@ -600,8 +600,8 @@ exports[`<ApplicationProcessingModal /> should match previous snapshot 1`] = `
                         {
                           "color": "#eb0055",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/shared/offer/components/AuthenticationModal/AuthenticationModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/AuthenticationModal/AuthenticationModal.native.test.tsx.native-snap
@@ -375,9 +375,9 @@ pour réserver l’offre
                   [
                     {
                       "color": "#161617",
-                      "fontFamily": "Montserrat-Bold",
-                      "fontSize": 15,
-                      "lineHeight": 20,
+                      "fontFamily": "Montserrat-SemiBold",
+                      "fontSize": 16,
+                      "lineHeight": 25.6,
                     },
                   ]
                 }

--- a/__snapshots__/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/ErrorApplicationModal/ErrorApplicationModal.native.test.tsx.native-snap
@@ -474,8 +474,8 @@ ton crédit
                         {
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]
@@ -601,8 +601,8 @@ ton crédit
                         {
                           "color": "#eb0055",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
+++ b/__snapshots__/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.native.test.tsx.native-snap
@@ -405,9 +405,9 @@ pour réserver cette offre
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -503,8 +503,8 @@ pour réserver cette offre
                         {
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]
@@ -928,9 +928,9 @@ pour réserver cette offre
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -1052,8 +1052,8 @@ pour réserver cette offre
                         {
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]
@@ -1477,9 +1477,9 @@ pour réserver cette offre
                       [
                         {
                           "color": "#161617",
-                          "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontFamily": "Montserrat-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                         },
                       ]
                     }
@@ -1575,8 +1575,8 @@ pour réserver cette offre
                         {
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]
@@ -2068,8 +2068,8 @@ pour réserver cette offre
                         {
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-Bold",
-                          "fontSize": 15,
-                          "lineHeight": 20,
+                          "fontSize": 16,
+                          "lineHeight": 25.6,
                           "maxWidth": "100%",
                         },
                       ]

--- a/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
+++ b/__snapshots__/ui/components/LayoutExpiredLink.native.test.tsx.native-snap
@@ -304,8 +304,8 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
               {
                 "color": "#ffffff",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -421,8 +421,8 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
               {
                 "color": "#ffffff",
                 "fontFamily": "Montserrat-Bold",
-                "fontSize": 15,
-                "lineHeight": 20,
+                "fontSize": 16,
+                "lineHeight": 25.6,
                 "maxWidth": "100%",
               },
             ]
@@ -543,8 +543,8 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
                 {
                   "color": "#eb0055",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]
@@ -670,8 +670,8 @@ exports[`<LayoutExpiredLink/> should render correctly 1`] = `
                 {
                   "color": "#ffffff",
                   "fontFamily": "Montserrat-Bold",
-                  "fontSize": 15,
-                  "lineHeight": 20,
+                  "fontSize": 16,
+                  "lineHeight": 25.6,
                   "maxWidth": "100%",
                 },
               ]

--- a/eslint-custom-rules/no-raw-text.test.js
+++ b/eslint-custom-rules/no-raw-text.test.js
@@ -14,10 +14,7 @@ const tests = {
     { code: '<TypoDS.Title2>toto</TypoDS.Title2>' },
     { code: '<TypoDS.Title3>toto</TypoDS.Title3>' },
     { code: '<TypoDS.Title4>toto</TypoDS.Title4>' },
-    { code: '<Typo.ButtonText>toto</Typo.ButtonText>' },
-    { code: '<Typo.ButtonTextNeutralInfo>toto</Typo.ButtonTextNeutralInfo>' },
-    { code: '<Typo.ButtonTextPrimary>toto</Typo.ButtonTextPrimary>' },
-    { code: '<Typo.ButtonTextSecondary>toto</Typo.ButtonTextSecondary>' },
+    { code: '<TypoDS.Button>toto</TypoDS.Button>' },
     { code: '<TypoDS.Body>toto</TypoDS.Body>' },
     { code: '<TypoDS.BodyAccentXs>toto</TypoDS.BodyAccentXs>' },
     // <Styled***>string</Styled***>

--- a/eslint-custom-rules/no-raw-text.test.js
+++ b/eslint-custom-rules/no-raw-text.test.js
@@ -9,7 +9,7 @@ const tests = {
   valid: [
     // <Text>string</Text>
     { code: '<Text>toto</Text>' },
-    // <Typo.***>string</Typo.***>
+    // <TypoDS.***>string</TypoDS.***>
     { code: '<TypoDS.Title1>toto</TypoDS.Title1>' },
     { code: '<TypoDS.Title2>toto</TypoDS.Title2>' },
     { code: '<TypoDS.Title3>toto</TypoDS.Title3>' },

--- a/scripts/dead_code_snapshot.txt
+++ b/scripts/dead_code_snapshot.txt
@@ -4,5 +4,6 @@ src/features/venueMap/constant.ts:22 - Record
 src/shared/credits/defaultCreditByAge.ts:22 - satisfies
 src/shared/credits/defaultCreditByAge.ts:22 - ReadonlyDeep (used in module)
 src/ui/theme/constants.ts:25 - AVATAR_MEDIUM
+src/ui/theme/index.ts:5 - Typo
 src/features/auth/helpers/contactSupport.ts:38 - satisfies
 src/features/auth/helpers/contactSupport.ts:38 - ContactSupport (used in module)

--- a/src/cheatcodes/pages/features/trustedDevice/CheatcodesScreenTrustedDeviceInfos.tsx
+++ b/src/cheatcodes/pages/features/trustedDevice/CheatcodesScreenTrustedDeviceInfos.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
+import styled from 'styled-components/native'
 
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { useDeviceInfo } from 'features/trustedDevice/helpers/useDeviceInfo'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export const CheatcodesScreenTrustedDeviceInfos = () => {
   const deviceInfo = useDeviceInfo()
@@ -26,12 +27,20 @@ type DataProps = {
 const Data = ({ title, data }: DataProps) => (
   <React.Fragment>
     <Spacer.Column numberOfSpaces={2} />
-    <Typo.ButtonText>{title}</Typo.ButtonText>
+    <TypoDS.Button>{title}</TypoDS.Button>
     {data ? (
-      <Typo.ButtonTextSecondary>{data}</Typo.ButtonTextSecondary>
+      <ButtonTextSecondary>{data}</ButtonTextSecondary>
     ) : (
-      <Typo.ButtonTextPrimary>Information non disponible</Typo.ButtonTextPrimary>
+      <ButtonTextPrimary>Information non disponible</ButtonTextPrimary>
     )}
     <Spacer.Column numberOfSpaces={2} />
   </React.Fragment>
 )
+
+const ButtonTextPrimary = styled(TypoDS.Button)(({ theme }) => ({
+  color: theme.colors.primary,
+}))
+
+const ButtonTextSecondary = styled(TypoDS.Button)(({ theme }) => ({
+  color: theme.colors.secondary,
+}))

--- a/src/cheatcodes/pages/others/CheatcodesScreenAccesLibre.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenAccesLibre.tsx
@@ -9,7 +9,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { TextInput } from 'ui/components/inputs/TextInput'
 import { Separator } from 'ui/components/Separator'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 // eslint-disable-next-line no-restricted-imports
 import { ColorsEnum } from 'ui/theme/colors'
 
@@ -49,7 +49,7 @@ export const CheatcodesScreenAccesLibre = () => {
                 </StyledView>
                 {Object.entries(detail.description).map(([key, value]) => (
                   <View key={key}>
-                    <Typo.ButtonText>{key}</Typo.ButtonText>
+                    <TypoDS.BodyAccent>{key}</TypoDS.BodyAccent>
                     <TypoDS.Body>{value}</TypoDS.Body>
                   </View>
                 ))}

--- a/src/features/achievements/components/AchievementBanner.tsx
+++ b/src/features/achievements/components/AchievementBanner.tsx
@@ -4,7 +4,7 @@ import { theme } from 'theme'
 import { GenericBanner } from 'ui/components/ModuleBanner/GenericBanner'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { BicolorTrophy } from 'ui/svg/icons/BicolorTrophy'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export const AchievementBanner: React.FC = () => {
   return (
@@ -14,7 +14,7 @@ export const AchievementBanner: React.FC = () => {
         params: { from: 'profile' },
       }}>
       <GenericBanner LeftIcon={<BicolorTrophy size={theme.icons.sizes.standard} />}>
-        <Typo.ButtonText>Mes succès</Typo.ButtonText>
+        <TypoDS.BodyAccent>Mes succès</TypoDS.BodyAccent>
         <Spacer.Column numberOfSpaces={1} />
         <TypoDS.Body numberOfLines={2}>Consulte tes exploits</TypoDS.Body>
       </GenericBanner>

--- a/src/features/artist/components/ArtistBody/ArtistBody.tsx
+++ b/src/features/artist/components/ArtistBody/ArtistBody.tsx
@@ -23,7 +23,7 @@ import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition
 import { CollapsibleText } from 'ui/components/CollapsibleText/CollapsibleText'
 import { ContentHeader } from 'ui/components/headers/ContentHeader'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 const isWeb = Platform.OS === 'web'
 
@@ -87,7 +87,7 @@ export const ArtistBody: FunctionComponent<Props> = ({ offer, artist, subcategor
             <ArtistHeader name={name} avatarImage={avatarImage} />
             {bio ? (
               <Description gap={1}>
-                <Typo.ButtonText>Quelques infos à son sujet</Typo.ButtonText>
+                <TypoDS.BodyAccent>Quelques infos à son sujet</TypoDS.BodyAccent>
                 <CollapsibleText numberOfLines={NUMBER_OF_LINES_OF_DESCRIPTION_SECTION}>
                   {highlightLinks(bio)}
                 </CollapsibleText>

--- a/src/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.tsx
+++ b/src/features/auth/pages/signup/VerifyEligiblity/VerifyEligibility.tsx
@@ -9,7 +9,7 @@ import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { GenericOfficialPage } from 'ui/pages/GenericOfficialPage'
 import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export const VerifyEligibility: FunctionComponent = () => {
   return (
@@ -36,10 +36,10 @@ export const VerifyEligibility: FunctionComponent = () => {
           l’aide financière de l’État.
         </StyledBody>
         <Spacer.Column numberOfSpaces={4} />
-        <Typo.ButtonText>
+        <TypoDS.BodyAccent>
           Assure-toi que toutes les informations que tu nous transmets sont correctes pour faciliter
           ton inscription.
-        </Typo.ButtonText>
+        </TypoDS.BodyAccent>
       </View>
     </GenericOfficialPage>
   )

--- a/src/features/bookOffer/components/BookDateChoice.tsx
+++ b/src/features/bookOffer/components/BookDateChoice.tsx
@@ -9,7 +9,7 @@ import { useBookingContext } from 'features/bookOffer/context/useBookingContext'
 import { getDistinctPricesFromAllStock } from 'features/bookOffer/helpers/bookingHelpers/bookingHelpers'
 import { formatToCompleteFrenchDate } from 'libs/parsers/formatDates'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
-import { Spacer, Typo, TypoDS, getSpacing } from 'ui/theme'
+import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 interface Props {
@@ -48,7 +48,7 @@ export const BookDateChoice = ({ stocks, userRemainingCredit }: Props) => {
       ) : (
         <TouchableOpacity onPress={showCalendar}>
           <Spacer.Column numberOfSpaces={2} />
-          <Typo.ButtonText>{buttonTitle}</Typo.ButtonText>
+          <TypoDS.Button>{buttonTitle}</TypoDS.Button>
         </TouchableOpacity>
       )}
     </StyledView>

--- a/src/features/bookOffer/components/BookDuoChoice.tsx
+++ b/src/features/bookOffer/components/BookDuoChoice.tsx
@@ -4,7 +4,7 @@ import { DuoChoiceSelector } from 'features/bookOffer/components/DuoChoiceSelect
 import { Step } from 'features/bookOffer/context/reducer'
 import { useBookingContext } from 'features/bookOffer/context/useBookingContext'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export const BookDuoChoice = () => {
@@ -27,7 +27,7 @@ export const BookDuoChoice = () => {
         <DuoChoiceSelector />
       ) : (
         <TouchableOpacity onPress={updateBookingStepToDuo}>
-          <Typo.ButtonText>{buttonTitle}</Typo.ButtonText>
+          <TypoDS.Button>{buttonTitle}</TypoDS.Button>
         </TouchableOpacity>
       )}
     </React.Fragment>

--- a/src/features/bookOffer/components/BookHourChoice.tsx
+++ b/src/features/bookOffer/components/BookHourChoice.tsx
@@ -15,7 +15,7 @@ import { useBookingStock } from 'features/bookOffer/helpers/useBookingStock'
 import { formatHour, formatToKeyDate } from 'features/bookOffer/helpers/utils'
 import { useCreditForOffer } from 'features/offer/helpers/useHasEnoughCredit/useHasEnoughCredit'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
-import { Typo, Spacer, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 function getHourChoiceForMultiplePrices(
@@ -178,7 +178,7 @@ export const BookHourChoice = () => {
         <View>{filteredStocks}</View>
       ) : (
         <TouchableOpacity onPress={changeHour}>
-          <Typo.ButtonText>{buttonTitle}</Typo.ButtonText>
+          <TypoDS.Button>{buttonTitle}</TypoDS.Button>
         </TouchableOpacity>
       )}
     </React.Fragment>

--- a/src/features/bookOffer/components/Calendar/DayComponent.tsx
+++ b/src/features/bookOffer/components/Calendar/DayComponent.tsx
@@ -6,7 +6,7 @@ import styled, { DefaultTheme } from 'styled-components/native'
 import { DiagonalStripe } from 'features/bookOffer/components/Calendar/DiagonalStripe'
 import { useBookingContext } from 'features/bookOffer/context/useBookingContext'
 import { OfferStatus } from 'features/bookOffer/helpers/utils'
-import { getSpacing, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 interface Props {
   status: OfferStatus
@@ -82,7 +82,7 @@ const Body = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 
-const Day = styled(Typo.ButtonText)<{ status: OfferStatus }>(({ theme, status }) => ({
+const Day = styled(TypoDS.Button)<{ status: OfferStatus }>(({ theme, status }) => ({
   textAlign: 'center',
   minWidth: getSpacing(6),
   color: getStatusColor(theme, status),
@@ -97,7 +97,7 @@ const SelectedDay = styled(View)(({ theme }) => ({
   justifyContent: 'center',
 }))
 
-const SelectedDayNumber = styled(Typo.ButtonText)(({ theme }) => ({
+const SelectedDayNumber = styled(TypoDS.Button)(({ theme }) => ({
   alignSelf: 'center',
   color: theme.colors.white,
 }))

--- a/src/features/bookOffer/components/DuoChoice.tsx
+++ b/src/features/bookOffer/components/DuoChoice.tsx
@@ -65,7 +65,7 @@ interface TypoProps {
   disabled: boolean
 }
 
-const ButtonText = styled(Typo.ButtonText)<TypoProps>(({ selected, disabled, theme }) => ({
+const ButtonText = styled(TypoDS.BodyAccent)<TypoProps>(({ selected, disabled, theme }) => ({
   color: getTextColor(theme, selected, disabled),
 }))
 

--- a/src/features/bookOffer/components/DuoChoice.tsx
+++ b/src/features/bookOffer/components/DuoChoice.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native'
 
 import { ChoiceBloc, getTextColor } from 'features/bookOffer/components/ChoiceBloc'
 import { AccessibleIcon } from 'ui/svg/icons/types'
-import { getSpacing, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 interface Props {
   title: string

--- a/src/features/bookings/components/ArchiveBookingModal.tsx
+++ b/src/features/bookings/components/ArchiveBookingModal.tsx
@@ -11,7 +11,7 @@ import { AppModal } from 'ui/components/modals/AppModal'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { Close } from 'ui/svg/icons/Close'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export interface ArchiveBookingModalProps {
   bookingId: number
@@ -78,7 +78,7 @@ const ModalContent = styled.View({
   width: '100%',
   alignItems: 'center',
 })
-const Title = styled(Typo.ButtonText)({
+const Title = styled(TypoDS.BodyAccent)({
   textAlign: 'center',
 })
 const StyledBody = styled(TypoDS.Body)({

--- a/src/features/bookings/components/BookingItemTitle.tsx
+++ b/src/features/bookings/components/BookingItemTitle.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 type Props = {
   title: string
@@ -10,12 +10,12 @@ type Props = {
 export function BookingItemTitle(props: Props) {
   return (
     <TitleContainer>
-      <ButtonText>{props.title}</ButtonText>
+      <BodyAccent>{props.title}</BodyAccent>
     </TitleContainer>
   )
 }
 
-const ButtonText = styled(Typo.ButtonText).attrs(() => ({
+const BodyAccent = styled(TypoDS.BodyAccent).attrs(() => ({
   numberOfLines: 2,
   shrink: true,
 }))``

--- a/src/features/bookings/components/CancelBookingModal.tsx
+++ b/src/features/bookings/components/CancelBookingModal.tsx
@@ -23,7 +23,7 @@ import { AppModal } from 'ui/components/modals/AppModal'
 import { SNACK_BAR_TIME_OUT, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { Close } from 'ui/svg/icons/Close'
 import { PlainArrowPrevious } from 'ui/svg/icons/PlainArrowPrevious'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   visible: boolean
@@ -113,7 +113,7 @@ const ModalContent = styled.View({
   width: '100%',
 })
 
-const OfferName = styled(Typo.ButtonText)({
+const OfferName = styled(TypoDS.BodyAccent)({
   textAlign: 'center',
 })
 

--- a/src/features/cookies/pages/CookiesDetails.tsx
+++ b/src/features/cookies/pages/CookiesDetails.tsx
@@ -8,7 +8,7 @@ import { Accordion } from 'ui/components/Accordion'
 import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export const CookiesDetails = (props: CookiesChoiceSettings) => {

--- a/src/features/cookies/pages/CookiesDetails.tsx
+++ b/src/features/cookies/pages/CookiesDetails.tsx
@@ -56,7 +56,7 @@ export const CookiesDetails = (props: CookiesChoiceSettings) => {
 
 const ACCORDION_BORDER_RADIUS = getSpacing(2)
 const StyledAccordionItem = styled(Accordion).attrs(({ theme }) => ({
-  title: <Typo.ButtonText>Qu’est-ce que les cookies&nbsp;?</Typo.ButtonText>,
+  title: <TypoDS.BodyAccent>Qu’est-ce que les cookies&nbsp;?</TypoDS.BodyAccent>,
   titleStyle: {
     backgroundColor: theme.colors.greyLight,
     paddingVertical: getSpacing(4),

--- a/src/features/culturalSurvey/components/CulturalSurveyCheckbox.tsx
+++ b/src/features/culturalSurvey/components/CulturalSurveyCheckbox.tsx
@@ -7,7 +7,7 @@ import { theme } from 'theme'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { AccessibleIcon } from 'ui/svg/icons/types'
 import { Validate } from 'ui/svg/icons/Validate'
-import { getSpacing, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 type CulturalSurveyCheckboxProps = {
   title: string
@@ -52,7 +52,7 @@ export const CulturalSurveyCheckbox = (props: CulturalSurveyCheckboxProps) => {
           </ActivityIconContainer>
         ) : null}
         <DescriptionContainer>
-          <Typo.ButtonText>{props.title}</Typo.ButtonText>
+          <TypoDS.BodyAccent>{props.title}</TypoDS.BodyAccent>
           {props.subtitle ? <CaptionNeutralInfo>{props.subtitle}</CaptionNeutralInfo> : null}
         </DescriptionContainer>
         {isSelected ? (

--- a/src/features/favorites/components/Buttons/Sort.tsx
+++ b/src/features/favorites/components/Buttons/Sort.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { Sort as SortIconDefault } from 'ui/svg/icons/Sort'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const Sort: FunctionComponent = () => {
   return (
@@ -43,6 +43,6 @@ const StyledLinearGradient = styled(LinearGradient).attrs(({ theme }) => ({
   height: getSpacing(10),
 }))
 
-const StyledButtonText = styled(Typo.ButtonText)(({ theme }) => ({
+const StyledButtonText = styled(TypoDS.Button)(({ theme }) => ({
   color: theme.colors.white,
 }))

--- a/src/features/favorites/components/Favorite.tsx
+++ b/src/features/favorites/components/Favorite.tsx
@@ -197,7 +197,7 @@ export const Favorite: React.FC<Props> = (props) => {
               <Spacer.Row numberOfSpaces={SPACER_BETWEEN_IMAGE_AND_CONTENT} />
               <ContentContainer>
                 <LeftContent>
-                  <Typo.ButtonText numberOfLines={2}>{offer.name}</Typo.ButtonText>
+                  <TypoDS.BodyAccent numberOfLines={2}>{offer.name}</TypoDS.BodyAccent>
                   <Spacer.Column numberOfSpaces={1} />
                   <Body>{searchGroupLabel}</Body>
                   {formattedDate ? <Body>{formattedDate}</Body> : null}

--- a/src/features/favorites/components/Favorite.tsx
+++ b/src/features/favorites/components/Favorite.tsx
@@ -29,7 +29,7 @@ import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouch
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { useLayout } from 'ui/hooks/useLayout'
 import { ExternalSite } from 'ui/svg/icons/ExternalSite'
-import { Spacer, Typo, TypoDS, getSpacing } from 'ui/theme'
+import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 
 interface Props {
   favorite: FavoriteResponse

--- a/src/features/home/components/banners/ActivationBanner.tsx
+++ b/src/features/home/components/banners/ActivationBanner.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
 import { BannerWithBackground } from 'ui/components/ModuleBanner/BannerWithBackground'
 import { AccessibleIcon } from 'ui/svg/icons/types'
-import { Typo, TypoDS } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 type ActivationBannerProps = {
   title: string
@@ -29,7 +29,7 @@ export const ActivationBanner = ({ title, subtitle, icon, from }: ActivationBann
   )
 }
 
-const StyledButtonText = styled(Typo.ButtonText)(({ theme }) => ({
+const StyledButtonText = styled(TypoDS.BodyAccent)(({ theme }) => ({
   color: theme.colors.white,
 }))
 

--- a/src/features/home/components/banners/SignupBanner.tsx
+++ b/src/features/home/components/banners/SignupBanner.tsx
@@ -8,7 +8,7 @@ import { analytics } from 'libs/analytics'
 import { BannerWithBackground } from 'ui/components/ModuleBanner/BannerWithBackground'
 import { SystemBanner } from 'ui/components/ModuleBanner/SystemBanner'
 import { BicolorUnlock } from 'ui/svg/icons/BicolorUnlock'
-import { Typo, TypoDS } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 const onBeforeNavigate = () => analytics.logSignUpClicked({ from: 'home' })
 
@@ -59,7 +59,7 @@ const StyledSystemBannerBicolorUnlock = styled(BicolorUnlock).attrs(({ theme }) 
   color: theme.colors.secondaryLight200,
 }))``
 
-const StyledButtonText = styled(Typo.ButtonText)(({ theme }) => ({
+const StyledButtonText = styled(TypoDS.BodyAccent)(({ theme }) => ({
   color: theme.colors.white,
 }))
 

--- a/src/features/home/components/modules/business/NewBusinessModule.tsx
+++ b/src/features/home/components/modules/business/NewBusinessModule.tsx
@@ -256,7 +256,7 @@ const StyledTitle4 = styled(TypoDS.Title4)(({ theme }) => ({
   color: theme.colors.white,
 }))
 
-const StyledButtonText = styled(Typo.ButtonText)(({ theme }) => ({
+const StyledButtonText = styled(TypoDS.BodyAccent)(({ theme }) => ({
   color: theme.colors.white,
 }))
 

--- a/src/features/home/components/modules/business/NewBusinessModule.tsx
+++ b/src/features/home/components/modules/business/NewBusinessModule.tsx
@@ -16,7 +16,7 @@ import { ImageBackground } from 'libs/resizing-image-on-demand/ImageBackground'
 import { SNACK_BAR_TIME_OUT_LONG, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { ArrowRight } from 'ui/svg/icons/ArrowRight'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 
 const FIXED_SIZE = getSpacing(81.75)

--- a/src/features/home/components/modules/business/OldBusinessModule.tsx
+++ b/src/features/home/components/modules/business/OldBusinessModule.tsx
@@ -14,7 +14,7 @@ import { useHandleFocus } from 'libs/hooks/useHandleFocus'
 import { ImageBackground } from 'libs/resizing-image-on-demand/ImageBackground'
 import { SNACK_BAR_TIME_OUT_LONG, useSnackBarContext } from 'ui/components/snackBar/SnackBarContext'
 import { ArrowNext } from 'ui/svg/icons/ArrowNext'
-import { LENGTH_XS, MARGIN_DP, RATIO_BUSINESS, Typo, TypoDS, getSpacing } from 'ui/theme'
+import { LENGTH_XS, MARGIN_DP, RATIO_BUSINESS, TypoDS, getSpacing } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 
 const UnmemoizedBusinessModule = (props: BusinessModuleProps) => {
@@ -180,7 +180,7 @@ const IconContainer = styled.View({
   alignItems: 'center',
 })
 
-const ButtonText = styled(Typo.ButtonText)(({ theme }) => ({
+const ButtonText = styled(TypoDS.BodyAccent)(({ theme }) => ({
   color: theme.colors.white,
 }))
 

--- a/src/features/home/components/modules/venues/VenueDetails.tsx
+++ b/src/features/home/components/modules/venues/VenueDetails.tsx
@@ -28,7 +28,7 @@ const Container = styled.View<{ maxWidth: number }>(({ maxWidth }) => ({
   position: 'relative',
 }))
 
-const VenueName = styled(Typo.ButtonText).attrs({
+const VenueName = styled(TypoDS.BodyAccent).attrs({
   numberOfLines: 2,
 })({})
 

--- a/src/features/home/components/modules/venues/VenueDetails.tsx
+++ b/src/features/home/components/modules/venues/VenueDetails.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { PixelRatio } from 'react-native'
 import styled from 'styled-components/native'
 
-import { Typo, GUTTER_DP, TypoDS } from 'ui/theme'
+import { GUTTER_DP, TypoDS } from 'ui/theme'
 
 interface VenueDetailsProps {
   width: number

--- a/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
@@ -20,7 +20,7 @@ import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
 import { OfferImage } from 'ui/components/tiles/OfferImage'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { PlainArrowNext } from 'ui/svg/icons/PlainArrowNext'
-import { Typo, TypoDS, getShadow, getSpacing } from 'ui/theme'
+import { TypoDS, getShadow, getSpacing } from 'ui/theme'
 
 type Props = {
   offer: Offer
@@ -165,7 +165,7 @@ const CategoryText = styled(TypoDS.BodyAccentXs)<{ color: string }>(({ color }) 
   marginBottom: getSpacing(1),
 }))
 
-const TitleText = styled(Typo.ButtonText)({
+const TitleText = styled(TypoDS.BodyAccent)({
   marginBottom: getSpacing(1),
 })
 

--- a/src/features/home/pages/GenericHome.native.test.tsx
+++ b/src/features/home/pages/GenericHome.native.test.tsx
@@ -17,7 +17,7 @@ import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategories
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, render, screen, waitFor, within } from 'tests/utils'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 const useShowSkeletonSpy = jest.spyOn(showSkeletonAPI, 'useShowSkeleton').mockReturnValue(false)
 
 const mockUseNetInfoContext = jest.spyOn(useNetInfoContextDefault, 'useNetInfoContext') as jest.Mock
@@ -28,7 +28,7 @@ jest.mock('features/auth/context/AuthContext', () => ({
 
 const defaultModules = [formattedVenuesModule]
 const homeId = 'fake-id'
-const Header = <Typo.Title1>Header</Typo.Title1>
+const Header = <TypoDS.Title1>Header</TypoDS.Title1>
 
 const mockStartTransaction = jest.fn()
 const mockFinishTransaction = jest.fn()

--- a/src/features/identityCheck/components/countryPicker/CountryButton.tsx
+++ b/src/features/identityCheck/components/countryPicker/CountryButton.tsx
@@ -10,7 +10,7 @@ import { useArrowNavigationForRadioButton } from 'ui/hooks/useArrowNavigationFor
 import { useSpaceBarAction } from 'ui/hooks/useSpaceBarAction'
 import { Validate } from 'ui/svg/icons/Validate'
 import { ValidateOff } from 'ui/svg/icons/ValidateOff'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 type Props = {
   country: Country
@@ -38,7 +38,7 @@ export const CountryButton = ({ country, selectedCountry, onCountrySelect }: Pro
       <CountryContainer ref={containerRef}>
         {selected ? <ValidateIcon /> : <ValidateOffIcon />}
         <Spacer.Row numberOfSpaces={2} />
-        <Typo.ButtonText>{country.name}</Typo.ButtonText>
+        <TypoDS.BodyAccent>{country.name}</TypoDS.BodyAccent>
         <Spacer.Row numberOfSpaces={1} />
         <CountryCallingCode>{countryCallingCode}</CountryCallingCode>
       </CountryContainer>
@@ -53,7 +53,7 @@ const CountryContainer = styled.View({
   paddingHorizontal: getSpacing(1),
 })
 
-const CountryCallingCode = styled(Typo.ButtonText)(({ theme }) => ({
+const CountryCallingCode = styled(TypoDS.BodyAccent)(({ theme }) => ({
   fontFamily: theme.fontFamily.medium,
 }))
 

--- a/src/features/identityCheck/pages/identification/IdentificationFork.tsx
+++ b/src/features/identityCheck/pages/identification/IdentificationFork.tsx
@@ -16,7 +16,7 @@ import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouch
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
 import { Marianne } from 'ui/svg/icons/Marianne'
 import { Ubble } from 'ui/svg/icons/Ubble'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const IdentificationFork: FunctionComponent = () => {
   return (
@@ -33,7 +33,7 @@ const IdentificationForkEduconnectContent: FunctionComponent = () => {
     <Container>
       <JustifiedLeftTitle title="S’identifier en 2 min avec&nbsp;:" />
       <IdentificationForkButton
-        Title={<Typo.ButtonText>Mes codes ÉduConnect</Typo.ButtonText>}
+        Title={<TypoDS.BodyAccent>Mes codes ÉduConnect</TypoDS.BodyAccent>}
         Subtitle={<StyledCaption>Fournis par ton établissement scolaire</StyledCaption>}
         icon={Marianne}
         navigateTo={{ screen: 'EduConnectForm' }}
@@ -54,7 +54,7 @@ const IdentificationForkEduconnectContent: FunctionComponent = () => {
         <SeparatorWithText label="ou" />
       </StyledSeparatorWithText>
       <IdentificationForkButton
-        Title={<Typo.ButtonText>Ma pièce d’identité</Typo.ButtonText>}
+        Title={<TypoDS.BodyAccent>Ma pièce d’identité</TypoDS.BodyAccent>}
         Subtitle={<StyledCaption>Carte d’identité ou passeport</StyledCaption>}
         icon={Ubble}
         navigateTo={{ screen: 'SelectIDOrigin' }}

--- a/src/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.tsx
+++ b/src/features/identityCheck/pages/identification/educonnect/EduConnectForm.web.tsx
@@ -11,7 +11,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { BicolorIdCardWithMagnifyingGlass } from 'ui/svg/icons/BicolorIdCardWithMagnifyingGlass'
 import { ExternalSite } from 'ui/svg/icons/ExternalSite'
 import { Info } from 'ui/svg/icons/Info'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const EduConnectForm = () => {
   const { error, openEduConnectTab } = useEduConnectLogin()
@@ -84,7 +84,7 @@ const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 
-const StyledButtonText = styled(Typo.ButtonText)(({ theme }) => ({
+const StyledButtonText = styled(TypoDS.BodyAccent)(({ theme }) => ({
   textAlign: 'center',
   color: theme.colors.greyDark,
 }))

--- a/src/features/identityCheck/pages/identification/ubble/ComeBackLater.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/ComeBackLater.tsx
@@ -9,7 +9,7 @@ import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
 import { BicolorIdCardInvalid } from 'ui/svg/icons/BicolorIdCardInvalid'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const ComeBackLater: FunctionComponent = () => {
   useEffect(() => {
@@ -26,9 +26,9 @@ export const ComeBackLater: FunctionComponent = () => {
       mobileBottomFlex={0.5}>
       <StyledText>
         <TypoDS.Body>Pour profiter du pass Culture, tu dois avoir </TypoDS.Body>
-        <Typo.ButtonText>
+        <TypoDS.BodyAccent>
           ta pièce d’identité originale et en cours de validité avec toi.
-        </Typo.ButtonText>
+        </TypoDS.BodyAccent>
       </StyledText>
       <StyledText>N’hésite pas à revenir t’identifier quand tu l’auras avec toi&nbsp;!</StyledText>
       <Spacer.Flex flex={1} />

--- a/src/features/identityCheck/pages/identification/ubble/SelectIDOrigin.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/SelectIDOrigin.tsx
@@ -10,7 +10,7 @@ import { SeparatorWithText } from 'ui/components/SeparatorWithText'
 import { BicolorEarth } from 'ui/svg/icons/BicolorEarth'
 import { BicolorFrance } from 'ui/svg/icons/BicolorFrance'
 import { BicolorIdCardWithMagnifyingGlass } from 'ui/svg/icons/BicolorIdCardWithMagnifyingGlass'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export enum IDOrigin {
@@ -37,7 +37,7 @@ const SelectIDOriginContent: FunctionComponent = () => {
         Title={
           <Text>
             <TypoDS.Body>J’ai une carte d’identité ou un passeport </TypoDS.Body>
-            <Typo.ButtonText>français</Typo.ButtonText>
+            <TypoDS.BodyAccent>français</TypoDS.BodyAccent>
           </Text>
         }
         Icon={<BicolorFrance />}

--- a/src/features/identityCheck/pages/identification/ubble/SelectIDStatus.tsx
+++ b/src/features/identityCheck/pages/identification/ubble/SelectIDStatus.tsx
@@ -11,7 +11,7 @@ import { SeparatorWithText } from 'ui/components/SeparatorWithText'
 import { BicolorIdCard } from 'ui/svg/icons/BicolorIdCard'
 import { BicolorLostId } from 'ui/svg/icons/BicolorLostId'
 import { BicolorNoId } from 'ui/svg/icons/BicolorNoId'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 export enum IDStatus {
@@ -30,7 +30,7 @@ export const SelectIDStatus: FunctionComponent = () => (
 
 const MainOptionButton = (
   <HeroButtonList
-    Title={<Typo.ButtonText>J’ai ma pièce d’identité en cours de validité</Typo.ButtonText>}
+    Title={<TypoDS.BodyAccent>J’ai ma pièce d’identité en cours de validité</TypoDS.BodyAccent>}
     Subtitle={<TypoDS.BodyAccentXs>Les copies ne sont pas acceptées</TypoDS.BodyAccentXs>}
     Icon={<BicolorIdCard />}
     navigateTo={{ screen: 'UbbleWebview' }}
@@ -66,9 +66,9 @@ const SelectIDStatusContent: FunctionComponent = () => {
       <Spacer.Column numberOfSpaces={4} />
       <StyledText>
         <TypoDS.Body>Tu dois avoir ta pièce d’identité </TypoDS.Body>
-        <Typo.ButtonText>originale </Typo.ButtonText>
+        <TypoDS.BodyAccent>originale </TypoDS.BodyAccent>
         <TypoDS.Body>et </TypoDS.Body>
-        <Typo.ButtonText>en cours de validité </Typo.ButtonText>
+        <TypoDS.BodyAccent>en cours de validité </TypoDS.BodyAccent>
         <TypoDS.Body>avec toi.</TypoDS.Body>
       </StyledText>
       <Spacer.Column numberOfSpaces={12} />

--- a/src/features/location/components/LocationWidgetWrapperDesktop.tsx
+++ b/src/features/location/components/LocationWidgetWrapperDesktop.tsx
@@ -15,7 +15,7 @@ import { ArrowDown } from 'ui/svg/icons/ArrowDown'
 import { LocationPointer } from 'ui/svg/icons/LocationPointer'
 import { LocationPointerAppV2 } from 'ui/svg/icons/LocationPointerAppV2'
 import { LocationPointerNotFilled } from 'ui/svg/icons/LocationPointerNotFilled'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 const TOOLTIP_WIDTH = getSpacing(58)
 const WIDGET_HEIGHT = getSpacing(5 + 1) // textSize + padding
@@ -152,7 +152,7 @@ const LocationPointerAppV2NotFilled = styled(LocationPointerAppV2).attrs(({ them
   size: theme.icons.sizes.small,
 }))({})
 
-const LocationTitle = styled(Typo.ButtonText).attrs({
+const LocationTitle = styled(TypoDS.BodyAccent).attrs({
   numberOfLines: 1,
 })({
   flexShrink: 1,

--- a/src/features/navigation/RootNavigator/Header/NavItem.tsx
+++ b/src/features/navigation/RootNavigator/Header/NavItem.tsx
@@ -7,7 +7,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { BicolorLogo } from 'ui/svg/icons/BicolorLogo'
 import { AccessibleBicolorIcon } from 'ui/svg/icons/types'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 interface NavItemInterface {
   isSelected?: boolean
@@ -60,7 +60,7 @@ const StyledTouchableLink = styled(InternalTouchableLink).attrs<{ isSelected?: b
   borderRadius: theme.borderRadius.button * 2,
 }))
 
-const Title = styled(Typo.ButtonText)<{ isSelected?: boolean }>(({ theme, isSelected }) => ({
+const Title = styled(TypoDS.BodyAccent)<{ isSelected?: boolean }>(({ theme, isSelected }) => ({
   marginLeft: 12,
   color: isSelected ? theme.uniqueColors.brand : theme.colors.black,
 }))

--- a/src/features/offer/components/VenueDetails/VenueDetails.tsx
+++ b/src/features/offer/components/VenueDetails/VenueDetails.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 
 import { VenueDetail } from 'features/offer/types'
 import { Tag } from 'ui/components/Tag/Tag'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { getHoverStyle } from 'ui/theme/getHoverStyle/getHoverStyle'
 
 export interface VenueDetailsProps extends VenueDetail, ViewProps {
@@ -55,7 +55,7 @@ const Wrapper = styled(View)<{ height: Size }>((props) => ({
   height: props.height === Size.Large ? getSpacing(23.5) : getSpacing(14.5),
 }))
 
-const Title = styled(Typo.ButtonText).attrs({
+const Title = styled(TypoDS.BodyAccent).attrs({
   numberOfLines: 1,
   ellipsizeMode: 'tail',
 })<{ isHover?: boolean }>(({ theme, isHover }) => ({

--- a/src/features/profile/components/Header/CreditHeader/CreditHeader.tsx
+++ b/src/features/profile/components/Header/CreditHeader/CreditHeader.tsx
@@ -17,7 +17,7 @@ import { useDepositAmountsByAge } from 'shared/user/useDepositAmountsByAge'
 import { GenericBanner } from 'ui/components/ModuleBanner/GenericBanner'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { BicolorOffers } from 'ui/svg/icons/BicolorOffers'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export type CreditHeaderProps = {
   firstName?: string | null
@@ -89,7 +89,7 @@ export function CreditHeader({
             params: { homeId: homeEntryIdFreeOffers, from: 'profile' },
           }}>
           <GenericBanner LeftIcon={<BicolorOffers />}>
-            <Typo.ButtonText>L’aventure continue&nbsp;!</Typo.ButtonText>
+            <TypoDS.BodyAccent>L’aventure continue&nbsp;!</TypoDS.BodyAccent>
             <Spacer.Column numberOfSpaces={1} />
             <StyledBody numberOfLines={3}>
               Tu peux profiter d’offres gratuites autour de toi.

--- a/src/features/profile/components/Header/HeaderWithGreyContainer/HeaderWithGreyContainer.stories.tsx
+++ b/src/features/profile/components/Header/HeaderWithGreyContainer/HeaderWithGreyContainer.stories.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/native'
 
 import { formatToSlashedFrenchDate } from 'libs/dates'
 import { theme } from 'theme'
-import { Typo, TypoDS } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 import { HeaderWithGreyContainer } from './HeaderWithGreyContainer'
 
@@ -48,7 +48,9 @@ WithComponentAsSubtitle.args = {
   subtitle: (
     <Row>
       <TypoDS.Body>Profite de ton crédit jusqu’au&nbsp;</TypoDS.Body>
-      <Typo.ButtonText>{formatToSlashedFrenchDate('2023-02-16T17:16:04.735235')}</Typo.ButtonText>
+      <TypoDS.BodyAccent>
+        {formatToSlashedFrenchDate('2023-02-16T17:16:04.735235')}
+      </TypoDS.BodyAccent>
     </Row>
   ),
 }

--- a/src/features/profile/components/StepCard/StepCard.tsx
+++ b/src/features/profile/components/StepCard/StepCard.tsx
@@ -3,7 +3,7 @@ import { View, ViewProps } from 'react-native'
 import styled, { DefaultTheme, useTheme } from 'styled-components/native'
 
 import { StepButtonState } from 'ui/components/StepButton/types'
-import { getSpacing, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 interface StepCardProps extends ViewProps {
   title: string
@@ -70,7 +70,7 @@ const TextContainter = styled.View({
   marginLeft: getSpacing(4),
 })
 
-const Title = styled(Typo.ButtonText)<{ type: StepButtonState }>(({ theme, type }) => ({
+const Title = styled(TypoDS.BodyAccent)<{ type: StepButtonState }>(({ theme, type }) => ({
   color: type === StepButtonState.CURRENT ? theme.colors.black : theme.colors.greyDark,
 }))
 

--- a/src/features/profile/components/Subtitle/Subtitle.tsx
+++ b/src/features/profile/components/Subtitle/Subtitle.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { Typo, TypoDS } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 type Props = {
   startSubtitle: string
@@ -12,7 +12,7 @@ export const Subtitle = ({ startSubtitle, boldEndSubtitle }: Props) => {
   return (
     <Row>
       <TypoDS.Body>{startSubtitle}</TypoDS.Body>
-      {boldEndSubtitle ? <Typo.ButtonText>&nbsp;{boldEndSubtitle}</Typo.ButtonText> : null}
+      {boldEndSubtitle ? <TypoDS.BodyAccent>&nbsp;{boldEndSubtitle}</TypoDS.BodyAccent> : null}
     </Row>
   )
 }

--- a/src/features/profile/pages/ValidateEmailChange/SubtitleComponent.tsx
+++ b/src/features/profile/pages/ValidateEmailChange/SubtitleComponent.tsx
@@ -2,14 +2,14 @@ import React from 'react'
 import styled from 'styled-components/native'
 
 import { Separator } from 'ui/components/Separator'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { TextProps } from 'ui/theme/typography'
 
 export function ValidateEmailChangeSubtitleComponent(props: TextProps) {
   return (
     <Wrapper>
       <TypoDS.Body>Nouvelle adresse e-mail&nbsp;:</TypoDS.Body>
-      <Typo.ButtonText {...props} />
+      <TypoDS.BodyAccent {...props} />
       <Spacer.Column numberOfSpaces={4} />
       <Separator.Horizontal />
       <Spacer.Column numberOfSpaces={4} />

--- a/src/features/search/components/AutoScrollSwitch/AutoScrollSwitch.web.tsx
+++ b/src/features/search/components/AutoScrollSwitch/AutoScrollSwitch.web.tsx
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import FilterSwitch from 'ui/components/FilterSwitch'
 import { InputLabel } from 'ui/components/InputLabel/InputLabel'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export const AutoScrollSwitch = ({
   title,
@@ -29,7 +29,7 @@ export const AutoScrollSwitch = ({
         />
         <Spacer.Row numberOfSpaces={5} />
         <InputLabel id={labelID} htmlFor={checkboxID}>
-          <Typo.ButtonText>{title}</Typo.ButtonText>
+          <TypoDS.BodyAccent>{title}</TypoDS.BodyAccent>
         </InputLabel>
         <Spacer.Column numberOfSpaces={2} />
       </FlexContainer>

--- a/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
+++ b/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
@@ -23,7 +23,7 @@ import { env } from 'libs/environment'
 import { useSearchGroupLabel } from 'libs/subcategories'
 import { useSubcategories } from 'libs/subcategories/useSubcategories'
 import { MagnifyingGlassFilled } from 'ui/svg/icons/MagnifyingGlassFilled'
-import { getSpacing, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 type AutocompleteOfferItemProps = {
   hit: AlgoliaSuggestionHit
@@ -233,7 +233,7 @@ const SuggestionContainer: FunctionComponent<{
 const Suggestion: FunctionComponent<{ categoryToDisplay: string }> = ({ categoryToDisplay }) => (
   <React.Fragment>
     <TypoDS.Body> dans </TypoDS.Body>
-    <Typo.ButtonTextPrimary>{categoryToDisplay}</Typo.ButtonTextPrimary>
+    <StyledBodyAccent>{categoryToDisplay}</StyledBodyAccent>
   </React.Fragment>
 )
 
@@ -253,3 +253,7 @@ const MagnifyingGlassFilledIcon = styled(MagnifyingGlassFilled).attrs(({ theme }
 const StyledText = styled(Text)({
   marginLeft: getSpacing(2),
 })
+
+const StyledBodyAccent = styled(TypoDS.BodyAccent)(({ theme }) => ({
+  color: theme.colors.primary,
+}))

--- a/src/features/search/components/HoursSlider/HoursSlider.tsx
+++ b/src/features/search/components/HoursSlider/HoursSlider.tsx
@@ -7,7 +7,7 @@ import { Hour, hoursSchema } from 'features/search/helpers/schema/datesHoursSche
 import { useGetFullscreenModalSliderLength } from 'features/search/helpers/useGetFullscreenModalSliderLength'
 import { DEFAULT_TIME_VALUE } from 'features/search/pages/modals/DatesHoursModal/DatesHoursModal'
 import { Slider, ValuesType } from 'ui/components/inputs/Slider'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 type HoursSliderProps = {
   value?: [Hour, Hour]
@@ -33,7 +33,7 @@ export function HoursSlider({ field }: Readonly<{ field: HoursSliderProps }>) {
       <Spacer.Column numberOfSpaces={3} />
       <LabelHoursContainer nativeID={hoursLabelId}>
         <TypoDS.Body>Sortir entre</TypoDS.Body>
-        <Typo.ButtonText>{`${minHour}\u00a0h et ${maxHour}\u00a0h`}</Typo.ButtonText>
+        <TypoDS.BodyAccent>{`${minHour}\u00a0h et ${maxHour}\u00a0h`}</TypoDS.BodyAccent>
       </LabelHoursContainer>
       <Spacer.Column numberOfSpaces={2} />
       <Slider

--- a/src/features/search/components/LocationChoice.tsx
+++ b/src/features/search/components/LocationChoice.tsx
@@ -9,7 +9,7 @@ import { useSpaceBarAction } from 'ui/hooks/useSpaceBarAction'
 import { ArrowNext as DefaultArrowNext } from 'ui/svg/icons/ArrowNext'
 import { AccessibleBicolorIcon } from 'ui/svg/icons/types'
 import { Validate as DefaultValidate } from 'ui/svg/icons/Validate'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 type Props = {
   onPress?: () => void
@@ -96,7 +96,7 @@ const SecondPart = styled.View({
   height: '100%',
 })
 
-const ButtonText = styled(Typo.ButtonText)<{ isSelected: boolean }>(({ isSelected, theme }) => ({
+const ButtonText = styled(TypoDS.BodyAccent)<{ isSelected: boolean }>(({ isSelected, theme }) => ({
   color: isSelected ? theme.colors.primary : theme.colors.black,
 }))
 

--- a/src/features/search/components/SearchTitleAndWidget/SearchTitleAndWidget.tsx
+++ b/src/features/search/components/SearchTitleAndWidget/SearchTitleAndWidget.tsx
@@ -48,7 +48,7 @@ export const SearchTitleAndWidget: FunctionComponent<Props> = ({
 }
 
 const StyledTitleMainText = styledInputLabel(InputLabel)(({ theme }) => ({
-  ...theme.typography.title1,
+  ...theme.designSystem.typography.title1,
 }))
 
 const CaptionSubtitle = styled(TypoDS.BodyAccentXs)(({ theme }) => ({

--- a/src/features/search/components/SearchVenueItemsDetails/SearchVenueItemDetails.tsx
+++ b/src/features/search/components/SearchVenueItemsDetails/SearchVenueItemDetails.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { PixelRatio } from 'react-native'
 import styled from 'styled-components/native'
 
-import { Typo, GUTTER_DP, TypoDS } from 'ui/theme'
+import { GUTTER_DP, TypoDS } from 'ui/theme'
 
 interface SearchVenueItemDetailsProps {
   width: number
@@ -33,7 +33,7 @@ const Container = styled.View<{ maxWidth: number; minHeight: number }>(
   })
 )
 
-const VenueName = styled(Typo.ButtonText).attrs({
+const VenueName = styled(TypoDS.BodyAccent).attrs({
   numberOfLines: 2,
 })({})
 

--- a/src/features/search/components/SelectionLabel/SelectionLabel.tsx
+++ b/src/features/search/components/SelectionLabel/SelectionLabel.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native'
 import { accessibleCheckboxProps } from 'shared/accessibilityProps/accessibleCheckboxProps'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { Validate } from 'ui/svg/icons/Validate'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { HiddenCheckbox } from 'ui/web/inputs/HiddenCheckbox'
 
 interface Props {
@@ -60,7 +60,7 @@ const StyledTouchableOpacity = styled(TouchableOpacity)<{ selected: boolean }>(
     alignSelf: 'flex-start',
   })
 )
-const Label = styled(Typo.ButtonText)<{ selected: boolean }>(({ theme, selected }) => ({
+const Label = styled(TypoDS.BodyAccent)<{ selected: boolean }>(({ theme, selected }) => ({
   marginVertical: getSpacing(2.5),
   color: selected ? theme.colors.white : theme.colors.black,
 }))

--- a/src/features/share/pages/ShareAppModal.tsx
+++ b/src/features/share/pages/ShareAppModal.tsx
@@ -8,7 +8,7 @@ import { MarketingModal } from 'ui/components/modals/MarketingModal'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Share } from 'ui/svg/icons/BicolorShare'
 import { Invalidate } from 'ui/svg/icons/Invalidate'
-import { Typo, TypoDS } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 import { LINE_BREAK } from 'ui/theme/constants'
 
 type Props = {
@@ -26,9 +26,9 @@ export const ShareAppModal: FunctionComponent<Props> = ({ visible, close, share 
       onBackdropPress={close}>
       <ViewGap gap={6}>
         <StyledBody>
-          <Typo.ButtonText>
+          <TypoDS.BodyAccent>
             35 % des jeunes en France n’ont pas encore le pass Culture.
-          </Typo.ButtonText>
+          </TypoDS.BodyAccent>
           {LINE_BREAK}
           Fais découvrir le pass à tes amis&nbsp;!
         </StyledBody>

--- a/src/features/trustedDevice/pages/AccountSecurity.tsx
+++ b/src/features/trustedDevice/pages/AccountSecurity.tsx
@@ -16,7 +16,7 @@ import { TouchableLink } from 'ui/components/touchableLink/TouchableLink'
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
 import { Invalidate } from 'ui/svg/icons/Invalidate'
 import { BicolorUserBlocked } from 'ui/svg/icons/UserBlocked'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 export const AccountSecurity = () => {
   const { params } = useRoute<UseRouteType<'AccountSecurity'>>()
@@ -37,7 +37,7 @@ export const AccountSecurity = () => {
       icon={BicolorUserBlocked}
       separateIconFromTitle={false}>
       <TypoDS.Body>
-        Tu as indiqué <Typo.ButtonText>ne pas être à l’origine</Typo.ButtonText> de cette
+        Tu as indiqué <TypoDS.BodyAccent>ne pas être à l’origine</TypoDS.BodyAccent> de cette
         connexion&nbsp;:
       </TypoDS.Body>
       <Spacer.Column numberOfSpaces={4} />
@@ -48,7 +48,7 @@ export const AccountSecurity = () => {
       />
       <Spacer.Column numberOfSpaces={4} />
       <TypoDS.Body>
-        Pour des raisons de <Typo.ButtonText>sécurité,</Typo.ButtonText> nous te conseillons de
+        Pour des raisons de <TypoDS.BodyAccent>sécurité,</TypoDS.BodyAccent> nous te conseillons de
         {isLoggedOutOrHasPassword
           ? ' modifier ton mot de passe ou de suspendre ton compte temporairement.'
           : ' sécuriser l’accès à ta boîte mail et de suspendre ton compte pass Culture temporairement.'}

--- a/src/features/trustedDevice/pages/SuspensionChoice.tsx
+++ b/src/features/trustedDevice/pages/SuspensionChoice.tsx
@@ -21,7 +21,7 @@ import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
 import { BicolorUserError } from 'ui/svg/BicolorUserError'
 import { EmailFilled } from 'ui/svg/icons/EmailFilled'
 import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { SPACE } from 'ui/theme/constants'
 
 export const SuspensionChoice = () => {
@@ -62,7 +62,7 @@ export const SuspensionChoice = () => {
       title="Souhaites-tu suspendre ton compte pass&nbsp;Culture&nbsp;?"
       separateIconFromTitle={false}
       icon={BicolorUserError}>
-      <Typo.ButtonText>Les conséquences&nbsp;:</Typo.ButtonText>
+      <TypoDS.BodyAccent>Les conséquences&nbsp;:</TypoDS.BodyAccent>
       <VerticalUl>
         <BulletListItem>
           <TypoDS.Body>
@@ -79,7 +79,7 @@ export const SuspensionChoice = () => {
         <BulletListItem text="tu n’auras plus accès au catalogue." />
       </VerticalUl>
       <Spacer.Column numberOfSpaces={4} />
-      <Typo.ButtonText>Les données que nous conservons&nbsp;:</Typo.ButtonText>
+      <TypoDS.BodyAccent>Les données que nous conservons&nbsp;:</TypoDS.BodyAccent>
       <TypoDS.Body>
         Nous gardons toutes les informations personnelles que tu nous as transmises lors de la
         vérification de ton identité.

--- a/src/features/tutorial/components/AgeButton.stories.tsx
+++ b/src/features/tutorial/components/AgeButton.stories.tsx
@@ -7,7 +7,7 @@ import { TutorialTypes } from 'features/tutorial/enums'
 import { selectArgTypeFromObject } from 'libs/storybook/selectArgTypeFromObject'
 import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storybook/VariantsTemplate'
 import { All } from 'ui/svg/icons/bicolor/All'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 import { AgeButton } from './AgeButton'
 
@@ -23,6 +23,10 @@ const StyledBody = styled(TypoDS.Body)(({ theme }) => ({
 
 const CaptionNeutralInfo = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   color: theme.colors.greyDark,
+}))
+
+const StyledBodyAccent = styled(TypoDS.BodyAccent)(({ theme }) => ({
+  color: theme.colors.secondary,
 }))
 
 const meta: ComponentMeta<typeof AgeButton> = {
@@ -47,7 +51,7 @@ export default meta
 const TextExample = ({ withSubtitle = false }) => (
   <React.Fragment>
     <StyledBody>
-      j’ai <Typo.ButtonTextSecondary>17 ans</Typo.ButtonTextSecondary>
+      j’ai <StyledBodyAccent>17 ans</StyledBodyAccent>
     </StyledBody>
     {withSubtitle ? (
       <React.Fragment>

--- a/src/features/tutorial/components/onboarding/OnboardingCreditBlockTitle.tsx
+++ b/src/features/tutorial/components/onboarding/OnboardingCreditBlockTitle.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { Typo, TypoDS } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 import { getNoHeadingAttrs } from 'ui/theme/typographyAttrs/getNoHeadingAttrs'
 
 interface Props {
@@ -16,7 +16,7 @@ export const OnboardingCreditBlockTitle = ({
   deposit,
 }: Props): React.ReactElement => {
   const TitleText: React.JSXElementConstructor<{ children: string }> =
-    age === userAge ? TitleSecondary : Typo.ButtonText
+    age === userAge ? TitleSecondary : TypoDS.BodyAccent
 
   if (age !== 18 && age > userAge) {
     return <TitleText>{`+ ${deposit}`}</TitleText>

--- a/src/features/tutorial/components/profileTutorial/InformationStepContent.tsx
+++ b/src/features/tutorial/components/profileTutorial/InformationStepContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { Spacer, Typo, TypoDS, getSpacing } from 'ui/theme'
+import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 
 interface Props {
   title: string
@@ -18,7 +18,7 @@ export const InformationStepContent = ({ title, subtitle }: Props) => {
   )
 }
 
-const StyledButtonText = styled(Typo.ButtonText).attrs({ numberOfLines: 3 })({
+const StyledButtonText = styled(TypoDS.BodyAccent).attrs({ numberOfLines: 3 })({
   marginLeft: getSpacing(1.5),
   justifyContent: 'center',
 })

--- a/src/features/tutorial/components/profileTutorial/ProfileTutorialCreditBlockTitle.tsx
+++ b/src/features/tutorial/components/profileTutorial/ProfileTutorialCreditBlockTitle.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { Typo, TypoDS, getSpacing } from 'ui/theme'
+import { TypoDS, getSpacing } from 'ui/theme'
 import { getNoHeadingAttrs } from 'ui/theme/typographyAttrs/getNoHeadingAttrs'
 
 interface Props {
@@ -42,10 +42,10 @@ const TitleSecondary = styled(TypoDS.Title3).attrs(getNoHeadingAttrs)(({ theme }
   marginBottom: getSpacing(2),
 }))
 
-const StyledButtonText = styled(Typo.ButtonText)({
+const StyledButtonText = styled(TypoDS.BodyAccent)({
   marginBottom: getSpacing(2),
 })
 
-const ButtonTextSecondary = styled(Typo.ButtonText)(({ theme }) => ({
+const ButtonTextSecondary = styled(TypoDS.BodyAccent)(({ theme }) => ({
   color: theme.colors.secondary,
 }))

--- a/src/libs/location/components/WhereSection.tsx
+++ b/src/libs/location/components/WhereSection.tsx
@@ -13,7 +13,7 @@ import { Spacer } from 'ui/components/spacer/Spacer'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { ArrowNext as DefaultArrowNext } from 'ui/svg/icons/ArrowNext'
 import { BicolorLocationBuilding as LocationBuilding } from 'ui/svg/icons/BicolorLocationBuilding'
-import { Typo, TypoDS, getSpacing } from 'ui/theme'
+import { TypoDS, getSpacing } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
 type Props = {
@@ -135,7 +135,7 @@ const StyledAddress = styled(TypoDS.Body)({
 const iconSize = getSpacing(8)
 const iconSpacing = Math.round(iconSize / 5)
 
-const StyledVenueName = styled(Typo.ButtonText)({
+const StyledVenueName = styled(TypoDS.BodyAccent)({
   textTransform: 'capitalize',
   flexShrink: 1,
   left: -iconSpacing,

--- a/src/shared/Banners/GeolocationBanner.tsx
+++ b/src/shared/Banners/GeolocationBanner.tsx
@@ -9,7 +9,7 @@ import { SystemBanner } from 'ui/components/ModuleBanner/SystemBanner'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { BicolorEverywhere as Everywhere } from 'ui/svg/icons/BicolorEverywhere'
-import { Typo, TypoDS } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 type Props = {
   title: string
@@ -52,7 +52,7 @@ export const GeolocationBanner: FunctionComponent<Props> = ({
       accessibilityLabel="Active ta géolocalisation">
       <GenericBanner LeftIcon={<LocationIcon />} testID="genericBanner">
         <ViewGap gap={1}>
-          <Typo.ButtonText>{title}</Typo.ButtonText>
+          <TypoDS.BodyAccent>{title}</TypoDS.BodyAccent>
           <TypoDS.Body numberOfLines={2}>{subtitle}</TypoDS.Body>
         </ViewGap>
       </GenericBanner>

--- a/src/shared/offer/components/AuthenticationModal/AuthenticationModal.tsx
+++ b/src/shared/offer/components/AuthenticationModal/AuthenticationModal.tsx
@@ -9,7 +9,7 @@ import { ButtonWithLinearGradient } from 'ui/components/buttons/buttonWithLinear
 import { AppModalWithIllustration } from 'ui/components/modals/AppModalWithIllustration'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { BicolorUserIdentification } from 'ui/svg/BicolorUserIdentification'
-import { Spacer, Typo, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { LINE_BREAK } from 'ui/theme/constants'
 
 type Props = {
@@ -52,7 +52,7 @@ export const AuthenticationModal: FunctionComponent<Props> = ({
       title={'Identifie-toi' + LINE_BREAK + 'pour réserver l’offre'}
       Illustration={BicolorUserIdentification}
       hideModal={closeModal}>
-      <Typo.ButtonText>{title}</Typo.ButtonText>
+      <TypoDS.BodyAccent>{title}</TypoDS.BodyAccent>
       <Spacer.Column numberOfSpaces={2} />
       <StyledBody>
         Identifie-toi pour bénéficier de ton crédit et profiter des offres culturelles.

--- a/src/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.tsx
+++ b/src/shared/offer/components/FinishSubscriptionModal/FinishSubscriptionModal.tsx
@@ -13,7 +13,7 @@ import { useGetDepositAmountsByAge } from 'shared/user/useGetDepositAmountsByAge
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { AppModalWithIllustration } from 'ui/components/modals/AppModalWithIllustration'
 import { BicolorIdCardWithMagnifyingGlass } from 'ui/svg/icons/BicolorIdCardWithMagnifyingGlass'
-import { Typo, Spacer, TypoDS } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 import { LINE_BREAK, SPACE } from 'ui/theme/constants'
 
 type Props = {
@@ -84,7 +84,7 @@ export const FinishSubscriptionModal: FunctionComponent<Props> = ({ visible, hid
 const Deposit = ({ depositAmountByAge }: { depositAmountByAge: string }) => (
   <StyledBody>
     {SPACE}
-    tes <Typo.ButtonText>{depositAmountByAge}</Typo.ButtonText>
+    tes <TypoDS.BodyAccent>{depositAmountByAge}</TypoDS.BodyAccent>
     {SPACE}
   </StyledBody>
 )

--- a/src/ui/components/Accordion.stories.tsx
+++ b/src/ui/components/Accordion.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 import FilterSwitch from 'ui/components/FilterSwitch'
 import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storybook/VariantsTemplate'
-import { Typo, TypoDS } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 import { Accordion } from './Accordion'
 
@@ -43,7 +43,7 @@ const variantConfig: Variants<typeof Accordion> = [
   },
   {
     label: 'Accordion with custom title component',
-    props: { ...baseProps, titleComponent: Typo.ButtonText },
+    props: { ...baseProps, titleComponent: TypoDS.BodyAccent },
   },
 ]
 

--- a/src/ui/components/CheckboxBlock/CheckboxBlock.tsx
+++ b/src/ui/components/CheckboxBlock/CheckboxBlock.tsx
@@ -7,7 +7,7 @@ import { useHandleHover } from 'libs/hooks/useHandleHover'
 import { accessibleCheckboxProps } from 'shared/accessibilityProps/accessibleCheckboxProps'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { CheckboxMark } from 'ui/svg/icons/CheckBoxTMark'
-import { getSpacing, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 import { getHoverStyle } from 'ui/theme/getHoverStyle/getHoverStyle'
 
@@ -40,7 +40,7 @@ export const CheckboxBlock = ({
       <InnerContainer>
         {LeftIcon ? <LeftIcon /> : null}
         <View>
-          <Typo.ButtonText>{label}</Typo.ButtonText>
+          <TypoDS.BodyAccent>{label}</TypoDS.BodyAccent>
           {sublabel ? <CaptionNeutralInfo>{sublabel}</CaptionNeutralInfo> : null}
         </View>
       </InnerContainer>

--- a/src/ui/components/InputLabel/InputLabel.web.tsx
+++ b/src/ui/components/InputLabel/InputLabel.web.tsx
@@ -5,6 +5,6 @@ export const InputLabel = styled.label.attrs<{ accessibilityDescribedBy?: string
     ['aria-describedby']: accessibilityDescribedBy,
   })
 )(({ theme }) => ({
-  ...theme.typography?.body,
+  ...theme.designSystem.typography?.body,
   cursor: 'pointer',
 }))

--- a/src/ui/components/Loader.tsx
+++ b/src/ui/components/Loader.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { ActivityIndicator } from 'react-native'
 import styled from 'styled-components/native'
 
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 type Props = {
   message?: string
@@ -16,7 +16,7 @@ export function Loader({ message }: Props) {
       {message ? (
         <React.Fragment>
           <Spacer.Column numberOfSpaces={4} />
-          <Typo.ButtonText>{message}</Typo.ButtonText>
+          <TypoDS.BodyAccent>{message}</TypoDS.BodyAccent>
         </React.Fragment>
       ) : null}
       <Spacer.Column numberOfSpaces={50} />

--- a/src/ui/components/ModuleBanner/SystemBanner.tsx
+++ b/src/ui/components/ModuleBanner/SystemBanner.tsx
@@ -8,7 +8,7 @@ import { styledButton } from 'ui/components/buttons/styledButton'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { ArrowRight } from 'ui/svg/icons/ArrowRight'
-import { getSpacing, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
 
 type Props = {
@@ -42,7 +42,7 @@ export const SystemBanner: FunctionComponent<Props> = ({
       <Container testID="systemBanner">
         {LeftIcon ? <IconContainer>{LeftIcon}</IconContainer> : null}
         <DescriptionContainer gap={1}>
-          <Typo.ButtonText>{title}</Typo.ButtonText>
+          <TypoDS.BodyAccent>{title}</TypoDS.BodyAccent>
           <TypoDS.Body numberOfLines={2}>{subtitle}</TypoDS.Body>
         </DescriptionContainer>
         <View>

--- a/src/ui/components/SeeMore.tsx
+++ b/src/ui/components/SeeMore.tsx
@@ -5,7 +5,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { ArrowNext as DefaultArrowNext } from 'ui/svg/icons/ArrowNext'
-import { getSpacing, Spacer, Typo, getShadow } from 'ui/theme'
+import { getSpacing, Spacer, getShadow, TypoDS } from 'ui/theme'
 
 interface SeeMoreProps {
   height: number
@@ -32,7 +32,7 @@ export const SeeMore: React.FC<SeeMoreProps> = ({ height, width, navigateTo, onP
         </Row>
         <Spacer.Column numberOfSpaces={2} />
         <Row>
-          <Typo.ButtonTextPrimary>En voir plus</Typo.ButtonTextPrimary>
+          <StyledBodyAccent>En voir plus</StyledBodyAccent>
         </Row>
       </ClickableArea>
     </Container>
@@ -104,3 +104,7 @@ const ArrowNext = styled(DefaultArrowNext).attrs(({ theme }) => ({
   color: theme.colors.primary,
   size: theme.icons.sizes.standard,
 }))``
+
+const StyledBodyAccent = styled(TypoDS.BodyAccent)(({ theme }) => ({
+  color: theme.colors.primary,
+}))

--- a/src/ui/components/SeeMoreWithEye.tsx
+++ b/src/ui/components/SeeMoreWithEye.tsx
@@ -6,7 +6,7 @@ import { Touchable } from 'ui/components/touchable/Touchable'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { EyeSophisticated as DefaultEyeSophisticated } from 'ui/svg/icons/EyeSophisticated'
-import { getSpacing, Spacer, Typo } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { getHoverStyle } from 'ui/theme/getHoverStyle/getHoverStyle'
 
 type Props = {
@@ -69,7 +69,7 @@ const StyledTouchable = styledButton(Touchable)(({ theme }) => ({
   ...getHoverStyle(theme.colors.black),
 }))
 
-const StyledButtonText = styled(Typo.ButtonText)(({ theme }) => ({
+const StyledButtonText = styled(TypoDS.BodyAccent)(({ theme }) => ({
   color: theme.colors.black,
 }))
 

--- a/src/ui/components/StepButton/StepButton.tsx
+++ b/src/ui/components/StepButton/StepButton.tsx
@@ -8,7 +8,7 @@ import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouch
 import { InternalNavigationProps } from 'ui/components/touchableLink/types'
 import { TouchableOpacity } from 'ui/components/TouchableOpacity'
 import { AccessibleIcon } from 'ui/svg/icons/types'
-import { getSpacing, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 interface Props {
   step: StepDetails
@@ -166,7 +166,7 @@ const StyledTouchableOpacity = styled(TouchableOpacity)({
   flexDirection: 'row',
 })
 
-const StyledButtonText = styled(Typo.ButtonText)<{ stepState: StepButtonState }>(
+const StyledButtonText = styled(TypoDS.BodyAccent)<{ stepState: StepButtonState }>(
   ({ stepState, theme }) => ({
     color:
       stepState === StepButtonState.CURRENT || stepState === StepButtonState.RETRY

--- a/src/ui/components/buttons/AppButton/AppButton.native.test.tsx
+++ b/src/ui/components/buttons/AppButton/AppButton.native.test.tsx
@@ -3,12 +3,12 @@ import React from 'react'
 import { render, screen } from 'tests/utils'
 import { Close } from 'ui/svg/icons/Close'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 import { AppButton } from './AppButton'
 
 const baseProps = {
-  title: Typo.ButtonText,
+  title: TypoDS.Button,
   loadingIndicator: InitialLoadingIndicator,
   wording: 'Testing Disabled',
   icon: Close,

--- a/src/ui/components/buttons/AppButton/AppButton.web.test.tsx
+++ b/src/ui/components/buttons/AppButton/AppButton.web.test.tsx
@@ -3,12 +3,12 @@ import React from 'react'
 import { fireEvent, render, screen } from 'tests/utils/web'
 import { Close } from 'ui/svg/icons/Close'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 import { AppButton } from './AppButton'
 
 const baseProps = {
-  title: Typo.ButtonText,
+  title: TypoDS.Button,
   loadingIndicator: InitialLoadingIndicator,
   wording: 'Testing Disabled',
   icon: Close,

--- a/src/ui/components/buttons/ButtonPrimary.ts
+++ b/src/ui/components/buttons/ButtonPrimary.ts
@@ -5,7 +5,7 @@ import { AppButton } from 'ui/components/buttons/AppButton/AppButton'
 import { BaseButtonProps } from 'ui/components/buttons/AppButton/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { Typo, TypoDS } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export const ButtonPrimary = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ isLoading, disabled, textSize, icon, theme, buttonHeight, ...rest }) => {
@@ -31,7 +31,7 @@ export const ButtonPrimary = styledButton(AppButton).attrs<BaseButtonProps>(
       backgroundColor = theme.buttons.disabled.primary.backgroundColor
     }
 
-    const Title = styled(buttonHeight === 'extraSmall' ? TypoDS.BodyAccentXs : Typo.ButtonText)({
+    const Title = styled(buttonHeight === 'extraSmall' ? TypoDS.BodyAccentXs : TypoDS.Button)({
       maxWidth: '100%',
       color: disabled ? theme.buttons.disabled.primary.textColor : theme.buttons.primary.textColor,
       fontSize: textSize,

--- a/src/ui/components/buttons/ButtonPrimaryWhite.ts
+++ b/src/ui/components/buttons/ButtonPrimaryWhite.ts
@@ -5,7 +5,7 @@ import { AppButton } from 'ui/components/buttons/AppButton/AppButton'
 import { BaseButtonProps } from 'ui/components/buttons/AppButton/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export const ButtonPrimaryWhite = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ disabled, icon, textSize, theme, ...rest }) => {
@@ -20,7 +20,7 @@ export const ButtonPrimaryWhite = styledButton(AppButton).attrs<BaseButtonProps>
       })``
     }
 
-    const Title = styled(Typo.ButtonText)({
+    const Title = styled(TypoDS.Button)({
       maxWidth: '100%',
       color: disabled
         ? theme.buttons.disabled.primaryWhite.textColor

--- a/src/ui/components/buttons/ButtonSecondary.ts
+++ b/src/ui/components/buttons/ButtonSecondary.ts
@@ -5,7 +5,7 @@ import { AppButton } from 'ui/components/buttons/AppButton/AppButton'
 import { BaseButtonProps } from 'ui/components/buttons/AppButton/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export const ButtonSecondary = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ icon, disabled, textSize, theme, color, ...rest }) => {
@@ -18,7 +18,7 @@ export const ButtonSecondary = styledButton(AppButton).attrs<BaseButtonProps>(
       })``
     }
 
-    const Title = styled(Typo.ButtonText)({
+    const Title = styled(TypoDS.Button)({
       maxWidth: '100%',
       color: disabled
         ? theme.buttons.disabled.secondary.textColor

--- a/src/ui/components/buttons/ButtonSecondaryBlack.ts
+++ b/src/ui/components/buttons/ButtonSecondaryBlack.ts
@@ -5,7 +5,7 @@ import { AppButton } from 'ui/components/buttons/AppButton/AppButton'
 import { BaseButtonProps } from 'ui/components/buttons/AppButton/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export const ButtonSecondaryBlack = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ icon, disabled, textSize, theme, ...rest }) => {
@@ -20,7 +20,7 @@ export const ButtonSecondaryBlack = styledButton(AppButton).attrs<BaseButtonProp
       })``
     }
 
-    const Title = styled(Typo.ButtonText)({
+    const Title = styled(TypoDS.Button)({
       maxWidth: '100%',
       color: disabled
         ? theme.buttons.disabled.secondaryBlack.textColor

--- a/src/ui/components/buttons/ButtonSecondaryWhite.ts
+++ b/src/ui/components/buttons/ButtonSecondaryWhite.ts
@@ -5,7 +5,7 @@ import { AppButton } from 'ui/components/buttons/AppButton/AppButton'
 import { BaseButtonProps } from 'ui/components/buttons/AppButton/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export const ButtonSecondaryWhite = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ icon, disabled, textSize, theme, ...rest }) => {
@@ -24,7 +24,7 @@ export const ButtonSecondaryWhite = styledButton(AppButton).attrs<BaseButtonProp
       ? theme.buttons.disabled.secondaryWhite.backgroundColor
       : theme.buttons.secondaryWhite.backgroundColor
 
-    const Title = styled(Typo.ButtonText)({
+    const Title = styled(TypoDS.Button)({
       maxWidth: '100%',
       color: disabled
         ? theme.buttons.disabled.secondaryWhite.textColor

--- a/src/ui/components/buttons/ButtonTertiaryBlack.ts
+++ b/src/ui/components/buttons/ButtonTertiaryBlack.ts
@@ -4,7 +4,7 @@ import { AppButton } from 'ui/components/buttons/AppButton/AppButton'
 import { BaseButtonProps } from 'ui/components/buttons/AppButton/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { getSpacing, Typo } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 
 export const ButtonTertiaryBlack = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ icon, disabled, textSize, theme, buttonHeight, ...rest }) => {
@@ -22,7 +22,7 @@ export const ButtonTertiaryBlack = styledButton(AppButton).attrs<BaseButtonProps
       })``
     }
 
-    const Title = styled(Typo.ButtonText)({
+    const Title = styled(TypoDS.Button)({
       maxWidth: '100%',
       color: disabled
         ? theme.buttons.disabled.tertiaryBlack.textColor

--- a/src/ui/components/buttons/ButtonTertiaryNeutralInfo.ts
+++ b/src/ui/components/buttons/ButtonTertiaryNeutralInfo.ts
@@ -4,7 +4,7 @@ import { AppButton } from 'ui/components/buttons/AppButton/AppButton'
 import { BaseButtonProps } from 'ui/components/buttons/AppButton/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export const ButtonTertiaryNeutralInfo = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ icon, disabled, textSize, theme, ...rest }) => {
@@ -19,7 +19,7 @@ export const ButtonTertiaryNeutralInfo = styledButton(AppButton).attrs<BaseButto
       })``
     }
 
-    const Title = styled(Typo.ButtonText)({
+    const Title = styled(TypoDS.Button)({
       maxWidth: '100%',
       color: disabled
         ? theme.buttons.disabled.tertiaryNeutralInfo.textColor

--- a/src/ui/components/buttons/ButtonTertiaryPrimary.ts
+++ b/src/ui/components/buttons/ButtonTertiaryPrimary.ts
@@ -4,7 +4,7 @@ import { AppButton } from 'ui/components/buttons/AppButton/AppButton'
 import { BaseButtonProps } from 'ui/components/buttons/AppButton/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export const ButtonTertiaryPrimary = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ icon, disabled, textSize, theme, ...rest }) => {
@@ -24,7 +24,7 @@ export const ButtonTertiaryPrimary = styledButton(AppButton).attrs<BaseButtonPro
       size: theme.buttons.tertiary.iconSize,
     })``
 
-    const Title = styled(Typo.ButtonText)({
+    const Title = styled(TypoDS.Button)({
       maxWidth: '100%',
       color: disabled
         ? theme.buttons.disabled.tertiary.textColor

--- a/src/ui/components/buttons/ButtonTertiaryWhite.ts
+++ b/src/ui/components/buttons/ButtonTertiaryWhite.ts
@@ -5,7 +5,7 @@ import { AppButton } from 'ui/components/buttons/AppButton/AppButton'
 import { BaseButtonProps } from 'ui/components/buttons/AppButton/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { Logo as InitialLoadingIndicator } from 'ui/svg/icons/Logo'
-import { Typo } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 
 export const ButtonTertiaryWhite = styledButton(AppButton).attrs<BaseButtonProps>(
   ({ disabled, icon, textSize, theme, ...rest }) => {
@@ -25,7 +25,7 @@ export const ButtonTertiaryWhite = styledButton(AppButton).attrs<BaseButtonProps
       size: theme.buttons.tertiaryWhite.iconSize,
     })``
 
-    const Title = styled(Typo.ButtonText)({
+    const Title = styled(TypoDS.Button)({
       maxWidth: '100%',
       color: disabled
         ? theme.buttons.disabled.tertiaryWhite.textColor

--- a/src/ui/components/buttons/HeroButtonList.stories.tsx
+++ b/src/ui/components/buttons/HeroButtonList.stories.tsx
@@ -8,7 +8,7 @@ import { Emoji } from 'ui/components/Emoji'
 import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storybook/VariantsTemplate'
 import { BicolorSmartphone } from 'ui/svg/icons/BicolorSmartphone'
 import { LocationPointer } from 'ui/svg/icons/LocationPointer'
-import { Typo, TypoDS } from 'ui/theme'
+import { TypoDS } from 'ui/theme'
 // eslint-disable-next-line no-restricted-imports
 import { ColorsEnum } from 'ui/theme/colors'
 import { iconSizes } from 'ui/theme/iconSizes'
@@ -29,14 +29,14 @@ export default meta
 const description = (
   <Text>
     <TypoDS.Body>J’ai une carte d’identité, un passeport </TypoDS.Body>
-    <Typo.ButtonText>étranger</Typo.ButtonText>
+    <TypoDS.BodyAccent>étranger</TypoDS.BodyAccent>
     <TypoDS.Body> ou un titre séjour français</TypoDS.Body>
   </Text>
 )
 const description2 = (
   <Text>
     <TypoDS.Body>J’ai ma pièce d’identité </TypoDS.Body>
-    <Typo.ButtonText>en cours de validité avec moi</Typo.ButtonText>
+    <TypoDS.BodyAccent>en cours de validité avec moi</TypoDS.BodyAccent>
   </Text>
 )
 

--- a/src/ui/components/buttons/externalLink/ExternalLink.tsx
+++ b/src/ui/components/buttons/externalLink/ExternalLink.tsx
@@ -6,7 +6,7 @@ import { openUrl } from 'features/navigation/helpers/openUrl'
 import { accessibilityAndTestId } from 'libs/accessibilityAndTestId'
 import { extractExternalLinkParts } from 'ui/components/buttons/externalLink/ExternalLink.service'
 import { ExternalSiteFilled as DefaultExternalSite } from 'ui/svg/icons/ExternalSiteFilled'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   url: string
@@ -34,7 +34,7 @@ export const ExternalLink: React.FC<Props> = ({ url, text, primary, testID }) =>
   )
 }
 
-const ButtonText = styled(Typo.ButtonText)<{ primary?: boolean }>(({ primary, theme }) => ({
+const ButtonText = styled(TypoDS.BodyAccent)<{ primary?: boolean }>(({ primary, theme }) => ({
   color: primary ? theme.colors.primary : undefined,
 }))
 

--- a/src/ui/components/buttons/externalLink/ExternalLink.web.tsx
+++ b/src/ui/components/buttons/externalLink/ExternalLink.web.tsx
@@ -39,7 +39,7 @@ export const ExternalLink: React.FC<Props> = ({ url, text, primary, testID }) =>
 const Text = webStyled.span(({ theme }) => ({
   whiteSpace: 'nowrap',
   verticalAlign: 'middle',
-  ...theme.typography.buttonText,
+  ...theme.designSystem.typography.button,
 }))
 
 const StyledTouchableLink = styled(ExternalTouchableLink).attrs<{

--- a/src/ui/components/buttons/externalLink/ExternalLink.web.tsx
+++ b/src/ui/components/buttons/externalLink/ExternalLink.web.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/native'
 import { extractExternalLinkParts } from 'ui/components/buttons/externalLink/ExternalLink.service'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 import { ExternalSiteFilled as DefaultExternalSite } from 'ui/svg/icons/ExternalSiteFilled'
-import { Spacer, Typo } from 'ui/theme'
+import { Spacer, TypoDS } from 'ui/theme'
 
 interface Props {
   url: string
@@ -50,7 +50,7 @@ const StyledTouchableLink = styled(ExternalTouchableLink).attrs<{
   display: 'inline',
 })
 
-const ButtonText = styled(Typo.ButtonText)<{ primary?: boolean }>(({ primary, theme }) => ({
+const ButtonText = styled(TypoDS.Button)<{ primary?: boolean }>(({ primary, theme }) => ({
   color: primary ? theme.colors.primary : undefined,
 }))
 

--- a/src/ui/components/inputs/BaseTextInput.tsx
+++ b/src/ui/components/inputs/BaseTextInput.tsx
@@ -78,7 +78,7 @@ export const BaseTextInput = forwardRef<RNTextInput, Props>(function BaseTextInp
 })
 
 const StyledTextInput = styled(RNTextInput).attrs(({ theme }) => ({
-  placeholderTextColor: theme.typography.placeholder.color,
+  placeholderTextColor: theme.colors.greyDark,
 }))<{ isEmpty: boolean; textStyle?: TypographyDS; multiline: boolean }>(
   ({ theme, isEmpty, textStyle, editable, multiline }) => {
     let inputStyle: TypographyDS = theme.designSystem.typography.body

--- a/src/ui/components/inputs/DropDown/DropDown.web.tsx
+++ b/src/ui/components/inputs/DropDown/DropDown.web.tsx
@@ -104,7 +104,10 @@ const StyledSelect = styled.select<SelectProps>`
       ? noBorderRadius
       : `${theme.borderRadius.button}px`
     const { fontFamily, fontSize, color, lineHeight } = isEmpty
-      ? theme.typography.placeholder
+      ? {
+          ...theme.designSystem.typography.bodyItalic,
+          color: theme.colors.greyDark,
+        }
       : theme.designSystem.typography.body
     return `
     font-family: ${fontFamily};

--- a/src/ui/components/inputs/Slider.tsx
+++ b/src/ui/components/inputs/Slider.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Platform, View } from 'react-native'
 import styled from 'styled-components/native'
 
-import { getSpacing, Spacer, Typo, TypoDS } from 'ui/theme'
+import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 export type ValuesType = [number] | [number, number]
 
@@ -222,7 +222,7 @@ const StyledMultiSlider = styled(MultiSlider).attrs(({ sliderLength, theme }) =>
   }
 })``
 
-const CenteredText = styled(Typo.ButtonText)<{ width?: number }>(({ width, theme }) => ({
+const CenteredText = styled(TypoDS.BodyAccent)<{ width?: number }>(({ width, theme }) => ({
   width: width ?? theme.appContentWidth - getSpacing(2 * 2 * 6),
   textAlign: 'center',
 }))

--- a/src/ui/web/link/QuickAccess.web.tsx
+++ b/src/ui/web/link/QuickAccess.web.tsx
@@ -15,7 +15,7 @@ export const QuickAccess = ({ href, title }: QuickAccessProps) => (
 
 const StyledA: React.FC<{ href: string; children: string }> = displayOnFocus(
   styled.a(({ theme }) => ({
-    ...theme.typography.buttonText,
+    ...theme.designSystem.typography.button,
     color: theme.uniqueColors.brand,
     backgroundColor: theme.colors.white,
     textDecoration: 'none',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33906

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
