### PR TITLE
(PC-34442) chore(lib): upgrade blur

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -571,7 +571,8 @@ PODS:
   - react-native-appsflyer (6.14.3):
     - AppsFlyerFramework (= 6.14.3)
     - React
-  - react-native-blur (4.3.2):
+  - react-native-blur (4.4.1):
+    - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - react-native-config (1.4.5):
     - react-native-config/App (= 1.4.5)
@@ -1228,7 +1229,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 8e291ed0ab371314de269001d6b9b25db6aabf42
   React-logger: d4010de0b0564e63637ad08373bc73b5d919974b
   react-native-appsflyer: 37a0053df435bb76c330c5c15488dca29a3baa9b
-  react-native-blur: cfdad7b3c01d725ab62a8a729f42ea463998afa2
+  react-native-blur: caa61c22f4b7b0a031b861aada567c20e7027f97
   react-native-config: 5e2fe7217716b5472ed7901477620b1370335d67
   react-native-date-picker: 90d1d60802a20085125657940b944f2bb4e5c113
   react-native-detector: 751696a5534f6bbc11be87515cca3d8d32593d73

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@ptomasroos/react-native-multi-slider": "^2.2.2",
     "@react-native-async-storage/async-storage": "^1.17.11",
     "@react-native-clipboard/clipboard": "^1.12.1",
-    "@react-native-community/blur": "^4.3.2",
+    "@react-native-community/blur": "^4.4.1",
     "@react-native-community/netinfo": "^9.0.0",
     "@react-native-firebase/analytics": "^14.9.0",
     "@react-native-firebase/app": "^14.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8505,13 +8505,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-community/blur@npm:^4.3.2":
-  version: 4.3.2
-  resolution: "@react-native-community/blur@npm:4.3.2"
+"@react-native-community/blur@npm:^4.4.1":
+  version: 4.4.1
+  resolution: "@react-native-community/blur@npm:4.4.1"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 4f7ed6a3bb58cd53346bb7d5755bb2733e8401fdae86334fde4f2fa0c554734e9bb52175c1f9ef1d99766aeb7a4991ac5dfe428c92da518d0353a1a6e5c3d39c
+  checksum: 1e47144b0c00dce562e72ea9f6c3e93d3bb392ec0ea001ce37ff801d9a496c9801927033ee4800bf92ea2ece9de0abe596715add3b7afe3c5d1533e260f5e09e
   languageName: node
   linkType: hard
 
@@ -12865,7 +12865,7 @@ __metadata:
     "@ptomasroos/react-native-multi-slider": ^2.2.2
     "@react-native-async-storage/async-storage": ^1.17.11
     "@react-native-clipboard/clipboard": ^1.12.1
-    "@react-native-community/blur": ^4.3.2
+    "@react-native-community/blur": ^4.4.1
     "@react-native-community/netinfo": ^9.0.0
     "@react-native-firebase/analytics": ^14.9.0
     "@react-native-firebase/app": ^14.9.0


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34442

Checked on ios `src/features/profile/pages/DeleteProfileReason/DeleteProfileReason.tsx`:
![image](https://github.com/user-attachments/assets/19ab05e6-2a5e-4637-bd7a-23fa3f9b567d)

Web:
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/aee77f38-5aec-4de8-ba94-3a488ef22ccc" />

For android we don't use the lib, so I just tested if I was able to open the app
