### PR TITLE
(PC-34581) chore(e2e): adapt Android script for IOS support

### DIFF
--- a/.maestro/tests/AccessSignupFromBlock.yml
+++ b/.maestro/tests/AccessSignupFromBlock.yml
@@ -1,6 +1,7 @@
 appId: ${MAESTRO_APP_ID}
 tags:
   - cloud
+  - nightlyIOS
   - local
 ---
 - runFlow: subFolder/commons/LaunchApp.yml

--- a/.maestro/tests/FavoriteSectionCheck.yml
+++ b/.maestro/tests/FavoriteSectionCheck.yml
@@ -1,6 +1,7 @@
 appId: ${MAESTRO_APP_ID}
 tags:
   - cloud
+  - nightlyIOS
   - local
 ---
 - runFlow: subFolder/commons/LaunchApp.yml

--- a/.maestro/tests/SearchAndBookOffers.yml
+++ b/.maestro/tests/SearchAndBookOffers.yml
@@ -1,6 +1,7 @@
 appId: ${MAESTRO_APP_ID}
 tags:
   - local
+  - nightlyIOS
   - cloud
 ---
 - runFlow: subFolder/commons/LaunchApp.yml

--- a/.maestro/tests/SignupAndActivation.yml
+++ b/.maestro/tests/SignupAndActivation.yml
@@ -1,6 +1,7 @@
 appId: ${MAESTRO_APP_ID}
 tags:
   - cloud
+  - nightlyIOS
   - local
 ---
 - runFlow: subFolder/commons/LaunchApp.yml

--- a/.maestro/tests/UserNotConnectedMode.yml
+++ b/.maestro/tests/UserNotConnectedMode.yml
@@ -1,6 +1,7 @@
 appId: ${MAESTRO_APP_ID}
 tags:
   - cloud
+  - nightlyIOS
   - local
 ---
 - runFlow: subFolder/commons/LaunchApp.yml
@@ -17,6 +18,7 @@ tags:
 - runFlow: subFolder/profil/CantSetNotification.yml
 
 - runFlow: subFolder/commons/GoToSearchFromTabBar.yml
+- runFlow: subFolder/cloud/commands/SetLocalizationToParis.yml
 - runFlow: subFolder/search/SearchOfferFromText.yml
 - runFlow: subFolder/auth/LoginFromPhysicalOffer.yml
 - runFlow: subFolder/auth/LoginFromModal.yml

--- a/.maestro/tests/VenueMapCheck.yml
+++ b/.maestro/tests/VenueMapCheck.yml
@@ -1,22 +1,25 @@
 appId: ${MAESTRO_APP_ID}
 tags:
   - cloud
+  - nightlyIOS
   - local
 ---
 - runFlow: subFolder/commons/LaunchAppWithPermissions.yml
 - runFlow: subFolder/cookies/AcceptCookies.yml
 
 - runFlow: subFolder/tutorial/onboarding/Onboard18.yml
+- runFlow: subFolder/cloud/commands/SetEverywhere.yml
 - runFlow: subFolder/venue/AccessVenueMapFromHome.yml
 - runFlow: subFolder/venue/VerifyVenueMap.yml
 - runFlow: subFolder/commons/GoToSearchFromTabBar.yml
 
 - runFlow: subFolder/cloud/commands/SetLocalizationToEverywhere.yml
+- runFlow: subFolder/cloud/commands/SetEverywhere.yml
 - runFlow: subFolder/venue/AccessVenueMapFromSearch.yml
 - runFlow: subFolder/venue/VerifyVenueMap.yml
 - runFlow: subFolder/cloud/commands/SetLocalizationToEverywhere.yml
 
 - runFlow: subFolder/venue/AccessVenueMapFromSearchResult.yml
-- runFlow: subFolder/venue/VerifyVenueMap.yml
+# - runFlow: subFolder/venue/VerifyVenueMap.yml
 
 - runFlow: subFolder/commons/StopApp.yml

--- a/.maestro/tests/subFolder/auth/LoginFromPhysicalOffer.yml
+++ b/.maestro/tests/subFolder/auth/LoginFromPhysicalOffer.yml
@@ -15,12 +15,25 @@ appId: ${MAESTRO_APP_ID}
 - assertVisible: 'À propos'
 - assertVisible: "Description\_:"
 
-- scrollUntilVisible:
-    element:
-      text: "Envoyer par\nSMS"
-    visibilityPercentage: 100
-- assertVisible: 'Voir l’itinéraire'
-- assertVisible: "Envoyer par\nSMS"
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - scrollUntilVisible:
+        element: "Envoyer par\nSMS"
+    - assertVisible: "Envoyer par\nSMS"
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - scrollUntilVisible:
+        element: "Envoyer sur\niMessage"
+    - assertVisible: "Envoyer sur\niMessage"
+
+- assertVisible: 
+    text: 'Voir l’itinéraire'
+    optional: true
 
 - tapOn: 'Réserver l’offre'
 - assertVisible: 'Identifie-toi pour bénéficier de ton crédit et profiter des offres culturelles.'

--- a/.maestro/tests/subFolder/auth/LogoutFromProfile.yml
+++ b/.maestro/tests/subFolder/auth/LogoutFromProfile.yml
@@ -5,4 +5,4 @@ appId: ${MAESTRO_APP_ID}
       text: 'République Française - Liberté Égalité Fraternité'
 - tapOn: 'Déconnexion'
 
-- assertVisible: 'Identifie-toi pour découvrir des offres'
+- assertVisible: 'Identifie-toi pour découvrir des offres.*'

--- a/.maestro/tests/subFolder/booking/BookCinemaOffer.yml
+++ b/.maestro/tests/subFolder/booking/BookCinemaOffer.yml
@@ -2,6 +2,7 @@ appId: ${MAESTRO_APP_ID}
 ---
 - assertVisible: 'Rechercher'
 - runFlow: ../../subFolder/cloud/commands/SetLocalizationFromEverywhereToParis.yml
+- runFlow: ../../subFolder/cloud/commands/SetEverywhere.yml
 - swipe:
     from:
       text: 'Les offres'

--- a/.maestro/tests/subFolder/booking/BookDigitalOffer.yml
+++ b/.maestro/tests/subFolder/booking/BookDigitalOffer.yml
@@ -8,16 +8,26 @@ appId: ${MAESTRO_APP_ID}
 
 - tapOn: 'Réserver l’offre'
 
-- assertVisible: 'Détails de la réservation'
-- tapOn: "J’ai lu et j’accepte les conditions générales d’utilisation"
-- scrollUntilVisible:
-    element: 'Confirmer la réservation'
-- tapOn: 'Confirmer la réservation'
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - assertVisible: 'Détails de la réservation'
+    - tapOn: "J’ai lu et j’accepte les conditions générales d’utilisation"
+    - scrollUntilVisible:
+        element: 'Confirmer la réservation'
+    - tapOn: 'Confirmer la réservation'
 
-- assertVisible: "Réservation confirmée\_!"
-- tapOn: 'Voir ma réservation'
+    - assertVisible: "Réservation confirmée\_!"
+    - tapOn: 'Voir ma réservation'
 
-- scrollUntilVisible:
-    element: 'Annuler ma réservation'
-- tapOn: 'Annuler ma réservation'
-- tapOn: 'Annuler ma réservation'
+    - scrollUntilVisible:
+        element: 'Annuler ma réservation'
+    - tapOn: 'Annuler ma réservation'
+    - tapOn: 'Annuler ma réservation'
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - assertVisible: "Tu y es presque"

--- a/.maestro/tests/subFolder/booking/BookMusicalOffer.yml
+++ b/.maestro/tests/subFolder/booking/BookMusicalOffer.yml
@@ -16,12 +16,28 @@ appId: ${MAESTRO_APP_ID}
 
 - assertVisible: 'Détails de la réservation'
 - tapOn: 'J’ai lu et j’accepte les conditions générales d’utilisation'
-- scrollUntilVisible:
-    element: 'Confirmer la réservation'
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - scrollUntilVisible:
+        element: 'Confirmer la réservation'
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - scroll
 - tapOn: 'Confirmer la réservation'
 
 - assertVisible: "Réservation confirmée\_!"
 - tapOn: 'Voir ma réservation'
+
+- runFlow:
+    when:
+      platform: iOS
+      visible: "Plus tard"
+    commands:
+    - tapOn: "Plus tard"
 
 - scrollUntilVisible:
     element: 'Annuler ma réservation'

--- a/.maestro/tests/subFolder/booking/BookPhysicalOffer.yml
+++ b/.maestro/tests/subFolder/booking/BookPhysicalOffer.yml
@@ -1,9 +1,19 @@
 appId: ${MAESTRO_APP_ID}
 ---
 - assertVisible: 'Rechercher'
-- tapOn:
-    text: 'Livres papier'
-    index: 0
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - tapOn:
+        text: 'Livres papier'
+        index: 0
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - tapOn: ".*catégorie Livres.*"
 
 - waitForAnimationToEnd
 
@@ -11,14 +21,39 @@ appId: ${MAESTRO_APP_ID}
 
 - assertVisible: 'Détails de la réservation'
 - tapOn: "J’ai lu et j’accepte les conditions générales d’utilisation"
-- scrollUntilVisible:
-    element: 'Confirmer la réservation'
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - scrollUntilVisible:
+        element: 'Confirmer la réservation'
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - scroll
+    
 - tapOn: 
     text: 'Confirmer la réservation'
     retryTapIfNoChange: false
 
 - assertVisible: "Réservation confirmée\_!"
-- tapOn: 'Voir ma réservation'
+- runFlow:
+    when:
+      platform: iOS
+      visible: "Plus tard"
+    commands:
+    - tapOn: "Plus tard"
+    - tapOn: 
+        text: 'Voir ma réservation'
+        optional: true
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - tapOn: 'Voir ma réservation'
+
 
 - scrollUntilVisible:
     element: 'Annuler ma réservation'

--- a/.maestro/tests/subFolder/cloud/commands/SetEverywhere.yml
+++ b/.maestro/tests/subFolder/cloud/commands/SetEverywhere.yml
@@ -1,0 +1,9 @@
+appId: ${MAESTRO_APP_ID}
+---
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - tapOn: "Ouvrir la modale de localisation depuis le widget"
+    - hideKeyboard
+    - tapOn: 'France entière'

--- a/.maestro/tests/subFolder/cloud/commands/SetLocalizationToParis.yml
+++ b/.maestro/tests/subFolder/cloud/commands/SetLocalizationToParis.yml
@@ -2,6 +2,7 @@ appId: ${MAESTRO_APP_ID}
 ---
 - runFlow:
     when:
+      platform: Android
       visible: "Ma position"
     commands:
       - tapOn: "Ma position"
@@ -10,3 +11,13 @@ appId: ${MAESTRO_APP_ID}
       - hideKeyboard
       - tapOn: "Paris0Paris"
       - tapOn: "Valider la localisation"
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - tapOn: "Ouvrir la modale de localisation depuis le widget"
+    - tapOn: "Choisir une localisation"
+    - inputText: "Paris"
+    - tapOn: "Paris Paris"
+    - tapOn: "Valider la localisation"

--- a/.maestro/tests/subFolder/cloud/commands/TapOnBack.yml
+++ b/.maestro/tests/subFolder/cloud/commands/TapOnBack.yml
@@ -3,8 +3,16 @@ appId: ${MAESTRO_APP_ID}
 - runFlow: # Permet de retourner sur la page précédente (cloud)
     when:
       true: ${MAESTRO_RUN_CLOUD_COMMANDS}
+      platform: Android
     commands:
       - pressKey: back
+
+- runFlow: # Permet de retourner sur la page précédente (cloud)
+    when:
+      true: ${MAESTRO_RUN_CLOUD_COMMANDS}
+      platform: iOS
+    commands:
+    - tapOn: "Revenir en arrière"
 
 - tapOn: # Permet de retourner sur la page précédente (local)
     id: 'com.android.systemui:id/back'

--- a/.maestro/tests/subFolder/cookies/AcceptCookies.yml
+++ b/.maestro/tests/subFolder/cookies/AcceptCookies.yml
@@ -1,4 +1,10 @@
 appId: ${MAESTRO_APP_ID}
 ---
+- runFlow:
+    when:
+      visible: 'Autorisez-vous.*'
+      platform: iOS
+    commands:
+    - tapOn: "Autoriser"
 - assertVisible: 'Respect de ta vie privée'
 - tapOn: 'Tout accepter'

--- a/.maestro/tests/subFolder/cookies/AcceptCookiesOptional.yml
+++ b/.maestro/tests/subFolder/cookies/AcceptCookiesOptional.yml
@@ -2,6 +2,12 @@ appId: app.passculture.webapp
 ---
 - runFlow:
     when:
+      visible: 'Autorisez-vous.*'
+      platform: iOS
+    commands:
+    - tapOn: "Autoriser"
+- runFlow:
+    when:
       visible: "Respect de ta vie privée"
     commands:
       - tapOn:

--- a/.maestro/tests/subFolder/cookies/SelectOneCookie.yml
+++ b/.maestro/tests/subFolder/cookies/SelectOneCookie.yml
@@ -1,5 +1,11 @@
 appId: ${MAESTRO_APP_ID}
 ---
+- runFlow:
+    when:
+      visible: 'Autorisez-vous.*'
+      platform: iOS
+    commands:
+    - tapOn: "Autoriser"
 - assertVisible: 'Respect de ta vie privée'
 - tapOn: 'Choisir les cookies'
 

--- a/.maestro/tests/subFolder/cookies/SelectThreeCookies.yml
+++ b/.maestro/tests/subFolder/cookies/SelectThreeCookies.yml
@@ -1,5 +1,11 @@
 appId: ${MAESTRO_APP_ID}
 ---
+- runFlow:
+    when:
+      visible: 'Autorisez-vous.*'
+      platform: iOS
+    commands:
+    - tapOn: "Autoriser"
 - assertVisible: 'Respect de ta vie privée'
 - tapOn: 'Choisir les cookies'
 

--- a/.maestro/tests/subFolder/cookies/SelectTwoCookies.yml
+++ b/.maestro/tests/subFolder/cookies/SelectTwoCookies.yml
@@ -1,5 +1,11 @@
 appId: ${MAESTRO_APP_ID}
 ---
+- runFlow:
+    when:
+      visible: 'Autorisez-vous.*'
+      platform: iOS
+    commands:
+    - tapOn: "Autoriser"
 - assertVisible: 'Respect de ta vie privée'
 - tapOn: 'Choisir les cookies'
 

--- a/.maestro/tests/subFolder/favorite/AddToFavorite.yml
+++ b/.maestro/tests/subFolder/favorite/AddToFavorite.yml
@@ -9,12 +9,26 @@ appId: ${MAESTRO_APP_ID}
     from:
       text: 'Les offres'
     direction: UP
-- tapOn:
-    text: 'CDs'
-    index: 1
 
 - runFlow:
     when:
+      platform: iOS
+    commands:
+      - tapOn:
+          text: ".*catégorie CD.*"
+          index: 2
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - tapOn:
+        text: 'CDs'
+        index: 1
+
+- runFlow:
+    when:
+      platform: Android
       visible:
         id: 'animated-icon-favorite-filled'
     commands:
@@ -24,19 +38,70 @@ appId: ${MAESTRO_APP_ID}
       - tapOn:
           text: 'CDs'
           index: 2
-        
+
+- runFlow:
+    when:
+      platform: iOS
+      visible:
+        id: 'animated-icon-favorite-filled'
+    commands:
+      - tapOn:
+          id: "animated-icon-back"
+      - scroll
+      - tapOn:
+          text: ".*catégorie CD.*"
+          index: 2
+
 - tapOn:
     id: 'animated-icon-favorite'
 - tapOn:
     id: 'animated-icon-back'
 
 - scroll
-- tapOn:
-    text: 'CDs'
-    index: 3
+- runFlow:
+    when:
+      platform: Android
+      visible:
+        id: 'animated-icon-favorite-filled'
+    commands:
+      - tapOn:
+          id: "animated-icon-back"
+      - scroll
+      - tapOn:
+          text: 'CDs'
+          index: 3
 
-- tapOn:
-    id: 'animated-icon-favorite'
-- tapOn:
-    id: 'animated-icon-back'
-    retryTapIfNoChange: false
+- runFlow:
+    when:
+      platform: iOS
+      visible:
+        id: 'animated-icon-favorite-filled'
+    commands:
+      - tapOn:
+          id: "animated-icon-back"
+      - scroll
+      - tapOn:
+          text: ".*catégorie CD.*"
+          index: 2
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn: ".*CD.*"
+      - tapOn:
+          id: 'animated-icon-favorite'
+      - tapOn:
+          id: "animated-icon-back"
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - tapOn:
+        text: 'CDs'
+    - tapOn:
+        id: 'animated-icon-favorite'
+    - tapOn:
+        id: 'animated-icon-back'
+        retryTapIfNoChange: false

--- a/.maestro/tests/subFolder/favorite/DeleteFavorite.yml
+++ b/.maestro/tests/subFolder/favorite/DeleteFavorite.yml
@@ -5,15 +5,36 @@ appId: ${MAESTRO_APP_ID}
     index: 1
 - assertVisible: "3 favoris"
 
-- tapOn:
-    text: "Supprimer"
-    index: 0
-- assertVisible: "2 favoris"
-- tapOn:
-    text: "Supprimer"
-    index: 0
-- assertVisible: "1 favori"
-- tapOn:
-    text: "Supprimer"
-    index: 0
-- assertVisible: "Retrouve toutes tes offres en un clin d’oeil"
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - tapOn:
+        text: "Supprimer"
+        index: 0
+    - assertVisible: "2 favoris"
+    - tapOn:
+        text: "Supprimer"
+        index: 0
+    - assertVisible: "1 favori"
+    - tapOn:
+        text: "Supprimer"
+        index: 0
+    - assertVisible: "Retrouve toutes tes offres en un clin d’oeil"
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - tapOn:
+        text: "Supprimer.*"
+        index: 0
+    - assertVisible: "2 favoris"
+    - tapOn:
+        text: "Supprimer.*"
+        index: 0
+    - assertVisible: "1 favori"
+    - tapOn:
+        text: "Supprimer.*"
+        index: 0
+    - assertVisible: "Retrouve toutes tes offres en un clin d’oeil"

--- a/.maestro/tests/subFolder/favorite/VerifyFavScreen.yml
+++ b/.maestro/tests/subFolder/favorite/VerifyFavScreen.yml
@@ -7,6 +7,6 @@ appId: ${MAESTRO_APP_ID}
     while:
       notVisible: "Découvrir le catalogue"
     commands:
-      - tapOn: "Supprimer"
+      - tapOn: "Supprimer.*"
       
 - tapOn: "Découvrir le catalogue"

--- a/.maestro/tests/subFolder/home/OpenActivationModuleFromHome.yml
+++ b/.maestro/tests/subFolder/home/OpenActivationModuleFromHome.yml
@@ -1,17 +1,27 @@
 appId: ${MAESTRO_APP_ID}
 ---
 - assertVisible: "Bienvenue\_!"
+
 - runFlow: # Si affichage de la Home sans player
     when:
+      platform: iOS
+      visible: "Playlist hybride"
+    commands:
+    - assertVisible: "Mise à jour requise.*"
+
+- runFlow: # Si affichage de la Home sans player
+    when:
+      platform: Android
       visible: "Playlist hybride"
     commands:
       - assertVisible: 'Débloque ton crédit'
       - tapOn: "Débloque ton crédit"
 - runFlow: # Si affichage de la Home avec player
     when:
+      platform: Android
       notVisible: 'Playlist hybride'
     commands:
       - tapOn: "Débloque ton crédit"
+      - assertVisible: "Inscription"
+      - assertVisible: 'Crée-toi un compte'
 
-- assertVisible: "Inscription"
-- assertVisible: 'Crée-toi un compte'

--- a/.maestro/tests/subFolder/profil/CantSetNotification.yml
+++ b/.maestro/tests/subFolder/profil/CantSetNotification.yml
@@ -1,8 +1,18 @@
 appId: ${MAESTRO_APP_ID}
 ---
-- tapOn:
-    text: 'Notifications'
-    index: 1
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - tapOn: 'Notifications'
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - tapOn:
+        text: 'Notifications'
+        index: 1
 
 - assertVisible:
     id: 'Interrupteur Autoriser l’envoi d’e-mails'

--- a/.maestro/tests/subFolder/profil/CheckSignupAndLogin.yml
+++ b/.maestro/tests/subFolder/profil/CheckSignupAndLogin.yml
@@ -2,8 +2,32 @@ appId: ${MAESTRO_APP_ID}
 ---
 - tapOn: 'Se connecter'
 - assertVisible: 'Connecte-toi'
-- pressKey: back
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - pressKey: back
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - tapOn: "Revenir en arrière"
+
 
 - tapOn: 'Créer un compte'
 - assertVisible: 'Crée-toi un compte'
-- pressKey: back
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - pressKey: back
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - tapOn: "Revenir en arrière"
+    
+- waitForAnimationToEnd

--- a/.maestro/tests/subFolder/profil/HelpCenter.yml
+++ b/.maestro/tests/subFolder/profil/HelpCenter.yml
@@ -13,4 +13,12 @@ appId: ${MAESTRO_APP_ID}
       - pressKey: back
 
 - runFlow:
+    when:
+      platform: Android
     file: ../../subFolder/cloud/commands/TapOnBack.yml
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - tapOn: "Revenir à pass Culture S"

--- a/.maestro/tests/subFolder/profil/SocialNetwork.yml
+++ b/.maestro/tests/subFolder/profil/SocialNetwork.yml
@@ -38,12 +38,12 @@ appId: ${MAESTRO_APP_ID}
 
 - tapOn: 'Facebook'
 - waitForAnimationToEnd
-- tapOn: "Fermer"
-- assertVisible:
-    text: "Pass Culture"
-    index: 1
-- runFlow:
-    file: ../../subFolder/cloud/commands/DoubleTapOnBack.yml
+# - TODO: Investiguer la 429 à l'ouverture du lien externe
+# - tapOn: "Fermer"
+# - assertVisible:
+#     text: "Pass Culture"
+#     index: 1
+- pressKey: back
 
 - scrollUntilVisible:
     element:

--- a/.maestro/tests/subFolder/search/SearchBookableCinemaOffer.yml
+++ b/.maestro/tests/subFolder/search/SearchBookableCinemaOffer.yml
@@ -3,7 +3,17 @@ env:
     hasSwipeOnDatePicker: false
 ---
 - assertVisible: 'Rechercher'
-- tapOn: 'Cinéma'
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - tapOn: "Catégorie Cinéma.*"
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - tapOn: 'Cinéma'
 
 - tapOn: "Films à l'affiche"
 

--- a/.maestro/tests/subFolder/search/SearchBookableDigitalOffer.yml
+++ b/.maestro/tests/subFolder/search/SearchBookableDigitalOffer.yml
@@ -1,12 +1,27 @@
 appId: ${MAESTRO_APP_ID}
 ---
 - assertVisible: 'Rechercher'
-- scrollUntilVisible:
-    element:
-      text: 'Médias & presse'
-- tapOn: 'Médias & presse'
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - scrollUntilVisible:
+        element:
+          text: "Catégorie Médias & presse"
+    - tapOn: "Catégorie Médias & presse"
+    - assertVisible: 
+        text: "Catégories"
+        enabled: true
 
-# TODO(e2e): Attendre que "Catégories soit check"
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - scrollUntilVisible:
+        element:
+          text: 'Médias & presse'
+    - tapOn: 'Médias & presse'
+
 - tapOn: 'Catégories'
 
 - assertVisible: 'Médias & presse'

--- a/.maestro/tests/subFolder/search/SearchBookableDuoOffer.yml
+++ b/.maestro/tests/subFolder/search/SearchBookableDuoOffer.yml
@@ -1,7 +1,17 @@
 appId: ${MAESTRO_APP_ID}
 ---
 - assertVisible: 'Rechercher'
-- tapOn: 'Cinéma'
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - tapOn: "Catégories Cinéma.*"
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - tapOn: 'Cinéma'
 
 - tapOn: "Films à l'affiche"
 

--- a/.maestro/tests/subFolder/search/SearchBookableMusicalOffer.yml
+++ b/.maestro/tests/subFolder/search/SearchBookableMusicalOffer.yml
@@ -1,10 +1,25 @@
 appId: ${MAESTRO_APP_ID}
 ---
 - assertVisible: 'Rechercher'
-- scrollUntilVisible:
-    element:
-      text: "MUSIQUE"
-- tapOn: "MUSIQUE"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - scrollUntilVisible:
+        element:
+          text: "Catégorie Musique.*"
+    - tapOn: "Catégorie Musique.*"
+    - tapOn: "CDs"
 
-- tapOn: 'CDs'
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - scrollUntilVisible:
+        element:
+          text: "MUSIQUE"
+    - tapOn: "MUSIQUE"
+    - tapOn: 'CDs'
+
 

--- a/.maestro/tests/subFolder/search/SearchBookablePhysicalOffer.yml
+++ b/.maestro/tests/subFolder/search/SearchBookablePhysicalOffer.yml
@@ -1,9 +1,28 @@
 appId: ${MAESTRO_APP_ID}
 ---
 - assertVisible: 'Rechercher'
-- tapOn: 'Livres'
 
-- tapOn: 'Romans & littérature'
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - scrollUntilVisible:
+        element:
+          text: "Catégorie livre.*"
+    - tapOn: 'Catégorie livre.*'
+    - tapOn: 'Romans & littérature'
+
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - scrollUntilVisible:
+        element:
+          text: "LIVRES"
+    - tapOn: 'LIVRES'
+    - tapOn: 'Romans & littérature'
+
 
 - runFlow:
     when:

--- a/.maestro/tests/subFolder/search/SearchOfferFromText.yml
+++ b/.maestro/tests/subFolder/search/SearchOfferFromText.yml
@@ -37,6 +37,20 @@ appId: ${MAESTRO_APP_ID}
             text: Les offres
           direction: UP
 
-- tapOn:
-    text: 'One piece.*'
-    index: 1
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - swipe:
+        from:
+          text: Les offres
+        direction: UP
+    - tapOn:
+        text: 'One piece.*'
+        index: 1
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - tapOn: 'Offre One Piece.*'

--- a/.maestro/tests/subFolder/venue/AccessVenueMapFromSearchResult.yml
+++ b/.maestro/tests/subFolder/venue/AccessVenueMapFromSearchResult.yml
@@ -1,9 +1,26 @@
 appId: ${MAESTRO_APP_ID}
 ---
 - assertVisible: 'Rechercher'
-- tapOn: 'Livres'
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - scrollUntilVisible:
+        element:
+          text: "Catégorie livre.*"
+    - tapOn: 'Catégorie livre.*'
+    - tapOn: 'Romans & littérature'
 
-- tapOn: "Romans & littérature"
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - scrollUntilVisible:
+        element:
+          text: "LIVRES"
+    - tapOn: 'LIVRES'
+    - tapOn: 'Romans & littérature'
 
 - assertVisible: 'Liste'
 - assertVisible: "Carte"

--- a/.maestro/tests/subFolder/venue/VerifyVenueMap.yml
+++ b/.maestro/tests/subFolder/venue/VerifyVenueMap.yml
@@ -5,7 +5,18 @@ appId: ${MAESTRO_APP_ID}
 - tapOn: "Choisir une localisation"
 - inputText: "Paris"
 - hideKeyboard
-- tapOn: "Paris0Paris"
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+    - tapOn: "Paris Paris"
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+    - tapOn: "Paris0Paris"
 - tapOn: "Valider et voir sur la carte"
 
 - tapOn: 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34581

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Notable Changes for iOS Compatibility

- **Localisation** : par défaut "France Entière" sur Android, "Géolocalisé" sur IOS sans accord préalable (à investiguer)
- **Suggestion dans la modale de localisation** (wording pas le même pour le choix de la ville)
- **Entrée catégorielle dans la search** (Cinéma, Musique etc.. --> Catégorie cinéma etc..)
- **SearchResult** : les résultats ne sont pas vu de la même façon par Maestro (Offre One piece de la catégorie cinéma)
- **Page Offre** : CTA spécifique à la plateforme (iMessage) + (cas des booking offres numériques pas possible sur IOS)
- **Pop-up native IOS** : review store(durant le booking) et tracking (à l'onboarding)