### PR TITLE
(PC-34485) feat(a11y): update RemoteBanner accessibility

### DIFF
--- a/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/pages/Home.native.test.tsx.native-snap
@@ -368,7 +368,6 @@ exports[`Home page should render correctly 1`] = `
                   }
                 >
                   <View
-                    accessibilityRole="link"
                     accessibilityState={
                       {
                         "busy": undefined,

--- a/src/features/remoteBanner/components/RemoteBanner.tsx
+++ b/src/features/remoteBanner/components/RemoteBanner.tsx
@@ -10,6 +10,7 @@ import {
   validateRemoteBanner,
 } from 'features/remoteBanner/components/remoteBannerSchema'
 import { accessibilityAndTestId } from 'libs/accessibilityAndTestId'
+import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { analytics } from 'libs/analytics/provider'
 import { useFeatureFlagOptions } from 'libs/firebase/firestore/featureFlags/useFeatureFlagOptions'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
@@ -31,9 +32,14 @@ export const RemoteBanner = ({ from }: { from: RemoteBannerOrigin }) => {
   const isExternalRedirection = redirectionType === RemoteBannerRedirectionType.EXTERNAL
   const isExternalAndDefined = isExternalRedirection && redirectionUrl
 
-  const storeAccessibilityLabel = isStoreRedirection ? `Nouvelle fenêtre\u00a0: ${STORE_LINK}` : ''
+  const isWebStoreBanner = isStoreRedirection && !isWeb
+  const accessibilityRole = isWebStoreBanner ? AccessibilityRole.BUTTON : AccessibilityRole.LINK
+
+  const externalAccessiblityLabel = `Nouvelle fenêtre\u00a0: ${String(redirectionUrl)}`
+  const storeAccessibilityLabel = isWebStoreBanner ? `Nouvelle fenêtre\u00a0: ${STORE_LINK}` : ''
+
   const accessibilityLabel = isExternalAndDefined
-    ? `Nouvelle fenêtre\u00a0: ${String(redirectionUrl)}`
+    ? externalAccessiblityLabel
     : storeAccessibilityLabel
 
   const onPress = () => {
@@ -44,8 +50,10 @@ export const RemoteBanner = ({ from }: { from: RemoteBannerOrigin }) => {
 
   return (
     <BannerWithBackground
+      accessibilityRole={accessibilityRole}
       disabled={!isStoreRedirection && !redirectionUrl}
       leftIcon={ArrowAgain}
+      noRightIcon={isStoreRedirection && isWeb}
       onPress={onPress}
       {...accessibilityAndTestId(accessibilityLabel)}>
       <StyledButtonText>{title}</StyledButtonText>

--- a/src/features/remoteBanner/components/RemoteBanner.web.test.tsx
+++ b/src/features/remoteBanner/components/RemoteBanner.web.test.tsx
@@ -34,6 +34,17 @@ describe('RemoteBanner', () => {
 
     expect(subtitle).not.toBeInTheDocument()
   })
+
+  it('should have noRightIcon for store redirection on web', async () => {
+    setFeatureFlags([
+      { featureFlag: RemoteStoreFeatureFlags.SHOW_REMOTE_BANNER, options: bannerStoreRedirection },
+    ])
+    render(<RemoteBanner from="Profile" />)
+
+    const rightIcon = screen.queryByTestId('ArrowNext')
+
+    expect(rightIcon).not.toBeInTheDocument()
+  })
 })
 
 const bannerExternalUrl: RemoteBannerType = {
@@ -42,4 +53,12 @@ const bannerExternalUrl: RemoteBannerType = {
   subtitleWeb: 'subtitleWeb',
   redirectionUrl: 'https://www.test.fr',
   redirectionType: RemoteBannerRedirectionType.EXTERNAL,
+}
+
+const bannerStoreRedirection: RemoteBannerType = {
+  title: 'title',
+  subtitleMobile: 'subtitleMobile',
+  subtitleWeb: 'subtitleWeb',
+  redirectionUrl: 'https://www.test.fr',
+  redirectionType: RemoteBannerRedirectionType.STORE,
 }

--- a/src/ui/components/ModuleBanner/BannerWithBackground.tsx
+++ b/src/ui/components/ModuleBanner/BannerWithBackground.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react'
-import { ImageSourcePropType } from 'react-native'
+import { AccessibilityRole, ImageSourcePropType } from 'react-native'
 import styled from 'styled-components/native'
 
 import { BANNER_BORDER_WIDTH, GenericBanner } from 'ui/components/ModuleBanner/GenericBanner'
@@ -24,8 +24,10 @@ type BannerWithBackgroundProps = TouchableProps & {
   leftIcon?: FunctionComponent<AccessibleIcon>
   rightIcon?: FunctionComponent<AccessibleIcon>
   backgroundSource?: ImageSourcePropType
+  noRightIcon?: boolean
   testID?: string
   disabled?: boolean
+  accessibilityRole?: AccessibilityRole
   children: React.ReactNode
 }
 
@@ -36,6 +38,7 @@ export const BannerWithBackground: FunctionComponent<BannerWithBackgroundProps> 
   backgroundSource,
   testID,
   disabled = false,
+  accessibilityRole,
   ...touchableProps
 }) => {
   const StyledLeftIcon =
@@ -56,14 +59,19 @@ export const BannerWithBackground: FunctionComponent<BannerWithBackgroundProps> 
   const TouchableComponent = 'navigateTo' in touchableProps ? StyledTouchableLink : TouchableOpacity
 
   return (
-    <TouchableComponent {...touchableProps} testID={testID} disabled={disabled}>
+    <TouchableComponent
+      {...touchableProps}
+      testID={testID}
+      disabled={disabled}
+      accessibilityRole={accessibilityRole}>
       <ImageContainer>
         <ImageBackground
           source={backgroundSource || BACKGROUND_IMAGE_SOURCE}
           testID="module-background">
           <GenericBannerWithoutBorder
             LeftIcon={StyledLeftIcon ? <StyledLeftIcon /> : undefined}
-            RightIcon={StyledRightIcon}>
+            RightIcon={StyledRightIcon}
+            noRightIcon={touchableProps.noRightIcon}>
             {children}
           </GenericBannerWithoutBorder>
         </ImageBackground>

--- a/src/ui/components/ModuleBanner/GenericBanner.stories.tsx
+++ b/src/ui/components/ModuleBanner/GenericBanner.stories.tsx
@@ -42,6 +42,10 @@ const variantConfig: Variants<typeof GenericBanner> = [
     label: 'GenericBanner active',
     props: { children: textExample({ withSubtitle: false }) },
   },
+  {
+    label: 'GenericBanner without right icon',
+    props: { children: textExample({}), noRightIcon: true },
+  },
 ]
 
 const Template: VariantsStory<typeof GenericBanner> = (args) => (

--- a/src/ui/components/ModuleBanner/GenericBanner.tsx
+++ b/src/ui/components/ModuleBanner/GenericBanner.tsx
@@ -10,6 +10,7 @@ import { getSpacing } from 'ui/theme'
 type GenericBannerProps = {
   LeftIcon?: ReactElement
   RightIcon?: FunctionComponent<AccessibleIcon>
+  noRightIcon?: boolean
   children: React.ReactNode
   style?: StyleProp<ViewStyle>
   testID?: string
@@ -18,6 +19,7 @@ type GenericBannerProps = {
 export const GenericBanner: FunctionComponent<GenericBannerProps> = ({
   LeftIcon,
   RightIcon,
+  noRightIcon = false,
   style,
   children,
   testID,
@@ -26,7 +28,7 @@ export const GenericBanner: FunctionComponent<GenericBannerProps> = ({
     <View style={[styles.container, style]} testID={testID}>
       {LeftIcon ? <IconContainer>{LeftIcon}</IconContainer> : null}
       <DescriptionContainer>{children}</DescriptionContainer>
-      <View>{RightIcon ? <RightIcon /> : <StyledArrowNextIcon />}</View>
+      {noRightIcon ? null : <View>{RightIcon ? <RightIcon /> : <StyledArrowNextIcon />}</View>}
     </View>
   )
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34485

En utilisant onPress plutot que navigateTo, l'utilisation d'un composant Link disparait. J'ai ajouté des roles comme fix car c'est le plus simple pour ce cas très spécifique. 
J'ai aussi retiré l'accessibilité label "Nouvelle fenetre" qui pouvait encore être présent en web + store alors que c'est juste un bouton. 
Enfin, j'ai retiré l'icon si c'est un bouton. 

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |   ![Simulator Screenshot - iPhone 15 Pro Max - 2025-02-14 at 14 49 27](https://github.com/user-attachments/assets/a986441d-e6cb-4e53-bdbb-fbf9e33a7cab) |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |  ![Capture d’écran 2025-02-14 à 14 48 03](https://github.com/user-attachments/assets/78c93476-9596-4626-9e87-7e3b45c0d81e) |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4