### PR TITLE
(PC-34395) feat(ChronicleCard): display button when the chronicle is too long

### DIFF
--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.native.test.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.native.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react'
+import { View } from 'react-native'
+
+import { chroniclesSnap } from 'features/chronicle/fixtures/chroniclesSnap'
+import { act, render, screen, userEvent } from 'tests/utils'
+import { ButtonTertiaryBlack } from 'ui/components/buttons/ButtonTertiaryBlack'
+
+import { ChronicleCard } from './ChronicleCard'
+
+const mockOnLayoutWithButton = {
+  nativeEvent: {
+    layout: {
+      height: 157,
+    },
+  },
+}
+
+const mockOnLayoutWithoutButton = {
+  nativeEvent: {
+    layout: {
+      height: 30,
+    },
+  },
+}
+
+const user = userEvent.setup()
+const mockOnSeeMoreButtonPress = jest.fn()
+jest.useFakeTimers()
+
+describe('ChronicleCard (Mobile)', () => {
+  it('should render the ChronicleCard component with correct title', () => {
+    render(
+      <ChronicleCard {...chroniclesSnap[0]}>
+        <View>
+          <ButtonTertiaryBlack
+            wording="Voir plus"
+            onPress={() => mockOnSeeMoreButtonPress(chroniclesSnap[0].id)}
+          />
+        </View>
+      </ChronicleCard>
+    )
+
+    expect(screen.getByText(chroniclesSnap[0].title)).toBeOnTheScreen()
+  })
+
+  it('should display the "Voir plus" button if content overflows', async () => {
+    render(
+      <ChronicleCard {...chroniclesSnap[0]}>
+        <View>
+          <ButtonTertiaryBlack
+            wording="Voir plus"
+            onPress={() => mockOnSeeMoreButtonPress(chroniclesSnap[0].id)}
+          />
+        </View>
+      </ChronicleCard>
+    )
+
+    const description = screen.getByTestId('description')
+
+    await act(async () => {
+      description.props.onLayout(mockOnLayoutWithButton)
+    })
+
+    expect(screen.getByText('Voir plus')).toBeOnTheScreen()
+  })
+
+  it('should not display the "Voir plus" button', async () => {
+    render(
+      <ChronicleCard {...chroniclesSnap[0]}>
+        <View>
+          <ButtonTertiaryBlack
+            wording="Voir plus"
+            onPress={() => mockOnSeeMoreButtonPress(chroniclesSnap[0].id)}
+          />
+        </View>
+      </ChronicleCard>
+    )
+
+    const description = screen.getByTestId('description')
+
+    await act(async () => {
+      description.props.onLayout(mockOnLayoutWithoutButton)
+    })
+
+    expect(screen.queryByText('Voir plus')).not.toBeOnTheScreen()
+  })
+
+  it('should call onSeeMoreButtonPress when "Voir plus" is clicked', async () => {
+    render(
+      <ChronicleCard {...chroniclesSnap[0]}>
+        <View>
+          <ButtonTertiaryBlack
+            wording="Voir plus"
+            onPress={() => mockOnSeeMoreButtonPress(chroniclesSnap[0].id)}
+          />
+        </View>
+      </ChronicleCard>
+    )
+
+    const description = screen.getByTestId('description')
+
+    await act(async () => {
+      description.props.onLayout(mockOnLayoutWithButton)
+    })
+
+    await user.press(screen.getByText('Voir plus'))
+
+    expect(mockOnSeeMoreButtonPress).toHaveBeenCalledTimes(1)
+    expect(mockOnSeeMoreButtonPress).toHaveBeenCalledWith(chroniclesSnap[0].id)
+  })
+})

--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.native.test.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.native.test.tsx
@@ -30,7 +30,7 @@ jest.useFakeTimers()
 describe('ChronicleCard (Mobile)', () => {
   it('should render the ChronicleCard component with correct title', () => {
     render(
-      <ChronicleCard {...chroniclesSnap[0]}>
+      <ChronicleCard {...chroniclesSnap[0]} shouldTruncate>
         <View>
           <ButtonTertiaryBlack
             wording="Voir plus"
@@ -45,7 +45,7 @@ describe('ChronicleCard (Mobile)', () => {
 
   it('should display the "Voir plus" button if content overflows', async () => {
     render(
-      <ChronicleCard {...chroniclesSnap[0]}>
+      <ChronicleCard {...chroniclesSnap[0]} shouldTruncate>
         <View>
           <ButtonTertiaryBlack
             wording="Voir plus"
@@ -66,7 +66,7 @@ describe('ChronicleCard (Mobile)', () => {
 
   it('should not display the "Voir plus" button', async () => {
     render(
-      <ChronicleCard {...chroniclesSnap[0]}>
+      <ChronicleCard {...chroniclesSnap[0]} shouldTruncate>
         <View>
           <ButtonTertiaryBlack
             wording="Voir plus"
@@ -87,7 +87,7 @@ describe('ChronicleCard (Mobile)', () => {
 
   it('should call onSeeMoreButtonPress when "Voir plus" is clicked', async () => {
     render(
-      <ChronicleCard {...chroniclesSnap[0]}>
+      <ChronicleCard {...chroniclesSnap[0]} shouldTruncate>
         <View>
           <ButtonTertiaryBlack
             wording="Voir plus"

--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.native.test.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.native.test.tsx
@@ -64,7 +64,7 @@ describe('ChronicleCard (Mobile)', () => {
     expect(screen.getByText('Voir plus')).toBeOnTheScreen()
   })
 
-  it('should not display the "Voir plus" button', async () => {
+  it('should not display the "Voir plus" button if not content overflows', async () => {
     render(
       <ChronicleCard {...chroniclesSnap[0]} shouldTruncate>
         <View>

--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
@@ -68,7 +68,7 @@ export const ChronicleCard: FunctionComponent<Props> = ({
         <Description
           testID="description"
           onLayout={shouldTruncate ? handleOnLayout : undefined}
-          numberOfLines={shouldTruncate ? currentNumberOfLines : undefined}>
+          numberOfLines={currentNumberOfLines}>
           {description}
         </Description>
       </DescriptionContainer>

--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
@@ -42,12 +42,12 @@ export const ChronicleCard: FunctionComponent<Props> = ({
     parseFloat(theme.designSystem.typography.bodyAccentS.lineHeight) * MAX_LINES * REM_TO_PX
   const DEFAULT_HEIGHT_MOBILE =
     parseFloat(theme.designSystem.typography.bodyAccentS.lineHeight) * MAX_LINES
-  const getDefaultHeight = Platform.OS === 'web' ? DEFAULT_HEIGHT_WEB : DEFAULT_HEIGHT_MOBILE
+  const defaultHeight = Platform.OS === 'web' ? DEFAULT_HEIGHT_WEB : DEFAULT_HEIGHT_MOBILE
 
   const handleOnLayout = (event: LayoutChangeEvent) => {
     // We use Math.floor to avoid floating-point precision issues when comparing heights
     const actualHeight = Math.floor(event.nativeEvent.layout.height)
-    const expectedMaxHeight = Math.floor(getDefaultHeight)
+    const expectedMaxHeight = Math.floor(defaultHeight)
 
     if (actualHeight > expectedMaxHeight) {
       setShouldDisplayButton(true)
@@ -64,7 +64,7 @@ export const ChronicleCard: FunctionComponent<Props> = ({
         thumbnailComponent={<BookClubCertification />}
       />
       <Separator.Horizontal />
-      <DescriptionContainer defaultHeight={getDefaultHeight}>
+      <DescriptionContainer defaultHeight={defaultHeight}>
         <Description
           testID="description"
           onLayout={shouldTruncate ? handleOnLayout : undefined}

--- a/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
+++ b/src/features/chronicle/components/ChronicleCard/ChronicleCard.tsx
@@ -15,6 +15,7 @@ const CHRONICLE_THUMBNAIL_SIZE = getSpacing(14)
 type Props = PropsWithChildren<
   ChronicleCardData & {
     cardWidth?: number
+    shouldTruncate?: boolean
   }
 >
 
@@ -29,6 +30,7 @@ export const ChronicleCard: FunctionComponent<Props> = ({
   date,
   cardWidth,
   children,
+  shouldTruncate = false,
 }) => {
   const theme = useTheme()
 
@@ -65,8 +67,8 @@ export const ChronicleCard: FunctionComponent<Props> = ({
       <DescriptionContainer defaultHeight={getDefaultHeight}>
         <Description
           testID="description"
-          onLayout={handleOnLayout}
-          numberOfLines={currentNumberOfLines}>
+          onLayout={shouldTruncate ? handleOnLayout : undefined}
+          numberOfLines={shouldTruncate ? currentNumberOfLines : undefined}>
           {description}
         </Description>
       </DescriptionContainer>
@@ -78,21 +80,23 @@ export const ChronicleCard: FunctionComponent<Props> = ({
   )
 }
 
-const Container = styled(ViewGap)<{ width?: number }>(({ theme, width }) => ({
-  padding: getSpacing(6),
-  borderRadius: getSpacing(2),
-  border: 1,
-  borderColor: theme.colors.greyMedium,
-  ...(width === undefined ? undefined : { width }),
-  height: CHRONICLE_CARD_HEIGHT,
-  backgroundColor: theme.colors.white,
-  ...getShadow({
-    shadowOffset: { width: 0, height: getSpacing(1) },
-    shadowRadius: getSpacing(1),
-    shadowColor: theme.colors.black,
-    shadowOpacity: 0.15,
-  }),
-}))
+const Container = styled(ViewGap)<{ width?: number; shouldTruncate?: boolean }>(
+  ({ theme, width, shouldTruncate }) => ({
+    padding: getSpacing(6),
+    borderRadius: getSpacing(2),
+    border: 1,
+    borderColor: theme.colors.greyMedium,
+    ...(width === undefined ? undefined : { width }),
+    height: shouldTruncate ? CHRONICLE_CARD_HEIGHT : undefined,
+    backgroundColor: theme.colors.white,
+    ...getShadow({
+      shadowOffset: { width: 0, height: getSpacing(1) },
+      shadowRadius: getSpacing(1),
+      shadowColor: theme.colors.black,
+      shadowOpacity: 0.15,
+    }),
+  })
+)
 
 const DescriptionContainer = styled.View<{ defaultHeight: number }>(({ defaultHeight }) => ({
   maxHeight: MAX_LINES * defaultHeight,

--- a/src/features/chronicle/components/ChronicleCardList/ChronicleCardList.web.tsx
+++ b/src/features/chronicle/components/ChronicleCardList/ChronicleCardList.web.tsx
@@ -32,6 +32,7 @@ export const ChronicleCardList = forwardRef<
     separatorSize = SEPARATOR_DEFAULT_VALUE,
     onSeeMoreButtonPress,
     onLayout,
+    shouldTruncate,
   },
   ref
 ) {
@@ -102,6 +103,7 @@ export const ChronicleCardList = forwardRef<
         snapToInterval={isDesktopViewport ? CHRONICLE_CARD_WIDTH : undefined}
         onSeeMoreButtonPress={onSeeMoreButtonPress}
         onLayout={onLayout}
+        shouldTruncate={shouldTruncate}
       />
     </View>
   )

--- a/src/features/chronicle/components/ChronicleCardList/ChronicleCardListBase.native.test.tsx
+++ b/src/features/chronicle/components/ChronicleCardList/ChronicleCardListBase.native.test.tsx
@@ -56,6 +56,7 @@ describe('ChronicleCardListBase', () => {
         horizontal
         ref={ref}
         onSeeMoreButtonPress={jest.fn()}
+        shouldTruncate
       />
     )
 
@@ -90,6 +91,7 @@ describe('ChronicleCardListBase', () => {
         horizontal
         ref={ref}
         onSeeMoreButtonPress={mockOnSeeMoreButtonPress}
+        shouldTruncate
       />
     )
 

--- a/src/features/chronicle/components/ChronicleCardList/ChronicleCardListBase.native.test.tsx
+++ b/src/features/chronicle/components/ChronicleCardList/ChronicleCardListBase.native.test.tsx
@@ -4,9 +4,17 @@ import { ReactTestInstance } from 'react-test-renderer'
 
 import { CHRONICLE_CARD_WIDTH } from 'features/chronicle/constant'
 import { chroniclesSnap } from 'features/chronicle/fixtures/chroniclesSnap'
-import { render, screen, userEvent } from 'tests/utils'
+import { act, render, screen, userEvent } from 'tests/utils'
 
 import { ChronicleCardListBase } from './ChronicleCardListBase'
+
+const mockOnLayoutWithButton = {
+  nativeEvent: {
+    layout: {
+      height: 157,
+    },
+  },
+}
 
 const user = userEvent.setup()
 
@@ -40,7 +48,7 @@ describe('ChronicleCardListBase', () => {
     expect(screen.getByText('La Nature Sauvage')).toBeOnTheScreen()
   })
 
-  it('should display "Voir plus" button on all cards when onPressSeeMoreButton defined', () => {
+  it('should display "Voir plus" button on all cards when onPressSeeMoreButton defined', async () => {
     render(
       <ChronicleCardListBase
         data={chroniclesSnap}
@@ -51,7 +59,13 @@ describe('ChronicleCardListBase', () => {
       />
     )
 
-    expect(screen.getAllByText('Voir plus')).toHaveLength(10)
+    const descriptions = screen.getAllByTestId('description')
+
+    await act(async () => {
+      descriptions[0]?.props.onLayout(mockOnLayoutWithButton)
+    })
+
+    expect(screen.getAllByText('Voir plus')).toHaveLength(1)
   })
 
   it('should not display "Voir plus" button on all cards when onSeeMoreButtonPress not defined', () => {
@@ -79,10 +93,16 @@ describe('ChronicleCardListBase', () => {
       />
     )
 
+    const descriptions = screen.getAllByTestId('description')
+
+    await act(async () => {
+      descriptions[0]?.props.onLayout(mockOnLayoutWithButton)
+    })
+
     const seeMoreButtons = screen.getAllByText('Voir plus')
 
     // Using as because links is never undefined and the typing is not correct
-    await user.press(seeMoreButtons[2] as ReactTestInstance)
+    await user.press(seeMoreButtons[0] as ReactTestInstance)
 
     expect(mockOnSeeMoreButtonPress).toHaveBeenCalledTimes(1)
   })

--- a/src/features/chronicle/components/ChronicleCardList/ChronicleCardListBase.tsx
+++ b/src/features/chronicle/components/ChronicleCardList/ChronicleCardListBase.tsx
@@ -38,6 +38,7 @@ export type ChronicleCardListProps = Pick<
   headerComponent?: ReactElement
   style?: StyleProp<ViewStyle>
   onSeeMoreButtonPress?: (chronicleId: number) => void
+  shouldTruncate?: boolean
 }
 
 export const ChronicleCardListBase = forwardRef<
@@ -58,6 +59,7 @@ export const ChronicleCardListBase = forwardRef<
     separatorSize = SEPARATOR_DEFAULT_VALUE,
     onSeeMoreButtonPress,
     onLayout,
+    shouldTruncate,
   },
   ref
 ) {
@@ -92,7 +94,8 @@ export const ChronicleCardListBase = forwardRef<
           subtitle={item.subtitle}
           description={item.description}
           date={item.date}
-          cardWidth={cardWidth}>
+          cardWidth={cardWidth}
+          shouldTruncate={shouldTruncate}>
           {onSeeMoreButtonPress ? (
             <View>
               <StyledButtonTertiaryBlack
@@ -104,7 +107,7 @@ export const ChronicleCardListBase = forwardRef<
         </ChronicleCard>
       )
     },
-    [cardWidth, onSeeMoreButtonPress]
+    [cardWidth, onSeeMoreButtonPress, shouldTruncate]
   )
 
   return (

--- a/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.web.tsx
+++ b/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSection.web.tsx
@@ -35,7 +35,11 @@ export const ChronicleSection = (props: ChronicleSectionProps) => {
         </Row>
         {subtitle ? <StyledSubtitle>{subtitle}</StyledSubtitle> : null}
       </Gutter>
-      <StyledChronicleCardlist data={data} onSeeMoreButtonPress={onSeeMoreButtonPress} />
+      <StyledChronicleCardlist
+        data={data}
+        onSeeMoreButtonPress={onSeeMoreButtonPress}
+        shouldTruncate
+      />
     </View>
   ) : (
     <ChronicleSectionBase {...props} />

--- a/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSectionBase.tsx
+++ b/src/features/offer/components/OfferContent/ChronicleSection/ChronicleSectionBase.tsx
@@ -26,7 +26,11 @@ export const ChronicleSectionBase = ({
         <TypoDS.Title3 {...getHeadingAttrs(3)}>{title}</TypoDS.Title3>
         {subtitle ? <StyledSubtitle>{subtitle}</StyledSubtitle> : null}
       </Gutter>
-      <StyledChronicleCardlist data={data} onSeeMoreButtonPress={onSeeMoreButtonPress} />
+      <StyledChronicleCardlist
+        data={data}
+        onSeeMoreButtonPress={onSeeMoreButtonPress}
+        shouldTruncate
+      />
       <Gutter>
         <InternalTouchableLink
           as={ButtonSecondaryBlack}

--- a/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.native.test.tsx
@@ -155,6 +155,15 @@ const nativeEventBottom = {
     contentSize: { height: 1900 },
   },
 }
+
+const mockOnLayoutWithButton = {
+  nativeEvent: {
+    layout: {
+      height: 157,
+    },
+  },
+}
+
 const BATCH_TRIGGER_DELAY_IN_MS = 5000
 
 jest.useFakeTimers()
@@ -656,14 +665,20 @@ describe('<OfferContent />', () => {
           offer: { ...offerResponseSnap, subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER },
         })
 
+        const descriptions = screen.getAllByTestId('description')
+
+        await act(async () => {
+          descriptions[0]?.props.onLayout(mockOnLayoutWithButton)
+        })
+
         const seeMoreButtons = screen.getAllByText('Voir plus')
 
         // Using as because links is never undefined and the typing is not correct
-        await user.press(seeMoreButtons[2] as ReactTestInstance)
+        await user.press(seeMoreButtons[0] as ReactTestInstance)
 
         expect(mockNavigate).toHaveBeenNthCalledWith(1, 'Chronicles', {
           offerId: 116656,
-          chronicleId: 3,
+          chronicleId: 1,
           from: 'chronicles',
         })
       })
@@ -673,14 +688,20 @@ describe('<OfferContent />', () => {
           offer: { ...offerResponseSnap, subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER },
         })
 
+        const descriptions = screen.getAllByTestId('description')
+
+        await act(async () => {
+          descriptions[0]?.props.onLayout(mockOnLayoutWithButton)
+        })
+
         const seeMoreButtons = screen.getAllByText('Voir plus')
 
         // Using as because links is never undefined and the typing is not correct
-        await user.press(seeMoreButtons[2] as ReactTestInstance)
+        await user.press(seeMoreButtons[0] as ReactTestInstance)
 
         expect(analytics.logConsultChronicle).toHaveBeenNthCalledWith(1, {
           offerId: 116656,
-          chronicleId: 3,
+          chronicleId: 1,
         })
       })
     })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34395

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |![Capture d’écran 2025-02-12 à 16 51 32](https://github.com/user-attachments/assets/83d079fa-e46d-4440-b0f6-2f1a38fd22f6)|
| Android          |               |![Capture d’écran 2025-02-13 à 09 54 39](https://github.com/user-attachments/assets/31c6f79b-6149-4e5e-a2be-b3f41138c902)|
| Phone - Chrome   |               |![Capture d’écran 2025-02-12 à 16 53 32](https://github.com/user-attachments/assets/f38c2ce5-9c0c-435f-a00d-d4e9d6a12a47)|
| Desktop - Chrome |               |![Capture d’écran 2025-02-12 à 16 52 09](https://github.com/user-attachments/assets/403fe443-2007-4cca-88df-bb2fb7e38ed8)|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
