### PR TITLE
(PC-34826) feat(creditV3): show recredit amount instead of max amount

### DIFF
--- a/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx
@@ -127,9 +127,29 @@ describe('<BeneficiaryAccountCreated/>', () => {
     })
   })
 
+  it('should show correct amount', async () => {
+    renderBeneficiaryAccountCreated()
+
+    const recreditAmount = screen.getByText('300 €')
+
+    await act(() => {
+      expect(recreditAmount).toBeOnTheScreen()
+    })
+  })
+
   describe('when enableCreditV3 activated', () => {
     beforeEach(() => {
       setSettings({ wipEnableCreditV3: true })
+    })
+
+    it('should have correct amount', async () => {
+      renderBeneficiaryAccountCreated()
+
+      const recreditAmount = screen.getByText('150 €')
+
+      await act(() => {
+        expect(recreditAmount).toBeOnTheScreen()
+      })
     })
 
     it('should have correct credit information text', async () => {

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx
@@ -11,6 +11,7 @@ import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { BatchProfile } from 'libs/react-native-batch'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { userEvent, render, screen, act } from 'tests/utils'
 
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
@@ -166,5 +167,13 @@ describe('<BeneficiaryAccountCreated/>', () => {
   })
 })
 
-const renderBeneficiaryAccountCreated = () =>
-  render(<BeneficiaryAccountCreated />, { wrapper: ShareAppWrapper })
+function renderBeneficiaryAccountCreated() {
+  return render(<BeneficiaryAccountCreated />, {
+    wrapper: (props) =>
+      reactQueryProviderHOC(
+        <ShareAppWrapper>
+          <React.Fragment>{props.children}</React.Fragment>
+        </ShareAppWrapper>
+      ),
+  })
+}

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.tsx
@@ -29,7 +29,7 @@ import { getNoHeadingAttrs } from 'ui/theme/typographyAttrs/getNoHeadingAttrs'
 export function BeneficiaryAccountCreated() {
   const maxPriceInCents = useMaxPrice()
   const { uniqueColors } = useTheme()
-  const { user } = useAuthContext()
+  const { user, refetchUser } = useAuthContext()
 
   const { data: settings } = useSettingsContext()
 
@@ -51,7 +51,11 @@ export function BeneficiaryAccountCreated() {
 
   const enableCreditV3 = settings?.wipEnableCreditV3
 
-  const { mutate: resetRecreditAmountToShow } = useResetRecreditAmountToShow({})
+  const { mutate: resetRecreditAmountToShow } = useResetRecreditAmountToShow({
+    onSuccess: () => {
+      refetchUser()
+    },
+  })
 
   const unnderageBeneficiaryText = isUnderageBeneficiary
     ? 'Tu as jusqu’à la veille de tes 18 ans pour profiter de ton crédit.'

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.tsx
@@ -10,6 +10,7 @@ import { useMaxPrice } from 'features/search/helpers/useMaxPrice/useMaxPrice'
 import { useShareAppContext } from 'features/share/context/ShareAppWrapper'
 import { ShareAppModalType } from 'features/share/types'
 import { BatchEvent, BatchProfile } from 'libs/react-native-batch'
+import { defaultCreditByAge } from 'shared/credits/defaultCreditByAge'
 import { useShouldShowCulturalSurveyForBeneficiaryUser } from 'shared/culturalSurvey/useShouldShowCulturalSurveyForBeneficiaryUser'
 import { formatCurrencyFromCents } from 'shared/currency/formatCurrencyFromCents'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
@@ -28,6 +29,7 @@ export function BeneficiaryAccountCreated() {
   const maxPriceInCents = useMaxPrice()
   const { uniqueColors } = useTheme()
   const { user } = useAuthContext()
+
   const { data: settings } = useSettingsContext()
 
   const isUnderageBeneficiary = isUserUnderageBeneficiary(user)
@@ -38,7 +40,13 @@ export function BeneficiaryAccountCreated() {
   const currency = useGetCurrencyToDisplay()
   const euroToPacificFrancRate = useGetPacificFrancToEuroRate()
   const maxPrice = formatCurrencyFromCents(maxPriceInCents, currency, euroToPacificFrancRate)
+  const recreditAmount = formatCurrencyFromCents(
+    user?.recreditAmountToShow || defaultCreditByAge.v3.age_18,
+    currency,
+    euroToPacificFrancRate
+  )
   const subtitle = `${maxPrice} viennent d’être crédités sur ton compte pass Culture`
+  const subtitleV3 = `${recreditAmount} viennent d’être crédités sur ton compte pass Culture`
 
   const enableCreditV3 = settings?.wipEnableCreditV3
 
@@ -60,7 +68,7 @@ export function BeneficiaryAccountCreated() {
 
   return (
     <GenericInfoPageWhite animation={TutorialPassLogo} title="Bonne nouvelle&nbsp;!">
-      <StyledSubtitle>{subtitle}</StyledSubtitle>
+      <StyledSubtitle>{enableCreditV3 ? subtitleV3 : subtitle}</StyledSubtitle>
 
       <Spacer.Column numberOfSpaces={4} />
       <ProgressBarContainer>
@@ -70,7 +78,7 @@ export function BeneficiaryAccountCreated() {
           icon={categoriesIcons.Show}
           isAnimated
         />
-        <Amount>{maxPrice}</Amount>
+        <Amount>{enableCreditV3 ? recreditAmount : maxPrice}</Amount>
       </ProgressBarContainer>
       <Spacer.Column numberOfSpaces={4} />
       <StyledBody>{text}</StyledBody>

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.tsx
@@ -5,6 +5,7 @@ import { useAuthContext } from 'features/auth/context/AuthContext'
 import { useSettingsContext } from 'features/auth/context/SettingsContext'
 import { creditActions } from 'features/identityCheck/api/useCreditStore'
 import { navigateToHome, navigateToHomeConfig } from 'features/navigation/helpers/navigateToHome'
+import { useResetRecreditAmountToShow } from 'features/profile/api/useResetRecreditAmountToShow'
 import { isUserUnderageBeneficiary } from 'features/profile/helpers/isUserUnderageBeneficiary'
 import { useMaxPrice } from 'features/search/helpers/useMaxPrice/useMaxPrice'
 import { useShareAppContext } from 'features/share/context/ShareAppWrapper'
@@ -50,6 +51,8 @@ export function BeneficiaryAccountCreated() {
 
   const enableCreditV3 = settings?.wipEnableCreditV3
 
+  const { mutate: resetRecreditAmountToShow } = useResetRecreditAmountToShow({})
+
   const unnderageBeneficiaryText = isUnderageBeneficiary
     ? 'Tu as jusqu’à la veille de tes 18 ans pour profiter de ton crédit.'
     : 'Tu as deux ans pour profiter de ton crédit.'
@@ -62,7 +65,8 @@ export function BeneficiaryAccountCreated() {
     BatchProfile.trackEvent(BatchEvent.hasValidatedSubscription)
     if (!user?.needsToFillCulturalSurvey) showShareAppModal(ShareAppModalType.BENEFICIARY)
     creditActions.setActivationDate(new Date())
-  }, [showShareAppModal, user?.needsToFillCulturalSurvey])
+    resetRecreditAmountToShow()
+  }, [resetRecreditAmountToShow, showShareAppModal, user?.needsToFillCulturalSurvey])
 
   useEnterKeyAction(navigateToHome)
 

--- a/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.web.test.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.web.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
+import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
 import { render, checkAccessibilityFor, screen } from 'tests/utils/web'
 
 import { BeneficiaryAccountCreated } from './BeneficiaryAccountCreated'
@@ -14,7 +15,7 @@ describe('<BeneficiaryAccountCreated/>', () => {
   describe('Accessibility', () => {
     it('should not have basic accessibility issues', async () => {
       setFeatureFlags([RemoteStoreFeatureFlags.ENABLE_PACIFIC_FRANC_CURRENCY])
-      const { container } = render(<BeneficiaryAccountCreated />)
+      const { container } = render(reactQueryProviderHOC(<BeneficiaryAccountCreated />))
 
       await screen.findByLabelText('C’est parti !')
 

--- a/src/features/profile/types.ts
+++ b/src/features/profile/types.ts
@@ -1,8 +1,8 @@
 import { StepVariant } from 'ui/components/VerticalStepper/types'
 
 export type ResetRecreditAmountToShowMutationOptions = {
-  onSuccess: () => void
-  onError: (error: unknown) => void
+  onSuccess?: () => void
+  onError?: (error: unknown) => void
 }
 
 export type FirstOrLastProps = {


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34826

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |![Simulator Screenshot - iPhone 13 - 2025-02-26 at 17 07 17](https://github.com/user-attachments/assets/5009fc83-d804-4651-a841-ab1674c8069b)|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
