### PR TITLE
(PC-34662) feat(ComingSoon): fix auth modal

### DIFF
--- a/__snapshots__/features/offer/components/FavoriteAuthModal/FavoriteAuthModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/offer/components/FavoriteAuthModal/FavoriteAuthModal.native.test.tsx.native-snap
@@ -386,19 +386,11 @@ retrouver tes favoris
                 Ton compte te permettra de retrouver tous tes bons plans en un clin d’oeil !
               </Text>
               <View
-                numberOfSpaces={6}
                 style={
                   [
                     {
-                      "height": 24,
-                    },
-                  ]
-                }
-              />
-              <View
-                style={
-                  [
-                    {
+                      "marginBottom": 16,
+                      "marginTop": 24,
                       "width": "100%",
                     },
                   ]
@@ -500,16 +492,6 @@ retrouver tes favoris
                   </View>
                 </View>
               </View>
-              <View
-                numberOfSpaces={4}
-                style={
-                  [
-                    {
-                      "height": 16,
-                    },
-                  ]
-                }
-              />
               <View
                 style={
                   [

--- a/src/features/offer/components/FavoriteAuthModal/FavoriteAuthModal.tsx
+++ b/src/features/offer/components/FavoriteAuthModal/FavoriteAuthModal.tsx
@@ -8,7 +8,7 @@ import { ButtonWithLinearGradient } from 'ui/components/buttons/buttonWithLinear
 import { AppModalWithIllustration } from 'ui/components/modals/AppModalWithIllustration'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { BicolorUserFavorite } from 'ui/svg/icons/BicolorUserFavorite'
-import { Spacer, TypoDS } from 'ui/theme'
+import { getSpacing, TypoDS } from 'ui/theme'
 import { LINE_BREAK } from 'ui/theme/constants'
 
 interface Props {
@@ -43,7 +43,6 @@ export const FavoriteAuthModal: FunctionComponent<Props> = ({ visible, offerId, 
       <StyledBody>
         Ton compte te permettra de retrouver tous tes bons plans en un clin d’oeil&nbsp;!
       </StyledBody>
-      <Spacer.Column numberOfSpaces={6} />
       <StyledButtonContainer>
         <InternalTouchableLink
           as={ButtonWithLinearGradient}
@@ -55,7 +54,6 @@ export const FavoriteAuthModal: FunctionComponent<Props> = ({ visible, offerId, 
           onBeforeNavigate={signUp}
         />
       </StyledButtonContainer>
-      <Spacer.Column numberOfSpaces={4} />
       <StyledAuthenticationButton
         type="login"
         params={{ from: StepperOrigin.FAVORITE, offerId }}
@@ -71,6 +69,8 @@ const StyledAuthenticationButton = styled(AuthenticationButton).attrs(({ theme }
 
 const StyledButtonContainer = styled.View({
   width: '100%',
+  marginTop: getSpacing(6),
+  marginBottom: getSpacing(4),
 })
 
 const StyledBody = styled(TypoDS.Body)({

--- a/src/features/offer/components/OfferFooter/StickyFooterContent.tsx
+++ b/src/features/offer/components/OfferFooter/StickyFooterContent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import styled from 'styled-components/native'
 
 import { useAuthContext } from 'features/auth/context/AuthContext'
@@ -46,23 +46,21 @@ export const StickyFooterContent = ({
     hideModal: hideNotificationAuthModal,
   } = useModal(false)
 
-  const handleAddToFavorites = () => {
-    if (isLoggedIn) {
+  const pressFavoriteCTA = useCallback(() => {
+    if (!isLoggedIn) {
+      showFavoriteAuthModal()
+    } else if (favorite) {
+      removeFavorite(favorite.id)
+    } else {
       addFavorite({ offerId })
     }
-    showFavoriteAuthModal()
-  }
+  }, [addFavorite, favorite, isLoggedIn, offerId, removeFavorite, showFavoriteAuthModal])
 
-  const handleRemoveFromFavorites = () => {
-    if (favorite) removeFavorite(favorite?.id)
-  }
-
-  const handleEnableNotifications = () => {
-    if (isLoggedIn) {
-      setHasEnabledNotifications(!hasEnabledNotifications)
-    } else {
+  const pressNotificationsCTA = () => {
+    if (!isLoggedIn) {
       showNotificationAuthModal()
     }
+    setHasEnabledNotifications(!hasEnabledNotifications)
   }
 
   return (
@@ -71,7 +69,7 @@ export const StickyFooterContent = ({
       {favorite ? (
         <ButtonSecondary
           wording="Retirer des favoris"
-          onPress={handleRemoveFromFavorites}
+          onPress={pressFavoriteCTA}
           icon={FavoriteFilled}
           isLoading={isRemoveFavoriteLoading}
         />
@@ -79,7 +77,7 @@ export const StickyFooterContent = ({
         <React.Fragment>
           <ButtonPrimary
             wording="Mettre en favori"
-            onPress={handleAddToFavorites}
+            onPress={pressFavoriteCTA}
             icon={Favorite}
             isLoading={isAddFavoriteLoading}
           />
@@ -93,7 +91,7 @@ export const StickyFooterContent = ({
       <React.Fragment>
         <ButtonTertiaryBlack
           wording={hasEnabledNotifications ? 'Désactiver le rappel' : 'Ajouter un rappel'}
-          onPress={handleEnableNotifications}
+          onPress={pressNotificationsCTA}
           icon={hasEnabledNotifications ? BellFilled : Bell}
         />
         <NotificationAuthModal


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34662

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [X] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [X] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [X] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome |               | <video src="https://github.com/user-attachments/assets/94c72ba8-1af0-4550-b022-89283cbfa816" /> |




[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
