### PR TITLE
(PC-34808) feat(CI): add ios app distribution 

### DIFF
--- a/.github/workflows/dev_on_workflow_environment_ios_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_ios_deploy.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           secrets: |-
             FIREBASE_TOKEN:passculture-metier-ehp/pc_native_${{ inputs.ENV }}_firebase_json
-        if: inputs.ENV != 'production'
+        if: ${{ inputs.ENV != 'production' }}
       - name: 'Render Template'
         run: |
           cp templates_github_ci/.sentryclirc .sentryclirc

--- a/.github/workflows/dev_on_workflow_environment_ios_deploy.yml
+++ b/.github/workflows/dev_on_workflow_environment_ios_deploy.yml
@@ -78,6 +78,13 @@ jobs:
             MATCH_SSH_KEY:passculture-metier-ehp/passculture-app-native-match-ssh-key
             MATCH_USERNAME:passculture-metier-ehp/passculture-app-native-match-username
             SENTRY_AUTH_TOKEN:passculture-metier-ehp/passculture-app-native-sentry-token
+      - name: Get Secret for App Distribution from Secret Manager (EHP only)
+        id: 'app_distribution_secret'
+        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        with:
+          secrets: |-
+            FIREBASE_TOKEN:passculture-metier-ehp/pc_native_${{ inputs.ENV }}_firebase_json
+        if: inputs.ENV != 'production'
       - name: 'Render Template'
         run: |
           cp templates_github_ci/.sentryclirc .sentryclirc
@@ -91,7 +98,11 @@ jobs:
           ssh-private-key: ${{  steps.secrets.outputs.MATCH_SSH_KEY }}
       - name: Deploy hard ios for ${{ inputs.ENV }}
         run: |
-          bundle exec fastlane ios deploy --env ${{ inputs.ENV }} --verbose
+          if [ "${{ inputs.ENV }}" != "production" ]; then
+            bundle exec fastlane ios deploy firebase_token:"${{ steps.app_distribution_secret.outputs.FIREBASE_TOKEN }}" --env ${{ inputs.ENV }} --verbose
+          else
+            bundle exec fastlane ios deploy --env ${{ inputs.ENV }} --verbose
+          fi
         env:
           LC_ALL: en_US.UTF-8
           LANG: en_US.UTF-8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,9 @@ GEM
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
     fastlane-plugin-appcenter (2.1.1)
+    fastlane-plugin-firebase_app_distribution (0.10.0)
+      google-apis-firebaseappdistribution_v1 (~> 0.3.0)
+      google-apis-firebaseappdistribution_v1alpha (~> 0.2.0)
     ffi (1.15.5)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -176,6 +179,10 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
       webrick
+    google-apis-firebaseappdistribution_v1 (0.3.0)
+      google-apis-core (>= 0.11.0, < 2.a)
+    google-apis-firebaseappdistribution_v1alpha (0.2.0)
+      google-apis-core (>= 0.11.0, < 2.a)
     google-apis-iamcredentials_v1 (0.17.0)
       google-apis-core (>= 0.11.0, < 2.a)
     google-apis-playcustomapp_v1 (0.13.0)
@@ -283,10 +290,11 @@ DEPENDENCIES
   cocoapods (>= 1.11.3)
   fastlane
   fastlane-plugin-appcenter
+  fastlane-plugin-firebase_app_distribution
   fastlane-plugin-load_json!
 
 RUBY VERSION
    ruby 2.7.5p203
 
 BUNDLED WITH
-   2.2.22
+   2.4.12

--- a/fastlane/.env.staging
+++ b/fastlane/.env.staging
@@ -14,3 +14,7 @@ ANDROID_FILE_PATH='android/app/build/outputs/apk/staging/release/app-staging-rel
 # AppCenter
 APPCENTER_IOS_APP_ID='passculture-staging-ios'
 APPCENTER_ANDROID_APP_ID='passculture-staging-android'
+
+# Firebase - App Distribution
+FIREBASE_PUBLIC_IOS_APP_ID='1:769039296481:ios:efdb52783252a214be14a0'
+FIREBASE_PUBLIC_ANDROID_APP_ID='1:769039296481:android:6f2e8d6205125335be14a0'

--- a/fastlane/.env.testing
+++ b/fastlane/.env.testing
@@ -14,3 +14,7 @@ ANDROID_FILE_PATH='android/app/build/outputs/apk/apptesting/release/app-apptesti
 # AppCenter
 APPCENTER_IOS_APP_ID='passculture-testing-ios'
 APPCENTER_ANDROID_APP_ID='passculture-testing-android'
+
+# Firebase - App Distribution
+FIREBASE_PUBLIC_IOS_APP_ID='1:557258398232:ios:7e115147acf19cda22816d'
+FIREBASE_PUBLIC_ANDROID_APP_ID='1:557258398232:android:981d2fd61e096ddf22816d'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -39,7 +39,7 @@ platform :ios do
   end
 
   lane :deploy_appDistribution do |options|
-    release = firebase_app_distribution(
+    firebase_app_distribution(
         app: ENV['FIREBASE_PUBLIC_IOS_APP_ID'],
         release_notes: escaped_release_notes,
         ipa_path: "#{ENV['IOS_IPA_DIRECTORY']}/#{ENV['IOS_IPA_NAME']}",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -38,6 +38,16 @@ platform :ios do
     )
   end
 
+  lane :deploy_appDistribution do |options|
+    release = firebase_app_distribution(
+        app: ENV['FIREBASE_PUBLIC_IOS_APP_ID'],
+        release_notes: escaped_release_notes,
+        ipa_path: "#{ENV['IOS_IPA_DIRECTORY']}/#{ENV['IOS_IPA_NAME']}",
+        service_credentials_file: options[:firebase_token],
+        groups: "devs"
+    )
+  end
+
   lane :upload_sentry_sourceMaps_soft do
     sh "cd .. && \
         export APPCENTER_ACCESS_TOKEN=#{ENV['IOS_APPCENTER_API_TOKEN']} && \
@@ -74,8 +84,11 @@ platform :ios do
         readonly: true
       )
       build
-      if ENV['DEPLOYMENT_PLATFORM'] === 'appcenter' then
+      if ENV['DEPLOYMENT_PLATFORM'] === 'appcenter'
         deploy_appCenter
+        if ENV['ENV'] == 'testing'
+          deploy_appDistribution(firebase_token: options[:firebase_token])
+        end
       else
         # after upgrading fastlane to version 2.212.2, an error occured "Could not determine the package’s bundle ID. The package is missing an Info.plist
         # or the CFBundlePackageType is not ‘APPL’ or ‘FMWK’. Unable to validate your application.".

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -86,9 +86,7 @@ platform :ios do
       build
       if ENV['DEPLOYMENT_PLATFORM'] === 'appcenter'
         deploy_appCenter
-        if ENV['ENV'] == 'testing'
-          deploy_appDistribution(firebase_token: options[:firebase_token])
-        end
+        deploy_appDistribution(firebase_token: options[:firebase_token])
       else
         # after upgrading fastlane to version 2.212.2, an error occured "Could not determine the package’s bundle ID. The package is missing an Info.plist
         # or the CFBundlePackageType is not ‘APPL’ or ‘FMWK’. Unable to validate your application.".

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -4,3 +4,4 @@
 
 gem 'fastlane-plugin-appcenter'
 gem 'fastlane-plugin-load_json', git: 'https://github.com/KrauseFx/fastlane-plugin-load_json'
+gem 'fastlane-plugin-firebase_app_distribution'


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34808

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
