### PR TITLE
(BSR) refactor(tests): replace fireEvent by userEvent

### DIFF
--- a/src/features/achievements/pages/Achievements.native.test.tsx
+++ b/src/features/achievements/pages/Achievements.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { mockCompletedAchievements } from 'features/achievements/data/AchievementData'
 import { beneficiaryUser } from 'fixtures/user'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { Achievements } from './Achievements'
 
@@ -13,6 +13,8 @@ jest.mock('react-native-safe-area-context', () => ({
   ...(jest.requireActual('react-native-safe-area-context') as Record<string, unknown>),
   useSafeAreaInsets: () => ({ bottom: 16, right: 16, left: 16, top: 16 }),
 }))
+
+jest.useFakeTimers()
 
 describe('<Achievements/>', () => {
   beforeEach(() => {
@@ -35,8 +37,8 @@ describe('<Achievements/>', () => {
     render(<Achievements />)
 
     const firstMovieBookingAchievement = screen.getByText('Mangeur de popcorns')
-    fireEvent.press(firstMovieBookingAchievement)
+    await userEvent.setup().press(firstMovieBookingAchievement)
 
-    expect(await screen.findByText('Tu as réservé ta première séance de cinéma')).toBeOnTheScreen()
+    expect(screen.getByText('Tu as réservé ta première séance de cinéma')).toBeOnTheScreen()
   })
 })

--- a/src/features/auth/components/AuthenticationButton/AuthenticationButton.native.test.tsx
+++ b/src/features/auth/components/AuthenticationButton/AuthenticationButton.native.test.tsx
@@ -3,17 +3,20 @@ import React from 'react'
 import { navigate } from '__mocks__/@react-navigation/native'
 import { AuthenticationButton } from 'features/auth/components/AuthenticationButton/AuthenticationButton'
 import { StepperOrigin } from 'features/navigation/RootNavigator/types'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 const NAV_PARAMS_LOGIN = { offerId: 1 }
 const NAV_PARAMS_SIGNUP = { offerId: 1, from: StepperOrigin.HOME }
+
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<AuthenticationButton />', () => {
   it('should navigate to the login page when is type login', async () => {
     render(<AuthenticationButton type="login" />)
 
     const connectButton = screen.getByRole('link')
-    fireEvent.press(connectButton)
+    await user.press(connectButton)
 
     expect(navigate).toHaveBeenCalledWith('Login', {})
   })
@@ -22,25 +25,25 @@ describe('<AuthenticationButton />', () => {
     render(<AuthenticationButton type="signup" />)
 
     const connectButton = screen.getByRole('link')
-    fireEvent.press(connectButton)
+    await user.press(connectButton)
 
     expect(navigate).toHaveBeenCalledWith('SignupForm', {})
   })
 
-  it('should navigate with additional params when defined for login', () => {
+  it('should navigate with additional params when defined for login', async () => {
     render(<AuthenticationButton type="login" params={NAV_PARAMS_LOGIN} />)
 
     const connectButton = screen.getByRole('link')
-    fireEvent.press(connectButton)
+    await user.press(connectButton)
 
     expect(navigate).toHaveBeenCalledWith('Login', NAV_PARAMS_LOGIN)
   })
 
-  it('should navigate with additional params when defined for signup', () => {
+  it('should navigate with additional params when defined for signup', async () => {
     render(<AuthenticationButton type="signup" params={NAV_PARAMS_SIGNUP} />)
 
     const connectButton = screen.getByRole('link')
-    fireEvent.press(connectButton)
+    await user.press(connectButton)
 
     expect(navigate).toHaveBeenCalledWith('SignupForm', NAV_PARAMS_SIGNUP)
   })

--- a/src/features/auth/pages/forgottenPassword/ResetPasswordExpiredLink/ResetPasswordExpiredLink.native.test.tsx
+++ b/src/features/auth/pages/forgottenPassword/ResetPasswordExpiredLink/ResetPasswordExpiredLink.native.test.tsx
@@ -10,7 +10,7 @@ import { RootStackParamList } from 'features/navigation/RootNavigator/types'
 import { analytics } from 'libs/analytics/provider'
 import { mockServer } from 'tests/mswServer'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 
 import { ResetPasswordExpiredLink } from './ResetPasswordExpiredLink'
 
@@ -27,19 +27,20 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   }
 })
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<ResetPasswordExpiredLink/>', () => {
   it('should redirect to home page WHEN go back to home button is clicked', async () => {
     mockServer.postApi('/v1/request_password_reset', {})
     renderResetPasswordExpiredLink()
 
-    fireEvent.press(screen.getByText(`Retourner à l’accueil`))
+    await user.press(screen.getByText(`Retourner à l’accueil`))
 
-    await waitFor(() => {
-      expect(navigateFromRef).toHaveBeenCalledWith(
-        navigateToHomeConfig.screen,
-        navigateToHomeConfig.params
-      )
-    })
+    expect(navigateFromRef).toHaveBeenCalledWith(
+      navigateToHomeConfig.screen,
+      navigateToHomeConfig.params
+    )
   })
 
   it('should redirect to reset password link sent page WHEN clicking on resend email and response is success', async () => {
@@ -48,11 +49,9 @@ describe('<ResetPasswordExpiredLink/>', () => {
     })
     renderResetPasswordExpiredLink()
 
-    fireEvent.press(screen.getByText(`Renvoyer l’email`))
+    await user.press(screen.getByText(`Renvoyer l’email`))
 
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalledTimes(1)
-    })
+    expect(navigate).toHaveBeenCalledTimes(1)
 
     expect(analytics.logResendEmailResetPasswordExpiredLink).toHaveBeenCalledTimes(1)
     expect(navigate).toHaveBeenCalledWith('ResetPasswordEmailSent', {
@@ -68,9 +67,7 @@ describe('<ResetPasswordExpiredLink/>', () => {
     const ResetPasswordExpiredLinkWithBoundary = withAsyncErrorBoundary(ResetPasswordExpiredLink)
     render(reactQueryProviderHOC(<ResetPasswordExpiredLinkWithBoundary {...navigationProps} />))
 
-    await act(async () => {
-      fireEvent.press(screen.getByText(`Renvoyer l’email`))
-    })
+    await user.press(screen.getByText(`Renvoyer l’email`))
 
     expect(useQuerySpy).toThrow()
   })

--- a/src/features/auth/pages/suspendedAccount/GenericSuspendedAccount/GenericSuspendedAccount.native.test.tsx
+++ b/src/features/auth/pages/suspendedAccount/GenericSuspendedAccount/GenericSuspendedAccount.native.test.tsx
@@ -5,7 +5,7 @@ import { GenericSuspendedAccount } from 'features/auth/pages/suspendedAccount/Ge
 import { navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
 import * as NavigationHelpers from 'features/navigation/helpers/openUrl'
 import { env } from 'libs/environment/env'
-import { act, fireEvent, render, screen, waitFor } from 'tests/utils'
+import { userEvent, render, screen } from 'tests/utils'
 
 const openUrl = jest.spyOn(NavigationHelpers, 'openUrl')
 
@@ -16,23 +16,24 @@ jest.mock('features/auth/helpers/useLogoutRoutine', () => ({
 
 jest.mock('libs/firebase/analytics/analytics')
 
+const user = userEvent.setup()
+jest.useFakeTimers()
+
 describe('<GenericSuspendedAccount />', () => {
   it('should open mail app when clicking on "Contacter le support" button', async () => {
     render(<GenericSuspendedAccount onBeforeNavigateContactFraudTeam={jest.fn()} />)
 
     const contactSupportButton = screen.getByText('Contacter le service fraude')
-    fireEvent.press(contactSupportButton)
+    await user.press(contactSupportButton)
 
-    await waitFor(() => {
-      expect(openUrl).toHaveBeenCalledWith(`mailto:${env.FRAUD_EMAIL_ADDRESS}`, undefined, true)
-    })
+    expect(openUrl).toHaveBeenCalledWith(`mailto:${env.FRAUD_EMAIL_ADDRESS}`, undefined, true)
   })
 
   it('should go to home page when clicking on go to home button', async () => {
     render(<GenericSuspendedAccount onBeforeNavigateContactFraudTeam={jest.fn()} />)
 
     const homeButton = screen.getByText('Retourner à l’accueil')
-    await act(async () => fireEvent.press(homeButton))
+    await user.press(homeButton)
 
     expect(navigate).toHaveBeenNthCalledWith(
       1,

--- a/src/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx
+++ b/src/features/birthdayNotifications/pages/EighteenBirthday.native.test.tsx
@@ -7,7 +7,7 @@ import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/
 import { storage } from 'libs/storage'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { EighteenBirthday } from './EighteenBirthday'
 
@@ -22,6 +22,8 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+
+jest.useFakeTimers()
 
 describe('<EighteenBirthday />', () => {
   beforeEach(() => {
@@ -43,10 +45,10 @@ describe('<EighteenBirthday />', () => {
     expect(await storage.readObject('has_seen_eligible_card')).toBe(true)
   })
 
-  it('should navigate to Stepper on button press', () => {
+  it('should navigate to Stepper on button press', async () => {
     render(reactQueryProviderHOC(<EighteenBirthday />))
 
-    fireEvent.press(screen.getByText('Confirmer mes informations'))
+    await userEvent.setup().press(screen.getByText('Confirmer mes informations'))
 
     expect(navigate).toHaveBeenCalledWith('Stepper', undefined)
   })

--- a/src/features/bookOffer/components/BookDuoChoice.native.test.tsx
+++ b/src/features/bookOffer/components/BookDuoChoice.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { BookingState, Step } from 'features/bookOffer/context/reducer'
 import { mockOffer } from 'features/bookOffer/fixtures/offer'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { BookDuoChoice } from './BookDuoChoice'
 
@@ -41,6 +41,8 @@ jest.mock('features/offer/helpers/useHasEnoughCredit/useHasEnoughCredit', () => 
   useCreditForOffer: jest.fn(() => mockCreditOffer),
 }))
 
+jest.useFakeTimers()
+
 describe('BookDuoChoice', () => {
   beforeEach(() => {
     setFeatureFlags()
@@ -57,12 +59,12 @@ describe('BookDuoChoice', () => {
     expect(duoChoice).toBeOnTheScreen()
   })
 
-  it('should select an item when pressed', () => {
+  it('should select an item when pressed', async () => {
     render(<BookDuoChoice />)
 
     const soloChoice = screen.getByTestId('DuoChoice1-price')
 
-    fireEvent.press(soloChoice)
+    await userEvent.setup().press(soloChoice)
 
     expect(mockDispatch).toHaveBeenCalledWith({ type: 'SELECT_QUANTITY', payload: 1 })
   })

--- a/src/features/bookOffer/components/BookingCloseInformation.native.test.tsx
+++ b/src/features/bookOffer/components/BookingCloseInformation.native.test.tsx
@@ -1,16 +1,18 @@
 import React from 'react'
 
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { BookingCloseInformation } from './BookingCloseInformation'
 
 const mockHideModal = jest.fn()
 
+jest.useFakeTimers()
+
 describe('BookingCloseInformation', () => {
-  it('calls hideModal when the "J’ai compris" button is press', () => {
+  it('calls hideModal when the "J’ai compris" button is press', async () => {
     render(<BookingCloseInformation visible hideModal={mockHideModal} />)
     const button = screen.getByText('J’ai compris')
-    fireEvent.press(button)
+    await userEvent.setup().press(button)
 
     expect(mockHideModal).toHaveBeenCalledTimes(1)
   })

--- a/src/features/bookings/components/NoBookingsView.native.test.tsx
+++ b/src/features/bookings/components/NoBookingsView.native.test.tsx
@@ -4,7 +4,7 @@ import { navigate } from '__mocks__/@react-navigation/native'
 import { analytics } from 'libs/analytics/provider'
 import * as useNetInfoContextDefault from 'libs/network/NetInfoWrapper'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { fireEvent, render, screen, waitFor } from 'tests/utils'
+import { render, screen, userEvent, waitFor } from 'tests/utils'
 import { DOUBLE_LINE_BREAK } from 'ui/theme/constants'
 
 import { NoBookingsView } from './NoBookingsView'
@@ -16,6 +16,8 @@ jest.mock('features/search/context/SearchWrapper', () => ({
     resetSearch: jest.fn(),
   }),
 }))
+
+jest.useFakeTimers()
 
 describe('<NoBookingsView />', () => {
   it('should render online no bookings view when netInfo.isConnected is true', () => {
@@ -47,7 +49,7 @@ describe('<NoBookingsView />', () => {
     render(reactQueryProviderHOC(<NoBookingsView />))
 
     const button = screen.getByText('Découvrir le catalogue')
-    fireEvent.press(button)
+    userEvent.setup().press(button)
 
     await waitFor(() => {
       expect(navigate).toHaveBeenCalledWith('TabNavigator', {

--- a/src/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx
+++ b/src/features/bookings/pages/BookingNotFound/BookingNotFound.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { navigate } from '__mocks__/@react-navigation/native'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { BookingNotFound } from './BookingNotFound'
 
@@ -12,6 +12,8 @@ jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
     return Component
   }
 })
+const user = userEvent.setup()
+jest.useFakeTimers()
 
 describe('<BookingNotFound/>', () => {
   beforeEach(() => {
@@ -24,9 +26,9 @@ describe('<BookingNotFound/>', () => {
     expect(screen).toMatchSnapshot()
   })
 
-  it('should navigate to ended bookings when clicking on cta', () => {
+  it('should navigate to ended bookings when clicking on cta', async () => {
     render(<BookingNotFound error={new Error('error')} resetErrorBoundary={() => null} />)
-    fireEvent.press(screen.getByText('Mes réservations terminées'))
+    await user.press(screen.getByText('Mes réservations terminées'))
 
     expect(navigate).toHaveBeenCalledWith('EndedBookings', undefined)
   })
@@ -36,9 +38,9 @@ describe('<BookingNotFound/>', () => {
       setFeatureFlags([RemoteStoreFeatureFlags.WIP_BOOKING_IMPROVE])
     })
 
-    it('should navigate to bookings when clicking on cta', () => {
+    it('should navigate to bookings when clicking on cta', async () => {
       render(<BookingNotFound error={new Error('error')} resetErrorBoundary={() => null} />)
-      fireEvent.press(screen.getByText('Mes réservations terminées'))
+      await user.press(screen.getByText('Mes réservations terminées'))
 
       expect(navigate).toHaveBeenCalledWith('Bookings', undefined)
     })

--- a/src/features/favorites/components/Buttons/Sort.native.test.tsx
+++ b/src/features/favorites/components/Buttons/Sort.native.test.tsx
@@ -1,16 +1,18 @@
 import React from 'react'
 
 import { navigate } from '__mocks__/@react-navigation/native'
-import { fireEvent, render, screen } from 'tests/utils'
+import { render, screen, userEvent } from 'tests/utils'
 
 import { Sort } from './Sort'
+
+jest.useFakeTimers()
 
 describe('Sort component', () => {
   afterAll(() => jest.resetAllMocks())
 
-  it('should navigate to Sort page on pressing', () => {
+  it('should navigate to Sort page on pressing', async () => {
     render(<Sort />)
-    fireEvent.press(screen.getByTestId('Trier'))
+    await userEvent.setup().press(screen.getByTestId('Trier'))
 
     expect(navigate).toHaveBeenCalledWith('FavoritesSorts', undefined)
   })

--- a/src/features/navigation/RootNavigator/linking/getNestedNavigationFromState.ts
+++ b/src/features/navigation/RootNavigator/linking/getNestedNavigationFromState.ts
@@ -5,7 +5,7 @@ import { NavigationResultState, RootNavigateParams } from 'features/navigation/R
 export function getNestedNavigationFromState(
   state: NavigationResultState | NavigationState
 ): RootNavigateParams {
-  if (!state || !state.routes) {
+  if (!state?.routes) {
     return ['PageNotFound', undefined]
   }
   const { routes, index } = state

--- a/src/features/navigation/RootNavigator/useScreenshotListener.ts
+++ b/src/features/navigation/RootNavigator/useScreenshotListener.ts
@@ -16,9 +16,7 @@ export const useScreenshotListener = () => {
       return () => {
         unsubscribe()
       }
-    }
-
-    return
+    } else return
   }, [isFocused, name, params])
 }
 

--- a/src/features/navigation/helpers/isAppUrl.ts
+++ b/src/features/navigation/helpers/isAppUrl.ts
@@ -2,7 +2,7 @@ import { linking } from 'features/navigation/RootNavigator/linking'
 
 export const isAppUrl = (url: string) => {
   for (const prefix of linking.prefixes) {
-    if (url.match('^' + prefix)) {
+    if (RegExp(`^${prefix}`).exec(url)) {
       return true
     }
   }

--- a/src/features/navigation/services.ts
+++ b/src/features/navigation/services.ts
@@ -7,7 +7,7 @@ import { analytics } from 'libs/analytics/provider'
 import { storage } from 'libs/storage'
 
 export function onNavigationStateChange(state?: NavigationState): void {
-  if (!state || !state.routes) {
+  if (!state?.routes) {
     return
   }
   if (Platform.OS === 'web') {


### PR DESCRIPTION


## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
