### PR TITLE
(PC-34596) fix(NotEligible): wording

### DIFF
--- a/__snapshots__/features/tutorial/pages/NotEligibleModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/NotEligibleModal.native.test.tsx.native-snap
@@ -438,7 +438,7 @@ exports[`NotEligibleModal without credit V3 for user under 15 years old should r
           ]
         }
       >
-        En attendant, tu peux explorer le catalogue des offres et découvrir des lieux culturels autour de toi.
+        En attendant, crée-toi un compte pour des suggestions à venir.
       </Text>
       <View
         numberOfSpaces={8}
@@ -863,7 +863,7 @@ exports[`NotEligibleModal without credit V3 for user under 15 years old should r
           ]
         }
       >
-        En attendant, tu peux explorer le catalogue des offres et découvrir des lieux culturels autour de toi.
+        En attendant, crée-toi un compte pour des suggestions à venir.
       </Text>
       <View
         numberOfSpaces={8}

--- a/__snapshots__/features/tutorial/pages/NotEligibleModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/NotEligibleModal.native.test.tsx.native-snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NotEligibleModal without credit V3 for user under 15 years old should render correctly for onboarding 1`] = `
+exports[`NotEligibleModal for user under 15 years old should render correctly for onboarding 1`] = `
 <Modal
   animationType="fade"
   hardwareAccelerated={false}
@@ -438,7 +438,7 @@ exports[`NotEligibleModal without credit V3 for user under 15 years old should r
           ]
         }
       >
-        En attendant, crée-toi un compte pour des suggestions à venir.
+        En attendant, tu peux explorer le catalogue des offres et découvrir des lieux culturels autour de toi.
       </Text>
       <View
         numberOfSpaces={8}
@@ -553,7 +553,7 @@ exports[`NotEligibleModal without credit V3 for user under 15 years old should r
 </Modal>
 `;
 
-exports[`NotEligibleModal without credit V3 for user under 15 years old should render correctly for profile tutorial 1`] = `
+exports[`NotEligibleModal for user under 15 years old should render correctly for profile tutorial 1`] = `
 <Modal
   animationType="fade"
   hardwareAccelerated={false}
@@ -863,7 +863,7 @@ exports[`NotEligibleModal without credit V3 for user under 15 years old should r
           ]
         }
       >
-        En attendant, crée-toi un compte pour des suggestions à venir.
+        En attendant, tu peux explorer le catalogue des offres et découvrir des lieux culturels autour de toi.
       </Text>
       <View
         numberOfSpaces={8}

--- a/__snapshots__/features/tutorial/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
+++ b/__snapshots__/features/tutorial/pages/onboarding/OnboardingNotEligible.native.test.tsx.native-snap
@@ -191,7 +191,7 @@ exports[`OnboardingNotEligible should render correctly 1`] = `
         ]
       }
     >
-      Ton crédit t’attend à partir de tes 17 ans. En attendant, crée-toi un compte pour explorer les offres autour de toi.
+      Ton crédit t’attend à partir de tes 17 ans. En attendant, crée-toi un compte pour des suggestions à venir.
     </Text>
     <View
       flex={1}

--- a/src/features/tutorial/pages/NotEligibleModal.native.test.tsx
+++ b/src/features/tutorial/pages/NotEligibleModal.native.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import { setSettings } from 'features/auth/tests/setSettings'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { NonEligible, TutorialTypes } from 'features/tutorial/enums'
@@ -24,106 +23,78 @@ const user = userEvent.setup()
 jest.useFakeTimers()
 
 describe('NotEligibleModal', () => {
-  describe('with credit V3', () => {
-    beforeEach(() => {
-      setSettings({ wipEnableCreditV3: true })
-    })
+  it('should display subtitle with credit V2', () => {
+    renderNotEligibleModal(NonEligible.UNDER_15, TutorialTypes.ONBOARDING)
 
-    it('for under 15, should display "Ton crédit t‘attend à partir de tes 17 ans."', async () => {
-      renderNotEligibleModal(NonEligible.UNDER_15, TutorialTypes.ONBOARDING)
+    const subtitle = 'Tu peux bénéficier de ton crédit sur l’application à partir de tes 15 ans.'
 
-      const text = await screen.findByText('Ton crédit t’attend à partir de tes 17 ans.')
+    expect(screen.getByText(subtitle)).toBeOnTheScreen()
+  })
 
-      expect(text).toBeTruthy()
-    })
+  describe('for user over 18 years old', () => {
+    it('should return null', () => {
+      renderNotEligibleModal(NonEligible.OVER_18, TutorialTypes.ONBOARDING)
 
-    it('for under 17, should display "Ton crédit t‘attend à partir de tes 17 ans."', async () => {
-      renderNotEligibleModal(NonEligible.UNDER_17, TutorialTypes.ONBOARDING)
-
-      const text = await screen.findByText('Ton crédit t’attend à partir de tes 17 ans.')
-
-      expect(text).toBeTruthy()
+      expect(screen.toJSON()).toBeNull()
     })
   })
 
-  describe('without credit V3', () => {
-    beforeEach(() => {
-      setSettings()
-    })
-
-    it('should display subtitle with credit V2', () => {
+  describe('for user under 15 years old', () => {
+    it('should render correctly for onboarding', () => {
       renderNotEligibleModal(NonEligible.UNDER_15, TutorialTypes.ONBOARDING)
 
-      const subtitle = 'Tu peux bénéficier de ton crédit sur l’application à partir de tes 15 ans.'
-
-      expect(screen.getByText(subtitle)).toBeOnTheScreen()
+      expect(screen).toMatchSnapshot()
     })
 
-    describe('for user over 18 years old', () => {
-      it('should return null', () => {
-        renderNotEligibleModal(NonEligible.OVER_18, TutorialTypes.ONBOARDING)
+    it('should render correctly for profile tutorial', () => {
+      renderNotEligibleModal(NonEligible.UNDER_15, TutorialTypes.PROFILE_TUTORIAL)
 
-        expect(screen.toJSON()).toBeNull()
-      })
+      expect(screen).toMatchSnapshot()
     })
 
-    describe('for user under 15 years old', () => {
-      it('should render correctly for onboarding', () => {
-        renderNotEligibleModal(NonEligible.UNDER_15, TutorialTypes.ONBOARDING)
+    it('should close modal when pressing right header icon', async () => {
+      renderNotEligibleModal(NonEligible.UNDER_15, TutorialTypes.ONBOARDING)
 
-        expect(screen).toMatchSnapshot()
-      })
+      const button = screen.getByTestId('Fermer la modale')
+      await user.press(button)
 
-      it('should render correctly for profile tutorial', () => {
-        renderNotEligibleModal(NonEligible.UNDER_15, TutorialTypes.PROFILE_TUTORIAL)
+      expect(hideModal).toHaveBeenCalledTimes(1)
+    })
 
-        expect(screen).toMatchSnapshot()
-      })
+    it('should close modal when pressing "Explorer le catalogue" on onboarding', async () => {
+      renderNotEligibleModal(NonEligible.UNDER_15, TutorialTypes.ONBOARDING)
 
-      it('should close modal when pressing right header icon', async () => {
-        renderNotEligibleModal(NonEligible.UNDER_15, TutorialTypes.ONBOARDING)
+      const button = screen.getByText('Explorer le catalogue')
+      await user.press(button)
 
-        const button = screen.getByTestId('Fermer la modale')
-        await user.press(button)
+      expect(hideModal).toHaveBeenCalledTimes(1)
+    })
 
-        expect(hideModal).toHaveBeenCalledTimes(1)
-      })
+    it('should navigate to home when pressing "Explorer le catalogue" on profile tutorial', async () => {
+      renderNotEligibleModal(NonEligible.UNDER_15, TutorialTypes.PROFILE_TUTORIAL)
 
-      it('should close modal when pressing "Explorer le catalogue" on onboarding', async () => {
-        renderNotEligibleModal(NonEligible.UNDER_15, TutorialTypes.ONBOARDING)
+      const button = screen.getByText('Explorer le catalogue')
+      await user.press(button)
 
-        const button = screen.getByText('Explorer le catalogue')
-        await user.press(button)
+      expect(navigateToHome).toHaveBeenCalledTimes(1)
+    })
 
-        expect(hideModal).toHaveBeenCalledTimes(1)
-      })
+    it('should not navigate to home when pressing "Explorer le catalogue" on onboarding', async () => {
+      renderNotEligibleModal(NonEligible.UNDER_15, TutorialTypes.ONBOARDING)
 
-      it('should navigate to home when pressing "Explorer le catalogue" on profile tutorial', async () => {
-        renderNotEligibleModal(NonEligible.UNDER_15, TutorialTypes.PROFILE_TUTORIAL)
+      const button = screen.getByText('Explorer le catalogue')
+      await user.press(button)
 
-        const button = screen.getByText('Explorer le catalogue')
-        await user.press(button)
+      expect(navigateToHome).not.toHaveBeenCalled()
+    })
 
-        expect(navigateToHome).toHaveBeenCalledTimes(1)
-      })
+    it('should redirect to FAQ when pressing "comment ça marche ?" on onboarding', async () => {
+      renderNotEligibleModal(NonEligible.UNDER_15, TutorialTypes.ONBOARDING)
 
-      it('should not navigate to home when pressing "Explorer le catalogue" on onboarding', async () => {
-        renderNotEligibleModal(NonEligible.UNDER_15, TutorialTypes.ONBOARDING)
+      const button = screen.getByText('comment ça marche\u00a0?')
+      await user.press(button)
 
-        const button = screen.getByText('Explorer le catalogue')
-        await user.press(button)
-
-        expect(navigateToHome).not.toHaveBeenCalled()
-      })
-
-      it('should redirect to FAQ when pressing "comment ça marche ?" on onboarding', async () => {
-        renderNotEligibleModal(NonEligible.UNDER_15, TutorialTypes.ONBOARDING)
-
-        const button = screen.getByText('comment ça marche\u00a0?')
-        await user.press(button)
-
-        expect(openUrl).toHaveBeenCalledWith(env.FAQ_LINK_CREDIT)
-      })
+      expect(openUrl).toHaveBeenCalledWith(env.FAQ_LINK_CREDIT)
     })
   })
 })

--- a/src/features/tutorial/pages/NotEligibleModal.tsx
+++ b/src/features/tutorial/pages/NotEligibleModal.tsx
@@ -63,10 +63,7 @@ export const NotEligibleModal = ({ visible, userStatus, hideModal, type }: Props
           </React.Fragment>
         ) : null}
         <Spacer.Column numberOfSpaces={4} />
-        <StyledBody>
-          En attendant, tu peux explorer le catalogue des offres et découvrir des lieux culturels
-          autour de toi.
-        </StyledBody>
+        <StyledBody>En attendant, crée-toi un compte pour des suggestions à venir.</StyledBody>
         <Spacer.Column numberOfSpaces={8} />
         <ButtonPrimary onPress={onButtonPress} wording="Explorer le catalogue" />
       </AppInformationModal>

--- a/src/features/tutorial/pages/NotEligibleModal.tsx
+++ b/src/features/tutorial/pages/NotEligibleModal.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react'
 import styled from 'styled-components/native'
 
-import { useSettingsContext } from 'features/auth/context/SettingsContext'
 import { navigateToHome } from 'features/navigation/helpers/navigateToHome'
 import { openUrl } from 'features/navigation/helpers/openUrl'
 import { NonEligible, TutorialTypes } from 'features/tutorial/enums'
@@ -22,8 +21,6 @@ type Props = {
 
 export const NotEligibleModal = ({ visible, userStatus, hideModal, type }: Props) => {
   const withFAQLink = type === TutorialTypes.ONBOARDING
-  const { data: settings } = useSettingsContext()
-  const enableCreditV3 = settings?.wipEnableCreditV3
 
   const onPress = useCallback(() => {
     openUrl(env.FAQ_LINK_CREDIT)
@@ -34,11 +31,7 @@ export const NotEligibleModal = ({ visible, userStatus, hideModal, type }: Props
     if (type === TutorialTypes.PROFILE_TUTORIAL) navigateToHome()
   }
 
-  if (
-    (enableCreditV3 &&
-      (userStatus === NonEligible.UNDER_15 || userStatus === NonEligible.UNDER_17)) ||
-    (!enableCreditV3 && userStatus === NonEligible.UNDER_15)
-  )
+  if (userStatus === NonEligible.UNDER_15)
     return (
       <AppInformationModal
         visible={visible}
@@ -48,9 +41,7 @@ export const NotEligibleModal = ({ visible, userStatus, hideModal, type }: Props
         <StyledIllustration />
         <Spacer.Column numberOfSpaces={4} />
         <StyledBody>
-          {enableCreditV3
-            ? 'Ton crédit t’attend à partir de tes 17 ans.'
-            : 'Tu peux bénéficier de ton crédit sur l’application à partir de tes 15 ans.'}
+          Tu peux bénéficier de ton crédit sur l’application à partir de tes 15 ans.
         </StyledBody>
         {withFAQLink ? (
           <React.Fragment>
@@ -63,7 +54,10 @@ export const NotEligibleModal = ({ visible, userStatus, hideModal, type }: Props
           </React.Fragment>
         ) : null}
         <Spacer.Column numberOfSpaces={4} />
-        <StyledBody>En attendant, crée-toi un compte pour des suggestions à venir.</StyledBody>
+        <StyledBody>
+          En attendant, tu peux explorer le catalogue des offres et découvrir des lieux culturels
+          autour de toi.
+        </StyledBody>
         <Spacer.Column numberOfSpaces={8} />
         <ButtonPrimary onPress={onButtonPress} wording="Explorer le catalogue" />
       </AppInformationModal>

--- a/src/features/tutorial/pages/onboarding/OnboardingNotEligible.tsx
+++ b/src/features/tutorial/pages/onboarding/OnboardingNotEligible.tsx
@@ -24,8 +24,8 @@ export const OnboardingNotEligible = () => {
       title="Encore un peu de patience&nbsp;!"
       onSkip={navigateToHomeWithReset}>
       <StyledBody>
-        Ton crédit t’attend à partir de tes 17 ans. En attendant, crée-toi un compte pour explorer
-        les offres autour de toi.
+        Ton crédit t’attend à partir de tes 17 ans. En attendant, crée-toi un compte pour des
+        suggestions à venir.
       </StyledBody>
       <Spacer.Flex flex={1} />
       <ButtonContainer>


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34596

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
