### PR TITLE
(PC-34793) feat(BookingPage): disposal forbidden banner

### DIFF
--- a/src/features/bookings/components/BookingDetailsContent.tsx
+++ b/src/features/bookings/components/BookingDetailsContent.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import { ScrollView } from 'react-native'
+import styled from 'styled-components/native'
 
 import { BookingOfferResponseAddress, BookingReponse, BookingVenueResponse } from 'api/gen'
 import { TicketCutout } from 'features/bookings/components/TicketCutout'
@@ -7,6 +9,7 @@ import { BookingProperties } from 'features/bookings/types'
 import { VenueBlockAddress, VenueBlockVenue } from 'features/offer/components/OfferVenueBlock/type'
 import { VenueBlockWithItinerary } from 'features/offer/components/OfferVenueBlock/VenueBlockWithItinerary'
 import { formatFullAddress } from 'shared/address/addressFormatter'
+import { ErrorBanner } from 'ui/components/banners/ErrorBanner'
 import { InfoBanner } from 'ui/components/banners/InfoBanner'
 import { IdCard } from 'ui/svg/icons/IdCard'
 import { getSpacing, TypoDS } from 'ui/theme'
@@ -30,30 +33,36 @@ export const BookingDetailsContent = ({
     !!offerFullAddress && (properties.isEvent || (properties.isPhysical && !properties.isDigital))
 
   const { hourLabel, dayLabel } = getBookingLabels(booking, properties)
+
   return (
-    <TicketCutout
-      hour={hourLabel == '' ? undefined : hourLabel}
-      day={dayLabel == '' ? undefined : dayLabel}
-      isDuo={properties.isDuo}
-      venueInfo={
-        <VenueBlockWithItinerary
-          shouldDisplayItineraryButton={shouldDisplayItineraryButton}
-          offerFullAddress={offerFullAddress}
-          venue={getVenueBlockVenue(booking.stock.offer.venue)}
-          address={getVenueBlockAddress(booking.stock.offer.address)}
-          offerId={offer.id}
-          thumbnailSize={VENUE_THUMBNAIL_SIZE}
-        />
-      }
-      title={offer.name}
-      infoBanner={
-        <InfoBanner
-          message="Tu auras besoin de ta carte d’identité pour accéder à l’évènement."
-          icon={IdCard}
-        />
-      }>
-      <TypoDS.Body>qrcode</TypoDS.Body>
-    </TicketCutout>
+    <ScrollView>
+      <TicketCutout
+        hour={hourLabel == '' ? undefined : hourLabel}
+        day={dayLabel == '' ? undefined : dayLabel}
+        isDuo={properties.isDuo}
+        venueInfo={
+          <VenueBlockWithItinerary
+            shouldDisplayItineraryButton={shouldDisplayItineraryButton}
+            offerFullAddress={offerFullAddress}
+            venue={getVenueBlockVenue(booking.stock.offer.venue)}
+            address={getVenueBlockAddress(booking.stock.offer.address)}
+            offerId={offer.id}
+            thumbnailSize={VENUE_THUMBNAIL_SIZE}
+          />
+        }
+        title={offer.name}
+        infoBanner={
+          <InfoBanner
+            message="Tu auras besoin de ta carte d’identité pour accéder à l’évènement."
+            icon={IdCard}
+          />
+        }>
+        <TypoDS.Body>qrcode</TypoDS.Body>
+      </TicketCutout>
+      <ErrorBannerContainer>
+        <ErrorBanner message="Tu n’as pas le droit de céder ou de revendre ton billet." />
+      </ErrorBannerContainer>
+    </ScrollView>
   )
 }
 
@@ -66,3 +75,8 @@ function getVenueBlockAddress(
 ): VenueBlockAddress | undefined {
   return address ?? undefined
 }
+
+const ErrorBannerContainer = styled.View({
+  marginHorizontal: getSpacing(6),
+  marginTop: getSpacing(8),
+})

--- a/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
@@ -741,6 +741,16 @@ describe('BookingDetails', () => {
       openItinerary.mockRestore()
       getBookingProperties.mockRestore()
     })
+
+    it('should display banner warning about disposal', async () => {
+      renderBookingDetails(ongoingBookings)
+
+      await screen.findByText(ongoingBookings.stock.offer.name)
+
+      expect(
+        screen.getByText('Tu n’as pas le droit de céder ou de revendre ton billet.')
+      ).toBeOnTheScreen()
+    })
   })
 })
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34793

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |<img width="289" alt="Screenshot 2025-03-04 at 11 47 51" src="https://github.com/user-attachments/assets/11f83ddf-a552-44fd-815d-42fbed99b7f3" />|![Simulator Screenshot - iPhone SE (3rd generation) - 2025-03-04 at 12 32 18](https://github.com/user-attachments/assets/c776926c-f50f-47e1-8a74-5a5221e09b2e)|


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
