### PR TITLE
(PC-34929) feat(e2e): add e2e ios run on staging deploy

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -320,3 +320,9 @@ jobs:
     secrets:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  run-e2e-tests-ios:
+    needs: hard-deploy-ios-staging
+    uses: ./.github/workflows/dev_on_workflow_call_e2e_ios.yml
+    secrets:
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/dev_on_workflow_call_e2e_android.yml
+++ b/.github/workflows/dev_on_workflow_call_e2e_android.yml
@@ -87,9 +87,13 @@ jobs:
       - name: Generate Robin Android upload name
         id: generate_name
         run: |
-          DATE=$(date +"%d-%m-%Y")
+          DATE=$(date +"%d/%m/%Y")
           COMMIT_HASH=$(git rev-parse --short=8 HEAD)
-          CUSTOM_NAME="[Nightly] - ${DATE} - ${COMMIT_HASH}"
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            CUSTOM_NAME="[Nightly][Android] Release du ${DATE} au soir (${COMMIT_HASH})"
+          else
+            CUSTOM_NAME="[MES][Android] Staging du ${DATE} (${COMMIT_HASH})"
+          fi
           echo "CUSTOM_NAME=$CUSTOM_NAME" >> $GITHUB_OUTPUT
 
       - name: Upload and run android tests with Robin

--- a/.github/workflows/dev_on_workflow_call_e2e_ios.yml
+++ b/.github/workflows/dev_on_workflow_call_e2e_ios.yml
@@ -11,7 +11,7 @@ on:
 permissions:
   contents: read
   id-token: write
-  
+
 jobs:
   build_e2e:
     name: 'Build E2E Staging'
@@ -97,9 +97,13 @@ jobs:
       - name: Generate Robin iOS upload name
         id: generate_name
         run: |
-          DATE=$(date +"%d-%m-%Y")
+          DATE=$(date +"%d/%m/%Y")
           COMMIT_HASH=$(git rev-parse --short=8 HEAD)
-          CUSTOM_NAME="[Nightly] - ${DATE} - ${COMMIT_HASH}"
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            CUSTOM_NAME="[Nightly][iOS] Release du ${DATE} au soir (${COMMIT_HASH})"
+          else
+            CUSTOM_NAME="[MES][iOS] Staging du ${DATE} (${COMMIT_HASH})"
+          fi
           echo "CUSTOM_NAME=$CUSTOM_NAME" >> $GITHUB_OUTPUT
       - name: Upload and run ios tests with Robin
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.6


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34929

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

Le nom de l'upload donnera ça :

<img width="318" alt="Capture d’écran 2025-03-04 à 16 58 31" src="https://github.com/user-attachments/assets/46396e1e-3646-48c4-b355-dd79cd0e4fe2" />

