### PR TITLE
(PC-34129) fix(venue): avoid empty artist object, takes into account the display conditions of an artist page and add artist with only has an offer in the venue

### DIFF
--- a/src/features/artist/constants.ts
+++ b/src/features/artist/constants.ts
@@ -1,0 +1,17 @@
+import { SubcategoryIdEnum } from 'api/gen'
+
+export const ARTIST_PAGE_SUBCATEGORIES: SubcategoryIdEnum[] = [
+  SubcategoryIdEnum.ABO_PLATEFORME_MUSIQUE,
+  SubcategoryIdEnum.CAPTATION_MUSIQUE,
+  SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_CD,
+  SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE,
+  SubcategoryIdEnum.TELECHARGEMENT_MUSIQUE,
+  SubcategoryIdEnum.ABO_BIBLIOTHEQUE,
+  SubcategoryIdEnum.ABO_LIVRE_NUMERIQUE,
+  SubcategoryIdEnum.ABO_MEDIATHEQUE,
+  SubcategoryIdEnum.FESTIVAL_LIVRE,
+  SubcategoryIdEnum.LIVRE_AUDIO_PHYSIQUE,
+  SubcategoryIdEnum.LIVRE_NUMERIQUE,
+  SubcategoryIdEnum.LIVRE_PAPIER,
+  SubcategoryIdEnum.TELECHARGEMENT_LIVRE_AUDIO,
+]

--- a/src/features/venue/api/useVenueOffersArtists/useVenueOffersArtists.test.ts
+++ b/src/features/venue/api/useVenueOffersArtists/useVenueOffersArtists.test.ts
@@ -48,7 +48,7 @@ describe('useVenueOffersArtists', () => {
               isDuo: false,
               name: 'I want something more',
               prices: [28.0],
-              subcategoryId: SubcategoryIdEnum.CONCERT,
+              subcategoryId: SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE,
               thumbUrl:
                 'https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/CDZQ',
               artist: 'Céline Dion',
@@ -71,7 +71,7 @@ describe('useVenueOffersArtists', () => {
               isDuo: false,
               name: 'I want something more',
               prices: [28.0],
-              subcategoryId: SubcategoryIdEnum.CONCERT,
+              subcategoryId: SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE,
               thumbUrl:
                 'https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/CDZQ',
               artist: 'Céline Dion',
@@ -117,6 +117,7 @@ describe('useVenueOffersArtists', () => {
         artist: `Artist ${index % 35}`,
         thumbUrl:
           'https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/mediations/CDZQ',
+        subcategoryId: SubcategoryIdEnum.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE,
       },
     }))
 

--- a/src/features/venue/helpers/isArtistPageCompatible/isArtistPageCompatible.test.ts
+++ b/src/features/venue/helpers/isArtistPageCompatible/isArtistPageCompatible.test.ts
@@ -1,0 +1,29 @@
+import { SubcategoryIdEnum } from 'api/gen'
+import { isArtistPageCompatible } from 'features/venue/helpers/isArtistPageCompatible/isArtistPageCompatible'
+
+describe('isArtistPageCompatible', () => {
+  it('should return true for a valid artist and compatible subcategory', () => {
+    expect(isArtistPageCompatible('Céline Dion', SubcategoryIdEnum.LIVRE_NUMERIQUE)).toEqual(true)
+  })
+
+  it('should return false if artist name contains a comma', () => {
+    expect(isArtistPageCompatible('Céline Dion,JJG', SubcategoryIdEnum.LIVRE_NUMERIQUE)).toEqual(
+      false
+    )
+  })
+
+  it('should return false if artist name contains a semicolon', () => {
+    expect(isArtistPageCompatible('Céline Dion;JJG', SubcategoryIdEnum.LIVRE_NUMERIQUE)).toEqual(
+      false
+    )
+  })
+
+  it('should return false if artist name is in the excluded list', () => {
+    expect(isArtistPageCompatible('Collectif', SubcategoryIdEnum.LIVRE_NUMERIQUE)).toEqual(false)
+    expect(isArtistPageCompatible('collectifs', SubcategoryIdEnum.LIVRE_NUMERIQUE)).toEqual(false)
+  })
+
+  it('should return false if subcategory is not compatible', () => {
+    expect(isArtistPageCompatible('Céline Dion', SubcategoryIdEnum.SEANCE_CINE)).toEqual(false)
+  })
+})

--- a/src/features/venue/helpers/isArtistPageCompatible/isArtistPageCompatible.ts
+++ b/src/features/venue/helpers/isArtistPageCompatible/isArtistPageCompatible.ts
@@ -1,0 +1,11 @@
+import { SubcategoryIdEnum } from 'api/gen'
+import { ARTIST_PAGE_SUBCATEGORIES } from 'features/artist/constants'
+import { COMMA_OR_SEMICOLON_REGEX, EXCLUDED_ARTISTS } from 'features/offer/helpers/constants'
+
+export function isArtistPageCompatible(artistName: string, subcategoryId: SubcategoryIdEnum) {
+  return (
+    !COMMA_OR_SEMICOLON_REGEX.test(artistName) &&
+    !EXCLUDED_ARTISTS.includes(artistName.toLowerCase()) &&
+    ARTIST_PAGE_SUBCATEGORIES.includes(subcategoryId)
+  )
+}


### PR DESCRIPTION


Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34129

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
