### PR TITLE
(PC-33727) fix(ci): add testing version in route_usage_changelog

### DIFF
--- a/.github/workflows/dev_on_dispatch_create_and_push_ehp_deploy_tags.yml
+++ b/.github/workflows/dev_on_dispatch_create_and_push_ehp_deploy_tags.yml
@@ -110,6 +110,7 @@ jobs:
           cmd: jq '.build = ${{ steps.build-number.outputs.build_number }}' package.json > tmp && mv tmp package.json
       - name: 'Get routes used by app version'
         run: |
+          TESTING_VERSION=${{ steps.package-version.outputs.current-version }}
           ./scripts/get_used_routes.sh "v${TESTING_VERSION}"
       - name: 'Commit changes'
         run: |


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33727

Update mineure de la CI pour ne pas avoir `v` sans numéro de version dans route_usage_changelog