### PR TITLE
(PC-33844) feat(NoResults): add new no results view for located search

### DIFF
--- a/src/features/search/components/NoSearchResults/NoSearchResult.native.test.tsx
+++ b/src/features/search/components/NoSearchResults/NoSearchResult.native.test.tsx
@@ -1,66 +1,31 @@
 import React from 'react'
 
-import { navigate } from '__mocks__/@react-navigation/native'
-import { initialSearchState } from 'features/search/context/reducer'
-import { SearchState } from 'features/search/types'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen } from 'tests/utils'
 
 import { NoSearchResult } from './NoSearchResult'
 
-let mockSearchState: SearchState = initialSearchState
-const mockDispatch = jest.fn()
-jest.mock('features/search/context/SearchWrapper', () => ({
-  useSearch: () => ({ searchState: mockSearchState, dispatch: mockDispatch }),
-}))
+describe('NoSearchResult', () => {
+  it('should render properly', () => {
+    renderNoSearchResult({})
 
-describe('NoSearchResult component', () => {
-  afterEach(() => {
-    mockSearchState = initialSearchState
-  })
-
-  it('should show the message without query entered', () => {
-    render(<NoSearchResult />)
-
-    const text = screen.getByText('Pas de résultat')
-    const textContinuation = screen.getByText(
-      'Vérifie ta localisation ou modifie tes filtres pour trouver plus de résultats.'
-    )
-
-    expect(text).toBeOnTheScreen()
-    expect(textContinuation).toBeOnTheScreen()
-  })
-
-  it('should show the message with query entered', () => {
-    mockSearchState = { ...initialSearchState, query: 'ZZZZZZ' }
-    render(<NoSearchResult />)
-
-    const text = screen.getByText('Pas de résultat')
-    const complement = screen.getByText('pour "ZZZZZZ"')
-    const textContinuation = screen.getByText(
-      'Essaye un autre mot-clé, vérifie ta localisation ou modifie tes filtres pour trouver plus de résultats.'
-    )
-
-    expect(text).toBeOnTheScreen()
-    expect(complement).toBeOnTheScreen()
-    expect(textContinuation).toBeOnTheScreen()
-  })
-
-  it('should redirect to the general filters page when pressing "Modifier mes filtres" button', async () => {
-    render(<NoSearchResult />)
-    const button = screen.getByText('Modifier mes filtres')
-
-    await fireEvent.press(button)
-
-    expect(navigate).toHaveBeenNthCalledWith(1, 'SearchFilter', mockSearchState)
-  })
-
-  it('should redirect to the general filters page when pressing "Modifier mes filtres" button with url params', async () => {
-    mockSearchState = { ...initialSearchState, query: 'vinyle' }
-    render(<NoSearchResult />)
-    const button = screen.getByText('Modifier mes filtres')
-
-    await fireEvent.press(button)
-
-    expect(navigate).toHaveBeenNthCalledWith(1, 'SearchFilter', mockSearchState)
+    expect(screen.getByText('Pas de résultat')).toBeOnTheScreen()
   })
 })
+
+const renderNoSearchResult = ({
+  title = 'Pas de résultat',
+  subtitle = 'subtitle',
+  errorDescription = 'error description',
+  ctaWording = 'cta wording',
+  onPress = jest.fn(),
+}) => {
+  render(
+    <NoSearchResult
+      title={title}
+      subtitle={subtitle}
+      errorDescription={errorDescription}
+      ctaWording={ctaWording}
+      onPress={onPress}
+    />
+  )
+}

--- a/src/features/search/components/NoSearchResults/NoSearchResult.tsx
+++ b/src/features/search/components/NoSearchResults/NoSearchResult.tsx
@@ -1,48 +1,45 @@
-import React, { useCallback } from 'react'
+import React from 'react'
 import { View } from 'react-native'
 import styled from 'styled-components/native'
 
-import { useSearch } from 'features/search/context/SearchWrapper'
-import { useNavigateToSearchFilter } from 'features/search/helpers/useNavigateToSearchFilter/useNavigateToSearchFilter'
 import { AccessibilityRole } from 'libs/accessibilityRole/accessibilityRole'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { NoOffer } from 'ui/svg/icons/NoOffer'
 import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 import { getHeadingAttrs } from 'ui/theme/typographyAttrs/getHeadingAttrs'
 
-export function NoSearchResult() {
-  const { searchState } = useSearch()
-  const { navigateToSearchFilter } = useNavigateToSearchFilter()
+type NoSearchResultProps = {
+  title: string
+  subtitle?: string
+  errorDescription: string
+  ctaWording: string
+  onPress: VoidFunction
+}
 
-  const onPressUpdateFilters = useCallback(() => {
-    navigateToSearchFilter(searchState)
-  }, [navigateToSearchFilter, searchState])
-
-  const mainTitle = 'Pas de résultat'
-  const mainTitleComplement = `pour "${searchState.query}"`
-  const descriptionErrorText = searchState.query
-    ? 'Essaye un autre mot-clé, vérifie ta localisation ou modifie tes filtres pour trouver plus de résultats.'
-    : 'Vérifie ta localisation ou modifie tes filtres pour trouver plus de résultats.'
-
+export const NoSearchResult: React.FC<NoSearchResultProps> = ({
+  title,
+  subtitle,
+  errorDescription,
+  ctaWording,
+  onPress,
+}) => {
   return (
     <Container accessibilityRole={AccessibilityRole.STATUS}>
       <ContainerNoOffer>
         <StyledNoOffer />
       </ContainerNoOffer>
       <ContainerText>
-        <MainTitle>{mainTitle}</MainTitle>
-        {searchState.query ? (
-          <MainTitleComplement>{mainTitleComplement}</MainTitleComplement>
-        ) : null}
-        <DescriptionErrorTextContainer>
-          <DescriptionErrorText accessibilityLiveRegion="assertive">
-            {descriptionErrorText}
-          </DescriptionErrorText>
-        </DescriptionErrorTextContainer>
+        <Title>{title}</Title>
+        {subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
+        <ErrorDescriptionContainer>
+          <ErrorDescription accessibilityLiveRegion="assertive">
+            {errorDescription}
+          </ErrorDescription>
+        </ErrorDescriptionContainer>
       </ContainerText>
       <Spacer.Column numberOfSpaces={6} />
       <View>
-        <ButtonPrimary wording="Modifier mes filtres" onPress={onPressUpdateFilters} />
+        <ButtonPrimary wording={ctaWording} onPress={onPress} />
       </View>
     </Container>
   )
@@ -76,22 +73,22 @@ const ContainerText = styled.View(({ theme }) => ({
     : {}),
 }))
 
-const MainTitle = styled(TypoDS.Title4).attrs({
+const Title = styled(TypoDS.Title4).attrs({
   ...getHeadingAttrs(2),
 })(({ theme }) => ({
   color: theme.colors.black,
   marginTop: getSpacing(4),
 }))
 
-const MainTitleComplement = styled(TypoDS.Body)(({ theme }) => ({
+const Subtitle = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.black,
 }))
 
-const DescriptionErrorText = styled(TypoDS.Body)(({ theme }) => ({
+const ErrorDescription = styled(TypoDS.Body)(({ theme }) => ({
   color: theme.colors.greyDark,
 }))
 
-const DescriptionErrorTextContainer = styled(TypoDS.Body)({
+const ErrorDescriptionContainer = styled(TypoDS.Body)({
   marginTop: getSpacing(6),
   textAlign: 'center',
 })

--- a/src/features/search/components/SearchList/SearchList.tsx
+++ b/src/features/search/components/SearchList/SearchList.tsx
@@ -2,7 +2,6 @@ import { FlashList } from '@shopify/flash-list'
 import React from 'react'
 import styled, { useTheme } from 'styled-components/native'
 
-import { NoSearchResult } from 'features/search/components/NoSearchResults/NoSearchResult'
 import { SearchListHeader } from 'features/search/components/SearchListHeader/SearchListHeader'
 import { LIST_ITEM_HEIGHT } from 'features/search/constants'
 import { SearchListProps } from 'features/search/types'
@@ -32,7 +31,7 @@ export const SearchList: React.FC<SearchListProps> = React.forwardRef<
   ) => {
     const theme = useTheme()
 
-    return nbHits > 0 ? (
+    return (
       <FlashList
         estimatedItemSize={LIST_ITEM_HEIGHT}
         ref={ref}
@@ -58,10 +57,6 @@ export const SearchList: React.FC<SearchListProps> = React.forwardRef<
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="on-drag"
       />
-    ) : (
-      <NoSearchResultsWrapper>
-        <NoSearchResult />
-      </NoSearchResultsWrapper>
     )
   }
 )
@@ -73,8 +68,3 @@ const Separator = styled.View(({ theme }) => ({
   marginHorizontal: getSpacing(6),
   marginVertical: getSpacing(4),
 }))
-
-const NoSearchResultsWrapper = styled.View({
-  flex: 1,
-  flexDirection: 'row',
-})

--- a/src/features/search/components/SearchList/SearchList.web.test.tsx
+++ b/src/features/search/components/SearchList/SearchList.web.test.tsx
@@ -55,15 +55,4 @@ describe('<SearchList />', () => {
 
     expect(screen.getByTestId('searchListHeader')).toBeInTheDocument()
   })
-
-  it('should not display search list header when number of offer results = 0', async () => {
-    const propsWithoutHits = {
-      ...props,
-      nbHits: 0,
-      hits: { offers: [], venues: [], duplicatedOffers: [] },
-    }
-    render(reactQueryProviderHOC(<SearchList {...propsWithoutHits} />))
-
-    expect(screen.queryByTestId('searchListHeader')).not.toBeInTheDocument()
-  })
 })

--- a/src/features/search/components/SearchList/SearchList.web.tsx
+++ b/src/features/search/components/SearchList/SearchList.web.tsx
@@ -5,7 +5,6 @@ import { ListOnScrollProps, VariableSizeList } from 'react-window'
 import styled from 'styled-components/native'
 
 import { usePreviousRoute } from 'features/navigation/helpers/usePreviousRoute'
-import { NoSearchResult } from 'features/search/components/NoSearchResults/NoSearchResult'
 import {
   footerPlaceholder,
   headerPlaceholder,
@@ -191,35 +190,31 @@ export const SearchList = forwardRef<never, SearchListProps>(
 
     return (
       <SearchResultList onLayout={onLayout} testID="searchResultsList">
-        {nbHits ? (
-          <React.Fragment>
-            <VariableSizeList
-              ref={listRef}
-              key={rerenderKey}
-              innerElementType="ul"
-              itemData={data}
-              itemSize={itemSizeFn}
-              height={availableHeight}
-              itemCount={data.items.length}
-              outerRef={outerListRef}
-              onScroll={handleScroll}
-              width="100%">
-              {SearchListItem}
-            </VariableSizeList>
+        <React.Fragment>
+          <VariableSizeList
+            ref={listRef}
+            key={rerenderKey}
+            innerElementType="ul"
+            itemData={data}
+            itemSize={itemSizeFn}
+            height={availableHeight}
+            itemCount={data.items.length}
+            outerRef={outerListRef}
+            onScroll={handleScroll}
+            width="100%">
+            {SearchListItem}
+          </VariableSizeList>
 
-            <ScrollToTopContainer style={{ opacity }}>
-              <Container onPress={handleScrollToTopPress}>
-                <StyledLinearGradient
-                  start={SCROLL_TO_TOP_BUTTON_LINEAR_GRADIENT_START}
-                  end={SCROLL_TO_TOP_BUTTON_LINEAR_GRADIENT_END}>
-                  <ScrollToTopIcon />
-                </StyledLinearGradient>
-              </Container>
-            </ScrollToTopContainer>
-          </React.Fragment>
-        ) : (
-          <NoSearchResult />
-        )}
+          <ScrollToTopContainer style={{ opacity }}>
+            <Container onPress={handleScrollToTopPress}>
+              <StyledLinearGradient
+                start={SCROLL_TO_TOP_BUTTON_LINEAR_GRADIENT_START}
+                end={SCROLL_TO_TOP_BUTTON_LINEAR_GRADIENT_END}>
+                <ScrollToTopIcon />
+              </StyledLinearGradient>
+            </Container>
+          </ScrollToTopContainer>
+        </React.Fragment>
       </SearchResultList>
     )
   }

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.native.test.tsx
@@ -26,7 +26,7 @@ import { mockedSuggestedVenue } from 'libs/venue/fixtures/mockedSuggestedVenues'
 import { Offer } from 'shared/offer/types'
 import { mockAuthContextWithUser, mockAuthContextWithoutUser } from 'tests/AuthContextUtils'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, render, screen, userEvent, waitFor } from 'tests/utils'
+import { act, render, screen, userEvent } from 'tests/utils'
 import { theme } from 'theme'
 
 const searchId = uuidv4()
@@ -709,9 +709,7 @@ describe('SearchResultsContent component', () => {
 
     screen.rerender(<SearchResultsContent />)
 
-    await waitFor(() => {
-      expect(analytics.logPerformSearch).toHaveBeenCalledTimes(1)
-    })
+    expect(analytics.logPerformSearch).toHaveBeenCalledTimes(1)
   })
 
   it('should log PerformSearch with search result when there is search query execution', async () => {
@@ -733,15 +731,13 @@ describe('SearchResultsContent component', () => {
     }
     screen.rerender(<SearchResultsContent />)
 
-    await waitFor(() => {
-      expect(analytics.logPerformSearch).toHaveBeenNthCalledWith(
-        1,
-        mockSearchState,
-        mockAccessibilityFilter,
-        0,
-        'SearchResults'
-      )
-    })
+    expect(analytics.logPerformSearch).toHaveBeenNthCalledWith(
+      1,
+      mockSearchState,
+      mockAccessibilityFilter,
+      0,
+      'SearchResults'
+    )
   })
 
   it('should log PerformSearch with accessibilityFilter when there is search query execution', async () => {
@@ -776,15 +772,13 @@ describe('SearchResultsContent component', () => {
 
     screen.rerender(<SearchResultsContent />)
 
-    await waitFor(() => {
-      expect(analytics.logPerformSearch).toHaveBeenNthCalledWith(
-        1,
-        mockSearchState,
-        mockDisabilitesPropertiesTruthy,
-        0,
-        'SearchResults'
-      )
-    })
+    expect(analytics.logPerformSearch).toHaveBeenNthCalledWith(
+      1,
+      mockSearchState,
+      mockDisabilitesPropertiesTruthy,
+      0,
+      'SearchResults'
+    )
   })
 
   describe('when search returns no results', () => {
@@ -903,9 +897,7 @@ describe('SearchResultsContent component', () => {
 
       screen.rerender(<SearchResultsContent />)
 
-      await waitFor(() => {
-        expect(analytics.logNoSearchResult).toHaveBeenCalledTimes(1)
-      })
+      expect(analytics.logNoSearchResult).toHaveBeenCalledTimes(1)
     })
 
     it('should log NoSearchResult with search result when there is search query execution and nbHits = 0', async () => {
@@ -921,9 +913,7 @@ describe('SearchResultsContent component', () => {
       })
       screen.rerender(<SearchResultsContent />)
 
-      await waitFor(() => {
-        expect(analytics.logNoSearchResult).toHaveBeenNthCalledWith(1, '', searchId)
-      })
+      expect(analytics.logNoSearchResult).toHaveBeenNthCalledWith(1, '', searchId)
     })
   })
 

--- a/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
+++ b/src/features/search/components/SearchResultsContent/SearchResultsContent.tsx
@@ -24,6 +24,8 @@ import {
   useAppliedFilters,
 } from 'features/search/helpers/useAppliedFilters/useAppliedFilters'
 import { useFilterCount } from 'features/search/helpers/useFilterCount/useFilterCount'
+import { useNavigateToSearch } from 'features/search/helpers/useNavigateToSearch/useNavigateToSearch'
+import { useNavigateToSearchFilter } from 'features/search/helpers/useNavigateToSearchFilter/useNavigateToSearchFilter'
 import { usePrevious } from 'features/search/helpers/usePrevious'
 import { CategoriesModal } from 'features/search/pages/modals/CategoriesModal/CategoriesModal'
 import { DatesHoursModal } from 'features/search/pages/modals/DatesHoursModal/DatesHoursModal'
@@ -86,11 +88,14 @@ export const SearchResultsContent: React.FC = () => {
 
   const { disabilities } = useAccessibilityFiltersContext()
   const { searchState } = useSearch()
+  const { navigateToSearchFilter } = useNavigateToSearchFilter()
+  const { navigateToSearch: navigateToSearchResults } = useNavigateToSearch('SearchResults')
+
   const showSkeleton = useIsFalseWithDelay(isLoading, ANIMATION_DURATION)
   const isRefreshing = useIsFalseWithDelay(isFetching, ANIMATION_DURATION)
   const isFocused = useIsFocused()
   const { user } = useAuthContext()
-  const { geolocPosition, selectedLocationMode } = useLocation()
+  const { geolocPosition, selectedLocationMode, onResetPlace } = useLocation()
   const previousGeolocPosition = usePrevious(geolocPosition)
   const shouldDisplayVenueMapInSearch = useFeatureFlag(
     RemoteStoreFeatureFlags.WIP_VENUE_MAP_IN_SEARCH
@@ -362,15 +367,55 @@ export const SearchResultsContent: React.FC = () => {
     />
   )
 
-  const renderSearchList = () => {
-    if (nbHits === 0) {
+  const renderNoSearchResults = () => {
+    const isEverywhereSearch = searchState.locationFilter.locationType === LocationMode.EVERYWHERE
+
+    const noResultsProps = {
+      title: 'Pas de résultat',
+      subtitle: searchState.query ? `pour "${searchState.query}"` : '',
+      errorDescription: searchState.query
+        ? 'Essaye un autre mot-clé, vérifie ta localisation ou modifie tes filtres pour trouver plus de résultats.'
+        : 'Vérifie ta localisation ou modifie tes filtres pour trouver plus de résultats.',
+    }
+
+    if (isEverywhereSearch) {
       return (
         <NoSearchResultsWrapper>
-          <NoSearchResult />
+          <NoSearchResult
+            {...noResultsProps}
+            ctaWording="Modifier mes filtres"
+            onPress={() => navigateToSearchFilter(searchState)}
+          />
         </NoSearchResultsWrapper>
       )
     }
-    return shouldDisplayTabLayout ? renderTabLayout() : tabPanels[Tab.SEARCHLIST]
+
+    return (
+      <NoSearchResultsWrapper>
+        <NoSearchResult
+          {...noResultsProps}
+          errorDescription="Élargis la zone de recherche pour plus de résultats."
+          ctaWording="Élargir la zone de recherche"
+          onPress={() => {
+            onResetPlace()
+            navigateToSearchResults({
+              ...searchState,
+              locationFilter: {
+                locationType: LocationMode.EVERYWHERE,
+              },
+            })
+          }}
+        />
+      </NoSearchResultsWrapper>
+    )
+  }
+
+  const renderSearchList = () => {
+    if (nbHits > 0) {
+      return shouldDisplayTabLayout ? renderTabLayout() : tabPanels[Tab.SEARCHLIST]
+    }
+
+    return renderNoSearchResults()
   }
 
   return (

--- a/src/features/search/helpers/useNavigateToSearch/useNavigateToSearch.ts
+++ b/src/features/search/helpers/useNavigateToSearch/useNavigateToSearch.ts
@@ -1,5 +1,6 @@
 import { StackActions, useNavigation } from '@react-navigation/native'
 
+import { defaultDisabilitiesProperties } from 'features/accessibility/context/AccessibilityFiltersWrapper'
 import { DisabilitiesProperties } from 'features/accessibility/types'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/helpers'
@@ -10,23 +11,23 @@ export const useNavigateToSearch = (routeName: SearchStackRouteName) => {
   const { navigate, dispatch } = useNavigation<UseNavigationType>()
   const navigateToSearch = (
     newSearchState: SearchState,
-    newAccessibilityFilter: DisabilitiesProperties
+    newAccessibilityFilter?: DisabilitiesProperties
   ): void => {
     navigate(
       ...getSearchStackConfig(routeName, {
         ...newSearchState,
-        accessibilityFilter: newAccessibilityFilter,
+        accessibilityFilter: newAccessibilityFilter ?? defaultDisabilitiesProperties,
       })
     )
   }
 
   const replaceToSearch = (
     newSearchState: SearchState,
-    newAccessibilityFilter: DisabilitiesProperties
+    newAccessibilityFilter?: DisabilitiesProperties
   ): void => {
     const replaceAction = StackActions.replace(routeName, {
       ...newSearchState,
-      accessibilityFilter: newAccessibilityFilter,
+      accessibilityFilter: newAccessibilityFilter ?? defaultDisabilitiesProperties,
     })
 
     dispatch(replaceAction)


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33844

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [X] Made sure my feature is working on web.
- [X] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [X] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [X] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome | <img width="1024" alt="Capture d’écran 2025-02-20 à 09 53 33" src="https://github.com/user-attachments/assets/0b24ea78-6ffe-4a85-b202-3e19c6a1b987" />          | <video src="https://github.com/user-attachments/assets/06cb62a4-9213-44fa-821d-a65c91d84390" width="600" /> |
| ios | <img src="https://github.com/user-attachments/assets/cb880d24-54c3-4322-9786-7bd84ce3dea9" width="500" /> | <img src="https://github.com/user-attachments/assets/658b2427-1f51-4ab7-ade7-5241b26d8f89" width="500" /> |


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
