### PR TITLE
(PC-34259) feat(profile): removed subtitle for passForAll and updated…

### DIFF
--- a/__snapshots__/features/profile/pages/Profile.web.test.tsx.web-snap
+++ b/__snapshots__/features/profile/pages/Profile.web.test.tsx.web-snap
@@ -249,7 +249,7 @@ exports[`<Profile/> should render correctly on desktop 1`] = `
                 class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
                 dir="ltr"
               >
-                Identifie-toi pour bénéficier de ton crédit pass Culture
+                Identifie-toi pour découvrir des offres culturelles et bénéficier de ton crédit si tu as entre 15 et 18 ans.
               </div>
               <div
                 class="css-view-175oi2r r-height-z80fyv"
@@ -1407,7 +1407,7 @@ exports[`<Profile/> should render correctly on mobile browser 1`] = `
                 class="css-text-1rynq56 r-color-1rmcaf9 r-fontFamily-g6644c r-fontSize-cygvgh r-lineHeight-u6qrkm"
                 dir="ltr"
               >
-                Identifie-toi pour bénéficier de ton crédit pass Culture
+                Identifie-toi pour découvrir des offres culturelles et bénéficier de ton crédit si tu as entre 15 et 18 ans.
               </div>
               <div
                 class="css-view-175oi2r r-height-z80fyv"

--- a/src/features/profile/components/Header/HeaderWithGreyContainer/HeaderWithGreyContainer.tsx
+++ b/src/features/profile/components/Header/HeaderWithGreyContainer/HeaderWithGreyContainer.tsx
@@ -32,7 +32,9 @@ export const HeaderWithGreyContainer: FunctionComponent<PropsWithChildren> = ({
           <Spacer.Column numberOfSpaces={1} />
           {typeof subtitle === 'string' ? <TypoDS.Body>{subtitle}</TypoDS.Body> : subtitle}
         </SubtitleContainer>
-      ) : null}
+      ) : (
+        <Spacer.Column numberOfSpaces={6} />
+      )}
       {showForceUpdateBanner ? (
         <BannerContainer>
           <ForceUpdateBanner />

--- a/src/features/profile/components/Header/LoggedOutHeader/LoggedOutHeader.native.test.tsx
+++ b/src/features/profile/components/Header/LoggedOutHeader/LoggedOutHeader.native.test.tsx
@@ -6,6 +6,7 @@ import { defaultSettings } from 'features/auth/fixtures/fixtures'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
 import { analytics } from 'libs/analytics'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { render, userEvent, screen } from 'tests/utils'
 
 import { LoggedOutHeader } from './LoggedOutHeader'
@@ -72,6 +73,16 @@ describe('LoggedOutHeader', () => {
       const subtitle = 'Tu as 17 ou 18 ans\u00a0?'
 
       expect(screen.getByText(subtitle)).toBeOnTheScreen()
+    })
+
+    it('should not display subtitle with passForAll enabled', () => {
+      setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_PASS_FOR_ALL])
+
+      render(<LoggedOutHeader />)
+
+      const subtitle = 'Tu as 17 ou 18 ans\u00a0?'
+
+      expect(screen.queryByText(subtitle)).not.toBeOnTheScreen()
     })
   })
 })

--- a/src/features/profile/components/Header/LoggedOutHeader/LoggedOutHeader.native.test.tsx
+++ b/src/features/profile/components/Header/LoggedOutHeader/LoggedOutHeader.native.test.tsx
@@ -78,7 +78,7 @@ describe('LoggedOutHeader', () => {
     it('should not display subtitle with passForAll enabled', () => {
       setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_PASS_FOR_ALL])
 
-      render(<LoggedOutHeader />)
+      render(<LoggedOutHeader showForceUpdateBanner={false} />)
 
       const subtitle = 'Tu as 17 ou 18 ans\u00a0?'
 

--- a/src/features/profile/components/Header/LoggedOutHeader/LoggedOutHeader.tsx
+++ b/src/features/profile/components/Header/LoggedOutHeader/LoggedOutHeader.tsx
@@ -6,6 +6,8 @@ import { useSettingsContext } from 'features/auth/context/SettingsContext'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
 import { HeaderWithGreyContainer } from 'features/profile/components/Header/HeaderWithGreyContainer/HeaderWithGreyContainer'
 import { analytics } from 'libs/analytics'
+import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
+import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { ButtonWithLinearGradient } from 'ui/components/buttons/buttonWithLinearGradient/ButtonWithLinearGradient'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { getSpacing, Spacer, TypoDS } from 'ui/theme'
@@ -20,6 +22,7 @@ const onBeforeNavigate = () => {
 }
 
 export const LoggedOutHeader: FunctionComponent<Props> = ({ showForceUpdateBanner }) => {
+  const isPassForAllEnabled = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_PASS_FOR_ALL)
   const { data: settings } = useSettingsContext()
   const enableCreditV3 = settings?.wipEnableCreditV3
   const subtitle = `Tu as ${enableCreditV3 ? '17 ou 18' : 'entre 15 et 18'} ans\u00a0?`
@@ -30,8 +33,11 @@ export const LoggedOutHeader: FunctionComponent<Props> = ({ showForceUpdateBanne
     <HeaderWithGreyContainer
       showForceUpdateBanner={showForceUpdateBanner}
       title="Mon profil"
-      subtitle={subtitle}>
-      <TypoDS.Body>Identifie-toi pour bénéficier de ton crédit pass Culture</TypoDS.Body>
+      subtitle={isPassForAllEnabled ? undefined : subtitle}>
+      <TypoDS.Body>
+        Identifie-toi pour découvrir des offres culturelles et bénéficier de ton crédit si tu as
+        entre 15 et 18 ans.
+      </TypoDS.Body>
       <Spacer.Column numberOfSpaces={5} />
       <Container>
         <InternalTouchableLink

--- a/src/features/profile/components/Header/ProfileHeader/ProfileHeader.native.test.tsx
+++ b/src/features/profile/components/Header/ProfileHeader/ProfileHeader.native.test.tsx
@@ -82,6 +82,16 @@ describe('ProfileHeader', () => {
     )
   })
 
+  it('should not display subtitle with passForAll enabled', () => {
+    setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_PASS_FOR_ALL])
+
+    renderProfileHeader({ user: undefined })
+
+    const subtitle = 'Tu as 17 ou 18 ans\u00a0?'
+
+    expect(screen.queryByText(subtitle)).not.toBeOnTheScreen()
+  })
+
   it('should display the LoggedOutHeader if no user', () => {
     renderProfileHeader({
       featureFlags: {
@@ -94,7 +104,9 @@ describe('ProfileHeader', () => {
     })
 
     expect(
-      screen.getByText('Identifie-toi pour bénéficier de ton crédit pass Culture')
+      screen.getByText(
+        'Identifie-toi pour découvrir des offres culturelles et bénéficier de ton crédit si tu as entre 15 et 18 ans.'
+      )
     ).toBeOnTheScreen()
   })
 

--- a/src/features/profile/components/Header/ProfileHeader/ProfileHeader.native.test.tsx
+++ b/src/features/profile/components/Header/ProfileHeader/ProfileHeader.native.test.tsx
@@ -83,9 +83,16 @@ describe('ProfileHeader', () => {
   })
 
   it('should not display subtitle with passForAll enabled', () => {
-    setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_PASS_FOR_ALL])
-
-    renderProfileHeader({ user: undefined })
+    renderProfileHeader({
+      featureFlags: {
+        enableAchievements: false,
+        enableSystemBanner: true,
+        disableActivation: false,
+        showForceUpdateBanner: false,
+        enablePassForAll: true,
+      },
+      user: undefined,
+    })
 
     const subtitle = 'Tu as 17 ou 18 ans\u00a0?'
 
@@ -99,6 +106,7 @@ describe('ProfileHeader', () => {
         enableSystemBanner: true,
         disableActivation: false,
         showForceUpdateBanner: false,
+        enablePassForAll: false,
       },
       user: undefined,
     })
@@ -117,6 +125,7 @@ describe('ProfileHeader', () => {
         enableSystemBanner: true,
         disableActivation: false,
         showForceUpdateBanner: false,
+        enablePassForAll: false,
       },
       user,
     })
@@ -132,6 +141,7 @@ describe('ProfileHeader', () => {
         enableSystemBanner: true,
         disableActivation: false,
         showForceUpdateBanner: false,
+        enablePassForAll: false,
       },
       user,
     })
@@ -146,6 +156,7 @@ describe('ProfileHeader', () => {
         enableSystemBanner: true,
         disableActivation: false,
         showForceUpdateBanner: false,
+        enablePassForAll: false,
       },
       user: exBeneficiaryUser,
     })
@@ -168,6 +179,7 @@ describe('ProfileHeader', () => {
         enableSystemBanner: true,
         disableActivation: false,
         showForceUpdateBanner: false,
+        enablePassForAll: false,
       },
       user: notBeneficiaryUser,
     })
@@ -183,6 +195,7 @@ describe('ProfileHeader', () => {
         enableSystemBanner: false,
         disableActivation: false,
         showForceUpdateBanner: false,
+        enablePassForAll: false,
       },
       user: exUnderageBeneficiaryUser,
     })
@@ -200,6 +213,7 @@ const renderProfileHeader = ({
     enableSystemBanner: boolean
     disableActivation: boolean
     showForceUpdateBanner: boolean
+    enablePassForAll: boolean
   }
   user?: UserProfileResponse
 }) => render(reactQueryProviderHOC(<ProfileHeader featureFlags={featureFlags} user={user} />))

--- a/src/features/profile/components/Header/ProfileHeader/ProfileHeader.tsx
+++ b/src/features/profile/components/Header/ProfileHeader/ProfileHeader.tsx
@@ -18,6 +18,7 @@ type ProfileHeaderProps = {
     enableSystemBanner: boolean
     disableActivation: boolean
     showForceUpdateBanner: boolean
+    enablePassForAll: boolean
   }
   user?: UserProfileResponse
 }

--- a/src/features/profile/components/Header/ProfileHeader/ProfileHeader.web.test.tsx
+++ b/src/features/profile/components/Header/ProfileHeader/ProfileHeader.web.test.tsx
@@ -60,6 +60,7 @@ describe('ProfileHeader', () => {
           enableSystemBanner: true,
           disableActivation: false,
           showForceUpdateBanner: false,
+          enablePassForAll: false,
         }}
         user={user}
       />
@@ -76,6 +77,7 @@ describe('ProfileHeader', () => {
           enableSystemBanner: true,
           disableActivation: false,
           showForceUpdateBanner: false,
+          enablePassForAll: false,
         }}
         user={exBeneficiaryUser}
       />

--- a/src/features/profile/pages/Profile.tsx
+++ b/src/features/profile/pages/Profile.tsx
@@ -60,6 +60,7 @@ const OnlineProfile: React.FC = () => {
   const enableSystemBanner = useFeatureFlag(RemoteStoreFeatureFlags.WIP_APP_V2_SYSTEM_BLOCK)
   const disableActivation = useFeatureFlag(RemoteStoreFeatureFlags.DISABLE_ACTIVATION)
   const showForceUpdateBanner = useFeatureFlag(RemoteStoreFeatureFlags.SHOW_FORCE_UPDATE_BANNER)
+  const enablePassForAll = useFeatureFlag(RemoteStoreFeatureFlags.ENABLE_PASS_FOR_ALL)
 
   const { dispatch: favoritesDispatch } = useFavoritesState()
   const { isLoggedIn, user } = useAuthContext()
@@ -170,6 +171,7 @@ const OnlineProfile: React.FC = () => {
                 enableSystemBanner,
                 disableActivation,
                 showForceUpdateBanner,
+                enablePassForAll,
               }}
               user={user}
             />


### PR DESCRIPTION
… loggedOutHeader text

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34259

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
