### PR TITLE
(PC-34595) build(codePush): bump code-push

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "react-native-animatable": "^1.3.3",
     "react-native-appsflyer": "^6.14.3",
     "react-native-calendars": "^1.1284.0",
-    "react-native-code-push": "^8.1.0",
+    "react-native-code-push": "^8.3.1",
     "react-native-date-picker": "^4.3.5",
     "react-native-detector": "^0.2.3",
     "react-native-device-info": "^11.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13107,7 +13107,7 @@ __metadata:
     react-native-animatable: ^1.3.3
     react-native-appsflyer: ^6.14.3
     react-native-calendars: ^1.1284.0
-    react-native-code-push: ^8.1.0
+    react-native-code-push: ^8.3.1
     react-native-date-picker: ^4.3.5
     react-native-detector: ^0.2.3
     react-native-device-info: ^11.1.0
@@ -15966,9 +15966,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"code-push@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "code-push@npm:4.2.0"
+"code-push@npm:^4.2.2":
+  version: 4.2.3
+  resolution: "code-push@npm:4.2.3"
   dependencies:
     appcenter-file-upload-client: 0.1.0
     proxy-agent: ^6.3.0
@@ -15976,7 +15976,7 @@ __metadata:
     slash: ^3.0.0
     superagent: ^8.0.0
     yazl: ^2.5.1
-  checksum: 1401720ac430c787930ffc8ad27d1bcc3673fbbe15ecec649b356f5ebd05dc4632b1b9cb121e863ad5025f9e95952fb930945ff59143130a4ec0e1573f6edb3b
+  checksum: 7455072a198ae6bdbf3161e9c649db8d5e4bf11ce375642f8f5cc894c4ed6d830b4886d4f07c88decd8dccc8f082ddc4aa590a27f43f77bacd83a94ab04b531d
   languageName: node
   linkType: hard
 
@@ -29267,18 +29267,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-code-push@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "react-native-code-push@npm:8.1.0"
+"react-native-code-push@npm:^8.3.1":
+  version: 8.3.1
+  resolution: "react-native-code-push@npm:8.3.1"
   dependencies:
-    code-push: ^4.2.0
+    code-push: ^4.2.2
     glob: ^7.1.7
     hoist-non-react-statics: ^3.3.2
     inquirer: ^8.1.5
     plist: ^3.0.4
     semver: ^7.3.5
     xcode: 3.0.1
-  checksum: 98b3864cb75e47fef16ed409a314b96dbc4d1afe93494920d3184531ac094679ca49bd164d526fa46aaf0438e419e47847bf869c1f64fc0cf1970200bed2a393
+  checksum: 2c8a834bd833c745abdbfdbc64d9f175b273ce7546732b7e0e54a4d9f9c370042a5dffc3aebf6a83cb8ea1a1d84f5613e7050cea0bcbb6b44693d46354614823
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34595

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
