### PR TITLE
(BSR) fix(ci): adjust cron to be triggered once

### DIFF
--- a/.github/workflows/dev_on_schedule_run_e2e_android.yml
+++ b/.github/workflows/dev_on_schedule_run_e2e_android.yml
@@ -3,7 +3,7 @@ name: '[Daily] Run E2E tests on Android'
 on:
   schedule:
     # 00:00 Paris in UTC
-    - cron: '* 23 * * *'
+    - cron: '0 23 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
Le cron se lance actuellement une fois toutes les minutes, il faut le lancer une fois à minuit: https://github.com/pass-culture/pass-culture-app-native/actions/workflows/dev_on_schedule_run_e2e_android.yml
