### PR TITLE
(PC-34322) feat(web): bundle split achievement illustrations

### DIFF
--- a/doc/development/general-info-web.md
+++ b/doc/development/general-info-web.md
@@ -42,6 +42,14 @@ Lastly, we have to define `__DEV__`.
 
 ### Plugins
 
+You can run the `vite-bundle-analyzer` by adding a local environnement variable like this:
+
+```sh
+export ANALYZE_BUNDLE=toto yarn vite build
+```
+
+You can set `ANALYZE_BUNDLE` to any value, as long as it's set it will start the bundler analyzer at `localhost:8888`. It can be useful to see what assets/files are bulking up your web app, and use this information to split files from the main bundle with dynamic imports (using `Suspense` and `lazy` from `react`).
+
 We of course use the `@vitejs/plugin-react` plugin. It enables fast refresh in development and sets a custom Babel configuration.
 
 Then we wrote a custom plugin to handle libraries with files with a `.js` extension that actually contained `jsx` components. This plugin is only necessary during builds, so we set `apply: 'build'` in the plugin's configuration.

--- a/package.json
+++ b/package.json
@@ -326,6 +326,7 @@
     "typescript": "5.0.4",
     "url-loader": "^4.1.1",
     "vite": "^5.3.1",
+    "vite-bundle-analyzer": "^0.16.2",
     "vite-plugin-html": "^3.2.2"
   },
   "resolutions": {

--- a/scripts/dead_code_snapshot.txt
+++ b/scripts/dead_code_snapshot.txt
@@ -1,4 +1,4 @@
-vite.config.js:32 - default
+vite.config.js:33 - default
 src/features/venueMap/constant.ts:22 - satisfies
 src/features/venueMap/constant.ts:22 - Record
 src/shared/credits/defaultCreditByAge.ts:22 - satisfies

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.dynamicAnalysis=reuseReports
 sonar.sources=src
 sonar.javascript.jstest.reportsPath=coverage
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.exclusions=**/*.test.*,**/*.stories.*,**/*.types.ts,src/**/*.d.ts,src/ui/svg/**,src/ui/animations/**,src/ui/storybook/**,src/cheatcodes/**,src/features/navigation/CheatcodesStackNavigator/**,src/features/internal/**,src/tests/**,src/theme/**,src/**/__mocks__/**,src/api/gen/**,src/**/fixtures/**,src/**/analytics.ts,src/ui/components/buttons/**,src/**/styleUtils.ts,src/libs/subcategories/placeholderData.ts,src/libs/analytics/logEventAnalytics.ts,vite.config.js,src/index.html
+sonar.exclusions=**/*.test.*,**/*.stories.*,**/*.types.ts,src/**/*.d.ts,src/ui/svg/**,src/ui/animations/**,src/ui/storybook/**,src/cheatcodes/**,src/features/navigation/CheatcodesStackNavigator/**,src/features/internal/**,src/tests/**,src/theme/**,src/**/__mocks__/**,src/api/gen/**,src/**/fixtures/**,src/**/analytics.ts,src/ui/components/buttons/**,src/**/styleUtils.ts,src/libs/subcategories/placeholderData.ts,src/libs/analytics/logEventAnalytics.ts,vite.config.js,src/index.html,src/features/navigation/RootNavigator/routes.tsx
 sonar.tests=src
 sonar.test.inclusions=src/**/*.test.*
 # We exclude .web files because we run sonar scan only after test-native

--- a/src/features/navigation/RootNavigator/__mocks__/routes.tsx
+++ b/src/features/navigation/RootNavigator/__mocks__/routes.tsx
@@ -4,7 +4,7 @@ import { tabNavigatorPathConfig } from 'features/navigation/TabBar/__mocks__/rou
 import { RootRoute } from '../types'
 
 const MockComponent = () => null
-export const routes: Array<RootRoute> = [
+export const routes: RootRoute[] = [
   { name: 'PageNotFound', component: MockComponent, path: '*' },
   { name: 'TabNavigator', component: MockComponent, pathConfig: tabNavigatorPathConfig },
   {

--- a/src/features/navigation/RootNavigator/routes.tsx
+++ b/src/features/navigation/RootNavigator/routes.tsx
@@ -1,4 +1,5 @@
-import { Achievements } from 'features/achievements/pages/Achievements'
+import React, { lazy, Suspense } from 'react'
+
 import { Artist } from 'features/artist/pages/Artist'
 import { ForgottenPassword } from 'features/auth/pages/forgottenPassword/ForgottenPassword/ForgottenPassword'
 import { ReinitializePassword } from 'features/auth/pages/forgottenPassword/ReinitializePassword/ReinitializePassword'
@@ -73,8 +74,15 @@ import { Venue } from 'features/venue/pages/Venue/Venue'
 import { VenuePreviewCarousel } from 'features/venue/pages/VenuePreviewCarousel/VenuePreviewCarousel'
 import { VenueMap } from 'features/venueMap/pages/VenueMap/VenueMap'
 import { ABTestingPOC } from 'libs/firebase/remoteConfig/ABTestingPOC'
+import { LoadingPage } from 'ui/components/LoadingPage'
 
 import { RootRoute } from './types'
+
+// This dynamic import allows us to separate all the achievements illustrations (1,06 MB) from the main web bundle.
+const Achievements = lazy(async () => {
+  const module = await import('features/achievements/pages/Achievements')
+  return { default: module.Achievements }
+})
 
 export const routes: RootRoute[] = [
   ...accessibilityRoutes,
@@ -535,7 +543,11 @@ export const routes: RootRoute[] = [
   },
   {
     name: 'Achievements',
-    component: Achievements,
+    component: () => (
+      <Suspense fallback={<LoadingPage />}>
+        <Achievements />
+      </Suspense>
+    ),
     path: 'profile/achievements',
   },
   {

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,7 @@ import { createHtmlPlugin } from 'vite-plugin-html'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
 import { whiteListEnv } from './whiteListEnv'
 import { execSync } from 'child_process'
+import { analyzer } from 'vite-bundle-analyzer'
 
 const defaultExtensions = ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json']
 const allExtensions = [...defaultExtensions.map((ext) => `.web${ext}`), ...defaultExtensions]
@@ -54,6 +55,7 @@ export default ({ mode }) => {
     },
     plugins: [
       react(),
+      env.ANALYZE_BUNDLE ? analyzer() : null,
       {
         apply: 'build', // This plugin runs only when building (not serve)
         name: 'treat-js-files-as-jsx',

--- a/yarn.lock
+++ b/yarn.lock
@@ -13080,6 +13080,7 @@ __metadata:
     url-loader: ^4.1.1
     uuid: ^8.3.2
     vite: ^5.3.1
+    vite-bundle-analyzer: ^0.16.2
     vite-plugin-html: ^3.2.2
     yup: ^0.32.11
     zustand: ^4.5.2
@@ -33830,6 +33831,15 @@ __metadata:
     unist-util-stringify-position: ^2.0.0
     vfile-message: ^2.0.0
   checksum: ee5726e10d170472cde778fc22e0f7499caa096eb85babea5d0ce0941455b721037ee1c9e6ae506ca2803250acd313d0f464328ead0b55cfe7cb6315f1b462d6
+  languageName: node
+  linkType: hard
+
+"vite-bundle-analyzer@npm:^0.16.2":
+  version: 0.16.2
+  resolution: "vite-bundle-analyzer@npm:0.16.2"
+  bin:
+    analyze: dist/bin.js
+  checksum: 0171efe988dccb68aeb9ae4e75703e32bdaf38f6592a0fc5f1e03bd27dc528163cc9901fa5d648ef1889a9c38a951581521556aebfd8a39c5f55a84ad2fc1ede
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34322

Using vite-bundle-analyzer, I found that achievement illustrations (around 1 MB total) were included in the main bundle of the web app. By dynamically loading the Achievements page, the illustrations are now in their own bundle that will no longer be downloaded at the start of the web app.

Note: the achievement feature is off for the web app anyways ATM.

Bundle analyzer after splitting illustrations:
![Screenshot 2025-02-03 at 15 14 58](https://github.com/user-attachments/assets/33aa4cdb-3a40-4d9a-b7bc-84ee1c34c972)
There are still a few files for the Achievement feature that are included in the main bundle because they are being used on the home but they only are 6,38 KB.

The main bundle is now 11,87 MB without compression (12,95 MB before).

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
