### PR TITLE
(PC-34599) feat(storybook): remove jest.setTimeout in Animations stories

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,7 +3,6 @@ const path = require('path')
 const appSrc = path.resolve('./src/')
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
-  jest: { testTimeout: 10000 },
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',

--- a/src/ui/storybook/Animations.stories.tsx
+++ b/src/ui/storybook/Animations.stories.tsx
@@ -5,12 +5,12 @@ import styled from 'styled-components/native'
 import LottieView from 'libs/lottie'
 import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 
-// Increase the timeout for animations
-jest.setTimeout(10000)
-
 export default {
   title: 'Fondations/Animations',
-  parameters: { chromatic: { disable: true } },
+  parameters: {
+    chromatic: { disable: true },
+    axe: { timeout: 5000 }, // Increase timeout for animations to finish
+  },
 }
 
 const LottieAnimations = {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34599

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
