### PR TITLE
(PC-34242) feat(identityCheck): add more informations in usePatchProf…

### DIFF
--- a/src/features/identityCheck/api/usePatchProfile.ts
+++ b/src/features/identityCheck/api/usePatchProfile.ts
@@ -17,7 +17,12 @@ export function usePatchProfile() {
       if (body) {
         return api.postNativeV1SubscriptionProfile(body)
       } else {
-        return Promise.reject(new Error('No body was provided for subscription profile'))
+        const profileWithMissingFileds = JSON.stringify(profile, (_, value) => value ?? null, 2)
+        return Promise.reject(
+          new Error(
+            `No body was provided for subscription profile. "getCompleteProfile()" return null because: ${profileWithMissingFileds}`
+          )
+        )
       }
     },
     {


### PR DESCRIPTION
…ile error

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34242
Link to Sentry : https://sentry.passculture.team/organizations/sentry/issues/1489369/?project=6&referrer=jira_integration

L'erreur est renvoyé lorsque que getCompleteProfile retourne null, c'est à dire quand une ou plusieurs valeurs du profile ne sont pas renseigné. Mais, actuellement nous ne savons pas quelle(s) valeur(s). J'ai décidé de passer profile directement dans l'erreur pour voir si il y a des récurences dans le ou les infos manquantes au patch.  

Potentielle solution : Récupérer les valeurs du profile dans le contexte et compléter celle qui seraient manquante ? 

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.