### PR TITLE
(PC-34225) fix(search): add offerNativeCategories empty to initialSea…

### DIFF
--- a/src/features/home/components/modules/OffersModule.native.test.tsx
+++ b/src/features/home/components/modules/OffersModule.native.test.tsx
@@ -132,6 +132,9 @@ describe('OffersModule', () => {
           query: '',
           tags: [],
           timeRange: null,
+          offerGtlLabel: undefined,
+          offerGtlLevel: undefined,
+          offerNativeCategories: [],
         },
       },
     })

--- a/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.native.test.tsx
+++ b/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.native.test.tsx
@@ -227,8 +227,8 @@ describe('AutocompleteOfferItem component', () => {
           priceRange: mockSearchState.priceRange,
           searchId,
           isAutocomplete: true,
-          offerNativeCategories: undefined,
-          offerGenreTypes: undefined,
+          offerNativeCategories: [],
+          isFromHistory: undefined,
         },
       })
     })
@@ -408,7 +408,6 @@ describe('AutocompleteOfferItem component', () => {
             ...initialSearchState,
             query: mockHitWithOnlyCategory.query,
             offerCategories: [],
-            offerNativeCategories: undefined,
             locationFilter: mockSearchState.locationFilter,
             venue: mockSearchState.venue,
             priceRange: mockSearchState.priceRange,
@@ -471,7 +470,7 @@ describe('AutocompleteOfferItem component', () => {
             ...initialSearchState,
             query: mockHitWithOnlyCategory.query,
             offerCategories: [SearchGroupNameEnumv2.MUSIQUE],
-            offerNativeCategories: undefined,
+            offerNativeCategories: [],
             locationFilter: mockSearchState.locationFilter,
             priceRange: mockSearchState.priceRange,
             searchId,

--- a/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
+++ b/src/features/search/components/AutocompleteOfferItem/AutocompleteOfferItem.tsx
@@ -174,7 +174,7 @@ export function AutocompleteOfferItem({
       offerNativeCategories:
         shouldFilterOnNativeCategory && orderedNativeCategories[0]?.value
           ? [orderedNativeCategories[0].value]
-          : undefined,
+          : [],
       offerCategories: shouldShowCategory ? mostPopularCategory : [],
       isFromHistory: undefined,
       gtls: [],

--- a/src/features/search/components/SearchBox/SearchBox.native.test.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.native.test.tsx
@@ -562,7 +562,6 @@ describe('SearchBox component', () => {
               ...initialSearchState,
               query: queryText.trim(),
               offerCategories: [SearchGroupNameEnumv2.LIVRES],
-              offerNativeCategories: undefined,
               searchId,
               accessibilityFilter: {
                 isAudioDisabilityCompliant: undefined,
@@ -840,7 +839,6 @@ describe('SearchBox component', () => {
             ...initialSearchState,
             query: 'HP',
             offerCategories: BOOK_OFFER_CATEGORIES,
-            offerNativeCategories: undefined,
             gtls: [],
             priceRange: mockSearchState.priceRange,
             searchId,

--- a/src/features/search/components/SearchBox/SearchBox.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.tsx
@@ -239,7 +239,7 @@ export const SearchBox: React.FunctionComponent<Props> = ({
         partialSearchState = {
           ...partialSearchState,
           offerCategories,
-          offerNativeCategories: undefined,
+          offerNativeCategories: [],
           gtls: [],
         }
       }

--- a/src/features/search/context/reducer.ts
+++ b/src/features/search/context/reducer.ts
@@ -24,6 +24,7 @@ export const initialSearchState: SearchState = {
   tags: [],
   timeRange: null,
   venue: undefined,
+  offerNativeCategories: [],
 }
 
 export type Action =

--- a/src/features/search/helpers/getStringifySearchStateWithoutLocation/getStringifySearchStateWithoutLocation.native.test.ts
+++ b/src/features/search/helpers/getStringifySearchStateWithoutLocation/getStringifySearchStateWithoutLocation.native.test.ts
@@ -7,7 +7,7 @@ describe('getStringifySearchStateWithoutLocation', () => {
       getStringifySearchStateWithoutLocation(initialSearchState)
 
     expect(stringifySearchStateWithoutLocation).toEqual(
-      '{"date":null,"defaultMaxPrice":"","defaultMinPrice":"","gtls":[],"hitsPerPage":20,"isDigital":false,"offerCategories":[],"offerIsDuo":false,"offerIsFree":false,"offerSubcategories":[],"priceRange":null,"query":"","tags":[],"timeRange":null}'
+      '{"date":null,"defaultMaxPrice":"","defaultMinPrice":"","gtls":[],"hitsPerPage":20,"isDigital":false,"offerCategories":[],"offerIsDuo":false,"offerIsFree":false,"offerSubcategories":[],"priceRange":null,"query":"","tags":[],"timeRange":null,"offerNativeCategories":[]}'
     )
   })
 })

--- a/src/libs/algolia/fetchAlgolia/fetchMultipleOffers/helpers/adaptOffersPlaylistParameters.ts
+++ b/src/libs/algolia/fetchAlgolia/fetchMultipleOffers/helpers/adaptOffersPlaylistParameters.ts
@@ -58,6 +58,7 @@ export const adaptOffersPlaylistParameters = (
     offerGenreTypes,
     offerGtlLabel: parameters.gtlLabel,
     offerGtlLevel: parameters.gtlLevel,
+    offerNativeCategories: [],
   }
 }
 


### PR DESCRIPTION
…rchState which is used to reset params

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34225

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
