### PR TITLE
(BSR) feat(CI): add e2e pipeline

### DIFF
--- a/.github/workflows/dev_on_schedule_e2e_android.yml
+++ b/.github/workflows/dev_on_schedule_e2e_android.yml
@@ -1,4 +1,4 @@
-name: 'Reusable E2E Android Workflow'
+name: '0 [on_schedule] Dev on schedule e2e android'
 
 on:
   workflow_call:

--- a/.github/workflows/pr_e2e_android.yml
+++ b/.github/workflows/pr_e2e_android.yml
@@ -1,12 +1,13 @@
-name: '4 [on_workflow] Build and upload to Maestro Cloud (Android)'
+name: '[Daily] Run E2E tests on Android'
 
 on:
-  workflow_call:
-    secrets:
-      GCP_EHP_SERVICE_ACCOUNT:
-        required: true
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER:
-        required: true
+  schedule:
+    # 00:00 Paris UTC
+    - cron: '* 22 * * *'
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   e2e-tests:

--- a/.github/workflows/reusable_e2e_android.yml
+++ b/.github/workflows/reusable_e2e_android.yml
@@ -1,0 +1,104 @@
+name: 'Reusable E2E Android Workflow'
+
+on:
+  workflow_call:
+    secrets:
+      GCP_EHP_SERVICE_ACCOUNT:
+        required: true
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER:
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  maestro-cloud:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Setup java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
+      - name: Yarn install
+        run: yarn install
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Authentification to Google
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+
+      - name: Get Secret
+        id: 'secrets'
+        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        with:
+          secrets: |-
+            ANDROID_GOOGLE_SERVICES_JSON:passculture-metier-ehp/pc-native-android-google-service-staging
+            ANDROID_KEYSTORE_STORE_PASSWORD:passculture-metier-ehp/passculture-app-native-android-staging-keystore-store-password
+            ANDROID_KEYSTORE_KEY_PASSWORD:passculture-metier-ehp/passculture-app-native-android-staging-keystore-key-password
+            ANDROID_KEYSTORE:passculture-metier-ehp/passculture-app-native-staging-keystore
+            ROBIN_API_KEY:passculture-metier-ehp/passculture-app-native-e2e-robin-api-key
+            MAESTRO_PASSWORD:passculture-metier-ehp/passculture-app-native-e2e-maestro-password
+
+      - name: Create a directory for keystores
+        run: mkdir --parents android/keystores/
+
+      - name: Setup android keystore for staging environment
+        run: |
+          echo '${{ steps.secrets.outputs.ANDROID_KEYSTORE }}' |  base64 --decode > android/keystores/staging.keystore
+
+      - name: Setup android keystore properties for staging environment
+        uses: chuhlomin/render-template@v1.9
+        with:
+          template: templates_github_ci/staging.keystore.properties
+          vars: |
+            ENVIRONMENT: staging
+            ANDROID_KEYSTORE_STORE_PASSWORD: ${{ steps.secrets.outputs.ANDROID_KEYSTORE_STORE_PASSWORD }}
+            ANDROID_KEYSTORE_KEY_PASSWORD: ${{ steps.secrets.outputs.ANDROID_KEYSTORE_KEY_PASSWORD }}
+          result_path: android/keystores/staging.keystore.properties
+
+      - name: Setup android Google services config
+        run: echo '${{ steps.secrets.outputs.ANDROID_GOOGLE_SERVICES_JSON }}' > android/app/google-services.json
+
+      - name: Build android apk
+        run: cd android && ENVFILE=.env.staging ./gradlew assembleDebug
+
+      - name: Run Maestro Tests
+        uses: mobile-dev-inc/action-maestro-cloud@v1.9.6
+        with:
+          api-key: ${{ steps.secrets.outputs.ROBIN_API_KEY }}
+          project-id: proj_01javz1ncreqb9dcshv3y4da44
+          app-file: android/app/build/outputs/apk/staging/debug/app-staging-debug.apk
+          device-locale: fr_FR
+          android-api-level: 34
+          workspace: .maestro/tests/
+          include-tags: cloud
+          env: |
+            MAESTRO_APP_ID=app.passculture.staging
+            MAESTRO_PASSWORD=${{ steps.secrets.outputs.MAESTRO_PASSWORD }}
+            MAESTRO_VALID_EMAIL=dev-tests-e2e@passculture.team
+            MAESTRO_INVALID_EMAIL=dev-tests-e2e-invalid@passculture.team
+            MAESTRO_UNREGISTERED_EMAIL=dev-tests-unregistered+e2e@passculture.team
+            MAESTRO_MOCK_ANALYTICS_SERVER=http://localhost:$MOCK_ANALYTICS_SERVER_PORT
+            MAESTRO_NUMBER_PHONE=0607080910
+            MAESTRO_RUN_TRACKING_TESTS=false
+            MAESTRO_RUN_CLOUD_COMMANDS=true


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
