### PR TITLE
(PC-34078) feat(Keychain): add more precise error logs

### DIFF
--- a/src/libs/keychain/keychain.native.test.ts
+++ b/src/libs/keychain/keychain.native.test.ts
@@ -3,69 +3,72 @@ import { env } from 'libs/environment/fixtures'
 
 import { getRefreshToken, saveRefreshToken } from './keychain'
 
-describe('saveRefreshToken()', () => {
-  it('should call setGenericPassword from Keychain', async () => {
-    expect.assertions(2)
+describe('keychain', () => {
+  describe('saveRefreshToken()', () => {
+    it('should call setGenericPassword from Keychain', async () => {
+      expect.assertions(2)
 
-    await saveRefreshToken('fake_access_token')
+      await saveRefreshToken('fake_access_token')
 
-    expect(Keychain.setGenericPassword).toHaveBeenCalledTimes(1)
-    expect(Keychain.setGenericPassword).toHaveBeenCalledWith(
-      'PASSCULTURE_REFRESH_TOKEN',
-      'fake_access_token',
-      { service: env.IOS_APP_ID }
-    )
-  })
-
-  it('should throws if access token is undefined', async () => {
-    expect.assertions(2)
-
-    await expect(saveRefreshToken(undefined)).rejects.toEqual(
-      Error('Aucun refresh token à sauvegarder')
-    )
-    expect(Keychain.setGenericPassword).not.toHaveBeenCalled()
-  })
-
-  it('should throw when setGenericPassword throws', async () => {
-    expect.assertions(1)
-
-    Keychain.setGenericPassword.mockImplementationOnce(async () => {
-      throw Error()
+      expect(Keychain.setGenericPassword).toHaveBeenCalledTimes(1)
+      expect(Keychain.setGenericPassword).toHaveBeenCalledWith(
+        'PASSCULTURE_REFRESH_TOKEN',
+        'fake_access_token',
+        { service: env.IOS_APP_ID }
+      )
     })
 
-    await expect(saveRefreshToken('fake_access_token')).rejects.toEqual(
-      Error('Keychain non accessible')
-    )
-  })
-})
+    it('should throws if access token is undefined', async () => {
+      expect.assertions(2)
 
-describe('getRefreshToken()', () => {
-  it('should call getGenericPassword from Keychain', async () => {
-    expect.assertions(2)
-
-    const refreshToken = await getRefreshToken()
-
-    expect(Keychain.getGenericPassword).toHaveBeenCalledTimes(1)
-    expect(refreshToken).toEqual('fake_access_token')
-  })
-
-  it('should return false when no credentials are found', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Keychain.getGenericPassword.mockImplementationOnce(async () => false as any)
-
-    const refreshToken = await getRefreshToken()
-
-    expect(Keychain.getGenericPassword).toHaveBeenCalledTimes(1)
-    expect(refreshToken).toBeNull()
-  })
-
-  it('should throw when getGenericPassword throws', async () => {
-    expect.assertions(1)
-
-    Keychain.getGenericPassword.mockImplementationOnce(async () => {
-      throw Error()
+      await expect(saveRefreshToken(undefined)).rejects.toEqual(
+        Error('[Keychain]: No refresh token to save')
+      )
+      expect(Keychain.setGenericPassword).not.toHaveBeenCalled()
     })
 
-    await expect(getRefreshToken()).rejects.toEqual(Error('Keychain non accessible'))
+    it('should throw when setGenericPassword throws', async () => {
+      expect.assertions(1)
+
+      Keychain.setGenericPassword.mockImplementationOnce(async () => {
+        throw Error()
+      })
+
+      await expect(saveRefreshToken('fake_access_token')).rejects.toEqual(
+        Error('[Keychain]: saving error: ')
+      )
+    })
+  })
+
+  describe('getRefreshToken()', () => {
+    it('should call getGenericPassword from Keychain', async () => {
+      expect.assertions(2)
+
+      await saveRefreshToken('fake_access_token')
+      const refreshToken = await getRefreshToken()
+
+      expect(Keychain.getGenericPassword).toHaveBeenCalledTimes(1)
+      expect(refreshToken).toEqual('fake_access_token')
+    })
+
+    it('should return false when no credentials are found', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      Keychain.getGenericPassword.mockImplementationOnce(async () => false as any)
+
+      const refreshToken = await getRefreshToken()
+
+      expect(Keychain.getGenericPassword).toHaveBeenCalledTimes(1)
+      expect(refreshToken).toBeNull()
+    })
+
+    it('should throw when getGenericPassword throws', async () => {
+      expect.assertions(1)
+
+      Keychain.getGenericPassword.mockImplementationOnce(async () => {
+        throw Error()
+      })
+
+      await expect(getRefreshToken()).rejects.toEqual(Error('[Keychain]: access error: '))
+    })
   })
 })

--- a/src/libs/keychain/keychain.ts
+++ b/src/libs/keychain/keychain.ts
@@ -8,22 +8,27 @@ const REFRESH_TOKEN_KEY = 'PASSCULTURE_REFRESH_TOKEN'
 // firebase sometimes overrides the default keychain credentials on iOS, see https://github.com/oblador/react-native-keychain/issues/363
 const keychainOptions = Platform.OS === 'ios' ? { service: env.IOS_APP_ID } : {}
 
+function handleKeychainError(error: unknown, operation: string): never {
+  const errorMessage = error instanceof Error ? error.message : 'unknown error'
+  throw Error(`[Keychain]: ${operation} error: ${errorMessage}`)
+}
+
 export async function saveRefreshToken(refreshToken: string | undefined): Promise<void> {
   if (!refreshToken) {
-    throw Error('Aucun refresh token à sauvegarder')
+    throw Error('No refresh token to save')
   }
   try {
     await Keychain.setGenericPassword(REFRESH_TOKEN_KEY, refreshToken, keychainOptions)
-  } catch {
-    throw Error('Keychain non accessible')
+  } catch (error: unknown) {
+    handleKeychainError(error, 'saving')
   }
 }
 
 export async function clearRefreshToken(): Promise<void> {
   try {
     await Keychain.resetGenericPassword(keychainOptions)
-  } catch {
-    throw Error('Keychain non accessible')
+  } catch (error: unknown) {
+    handleKeychainError(error, 'deletion')
   }
 }
 
@@ -34,7 +39,7 @@ export async function getRefreshToken(): Promise<string | null> {
       return credentials.password
     }
     return null
-  } catch {
-    throw Error('Keychain non accessible')
+  } catch (error: unknown) {
+    handleKeychainError(error, 'access')
   }
 }

--- a/src/libs/keychain/keychain.ts
+++ b/src/libs/keychain/keychain.ts
@@ -15,7 +15,7 @@ function handleKeychainError(error: unknown, operation: string): never {
 
 export async function saveRefreshToken(refreshToken: string | undefined): Promise<void> {
   if (!refreshToken) {
-    throw Error('No refresh token to save')
+    throw Error('[Keychain]: No refresh token to save')
   }
   try {
     await Keychain.setGenericPassword(REFRESH_TOKEN_KEY, refreshToken, keychainOptions)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34078

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
