### PR TITLE
(PC-34297) fix(Badge): center text

### DIFF
--- a/__snapshots__/features/bookings/pages/Bookings/Bookings.native.test.tsx.native-snap
+++ b/__snapshots__/features/bookings/pages/Bookings/Bookings.native.test.tsx.native-snap
@@ -969,7 +969,7 @@ exports[`Bookings should render correctly 1`] = `
                           "alignSelf": "center",
                           "backgroundColor": "#eb0055",
                           "borderColor": "#ffffff",
-                          "borderRadius": 12,
+                          "borderRadius": 16,
                           "borderStyle": "solid",
                           "borderWidth": 1,
                         },
@@ -994,7 +994,7 @@ exports[`Bookings should render correctly 1`] = `
                               "color": "#ffffff",
                               "fontFamily": "Montserrat-SemiBold",
                               "fontSize": 12,
-                              "lineHeight": 19.2,
+                              "lineHeight": 16,
                               "textAlign": "center",
                             },
                           ]

--- a/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/pages/SearchResults/SearchResults.native.test.tsx.native-snap
@@ -414,7 +414,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                       "alignSelf": "center",
                       "backgroundColor": "#eb0055",
                       "borderColor": "#ffffff",
-                      "borderRadius": 12,
+                      "borderRadius": 16,
                       "borderStyle": "solid",
                       "borderWidth": 1,
                     },
@@ -446,7 +446,7 @@ exports[`<SearchResults/> should render SearchResults 1`] = `
                           "color": "#ffffff",
                           "fontFamily": "Montserrat-SemiBold",
                           "fontSize": 12,
-                          "lineHeight": 19.2,
+                          "lineHeight": 16,
                           "textAlign": "center",
                         },
                       ]

--- a/src/ui/components/Badge/Badge.tsx
+++ b/src/ui/components/Badge/Badge.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components/native'
 
 import { getSpacing, TypoDS } from 'ui/theme'
 
+const BADGE_SIZE = getSpacing(4)
+
 type Props = {
   value: number
   testID?: string
@@ -22,17 +24,18 @@ const Container = styled.View(({ theme }) => ({
   borderWidth: getSpacing(0.25),
   borderStyle: 'solid',
   borderColor: theme.colors.white,
-  borderRadius: getSpacing(3),
+  borderRadius: BADGE_SIZE,
   backgroundColor: theme.colors.primary,
 }))
 
 const Wrapper = styled.View({
-  minWidth: getSpacing(4),
-  height: getSpacing(4),
+  minWidth: BADGE_SIZE,
+  height: BADGE_SIZE,
   paddingHorizontal: getSpacing(0.5),
 })
 
 const Caption = styled(TypoDS.BodyAccentXs)(({ theme }) => ({
   textAlign: 'center',
   color: theme.colors.white,
+  lineHeight: `${BADGE_SIZE}px`,
 }))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34297

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots
iOS / Android

<img width="745" alt="image" src="https://github.com/user-attachments/assets/593b6c0a-dbb9-4001-9d42-d4c4ddcf3685" />

Web

<img width="1506" alt="image" src="https://github.com/user-attachments/assets/db61d21c-4de0-4bcc-b5fd-98e30b647eba" />



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
