### PR TITLE
(PC-33992) feat(chronicles): Chronicle page - desktop mode

### DIFF
--- a/src/features/chronicle/components/ChronicleCardList/ChronicleCardListBase.tsx
+++ b/src/features/chronicle/components/ChronicleCardList/ChronicleCardListBase.tsx
@@ -6,7 +6,7 @@ import React, {
   useMemo,
   useRef,
 } from 'react'
-import { FlatList, FlatListProps } from 'react-native'
+import { FlatList, FlatListProps, StyleProp, ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
 
 import { ChronicleCardData } from 'features/chronicle/type'
@@ -31,6 +31,7 @@ export type ChronicleCardListProps = Pick<
   cardWidth?: number
   separatorSize?: number
   headerComponent?: ReactElement
+  style?: StyleProp<ViewStyle>
 }
 
 const renderItem = ({ item, cardWidth }: { item: ChronicleCardData; cardWidth?: number }) => {
@@ -60,6 +61,7 @@ export const ChronicleCardListBase = forwardRef<
     snapToInterval,
     headerComponent,
     onContentSizeChange,
+    style,
     separatorSize = SEPARATOR_DEFAULT_VALUE,
   },
   ref
@@ -89,6 +91,7 @@ export const ChronicleCardListBase = forwardRef<
     <FlatList
       ref={listRef}
       data={data}
+      style={style}
       ListHeaderComponent={headerComponent}
       renderItem={({ item }) => renderItem({ item, cardWidth })}
       keyExtractor={keyExtractor}

--- a/src/features/chronicle/components/ChronicleOfferInfo/ChronicleOfferInfo.web.test.tsx
+++ b/src/features/chronicle/components/ChronicleOfferInfo/ChronicleOfferInfo.web.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Button } from 'react-native'
+
+import { render, screen } from 'tests/utils/web'
+
+import { ChronicleOfferInfo } from './ChronicleOfferInfo.web'
+
+describe('ChronicleOfferInfo', () => {
+  it('should render correctly', () => {
+    render(<ChronicleOfferInfo imageUrl="http://image.jpeg" price="12€" title="lorem ipsum" />)
+
+    expect(screen.getByText('12€')).toBeInTheDocument()
+    expect(screen.getByText('lorem ipsum')).toBeInTheDocument()
+  })
+
+  it('should render correctly with custom children', () => {
+    render(
+      <ChronicleOfferInfo imageUrl="http://image.jpeg" price="12€" title="lorem ipsum">
+        <Button testID="button" title="button" />
+      </ChronicleOfferInfo>
+    )
+
+    expect(screen.getByText('12€')).toBeInTheDocument()
+    expect(screen.getByText('lorem ipsum')).toBeInTheDocument()
+    expect(screen.getByTestId('button')).toBeInTheDocument()
+  })
+})

--- a/src/features/chronicle/components/ChronicleOfferInfo/ChronicleOfferInfo.web.tsx
+++ b/src/features/chronicle/components/ChronicleOfferInfo/ChronicleOfferInfo.web.tsx
@@ -1,0 +1,43 @@
+import React, { PropsWithChildren } from 'react'
+import { StyleProp, View, ViewStyle } from 'react-native'
+import styled from 'styled-components/native'
+
+import { useOfferImageContainerDimensions } from 'features/offer/helpers/useOfferImageContainerDimensions'
+import { FastImage } from 'libs/resizing-image-on-demand/FastImage'
+import { TypoDS, getSpacing } from 'ui/theme'
+
+type ChronicleOfferInfoProps = PropsWithChildren<{
+  imageUrl: string
+  title: string
+  price: string
+  style?: StyleProp<ViewStyle>
+}>
+
+export const ChronicleOfferInfo = ({
+  imageUrl,
+  title,
+  price,
+  style,
+  children,
+}: ChronicleOfferInfoProps) => {
+  const { imageStyle } = useOfferImageContainerDimensions()
+
+  return (
+    <View style={[style, { maxWidth: imageStyle.width }]}>
+      <FastImage style={imageStyle} url={imageUrl} />
+      <TextWrapper>
+        <TypoDS.Title3 numberOfLines={1}>{title}</TypoDS.Title3>
+        <StyledTitle3>{price}</StyledTitle3>
+      </TextWrapper>
+      {children}
+    </View>
+  )
+}
+
+const StyledTitle3 = styled(TypoDS.Title3)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))
+
+const TextWrapper = styled.View({
+  paddingVertical: getSpacing(4),
+})

--- a/src/features/chronicle/pages/Chronicles/Chronicles.web.test.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.web.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+
+import { useRoute } from '__mocks__/@react-navigation/native'
+import { offerChroniclesFixture } from 'features/chronicle/fixtures/offerChronicles.fixture'
+import { Chronicles } from 'features/chronicle/pages/Chronicles/Chronicles'
+import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
+import { subcategoriesDataTest } from 'libs/subcategories/fixtures/subcategoriesResponse'
+import { mockServer } from 'tests/mswServer'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
+import { render, screen } from 'tests/utils/web'
+
+useRoute.mockReturnValue({
+  params: {
+    offerId: offerResponseSnap.id,
+  },
+})
+
+jest.mock('libs/firebase/analytics/analytics')
+jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
+jest.mock('features/navigation/helpers/openUrl')
+
+describe('Chronicles', () => {
+  beforeEach(() => {
+    mockServer.getApi(`/v2/offer/${offerResponseSnap.id}`, offerResponseSnap)
+    mockServer.getApi(`/v1/offer/${offerResponseSnap.id}/chronicles`, offerChroniclesFixture)
+    mockServer.getApi('/v1/subcategories/v2', subcategoriesDataTest)
+  })
+
+  it('should render correctly in mobile', async () => {
+    render(reactQueryProviderHOC(<Chronicles />), {
+      theme: {
+        isDesktopViewport: false,
+      },
+    })
+
+    expect(await screen.findByText('Tous les avis')).toBeInTheDocument()
+    expect(screen.queryByText("Réserver l'offre")).not.toBeInTheDocument()
+    expect(screen.getAllByTestId(/chronicle-*/).length).toBeGreaterThan(0)
+  })
+
+  it('should render correctly in desktop', async () => {
+    render(reactQueryProviderHOC(<Chronicles />), {
+      theme: {
+        isDesktopViewport: true,
+      },
+    })
+
+    expect(await screen.findByText('Tous les avis')).toBeInTheDocument()
+    expect(screen.getByText('Sous les étoiles de Paris - VF')).toBeInTheDocument()
+    expect(screen.getByText('Dès 5,00 €')).toBeInTheDocument()
+    expect(screen.getByTestId('booking-button')).toBeInTheDocument()
+    expect(screen.getAllByTestId(/chronicle-*/).length).toBeGreaterThan(0)
+  })
+})

--- a/src/features/chronicle/pages/Chronicles/Chronicles.web.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.web.tsx
@@ -1,0 +1,135 @@
+import { useRoute } from '@react-navigation/native'
+import React, { FunctionComponent } from 'react'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import styled, { useTheme } from 'styled-components/native'
+
+import { SubcategoryIdEnumv2 } from 'api/gen'
+import { useAuthContext } from 'features/auth/context/AuthContext'
+import { offerChroniclesToChronicleCardData } from 'features/chronicle/adapters/offerChroniclesToChronicleCardData/offerChroniclesToChronicleCardData'
+import { useChronicles } from 'features/chronicle/api/useChronicles/useChronicles'
+import { ChronicleCardList } from 'features/chronicle/components/ChronicleCardList/ChronicleCardList'
+import { ChronicleOfferInfo } from 'features/chronicle/components/ChronicleOfferInfo/ChronicleOfferInfo.web'
+import { ChroniclesHeader } from 'features/chronicle/components/ChroniclesHeader/ChroniclesHeader'
+import { ChroniclesWebMetaHeader } from 'features/chronicle/components/ChroniclesWebMetaHeader/ChroniclesWebMetaHeader'
+import { ChronicleCardData } from 'features/chronicle/type'
+import { UseRouteType } from 'features/navigation/RootNavigator/types'
+import { useGoBack } from 'features/navigation/useGoBack'
+import { useOffer } from 'features/offer/api/useOffer'
+import { OfferCTAButton } from 'features/offer/components/OfferCTAButton/OfferCTAButton'
+import { getOfferPrices } from 'features/offer/helpers/getOfferPrice/getOfferPrice'
+import { useOfferBatchTracking } from 'features/offer/helpers/useOfferBatchTracking/useOfferBatchTracking'
+import { getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
+import { useSubcategoriesMapping } from 'libs/subcategories'
+import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
+import { useGetPacificFrancToEuroRate } from 'shared/exchangeRates/useGetPacificFrancToEuroRate'
+import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
+import { TypoDS, getSpacing } from 'ui/theme'
+
+export const Chronicles: FunctionComponent = () => {
+  const route = useRoute<UseRouteType<'Chronicles'>>()
+  const offerId = route.params?.offerId
+  const { goBack } = useGoBack('Offer', { id: offerId })
+  const { data: offer } = useOffer({ offerId })
+  const subcategoriesMapping = useSubcategoriesMapping()
+
+  const { data: chronicleCardsData } = useChronicles<ChronicleCardData[]>({
+    offerId,
+    select: ({ chronicles }) => offerChroniclesToChronicleCardData(chronicles),
+  })
+
+  const { user } = useAuthContext()
+  const { appBarHeight, isDesktopViewport } = useTheme()
+  const { top } = useSafeAreaInsets()
+  const headerHeight = appBarHeight + top
+  const subcategory = offer
+    ? subcategoriesMapping[offer.subcategoryId]
+    : subcategoriesMapping[SubcategoryIdEnumv2.CONCERT]
+
+  const { headerTransition, onScroll } = useOpacityTransition()
+  const { trackEventHasSeenOfferOnce } = useOfferBatchTracking(subcategory.id)
+  const prices = getOfferPrices(offer?.stocks ?? [])
+  const currency = useGetCurrencyToDisplay()
+  const euroToPacificFrancRate = useGetPacificFrancToEuroRate()
+
+  const displayedPrice = getDisplayedPrice(
+    prices,
+    currency,
+    euroToPacificFrancRate,
+    offer?.isDuo && user?.isBeneficiary,
+    { fractionDigits: 2 }
+  )
+
+  if (!offer || !chronicleCardsData) return null
+
+  const title = `Tous les avis sur "${offer.name}"`
+
+  const listComponent = (
+    <StyledChronicleCardList
+      data={chronicleCardsData}
+      onScroll={onScroll}
+      paddingTop={headerHeight}
+      headerComponent={<StyledTitle2>Tous les avis</StyledTitle2>}
+    />
+  )
+
+  return (
+    <Container>
+      <ChroniclesWebMetaHeader title={title} />
+      <ChroniclesHeader handleGoBack={goBack} headerTransition={headerTransition} title={title} />
+
+      {isDesktopViewport ? (
+        <FullFlexRow>
+          <StyledChronicleOfferInfo
+            imageUrl={offer.images?.[0]?.url ?? ''}
+            title={offer.name}
+            price={displayedPrice}
+            paddingTop={headerHeight}>
+            <OfferCTAButton
+              offer={offer}
+              subcategory={subcategoriesMapping[offer.subcategoryId]}
+              trackEventHasSeenOfferOnce={trackEventHasSeenOfferOnce}
+            />
+          </StyledChronicleOfferInfo>
+          {listComponent}
+        </FullFlexRow>
+      ) : (
+        listComponent
+      )}
+    </Container>
+  )
+}
+
+const StyledTitle2 = styled(TypoDS.Title2)({
+  marginBottom: getSpacing(6),
+})
+
+const FullFlexView = styled.View({
+  flex: 1,
+})
+
+const FullFlexRow = styled(FullFlexView)({
+  flexDirection: 'row',
+  columnGap: getSpacing(18),
+})
+
+const Container = styled(FullFlexView)(({ theme }) => ({
+  paddingHorizontal: theme.contentPage.marginHorizontal,
+  paddingTop: theme.contentPage.marginVertical,
+}))
+
+const StyledChronicleCardList = styled(ChronicleCardList).attrs<{ paddingTop: number }>(
+  ({ paddingTop }) => ({
+    horizontal: false,
+    separatorSize: 6,
+    contentContainerStyle: { paddingVertical: paddingTop },
+  })
+)<{ paddingTop: number }>({
+  flex: 1,
+})
+
+const StyledChronicleOfferInfo = styled(ChronicleOfferInfo)<{ paddingTop: number }>(
+  ({ paddingTop }) => ({
+    paddingTop,
+    flex: 1,
+  })
+)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33992

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

https://github.com/user-attachments/assets/076f3b55-9ed8-4b78-ad8d-665bd70599da



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
