### PR TITLE
(PC-34936) refactor(venueMap): remove setVenueTypeCode of venueMapStore

### DIFF
--- a/src/features/venueMap/components/FilterBannerContainer/SingleFilterBannerContainer.native.test.tsx
+++ b/src/features/venueMap/components/FilterBannerContainer/SingleFilterBannerContainer.native.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { VenueTypeCodeKey } from 'api/gen'
-import { setVenueTypeCode } from 'features/venueMap/store/venueMapStore'
+import { venuesFilterActions } from 'features/venueMap/store/venuesFilterStore'
 import { parseType } from 'libs/parsers/venueType'
 import { ellipseString } from 'shared/string/ellipseString'
 import { render, screen } from 'tests/utils'
@@ -12,7 +12,7 @@ const VENUE_TYPE = VenueTypeCodeKey.MOVIE
 
 describe('SingleFilterBannerContainer', () => {
   beforeEach(() => {
-    setVenueTypeCode(VENUE_TYPE)
+    venuesFilterActions.setVenuesFilters([VENUE_TYPE])
   })
 
   it('should render correctly', async () => {
@@ -22,7 +22,7 @@ describe('SingleFilterBannerContainer', () => {
   })
 
   it('Should filter with no venueCode', async () => {
-    setVenueTypeCode(null)
+    venuesFilterActions.setVenuesFilters([])
 
     render(<SingleFilterBannerContainer />)
 

--- a/src/features/venueMap/components/FilterBannerContainer/SingleFilterBannerContainer.tsx
+++ b/src/features/venueMap/components/FilterBannerContainer/SingleFilterBannerContainer.tsx
@@ -4,7 +4,8 @@ import styled from 'styled-components/native'
 import { SingleFilterButton } from 'features/search/components/Buttons/SingleFilterButton/SingleFilterButton'
 import { getVenueTypeLabel } from 'features/venueMap/helpers/getVenueTypeLabel/getVenueTypeLabel'
 import { VenueTypeModal } from 'features/venueMap/pages/modals/VenueTypeModal/VenueTypeModal'
-import { useVenueMapStore } from 'features/venueMap/store/venueMapStore'
+import { useVenuesFilter } from 'features/venueMap/store/venuesFilterStore'
+import { VenueTypeCode } from 'libs/parsers/venueType'
 import { ellipseString } from 'shared/string/ellipseString'
 import { Li } from 'ui/components/Li'
 import { useModal } from 'ui/components/modals/useModal'
@@ -15,8 +16,9 @@ import { getSpacing } from 'ui/theme'
 const MAX_VENUE_CHARACTERS = 20
 
 export const SingleFilterBannerContainer = () => {
-  const venueTypeCode = useVenueMapStore((state) => state.venueTypeCode)
-  const venueTypeLabel = getVenueTypeLabel(venueTypeCode) ?? 'Tous les lieux'
+  const venueFilters = useVenuesFilter()
+  const venueTypeCode = venueFilters.length ? venueFilters[0] : null
+  const venueTypeLabel = getVenueTypeLabel(venueTypeCode as VenueTypeCode) ?? 'Tous les lieux'
 
   const {
     visible: venueTypeModalVisible,

--- a/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.native.test.tsx
@@ -16,6 +16,7 @@ import { VenueMapViewContainer } from 'features/venueMap/components/VenueMapView
 import { useCenterOnLocation } from 'features/venueMap/hook/useCenterOnLocation'
 import * as useVenueMapFilters from 'features/venueMap/hook/useVenueMapFilters'
 import * as useVenueMapStore from 'features/venueMap/store/venueMapStore'
+import { venuesFilterActions } from 'features/venueMap/store/venuesFilterStore'
 import { useVenuesInRegionQuery } from 'features/venueMap/useVenuesInRegionQuery'
 import mockVenueSearchParams from 'fixtures/venueSearchParams'
 import { venuesFixture } from 'libs/algolia/fetchAlgolia/fetchVenues/fixtures/venuesFixture'
@@ -107,8 +108,7 @@ const pressVenueMarker = (venue: GeolocatedVenue, forcedVenueId?: string) => {
 }
 
 const initStore = () => {
-  const { setVenues, setVenueTypeCode, setOffersPlaylistType, setInitialRegion, setRegion } =
-    useVenueMapStore
+  const { setVenues, setOffersPlaylistType, setInitialRegion, setRegion } = useVenueMapStore
 
   const mockCurrentRegion = {
     latitude: 48.871728,
@@ -118,7 +118,7 @@ const initStore = () => {
   }
 
   setVenues(venuesFixture)
-  setVenueTypeCode(VenueTypeCodeKey.VISUAL_ARTS)
+  venuesFilterActions.setVenuesFilters([VenueTypeCodeKey.VISUAL_ARTS])
   setOffersPlaylistType(PlaylistType.SEARCH_RESULTS)
   setInitialRegion(mockCurrentRegion)
   setRegion(mockCurrentRegion)

--- a/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.tsx
@@ -33,6 +33,7 @@ import {
   setVenues,
   useVenueMapStore,
 } from 'features/venueMap/store/venueMapStore'
+import { useVenuesFilter } from 'features/venueMap/store/venuesFilterStore'
 import { useTransformOfferHits } from 'libs/algolia/fetchAlgolia/transformOfferHit'
 import { analytics } from 'libs/analytics/provider'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
@@ -49,7 +50,7 @@ export const VenueMapViewContainer: FunctionComponent = () => {
   const venues = useVenueMapStore((state) => state.venues)
   const currentRegion = useVenueMapStore((state) => state.region)
   const selectedVenue = useVenueMapStore((state) => state.selectedVenue)
-  const venueTypeCode = useVenueMapStore((state) => state.venueTypeCode)
+  const venueFilters = useVenuesFilter()
 
   const { navigate } = useNavigation<UseNavigationType>()
   const { bottom } = useSafeAreaInsets()
@@ -235,9 +236,11 @@ export const VenueMapViewContainer: FunctionComponent = () => {
       if (activeFilters.length === 0) return venues
       return venues?.filter((venue) => venue.venue_type && activeFilters.includes(venue.venue_type))
     } else {
-      return venueTypeCode ? venues?.filter((venue) => venue.venue_type === venueTypeCode) : venues
+      return venueFilters.length
+        ? venues?.filter((venue) => venue.venue_type === venueFilters[0])
+        : venues
     }
-  }, [venues, activeFilters, filterCategoriesActive, venueTypeCode])
+  }, [filterCategoriesActive, activeFilters, venues, venueFilters])
 
   return initialRegion ? (
     <Container>

--- a/src/features/venueMap/pages/VenueMap/VenueMap.native.test.tsx
+++ b/src/features/venueMap/pages/VenueMap/VenueMap.native.test.tsx
@@ -75,7 +75,7 @@ describe('<VenueMap />', () => {
       RemoteStoreFeatureFlags.WIP_VENUE_MAP_TYPE_FILTER_V2,
       RemoteStoreFeatureFlags.WIP_VENUE_MAP,
     ])
-    venueMapStore.setVenueTypeCode(VENUE_TYPE)
+    venuesFilterActions.setVenuesFilters([VENUE_TYPE])
   })
 
   afterEach(() => {
@@ -121,13 +121,13 @@ describe('<VenueMap />', () => {
   })
 
   it('Should reset venue type code in store when pressing go back button', async () => {
-    const spy = jest.spyOn(venueMapStore, 'setVenueTypeCode')
+    const spy = jest.spyOn(venuesFilterActions, 'setVenuesFilters')
     render(reactQueryProviderHOC(<VenueMap />))
 
     const goBackButton = screen.getByTestId('Revenir en arrière')
     await user.press(goBackButton)
 
-    await waitFor(() => expect(spy).toHaveBeenNthCalledWith(1, null))
+    await waitFor(() => expect(spy).toHaveBeenNthCalledWith(1, []))
   })
 
   it('Should reset store + filters when unmounting', async () => {

--- a/src/features/venueMap/pages/VenueMap/VenueMapBase.tsx
+++ b/src/features/venueMap/pages/VenueMap/VenueMapBase.tsx
@@ -4,14 +4,15 @@ import styled from 'styled-components/native'
 import { getSearchStackConfig } from 'features/navigation/SearchStackNavigator/helpers'
 import { useGoBack } from 'features/navigation/useGoBack'
 import { FilterBannerContainer } from 'features/venueMap/components/FilterBannerContainer/FilterBannerContainer'
-import { setVenueTypeCode } from 'features/venueMap/store/venueMapStore'
+import { venuesFilterActions } from 'features/venueMap/store/venuesFilterStore'
 import { PageHeaderWithoutPlaceholder } from 'ui/components/headers/PageHeaderWithoutPlaceholder'
 
 export const VenueMapBase: FunctionComponent<PropsWithChildren> = ({ children }) => {
   const { goBack } = useGoBack(...getSearchStackConfig('SearchLanding'))
+  const { setVenuesFilters } = venuesFilterActions
 
   const handleGoBack = () => {
-    setVenueTypeCode(null)
+    setVenuesFilters([])
     goBack()
   }
 

--- a/src/features/venueMap/pages/modals/VenueTypeModal/VenueTypeModal.native.test.tsx
+++ b/src/features/venueMap/pages/modals/VenueTypeModal/VenueTypeModal.native.test.tsx
@@ -3,13 +3,14 @@ import React from 'react'
 import { VenueTypeCodeKey } from 'api/gen'
 import { VenueTypeModal } from 'features/venueMap/pages/modals/VenueTypeModal/VenueTypeModal'
 import * as useVenueMapStore from 'features/venueMap/store/venueMapStore'
+import { venuesFilterActions } from 'features/venueMap/store/venuesFilterStore'
 import { venuesFixture } from 'libs/algolia/fetchAlgolia/fetchVenues/fixtures/venuesFixture'
 import { analytics } from 'libs/analytics/provider'
 import { act, fireEvent, render, screen, userEvent, waitFor } from 'tests/utils'
 
 const mockHideModal = jest.fn()
 
-const setVenueTypeCodeSpy = jest.spyOn(useVenueMapStore, 'setVenueTypeCode')
+const mockSetVenuesFilters = jest.spyOn(venuesFilterActions, 'setVenuesFilters')
 
 jest.mock('react-native/Libraries/Animated/createAnimatedComponent', () => {
   return function createAnimatedComponent(Component: unknown) {
@@ -30,7 +31,7 @@ describe('<VenueTypeModal />', () => {
 
   describe('When venue type is null', () => {
     beforeEach(() => {
-      useVenueMapStore.setVenueTypeCode(null)
+      venuesFilterActions.setVenuesFilters([])
       useVenueMapStore.setVenues(venuesFixture)
     })
 
@@ -110,14 +111,14 @@ describe('<VenueTypeModal />', () => {
       await user.press(screen.getByText('Rechercher'))
 
       await waitFor(() => {
-        expect(setVenueTypeCodeSpy).toHaveBeenCalledWith(VenueTypeCodeKey.MOVIE)
+        expect(mockSetVenuesFilters).toHaveBeenCalledWith([VenueTypeCodeKey.MOVIE])
       })
     })
   })
 
   describe('When venue type is not null', () => {
     beforeEach(() => {
-      useVenueMapStore.setVenueTypeCode(VenueTypeCodeKey.MOVIE)
+      venuesFilterActions.setVenuesFilters([VenueTypeCodeKey.MOVIE])
       useVenueMapStore.setVenues([])
     })
 

--- a/src/features/venueMap/store/venueMapStore.test.ts
+++ b/src/features/venueMap/store/venueMapStore.test.ts
@@ -21,7 +21,6 @@ describe('VenueMapStore', () => {
     expect(result.current.region).toBeUndefined()
     expect(result.current.offersPlaylistType).toBe(PlaylistType.TOP_OFFERS)
     expect(result.current.selectedVenue).toBeUndefined()
-    expect(result.current.venueTypeCode).toBeUndefined()
   })
 
   it('should set venues', () => {

--- a/src/features/venueMap/store/venueMapStore.test.ts
+++ b/src/features/venueMap/store/venueMapStore.test.ts
@@ -1,4 +1,3 @@
-import { VenueTypeCodeKey } from 'api/gen'
 import { PlaylistType } from 'features/offer/enums'
 import { venuesFixture } from 'libs/algolia/fetchAlgolia/fetchVenues/fixtures/venuesFixture'
 import { act, renderHook } from 'tests/utils'
@@ -9,7 +8,6 @@ import {
   setOffersPlaylistType,
   setRegion,
   setSelectedVenue,
-  setVenueTypeCode,
   setVenues,
   useVenueMapStore,
 } from './venueMapStore'
@@ -60,7 +58,6 @@ describe('VenueMapStore', () => {
     const REGION = { latitude: 22.9, longitude: 33.2, longitudeDelta: 2, latitudeDelta: 3 }
     act(() => {
       setVenues(venuesFixture)
-      setVenueTypeCode(VenueTypeCodeKey.BOOKSTORE)
       setOffersPlaylistType(PlaylistType.SEARCH_RESULTS)
       setInitialRegion(REGION)
       setRegion(REGION)
@@ -72,6 +69,5 @@ describe('VenueMapStore', () => {
     expect(result.current.region).toStrictEqual(REGION)
     expect(result.current.offersPlaylistType).toBe(PlaylistType.SEARCH_RESULTS)
     expect(result.current.selectedVenue).toStrictEqual(venuesFixture[1])
-    expect(result.current.venueTypeCode).toStrictEqual(VenueTypeCodeKey.BOOKSTORE)
   })
 })

--- a/src/features/venueMap/store/venueMapStore.ts
+++ b/src/features/venueMap/store/venueMapStore.ts
@@ -44,8 +44,6 @@ export const setInitialRegion = (initialRegion: Region) => {
 export const setVenues = (venues: GeolocatedVenue[]) => {
   useVenueMapStore.setState({ venues })
 }
-export const setVenueTypeCode = (venueTypeCode: VenueTypeCode | null) =>
-  useVenueMapStore.setState({ venueTypeCode })
 export const setSelectedVenue = (selectedVenue: GeolocatedVenue) =>
   useVenueMapStore.setState({ selectedVenue })
 export const removeSelectedVenue = () => useVenueMapStore.setState({ selectedVenue: undefined })

--- a/src/features/venueMap/store/venueMapStore.ts
+++ b/src/features/venueMap/store/venueMapStore.ts
@@ -4,11 +4,9 @@ import { create } from 'zustand'
 import { PlaylistType } from 'features/offer/enums'
 import { GeolocatedVenue } from 'features/venueMap/components/VenueMapView/types'
 import { Region } from 'libs/maps/maps'
-import { VenueTypeCode } from 'libs/parsers/venueType'
 
 type VenueMapStoreState = {
   offersPlaylistType: PlaylistType
-  venueTypeCode?: VenueTypeCode | null
   venues: GeolocatedVenue[]
   selectedVenue?: GeolocatedVenue | null
   region?: Region
@@ -19,7 +17,6 @@ const DEFAULT_STATE: VenueMapStoreState = {
   offersPlaylistType: PlaylistType.TOP_OFFERS,
   venues: [],
   selectedVenue: undefined,
-  venueTypeCode: undefined,
   region: undefined,
   initialRegion: undefined,
 }

--- a/src/features/venueMap/useVenuesInRegionQuery.native.test.ts
+++ b/src/features/venueMap/useVenuesInRegionQuery.native.test.ts
@@ -1,4 +1,5 @@
 import * as venueMapStore from 'features/venueMap/store/venueMapStore'
+import { venuesFilterActions } from 'features/venueMap/store/venuesFilterStore'
 import { venuesFixture as mockVenues } from 'libs/algolia/fetchAlgolia/fetchVenues/fixtures/venuesFixture'
 import { Region } from 'libs/maps/maps'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
@@ -25,7 +26,7 @@ describe('useVenuesInRegionQuery', () => {
 
   beforeAll(() => {
     act(() => {
-      venueMapStore.setVenueTypeCode(null)
+      venuesFilterActions.setVenuesFilters([])
     })
   })
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34936

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
