### PR TITLE
(BSR) docs(adr): add ADR doc for venueMap refactor

### DIFF
--- a/doc/decision-records/DR002 - venue-map.md
+++ b/doc/decision-records/DR002 - venue-map.md
@@ -1,0 +1,65 @@
+# DR002 - carte des lieux
+
+> Statut : Adopté
+
+## Décision
+
+Il a été décidé de refactoriser la page [VenueMap](../../src/features/venueMap/pages/VenueMap/VenueMap.tsx) et ses composants associés pour améliorer la lisibilité, la maintenabilité et la séparation des responsabilités. Les principales actions entreprises sont :
+
+- Réorganisation des responsabilités entre les composants existants ([VenueMapView](../../src/features/venueMap/components/VenueMapView/VenueMapView.tsx) et [VenueMapBottomSheet](../../src/features/venueMap/components/VenueMapBottomSheet/VenueMapBottomSheet.tsx)).
+
+- Refactorisation du [venueMapStore](../../src/features/venueMap/store/venueMapStore.ts) pour une meilleure gestion des données, en fusionnant plusieurs stores en un seul store unique.
+
+- Création d'un nouveau composant conteneur, [VenueMapViewContainer](../../src/features/venueMap/components/VenueMapView/VenueMapViewContainer.tsx), pour gérer les interactions et la communication entre les composants.
+
+## Contexte
+
+La page VenueMap et ses composants associés manquaient de clarté dans la séparation des responsabilités, ce qui rendait le code difficile à maintenir et à faire évoluer. De plus, l'utilisation de plusieurs stores séparés pour gérer les différents aspects de la fonctionnalité (affichage d'une carte avec des points associés à des lieux proposant des offres culturelles) rendait le code verbeux et compliquait la gestion de l'état global. Il était nécessaire d'améliorer la structure et l'organisation du code pour faciliter les développements futurs et améliorer les performances.
+
+## Alternatives considérées
+
+- Conserver la structure existante et optimiser le code en place : Cette option a été rejetée car elle n'aurait pas résolu les problèmes fondamentaux de séparation des responsabilités.
+
+- Réécrire entièrement la fonctionnalité : Cette approche a été jugée trop coûteuse en temps et en ressources, et potentiellement risquée.
+
+- Garder plusieurs stores mais améliorer leur organisation : Cette option a été écartée car elle ne résolvait pas complètement le problème de verbosité et de complexité de gestion de l'état.
+
+## Justification
+
+- Amélioration de la lisibilité et de la maintenabilité du code.
+
+- Meilleure séparation des responsabilités entre les composants.
+
+- Simplification de la gestion de l'état grâce à un store unique pour la fonctionnalité VenueMap.
+
+- Facilitation des tests unitaires et de l'intégration de nouvelles fonctionnalités.
+
+- Réduction de la verbosité du code et amélioration de la cohérence des données.
+
+- Optimisation potentielle des performances grâce à une meilleure gestion des états et des rendus.
+
+## Conséquences
+
+### Positives :
+
+Code plus facile à comprendre et à maintenir.
+
+Meilleure modularité permettant des évolutions futures plus aisées.
+
+Gestion de l'état simplifiée et plus cohérente.
+
+Potentielle amélioration des performances.
+
+### Négatives :
+
+Temps de développement nécessaire pour la refactorisation.
+
+Risque de régression temporaire pendant la phase de transition.
+
+## Actions à mettre en oeuvre
+
+Mettre à jour la documentation technique pour refléter la nouvelle structure, en particulier la gestion de l'état avec le store unique.
+
+Adapter les tests unitaires et d'intégration existants à la nouvelle architecture et au nouveau store.
+
+Surveiller les performances de l'application après la mise en production pour vérifier les améliorations.


### PR DESCRIPTION
Ajout d'un document expliquant la decision de refactoriser la partie "carte des lieux" de l'App Native

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
