### PR TITLE
(BSR) tests(best-practices): userEvent instead of fireEvent

### DIFF
--- a/src/features/achievements/pages/AchievementDetailsModal.native.test.tsx
+++ b/src/features/achievements/pages/AchievementDetailsModal.native.test.tsx
@@ -1,14 +1,16 @@
 import React from 'react'
 
 import { AchievementEnum } from 'api/gen'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { AchievementDetailsModal } from './AchievementDetailsModal'
 
 const hideModalMock = jest.fn()
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<AchievementDetailsModal/>', () => {
-  it('should call hideModal function when clicking on Close icon', () => {
+  it('should call hideModal function when clicking on Close icon', async () => {
     render(
       <AchievementDetailsModal
         name={AchievementEnum.FIRST_ART_LESSON_BOOKING}
@@ -18,7 +20,7 @@ describe('<AchievementDetailsModal/>', () => {
     )
 
     const rightIcon = screen.getByTestId('Fermer la modale')
-    fireEvent.press(rightIcon)
+    await user.press(rightIcon)
 
     expect(hideModalMock).toHaveBeenCalledTimes(1)
   })

--- a/src/features/artist/components/ArtistBody/ArtistBody.native.test.tsx
+++ b/src/features/artist/components/ArtistBody/ArtistBody.native.test.tsx
@@ -11,7 +11,7 @@ import * as useArtistResults from 'features/offer/helpers/useArtistResults/useAr
 import { mockedAlgoliaOffersWithSameArtistResponse } from 'libs/algolia/fixtures/algoliaFixtures'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 
 jest.unmock('react-native/Libraries/Animated/createAnimatedComponent')
 jest.mock('libs/firebase/analytics/analytics')
@@ -47,6 +47,8 @@ const mockArtist = {
   bio: 'chanteuse',
 }
 
+jest.useFakeTimers()
+
 describe('<ArtistBody />', () => {
   beforeEach(() => {
     setFeatureFlags()
@@ -66,14 +68,14 @@ describe('<ArtistBody />', () => {
     expect(screen.getAllByText('Céline Dion')[0]).toBeOnTheScreen()
   })
 
-  it('should call goBack when pressing the back button', () => {
+  it('should call goBack when pressing the back button', async () => {
     render(
       reactQueryProviderHOC(
         <ArtistBody offer={offerResponseSnap} subcategory={mockSubcategory} artist={mockArtist} />
       )
     )
     const backButton = screen.getByTestId('Revenir en arrière')
-    fireEvent.press(backButton)
+    await userEvent.setup().press(backButton)
 
     expect(mockGoBack).toHaveBeenCalledTimes(1)
   })

--- a/src/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx
+++ b/src/features/auth/pages/signup/SetPassword/SetPassword.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { act, render, screen, userEvent } from 'tests/utils'
 
 import { SetPassword } from './SetPassword'
 
@@ -23,6 +23,8 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('SetPassword Page', () => {
   it('should render correctly', () => {
@@ -54,7 +56,7 @@ describe('SetPassword Page', () => {
 
     const passwordInput = screen.getByPlaceholderText('Ton mot de passe')
     await act(async () => {
-      fireEvent.changeText(passwordInput, 'user@AZERTY123')
+      user.type(passwordInput, 'user@AZERTY123')
     })
 
     expect(await screen.findByTestId('Continuer')).toBeEnabled()
@@ -65,11 +67,11 @@ describe('SetPassword Page', () => {
 
     await act(async () => {
       const passwordInput = screen.getByPlaceholderText('Ton mot de passe')
-      fireEvent.changeText(passwordInput, 'user@AZERTY123')
+      user.type(passwordInput, 'user@AZERTY123')
     })
 
     await act(async () => {
-      fireEvent.press(screen.getByTestId('Continuer'))
+      user.press(screen.getByTestId('Continuer'))
     })
 
     expect(props.goToNextStep).toHaveBeenCalledWith({ password: 'user@AZERTY123' })

--- a/src/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSent.native.test.tsx
+++ b/src/features/auth/pages/signup/SignupConfirmationEmailSent/SignupConfirmationEmailSent.native.test.tsx
@@ -8,7 +8,7 @@ import { usePreviousRoute } from 'features/navigation/helpers/usePreviousRoute'
 import { analytics } from 'libs/analytics/provider'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { act, render, screen, userEvent } from 'tests/utils'
 
 import { SignupConfirmationEmailSent } from './SignupConfirmationEmailSent'
 
@@ -28,6 +28,8 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<SignupConfirmationEmailSent />', () => {
   beforeEach(() => {
@@ -46,7 +48,7 @@ describe('<SignupConfirmationEmailSent />', () => {
     await screen.findByText('Confirme ton adresse e-mail')
 
     const consultHelpSupportButton = screen.getByText('Consulter notre centre d’aide')
-    await act(async () => fireEvent.press(consultHelpSupportButton))
+    await act(async () => user.press(consultHelpSupportButton))
 
     expect(analytics.logHelpCenterContactSignupConfirmationEmailSent).toHaveBeenCalledTimes(1)
     expect(mockedOpenUrl).toHaveBeenCalledWith(
@@ -62,7 +64,7 @@ describe('<SignupConfirmationEmailSent />', () => {
 
     const checkEmailsButton = screen.getByText('Consulter mes e-mails')
     await act(async () => {
-      fireEvent.press(checkEmailsButton)
+      user.press(checkEmailsButton)
     })
 
     expect(openInbox).toHaveBeenCalledTimes(1)
@@ -83,7 +85,7 @@ describe('<SignupConfirmationEmailSent />', () => {
     await screen.findByText('Confirme ton adresse e-mail')
 
     const checkEmailsButton = screen.getByText('Consulter mes e-mails')
-    await act(async () => fireEvent.press(checkEmailsButton))
+    await act(async () => user.press(checkEmailsButton))
 
     expect(analytics.logEmailConfirmationConsultEmailClicked).toHaveBeenCalledTimes(1)
   })
@@ -99,7 +101,7 @@ describe('<SignupConfirmationEmailSent />', () => {
     renderSignupConfirmationEmailSent()
     await screen.findByText('Confirme ton adresse e-mail')
 
-    fireEvent.press(screen.getByText('Recevoir un nouveau lien'))
+    await user.press(screen.getByText('Recevoir un nouveau lien'))
 
     expect(screen.getByText('Demander un nouveau lien')).toBeOnTheScreen()
   })

--- a/src/features/auth/pages/signup/SignupConfirmationExpiredLink/SignupConfirmationExpiredLink.native.test.tsx
+++ b/src/features/auth/pages/signup/SignupConfirmationExpiredLink/SignupConfirmationExpiredLink.native.test.tsx
@@ -8,7 +8,7 @@ import { RootStackParamList } from 'features/navigation/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { act, render, screen, userEvent, waitFor } from 'tests/utils'
 
 import { SignupConfirmationExpiredLink } from './SignupConfirmationExpiredLink'
 
@@ -38,12 +38,15 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<SignupConfirmationExpiredLink/>', () => {
   it('should redirect to home page WHEN go back to home button is clicked', async () => {
     renderSignupConfirmationExpiredLink()
 
     const button = screen.getByText('Retourner à l’accueil')
-    fireEvent.press(button)
+    user.press(button)
 
     await waitFor(() => {
       expect(navigateFromRef).toHaveBeenCalledWith(
@@ -57,7 +60,7 @@ describe('<SignupConfirmationExpiredLink/>', () => {
     mockServer.postApi('/v1/resend_email_validation', {})
     renderSignupConfirmationExpiredLink()
 
-    fireEvent.press(screen.getByText(`Renvoyer l’email`))
+    user.press(screen.getByText(`Renvoyer l’email`))
 
     await waitFor(() => {
       expect(navigate).toHaveBeenCalledTimes(1)
@@ -76,7 +79,7 @@ describe('<SignupConfirmationExpiredLink/>', () => {
     renderSignupConfirmationExpiredLink()
 
     await act(async () => {
-      fireEvent.press(screen.getByText(`Renvoyer l’email`))
+      user.press(screen.getByText(`Renvoyer l’email`))
     })
 
     expect(navigate).not.toHaveBeenCalled()

--- a/src/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx
+++ b/src/features/auth/pages/suspendedAccount/AccountReactivationSuccess/AccountReactivationSuccess.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { AccountReactivationSuccess } from './AccountReactivationSuccess'
 
@@ -13,6 +13,8 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<AccountReactivationSuccess />', () => {
   it('should match snapshot', () => {
@@ -21,11 +23,11 @@ describe('<AccountReactivationSuccess />', () => {
     expect(screen).toMatchSnapshot()
   })
 
-  it('should go to home page when clicking on go to home button', () => {
+  it('should go to home page when clicking on go to home button', async () => {
     render(<AccountReactivationSuccess />)
 
     const homeButton = screen.getByText('Découvrir le catalogue')
-    fireEvent.press(homeButton)
+    await user.press(homeButton)
 
     expect(navigate).toHaveBeenNthCalledWith(
       1,

--- a/src/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx
+++ b/src/features/auth/pages/suspendedAccount/FraudulentSuspendedAccount/FraudulentSuspendedAccount.native.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { analytics } from 'libs/analytics/provider'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { FraudulentSuspendedAccount } from './FraudulentSuspendedAccount'
 
@@ -15,6 +15,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<FraudulentSuspendedAccount />', () => {
   it('should match snapshot', () => {
     render(<FraudulentSuspendedAccount />)
@@ -22,11 +25,11 @@ describe('<FraudulentSuspendedAccount />', () => {
     expect(screen).toMatchSnapshot()
   })
 
-  it('should log analytics when clicking on "Contacter le service fraude" button', () => {
+  it('should log analytics when clicking on "Contacter le service fraude" button', async () => {
     render(<FraudulentSuspendedAccount />)
 
     const contactSupportButton = screen.getByText('Contacter le service fraude')
-    fireEvent.press(contactSupportButton)
+    await user.press(contactSupportButton)
 
     expect(analytics.logContactFraudTeam).toHaveBeenCalledWith({
       from: 'fraudulentsuspendedaccount',

--- a/src/features/bookOffer/components/BookPricesChoice.native.test.tsx
+++ b/src/features/bookOffer/components/BookPricesChoice.native.test.tsx
@@ -5,7 +5,7 @@ import { BookingState, initialBookingState } from 'features/bookOffer/context/re
 import { mockStocks } from 'features/bookOffer/fixtures/stocks'
 import { IBookingContext } from 'features/bookOffer/types'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
-import { fireEvent, render, screen } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 
 const mockInitialBookingState = initialBookingState
 
@@ -25,6 +25,9 @@ const mockCreditOffer = 50000
 jest.mock('features/offer/helpers/useHasEnoughCredit/useHasEnoughCredit', () => ({
   useCreditForOffer: jest.fn(() => mockCreditOffer),
 }))
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('BookPricesChoice', () => {
   beforeEach(() => {
@@ -48,19 +51,19 @@ describe('BookPricesChoice', () => {
     expect(screen.getByText('Pelouse')).toBeOnTheScreen()
   })
 
-  it('should select price stock when pressing a price and offer is duo', () => {
+  it('should select price stock when pressing a price and offer is duo', async () => {
     render(<BookPricesChoice stocks={mockStocks} isDuo />)
 
-    fireEvent.press(screen.getByText('Pelouse or'))
+    await user.press(screen.getByText('Pelouse or'))
 
     expect(mockDispatch).toHaveBeenNthCalledWith(1, { type: 'SELECT_STOCK', payload: 18757 })
     expect(mockDispatch).toHaveBeenCalledTimes(1)
   })
 
-  it('should select a quantity of 1 in addition to the price stock when pressing a price and offer is not duo', () => {
+  it('should select a quantity of 1 in addition to the price stock when pressing a price and offer is not duo', async () => {
     render(<BookPricesChoice stocks={mockStocks} />)
 
-    fireEvent.press(screen.getByText('Pelouse or'))
+    await user.press(screen.getByText('Pelouse or'))
 
     expect(mockDispatch).toHaveBeenNthCalledWith(1, { type: 'SELECT_STOCK', payload: 18757 })
     expect(mockDispatch).toHaveBeenNthCalledWith(2, { type: 'SELECT_QUANTITY', payload: 1 })

--- a/src/features/cookies/components/CookiesSettings.native.test.tsx
+++ b/src/features/cookies/components/CookiesSettings.native.test.tsx
@@ -5,7 +5,7 @@ import { CookiesSettings } from 'features/cookies/components/CookiesSettings'
 import { CookieCategoriesEnum } from 'features/cookies/enums'
 import { analytics } from 'libs/analytics/provider'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
 
 jest.mock('features/profile/api/usePatchProfile')
 
@@ -16,6 +16,8 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+jest.useFakeTimers()
 
 describe('<CookiesSettings/>', () => {
   it('should disable and check essential cookies switch', async () => {
@@ -34,7 +36,7 @@ describe('<CookiesSettings/>', () => {
 
     const cookieCategory = CookieCategoriesEnum.customization
     const customizationAccordion = screen.getByText(cookiesInfo[cookieCategory].title)
-    fireEvent.press(customizationAccordion)
+    await userEvent.setup().press(customizationAccordion)
 
     await waitFor(() =>
       expect(analytics.logHasOpenedCookiesAccordion).toHaveBeenCalledWith(cookieCategory)

--- a/src/features/home/components/modules/business/NewBusinessModule.native.test.tsx
+++ b/src/features/home/components/modules/business/NewBusinessModule.native.test.tsx
@@ -9,7 +9,7 @@ import { analytics } from 'libs/analytics/provider'
 import { ContentTypes } from 'libs/contentful/types'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
 import { SNACK_BAR_TIME_OUT_LONG } from 'ui/components/snackBar/SnackBarContext'
 import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
 
@@ -42,12 +42,15 @@ const props: BusinessModuleProps = {
 
 jest.mock('libs/firebase/analytics/analytics')
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('NewBusinessModule component', () => {
   const openURLSpy = jest.spyOn(Linking, 'openURL')
 
-  it('should log "BusinessBlockClicked" when clicking on the image', () => {
+  it('should log "BusinessBlockClicked" when clicking on the image', async () => {
     renderModule(props)
-    fireEvent.press(screen.getByTestId('imageBusiness'))
+    await user.press(screen.getByTestId('imageBusiness'))
 
     expect(analytics.logBusinessBlockClicked).toHaveBeenCalledWith({
       moduleName: props.analyticsTitle,
@@ -76,7 +79,7 @@ describe('NewBusinessModule component', () => {
 
   it('should open url when clicking on the image', async () => {
     renderModule(props)
-    fireEvent.press(screen.getByTestId('imageBusiness'))
+    user.press(screen.getByTestId('imageBusiness'))
 
     await waitFor(() => {
       expect(openURLSpy).toHaveBeenCalledWith('url')
@@ -95,7 +98,7 @@ describe('NewBusinessModule component', () => {
       url: 'some_url_with_email={email}',
     })
 
-    fireEvent.press(screen.getByTestId('imageBusiness'))
+    user.press(screen.getByTestId('imageBusiness'))
 
     await waitFor(() => {
       expect(mockShowInfoSnackBar).toHaveBeenCalledWith({
@@ -117,7 +120,7 @@ describe('NewBusinessModule component', () => {
       url: 'some_url_with_email={email}',
     })
 
-    fireEvent.press(screen.getByTestId('imageBusiness'))
+    user.press(screen.getByTestId('imageBusiness'))
     await waitFor(() =>
       expect(openURLSpy).toHaveBeenCalledWith('some_url_with_email=email2@domain.ext')
     )
@@ -141,7 +144,7 @@ describe('NewBusinessModule component', () => {
       url: 'some_url_with_no_email',
     })
 
-    fireEvent.press(screen.getByTestId('imageBusiness'))
+    user.press(screen.getByTestId('imageBusiness'))
     await waitFor(() => expect(openURLSpy).toHaveBeenCalledWith('some_url_with_no_email'))
 
     expect(mockShowInfoSnackBar).not.toHaveBeenCalled()

--- a/src/features/home/components/modules/business/OldBusinessModule.native.test.tsx
+++ b/src/features/home/components/modules/business/OldBusinessModule.native.test.tsx
@@ -9,7 +9,7 @@ import { analytics } from 'libs/analytics/provider'
 import { ContentTypes } from 'libs/contentful/types'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
 import { SNACK_BAR_TIME_OUT_LONG } from 'ui/components/snackBar/SnackBarContext'
 import { SnackBarHelperSettings } from 'ui/components/snackBar/types'
 
@@ -41,13 +41,15 @@ const props: BusinessModuleProps = {
 }
 
 jest.mock('libs/firebase/analytics/analytics')
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('OldBusinessModule component', () => {
   const openURLSpy = jest.spyOn(Linking, 'openURL')
 
-  it('should log "BusinessBlockClicked" when clicking on the image', () => {
+  it('should log "BusinessBlockClicked" when clicking on the image', async () => {
     renderModule(props)
-    fireEvent.press(screen.getByTestId('imageBusiness'))
+    await user.press(screen.getByTestId('imageBusiness'))
 
     expect(analytics.logBusinessBlockClicked).toHaveBeenCalledWith({
       moduleName: props.analyticsTitle,
@@ -75,7 +77,7 @@ describe('OldBusinessModule component', () => {
 
   it('should open url when clicking on the image', async () => {
     renderModule(props)
-    fireEvent.press(screen.getByTestId('imageBusiness'))
+    user.press(screen.getByTestId('imageBusiness'))
 
     await waitFor(() => {
       expect(openURLSpy).toHaveBeenCalledWith('url')
@@ -94,7 +96,7 @@ describe('OldBusinessModule component', () => {
       url: 'some_url_with_email={email}',
     })
 
-    fireEvent.press(screen.getByTestId('imageBusiness'))
+    user.press(screen.getByTestId('imageBusiness'))
 
     await waitFor(() => {
       expect(mockShowInfoSnackBar).toHaveBeenCalledWith({
@@ -116,7 +118,7 @@ describe('OldBusinessModule component', () => {
       url: 'some_url_with_email={email}',
     })
 
-    fireEvent.press(screen.getByTestId('imageBusiness'))
+    user.press(screen.getByTestId('imageBusiness'))
     await waitFor(() =>
       expect(openURLSpy).toHaveBeenCalledWith('some_url_with_email=email2@domain.ext')
     )
@@ -140,7 +142,7 @@ describe('OldBusinessModule component', () => {
       url: 'some_url_with_no_email',
     })
 
-    fireEvent.press(screen.getByTestId('imageBusiness'))
+    user.press(screen.getByTestId('imageBusiness'))
     await waitFor(() => expect(openURLSpy).toHaveBeenCalledWith('some_url_with_no_email'))
 
     expect(mockShowInfoSnackBar).not.toHaveBeenCalled()

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileAccountNotDeletable.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { navigate } from '__mocks__/@react-navigation/native'
 import * as OpenUrlAPI from 'features/navigation/helpers/openUrl'
 import { env } from 'libs/environment/fixtures'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { DeleteProfileAccountNotDeletable } from './DeleteProfileAccountNotDeletable'
 
@@ -16,6 +16,8 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('DeleteProfileAccountNotDeletable', () => {
   it('should render correctly', () => {
@@ -28,7 +30,7 @@ describe('DeleteProfileAccountNotDeletable', () => {
     render(<DeleteProfileAccountNotDeletable />)
 
     const button = screen.getByText('Retourner sur mon profil')
-    fireEvent.press(button)
+    await user.press(button)
 
     expect(navigate).toHaveBeenCalledWith('TabNavigator', { params: undefined, screen: 'Profile' })
   })
@@ -37,16 +39,16 @@ describe('DeleteProfileAccountNotDeletable', () => {
     render(<DeleteProfileAccountNotDeletable />)
 
     const button = screen.getByText('Désactiver mes notifications')
-    fireEvent.press(button)
+    await user.press(button)
 
     expect(navigate).toHaveBeenCalledWith('NotificationsSettings')
   })
 
-  it('should open FAQ link when clicking on "consultant cette page" button', () => {
+  it('should open FAQ link when clicking on "consultant cette page" button', async () => {
     render(<DeleteProfileAccountNotDeletable />)
 
     const faqButton = screen.getByText('consultant cette page.')
-    fireEvent.press(faqButton)
+    await user.press(faqButton)
 
     expect(openUrl).toHaveBeenNthCalledWith(1, env.FAQ_LINK_RIGHT_TO_ERASURE, undefined, true)
   })

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileEmailHacked.native.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { DeleteProfileEmailHacked } from './DeleteProfileEmailHacked'
 
@@ -10,6 +10,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('DeleteProfileEmailHacked', () => {
   it('should render correctly', () => {
@@ -22,7 +25,7 @@ describe('DeleteProfileEmailHacked', () => {
     render(<DeleteProfileEmailHacked />)
     const button = screen.getByText('Ne pas sécuriser mon compte')
 
-    fireEvent.press(button)
+    await user.press(button)
 
     expect(navigate).toHaveBeenCalledWith('TabNavigator', { params: undefined, screen: 'Profile' })
   })
@@ -31,7 +34,7 @@ describe('DeleteProfileEmailHacked', () => {
     render(<DeleteProfileEmailHacked />)
     const button = screen.getByText('Modifier mon adresse e-mail')
 
-    fireEvent.press(button)
+    await user.press(button)
 
     expect(navigate).toHaveBeenCalledWith('ChangeEmail')
   })
@@ -40,7 +43,7 @@ describe('DeleteProfileEmailHacked', () => {
     render(<DeleteProfileEmailHacked />)
     const button = screen.getByText('Suspendre mon compte')
 
-    fireEvent.press(button)
+    await user.press(button)
 
     expect(navigate).toHaveBeenCalledWith('SuspendAccountConfirmationWithoutAuthentication')
   })

--- a/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/DeleteProfileSuccess.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import * as LogoutRoutine from 'features/auth/helpers/useLogoutRoutine'
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import { navigateFromRef } from 'features/navigation/navigationRef'
-import { fireEvent, render, screen } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 
 import { DeleteProfileSuccess } from './DeleteProfileSuccess'
 
@@ -21,6 +21,8 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+jest.useFakeTimers()
+
 describe('DeleteProfileSuccess component', () => {
   it('should render delete profile success', () => {
     render(<DeleteProfileSuccess />)
@@ -34,10 +36,10 @@ describe('DeleteProfileSuccess component', () => {
     expect(signOutMock).toHaveBeenCalledTimes(1)
   })
 
-  it('should redirect to Home page when clicking on "Retourner à l’accueil" button', () => {
+  it('should redirect to Home page when clicking on "Retourner à l’accueil" button', async () => {
     render(<DeleteProfileSuccess />)
 
-    fireEvent.press(screen.getByText(`Retourner à l’accueil`))
+    await userEvent.setup().press(screen.getByText(`Retourner à l’accueil`))
 
     expect(navigateFromRef).toHaveBeenCalledWith(
       navigateToHomeConfig.screen,

--- a/src/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx
+++ b/src/features/profile/pages/DeleteProfile/SuspendAccountConfirmationWithoutAuthentication.native.test.tsx
@@ -5,7 +5,7 @@ import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { analytics } from 'libs/analytics/__mocks__/provider'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 
 import { SuspendAccountConfirmationWithoutAuthentication } from './SuspendAccountConfirmationWithoutAuthentication'
 
@@ -24,6 +24,9 @@ const confirmationSuccessResponse = {
   refreshToken: 'refreshToken',
 }
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('SuspendAccountConfirmationWithoutAuthentication', () => {
   it('should render correctly', () => {
     renderSuspendAccountConfirmationWithoutAuthentication()
@@ -31,11 +34,11 @@ describe('SuspendAccountConfirmationWithoutAuthentication', () => {
     expect(screen).toMatchSnapshot()
   })
 
-  it('should send analytics event when clicking on "Contacter le support" button', () => {
+  it('should send analytics event when clicking on "Contacter le support" button', async () => {
     renderSuspendAccountConfirmationWithoutAuthentication()
 
     const contactSupportButton = screen.getByText('Contacter le service fraude')
-    fireEvent.press(contactSupportButton)
+    await user.press(contactSupportButton)
 
     expect(analytics.logContactFraudTeam).toHaveBeenCalledWith({
       from: 'suspendaccountconfirmation',
@@ -47,11 +50,9 @@ describe('SuspendAccountConfirmationWithoutAuthentication', () => {
     renderSuspendAccountConfirmationWithoutAuthentication()
 
     const suspendAccountButton = screen.getByText('Oui, suspendre mon compte')
-    fireEvent.press(suspendAccountButton)
+    await user.press(suspendAccountButton)
 
-    await waitFor(() => {
-      expect(navigate).toHaveBeenNthCalledWith(1, 'SuspiciousLoginSuspendedAccount')
-    })
+    expect(navigate).toHaveBeenNthCalledWith(1, 'SuspiciousLoginSuspendedAccount')
   })
 
   it('should show error snackbar when an error occur during account suspension', async () => {
@@ -59,13 +60,11 @@ describe('SuspendAccountConfirmationWithoutAuthentication', () => {
     renderSuspendAccountConfirmationWithoutAuthentication()
 
     const suspendAccountButton = screen.getByText('Oui, suspendre mon compte')
-    fireEvent.press(suspendAccountButton)
+    await user.press(suspendAccountButton)
 
-    await waitFor(() => {
-      expect(mockShowErrorSnackBar).toHaveBeenNthCalledWith(1, {
-        message:
-          'Une erreur est survenue. Pour suspendre ton compte, contacte le support par e-mail.',
-      })
+    expect(mockShowErrorSnackBar).toHaveBeenNthCalledWith(1, {
+      message:
+        'Une erreur est survenue. Pour suspendre ton compte, contacte le support par e-mail.',
     })
   })
 

--- a/src/features/profile/pages/LegalNotices/LegalNotices.native.test.tsx
+++ b/src/features/profile/pages/LegalNotices/LegalNotices.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { env } from 'libs/environment/env'
-import { render, fireEvent, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { LegalNotices } from './LegalNotices'
 
@@ -15,6 +15,8 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('LegalNotices', () => {
   it('should render correctly', async () => {
@@ -27,7 +29,7 @@ describe('LegalNotices', () => {
     render(<LegalNotices />)
 
     const row = screen.getByText('Conditions Générales d’Utilisation')
-    fireEvent.press(row)
+    await user.press(row)
 
     expect(openUrl).toHaveBeenCalledWith(env.CGU_LINK, undefined, true)
   })
@@ -36,7 +38,7 @@ describe('LegalNotices', () => {
     render(<LegalNotices />)
 
     const row = screen.getByText('Charte de protection des données personnelles')
-    fireEvent.press(row)
+    await user.press(row)
 
     expect(openUrl).toHaveBeenCalledWith(env.PRIVACY_POLICY_LINK, undefined, true)
   })

--- a/src/features/search/components/AutocompleteVenueItem/AutocompleteVenueItem.native.test.tsx
+++ b/src/features/search/components/AutocompleteVenueItem/AutocompleteVenueItem.native.test.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 
 import { AutocompleteVenueItem } from 'features/search/components/AutocompleteVenueItem/AutocompleteVenueItem'
 import { mockVenueHits } from 'features/search/fixtures/algolia'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
+
+jest.useFakeTimers()
 
 describe('AutocompleteVenueItem component', () => {
   it('should call onPress on press', async () => {
@@ -10,7 +12,7 @@ describe('AutocompleteVenueItem component', () => {
 
     render(<AutocompleteVenueItem hit={mockVenueHits[0]} onPress={pressHandler} />)
 
-    await fireEvent.press(screen.getByTestId('autocompleteVenueItem_9898'))
+    await userEvent.setup().press(screen.getByTestId('autocompleteVenueItem_9898'))
 
     expect(pressHandler).toHaveBeenCalledTimes(1)
   })

--- a/src/features/search/components/Buttons/FilterButton/FilterButton.native.test.tsx
+++ b/src/features/search/components/Buttons/FilterButton/FilterButton.native.test.tsx
@@ -1,65 +1,54 @@
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import { fireEvent, render, waitFor, screen } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 
 import { FilterButton } from './FilterButton'
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('FilterButton', () => {
-  it('should contains the number of active filters', async () => {
+  it('should contains the number of active filters', () => {
     render(<FilterButton activeFilters={2} navigateTo={{ screen: 'SearchFilter' }} />)
 
-    await waitFor(() => {
-      expect(screen.getByText('2')).toBeOnTheScreen()
-    })
+    expect(screen.getByText('2')).toBeOnTheScreen()
   })
 
-  it('should not display badge when there are no active filters', async () => {
+  it('should not display badge when there are no active filters', () => {
     render(<FilterButton activeFilters={0} navigateTo={{ screen: 'SearchFilter' }} />)
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('searchFilterBadge')).not.toBeOnTheScreen()
-    })
+    expect(screen.queryByTestId('searchFilterBadge')).not.toBeOnTheScreen()
   })
 
   it('should navigate with undefined params when pressing filter button', async () => {
     render(<FilterButton activeFilters={1} navigateTo={{ screen: 'SearchFilter' }} />)
 
     const filterButton = screen.getByTestId('searchFilterBadge')
-    fireEvent.press(filterButton)
+    await user.press(filterButton)
 
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith('SearchFilter', undefined)
-    })
+    expect(navigate).toHaveBeenCalledWith('SearchFilter', undefined)
   })
 
   describe('Accessibility', () => {
-    it('should have an accessible label with the number of active filters', async () => {
+    it('should have an accessible label with the number of active filters', () => {
       render(<FilterButton activeFilters={2} navigateTo={{ screen: 'SearchFilter' }} />)
 
-      await waitFor(() => {
-        expect(
-          screen.getByLabelText('Voir tous les filtres\u00a0: 2 filtres actifs')
-        ).toBeOnTheScreen()
-      })
+      expect(
+        screen.getByLabelText('Voir tous les filtres\u00a0: 2 filtres actifs')
+      ).toBeOnTheScreen()
     })
 
-    it('should have an accessible label with one active filter', async () => {
+    it('should have an accessible label with one active filter', () => {
       render(<FilterButton activeFilters={1} navigateTo={{ screen: 'SearchFilter' }} />)
 
-      await waitFor(() => {
-        expect(
-          screen.getByLabelText('Voir tous les filtres\u00a0: 1 filtre actif')
-        ).toBeOnTheScreen()
-      })
+      expect(screen.getByLabelText('Voir tous les filtres\u00a0: 1 filtre actif')).toBeOnTheScreen()
     })
 
-    it('should have an accessible label without active filter', async () => {
+    it('should have an accessible label without active filter', () => {
       render(<FilterButton activeFilters={0} navigateTo={{ screen: 'SearchFilter' }} />)
 
-      await waitFor(() => {
-        expect(screen.getByLabelText('Voir tous les filtres')).toBeOnTheScreen()
-      })
+      expect(screen.getByLabelText('Voir tous les filtres')).toBeOnTheScreen()
     })
   })
 })

--- a/src/features/search/components/Buttons/SingleFilterButton/SingleFilterButton.native.test.tsx
+++ b/src/features/search/components/Buttons/SingleFilterButton/SingleFilterButton.native.test.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 
 import { SingleFilterButton } from 'features/search/components/Buttons/SingleFilterButton/SingleFilterButton'
-import { fireEvent, render, screen } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('SingleFilterButton', () => {
-  it('should execute onPress function when the button is clicked', () => {
+  it('should execute onPress function when the button is clicked', async () => {
     const mockedOnPress = jest.fn()
 
     render(
@@ -17,7 +20,7 @@ describe('SingleFilterButton', () => {
     )
 
     const button = screen.getByTestId('CD, vinyles, musique en ligne\u00a0: Filtre sélectionné')
-    fireEvent.press(button)
+    await user.press(button)
 
     expect(mockedOnPress).toHaveBeenCalledTimes(1)
   })

--- a/src/features/search/components/FilterPageButtons/FilterPageButtons.native.test.tsx
+++ b/src/features/search/components/FilterPageButtons/FilterPageButtons.native.test.tsx
@@ -2,13 +2,15 @@ import React from 'react'
 
 import { FilterPageButtons } from 'features/search/components/FilterPageButtons/FilterPageButtons'
 import { FilterBehaviour } from 'features/search/enums'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 const onResetPress = jest.fn()
 const onSearchPress = jest.fn()
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('FilterPageButtons', () => {
-  it('should call button action when pressing reset button', () => {
+  it('should call button action when pressing reset button', async () => {
     render(
       <FilterPageButtons
         onSearchPress={onSearchPress}
@@ -18,12 +20,12 @@ describe('FilterPageButtons', () => {
     )
 
     const resetButton = screen.getByText('Réinitialiser')
-    fireEvent.press(resetButton)
+    await user.press(resetButton)
 
     expect(onResetPress).toHaveBeenCalledTimes(1)
   })
 
-  it('should call button action when pressing search button', () => {
+  it('should call button action when pressing search button', async () => {
     render(
       <FilterPageButtons
         onSearchPress={onSearchPress}
@@ -33,12 +35,12 @@ describe('FilterPageButtons', () => {
     )
 
     const searchButton = screen.getByText('Rechercher')
-    fireEvent.press(searchButton)
+    await user.press(searchButton)
 
     expect(onSearchPress).toHaveBeenCalledTimes(1)
   })
 
-  it('should call button action when pressing apply filter button', () => {
+  it('should call button action when pressing apply filter button', async () => {
     render(
       <FilterPageButtons
         onSearchPress={onSearchPress}
@@ -48,7 +50,7 @@ describe('FilterPageButtons', () => {
     )
 
     const searchButton = screen.getByText('Appliquer le filtre')
-    fireEvent.press(searchButton)
+    await user.press(searchButton)
 
     expect(onSearchPress).toHaveBeenCalledTimes(1)
   })

--- a/src/features/search/components/SearchHistory/SearchHistory.native.test.tsx
+++ b/src/features/search/components/SearchHistory/SearchHistory.native.test.tsx
@@ -3,13 +3,15 @@ import React from 'react'
 
 import { SearchHistory } from 'features/search/components/SearchHistory/SearchHistory'
 import { mockedSearchHistory } from 'features/search/fixtures/mockedSearchHistory'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 const TODAY_DATE = new Date('2023-09-26T00:00:00.000Z')
 
 const mockRemoveItem = jest.fn()
 
 const mockHistory = [mockedSearchHistory[0]]
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('SearchHistory', () => {
   beforeEach(() => {
@@ -37,7 +39,7 @@ describe('SearchHistory', () => {
     expect(screen.getByTestId('Supprimer manga de l’historique')).toBeOnTheScreen()
   })
 
-  it('should execute remove history item when pressing delete button', () => {
+  it('should execute remove history item when pressing delete button', async () => {
     render(
       <SearchHistory
         history={mockHistory}
@@ -47,7 +49,7 @@ describe('SearchHistory', () => {
       />
     )
 
-    fireEvent.press(screen.getByTestId('Supprimer manga de l’historique'))
+    await user.press(screen.getByTestId('Supprimer manga de l’historique'))
 
     expect(mockRemoveItem).toHaveBeenNthCalledWith(1, mockHistory[0])
   })
@@ -65,7 +67,7 @@ describe('SearchHistory', () => {
     expect(screen.queryByTestId('Supprimer manga de l’historique')).not.toBeOnTheScreen()
   })
 
-  it('should execute onPress when pressing history item', () => {
+  it('should execute onPress when pressing history item', async () => {
     const mockOnPress = jest.fn()
 
     render(
@@ -77,7 +79,7 @@ describe('SearchHistory', () => {
       />
     )
 
-    fireEvent.press(screen.getByText('manga'))
+    await user.press(screen.getByText('manga'))
 
     expect(mockOnPress).toHaveBeenNthCalledWith(1, {
       ...mockHistory[0],

--- a/src/features/search/components/SearchHistoryItem/SearchHistoryItem.native.test.tsx
+++ b/src/features/search/components/SearchHistoryItem/SearchHistoryItem.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { NativeCategoryIdEnumv2, SearchGroupNameEnumv2 } from 'api/gen'
 import { SearchHistoryItem } from 'features/search/components/SearchHistoryItem/SearchHistoryItem'
 import { Highlighted, HistoryItem } from 'features/search/types'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 const defaultItem: Highlighted<HistoryItem> = {
   createdAt: new Date('2023-09-25T09:01:00.000Z').getTime(),
@@ -11,6 +11,8 @@ const defaultItem: Highlighted<HistoryItem> = {
   label: 'manga',
   _highlightResult: { query: { value: 'manga' } },
 }
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('SearchHistoryItem', () => {
   it('should not display "dans" a category or a native category when item has not it', () => {
@@ -57,12 +59,12 @@ describe('SearchHistoryItem', () => {
     expect(screen.getByText('Livres papier')).toBeOnTheScreen()
   })
 
-  it('should execute onPress when pressing item', () => {
+  it('should execute onPress when pressing item', async () => {
     const mockOnPress = jest.fn()
 
     render(<SearchHistoryItem item={defaultItem} queryHistory="" onPress={mockOnPress} />)
 
-    fireEvent.press(screen.getByText('manga'))
+    await user.press(screen.getByText('manga'))
 
     expect(mockOnPress).toHaveBeenNthCalledWith(1, defaultItem)
   })

--- a/src/features/search/components/sections/Category/Category.native.test.tsx
+++ b/src/features/search/components/sections/Category/Category.native.test.tsx
@@ -5,7 +5,7 @@ import { ALL_CATEGORIES_LABEL } from 'features/search/constants'
 import { initialSearchState } from 'features/search/context/reducer'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { PLACEHOLDER_DATA as mockData } from 'libs/subcategories/placeholderData'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, waitFor, userEvent } from 'tests/utils'
 
 import { Category } from './Category'
 
@@ -46,6 +46,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('Category component', () => {
   beforeEach(() => {
@@ -94,7 +97,7 @@ describe('Category component', () => {
 
     const categoryButton = screen.getByTestId('FilterRow')
 
-    fireEvent.press(categoryButton)
+    user.press(categoryButton)
 
     let fullscreenModalScrollView
     await waitFor(() => {

--- a/src/features/search/components/sections/Venue/Venue.native.test.tsx
+++ b/src/features/search/components/sections/Venue/Venue.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { Venue } from 'features/search/components/sections/Venue/Venue'
 import { initialSearchState } from 'features/search/context/reducer'
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 let mockSearchState = initialSearchState
 
@@ -18,6 +18,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('Venue component', () => {
   it('should display the venue label when a venue is selected', async () => {
@@ -36,9 +39,7 @@ describe('Venue component', () => {
     })
     const searchVenueButton = screen.getByTestId('FilterRow')
 
-    await act(async () => {
-      fireEvent.press(searchVenueButton)
-    })
+    await user.press(searchVenueButton)
 
     const modalButton = screen.getByText('Rechercher')
 

--- a/src/features/search/context/SearchWrapper.native.test.tsx
+++ b/src/features/search/context/SearchWrapper.native.test.tsx
@@ -11,7 +11,7 @@ import {
 import { getGeolocPosition } from 'libs/location/geolocation/getGeolocPosition/getGeolocPosition'
 import { LocationLabel, LocationMode } from 'libs/location/types'
 import { SuggestedPlace } from 'libs/place/types'
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 
 jest.mock('libs/location/geolocation/getGeolocPosition/getGeolocPosition')
 const getGeolocPositionMock = getGeolocPosition as jest.MockedFunction<typeof getGeolocPosition>
@@ -31,14 +31,14 @@ const mockPlace: SuggestedPlace = {
   type: 'street',
   geolocation: { longitude: -52.669736, latitude: 5.16186 },
 }
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('SearchWrapper', () => {
   it('should update locationType with type Around Place when Location Context is switched to a specified place', async () => {
     renderDummyComponent()
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('setLocationModeAroundPlace'))
-    })
+    await user.press(screen.getByText('setLocationModeAroundPlace'))
 
     expect(screen.getByText(LocationMode.AROUND_PLACE)).toBeOnTheScreen()
   })
@@ -48,15 +48,11 @@ describe('SearchWrapper', () => {
 
     renderDummyComponent()
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('setLocationModeAroundPlace'))
-    })
+    await user.press(screen.getByText('setLocationModeAroundPlace'))
 
     screen.getByText(LocationMode.AROUND_PLACE)
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('setLocationModeAroundMe'))
-    })
+    await user.press(screen.getByText('setLocationModeAroundMe'))
 
     expect(screen.getByText(LocationMode.AROUND_ME)).toBeOnTheScreen()
   })
@@ -64,15 +60,11 @@ describe('SearchWrapper', () => {
   it(`should update locationType with type Everywhere when Location Context is switched to ${LocationLabel.everywhereLabel}`, async () => {
     renderDummyComponent()
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('setLocationModeAroundPlace'))
-    })
+    await user.press(screen.getByText('setLocationModeAroundPlace'))
 
     screen.getByText(LocationMode.AROUND_PLACE)
 
-    await act(async () => {
-      fireEvent.press(screen.getByText('setLocationModeEverywhere'))
-    })
+    await user.press(screen.getByText('setLocationModeEverywhere'))
 
     expect(screen.getByText(LocationMode.EVERYWHERE)).toBeOnTheScreen()
   })

--- a/src/features/search/pages/ThematicSearch/ThematicSearchPlaylist.native.test.tsx
+++ b/src/features/search/pages/ThematicSearch/ThematicSearchPlaylist.native.test.tsx
@@ -7,7 +7,7 @@ import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { mockBuilder } from 'tests/mockBuilder'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen, act } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('@shopify/flash-list', () => {
   const ActualFlashList = jest.requireActual('@shopify/flash-list').FlashList
@@ -28,6 +28,8 @@ const DEFAULT_PLAYLIST_OFFERS = mockBuilder.searchResponseOffer({})
 const DEFAULT_PLAYLIST_TITLE = 'Titre de la playlist'
 const DEFAULT_PLAYLIST = { title: DEFAULT_PLAYLIST_TITLE, offers: DEFAULT_PLAYLIST_OFFERS }
 
+jest.useFakeTimers()
+
 describe('ThematicSearchPlaylist', () => {
   beforeEach(() => {
     setFeatureFlags([])
@@ -38,9 +40,7 @@ describe('ThematicSearchPlaylist', () => {
 
     const offer = await screen.findByText('Harry potter à l’école des sorciers')
 
-    await act(async () => {
-      fireEvent.press(offer)
-    })
+    await userEvent.setup().press(offer)
 
     expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {
       from: 'thematicsearch',

--- a/src/features/share/components/MessagingApps/MessagingApps.native.test.tsx
+++ b/src/features/share/components/MessagingApps/MessagingApps.native.test.tsx
@@ -4,7 +4,7 @@ import Share, { Social } from 'react-native-share'
 
 import { MessagingApps } from 'features/share/components/MessagingApps/MessagingApps'
 import { ShareContent } from 'libs/share/types'
-import { fireEvent, render, screen } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 
 const mockShareSingle = jest.spyOn(Share, 'shareSingle')
 const canOpenURLSpy = jest.spyOn(Linking, 'canOpenURL').mockResolvedValue(false)
@@ -14,6 +14,8 @@ const defaultShareContent: ShareContent = {
   subject: 'title',
   url: 'url',
 }
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<MessagingApps />', () => {
   it('should use share on other press', async () => {
@@ -27,7 +29,7 @@ describe('<MessagingApps />', () => {
     )
     const otherButton = await screen.findByText('Plus\nd’options')
 
-    fireEvent.press(otherButton)
+    await user.press(otherButton)
 
     expect(mockShare).toHaveBeenCalledTimes(1)
   })
@@ -45,7 +47,7 @@ describe('<MessagingApps />', () => {
 
     const whatsappButton = await screen.findByText('Envoyer sur WhatsApp')
 
-    fireEvent.press(whatsappButton)
+    await user.press(whatsappButton)
 
     expect(mockShareSingle).toHaveBeenCalledWith({
       message: 'message\u00a0:\n',
@@ -66,7 +68,7 @@ describe('<MessagingApps />', () => {
     )
     const otherButton = await screen.findByText('Plus\nd’options')
 
-    fireEvent.press(otherButton)
+    await user.press(otherButton)
 
     expect(mockAnalytics).toHaveBeenCalledTimes(1)
   })

--- a/src/features/venue/components/VenueHeader/VenueHeader.native.test.tsx
+++ b/src/features/venue/components/VenueHeader/VenueHeader.native.test.tsx
@@ -6,7 +6,7 @@ import { VenueHeader } from 'features/venue/components/VenueHeader/VenueHeader'
 import { venueDataTest } from 'features/venue/fixtures/venueDataTest'
 import { analytics } from 'libs/analytics/provider'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { act, userEvent, render, screen } from 'tests/utils'
 
 jest.unmock('react-native/Libraries/Animated/createAnimatedComponent')
 jest.mock('features/venue/api/useVenue')
@@ -21,6 +21,8 @@ jest.spyOn(useGoBack, 'useGoBack').mockReturnValue({
 })
 
 jest.mock('libs/firebase/analytics/analytics')
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<VenueHeader />', () => {
   it('should render all icons', () => {
@@ -30,9 +32,9 @@ describe('<VenueHeader />', () => {
     expect(screen.getByTestId('animated-icon-share')).toBeOnTheScreen()
   })
 
-  it('should goBack when we press on the back button', () => {
+  it('should goBack when we press on the back button', async () => {
     renderVenueHeader()
-    fireEvent.press(screen.getByTestId('animated-icon-back'))
+    await user.press(screen.getByTestId('animated-icon-back'))
 
     expect(mockGoBack).toHaveBeenCalledTimes(1)
   })
@@ -56,11 +58,11 @@ describe('<VenueHeader />', () => {
     expect(screen.getByTestId('venueHeaderName').props.style.opacity).toBe(1)
   })
 
-  it('should log analytics when clicking on the share button', () => {
+  it('should log analytics when clicking on the share button', async () => {
     renderVenueHeader()
 
     const shareButton = screen.getByLabelText('Partager')
-    fireEvent.press(shareButton)
+    await user.press(shareButton)
 
     expect(analytics.logShare).toHaveBeenNthCalledWith(1, {
       type: 'Venue',

--- a/src/features/venueMap/components/VenueMapBlock/VenueMapBlock.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapBlock/VenueMapBlock.native.test.tsx
@@ -7,11 +7,13 @@ import { selectedVenueActions } from 'features/venueMap/store/selectedVenueStore
 import { analytics } from 'libs/analytics/provider'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { userEvent, render, screen, waitFor } from 'tests/utils'
 
 const mockRemoveSelectedVenue = jest.spyOn(selectedVenueActions, 'removeSelectedVenue')
 
 const mockSetInitialVenues = jest.spyOn(initialVenuesActions, 'setInitialVenues')
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<VenueMapBlock />', () => {
   describe('When wipAppV2VenueMapBlock feature flag activated', () => {
@@ -65,7 +67,7 @@ describe('<VenueMapBlock />', () => {
   it('should reset selected venue in store', async () => {
     render(<VenueMapBlock from="searchLanding" />)
 
-    fireEvent.press(screen.getByText('Explorer les lieux'))
+    user.press(screen.getByText('Explorer les lieux'))
 
     await waitFor(() => {
       expect(mockRemoveSelectedVenue).toHaveBeenCalledTimes(1)
@@ -75,7 +77,7 @@ describe('<VenueMapBlock />', () => {
   it('should reset initial venues in store', async () => {
     render(<VenueMapBlock from="searchLanding" />)
 
-    fireEvent.press(screen.getByText('Explorer les lieux'))
+    user.press(screen.getByText('Explorer les lieux'))
 
     await waitFor(() => {
       expect(mockSetInitialVenues).toHaveBeenCalledTimes(1)
@@ -85,7 +87,7 @@ describe('<VenueMapBlock />', () => {
   it('should navigate to venue map screen', async () => {
     render(<VenueMapBlock from="searchLanding" />)
 
-    fireEvent.press(screen.getByText('Explorer les lieux'))
+    user.press(screen.getByText('Explorer les lieux'))
 
     await waitFor(() => {
       expect(navigate).toHaveBeenNthCalledWith(1, 'VenueMap', undefined)
@@ -95,7 +97,7 @@ describe('<VenueMapBlock />', () => {
   it('should trigger log ConsultVenueMap', async () => {
     render(<VenueMapBlock from="searchLanding" />)
 
-    fireEvent.press(screen.getByText('Explorer les lieux'))
+    user.press(screen.getByText('Explorer les lieux'))
 
     await waitFor(() => {
       expect(analytics.logConsultVenueMap).toHaveBeenNthCalledWith(1, { from: 'searchLanding' })

--- a/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapPreview/VenueMapPreview.native.test.tsx
@@ -3,7 +3,10 @@ import React, { ComponentProps } from 'react'
 import { navigate } from '__mocks__/@react-navigation/native'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { VenueMapPreview } from 'features/venueMap/components/VenueMapPreview/VenueMapPreview'
-import { fireEvent, render, screen } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<VenueMapPreview />', () => {
   it('should render correctly with border by default', () => {
@@ -42,12 +45,12 @@ describe('<VenueMapPreview />', () => {
     expect(screen.getByLabelText('Fermer')).toBeOnTheScreen()
   })
 
-  it('should navigate to Venue when pressing on the preview', () => {
+  it('should navigate to Venue when pressing on the preview', async () => {
     renderVenueMapPreview({
       navigateTo: { screen: 'Venue', params: { id: offerResponseSnap.venue.id } },
     })
 
-    fireEvent.press(screen.getByText(offerResponseSnap.venue.name))
+    await user.press(screen.getByText(offerResponseSnap.venue.name))
 
     expect(navigate).toHaveBeenCalledWith('Venue', { id: 1664 })
   })

--- a/src/features/venueMap/pages/VenueMap/VenueMap.native.test.tsx
+++ b/src/features/venueMap/pages/VenueMap/VenueMap.native.test.tsx
@@ -8,7 +8,7 @@ import { useVenueTypeCode, venueTypeCodeActions } from 'features/venueMap/store/
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('features/venue/api/useVenueOffers')
 
@@ -45,6 +45,9 @@ jest.mock('@gorhom/bottom-sheet', () => {
 
 const VENUE_TYPE = VenueTypeCodeKey.MOVIE
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<VenueMap />', () => {
   beforeEach(() => {
     setFeatureFlags([
@@ -69,7 +72,8 @@ describe('<VenueMap />', () => {
   it('Should handle go back action when pressing go back button', async () => {
     render(reactQueryProviderHOC(<VenueMap />))
 
-    fireEvent.press(await screen.findByTestId('Revenir en arrière'))
+    const goBackButton = screen.getByTestId('Revenir en arrière')
+    await user.press(goBackButton)
 
     expect(mockGoBack).toHaveBeenCalledTimes(1)
   })
@@ -77,7 +81,8 @@ describe('<VenueMap />', () => {
   it('Should reset venue type code in store when pressing go back button', async () => {
     render(reactQueryProviderHOC(<VenueMap />))
 
-    fireEvent.press(await screen.findByTestId('Revenir en arrière'))
+    const goBackButton = screen.getByTestId('Revenir en arrière')
+    await user.press(goBackButton)
 
     expect(mockSetVenueTypeCode).toHaveBeenNthCalledWith(1, null)
   })

--- a/src/shared/Banners/GeolocationBanner.native.test.tsx
+++ b/src/shared/Banners/GeolocationBanner.native.test.tsx
@@ -5,10 +5,13 @@ import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { GeolocPermissionState, useLocation } from 'libs/location'
 import { requestGeolocPermission, showGeolocPermissionModal } from 'libs/location/__mocks__'
 import { GeolocationBanner } from 'shared/Banners/GeolocationBanner'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 jest.mock('libs/location')
 const mockUseLocation = useLocation as jest.Mock
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<GeolocationBanner />', () => {
   describe('When wipAppV2SystemBlock feature flag activated', () => {
@@ -55,7 +58,7 @@ describe('<GeolocationBanner />', () => {
     })
   })
 
-  it('should open "Paramètres de localisation" modal when pressing button and permission is never ask again', () => {
+  it('should open "Paramètres de localisation" modal when pressing button and permission is never ask again', async () => {
     mockUseLocation.mockReturnValueOnce({
       permissionState: GeolocPermissionState.NEVER_ASK_AGAIN,
       showGeolocPermissionModal,
@@ -69,12 +72,12 @@ describe('<GeolocationBanner />', () => {
     )
     const button = screen.getByText('Géolocalise-toi')
 
-    fireEvent.press(button)
+    await user.press(button)
 
     expect(showGeolocPermissionModal).toHaveBeenCalledWith()
   })
 
-  it('should ask for permission when pressing button and permission is denied', () => {
+  it('should ask for permission when pressing button and permission is denied', async () => {
     mockUseLocation.mockReturnValueOnce({
       permissionState: GeolocPermissionState.DENIED,
       requestGeolocPermission,
@@ -88,12 +91,12 @@ describe('<GeolocationBanner />', () => {
     )
     const button = screen.getByText('Géolocalise-toi')
 
-    fireEvent.press(button)
+    await user.press(button)
 
     expect(requestGeolocPermission).toHaveBeenCalledWith()
   })
 
-  it('should call onPress externaly when specified', () => {
+  it('should call onPress externaly when specified', async () => {
     const mockOnPress = jest.fn()
     render(
       <GeolocationBanner
@@ -106,7 +109,7 @@ describe('<GeolocationBanner />', () => {
 
     const button = screen.getByText('Géolocalise-toi')
 
-    fireEvent.press(button)
+    await user.press(button)
 
     expect(mockOnPress).toHaveBeenCalledTimes(1)
   })

--- a/src/shared/CopyToClipboardButton/CopyToClipboardButton.native.test.tsx
+++ b/src/shared/CopyToClipboardButton/CopyToClipboardButton.native.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { CopyToClipboardButton } from 'shared/CopyToClipboardButton/CopyToClipboardButton'
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 
 const mockCopyToClipboard = jest.fn()
 jest.mock('libs/useCopyToClipboard/useCopyToClipboard', () => ({
@@ -11,6 +11,9 @@ jest.mock('libs/useCopyToClipboard/useCopyToClipboard', () => ({
 const successSnackBarMessage = 'Copié avec succès\u00a0!'
 const wording = 'Copier l’adresse'
 const textToCopy = 'Le sucre, 69002 LYON'
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('CopyToClipboardButton', () => {
   it('should show right text', async () => {
@@ -25,9 +28,7 @@ describe('CopyToClipboardButton', () => {
     renderCopyToClipboardButton()
     const button = screen.getByText(wording)
 
-    await act(async () => {
-      fireEvent.press(button)
-    })
+    await user.press(button)
 
     expect(mockCopyToClipboard).toHaveBeenCalledTimes(1)
   })

--- a/src/ui/components/AnimatedIcon.native.test.tsx
+++ b/src/ui/components/AnimatedIcon.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 // eslint-disable-next-line no-restricted-imports
 import { Animated, TouchableOpacity } from 'react-native'
 
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
 import { theme } from 'theme'
 import { Logo } from 'ui/svg/icons/Logo'
 
@@ -28,6 +28,8 @@ const DummyComponent: React.FC = () => {
     </TouchableOpacity>
   )
 }
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('AnimatedIcon', () => {
   it('should display only the first color before animation', () => {
@@ -43,7 +45,7 @@ describe('AnimatedIcon', () => {
   it('should display only the last color after animation', async () => {
     render(<DummyComponent />)
 
-    fireEvent.press(screen.getByTestId('dummyPressable'))
+    user.press(screen.getByTestId('dummyPressable'))
 
     const initialContainer = screen.getByTestId('initial-icon-container')
     const finalContainer = screen.getByTestId('final-icon-container')

--- a/src/ui/components/FilterSwitch.native.test.tsx
+++ b/src/ui/components/FilterSwitch.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 import FilterSwitch from 'ui/components/FilterSwitch'
 
 const active = false
@@ -12,13 +12,16 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<FilterSwitch />', () => {
-  it('should call toggle when press on switch', () => {
+  it('should call toggle when press on switch', async () => {
     render(<FilterSwitch active={active} toggle={toggle} />)
 
     const Switch = screen.getByTestId('Interrupteur')
 
-    fireEvent.press(Switch)
+    await user.press(Switch)
 
     expect(toggle).toHaveBeenCalledTimes(1)
   })
@@ -28,7 +31,7 @@ describe('<FilterSwitch />', () => {
 
     const Switch = screen.getByTestId('Interrupteur')
 
-    fireEvent.press(Switch)
+    user.press(Switch)
 
     expect(toggle).not.toHaveBeenCalledTimes(1)
   })

--- a/src/ui/components/SeeMore.native.test.tsx
+++ b/src/ui/components/SeeMore.native.test.tsx
@@ -1,22 +1,25 @@
 import React from 'react'
 
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { SeeMore } from './SeeMore'
 
 const props = { height: 100, width: 100, onPress: jest.fn() }
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<SeeMore />', () => {
-  it('calls onPress when clicking the arrow', () => {
+  it('calls onPress when clicking the arrow', async () => {
     render(<SeeMore {...props} />)
-    fireEvent.press(screen.getByTestId('En voir plus'))
+    await user.press(screen.getByTestId('En voir plus'))
 
     expect(props.onPress).toHaveBeenCalledTimes(1)
   })
 
-  it('calls onPress when clicking the text', () => {
+  it('calls onPress when clicking the text', async () => {
     render(<SeeMore {...props} />)
-    fireEvent.press(screen.getByText('En voir plus'))
+    await user.press(screen.getByText('En voir plus'))
 
     expect(props.onPress).toHaveBeenCalledTimes(1)
   })

--- a/src/ui/components/SocialNetworkCard.native.test.tsx
+++ b/src/ui/components/SocialNetworkCard.native.test.tsx
@@ -2,11 +2,14 @@ import React from 'react'
 
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { analytics } from 'libs/analytics/provider'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
 
 import { SocialNetworkCard } from './SocialNetworkCard'
 
 jest.mock('libs/firebase/analytics/analytics')
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('SocialNetworkCard', () => {
   it('should openUrl onClick and track analytics', async () => {
@@ -16,7 +19,7 @@ describe('SocialNetworkCard', () => {
     render(<SocialNetworkCard network="facebook" />)
 
     const button = screen.getByText('Facebook')
-    fireEvent.press(button)
+    user.press(button)
 
     await waitFor(() => {
       expect(analytics.logClickSocialNetwork).toHaveBeenCalledWith('Facebook')
@@ -31,7 +34,7 @@ describe('SocialNetworkCard', () => {
     render(<SocialNetworkCard network="x" />)
 
     const button = screen.getByText('X')
-    fireEvent.press(button)
+    user.press(button)
 
     await waitFor(() => {
       expect(analytics.logClickSocialNetwork).toHaveBeenCalledWith('Twitter')

--- a/src/ui/components/accessibility/DetailedAccessibilityInfo.native.test.tsx
+++ b/src/ui/components/accessibility/DetailedAccessibilityInfo.native.test.tsx
@@ -3,7 +3,7 @@ import { Linking } from 'react-native'
 
 import { venueDataTest } from 'features/venue/fixtures/venueDataTest'
 import { analytics } from 'libs/analytics/provider'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
 
 import { DetailedAccessibilityInfo } from './DetailedAccessibilityInfo'
 
@@ -16,6 +16,8 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('DetailedAccessibilityInfo', () => {
   it('should redirect to acceslibre when clicking on the banner link', async () => {
@@ -28,7 +30,7 @@ describe('DetailedAccessibilityInfo', () => {
     )
 
     const accesLibreLink = screen.getByText('Voir plus d’infos sur l’accessibilité du lieu')
-    fireEvent.press(accesLibreLink)
+    user.press(accesLibreLink)
 
     await waitFor(() => expect(Linking.openURL).toHaveBeenCalledWith(fakeAccesLibreUrl))
   })
@@ -43,7 +45,7 @@ describe('DetailedAccessibilityInfo', () => {
     )
 
     const accesLibreLink = screen.getByText('Voir plus d’infos sur l’accessibilité du lieu')
-    fireEvent.press(accesLibreLink)
+    user.press(accesLibreLink)
 
     await waitFor(() =>
       expect(analytics.logAccessibilityBannerClicked).toHaveBeenCalledWith(
@@ -61,7 +63,7 @@ describe('DetailedAccessibilityInfo', () => {
     )
 
     const accesLibreLink = screen.getByText('Voir plus d’infos sur l’accessibilité du lieu')
-    fireEvent.press(accesLibreLink)
+    user.press(accesLibreLink)
 
     await waitFor(() =>
       expect(analytics.logAccessibilityBannerClicked).toHaveBeenCalledWith(undefined)
@@ -82,7 +84,7 @@ describe('DetailedAccessibilityInfo', () => {
     expect(screen.getByLabelText('Handicap visuel: Non accessible')).toBeOnTheScreen()
   })
 
-  it('should display multiple description info on separate lines', () => {
+  it('should display multiple description info on separate lines', async () => {
     render(
       <DetailedAccessibilityInfo
         url={fakeAccesLibreUrl}
@@ -90,7 +92,7 @@ describe('DetailedAccessibilityInfo', () => {
       />
     )
 
-    fireEvent.press(screen.getByText('Handicap auditif'))
+    await user.press(screen.getByText('Handicap auditif'))
 
     expect(screen.getByText('Boucle à induction magnétique portative')).toBeOnTheScreen()
     expect(screen.getByText('Autre système non renseigné')).toBeOnTheScreen()
@@ -115,7 +117,7 @@ describe('DetailedAccessibilityInfo', () => {
       />
     )
 
-    fireEvent.press(screen.getByText('Handicap auditif'))
+    user.press(screen.getByText('Handicap auditif'))
 
     await waitFor(() =>
       expect(analytics.logHasOpenedAccessibilityAccordion).toHaveBeenCalledWith('Handicap auditif')

--- a/src/ui/components/buttons/RoundedButton.native.test.tsx
+++ b/src/ui/components/buttons/RoundedButton.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Animated, TouchableOpacity } from 'react-native'
 import { ReactTestInstance } from 'react-test-renderer'
 
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
 
 import { RoundedButton } from './RoundedButton'
 
@@ -34,6 +34,8 @@ const DummyComponent: React.FC = () => {
     </TouchableOpacity>
   )
 }
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('RoundedButton', () => {
   describe('Icon', () => {
@@ -71,7 +73,7 @@ describe('RoundedButton', () => {
     it('should display final colors after animation', async () => {
       render(<DummyComponent />)
 
-      fireEvent.press(screen.getByTestId('dummyPressable'))
+      user.press(screen.getByTestId('dummyPressable'))
 
       const roundContainer = screen.getByTestId('AnimatedHeaderIconRoundContainer')
       await waitFor(() => {

--- a/src/ui/components/buttons/externalLink/ExternalLink.native.test.tsx
+++ b/src/ui/components/buttons/externalLink/ExternalLink.native.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Linking } from 'react-native'
 
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { act, render, screen, userEvent } from 'tests/utils'
 
 import { ExternalLink } from './ExternalLink'
 
@@ -9,30 +9,30 @@ const openURLSpy = jest.spyOn(Linking, 'openURL')
 const someUrl = 'https://domain-that-does-not-exist.fr'
 
 jest.mock('libs/firebase/analytics/analytics')
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('ExternalLink', () => {
   it('should open given url when text clicked', async () => {
     render(<ExternalLink url={someUrl} />)
 
-    await act(async () =>
-      fireEvent.press(screen.getByLabelText('Nouvelle fenêtre\u00a0: ' + someUrl))
-    )
+    await act(async () => user.press(screen.getByLabelText('Nouvelle fenêtre\u00a0: ' + someUrl)))
 
     expect(openURLSpy).toHaveBeenNthCalledWith(1, someUrl)
   })
 
-  it('should open given url when text clicked and text not matching url', () => {
+  it('should open given url when text clicked and text not matching url', async () => {
     render(<ExternalLink text="anchor text" url={someUrl} />)
 
-    fireEvent.press(screen.getByLabelText('Nouvelle fenêtre\u00a0: anchor text'))
+    await user.press(screen.getByLabelText('Nouvelle fenêtre\u00a0: anchor text'))
 
     expect(openURLSpy).toHaveBeenNthCalledWith(1, someUrl)
   })
 
-  it('should open given url when icon clicked', () => {
+  it('should open given url when icon clicked', async () => {
     render(<ExternalLink url={someUrl} />)
 
-    fireEvent.press(screen.getByTestId('externalSiteIcon'))
+    await user.press(screen.getByTestId('externalSiteIcon'))
 
     expect(openURLSpy).toHaveBeenNthCalledWith(1, someUrl)
   })

--- a/src/ui/components/eventCard/EventCard.native.test.tsx
+++ b/src/ui/components/eventCard/EventCard.native.test.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
 
 import { analytics } from 'libs/analytics/provider'
-import { fireEvent, render, screen } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 import { EventCard, EventCardProps } from 'ui/components/eventCard/EventCard'
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('EventCard', () => {
   const defaultEventCardProps: EventCardProps = {
@@ -17,7 +20,7 @@ describe('EventCard', () => {
     it('should send log ConsultOffer event when on venue page and user clicks on an eventCard', async () => {
       render(<EventCard {...defaultEventCardProps} analyticsFrom="venue" offerId={1} />)
       const eventCard = await screen.findByLabelText('Film 1')
-      fireEvent.press(eventCard)
+      await user.press(eventCard)
 
       expect(analytics.logConsultOffer).toHaveBeenNthCalledWith(1, {
         offerId: 1,
@@ -28,7 +31,7 @@ describe('EventCard', () => {
     it('should not send log ConsultOffer event when not on venue page and user clicks on an eventCard', async () => {
       render(<EventCard {...defaultEventCardProps} analyticsFrom="offer" offerId={1} />)
       const eventCard = await screen.findByLabelText('Film 1')
-      fireEvent.press(eventCard)
+      user.press(eventCard)
 
       expect(analytics.logConsultOffer).not.toHaveBeenCalled()
     })

--- a/src/ui/components/inputs/EmailInputWithSpellingHelp/EmailInputWithSpellingHelp.native.test.tsx
+++ b/src/ui/components/inputs/EmailInputWithSpellingHelp/EmailInputWithSpellingHelp.native.test.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentProps } from 'react'
 
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { act, render, screen, userEvent } from 'tests/utils'
 import { SUGGESTION_DELAY_IN_MS } from 'ui/components/inputs/EmailInputWithSpellingHelp/useEmailSpellingHelp'
 
 import { EmailInputWithSpellingHelp } from './EmailInputWithSpellingHelp'
@@ -14,6 +14,7 @@ const props: ComponentProps<typeof EmailInputWithSpellingHelp> = {
 }
 
 jest.useFakeTimers()
+const user = userEvent.setup()
 
 describe('<EmailInputWithSpellingHelp />', () => {
   it('should not display suggestion for empty email', () => {
@@ -54,7 +55,7 @@ describe('<EmailInputWithSpellingHelp />', () => {
     })
 
     const suggestionButton = screen.getByText('Appliquer la modification')
-    fireEvent.press(suggestionButton)
+    await user.press(suggestionButton)
 
     expect(props.onEmailChange).toHaveBeenNthCalledWith(1, 'firstname.lastname@gmail.com')
   })
@@ -71,7 +72,7 @@ describe('<EmailInputWithSpellingHelp />', () => {
     })
 
     const suggestionButton = screen.getByText('Appliquer la modification')
-    fireEvent.press(suggestionButton)
+    await user.press(suggestionButton)
 
     expect(mockOnSpellingHelpPress).toHaveBeenCalledTimes(1)
   })

--- a/src/ui/components/inputs/PasswordInput.native.test.tsx
+++ b/src/ui/components/inputs/PasswordInput.native.test.tsx
@@ -1,12 +1,15 @@
 import React from 'react'
 import { TextInput as RNTextInput } from 'react-native'
 
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { PasswordInput } from './PasswordInput'
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<PasswordInput />', () => {
-  it('should change accessibilityLabel when password is hidden or it was displayed', () => {
+  it('should change accessibilityLabel when password is hidden or it was displayed', async () => {
     render(<PasswordInput />)
 
     expect(screen.getByLabelText('Afficher le mot de passe')).toBeOnTheScreen()
@@ -14,7 +17,7 @@ describe('<PasswordInput />', () => {
 
     const switchPasswordVisibilityButton = screen.getByTestId('Afficher le mot de passe')
 
-    fireEvent.press(switchPasswordVisibilityButton)
+    await user.press(switchPasswordVisibilityButton)
 
     expect(screen.getByLabelText('Cacher le mot de passe')).toBeOnTheScreen()
     expect(screen.queryByLabelText('Afficher le mot de passe')).not.toBeOnTheScreen()

--- a/src/ui/components/modals/AppModal.native.test.tsx
+++ b/src/ui/components/modals/AppModal.native.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { DeviceEventEmitter } from 'react-native'
 import { ReactNativeModal } from 'react-native-modal'
 
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { act, render, screen, userEvent } from 'tests/utils'
 
 import { AppModal } from './AppModal'
 import {
@@ -19,6 +19,9 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<AppModal />', () => {
   it('with minimal props', () => {
@@ -127,11 +130,11 @@ describe('<AppModal />', () => {
       expect(screen).toMatchSnapshot()
     })
 
-    it('should call the callback when clicking on left icon', () => {
+    it('should call the callback when clicking on left icon', async () => {
       render(<AppModal {...defaultProps} {...leftIconProps} />)
       const leftIcon = screen.getByTestId(leftIconProps.leftIconAccessibilityLabel)
 
-      fireEvent.press(leftIcon)
+      await user.press(leftIcon)
 
       expect(leftIconCallbackMock).toHaveBeenCalledTimes(1)
     })
@@ -149,11 +152,11 @@ describe('<AppModal />', () => {
       expect(screen).toMatchSnapshot()
     })
 
-    it('should call the callback when clicking on right icon', () => {
+    it('should call the callback when clicking on right icon', async () => {
       render(<AppModal {...defaultProps} {...rightIconProps} />)
       const rightIcon = screen.getByTestId(rightIconProps.rightIconAccessibilityLabel)
 
-      fireEvent.press(rightIcon)
+      await user.press(rightIcon)
 
       expect(rightIconCallbackMock).toHaveBeenCalledTimes(1)
     })

--- a/src/ui/components/modals/MarketingModal.native.test.tsx
+++ b/src/ui/components/modals/MarketingModal.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { MarketingModal } from './MarketingModal'
 
@@ -16,6 +16,8 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('MarketingModal', () => {
   it('should render correctly', () => {
@@ -27,7 +29,7 @@ describe('MarketingModal', () => {
   it('should call onBackdropPress when clicking outside modal', async () => {
     render(<MarketingModal {...props} />)
     const clickAwayArea = screen.getByTestId('clickaway-area')
-    fireEvent.press(clickAwayArea)
+    await user.press(clickAwayArea)
 
     expect(props.onBackdropPress).toHaveBeenCalledTimes(1)
   })

--- a/src/ui/components/modals/ModalHeader.native.test.tsx
+++ b/src/ui/components/modals/ModalHeader.native.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 import { ArrowPrevious } from 'ui/svg/icons/ArrowPrevious'
 import { Close } from 'ui/svg/icons/Close'
 
@@ -15,6 +15,9 @@ const props = {
   rightIcon: Close,
   onRightIconPress: jest.fn(),
 }
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('ModalHeader component', () => {
   describe('left icon', () => {
@@ -37,7 +40,7 @@ describe('ModalHeader component', () => {
       expect(screen.getByTestId('Revenir en arrière')).toBeOnTheScreen()
 
       const leftIconButton = await screen.findByTestId(props.leftIconAccessibilityLabel)
-      fireEvent.press(leftIconButton)
+      await user.press(leftIconButton)
 
       expect(props.onLeftIconPress).toHaveBeenCalledTimes(1)
     })
@@ -63,7 +66,7 @@ describe('ModalHeader component', () => {
       expect(screen.getByTestId('Fermer la modale')).toBeOnTheScreen()
 
       const rightIconButton = await screen.findByTestId(props.rightIconAccessibilityLabel)
-      fireEvent.press(rightIconButton)
+      await user.press(rightIconButton)
 
       expect(props.onRightIconPress).toHaveBeenCalledTimes(1)
     })

--- a/src/ui/components/modals/SurveyModal.native.test.tsx
+++ b/src/ui/components/modals/SurveyModal.native.test.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentProps } from 'react'
 
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
 import { SurveyModal } from 'ui/components/modals/SurveyModal'
 import { BicolorCircledClock } from 'ui/svg/icons/BicolorCircledClock'
 
@@ -11,11 +11,14 @@ const hideModalMock = jest.fn()
 
 jest.mock('libs/firebase/analytics/analytics')
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<SurveyModal />', () => {
   it('should redirect to survey when pressing "Répondre au questionnaire" button', async () => {
     renderSurveyModal({ surveyUrl: 'https://fr.wikipedia.org/wiki/FIEALD' })
 
-    fireEvent.press(screen.getByText('Répondre au questionnaire'))
+    user.press(screen.getByText('Répondre au questionnaire'))
 
     await waitFor(() => {
       expect(openUrl).toHaveBeenNthCalledWith(
@@ -27,10 +30,10 @@ describe('<SurveyModal />', () => {
     })
   })
 
-  it('should call hideModal function when pressing close icon', () => {
+  it('should call hideModal function when pressing close icon', async () => {
     renderSurveyModal({ surveyUrl: 'https://fr.wikipedia.org/wiki/FIEALD' })
     const rightIcon = screen.getByTestId('Fermer la modale')
-    fireEvent.press(rightIcon)
+    await user.press(rightIcon)
 
     expect(hideModalMock).toHaveBeenCalledTimes(1)
   })
@@ -50,7 +53,7 @@ describe('<SurveyModal />', () => {
   it('should call hideModal function  when pressing "Répondre au questionnaire" button', async () => {
     renderSurveyModal({ surveyUrl: 'https://fr.wikipedia.org/wiki/FIEALD' })
 
-    fireEvent.press(screen.getByText('Répondre au questionnaire'))
+    user.press(screen.getByText('Répondre au questionnaire'))
 
     await waitFor(() => {
       expect(hideModalMock).toHaveBeenCalledTimes(1)

--- a/src/ui/components/radioSelector/RadioSelector.native.test.tsx
+++ b/src/ui/components/radioSelector/RadioSelector.native.test.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
 
-import { fireEvent, render, screen } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 
 import { RadioSelector } from './RadioSelector'
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<RadioSelector />', () => {
   const defaultProps = {
@@ -11,16 +14,16 @@ describe('<RadioSelector />', () => {
     onPress: jest.fn(),
   }
 
-  it('should call onPress when pressed', () => {
+  it('should call onPress when pressed', async () => {
     render(<RadioSelector {...defaultProps} />)
-    fireEvent.press(screen.getByText('Test Label'))
+    await user.press(screen.getByText('Test Label'))
 
     expect(defaultProps.onPress).toHaveBeenCalledWith()
   })
 
   it('should not call onPress when disabled', () => {
     render(<RadioSelector {...defaultProps} disabled />)
-    fireEvent.press(screen.getByText('Test Label'))
+    user.press(screen.getByText('Test Label'))
 
     expect(defaultProps.onPress).not.toHaveBeenCalled()
   })

--- a/src/ui/components/snackBar/SnackBar.native.test.tsx
+++ b/src/ui/components/snackBar/SnackBar.native.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Animated } from 'react-native'
 
-import { fireEvent, render, waitFor, screen } from 'tests/utils'
+import { render, waitFor, screen, userEvent } from 'tests/utils'
 import { theme } from 'theme'
 import { Check } from 'ui/svg/icons/Check'
 
@@ -17,6 +17,9 @@ jest.mock('react-native-safe-area-context', () => ({
   ...(jest.requireActual('react-native-safe-area-context') as Record<string, unknown>),
   useSafeAreaInsets: () => ({ bottom: 16, right: 16, left: 16, top: 16 }),
 }))
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('SnackBar Component', () => {
   afterEach(async () => {
@@ -119,7 +122,7 @@ describe('SnackBar Component', () => {
 
       const touchable = screen.getByTestId(`Supprimer le message\u00a0: ${snackBarMessage}`)
 
-      fireEvent.press(touchable)
+      user.press(touchable)
 
       await waitFor(async () => expect(onClose).toHaveBeenCalledTimes(1))
     })

--- a/src/ui/components/touchable/Touchable.native.test.tsx
+++ b/src/ui/components/touchable/Touchable.native.test.tsx
@@ -1,12 +1,15 @@
 import React from 'react'
 import { Text } from 'react-native'
 
-import { fireEvent, render, screen } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 
 import { Touchable } from './Touchable'
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<Touchable />', () => {
-  it('should execute callback on press', () => {
+  it('should execute callback on press', async () => {
     const handleClick = jest.fn()
     render(
       <Touchable onPress={handleClick} accessibilityLabel="accessibility label">
@@ -15,7 +18,7 @@ describe('<Touchable />', () => {
     )
 
     const button = screen.getByRole('button')
-    fireEvent.press(button)
+    await user.press(button)
 
     expect(handleClick).toHaveBeenCalledTimes(1)
   })

--- a/src/ui/components/touchableLink/ExternalTouchableLink.native.test.tsx
+++ b/src/ui/components/touchableLink/ExternalTouchableLink.native.test.tsx
@@ -7,7 +7,7 @@ import { homeNavConfig } from 'features/navigation/TabBar/helpers'
 import { mockedFullAddress } from 'libs/address/fixtures/mockedFormatFullAddress'
 import { WEBAPP_V2_URL } from 'libs/environment/useWebAppUrl'
 import { getGoogleMapsItineraryUrl } from 'libs/itinerary/openGoogleMapsItinerary'
-import { render, fireEvent, screen, waitFor } from 'tests/utils'
+import { render, screen, waitFor, userEvent } from 'tests/utils'
 import { SocialNetworkIconsMap } from 'ui/components/socials/types'
 import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
 
@@ -34,6 +34,9 @@ const externalNav = {
 
 jest.mock('libs/firebase/analytics/analytics')
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<ExternalTouchableLink />', () => {
   describe('External Navigation', () => {
     it('should open url with expected parameters (nominal case)', async () => {
@@ -43,7 +46,7 @@ describe('<ExternalTouchableLink />', () => {
         </ExternalTouchableLink>
       )
 
-      fireEvent.press(screen.getByText(linkText))
+      user.press(screen.getByText(linkText))
 
       await waitFor(() => {
         expect(openUrl).toHaveBeenCalledWith(externalNav.url, externalNav.params, true)
@@ -61,7 +64,7 @@ describe('<ExternalTouchableLink />', () => {
         </ExternalTouchableLink>
       )
 
-      fireEvent.press(screen.getByText(linkText))
+      user.press(screen.getByText(linkText))
 
       await waitFor(() => {
         expect(mockNavigateToItinerary).toHaveBeenCalledWith(mockedFullAddress)
@@ -78,7 +81,7 @@ describe('<ExternalTouchableLink />', () => {
         </ExternalTouchableLink>
       )
 
-      fireEvent.press(screen.getByText(linkText))
+      user.press(screen.getByText(linkText))
 
       await waitFor(() => {
         expect(openUrl).toHaveBeenCalledWith(WEBAPP_V2_URL, undefined, true)
@@ -96,7 +99,7 @@ describe('<ExternalTouchableLink />', () => {
         </ExternalTouchableLink>
       )
 
-      fireEvent.press(screen.getByText(linkText))
+      user.press(screen.getByText(linkText))
 
       await waitFor(() => {
         expect(navigateFromRef).toHaveBeenCalledWith(...homeNavConfig)

--- a/src/ui/pages/GenericInfoPageWhite.native.test.tsx
+++ b/src/ui/pages/GenericInfoPageWhite.native.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 import { GenericInfoPageWhite } from 'ui/pages/GenericInfoPageWhite'
 import { BicolorPhonePending } from 'ui/svg/icons/BicolorPhonePending'
 
 const onSkip = jest.fn()
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<GenericInfoPageWhite />', () => {
   it('should render correctly', () => {
@@ -13,7 +15,7 @@ describe('<GenericInfoPageWhite />', () => {
     expect(screen).toMatchSnapshot()
   })
 
-  it('should call skip when onSkip is provided', () => {
+  it('should call skip when onSkip is provided', async () => {
     render(
       <GenericInfoPageWhite
         title="GenericInfoPageWhite"
@@ -23,7 +25,7 @@ describe('<GenericInfoPageWhite />', () => {
     )
 
     const skipButton = screen.getByText('Passer')
-    fireEvent.press(skipButton)
+    await user.press(skipButton)
 
     expect(onSkip).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
