### PR TITLE
(PC-34153) fix(ChronicleCard): drop shadow

### DIFF
--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
@@ -47,7 +47,7 @@ const Container = styled(ViewGap)<{ width?: number }>(({ theme, width }) => ({
   backgroundColor: theme.colors.white,
   ...getShadow({
     shadowOffset: { width: 0, height: getSpacing(1) },
-    shadowRadius: getSpacing(6),
+    shadowRadius: getSpacing(1),
     shadowColor: theme.colors.black,
     shadowOpacity: 0.15,
   }),

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -160,9 +160,9 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
           {chronicles?.length ? (
             <StyledSectionWithDivider visible testID="chronicles-section" gap={8}>
               <ChronicleSection
-                title="L’avis du book club"
+                title="La reco du Book Club"
                 ctaLabel="Voir tous les avis"
-                subtitle="Des avis de jeunes passionnés sélectionnés par le pass Culture&nbsp;!"
+                subtitle="Notre communauté de lecteurs te partagent leurs avis sur ce livre&nbsp;!"
                 data={chronicles}
                 navigateTo={{ screen: 'Chronicles', params: { offerId: offer.id } }}
               />

--- a/src/features/offer/pages/Offer/Offer.native.test.tsx
+++ b/src/features/offer/pages/Offer/Offer.native.test.tsx
@@ -90,7 +90,7 @@ describe('<Offer />', () => {
 
     renderOfferPage({ mockOffer: offerResponseSnap })
 
-    expect(await screen.findByText('L’avis du book club')).toBeOnTheScreen()
+    expect(await screen.findByText('La reco du Book Club')).toBeOnTheScreen()
   })
 
   it('should display offer placeholder on init', async () => {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34153

Fix sur les ombres portées des cards dans les chroniques du Book Club. 
Ticket fait en MOB

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots
iOS : 

<img width="375" alt="image" src="https://github.com/user-attachments/assets/25faab8f-c9de-4f21-b7fa-1ea555dc33d0" />

<img width="371" alt="image" src="https://github.com/user-attachments/assets/1f3f93c9-2fb6-4696-94d0-1aba1ddd7de6" />

Android : 

<img width="351" alt="image" src="https://github.com/user-attachments/assets/87dadfc1-fe3a-4fc1-8adf-1bf7e39ed645" />

<img width="365" alt="image" src="https://github.com/user-attachments/assets/e47ab01b-3898-4bbf-97e3-530f3887c765" />

Web :

<img width="1496" alt="image" src="https://github.com/user-attachments/assets/1620ad22-b48b-4812-88d5-be548ee6b819" />








[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
