### PR TITLE
(PC-34130) feat(venueMap): add search and reset buttons on filters modal

### DIFF
--- a/src/features/venueMap/pages/modals/VenueMapFiltersModal/VenueMapFiltersModal.native.test.tsx
+++ b/src/features/venueMap/pages/modals/VenueMapFiltersModal/VenueMapFiltersModal.native.test.tsx
@@ -2,10 +2,13 @@ import React from 'react'
 import { View } from 'react-native'
 
 import { VenueMapFiltersModal } from 'features/venueMap/pages/modals/VenueMapFiltersModal/VenueMapFiltersModal'
+import { venuesFilterActions } from 'features/venueMap/store/venuesFilterStore'
 import { render, screen, userEvent } from 'tests/utils'
 
 const mockHandleOnClose = jest.fn()
 const mockHandleGoBack = jest.fn()
+
+const mockResetFilters = jest.spyOn(venuesFilterActions, 'reset')
 
 const user = userEvent.setup()
 
@@ -45,5 +48,39 @@ describe('<VenueMapFiltersModal />', () => {
     await user.press(screen.getByLabelText('Revenir en arrière'))
 
     expect(mockHandleOnClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('should close the modal when pressing search button', async () => {
+    render(
+      <VenueMapFiltersModal
+        titleId="uuid"
+        title="Filtres"
+        shouldDisplayBackButton
+        shouldDisplayCloseButton
+        handleOnClose={mockHandleOnClose}>
+        <View />
+      </VenueMapFiltersModal>
+    )
+
+    await user.press(screen.getByText('Rechercher'))
+
+    expect(mockHandleOnClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('should reset the filters when pressing reset button', async () => {
+    render(
+      <VenueMapFiltersModal
+        titleId="uuid"
+        title="Filtres"
+        shouldDisplayBackButton
+        shouldDisplayCloseButton
+        handleOnClose={mockHandleOnClose}>
+        <View />
+      </VenueMapFiltersModal>
+    )
+
+    await user.press(screen.getByText('Réinitialiser'))
+
+    expect(mockResetFilters).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/features/venueMap/pages/modals/VenueMapFiltersModal/VenueMapFiltersModal.tsx
+++ b/src/features/venueMap/pages/modals/VenueMapFiltersModal/VenueMapFiltersModal.tsx
@@ -1,17 +1,20 @@
 import React, { FunctionComponent, PropsWithChildren } from 'react'
-import { ScrollView } from 'react-native'
+import { Platform, ScrollView } from 'react-native'
 import styled from 'styled-components/native'
 
+import { FilterPageButtons } from 'features/search/components/FilterPageButtons/FilterPageButtons'
 import { SearchCustomModalHeader } from 'features/search/components/SearchCustomModalHeader'
+import { FilterBehaviour } from 'features/search/enums'
+import { venuesFilterActions } from 'features/venueMap/store/venuesFilterStore'
 
-type Props = {
+type Props = PropsWithChildren<{
   titleId: string
   title: string
   shouldDisplayBackButton: boolean
   shouldDisplayCloseButton: boolean
   handleOnClose: VoidFunction
   handleGoBack?: VoidFunction
-} & PropsWithChildren
+}>
 
 export const VenueMapFiltersModal: FunctionComponent<Props> = ({
   titleId,
@@ -22,6 +25,8 @@ export const VenueMapFiltersModal: FunctionComponent<Props> = ({
   handleGoBack,
   children,
 }) => {
+  const { reset } = venuesFilterActions
+
   return (
     <React.Fragment>
       <HeaderContainer>
@@ -35,6 +40,13 @@ export const VenueMapFiltersModal: FunctionComponent<Props> = ({
         />
       </HeaderContainer>
       <StyledScrollView>{children}</StyledScrollView>
+      <ButtonsContainer>
+        <FilterPageButtons
+          onResetPress={reset}
+          onSearchPress={handleOnClose}
+          filterBehaviour={FilterBehaviour.SEARCH}
+        />
+      </ButtonsContainer>
     </React.Fragment>
   )
 }
@@ -48,4 +60,8 @@ const StyledScrollView = styled(ScrollView)(({ theme }) => ({
   width: '100%',
   flex: 1,
   paddingHorizontal: theme.modal.spacing.MD,
+}))
+
+const ButtonsContainer = styled.View(({ theme }) => ({
+  paddingBottom: Platform.OS === 'ios' ? theme.modal.spacing.MD : theme.modal.spacing.SM,
 }))


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34130

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |![Capture d’écran 2025-02-03 à 18 28 06](https://github.com/user-attachments/assets/93c13432-6faa-4f7b-b908-35166c4b4ce3)|
| Android          |               |![Capture d’écran 2025-02-03 à 18 28 36](https://github.com/user-attachments/assets/34477a85-626a-47f0-a5f1-49e2ff0b2c0f)|
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
