### PR TITLE
(BSR) fix(server): proxy snapshot update

### DIFF
--- a/server/src/middlewares/tests/__snapshots__/webAppProxyMiddleware.test.ts.snap
+++ b/server/src/middlewares/tests/__snapshots__/webAppProxyMiddleware.test.ts.snap
@@ -7,26 +7,43 @@ exports[`metasResponseInterceptor with real backend should request the real test
     <meta charset=\\"utf-8\\">
     <title>Relais culturel La Nef | pass Culture</title>
     <meta name=\\"title\\" content=\\"Relais culturel La Nef | pass Culture\\" />
-    <meta name=\\"description\\"
-          content=\\"Dispositif porté par le ministère de la Culture, a pour but de faciliter l’accès des jeunes de 18 ans à la culture en leur offrant un crédit de 300€ à dépenser sur l’application pass Culture.\\"/>
+    <meta name=\\"description\\" content=\\"Créé en 1981, le Relais Culturel La Nef de Wissembourg, propose chaque année une programmation pluridisciplinaire placée sous le signe de l’exigence artistique.
+
+Plus de vingt-cinq spectacles vivants sont proposés chaque saison en théâtre, musique, cirque, humour et jeune public.
+
+Côté cinéma, la Nef offre toute l’année une programmation éclectique destinée aux petits et grands.\\" />
     <meta name=\\"author\\" content=\\"pass Culture\\"/>
     <meta name=\\"keywords\\" content=\\"pass Culture\\" />
     <meta property=\\"og:type\\" content=\\"website\\"/>
     <meta property=\\"og:url\\" content=\\"http://localhost:8080/lieu/9\\" />
     <meta property=\\"og:title\\" content=\\"Relais culturel La Nef | pass Culture\\" />
-    <meta property=\\"og:description\\"
-          content=\\"Dispositif porté par le ministère de la Culture, a pour but de faciliter l’accès des jeunes de 18 ans à la culture en leur offrant un crédit de 300€ à dépenser sur l’application pass Culture.\\"/>
-    <meta property=\\"og:image\\" content=\\"https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/google_places/9.jpeg\\" />
-    <meta property=\\"og:image:alt\\" content=\\"pass Culture\\"/>
+    <meta property=\\"og:description\\" content=\\"Créé en 1981, le Relais Culturel La Nef de Wissembourg, propose chaque année une programmation pluridisciplinaire placée sous le signe de l’exigence artistique.
+
+Plus de vingt-cinq spectacles vivants sont proposés chaque saison en théâtre, musique, cirque, humour et jeune public.
+
+Côté cinéma, la Nef offre toute l’année une programmation éclectique destinée aux petits et grands.\\" />
+    <meta property=\\"og:image\\" content=\\"https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/venues/BE_1737707633\\" />
+    <meta property=\\"og:image:alt\\" content=\\"Créé en 1981, le Relais Culturel La Nef de Wissembourg, propose chaque année une programmation pluridisciplinaire placée sous le signe de l’exigence artistique.
+
+Plus de vingt-cinq spectacles vivants sont proposés chaque saison en théâtre, musique, cirque, humour et jeune public.
+
+Côté cinéma, la Nef offre toute l’année une programmation éclectique destinée aux petits et grands.\\" />
     <meta property=\\"og:locale\\" content=\\"fr_FR\\"/>
     <meta property=\\"og:site_name\\" content=\\"pass Culture\\"/>
     <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
     <meta name=\\"twitter:url\\" content=\\"http://localhost:8080/lieu/9\\" />
     <meta name=\\"twitter:title\\" content=\\"Relais culturel La Nef | pass Culture\\" />
-    <meta name=\\"twitter:description\\"
-          content=\\"Dispositif porté par le ministère de la Culture, a pour but de faciliter l’accès des jeunes de 18 ans à la culture en leur offrant un crédit de 300€ à dépenser sur l’application pass Culture.\\"/>
-    <meta name=\\"twitter:image\\" content=\\"https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/google_places/9.jpeg\\" />
-    <meta name=\\"twitter:image:alt\\" content=\\"claus sandy\\" />
+    <meta name=\\"twitter:description\\" content=\\"Créé en 1981, le Relais Culturel La Nef de Wissembourg, propose chaque année une programmation pluridisciplinaire placée sous le signe de l’exigence artistique.
+
+Plus de vingt-cinq spectacles vivants sont proposés chaque saison en théâtre, musique, cirque, humour et jeune public.
+
+Côté cinéma, la Nef offre toute l’année une programmation éclectique destinée aux petits et grands.\\" />
+    <meta name=\\"twitter:image\\" content=\\"https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/thumbs/venues/BE_1737707633\\" />
+    <meta name=\\"twitter:image:alt\\" content=\\"Créé en 1981, le Relais Culturel La Nef de Wissembourg, propose chaque année une programmation pluridisciplinaire placée sous le signe de l’exigence artistique.
+
+Plus de vingt-cinq spectacles vivants sont proposés chaque saison en théâtre, musique, cirque, humour et jeune public.
+
+Côté cinéma, la Nef offre toute l’année une programmation éclectique destinée aux petits et grands.\\" />
     <meta name=\\"twitter:site\\" content=\\"@pass_Culture\\"/>
     <meta name=\\"twitter:app:country\\" content=\\"FR\\"/>
     <meta name=\\"twitter:app:name:iphone\\" content=\\"pass Culture\\"/>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
