### PR TITLE
(BSR) build(yarn): add yarn/versions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ node_modules/
 npm-debug.log
 yarn-error.log
 **/.yarn/install-state.gz
+**/.yarn/versions
 
 # fastlane
 #


### PR DESCRIPTION
When triggering a testing or staging hard deploy, yarn will generate versions file in the .yarn folder.
We don't want to have those files in the git history 