### PR TITLE
(PC-34367) feat(firebase): add link to staging and production feature…

### DIFF
--- a/src/cheatcodes/pages/others/CheatcodesScreenFeatureFlags.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenFeatureFlags.tsx
@@ -4,15 +4,56 @@ import styled from 'styled-components/native'
 
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
 import { useFeatureFlagAll } from 'cheatcodes/hooks/useFeatureFlagAll'
+import { env } from 'libs/environment/env'
+import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
 import { Separator } from 'ui/components/Separator'
-import { TypoDS, getSpacing } from 'ui/theme'
+import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
+import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
+import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 
 export const CheatcodesScreenFeatureFlags = () => {
   const featureFlags = useFeatureFlagAll()
   const featureFlagsArray = Object.entries(featureFlags)
 
+  const title = `Feature Flags ${env.ENV} 🏳️`
+  const showTestingFeatureFlags = env.ENV !== 'testing'
+  const showStagingFeatureFlags = env.ENV !== 'staging'
+  const showProductionFeatureFlags = env.ENV !== 'production'
+
   return (
-    <CheatcodesTemplateScreen title="Feature Flags 🏳️" flexDirection="column">
+    <CheatcodesTemplateScreen title={title} flexDirection="column">
+      {showTestingFeatureFlags ? (
+        <ExternalTouchableLink
+          as={ButtonInsideTextBlack}
+          buttonHeight="extraSmall"
+          icon={ExternalSiteFilled}
+          wording="Voir les feature flags testing"
+          externalNav={{
+            url: 'https://app.testing.passculture.team/cheatcodes/other/feature-flags',
+          }}
+        />
+      ) : null}
+      {showStagingFeatureFlags ? (
+        <ExternalTouchableLink
+          as={ButtonInsideTextBlack}
+          buttonHeight="extraSmall"
+          icon={ExternalSiteFilled}
+          wording="Voir les feature flags staging"
+          externalNav={{
+            url: 'https://app.staging.passculture.team/cheatcodes/other/feature-flags',
+          }}
+        />
+      ) : null}
+      {showProductionFeatureFlags ? (
+        <ExternalTouchableLink
+          as={ButtonInsideTextBlack}
+          buttonHeight="extraSmall"
+          icon={ExternalSiteFilled}
+          wording="Voir les feature flags production"
+          externalNav={{ url: 'https://passculture.app/cheatcodes/other/feature-flags' }}
+        />
+      ) : null}
+      <Spacer.Column numberOfSpaces={6} />
       <TypoDS.BodyItalicAccent>
         Nombre de feature flags&nbsp;: {featureFlagsArray.length}
       </TypoDS.BodyItalicAccent>
@@ -45,3 +86,7 @@ const StyledTitle4 = styled(TypoDS.Title4)<{ active: boolean }>(({ theme, active
 const StyledSeparator = styled(Separator.Horizontal)({
   marginVertical: getSpacing(2),
 })
+
+const ButtonInsideTextBlack = styled(ButtonInsideText).attrs(({ theme }) => ({
+  buttonColor: theme.colors.black,
+}))``


### PR DESCRIPTION
… flags in CheatcodesScreenFeatureFlags

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34367

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |  ![Capture d’écran 2025-02-06 à 17 54 11](https://github.com/user-attachments/assets/8fa5df00-1345-4bf0-9593-26f4de38213b) |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
