### PR TITLE
(BSR) refactor(Algolia): remove unused boolean

### DIFF
--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -152,7 +152,6 @@ export type OffersModuleParameters = {
   aroundRadius?: number
   gtlLevel?: GtlLevel
   gtlLabel?: string
-  enrichPlaylistWithRecoOffers?: boolean
 }
 
 export type PlaylistOffersParams = {

--- a/src/libs/contentful/adapters/modules/adaptOffersModule.native.test.ts
+++ b/src/libs/contentful/adapters/modules/adaptOffersModule.native.test.ts
@@ -58,7 +58,6 @@ describe('adaptOffersModule', () => {
           title: 'Musique',
           categories: ['Cartes jeunes', 'Spectacles'],
           hitsPerPage: 2,
-          enrichPlaylistWithRecoOffers: false,
         },
       ],
     }

--- a/src/libs/contentful/fixtures/algoliaModules.fixture.ts
+++ b/src/libs/contentful/fixtures/algoliaModules.fixture.ts
@@ -130,7 +130,6 @@ export const additionalAlgoliaParametersWithOffersFixture: AlgoliaParameters[] =
       title: 'Musique',
       algoliaCategories: categoriesFixture,
       hitsPerPage: 2,
-      enrichPlaylistWithRecoOffers: false,
     },
   },
 ]

--- a/src/libs/contentful/types.ts
+++ b/src/libs/contentful/types.ts
@@ -275,7 +275,6 @@ export interface SearchParametersFields {
   bookTypes?: BookTypes
   gtlLevel?: GtlLevel
   gtlLabel?: string
-  enrichPlaylistWithRecoOffers?: boolean
 }
 
 // Taken from https://app.contentful.com/spaces/2bg01iqy0isv/environments/testing/content_types/venuesSearchParameters/fields


### PR DESCRIPTION
Dans le cadre de  [ce ticket](https://passculture.atlassian.net/browse/PC-28834, j'avais crée un booléen dans Contentful mais nous avons finalement pris une autre direction donc j'ai supprimer le bouton sur contentful en testing et dans le code

<img width="365" alt="Capture d’écran 2025-01-23 à 10 55 45" src="https://github.com/user-attachments/assets/5b4a1fe9-7cdc-4f03-a853-8fc1e44c0ef2" />
<img width="1370" alt="Capture d’écran 2025-01-23 à 10 56 31" src="https://github.com/user-attachments/assets/4f26ef09-a264-4fe2-9707-2706debc3c0f" />
