### PR TITLE
(PC-34486) feat(FF): added FF owners to cheatcodes page

### DIFF
--- a/src/cheatcodes/hooks/useFeatureFlagAll.ts
+++ b/src/cheatcodes/hooks/useFeatureFlagAll.ts
@@ -1,7 +1,7 @@
 import { onlineManager, useQuery } from 'react-query'
 
 import { getAllFeatureFlags } from 'libs/firebase/firestore/featureFlags/getAllFeatureFlags'
-import { FeatureFlagConfig } from 'libs/firebase/firestore/featureFlags/types'
+import { FeatureFlagConfig, squads } from 'libs/firebase/firestore/featureFlags/types'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { getAppBuildVersion } from 'libs/packageJson'
 
@@ -16,6 +16,11 @@ const isFeatureFlagActive = (
     (!minimalBuildNumber || minimalBuildNumber <= appBuildVersion) &&
     (!maximalBuildNumber || maximalBuildNumber >= appBuildVersion)
   )
+}
+
+export type FeatureFlagAll = {
+  featureFlag: RemoteStoreFeatureFlags
+  isFeatureFlagActive: boolean
 }
 
 export const useFeatureFlagAll = () => {
@@ -36,10 +41,17 @@ export const useFeatureFlagAll = () => {
   const featureFlags = Object.values(RemoteStoreFeatureFlags).reduce(
     (flags, key) => {
       const config = docSnapshot.get<FeatureFlagConfig>(key)
-      flags[key] = isFeatureFlagActive(config, appBuildVersion)
+      const owner = config.owner ?? 'squad non-definie'
+      if (!flags[owner]) {
+        flags[owner] = [] // can't push an array that doesn't exist so we create it.
+      }
+      flags[owner].push({
+        featureFlag: key,
+        isFeatureFlagActive: isFeatureFlagActive(config, appBuildVersion),
+      })
       return flags
     },
-    {} as Record<RemoteStoreFeatureFlags, boolean>
+    {} as Record<squads | 'squad non-definie', FeatureFlagAll[]>
   )
 
   return featureFlags

--- a/src/cheatcodes/hooks/useFeatureFlagAll.ts
+++ b/src/cheatcodes/hooks/useFeatureFlagAll.ts
@@ -41,9 +41,9 @@ export const useFeatureFlagAll = () => {
   const featureFlags = Object.values(RemoteStoreFeatureFlags).reduce(
     (flags, key) => {
       const config = docSnapshot.get<FeatureFlagConfig>(key)
-      const owner = config.owner ?? 'squad non-definie'
+      const owner = (config.owner?.toLowerCase() as squads) ?? 'squad non-definie'
       if (!flags[owner]) {
-        flags[owner] = [] // can't push an array that doesn't exist so we create it.
+        flags[owner] = []
       }
       flags[owner].push({
         featureFlag: key,

--- a/src/cheatcodes/pages/others/CheatcodesScreenFeatureFlags.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenFeatureFlags.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { FlatList } from 'react-native'
+import { SectionList } from 'react-native'
 import styled from 'styled-components/native'
 
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
-import { useFeatureFlagAll } from 'cheatcodes/hooks/useFeatureFlagAll'
+import { FeatureFlagAll, useFeatureFlagAll } from 'cheatcodes/hooks/useFeatureFlagAll'
 import { env } from 'libs/environment/env'
 import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
 import { Separator } from 'ui/components/Separator'
@@ -13,7 +13,18 @@ import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 
 export const CheatcodesScreenFeatureFlags = () => {
   const featureFlags = useFeatureFlagAll()
-  const featureFlagsArray = Object.entries(featureFlags)
+
+  type Section = {
+    title: string
+    data: { featureFlag: string; isFeatureFlagActive: boolean }[]
+  }
+
+  const sections: Section[] = Object.entries(featureFlags).map(([owner, data]) => ({
+    title: owner,
+    data: data as FeatureFlagAll[], // "as" to avoid typing error
+  }))
+
+  const totalFeatureFlags = sections.reduce((sum, section) => sum + section.data.length, 0)
 
   const title = `Feature Flags ${env.ENV} 🏳️`
   const showTestingFeatureFlags = env.ENV !== 'testing'
@@ -55,17 +66,30 @@ export const CheatcodesScreenFeatureFlags = () => {
       ) : null}
       <Spacer.Column numberOfSpaces={6} />
       <TypoDS.BodyItalicAccent>
-        Nombre de feature flags&nbsp;: {featureFlagsArray.length}
+        Nombre de feature flags&nbsp;: {totalFeatureFlags}
       </TypoDS.BodyItalicAccent>
       <StyledSeparator />
-      <FlatList
-        data={featureFlagsArray}
-        keyExtractor={([featureFlag]) => featureFlag}
-        renderItem={({ item: [featureFlag, isActive] }) => (
-          <StyledFeatureFlag>
-            <TypoDS.Body numberOfLines={1}>{featureFlag}</TypoDS.Body>
-            <StyledTitle4 active={!!isActive}>{isActive ? 'Actif' : 'Inactif'}</StyledTitle4>
-          </StyledFeatureFlag>
+      <SectionList
+        sections={sections}
+        keyExtractor={(item) => item.featureFlag}
+        renderItem={({ item, index, section }) => (
+          <React.Fragment>
+            <StyledFeatureFlag>
+              <TypoDS.Body numberOfLines={1}>{item.featureFlag}</TypoDS.Body>
+              <StyledTitle4 active={!!item.isFeatureFlagActive}>
+                {item.isFeatureFlagActive ? 'Actif' : 'Inactif'}
+              </StyledTitle4>
+            </StyledFeatureFlag>
+            {index === section.data.length - 1 ? <Spacer.Column numberOfSpaces={10} /> : null}
+          </React.Fragment>
+        )}
+        renderSectionHeader={({ section: { title, data } }) => (
+          <React.Fragment>
+            <TypoDS.Title1>
+              {title} ({data.length})
+            </TypoDS.Title1>
+            <Spacer.Column numberOfSpaces={5} />
+          </React.Fragment>
         )}
         ItemSeparatorComponent={() => <StyledSeparator />}
       />

--- a/src/cheatcodes/pages/others/CheatcodesScreenFeatureFlags.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenFeatureFlags.tsx
@@ -85,9 +85,9 @@ export const CheatcodesScreenFeatureFlags = () => {
         )}
         renderSectionHeader={({ section: { title, data } }) => (
           <React.Fragment>
-            <TypoDS.Title1>
+            <TypoDS.Title2>
               {title} ({data.length})
-            </TypoDS.Title1>
+            </TypoDS.Title2>
             <Spacer.Column numberOfSpaces={5} />
           </React.Fragment>
         )}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34486

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/6ee17d76-5859-4eb1-8d0c-b194100caa42" />

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
