### PR TITLE
(PC-34929) feat(e2e): remove legacy slack notifs on runs

### DIFF
--- a/.maestro/tests/config.yaml
+++ b/.maestro/tests/config.yaml
@@ -1,9 +1,2 @@
 flows:
   - '**'
-
-notifications:
-  email:
-    enabled: true
-    onSuccess: true
-    recipients:
-      - equipe-e2e-jeunes-aaaakntkqy3ta5ksdafyew6dae@passcultureteam.slack.com


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34929

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**Before**
<img width="665" alt="Capture d’écran 2025-03-04 à 11 20 57" src="https://github.com/user-attachments/assets/187ab75c-2c84-496a-a8ad-3107829c0795" />

**After**
<img width="752" alt="Capture d’écran 2025-03-04 à 11 21 24" src="https://github.com/user-attachments/assets/4313dc1e-ba62-420c-be07-85bf33fb5a9d" />
