### PR TITLE
(PC-34546) fix(venuePlaylists): add search state dispatch with offerC…

### DIFF
--- a/src/features/search/components/CategoriesList/CategoriesList.native.test.tsx
+++ b/src/features/search/components/CategoriesList/CategoriesList.native.test.tsx
@@ -69,6 +69,21 @@ describe('CategoriesList', () => {
     })
   })
 
+  it('should dispatch with offerCategory before navigation', async () => {
+    render(<CategoriesList />)
+    const categoryButton = screen.getByText('Spectacles'.toUpperCase())
+    await act(async () => {
+      fireEvent.press(categoryButton)
+    })
+
+    await waitFor(async () => {
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_STATE',
+        payload: { ...initialSearchState, offerCategories: ['SPECTACLES'] },
+      })
+    })
+  })
+
   it('should navigate to search results with search params on press', async () => {
     render(<CategoriesList />)
 

--- a/src/features/search/helpers/useSortedSearchCategories/useSortedSearchCategories.native.test.ts
+++ b/src/features/search/helpers/useSortedSearchCategories/useSortedSearchCategories.native.test.ts
@@ -1,3 +1,4 @@
+import { initialSearchState } from 'features/search/context/reducer'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { renderHook } from 'tests/utils'
@@ -9,6 +10,14 @@ import {
 } from './useSortedSearchCategories'
 
 jest.mock('libs/subcategories/useSubcategories')
+
+const mockUseSearch = jest.fn(() => ({
+  searchState: initialSearchState,
+  dispatch: jest.fn(),
+}))
+jest.mock('features/search/context/SearchWrapper', () => ({
+  useSearch: () => mockUseSearch(),
+}))
 
 describe('useSortedSearchCategories', () => {
   beforeEach(() => {

--- a/src/features/search/helpers/useSortedSearchCategories/useSortedSearchCategories.ts
+++ b/src/features/search/helpers/useSortedSearchCategories/useSortedSearchCategories.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { SearchGroupNameEnumv2 } from 'api/gen'
 import { getNavigateToConfig } from 'features/navigation/SearchStackNavigator/helpers'
 import { ListCategoryButtonProps } from 'features/search/components/CategoriesListDumb/CategoriesListDumb'
+import { useSearch } from 'features/search/context/SearchWrapper'
 import { isOnlyOnline } from 'features/search/helpers/categoriesHelpers/categoriesHelpers'
 import { useAvailableCategories } from 'features/search/helpers/useAvailableCategories/useAvailableCategories'
 import { useHasAThematicPageList } from 'features/search/helpers/useHasAThematicPageList/useHasAThematicPageList'
@@ -23,7 +24,7 @@ export const useSortedSearchCategories = (): ListCategoryButtonProps => {
   const categories = useAvailableCategories()
   const { data } = useSubcategories()
   const hasAThematicSearch = useHasAThematicPageList()
-
+  const { searchState, dispatch } = useSearch()
   const navigateTo = (facetFilter: SearchGroupNameEnumv2) => {
     const searchTabConfig = getNavigateToConfig(
       hasAThematicSearch.includes(facetFilter) ? 'ThematicSearch' : 'SearchResults',
@@ -35,10 +36,18 @@ export const useSortedSearchCategories = (): ListCategoryButtonProps => {
     )
     return searchTabConfig
   }
+
+  const onBeforeNavigate = (facetFilter: SearchGroupNameEnumv2) => {
+    dispatch({
+      type: 'SET_STATE',
+      payload: { ...searchState, offerCategories: [facetFilter] },
+    })
+  }
   return categories
     .map<MappingOutput>((category) => ({
       label: searchGroupLabelMapping?.[category.facetFilter] || '',
       navigateTo: navigateTo(category.facetFilter),
+      onBeforeNavigate: () => onBeforeNavigate(category.facetFilter),
       position: category.position,
       borderColor: category.borderColor,
       fillColor: category.fillColor,

--- a/src/features/search/helpers/useSortedSearchCategories/useSortedSearchCategories.ts
+++ b/src/features/search/helpers/useSortedSearchCategories/useSortedSearchCategories.ts
@@ -41,7 +41,7 @@ export const useSortedSearchCategories = (): ListCategoryButtonProps => {
     dispatch({
       type: 'SET_STATE',
       payload: { ...searchState, offerCategories: [facetFilter] },
-    })
+    }) // we'd rather have it in url params but URL is not the only source of truth. When it is, this dispatch should be removed.
   }
   return categories
     .map<MappingOutput>((category) => ({

--- a/src/features/venue/api/useVenueOffers.test.ts
+++ b/src/features/venue/api/useVenueOffers.test.ts
@@ -27,6 +27,7 @@ jest.mock('libs/location/LocationWrapper', () => ({
 jest.mock('features/search/context/SearchWrapper', () => ({
   useSearch: () => ({
     resetSearch: jest.fn(),
+    dispatch: jest.fn(),
   }),
 }))
 
@@ -236,7 +237,9 @@ describe('useVenueOffers', () => {
         nbHits: 1,
       },
     ]
-    mockFetchMultipleOffers.mockResolvedValueOnce(FETCH_MULTIPLE_OFFERS_RESPONSE)
+    mockFetchMultipleOffers
+      .mockResolvedValueOnce(FETCH_MULTIPLE_OFFERS_RESPONSE)
+      .mockResolvedValueOnce(FETCH_MULTIPLE_OFFERS_RESPONSE)
 
     const { result } = renderHook(() => useVenueOffers(mockVenueResponse), {
       wrapper: ({ children }) => reactQueryProviderHOC(children),


### PR DESCRIPTION
…ategory before navigation to ThematicSearch

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34546

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Android          |[casse.webm](https://github.com/user-attachments/assets/529f43a0-265a-4013-815e-317966771651)| [fixe.webm](https://github.com/user-attachments/assets/001f28de-61fa-477f-a577-742e89b5e778)|


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
