### PR TITLE
(PC-34589) fix(OfferTile): add navigation method prop

### DIFF
--- a/src/features/offer/components/OfferPlaylistItem/OfferPlaylistItem.tsx
+++ b/src/features/offer/components/OfferPlaylistItem/OfferPlaylistItem.tsx
@@ -4,6 +4,7 @@ import { OfferResponseV2, RecommendationApiParams } from 'api/gen'
 import { Referrals } from 'features/navigation/RootNavigator/types'
 import { OfferTile } from 'features/offer/components/OfferTile/OfferTile'
 import { PlaylistType } from 'features/offer/enums'
+import { OfferTileProps } from 'features/offer/types'
 import { formatDates, getTimeStampInMillis } from 'libs/parsers/formatDates'
 import {
   CategoryHomeLabelMapping,
@@ -23,6 +24,7 @@ type OfferPlaylistItemProps = {
   apiRecoParams?: RecommendationApiParams
   analyticsFrom?: Referrals
   priceDisplay: (item: Offer) => string
+  navigationMethod?: OfferTileProps['navigationMethod']
 }
 
 type RenderOfferPlaylistItemProps = {
@@ -39,6 +41,7 @@ export const OfferPlaylistItem = ({
   artistName,
   apiRecoParams,
   analyticsFrom = 'offer',
+  navigationMethod,
   priceDisplay,
 }: OfferPlaylistItemProps) => {
   return function RenderItem({ item, width, height, playlistType }: RenderOfferPlaylistItemProps) {
@@ -64,6 +67,7 @@ export const OfferPlaylistItem = ({
         playlistType={playlistType}
         apiRecoParams={apiRecoParams}
         artistName={artistName}
+        navigationMethod={navigationMethod}
       />
     )
   }

--- a/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.tsx
+++ b/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.tsx
@@ -118,6 +118,7 @@ export function OfferPlaylistList({
                 categoryMapping,
                 currency,
                 euroToPacificFrancRate,
+                navigationMethod: 'push',
                 apiRecoParams: playlist.apiRecoParams,
                 priceDisplay: (item: Offer) =>
                   getDisplayedPrice(item.offer.prices, currency, euroToPacificFrancRate),

--- a/src/features/offer/components/OfferTile/OfferTile.tsx
+++ b/src/features/offer/components/OfferTile/OfferTile.tsx
@@ -8,6 +8,7 @@ import { useHandleFocus } from 'libs/hooks/useHandleFocus'
 import { useLocation } from 'libs/location'
 import { getDistance } from 'libs/location/getDistance'
 import { tileAccessibilityLabel, TileContentType } from 'libs/tileAccessibilityLabel'
+import { NAVIGATION_METHOD } from 'shared/constants'
 import { usePrePopulateOffer } from 'shared/offer/usePrePopulateOffer'
 import { InternalTouchableLink } from 'ui/components/touchableLink/InternalTouchableLink'
 import { customFocusOutline } from 'ui/theme/customFocusOutline/customFocusOutline'
@@ -31,6 +32,7 @@ const UnmemoizedOfferTile = (props: OfferTileProps) => {
     apiRecoParams,
     index,
     artistName,
+    navigationMethod = NAVIGATION_METHOD.NAVIGATE,
     ...offer
   } = props
 
@@ -94,7 +96,7 @@ const UnmemoizedOfferTile = (props: OfferTileProps) => {
             apiRecoParams: JSON.stringify(apiRecoParams),
             playlistType,
           },
-          withPush: true,
+          withPush: navigationMethod === NAVIGATION_METHOD.PUSH,
         }}
         onBeforeNavigate={handlePressOffer}
         onFocus={onFocus}

--- a/src/features/offer/types.ts
+++ b/src/features/offer/types.ts
@@ -12,6 +12,10 @@ import { Referrals } from 'features/navigation/RootNavigator/types'
 import { PlaylistType } from 'features/offer/enums'
 import { AlgoliaGeoloc } from 'libs/algolia/types'
 import { Subcategory } from 'libs/subcategories/types'
+import { NAVIGATION_METHOD } from 'shared/constants'
+
+type ValueOf<T> = T[keyof T]
+type NavigationMethod = ValueOf<typeof NAVIGATION_METHOD>
 
 export interface OfferTileProps {
   categoryId: CategoryIdEnum | null | undefined
@@ -38,6 +42,7 @@ export interface OfferTileProps {
   apiRecoParams?: RecommendationApiParams
   index?: number
   artistName?: string
+  navigationMethod?: NavigationMethod
 }
 
 export interface SimilarOffersResponse {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,0 +1,4 @@
+export const NAVIGATION_METHOD = {
+  PUSH: 'push',
+  NAVIGATE: 'navigate',
+} as const


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34589

Mise en place d'une prop permettant de choisir la méthode de navigation depuis un composant `OfferTile`. Les  méthodes sont "navigate" (par défaut) ou "push"

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
