### PR TITLE
(PC-33732) feat(Search): use Algolia Rules to redirect to book themat…

### DIFF
--- a/src/features/search/components/SearchBox/SearchBox.native.test.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.native.test.tsx
@@ -535,40 +535,6 @@ describe('SearchBox component', () => {
       expect(screen.queryByLabelText('Réinitialiser la recherche')).not.toBeOnTheScreen()
     })
 
-    it.each(['LIVRE', 'Livre ', 'livre', 'LIVRES', 'Livres', 'livres '])(
-      'should redirect to ThematicSearch when queryText is `%s` and SearchView is `Landing`',
-      async (queryText) => {
-        // TODO(PC-32646): useRoute is called every time a letter is inputted +1 (sic!)
-        useRoute.mockReturnValue({ name: SearchView.Landing })
-
-        renderSearchBox()
-
-        const searchInput = screen.getByPlaceholderText('Offre, artiste, lieu culturel...')
-        await user.type(searchInput, queryText, { submitEditing: true })
-
-        expect(navigate).toHaveBeenCalledWith('TabNavigator', {
-          params: {
-            params: {
-              ...initialSearchState,
-              query: queryText.trim(),
-              offerCategories: [SearchGroupNameEnumv2.LIVRES],
-              searchId,
-              accessibilityFilter: {
-                isAudioDisabilityCompliant: undefined,
-                isMentalDisabilityCompliant: undefined,
-                isMotorDisabilityCompliant: undefined,
-                isVisualDisabilityCompliant: undefined,
-              },
-              priceRange: mockSearchState.priceRange,
-              shouldRedirect: false,
-            },
-            screen: 'ThematicSearch',
-          },
-          screen: 'SearchStackNavigator',
-        })
-      }
-    )
-
     it('should log HasSearchedCinemaQuery analytic when shouldRedirectToThematicSearch is disabled', async () => {
       // TODO(PC-32646): useRoute & useRemoteConfigContext are called every time a letter is inputted +1
       useRoute.mockReturnValueOnce({ name: SearchView.Landing })

--- a/src/features/search/components/SearchBox/SearchBox.tsx
+++ b/src/features/search/components/SearchBox/SearchBox.tsx
@@ -44,7 +44,6 @@ type Props = UseSearchBoxProps & {
 
 const accessibilityDescribedBy = uuidv4()
 
-const BOOK_KEYWORD_PATTERN = /\bLIVRES?\b$/i
 const CINEMA_KEYWORD_PATTERN = /\bCINEMAS?\b$/i
 
 export const SearchBox: React.FunctionComponent<Props> = ({
@@ -241,19 +240,7 @@ export const SearchBox: React.FunctionComponent<Props> = ({
         }
       }
 
-      let hasSearchedForBookKeyword = false
-
       if (currentView === SearchView.Landing) {
-        hasSearchedForBookKeyword = BOOK_KEYWORD_PATTERN.test(queryText.trim())
-
-        if (hasSearchedForBookKeyword) {
-          partialSearchState = {
-            ...partialSearchState,
-            query: queryText.trim(),
-            offerCategories: [SearchGroupNameEnumv2.LIVRES],
-          }
-        }
-
         if (
           CINEMA_KEYWORD_PATTERN.test(
             queryText
@@ -266,7 +253,7 @@ export const SearchBox: React.FunctionComponent<Props> = ({
         }
       }
 
-      pushWithSearch(partialSearchState, {}, hasSearchedForBookKeyword)
+      pushWithSearch(partialSearchState, {})
       hideSuggestions()
     },
     [


### PR DESCRIPTION
…ic search when query is livre

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-33732

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.


Uploading Screen Recording 2025-02-24 at 10.38.30.mov…

rules sur Algolia : 
- en testing : https://dashboard.algolia.com/apps/testingHXXTDUE7H0/rules/TESTING
- en staging : https://dashboard.algolia.com/apps/testingHXXTDUE7H0/rules/STAGING
-  en prod : https://dashboard.algolia.com/apps/E2IKXJ325N/rules/PRODUCTION



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
