### PR TITLE
(PC-34957) fix(BookingPage): Revert "(PC-34243) feat(BookingPage): do…

### DIFF
--- a/src/features/bookings/components/BookingDetailsTicketContent.tsx
+++ b/src/features/bookings/components/BookingDetailsTicketContent.tsx
@@ -54,7 +54,6 @@ export function BookingDetailsTicketContent({
   const activationCode = booking.activationCode ? (
     <TicketCode withdrawalType={withdrawalType ?? undefined} code={booking.activationCode.code} />
   ) : null
-
   const accessExternalOfferButton = completedUrl ? (
     <ExternalTouchableLink
       as={ButtonWithLinearGradient}
@@ -79,7 +78,6 @@ export function BookingDetailsTicketContent({
       qrCodeData={booking.qrCodeData ?? undefined}
       externalBookings={externalBookings}
       venue={venue}
-      isEvent={isEvent}
     />
   )
 

--- a/src/features/bookings/components/TicketBody/TicketBody.native.test.tsx
+++ b/src/features/bookings/components/TicketBody/TicketBody.native.test.tsx
@@ -32,26 +32,18 @@ describe('TicketBody', () => {
   })
 
   describe('<QrCode/> display', () => {
-    it('should display the QR code when booking have a QR code and offer is not an event', () => {
-      render(
-        <TicketBody
-          {...initialProps}
-          subcategoryId={SubcategoryIdEnum.PARTITION}
-          venue={venue}
-          isEvent={false}
-        />
-      )
+    it('should display the QR code when the the booking have a QR code and the offer subcategory allows to have a qr code', () => {
+      render(<TicketBody {...initialProps} venue={venue} />)
 
       expect(screen.getByTestId('qr-code')).toBeOnTheScreen()
     })
 
-    it('should not display the QR code when booking is an event and not an external booking', () => {
+    it('should not display the QR code when event subcategory is in subcategories list without QR code display', () => {
       render(
         <TicketBody
           {...initialProps}
           subcategoryId={SubcategoryIdEnum.FESTIVAL_MUSIQUE}
           venue={venue}
-          isEvent
         />
       )
 
@@ -73,7 +65,6 @@ describe('TicketBody', () => {
               subcategoryId={SubcategoryIdEnum.FESTIVAL_MUSIQUE}
               externalBookings={{ barcode: 'barcode' }}
               venue={venue}
-              isEvent
             />
           )
 
@@ -88,7 +79,6 @@ describe('TicketBody', () => {
               subcategoryId={SubcategoryIdEnum.FESTIVAL_MUSIQUE}
               externalBookings={{ barcode: 'barcode' }}
               venue={venue}
-              isEvent
             />
           )
 
@@ -104,7 +94,6 @@ describe('TicketBody', () => {
             subcategoryId={SubcategoryIdEnum.FESTIVAL_MUSIQUE}
             externalBookings={{ barcode: 'barcode' }}
             venue={venue}
-            isEvent
           />
         )
 
@@ -119,7 +108,6 @@ describe('TicketBody', () => {
             subcategoryId={SubcategoryIdEnum.FESTIVAL_MUSIQUE}
             externalBookings={{ barcode: 'barcode' }}
             venue={venue}
-            isEvent
           />
         )
 
@@ -138,7 +126,6 @@ describe('TicketBody', () => {
               subcategoryId={SubcategoryIdEnum.FESTIVAL_MUSIQUE}
               externalBookings={{ barcode: 'barcode' }}
               venue={venue}
-              isEvent
             />
           )
 
@@ -154,7 +141,6 @@ describe('TicketBody', () => {
           subcategoryId={SubcategoryIdEnum.EVENEMENT_PATRIMOINE}
           externalBookings={{ barcode: 'barcode' }}
           venue={venue}
-          isEvent
         />
       )
 
@@ -164,7 +150,7 @@ describe('TicketBody', () => {
 
   describe('Withdrawal', () => {
     it("should not display withdrawal informations for legacy offer that doesn't withdrawal informations", () => {
-      render(<TicketBody {...initialProps} withdrawalType={undefined} venue={venue} isEvent />)
+      render(<TicketBody {...initialProps} withdrawalType={undefined} venue={venue} />)
 
       expect(screen.queryByTestId('withdrawal-info')).not.toBeOnTheScreen()
     })
@@ -178,7 +164,6 @@ describe('TicketBody', () => {
             withdrawalType={WithdrawalTypeEnum.no_ticket}
             withdrawalDelay={0}
             venue={venue}
-            isEvent
           />
         )
 
@@ -197,7 +182,6 @@ describe('TicketBody', () => {
           withdrawalType={WithdrawalTypeEnum.by_email}
           withdrawalDelay={twoDays}
           venue={venue}
-          isEvent
         />
       )
 
@@ -212,7 +196,6 @@ describe('TicketBody', () => {
             subcategoryId={SubcategoryIdEnum.FESTIVAL_MUSIQUE}
             withdrawalType={WithdrawalTypeEnum.on_site}
             venue={venue}
-            isEvent
           />
         )
 
@@ -222,7 +205,7 @@ describe('TicketBody', () => {
 
     describe('Consulter mes e-mails display', () => {
       it('should show the button to open mail', async () => {
-        render(<TicketBody {...initialProps} withdrawalType={undefined} venue={venue} isEvent />)
+        render(<TicketBody {...initialProps} withdrawalType={undefined} venue={venue} />)
 
         const checkEmailsButton = screen.queryByText('Consulter mes e-mails')
 
@@ -231,7 +214,7 @@ describe('TicketBody', () => {
 
       it('should not show the button to open mail if no mail app is available', async () => {
         mockIsMailAppAvailable = false
-        render(<TicketBody {...initialProps} withdrawalType={undefined} venue={venue} isEvent />)
+        render(<TicketBody {...initialProps} withdrawalType={undefined} venue={venue} />)
 
         const checkEmailsButton = screen.queryByText('Consulter mes e-mails')
 

--- a/src/features/bookings/components/TicketBody/TicketBody.tsx
+++ b/src/features/bookings/components/TicketBody/TicketBody.tsx
@@ -18,8 +18,15 @@ type Props = {
   qrCodeData?: string
   externalBookings?: SeatWithQrCodeProps
   venue: BookingVenueResponse
-  isEvent: boolean
 }
+
+const notQrCodeSubcategories = [
+  SubcategoryIdEnum.FESTIVAL_MUSIQUE,
+  SubcategoryIdEnum.CONCERT,
+  SubcategoryIdEnum.EVENEMENT_MUSIQUE,
+  SubcategoryIdEnum.FESTIVAL_SPECTACLE,
+  SubcategoryIdEnum.SPECTACLE_REPRESENTATION,
+]
 
 export const TicketBody: FunctionComponent<Props> = ({
   withdrawalDelay,
@@ -29,8 +36,9 @@ export const TicketBody: FunctionComponent<Props> = ({
   qrCodeData,
   externalBookings,
   venue,
-  isEvent,
 }) => {
+  const subcategoryShouldHaveQrCode = !notQrCodeSubcategories.includes(subcategoryId)
+
   if (externalBookings)
     return (
       <SafeSeatWithQrCode
@@ -42,7 +50,7 @@ export const TicketBody: FunctionComponent<Props> = ({
         {...externalBookings}
       />
     )
-  const subcategoryShouldHaveQrCode = !isEvent
+
   if (qrCodeData && subcategoryShouldHaveQrCode) return <QrCode qrCode={qrCodeData} />
 
   if (!withdrawalType) return null

--- a/src/features/bookings/components/TicketCutout.stories.tsx
+++ b/src/features/bookings/components/TicketCutout.stories.tsx
@@ -54,7 +54,6 @@ const variantConfig: Variants<typeof TicketCutout> = [
             qrCodeData={undefined}
             externalBookings={{ barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A12' }}
             venue={bookingsSnap.ongoing_bookings[0].stock.offer.venue}
-            isEvent
           />
           <StyledBody>Présente ce billet pour accéder à l’évènement</StyledBody>
         </ViewGap>
@@ -84,7 +83,6 @@ const variantConfig: Variants<typeof TicketCutout> = [
             subcategoryId={SubcategoryIdEnum.CONCERT}
             qrCodeData={undefined}
             venue={bookingsSnap.ongoing_bookings[0].stock.offer.venue}
-            isEvent
           />
         </ViewGap>
       ),

--- a/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
+++ b/src/features/bookings/pages/BookingDetails/BookingDetails.native.test.tsx
@@ -158,20 +158,7 @@ describe('BookingDetails', () => {
         expect(screen.queryByText('Accéder à l’offre')).not.toBeOnTheScreen()
       })
 
-      it('should display booking qr code when offer is not digital and is event and external booking', async () => {
-        const externalBooking: BookingsResponse['ongoing_bookings'][number] = structuredClone({
-          ...ongoingBookings,
-          externalBookings: [{ barcode: 'PASSCULTURE:v3;TOKEN:352UW4', seat: 'A12' }],
-        })
-        externalBooking.stock.offer.isDigital = false
-        renderBookingDetails(externalBooking)
-
-        await screen.findByText('Ma réservation')
-
-        expect(await screen.findByTestId('qr-code')).toBeOnTheScreen()
-      })
-
-      it('should not display booking qr code when offer is not digital and is event and not an external booking', async () => {
+      it('should display booking qr code if offer is physical', async () => {
         const booking: BookingsResponse['ongoing_bookings'][number] =
           structuredClone(ongoingBookings)
         booking.stock.offer.isDigital = false
@@ -179,7 +166,7 @@ describe('BookingDetails', () => {
 
         await screen.findByText('Ma réservation')
 
-        expect(screen.queryByTestId('qr-code')).not.toBeOnTheScreen()
+        expect(await screen.findByTestId('qr-code')).toBeOnTheScreen()
       })
 
       it('should display EAN code if offer is a book (digital or physical)', async () => {


### PR DESCRIPTION
… not show Qr code for subcategoies that are event and not coming from syncro (#7657)"

This reverts commit 65aafa51bf9d192938cea600c02a38fbdc35a1ac.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34957
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

![Screenshot 2025-03-05 at 14 42 31](https://github.com/user-attachments/assets/9b53f256-5bb9-4bf2-ab81-61a84ec0f103)


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
