### PR TITLE
(BSR) feat(offer): chronicle section title in desktop web

### DIFF
--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
@@ -23,7 +23,7 @@ export const ChronicleCard: FunctionComponent<Props> = ({
   cardWidth,
 }) => {
   return (
-    <Container gap={3} testID={`chronicle-${id.toString()}`} width={cardWidth}>
+    <Container gap={3} testID={`chronicle-card-${id.toString()}`} width={cardWidth}>
       <InfoHeader
         title={title}
         subtitle={subtitle}

--- a/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.native.test.tsx
+++ b/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.native.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+
+import { chroniclesSnap } from 'features/chronicle/fixtures/chroniclesSnap'
+import { render, screen, userEvent } from 'tests/utils'
+
+import { ChronicleSection } from './ChronicleSection'
+
+const mockNavigate = jest.fn()
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({ navigate: mockNavigate, push: jest.fn() }),
+}))
+
+describe('ChroniclesSection', () => {
+  const user = userEvent.setup()
+
+  it('should render correctly', () => {
+    render(
+      <ChronicleSection
+        title="title"
+        ctaLabel="Voir tous les avis"
+        data={chroniclesSnap}
+        subtitle="subtitle"
+        navigateTo={{ screen: 'Offer' }}
+      />
+    )
+
+    expect(screen.getByText('title')).toBeOnTheScreen()
+    expect(screen.getByText('subtitle')).toBeOnTheScreen()
+    expect(screen.getByText('Voir tous les avis')).toBeOnTheScreen()
+    expect(screen.getAllByTestId(/chronicle-card-*/).length).toBeGreaterThan(0)
+  })
+
+  it('should navigate', async () => {
+    jest.useFakeTimers()
+    render(
+      <ChronicleSection
+        title="title"
+        ctaLabel="Voir tous les avis"
+        data={chroniclesSnap}
+        subtitle="subtitle"
+        navigateTo={{ screen: 'Offer' }}
+      />
+    )
+
+    await user.press(screen.getByText('Voir tous les avis'))
+
+    expect(mockNavigate.mock.calls[0][0]).toBe('Offer')
+
+    jest.useRealTimers()
+  })
+})

--- a/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.tsx
+++ b/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.tsx
@@ -1,0 +1,3 @@
+import { ChronicleSectionBase } from 'features/offer/components/OfferContent/ChronicleSection/ChronicleSectionBase'
+
+export const ChronicleSection = ChronicleSectionBase

--- a/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.web.test.tsx
+++ b/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.web.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+
+import { chroniclesSnap } from 'features/chronicle/fixtures/chroniclesSnap'
+import { fireEvent, render, screen } from 'tests/utils/web'
+
+import { ChronicleSection } from './ChronicleSection'
+
+const mockNavigate = jest.fn()
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({ navigate: mockNavigate, push: jest.fn() }),
+}))
+
+describe('ChroniclesSection', () => {
+  it('should render correctly in mobile', () => {
+    render(
+      <ChronicleSection
+        title="title"
+        ctaLabel="Voir tous les avis"
+        data={chroniclesSnap}
+        subtitle="subtitle"
+        navigateTo={{ screen: 'Offer' }}
+      />
+    )
+
+    expect(screen.getByText('title')).toBeInTheDocument()
+    expect(screen.getByText('subtitle')).toBeInTheDocument()
+    expect(screen.getByText('Voir tous les avis')).toBeInTheDocument()
+    expect(screen.getAllByTestId(/chronicle-card-*/).length).toBeGreaterThan(0)
+  })
+
+  it('should render correctly in desktop', () => {
+    render(
+      <ChronicleSection
+        title="title"
+        ctaLabel="Voir tous les avis"
+        data={chroniclesSnap}
+        subtitle="subtitle"
+        navigateTo={{ screen: 'Offer' }}
+      />,
+      { theme: { isDesktopViewport: true } }
+    )
+
+    expect(screen.getByText('title')).toBeInTheDocument()
+    expect(screen.getByText('subtitle')).toBeInTheDocument()
+    expect(screen.getByText('Voir tous les avis')).toBeInTheDocument()
+    expect(screen.getAllByTestId(/chronicle-card-*/).length).toBeGreaterThan(0)
+  })
+
+  it('should navigate', async () => {
+    render(
+      <ChronicleSection
+        title="title"
+        ctaLabel="Voir tous les avis"
+        data={chroniclesSnap}
+        subtitle="subtitle"
+        navigateTo={{ screen: 'Offer' }}
+      />
+    )
+
+    // Have to use fireEvent here, otherwise test is flaky :/
+    await fireEvent.click(screen.getByText('Voir tous les avis'))
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.web.tsx
+++ b/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.web.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { StyleSheet, View } from 'react-native'
+import { useTheme } from 'styled-components'
+import styled from 'styled-components/native'
+
+import { ChronicleCardList } from 'features/chronicle/components/ChronicleCardList/ChronicleCardList'
+import { CHRONICLE_CARD_WIDTH } from 'features/chronicle/constant'
+import { ChronicleSectionBase } from 'features/offer/components/OfferContent/ChronicleSection/ChronicleSectionBase'
+import { ButtonSecondaryBlack } from 'ui/components/buttons/ButtonSecondaryBlack'
+import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
+import { Show } from 'ui/svg/icons/Show'
+import { getSpacing, TypoDS } from 'ui/theme'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+
+import { ChronicleSectionProps } from './types'
+
+export const ChronicleSection = (props: ChronicleSectionProps) => {
+  const { isDesktopViewport } = useTheme()
+  const { data, title, subtitle, ctaLabel, navigateTo, style } = props
+
+  return isDesktopViewport ? (
+    <View style={style}>
+      <Gutter>
+        <Row>
+          <StyledTitle3 {...getHeadingAttrs(3)}>{title}</StyledTitle3>
+          <InternalTouchableLink
+            as={ButtonSecondaryBlack}
+            icon={Show}
+            wording={ctaLabel}
+            navigateTo={navigateTo}
+            // If i use styled-component in that case (i.e using "as" prop), i have an error in web :'(
+            // eslint-disable-next-line react-native/no-inline-styles
+            style={{ width: 'auto', borderWidth: 0, paddingLeft: getSpacing(2) }}
+          />
+        </Row>
+        {subtitle ? <StyledSubtitle>{subtitle}</StyledSubtitle> : null}
+      </Gutter>
+      <StyledChronicleCardlist data={data} />
+    </View>
+  ) : (
+    <ChronicleSectionBase {...props} />
+  )
+}
+
+const StyledChronicleCardlist = styled(ChronicleCardList).attrs(({ theme }) => ({
+  contentContainerStyle: {
+    paddingHorizontal: theme.contentPage.marginHorizontal,
+    paddingVertical: theme.contentPage.marginHorizontal,
+  },
+  cardWidth: CHRONICLE_CARD_WIDTH,
+  snapToInterval: CHRONICLE_CARD_WIDTH,
+}))``
+
+const Gutter = styled.View(({ theme }) => ({
+  paddingHorizontal: theme.contentPage.marginHorizontal,
+}))
+
+const Row = styled.View({ flexDirection: 'row', alignItems: 'center' })
+
+const StyledTitle3 = styled(TypoDS.Title3)(({ theme }) => ({
+  borderRightWidth: StyleSheet.hairlineWidth,
+  borderRightColor: theme.colors.black,
+  paddingRight: getSpacing(2),
+}))
+
+const StyledSubtitle = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSectionBase.tsx
+++ b/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSectionBase.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { View } from 'react-native'
+import styled from 'styled-components/native'
+
+import { ChronicleCardList } from 'features/chronicle/components/ChronicleCardList/ChronicleCardList'
+import { CHRONICLE_CARD_WIDTH } from 'features/chronicle/constant'
+import { ButtonSecondaryBlack } from 'ui/components/buttons/ButtonSecondaryBlack'
+import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
+import { TypoDS } from 'ui/theme'
+import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+
+import { ChronicleSectionProps } from './types'
+
+export const ChronicleSectionBase = ({
+  data,
+  title,
+  subtitle,
+  ctaLabel,
+  navigateTo,
+  style,
+}: ChronicleSectionProps) => {
+  return (
+    <View style={style}>
+      <Gutter>
+        <TypoDS.Title3 {...getHeadingAttrs(3)}>{title}</TypoDS.Title3>
+        {subtitle ? <StyledSubtitle>{subtitle}</StyledSubtitle> : null}
+      </Gutter>
+      <StyledChronicleCardlist data={data} />
+      <Gutter>
+        <InternalTouchableLink
+          as={ButtonSecondaryBlack}
+          wording={ctaLabel}
+          navigateTo={navigateTo}
+          // If i use styled-component in that case (i.e using "as" prop), i have an error in web :'(
+          // eslint-disable-next-line react-native/no-inline-styles
+          style={{ alignSelf: 'center' }}
+        />
+      </Gutter>
+    </View>
+  )
+}
+
+const StyledChronicleCardlist = styled(ChronicleCardList).attrs(({ theme }) => ({
+  contentContainerStyle: {
+    paddingHorizontal: theme.contentPage.marginHorizontal,
+    paddingVertical: theme.contentPage.marginHorizontal,
+  },
+  cardWidth: CHRONICLE_CARD_WIDTH,
+  snapToInterval: CHRONICLE_CARD_WIDTH,
+}))``
+
+const Gutter = styled.View(({ theme }) => ({
+  paddingHorizontal: theme.contentPage.marginHorizontal,
+}))
+
+const StyledSubtitle = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
+  color: theme.colors.greyDark,
+}))

--- a/src/features/offer/components/OfferContent/ChronicleSection/types.ts
+++ b/src/features/offer/components/OfferContent/ChronicleSection/types.ts
@@ -1,0 +1,13 @@
+import { StyleProp, ViewStyle } from 'react-native'
+
+import { ChronicleCardData } from 'features/chronicle/type'
+import { InternalNavigationProps } from 'ui/components/touchableLink/types'
+
+export type ChronicleSectionProps = {
+  data: ChronicleCardData[]
+  title: string
+  subtitle?: string
+  ctaLabel: string
+  navigateTo: InternalNavigationProps['navigateTo']
+  style?: StyleProp<ViewStyle>
+}

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -633,9 +633,8 @@ describe('<OfferContent />', () => {
         renderOfferContent({
           offer: { ...offerResponseSnap, subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER },
         })
-        await screen.findByText("L'avis du book club")
 
-        expect(screen.getByText('Voir tous les avis')).toBeOnTheScreen()
+        expect(await screen.findByText('Voir tous les avis')).toBeOnTheScreen()
       })
 
       it('should navigate to chronicles page when pressing "Voir tous les avis" button', async () => {

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -18,11 +18,10 @@ import { useQueryClient } from 'react-query'
 import styled from 'styled-components/native'
 
 import { OfferImageResponse, OfferResponseV2 } from 'api/gen'
-import { ChronicleCardList } from 'features/chronicle/components/ChronicleCardList/ChronicleCardList'
-import { CHRONICLE_CARD_WIDTH } from 'features/chronicle/constant'
 import { ChronicleCardData } from 'features/chronicle/type'
 import { OfferBody } from 'features/offer/components/OfferBody/OfferBody'
 import { CineContentCTA } from 'features/offer/components/OfferCine/CineContentCTA'
+import { ChronicleSection } from 'features/offer/components/OfferContent/ChronicleSection/ChronicleSection'
 import { useOfferCTA } from 'features/offer/components/OfferContent/OfferCTAProvider'
 import { OfferHeader } from 'features/offer/components/OfferHeader/OfferHeader'
 import { OfferImageContainer } from 'features/offer/components/OfferImageContainer/OfferImageContainer'
@@ -39,11 +38,8 @@ import { QueryKeys } from 'libs/queryKeys'
 import { getImagesUrls } from 'shared/getImagesUrls/getImagesUrls'
 import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
 import { AnchorProvider } from 'ui/components/anchor/AnchorContext'
-import { ButtonSecondaryBlack } from 'ui/components/buttons/ButtonSecondaryBlack'
 import { SectionWithDivider } from 'ui/components/SectionWithDivider'
-import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
-import { getSpacing, TypoDS } from 'ui/theme'
-import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
+import { getSpacing } from 'ui/theme'
 
 type OfferContentBaseProps = OfferContentProps & {
   BodyWrapper: FunctionComponent
@@ -161,19 +157,14 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
             />
           </BodyWrapper>
           {chronicles?.length ? (
-            <StyledSectionWithDivider visible gap={8}>
-              <ChroniclesTitle {...getHeadingAttrs(3)}>{"L'avis du book club"}</ChroniclesTitle>
-              <StyledChronicleCardlist data={chronicles} />
-              <Gutter>
-                <InternalTouchableLink
-                  as={ButtonSecondaryBlack}
-                  wording="Voir tous les avis"
-                  navigateTo={{ screen: 'Chronicles', params: { offerId: offer.id } }}
-                  // If i use styled-component in that case (i.e using "as" prop), i have an error in web :'(
-                  // eslint-disable-next-line react-native/no-inline-styles
-                  style={{ alignSelf: 'center' }}
-                />
-              </Gutter>
+            <StyledSectionWithDivider visible testID="chronicles-section" gap={8}>
+              <ChronicleSection
+                title="L’avis du book club"
+                ctaLabel="Voir tous les avis"
+                subtitle="Des avis de jeunes passionnés sélectionnés par le pass Culture&nbsp;!"
+                data={chronicles}
+                navigateTo={{ screen: 'Chronicles', params: { offerId: offer.id } }}
+              />
             </StyledSectionWithDivider>
           ) : null}
           <StyledSectionWithDivider
@@ -202,23 +193,6 @@ const scrollIndicatorInsets = { right: 1 }
 const Container = styled.View({
   flex: 1,
 })
-
-const StyledChronicleCardlist = styled(ChronicleCardList).attrs(({ theme }) => ({
-  contentContainerStyle: {
-    paddingHorizontal: theme.contentPage.marginHorizontal,
-    paddingVertical: theme.contentPage.marginHorizontal,
-  },
-  cardWidth: CHRONICLE_CARD_WIDTH,
-  snapToInterval: CHRONICLE_CARD_WIDTH,
-}))``
-
-const ChroniclesTitle = styled(TypoDS.Title3)(({ theme }) => ({
-  paddingHorizontal: theme.contentPage.marginHorizontal,
-}))
-
-const Gutter = styled.View(({ theme }) => ({
-  paddingHorizontal: theme.contentPage.marginHorizontal,
-}))
 
 const ScrollViewContainer = React.memo(
   styled(IntersectionObserverScrollView)({

--- a/src/features/offer/pages/Offer/Offer.native.test.tsx
+++ b/src/features/offer/pages/Offer/Offer.native.test.tsx
@@ -90,7 +90,7 @@ describe('<Offer />', () => {
 
     renderOfferPage({ mockOffer: offerResponseSnap })
 
-    expect(await screen.findByText("L'avis du book club")).toBeOnTheScreen()
+    expect(await screen.findByText('L’avis du book club')).toBeOnTheScreen()
   })
 
   it('should display offer placeholder on init', async () => {


### PR DESCRIPTION
Faire en sorte d'être raccord avec le design pour afficher la section critique du book club
En lien avec le ticket https://passculture.atlassian.net/browse/PC-33991

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

Web Mobile

<img width="322" alt="image" src="https://github.com/user-attachments/assets/abc1a9c9-a310-4986-aef4-53cf0359e2ba" />


Web Desktop

<img width="1216" alt="image" src="https://github.com/user-attachments/assets/e9c32511-bfe9-4441-b35b-8c7371366066" />


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
