### PR TITLE
(PC-34926) feat(search): use associated venue types to search group to filter when pressing see map button

### DIFF
--- a/src/features/search/components/VenuePlaylist/VenuePlaylist.tsx
+++ b/src/features/search/components/VenuePlaylist/VenuePlaylist.tsx
@@ -3,14 +3,15 @@ import React, { useEffect } from 'react'
 import { Platform, View } from 'react-native'
 import styled from 'styled-components/native'
 
-import { SearchGroupNameEnumv2, VenueTypeCodeKey } from 'api/gen'
+import { SearchGroupNameEnumv2 } from 'api/gen'
 import { VenueMapLocationModal } from 'features/location/components/VenueMapLocationModal'
 import { UseNavigationType } from 'features/navigation/RootNavigator/types'
 import { SearchStackParamList } from 'features/navigation/SearchStackNavigator/types'
 import { NumberOfResults } from 'features/search/components/NumberOfResults/NumberOfResults'
 import { SearchVenueItem } from 'features/search/components/SearchVenueItems/SearchVenueItem'
 import { useSearch } from 'features/search/context/SearchWrapper'
-import { setVenueTypeCode } from 'features/venueMap/store/venueMapStore'
+import { getVenueTypesFromSearchGroup } from 'features/search/helpers/getVenueTypesFromSearchGroup/getVenueTypesFromSearchGroup'
+import { venuesFilterActions } from 'features/venueMap/store/venuesFilterStore'
 import { AlgoliaVenue } from 'libs/algolia/types'
 import { analytics } from 'libs/analytics/provider'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
@@ -64,6 +65,7 @@ export const VenuePlaylist: React.FC<Props> = ({
     searchState: { searchId },
   } = useSearch()
   const enabledVenueMap = useFeatureFlag(RemoteStoreFeatureFlags.WIP_VENUE_MAP)
+  const { setVenuesFilters } = venuesFilterActions
 
   const logVenuePlaylistDisplayedOnSearchResultsOnce = useFunctionOnce(() =>
     analytics.logVenuePlaylistDisplayedOnSearchResults({
@@ -88,9 +90,8 @@ export const VenuePlaylist: React.FC<Props> = ({
   const isMapWithoutPositionAndNotLocated = !isLocated && !isWeb
 
   const handleSeeMapPress = () => {
-    if (offerCategory === SearchGroupNameEnumv2.LIVRES) {
-      setVenueTypeCode(VenueTypeCodeKey.BOOKSTORE)
-    }
+    setVenuesFilters(offerCategory ? getVenueTypesFromSearchGroup(offerCategory) : [])
+
     if (isMapWithoutPositionAndNotLocated) {
       showVenueMapLocationModal()
       return

--- a/src/features/search/constants.ts
+++ b/src/features/search/constants.ts
@@ -1,3 +1,5 @@
+import { SearchGroupNameEnumv2, VenueTypeCodeKey } from 'api/gen'
+
 export const HISTORY_KEY = 'search_history'
 export const MAX_HISTORY_RESULTS = 20
 export const MIN_HISTORY_RESULTS = 2
@@ -6,3 +8,25 @@ export const SCROLL_TO_TOP_BUTTON_LINEAR_GRADIENT_START = { x: 0, y: 0 }
 export const SCROLL_TO_TOP_BUTTON_LINEAR_GRADIENT_END = { x: 0, y: 1 }
 export const DEFAULT_RADIUS = 50
 export const ALL_CATEGORIES_LABEL = 'Toutes les catégories'
+
+export const VENUE_TYPES_BY_SEARCH_GROUP: Partial<
+  Record<SearchGroupNameEnumv2, VenueTypeCodeKey[]>
+> = {
+  [SearchGroupNameEnumv2.LIVRES]: [
+    VenueTypeCodeKey.BOOKSTORE,
+    VenueTypeCodeKey.DISTRIBUTION_STORE,
+    VenueTypeCodeKey.LIBRARY,
+  ],
+  [SearchGroupNameEnumv2.CINEMA]: [VenueTypeCodeKey.MOVIE],
+  [SearchGroupNameEnumv2.FILMS_DOCUMENTAIRES_SERIES]: [VenueTypeCodeKey.DISTRIBUTION_STORE],
+  [SearchGroupNameEnumv2.MUSIQUE]: [
+    VenueTypeCodeKey.RECORD_STORE,
+    VenueTypeCodeKey.DISTRIBUTION_STORE,
+    VenueTypeCodeKey.CONCERT_HALL,
+    VenueTypeCodeKey.FESTIVAL,
+  ],
+  [SearchGroupNameEnumv2.CONCERTS_FESTIVALS]: [
+    VenueTypeCodeKey.FESTIVAL,
+    VenueTypeCodeKey.CONCERT_HALL,
+  ],
+}

--- a/src/features/search/helpers/getVenueTypesFromSearchGroup/getVenueTypesFromSearchGroup.test.ts
+++ b/src/features/search/helpers/getVenueTypesFromSearchGroup/getVenueTypesFromSearchGroup.test.ts
@@ -1,0 +1,44 @@
+import { SearchGroupNameEnumv2, VenueTypeCodeKey } from 'api/gen'
+import { getVenueTypesFromSearchGroup } from 'features/search/helpers/getVenueTypesFromSearchGroup/getVenueTypesFromSearchGroup'
+
+describe('getVenueTypesFromSearchGroup', () => {
+  it('should return venue types for LIVRES search group', () => {
+    expect(getVenueTypesFromSearchGroup(SearchGroupNameEnumv2.LIVRES)).toEqual([
+      VenueTypeCodeKey.BOOKSTORE,
+      VenueTypeCodeKey.DISTRIBUTION_STORE,
+      VenueTypeCodeKey.LIBRARY,
+    ])
+  })
+
+  it('should return venue types for CINEMA search group', () => {
+    expect(getVenueTypesFromSearchGroup(SearchGroupNameEnumv2.CINEMA)).toEqual([
+      VenueTypeCodeKey.MOVIE,
+    ])
+  })
+
+  it('should return venue types for FILMS_DOCUMENTAIRES_SERIES search group', () => {
+    expect(getVenueTypesFromSearchGroup(SearchGroupNameEnumv2.FILMS_DOCUMENTAIRES_SERIES)).toEqual([
+      VenueTypeCodeKey.DISTRIBUTION_STORE,
+    ])
+  })
+
+  it('should return venue types for MUSIQUE search group', () => {
+    expect(getVenueTypesFromSearchGroup(SearchGroupNameEnumv2.MUSIQUE)).toEqual([
+      VenueTypeCodeKey.RECORD_STORE,
+      VenueTypeCodeKey.DISTRIBUTION_STORE,
+      VenueTypeCodeKey.CONCERT_HALL,
+      VenueTypeCodeKey.FESTIVAL,
+    ])
+  })
+
+  it('should return venue types for CONCERTS_FESTIVALS search group', () => {
+    expect(getVenueTypesFromSearchGroup(SearchGroupNameEnumv2.CONCERTS_FESTIVALS)).toEqual([
+      VenueTypeCodeKey.FESTIVAL,
+      VenueTypeCodeKey.CONCERT_HALL,
+    ])
+  })
+
+  it('should return an empty an empty for a search group not specified in VENUE_TYPES_BY_SEARCH_GROUP', () => {
+    expect(getVenueTypesFromSearchGroup(SearchGroupNameEnumv2.ARTS_LOISIRS_CREATIFS)).toEqual([])
+  })
+})

--- a/src/features/search/helpers/getVenueTypesFromSearchGroup/getVenueTypesFromSearchGroup.ts
+++ b/src/features/search/helpers/getVenueTypesFromSearchGroup/getVenueTypesFromSearchGroup.ts
@@ -1,0 +1,6 @@
+import { SearchGroupNameEnumv2 } from 'api/gen'
+import { VENUE_TYPES_BY_SEARCH_GROUP } from 'features/search/constants'
+
+export function getVenueTypesFromSearchGroup(searchGroup: SearchGroupNameEnumv2) {
+  return VENUE_TYPES_BY_SEARCH_GROUP[searchGroup] ?? []
+}


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34926

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

Before :

https://github.com/user-attachments/assets/a1e4e986-df8a-48cd-85ab-5aa7e3ffc90a

After :

https://github.com/user-attachments/assets/ce7815cf-b338-4928-bdc2-ab31b157b66b


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
