### PR TITLE
(PC-34735) feat(chronicle): improve close modal and redirection transition

### DIFF
--- a/src/features/chronicle/pages/Chronicles/Chronicles.native.test.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.native.test.tsx
@@ -1,10 +1,12 @@
+import * as reactNavigationNative from '@react-navigation/native'
 import React from 'react'
 import { FlatList } from 'react-native'
 
-import { navigate, useRoute } from '__mocks__/@react-navigation/native'
+import { useRoute } from '__mocks__/@react-navigation/native'
 import { offerChroniclesFixture } from 'features/chronicle/fixtures/offerChronicles.fixture'
 import { Chronicles } from 'features/chronicle/pages/Chronicles/Chronicles'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
+import { env } from 'libs/environment/env'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { act, fireEvent, render, screen, userEvent } from 'tests/utils'
@@ -27,6 +29,16 @@ jest.mock('features/chronicle/api/useChronicles/useChronicles', () => ({
   useChronicles: () => ({ data: mockChronicles, isLoading: false }),
 }))
 
+const mockNavigate = jest.fn()
+jest.spyOn(reactNavigationNative, 'useNavigation').mockReturnValue({
+  navigate: mockNavigate,
+})
+
+const mockShowModal = jest.fn()
+const mockCloseModal = jest.fn()
+
+const defaultEnvironment = env.ENV
+
 const user = userEvent.setup()
 
 describe('Chronicles', () => {
@@ -35,67 +47,8 @@ describe('Chronicles', () => {
     mockServer.getApi(`/v1/offer/${offerResponseSnap.id}/chronicles`, offerChroniclesFixture)
   })
 
-  describe('When chronicle id not defined', () => {
-    beforeAll(() => {
-      useRoute.mockReturnValue({
-        params: {
-          offerId: offerResponseSnap.id,
-          openModalOnNavigation: true,
-        },
-      })
-    })
-
-    it('should render correctly', async () => {
-      render(reactQueryProviderHOC(<Chronicles />))
-
-      expect(await screen.findByText('Tous les avis')).toBeOnTheScreen()
-    })
-
-    it('should navigate to offer page without openModalOnNavigation param when pressing back button', async () => {
-      jest.useFakeTimers()
-      render(reactQueryProviderHOC(<Chronicles />))
-
-      await user.press(await screen.findByLabelText('Revenir en arrière'))
-
-      expect(navigate).toHaveBeenNthCalledWith(1, 'Offer', {
-        id: offerResponseSnap.id,
-        openModalOnNavigation: undefined,
-      })
-
-      jest.useRealTimers()
-    })
-
-    it('should not scroll to selected chronicle on layout', async () => {
-      render(reactQueryProviderHOC(<Chronicles />))
-
-      await screen.findByText('Tous les avis')
-
-      await act(async () => {
-        fireEvent(screen.getByTestId('chronicle-list'), 'onLayout', mockOnLayout)
-      })
-
-      expect(mockScrollToIndex).not.toHaveBeenCalled()
-    })
-
-    it('should open chronicle modal when pressing "Qui écrit les avis ?" button', async () => {
-      jest.useFakeTimers()
-      const mockShowModal = jest.fn()
-      jest.spyOn(useModal, 'useModal').mockReturnValueOnce({
-        visible: false,
-        showModal: mockShowModal,
-        hideModal: jest.fn(),
-        toggleModal: jest.fn(),
-      })
-      render(reactQueryProviderHOC(<Chronicles />))
-
-      await screen.findByText('Tous les avis')
-
-      await user.press(screen.getByText('Qui écrit les avis ?'))
-
-      expect(mockShowModal).toHaveBeenCalledTimes(1)
-
-      jest.useRealTimers()
-    })
+  afterEach(() => {
+    env.ENV = defaultEnvironment
   })
 
   describe('When chronicle id defined', () => {
@@ -118,6 +71,105 @@ describe('Chronicles', () => {
       })
 
       expect(mockScrollToIndex).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('When chronicle id not defined', () => {
+    beforeAll(() => {
+      jest.useFakeTimers()
+      useRoute.mockReturnValue({
+        params: {
+          offerId: offerResponseSnap.id,
+          openModalOnNavigation: true,
+        },
+      })
+    })
+
+    it('should render correctly', async () => {
+      render(reactQueryProviderHOC(<Chronicles />))
+
+      expect(await screen.findByText('Tous les avis')).toBeOnTheScreen()
+    })
+
+    it('should navigate to offer page without openModalOnNavigation param when pressing back button', async () => {
+      render(reactQueryProviderHOC(<Chronicles />))
+
+      await user.press(await screen.findByLabelText('Revenir en arrière'))
+
+      expect(mockNavigate).toHaveBeenNthCalledWith(1, 'Offer', {
+        id: offerResponseSnap.id,
+        openModalOnNavigation: undefined,
+      })
+    })
+
+    it('should not scroll to selected chronicle on layout', async () => {
+      render(reactQueryProviderHOC(<Chronicles />))
+
+      await screen.findByText('Tous les avis')
+
+      await act(async () => {
+        fireEvent(screen.getByTestId('chronicle-list'), 'onLayout', mockOnLayout)
+      })
+
+      expect(mockScrollToIndex).not.toHaveBeenCalled()
+    })
+
+    it('should open chronicle modal when pressing "Qui écrit les avis ?" button', async () => {
+      jest.spyOn(useModal, 'useModal').mockReturnValueOnce({
+        visible: false,
+        showModal: mockShowModal,
+        hideModal: jest.fn(),
+        toggleModal: jest.fn(),
+      })
+      render(reactQueryProviderHOC(<Chronicles />))
+
+      await screen.findByText('Tous les avis')
+
+      await user.press(screen.getByText('Qui écrit les avis ?'))
+
+      expect(mockShowModal).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('When modale is visible', () => {
+    beforeEach(() => {
+      jest.spyOn(useModal, 'useModal').mockReturnValueOnce({
+        visible: true,
+        showModal: jest.fn(),
+        hideModal: mockCloseModal,
+        toggleModal: jest.fn(),
+      })
+    })
+
+    it('should navigate to recommandation thematic home when pressing button in production', async () => {
+      env.ENV = 'production'
+
+      render(reactQueryProviderHOC(<Chronicles />))
+
+      await user.press(await screen.findByText('Voir toutes les recos du book club'))
+
+      expect(mockNavigate).toHaveBeenNthCalledWith(1, 'ThematicHome', {
+        homeId: '4mlVpAZySUZO6eHazWKZeV',
+        from: 'chronicles',
+      })
+    })
+
+    it('should navigate to home when pressing button when environment is not production', async () => {
+      env.ENV = 'testing'
+
+      render(reactQueryProviderHOC(<Chronicles />))
+
+      await user.press(await screen.findByText('Voir toutes les recos du book club'))
+
+      expect(mockNavigate).toHaveBeenNthCalledWith(1, 'TabNavigator', { screen: 'Home' })
+    })
+
+    it('should close the modal when pressing close button', async () => {
+      render(reactQueryProviderHOC(<Chronicles />))
+
+      await user.press(await screen.findByLabelText('Fermer la modale'))
+
+      expect(mockCloseModal).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/features/chronicle/pages/Chronicles/ChroniclesBase.tsx
+++ b/src/features/chronicle/pages/Chronicles/ChroniclesBase.tsx
@@ -12,8 +12,6 @@ import { ChroniclesWebMetaHeader } from 'features/chronicle/components/Chronicle
 import { ChroniclesWritersModal } from 'features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal'
 import { ChronicleCardData } from 'features/chronicle/type'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
-import { homeNavConfig } from 'features/navigation/TabBar/helpers'
-import { env } from 'libs/environment/env'
 import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
 import { useModal } from 'ui/components/modals/useModal'
 import { getSpacing } from 'ui/theme'
@@ -65,11 +63,7 @@ export const ChroniclesBase: FunctionComponent<Props> = ({
   const handleOnShowRecoButtonPress = () => {
     hideModal()
     InteractionManager.runAfterInteractions(() => {
-      if (env.ENV === 'production') {
-        navigate('ThematicHome', { homeId: '4mlVpAZySUZO6eHazWKZeV', from: 'chronicles' })
-      } else {
-        navigate(...homeNavConfig)
-      }
+      navigate('ThematicHome', { homeId: '4mlVpAZySUZO6eHazWKZeV', from: 'chronicles' })
     })
   }
 

--- a/src/features/chronicle/pages/Chronicles/ChroniclesBase.tsx
+++ b/src/features/chronicle/pages/Chronicles/ChroniclesBase.tsx
@@ -12,6 +12,8 @@ import { ChroniclesWebMetaHeader } from 'features/chronicle/components/Chronicle
 import { ChroniclesWritersModal } from 'features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal'
 import { ChronicleCardData } from 'features/chronicle/type'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
+import { homeNavConfig } from 'features/navigation/TabBar/helpers'
+import { env } from 'libs/environment/env'
 import { useOpacityTransition } from 'ui/animations/helpers/useOpacityTransition'
 import { useModal } from 'ui/components/modals/useModal'
 import { getSpacing } from 'ui/theme'
@@ -60,6 +62,17 @@ export const ChroniclesBase: FunctionComponent<Props> = ({
     navigate('Offer', { id: offerId, openModalOnNavigation: undefined })
   }
 
+  const handleOnShowRecoButtonPress = () => {
+    hideModal()
+    InteractionManager.runAfterInteractions(() => {
+      if (env.ENV === 'production') {
+        navigate('ThematicHome', { homeId: '4mlVpAZySUZO6eHazWKZeV', from: 'chronicles' })
+      } else {
+        navigate(...homeNavConfig)
+      }
+    })
+  }
+
   return (
     <React.Fragment>
       <ChroniclesWebMetaHeader title={title} />
@@ -91,7 +104,11 @@ export const ChroniclesBase: FunctionComponent<Props> = ({
           onLayout={handleLayout}
         />
       </FullFlexRow>
-      <ChroniclesWritersModal closeModal={hideModal} isVisible={visible} />
+      <ChroniclesWritersModal
+        closeModal={hideModal}
+        isVisible={visible}
+        onShowRecoButtonPress={handleOnShowRecoButtonPress}
+      />
     </React.Fragment>
   )
 }

--- a/src/features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal.native.test.tsx
+++ b/src/features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal.native.test.tsx
@@ -1,56 +1,16 @@
-import * as reactNavigationNative from '@react-navigation/native'
 import React from 'react'
 
 import { ChroniclesWritersModal } from 'features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal'
-import { env } from 'libs/environment/env'
-import { render, screen, userEvent } from 'tests/utils'
-
-const mockNavigate = jest.fn()
-jest.spyOn(reactNavigationNative, 'useNavigation').mockReturnValue({
-  navigate: mockNavigate,
-})
-
-jest.mock('features/navigation/helpers/navigateToHome')
-
-const defaultEnvironment = env.ENV
-
-const user = userEvent.setup()
-
-jest.useFakeTimers()
+import { render, screen } from 'tests/utils'
 
 describe('<ChroniclesWritersModal/>', () => {
-  afterEach(() => {
-    env.ENV = defaultEnvironment
-  })
-
   it('should render correctly', () => {
-    render(<ChroniclesWritersModal isVisible closeModal={jest.fn} />)
+    render(
+      <ChroniclesWritersModal isVisible closeModal={jest.fn} onShowRecoButtonPress={jest.fn()} />
+    )
 
     expect(
       screen.getByText('Les avis du book club sont écrits par des jeunes passionnés de lecture.')
     ).toBeOnTheScreen()
-  })
-
-  it('should navigate to recommandation thematic home when pressing button in production', async () => {
-    env.ENV = 'production'
-
-    render(<ChroniclesWritersModal isVisible closeModal={jest.fn} />)
-
-    await user.press(screen.getByText('Voir toutes les recos du book club'))
-
-    expect(mockNavigate).toHaveBeenNthCalledWith(1, 'ThematicHome', {
-      homeId: '4mlVpAZySUZO6eHazWKZeV',
-      from: 'chronicles',
-    })
-  })
-
-  it('should close the modal when pressing close button', async () => {
-    const mockCloseModal = jest.fn()
-
-    render(<ChroniclesWritersModal isVisible closeModal={mockCloseModal} />)
-
-    await user.press(screen.getByLabelText('Fermer la modale'))
-
-    expect(mockCloseModal).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal.tsx
+++ b/src/features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal.tsx
@@ -1,10 +1,7 @@
 import React, { FunctionComponent } from 'react'
 
-import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
-import { env } from 'libs/environment/env'
 import { ButtonPrimary } from 'ui/components/buttons/ButtonPrimary'
 import { AppModal } from 'ui/components/modals/AppModal'
-import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { Close } from 'ui/svg/icons/Close'
 import { TypoDS } from 'ui/theme'
@@ -12,11 +9,17 @@ import { TypoDS } from 'ui/theme'
 type Props = {
   isVisible: boolean
   closeModal: VoidFunction
+  onShowRecoButtonPress: VoidFunction
 }
 
-export const ChroniclesWritersModal: FunctionComponent<Props> = ({ isVisible, closeModal }) => {
+export const ChroniclesWritersModal: FunctionComponent<Props> = ({
+  isVisible,
+  closeModal,
+  onShowRecoButtonPress,
+}) => {
   return (
     <AppModal
+      animationOutTiming={1}
       visible={isVisible}
       title="Qui écrit les avis&nbsp;?"
       rightIconAccessibilityLabel="Fermer la modale"
@@ -30,21 +33,10 @@ export const ChroniclesWritersModal: FunctionComponent<Props> = ({ isVisible, cl
           Ils sont sélectionnés par le pass Culture pour te faire leurs meilleures recos tous les
           mois.
         </TypoDS.Body>
-        <InternalTouchableLink
-          as={ButtonPrimary}
+
+        <ButtonPrimary
           wording="Voir toutes les recos du book club"
-          navigateTo={
-            env.ENV === 'production'
-              ? {
-                  screen: 'ThematicHome',
-                  params: {
-                    homeId: '4mlVpAZySUZO6eHazWKZeV',
-                    from: 'chronicles',
-                  },
-                }
-              : navigateToHomeConfig
-          }
-          onBeforeNavigate={closeModal}
+          onPress={onShowRecoButtonPress}
         />
       </ViewGap>
     </AppModal>

--- a/src/features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal.web.test.tsx
+++ b/src/features/chronicle/pages/ChroniclesWritersModal/ChroniclesWritersModal.web.test.tsx
@@ -6,7 +6,13 @@ import { act, checkAccessibilityFor, render } from 'tests/utils/web'
 describe('<ChroniclesWritersModal/>', () => {
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
-      const { container } = render(<ChroniclesWritersModal isVisible closeModal={jest.fn()} />)
+      const { container } = render(
+        <ChroniclesWritersModal
+          isVisible
+          closeModal={jest.fn()}
+          onShowRecoButtonPress={jest.fn()}
+        />
+      )
       await act(async () => {
         const results = await checkAccessibilityFor(container)
 

--- a/src/features/navigation/RootNavigator/types.ts
+++ b/src/features/navigation/RootNavigator/types.ts
@@ -46,7 +46,7 @@ type BaseThematicHome = {
 }
 
 type OtherThematicBlockHome = {
-  from?: 'deeplink'
+  from?: 'deeplink' | 'chronicles'
   moduleId?: string
   moduleListId?: string
 }
@@ -61,6 +61,7 @@ type HighlightThematicBlockThematicHome = {
   moduleId: string
   moduleListId?: never
 }
+
 export type ThematicHomeParams = BaseThematicHome &
   (OtherThematicBlockHome | CategoryBlockThematicHome | HighlightThematicBlockThematicHome)
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34735

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

Before :

https://github.com/user-attachments/assets/15412b09-4d2a-4edd-a223-f6aa9ac1f741

After :

https://github.com/user-attachments/assets/c480f5fd-2e4e-4d97-8ee6-4c76be8d9c67

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
