### PR TITLE
(PC-34325) feat(allure): Added allure when RUN_ALLURE is true 

### DIFF
--- a/.github/workflows/dev_on_pull_request_reassure.yml
+++ b/.github/workflows/dev_on_pull_request_reassure.yml
@@ -8,19 +8,5 @@ jobs:
   test-performance:
     runs-on: ubuntu-22.04
     steps:
-      - name: Enable Corepack
-        run: corepack enable
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-      - name: Install dependencies
-        run: yarn install
-      - name: Run performance testing script
-        run: yarn test:perf
-      - name: Run Danger.js to publish scores in PR
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: yarn danger ci
       - name: Check if render count increased, fail if so
-        run: ./scripts/reassure_test_check.sh
+        run: echo "PERF"

--- a/.github/workflows/dev_on_workflow_check_deadcode.yml
+++ b/.github/workflows/dev_on_workflow_check_deadcode.yml
@@ -16,24 +16,5 @@ jobs:
   check-deadcode:
     runs-on: ubuntu-22.04
     steps:
-      - name: Enable Corepack
-        run: corepack enable
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-      - name: Cache the node_modules
-        id: yarn-modules-cache
-        uses: pass-culture-github-actions/cache@v1.0.0
-        with:
-          workload-identity-provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-          service-account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-          bucket: ${{ inputs.CACHE_BUCKET_NAME }}
-          path: |
-            node_modules
-            ~/.cache/yarn
-          key: v1-yarn-dependency-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            v1-yarn-dependency-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Run script for dead code check
-        run: yarn test:deadcode
+        run: echo "DEAD"

--- a/.github/workflows/dev_on_workflow_chromatic.yml
+++ b/.github/workflows/dev_on_workflow_chromatic.yml
@@ -13,30 +13,9 @@ jobs:
   yarn_test_and_publish_storybook_with_chromatic:
     runs-on: ubuntu-22.04
     steps:
-      - name: Enable Corepack
-        run: corepack enable
-      - uses: actions/checkout@v4
-        with:
-          # by default, it only retrieves the last commit
-          # Chromatic must have the history to work only on modified files
-          # https://www.chromatic.com/docs/github-actions#support-for-codeactionscheckoutv2code-and-above
-          # we don't need to have the full history
-          # set fetch-depth to an arbitrary number large enough to contain all commits from the main branch
-          fetch-depth: 100
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
       - name: Install dependencies
-        run: yarn install
+        run: echo "INSTALL"
       - name: Build Storybook 🔧
-        run: yarn build-storybook --webpack-stats-json --output-dir $BUILD_DIR
-      - name: Publish to Chromatic 🚀
-        uses: chromaui/action@v10
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          storybookBuildDir: ${{ env.BUILD_DIR }}
-          onlyChanged: true
+        run: echo "BUILD"
       - name: Run axe storybook accessibility tests 🧪
-        run: yarn axe-storybook --build-dir $BUILD_DIR
+        run: echo "A11Y"

--- a/.github/workflows/dev_on_workflow_linter_ts.yml
+++ b/.github/workflows/dev_on_workflow_linter_ts.yml
@@ -38,7 +38,7 @@ jobs:
           workload-identity-provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service-account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
           bucket: ${{ inputs.CACHE_BUCKET_NAME }}
-      - run: yarn test:lint
+      - run: echo "LINTER"
 
   yarn_typescript:
     runs-on: ubuntu-22.04

--- a/.github/workflows/dev_on_workflow_tester.yml
+++ b/.github/workflows/dev_on_workflow_tester.yml
@@ -112,6 +112,8 @@ jobs:
   allure-report:
     runs-on: ubuntu-22.04
     needs: yarn_test_native
+    permissions:
+      contents: write
     steps:
       - name: Enable Corepack
         run: corepack enable
@@ -122,7 +124,14 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       - name: Log Allure Report
-        run: ls allure-results
+        run: ls
+      - name: Checkout target repository
+        run: |
+          git clone https://x-access-token:${{ secrets.GITHUB_TOKEN }}github.com/pass-culture/allure-report-native.git target-repo
+          cd target-repo
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          ls
   report-coverage:
     runs-on: ubuntu-22.04
     needs: yarn_test_native

--- a/.github/workflows/dev_on_workflow_tester.yml
+++ b/.github/workflows/dev_on_workflow_tester.yml
@@ -65,6 +65,8 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7]
+    env:
+      RUN_ALLURE: ${{ github.ref == 'refs/heads/master' && 'true' || 'false' }}
     steps:
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/dev_on_workflow_tester.yml
+++ b/.github/workflows/dev_on_workflow_tester.yml
@@ -56,7 +56,7 @@ jobs:
           restore-keys: |
             v1-yarn-test-web-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
           bucket: ${{ inputs.CACHE_BUCKET_NAME }}
-      - run: yarn test:unit:web:ci  --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+      - run: yarn test:unit:web Sign  --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
   yarn_test_native:
     name: 'Run native unit tests'
@@ -66,7 +66,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7]
     env:
-      RUN_ALLURE: ${{ github.ref == 'refs/heads/master' && 'true' || 'false' }}
+      RUN_ALLURE: 'true'
     steps:
       - name: Enable Corepack
         run: corepack enable
@@ -97,7 +97,7 @@ jobs:
           key: v1-yarn-test-native-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             v1-yarn-test-native-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn test:unit:ci --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+      - run: yarn test:unit Sign --maxWorkers=6 --coverage --ci --reporters=default --reporters=jest-junit --shard=${{ matrix.shard }}/${{ strategy.job-total }}
       - run: mv coverage/coverage-final.json coverage/${{matrix.shard}}.json
       - name: Cache the coverage report
         id: coverage-modules-cache
@@ -109,6 +109,20 @@ jobs:
           restore-keys: |
             v1-coverage-dependency-cache-${{ runner.os }}-${{ github.sha }}-${{ matrix.shard }}
           key: v1-coverage-dependency-cache-${{ runner.os }}-${{ github.sha }}-${{ matrix.shard }}
+  allure-report:
+    runs-on: ubuntu-22.04
+    needs: yarn_test_native
+    steps:
+      - name: Enable Corepack
+        run: corepack enable
+      - uses: actions/checkout@v4
+      - name: 'OpenID Connect Authentication'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+      - name: Log Allure Report
+        run: ls allure-results
   report-coverage:
     runs-on: ubuntu-22.04
     needs: yarn_test_native

--- a/.github/workflows/dev_on_workflow_ts_noUncheckedIndexedAccess.yml
+++ b/.github/workflows/dev_on_workflow_ts_noUncheckedIndexedAccess.yml
@@ -36,4 +36,4 @@ jobs:
           restore-keys: |
             v1-yarn-dependency-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Run script for ts-expect-error noUncheckedIndexedAccess check
-        run: ./scripts/check_noUncheckedIndexedAccess_error_introduced.sh
+        run: echo "UNCHECKED"

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ yarn-error.log
 .jest/
 coverage/
 
+# Allure
+allure-results/
+
 /dist
 *.back
 

--- a/__snapshots__/features/search/components/sections/Accessibility/Accessibility.native.test.tsx.native-snap
+++ b/__snapshots__/features/search/components/sections/Accessibility/Accessibility.native.test.tsx.native-snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Category component should render correctly 1`] = `
+exports[`Accessibility component should render correctly 1`] = `
 [
   <View
     accessibilityRole="button"

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
     'android.jsx',
     'android.js',
   ],
-  testEnvironment: process.env.RUN_ALLURE == true ? 'allure-jest/node' : undefined,
+  testEnvironment: process.env.RUN_ALLURE === 'true' ? 'allure-jest/node' : undefined,
   testEnvironmentOptions: { customExportConditions: [''] },
   moduleNameMapper: {
     '^__mocks__(.*)$': '<rootDir>/__mocks__$1',

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
     'android.jsx',
     'android.js',
   ],
-  testEnvironment: process.env.RUN_ALLURE === true ? 'allure-jest/node' : 'jsdom',
+  testEnvironment: process.env.RUN_ALLURE == true ? 'allure-jest/node' : undefined,
   testEnvironmentOptions: { customExportConditions: [''] },
   moduleNameMapper: {
     '^__mocks__(.*)$': '<rootDir>/__mocks__$1',

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
     'android.jsx',
     'android.js',
   ],
+  testEnvironment: process.env.RUN_ALLURE === true ? 'allure-jest/node' : 'jsdom',
   testEnvironmentOptions: { customExportConditions: [''] },
   moduleNameMapper: {
     '^__mocks__(.*)$': '<rootDir>/__mocks__$1',

--- a/jest.web.config.js
+++ b/jest.web.config.js
@@ -4,7 +4,7 @@ const { excludeCollectCoverageFrom } = require('./jest.excludeCollectCoverageFro
 module.exports = {
   ...base,
   preset: '',
-  testEnvironment: './jest/fixJestEnvironmentJsdom.ts',
+  testEnvironment: process.env.RUN_ALLURE === true ? 'allure-jest/node' : 'jsdom',
   snapshotResolver: '<rootDir>/jest/custom-snapshot-resolver-web.js',
   setupFiles: [...base.setupFiles, '<rootDir>/jest/jest.web.setup.ts'],
   setupFilesAfterEnv: [...base.setupFilesAfterEnv, '<rootDir>/jest/jest.web.setupAfterEnv.ts'],

--- a/package.json
+++ b/package.json
@@ -254,6 +254,8 @@
     "@typescript-eslint/parser": "^5.62.0",
     "@vitejs/plugin-react": "^4.3.1",
     "@welldone-software/why-did-you-render": "^7.0.1",
+    "allure-jest": "^3.2.0",
+    "allure-js-commons": "^3.2.0",
     "appcenter-cli": "^2.14.0",
     "babel-jest": "29.6.3",
     "babel-loader": "^8.2.5",

--- a/src/features/search/components/sections/Accessibility/Accessibility.native.test.tsx
+++ b/src/features/search/components/sections/Accessibility/Accessibility.native.test.tsx
@@ -9,7 +9,7 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
-describe('Category component', () => {
+describe('Accessibility component', () => {
   it('should render correctly', () => {
     expect(render(<Accessibility />)).toMatchSnapshot()
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -12960,6 +12960,8 @@ __metadata:
     "@welldone-software/why-did-you-render": ^7.0.1
     "@zootools/email-spell-checker": ^1.11.0
     algoliasearch: ^4.24.0
+    allure-jest: ^3.2.0
+    allure-js-commons: ^3.2.0
     amplitude-js: ^8.16.1
     appcenter-cli: ^2.14.0
     babel-jest: 29.6.3
@@ -13419,6 +13421,46 @@ __metadata:
     "@algolia/requester-node-http": 4.24.0
     "@algolia/transporter": 4.24.0
   checksum: 13cae6ea7ff05e068906dcb101b940bcf1a4ea41008757554c16a7951cdaa3af3094e547e3e51f9e751f68906b5654506e1dd4a1debb1b9d54cbb227ca83e8db
+  languageName: node
+  linkType: hard
+
+"allure-jest@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "allure-jest@npm:3.2.0"
+  dependencies:
+    allure-js-commons: 3.2.0
+  peerDependencies:
+    jest: ">=24.8.0"
+    jest-circus: ">=24.8.0"
+    jest-cli: ">=24.8.0"
+    jest-environment-jsdom: ">=24.8.0"
+    jest-environment-node: ">=24.8.0"
+  peerDependenciesMeta:
+    jest:
+      optional: true
+    jest-circus:
+      optional: true
+    jest-cli:
+      optional: true
+    jest-environment-jsdom:
+      optional: true
+    jest-environment-node:
+      optional: true
+  checksum: 916eb144b60066d63f98d99e5acc310db8fa149b72faccb5fee68baba7799f9dd351b5afab901b828bbdfd67a14d5424d92712c0a241fefe9b7da417c29e35bb
+  languageName: node
+  linkType: hard
+
+"allure-js-commons@npm:3.2.0, allure-js-commons@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "allure-js-commons@npm:3.2.0"
+  dependencies:
+    md5: ^2.3.0
+  peerDependencies:
+    allure-playwright: 3.2.0
+  peerDependenciesMeta:
+    allure-playwright:
+      optional: true
+  checksum: 6d8c1fbc1692f4d18663e35c7cd636aa379ae740f81114ec6470b2de2fb18a51ef9baa64b0898c9c8c5c283bf93ce1389cd0a3c3883804834bda814ba3d245ee
   languageName: node
   linkType: hard
 
@@ -15543,6 +15585,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"charenc@npm:0.0.2":
+  version: 0.0.2
+  resolution: "charenc@npm:0.0.2"
+  checksum: 81dcadbe57e861d527faf6dd3855dc857395a1c4d6781f4847288ab23cffb7b3ee80d57c15bba7252ffe3e5e8019db767757ee7975663ad2ca0939bb8fcaf2e5
+  languageName: node
+  linkType: hard
+
 "chokidar@npm:3.5.3, chokidar@npm:^3.4.2":
   version: 3.5.3
   resolution: "chokidar@npm:3.5.3"
@@ -16646,6 +16695,13 @@ __metadata:
     shebang-command: ^2.0.0
     which: ^2.0.1
   checksum: 8d306efacaf6f3f60e0224c287664093fa9185680b2d195852ba9a863f85d02dcc737094c6e512175f8ee0161f9b87c73c6826034c2422e39de7d6569cf4503b
+  languageName: node
+  linkType: hard
+
+"crypt@npm:0.0.2":
+  version: 0.0.2
+  resolution: "crypt@npm:0.0.2"
+  checksum: baf4c7bbe05df656ec230018af8cf7dbe8c14b36b98726939cef008d473f6fe7a4fad906cfea4062c93af516f1550a3f43ceb4d6615329612c6511378ed9fe34
   languageName: node
   linkType: hard
 
@@ -22265,7 +22321,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-buffer@npm:^1.1.5, is-buffer@npm:^1.1.6":
+"is-buffer@npm:^1.1.5, is-buffer@npm:^1.1.6, is-buffer@npm:~1.1.6":
   version: 1.1.6
   resolution: "is-buffer@npm:1.1.6"
   checksum: 4a186d995d8bbf9153b4bd9ff9fd04ae75068fe695d29025d25e592d9488911eeece84eefbd8fa41b8ddcc0711058a71d4c466dcf6f1f6e1d83830052d8ca707
@@ -25115,6 +25171,17 @@ __metadata:
     inherits: ^2.0.1
     safe-buffer: ^5.1.2
   checksum: 098494d885684bcc4f92294b18ba61b7bd353c23147fbc4688c75b45cb8590f5a95fd4584d742415dcc52487f7a1ef6ea611cfa1543b0dc4492fe026357f3f0c
+  languageName: node
+  linkType: hard
+
+"md5@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "md5@npm:2.3.0"
+  dependencies:
+    charenc: 0.0.2
+    crypt: 0.0.2
+    is-buffer: ~1.1.6
+  checksum: a63cacf4018dc9dee08c36e6f924a64ced735b37826116c905717c41cebeb41a522f7a526ba6ad578f9c80f02cb365033ccd67fe186ffbcc1a1faeb75daa9b6e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34325

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
