### PR TITLE
(BSR) feat(cheatcodes): alphabetical order in CheatcodesScreenFeature…

### DIFF
--- a/src/cheatcodes/pages/others/CheatcodesScreenFeatureFlags.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenFeatureFlags.tsx
@@ -19,10 +19,12 @@ export const CheatcodesScreenFeatureFlags = () => {
     data: { featureFlag: string; isFeatureFlagActive: boolean }[]
   }
 
-  const sections: Section[] = Object.entries(featureFlags).map(([owner, data]) => ({
-    title: owner,
-    data: data as FeatureFlagAll[], // "as" to avoid typing error
-  }))
+  const sections: Section[] = Object.entries(featureFlags)
+    .map(([owner, data]) => ({
+      title: owner,
+      data: data as FeatureFlagAll[], // "as" to avoid typing error
+    }))
+    .sort((a, b) => a.title.localeCompare(b.title))
 
   const totalFeatureFlags = sections.reduce((sum, section) => sum + section.data.length, 0)
 
@@ -72,6 +74,14 @@ export const CheatcodesScreenFeatureFlags = () => {
       <SectionList
         sections={sections}
         keyExtractor={(item) => item.featureFlag}
+        renderSectionHeader={({ section: { title, data } }) => (
+          <React.Fragment>
+            <TypoDS.Title2>
+              {title} ({data.length})
+            </TypoDS.Title2>
+            <Spacer.Column numberOfSpaces={5} />
+          </React.Fragment>
+        )}
         renderItem={({ item, index, section }) => (
           <React.Fragment>
             <StyledFeatureFlag>
@@ -81,14 +91,6 @@ export const CheatcodesScreenFeatureFlags = () => {
               </StyledTitle4>
             </StyledFeatureFlag>
             {index === section.data.length - 1 ? <Spacer.Column numberOfSpaces={10} /> : null}
-          </React.Fragment>
-        )}
-        renderSectionHeader={({ section: { title, data } }) => (
-          <React.Fragment>
-            <TypoDS.Title2>
-              {title} ({data.length})
-            </TypoDS.Title2>
-            <Spacer.Column numberOfSpaces={5} />
           </React.Fragment>
         )}
         ItemSeparatorComponent={() => <StyledSeparator />}


### PR DESCRIPTION
…Flags

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |  ![Capture d’écran 2025-02-24 à 15 29 34](https://github.com/user-attachments/assets/18db5b37-c22c-448e-b8d2-9f7d880f0e56) |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4