### PR TITLE
(PC-33896) fix(Url): fix web app url preview

### DIFF
--- a/src/features/navigation/RootNavigator/Header/AccessibleTabBar.web.tsx
+++ b/src/features/navigation/RootNavigator/Header/AccessibleTabBar.web.tsx
@@ -2,17 +2,12 @@ import React from 'react'
 import styled from 'styled-components'
 import nativeStyled from 'styled-components/native'
 
-import {
-  defaultDisabilitiesProperties,
-  useAccessibilityFiltersContext,
-} from 'features/accessibility/context/AccessibilityFiltersWrapper'
 import { useCurrentRoute } from 'features/navigation/helpers/useCurrentRoute'
 import { useTabBarItemBadges } from 'features/navigation/helpers/useTabBarItemBadges'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabNavigatorConfig } from 'features/navigation/RootNavigator/Header/getTabNavigatorConfig'
 import { TabBarComponent } from 'features/navigation/TabBar/TabBarComponent'
 import { TabBarContainer } from 'features/navigation/TabBar/TabBarContainer'
 import { useTabNavigationContext } from 'features/navigation/TabBar/TabNavigationStateContext'
-import { initialSearchState } from 'features/search/context/reducer'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { Li } from 'ui/components/Li'
 import { Ul } from 'ui/components/Ul'
@@ -21,7 +16,6 @@ export const AccessibleTabBar = ({ id }: { id: string }) => {
   const { tabRoutes } = useTabNavigationContext()
   const currentRoute = useCurrentRoute()
   const { searchState, hideSuggestions } = useSearch()
-  const { disabilities } = useAccessibilityFiltersContext()
   const routeBadgeMap = useTabBarItemBadges()
 
   if (currentRoute && currentRoute.name !== 'TabNavigator') return null
@@ -31,20 +25,7 @@ export const AccessibleTabBar = ({ id }: { id: string }) => {
       <TabBarContainer>
         <StyledUl>
           {tabRoutes.map((route) => {
-            let tabNavConfig = getTabNavConfig(route.name)
-            if (route.name === 'SearchStackNavigator') {
-              const searchParams = route.isSelected
-                ? {
-                    ...initialSearchState,
-                    locationFilter: searchState.locationFilter,
-                    accessibilityFilter: defaultDisabilitiesProperties,
-                  }
-                : { ...searchState, accessibilityFilter: disabilities }
-              tabNavConfig = getTabNavConfig(route.name, {
-                screen: 'SearchLanding',
-                params: searchParams,
-              })
-            }
+            const tabNavConfig = getTabNavigatorConfig(route, searchState)
             return (
               <LinkContainer key={route.name}>
                 <TabBarComponent

--- a/src/features/navigation/RootNavigator/Header/Nav.tsx
+++ b/src/features/navigation/RootNavigator/Header/Nav.tsx
@@ -1,13 +1,10 @@
 import React from 'react'
 import styled from 'styled-components/native'
 
-import { defaultDisabilitiesProperties } from 'features/accessibility/context/AccessibilityFiltersWrapper'
-import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/helpers'
-import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { getTabNavigatorConfig } from 'features/navigation/RootNavigator/Header/getTabNavigatorConfig'
 import { mapTabRouteToBicolorIcon } from 'features/navigation/TabBar/mapTabRouteToBicolorIcon'
 import { useTabNavigationContext } from 'features/navigation/TabBar/TabNavigationStateContext'
 import { TabParamList } from 'features/navigation/TabBar/types'
-import { initialSearchState } from 'features/search/context/reducer'
 import { useSearch } from 'features/search/context/SearchWrapper'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
@@ -29,10 +26,7 @@ type Props = {
 export const Nav: React.FC<Props> = ({ maxWidth, height, noShadow, routeBadgeMap }) => {
   const enableReactionFeature = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
   const { tabRoutes } = useTabNavigationContext()
-  const {
-    searchState: { locationFilter },
-    hideSuggestions,
-  } = useSearch()
+  const { searchState, hideSuggestions } = useSearch()
 
   return (
     <NavItemsContainer
@@ -42,15 +36,7 @@ export const Nav: React.FC<Props> = ({ maxWidth, height, noShadow, routeBadgeMap
       noShadow={noShadow}>
       <Ul>
         {tabRoutes.map((route, index) => {
-          let tabNavConfig = getTabNavConfig(route.name)
-
-          if (route.isSelected && route.name === 'SearchStackNavigator') {
-            tabNavConfig = getSearchStackConfig('SearchLanding', {
-              ...initialSearchState,
-              locationFilter,
-              accessibilityFilter: defaultDisabilitiesProperties,
-            })
-          }
+          const tabNavConfig = getTabNavigatorConfig(route, searchState)
           return (
             <StyledLi key={`key-tab-nav-${route.name}`}>
               {index > 0 ? <Spacer.Row numberOfSpaces={1.5} /> : null}

--- a/src/features/navigation/RootNavigator/Header/getTabNavigatorConfig.test.ts
+++ b/src/features/navigation/RootNavigator/Header/getTabNavigatorConfig.test.ts
@@ -1,0 +1,83 @@
+jest.mock('features/navigation/TabBar/helpers', () => ({
+  getTabNavConfig: jest.fn((name, config) => ({ name, config })),
+}))
+
+import { defaultDisabilitiesProperties } from 'features/accessibility/context/AccessibilityFiltersWrapper'
+import { getTabNavigatorConfig } from 'features/navigation/RootNavigator/Header/getTabNavigatorConfig'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { TabStateRoute } from 'features/navigation/TabBar/types'
+import { initialSearchState } from 'features/search/context/reducer'
+import { LocationMode } from 'libs/location/types'
+import { SuggestedPlace } from 'libs/place/types'
+
+describe('getTabNavigatorConfig', () => {
+  const mockGetTabNavConfig = getTabNavConfig as jest.Mock
+
+  beforeEach(() => {
+    mockGetTabNavConfig.mockClear()
+  })
+
+  describe('for non-SearchStackNavigator routes', () => {
+    const homeRoute: TabStateRoute = { name: 'Home', key: 'home-initial', isSelected: true }
+
+    it('should call getTabNavConfig with received route', () => {
+      getTabNavigatorConfig(homeRoute, initialSearchState)
+
+      expect(mockGetTabNavConfig).toHaveBeenCalledWith('Home')
+    })
+  })
+
+  describe('for SearchStackNavigator route', () => {
+    const searchRouteSelected: TabStateRoute = {
+      name: 'SearchStackNavigator',
+      key: 'search-initial',
+      isSelected: true,
+    }
+
+    const searchRouteNotSelected: TabStateRoute = {
+      name: 'SearchStackNavigator',
+      key: 'search-initial',
+      isSelected: false,
+    }
+
+    const mockedPlace: SuggestedPlace = {
+      label: 'Kourou',
+      info: 'Guyane',
+      type: 'street',
+      geolocation: { longitude: -52.669736, latitude: 5.16186 },
+    }
+
+    const mockedSearchState = {
+      ...initialSearchState,
+      accessibilityFilter: defaultDisabilitiesProperties,
+    }
+
+    it('should return config with empty params when route is not selected', () => {
+      getTabNavigatorConfig(searchRouteNotSelected, initialSearchState)
+
+      expect(mockGetTabNavConfig).toHaveBeenCalledWith('SearchStackNavigator', {
+        screen: 'SearchLanding',
+        params: {},
+      })
+    })
+
+    it('should return config with searchState reinitialized except for location when route is selected', () => {
+      const mockedLocation = {
+        locationType: LocationMode.AROUND_ME,
+        aroundRadius: 10,
+        place: mockedPlace,
+      }
+
+      getTabNavigatorConfig(searchRouteSelected, {
+        ...mockedSearchState,
+        query: 'hello',
+        locationFilter: mockedLocation,
+      })
+
+      expect(mockGetTabNavConfig).toHaveBeenCalledWith('SearchStackNavigator', {
+        screen: 'SearchLanding',
+        params: { ...mockedSearchState, query: '', locationFilter: mockedLocation },
+      })
+    })
+  })
+})

--- a/src/features/navigation/RootNavigator/Header/getTabNavigatorConfig.ts
+++ b/src/features/navigation/RootNavigator/Header/getTabNavigatorConfig.ts
@@ -1,0 +1,24 @@
+import { defaultDisabilitiesProperties } from 'features/accessibility/context/AccessibilityFiltersWrapper'
+import { getTabNavConfig } from 'features/navigation/TabBar/helpers'
+import { TabStateRoute } from 'features/navigation/TabBar/types'
+import { initialSearchState } from 'features/search/context/reducer'
+import { SearchState } from 'features/search/types'
+
+export const getTabNavigatorConfig = (route: TabStateRoute, searchState: SearchState) => {
+  if (route.name !== 'SearchStackNavigator') {
+    return getTabNavConfig(route.name)
+  }
+
+  const searchParams = route.isSelected
+    ? {
+        ...initialSearchState,
+        locationFilter: searchState.locationFilter,
+        accessibilityFilter: defaultDisabilitiesProperties,
+      }
+    : {}
+
+  return getTabNavConfig(route.name, {
+    screen: 'SearchLanding',
+    params: searchParams,
+  })
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33896

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [X] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [X] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [X] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome | <img width="774" alt="Capture d’écran 2025-01-24 à 15 45 02" src="https://github.com/user-attachments/assets/e076d4e1-5c2f-467a-865a-60bfd8654bd0" /> | <img width="753" alt="Capture d’écran 2025-01-24 à 17 39 21" src="https://github.com/user-attachments/assets/ca53a5a1-8a93-4a45-9e97-5fc74be81176" /> |


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
