### PR TITLE
(BSR) fix(web): fix vite build error JavaScript heap out of memory

### DIFF
--- a/.github/workflows/dev_on_workflow_web_deploy.yml
+++ b/.github/workflows/dev_on_workflow_web_deploy.yml
@@ -71,8 +71,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ steps.secrets.outputs.SENTRY_AUTH_TOKEN }}
         run: |
-          echo $SENTRY_AUTH_TOKEN | wc -m
-          NODE_OPTIONS='--max-old-space-size=4096' UPLOAD_SOURCEMAPS_TO_SENTRY=true yarn build:${{ inputs.ENV }}
+          NODE_OPTIONS='--max-old-space-size=8192' UPLOAD_SOURCEMAPS_TO_SENTRY=true yarn build:${{ inputs.ENV }}
       - name: 'Push assets to bucket'
         run: |
           gsutil rsync -x "index\.html$" -r dist gs://${{ inputs.BUCKET_NAME }}

--- a/vite.config.js
+++ b/vite.config.js
@@ -33,7 +33,6 @@ export default ({ mode }) => {
   const isDevMode = mode === 'development'
   const isProdMode = mode === 'production'
   const env = loadEnv(isDevMode ? 'testing' : mode, process.cwd(), '')
-  console.log(process.env.SENTRY_AUTH_TOKEN ? process.env.SENTRY_AUTH_TOKEN.length : 0)
   const proxyConfig = {
     host: true, // This allows VSCode live share port forwarding
     proxy: {


### PR DESCRIPTION
https://github.com/vitejs/vite/issues/2433

Several people report that setting sourcemaps to false in the vite config solves the issue, but we want sourcemaps, so we will attempt to manually allocating RAM for Vite's initialization cycle.

