### PR TITLE
(PC-32105) feat(offer): change venue button icon

### DIFF
--- a/src/features/offer/components/OfferVenueButton/OfferVenueButton.native.test.tsx
+++ b/src/features/offer/components/OfferVenueButton/OfferVenueButton.native.test.tsx
@@ -5,7 +5,11 @@ import { OfferVenueResponse } from 'api/gen'
 import { OfferVenueButton } from 'features/offer/components/OfferVenueButton/OfferVenueButton'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { analytics } from 'libs/analytics/provider'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
+
+const user = userEvent.setup()
+
+jest.useFakeTimers()
 
 describe('<OfferVenueButton />', () => {
   it('should display public name when informed', () => {
@@ -63,17 +67,15 @@ describe('<OfferVenueButton />', () => {
   it('should redirect to venue page when pressing button', async () => {
     render(<OfferVenueButton venue={offerResponseSnap.venue} />)
 
-    fireEvent.press(screen.getByTestId('Accéder à la page du lieu PATHE BEAUGRENELLE'))
+    await user.press(screen.getByTestId('Accéder à la page du lieu PATHE BEAUGRENELLE'))
 
-    await waitFor(() =>
-      expect(navigate).toHaveBeenCalledWith('Venue', { id: offerResponseSnap.venue.id })
-    )
+    expect(navigate).toHaveBeenCalledWith('Venue', { id: offerResponseSnap.venue.id })
   })
 
-  it('should track the venue redirection when the pressing button', () => {
+  it('should track the venue redirection when the pressing button', async () => {
     render(<OfferVenueButton venue={offerResponseSnap.venue} />)
 
-    fireEvent.press(screen.getByTestId('Accéder à la page du lieu PATHE BEAUGRENELLE'))
+    await user.press(screen.getByTestId('Accéder à la page du lieu PATHE BEAUGRENELLE'))
 
     expect(analytics.logConsultVenue).toHaveBeenCalledWith({
       venueId: offerResponseSnap.venue.id,

--- a/src/features/offer/components/OfferVenueButton/OfferVenueButton.tsx
+++ b/src/features/offer/components/OfferVenueButton/OfferVenueButton.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/native'
 import { OfferVenueResponse } from 'api/gen'
 import { analytics } from 'libs/analytics/provider'
 import { HeroButtonList } from 'ui/components/buttons/HeroButtonList'
-import { LocationPointer } from 'ui/svg/icons/LocationPointer'
+import { LocationBuildingFilled } from 'ui/svg/icons/LocationBuildingFilled'
 import { TypoDS } from 'ui/theme'
 
 interface Props {
@@ -22,7 +22,7 @@ export function OfferVenueButton({ venue }: Readonly<Props>) {
       Subtitle={
         venue.city ? <SubtitleText testID="subtitle">{venue.city}</SubtitleText> : undefined
       }
-      Icon={<LocationPointer color={theme.colors.black} size={theme.icons.sizes.small} />}
+      Icon={<LocationBuildingFilled color={theme.colors.black} size={theme.icons.sizes.small} />}
       navigateTo={{ screen: 'Venue', params: { id: venue.id } }}
       onBeforeNavigate={() => analytics.logConsultVenue({ venueId: venue.id, from: 'offer' })}
       accessibilityLabel={`Accéder à la page du lieu ${venueName}`}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-32105

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |![Capture d’écran 2025-02-10 à 10 40 01](https://github.com/user-attachments/assets/d870e147-f9a8-48a0-a543-3f5bdff4e7d9)|![Capture d’écran 2025-02-10 à 10 39 27](https://github.com/user-attachments/assets/0dce4f4d-5f00-4811-8c9d-4036ca37d9b8)|
| Android          |![Capture d’écran 2025-02-10 à 10 39 56](https://github.com/user-attachments/assets/a46f3588-63bc-4c82-950a-d810a38583fe)|![Capture d’écran 2025-02-10 à 10 38 32](https://github.com/user-attachments/assets/dece9bea-e870-4de4-86a0-a2cc7eb21500)|
| Phone - Chrome   |![Capture d’écran 2025-02-10 à 10 41 16](https://github.com/user-attachments/assets/293b8f26-4666-41b9-86b3-65ee1dd51bf9)|![Capture d’écran 2025-02-10 à 10 41 28](https://github.com/user-attachments/assets/5b46711b-8e34-4a9c-9fbb-5b11d0c8fe2a)|
| Desktop - Chrome |<img width="1724" alt="Capture d’écran 2025-02-10 à 10 41 00" src="https://github.com/user-attachments/assets/e62027b9-8269-4f3a-abdf-0f766919bf61" />|![Capture d’écran 2025-02-10 à 10 41 43](https://github.com/user-attachments/assets/37af2929-889a-4f4d-97bd-15c6a316b7da)|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
