### PR TITLE
(BSR) fix(chronicle): add placeholder image for offer preview

### DIFF
--- a/src/features/chronicle/components/ChronicleOfferInfo/ChronicleOfferInfo.web.test.tsx
+++ b/src/features/chronicle/components/ChronicleOfferInfo/ChronicleOfferInfo.web.test.tsx
@@ -11,6 +11,7 @@ describe('ChronicleOfferInfo', () => {
 
     expect(screen.getByText('12€')).toBeInTheDocument()
     expect(screen.getByText('lorem ipsum')).toBeInTheDocument()
+    expect(screen.getByTestId('imagePlaceholder')).toBeInTheDocument()
   })
 
   it('should render correctly with custom children', () => {
@@ -23,5 +24,6 @@ describe('ChronicleOfferInfo', () => {
     expect(screen.getByText('12€')).toBeInTheDocument()
     expect(screen.getByText('lorem ipsum')).toBeInTheDocument()
     expect(screen.getByTestId('button')).toBeInTheDocument()
+    expect(screen.getByTestId('imagePlaceholder')).toBeInTheDocument()
   })
 })

--- a/src/features/chronicle/components/ChronicleOfferInfo/ChronicleOfferInfo.web.tsx
+++ b/src/features/chronicle/components/ChronicleOfferInfo/ChronicleOfferInfo.web.tsx
@@ -2,6 +2,8 @@ import React, { PropsWithChildren } from 'react'
 import { StyleProp, View, ViewStyle } from 'react-native'
 import styled from 'styled-components/native'
 
+import { CategoryIdEnum } from 'api/gen'
+import { OfferBodyImagePlaceholder } from 'features/offer/components/OfferBodyImagePlaceholder'
 import { useOfferImageContainerDimensions } from 'features/offer/helpers/useOfferImageContainerDimensions'
 import { FastImage } from 'libs/resizing-image-on-demand/FastImage'
 import { TypoDS, getSpacing } from 'ui/theme'
@@ -10,6 +12,7 @@ type ChronicleOfferInfoProps = PropsWithChildren<{
   imageUrl: string
   title: string
   price: string
+  categoryId?: CategoryIdEnum
   style?: StyleProp<ViewStyle>
 }>
 
@@ -18,13 +21,17 @@ export const ChronicleOfferInfo = ({
   title,
   price,
   style,
+  categoryId,
   children,
 }: ChronicleOfferInfoProps) => {
   const { imageStyle } = useOfferImageContainerDimensions()
 
   return (
     <View style={[style, { maxWidth: imageStyle.width }]}>
-      <FastImage style={imageStyle} url={imageUrl} />
+      <View style={imageStyle}>
+        <OfferBodyImagePlaceholder categoryId={categoryId ?? CategoryIdEnum.LIVRE} />
+        <OfferImage style={imageStyle} url={imageUrl} />
+      </View>
       <TextWrapper>
         <TypoDS.Title3 numberOfLines={1}>{title}</TypoDS.Title3>
         <StyledTitle3>{price}</StyledTitle3>
@@ -33,6 +40,11 @@ export const ChronicleOfferInfo = ({
     </View>
   )
 }
+
+const OfferImage = styled(FastImage)({
+  position: 'absolute',
+  zIndex: 2,
+})
 
 const StyledTitle3 = styled(TypoDS.Title3)(({ theme }) => ({
   color: theme.colors.greyDark,

--- a/src/features/chronicle/pages/Chronicles/Chronicles.web.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.web.tsx
@@ -103,6 +103,7 @@ export const Chronicles: FunctionComponent = () => {
             imageUrl={offer.images?.[0]?.url ?? ''}
             title={offer.name}
             price={displayedPrice}
+            categoryId={subcategory.categoryId}
             paddingTop={headerHeight}>
             <OfferCTAButton
               offer={offer}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

Ajout d'un placeholder sur l'image d'offre dans la page des chroniques du Book Club

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

https://github.com/user-attachments/assets/4f72a33f-3b97-493b-abca-8d213e04c759



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
