### PR TITLE
(PC-34965) feat(location): remove wipAppV2LocationWidget FF

### DIFF
--- a/src/features/location/components/LocationWidget.native.test.tsx
+++ b/src/features/location/components/LocationWidget.native.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import { LocationWidget } from 'features/location/components/LocationWidget'
 import { ScreenOrigin } from 'features/location/enums'
-import { act, fireEvent, render, screen } from 'tests/utils'
+import { act, render, screen, userEvent } from 'tests/utils'
 
 jest.unmock('@react-navigation/native')
 
@@ -17,13 +17,17 @@ jest.mock('ui/components/modals/useModal', () => ({
   }),
 }))
 
+const user = userEvent.setup()
+
+jest.useFakeTimers()
+
 describe('LocationWidget', () => {
   it('should show modal when pressing widget', async () => {
     renderLocationWidget()
 
     const button = screen.getByTestId('Ouvrir la modale de localisation depuis le widget')
 
-    fireEvent.press(button)
+    await user.press(button)
 
     expect(mockShowModal).toHaveBeenCalledTimes(1)
   })
@@ -63,7 +67,7 @@ describe('LocationWidget', () => {
 
     const button = screen.getByLabelText('Fermer le tooltip')
 
-    fireEvent.press(button)
+    await user.press(button)
 
     expect(
       screen.queryByText(

--- a/src/features/location/components/LocationWidget.native.test.tsx
+++ b/src/features/location/components/LocationWidget.native.test.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 
 import { LocationWidget } from 'features/location/components/LocationWidget'
 import { ScreenOrigin } from 'features/location/enums'
-import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { act, fireEvent, render, screen } from 'tests/utils'
 
 jest.unmock('@react-navigation/native')
@@ -19,10 +18,6 @@ jest.mock('ui/components/modals/useModal', () => ({
 }))
 
 describe('LocationWidget', () => {
-  beforeEach(() => {
-    setFeatureFlags() // TODO(PC-34435): add tests for WIP_APP_V2_LOCATION_WIDGET
-  })
-
   it('should show modal when pressing widget', async () => {
     renderLocationWidget()
 

--- a/src/features/location/components/LocationWidget.stories.tsx
+++ b/src/features/location/components/LocationWidget.stories.tsx
@@ -1,5 +1,5 @@
 import { NavigationContainer } from '@react-navigation/native'
-import { ComponentStory, ComponentMeta } from '@storybook/react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
 
 import { ScreenOrigin } from 'features/location/enums'
@@ -23,6 +23,5 @@ const Template: ComponentStory<typeof LocationWidget> = () => (
   <LocationWidget screenOrigin={ScreenOrigin.HOME} />
 )
 
-// Not exported and broken story story du to FF
-const Default = Template.bind({})
-Default.args = {}
+export const Default = Template.bind({})
+Default.storyName = 'LocationWidget'

--- a/src/features/location/components/LocationWidget.tsx
+++ b/src/features/location/components/LocationWidget.tsx
@@ -7,16 +7,12 @@ import { SearchLocationModal } from 'features/location/components/SearchLocation
 import { ScreenOrigin } from 'features/location/enums'
 import { getLocationTitle } from 'features/location/helpers/getLocationTitle'
 import { useLocationWidgetTooltip } from 'features/location/helpers/useLocationWidgetTooltip'
-import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
-import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { useLocation } from 'libs/location'
 import { LocationMode } from 'libs/location/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { useModal } from 'ui/components/modals/useModal'
 import { Tooltip } from 'ui/components/Tooltip'
 import { Touchable } from 'ui/components/touchable/Touchable'
-import { BicolorLocationPointer } from 'ui/svg/icons/BicolorLocationPointer'
-import { LocationPointer } from 'ui/svg/icons/LocationPointer'
 import { LocationPointerAppV2 } from 'ui/svg/icons/LocationPointerAppV2'
 import { getSpacing, TypoDS } from 'ui/theme'
 
@@ -30,10 +26,6 @@ type Props = {
 }
 
 export const LocationWidget: FunctionComponent<Props> = ({ screenOrigin }) => {
-  const shouldDisplayLocationWidgetAppV2 = useFeatureFlag(
-    RemoteStoreFeatureFlags.WIP_APP_V2_LOCATION_WIDGET
-  )
-
   const shouldShowHomeLocationModal = screenOrigin === ScreenOrigin.HOME
 
   const { place, selectedLocationMode } = useLocation()
@@ -56,11 +48,6 @@ export const LocationWidget: FunctionComponent<Props> = ({ screenOrigin }) => {
 
   const isWidgetHighlighted = selectedLocationMode !== LocationMode.EVERYWHERE
 
-  const locationIconAppV2 = isWidgetHighlighted ? (
-    <LocationPointerAppV2Filled />
-  ) : (
-    <LocationPointerAppV2NotFilled />
-  )
   const locationIcon = isWidgetHighlighted ? (
     <LocationPointerFilled />
   ) : (
@@ -82,9 +69,7 @@ export const LocationWidget: FunctionComponent<Props> = ({ screenOrigin }) => {
         onPress={showLocationModal}
         accessibilityLabel="Ouvrir la modale de localisation depuis le widget"
         {...(Platform.OS === 'web' ? { ref: touchableRef } : { onLayout: onWidgetLayout })}>
-        <IconContainer isActive={isWidgetHighlighted}>
-          {shouldDisplayLocationWidgetAppV2 ? locationIconAppV2 : locationIcon}
-        </IconContainer>
+        <IconContainer isActive={isWidgetHighlighted}>{locationIcon}</IconContainer>
         <StyledCaption numberOfLines={1}>{locationTitle}</StyledCaption>
       </StyledTouchable>
       {shouldShowHomeLocationModal ? (
@@ -125,23 +110,12 @@ const IconContainer = styled(Animated.View)<{ isActive: boolean }>(({ theme, isA
   backgroundColor: theme.colors.white,
 }))
 
-const LocationPointerFilled = styled(LocationPointer).attrs(({ theme }) => ({
+const LocationPointerFilled = styled(LocationPointerAppV2).attrs(({ theme }) => ({
   color: theme.colors.primary,
   size: theme.icons.sizes.small,
 }))({})
 
-const LocationPointerNotFilled = styled(BicolorLocationPointer).attrs(({ theme }) => ({
-  color: theme.colors.black,
-  color2: theme.colors.black,
-  size: theme.icons.sizes.small,
-}))``
-
-const LocationPointerAppV2Filled = styled(LocationPointerAppV2).attrs(({ theme }) => ({
-  color: theme.colors.primary,
-  size: theme.icons.sizes.small,
-}))({})
-
-const LocationPointerAppV2NotFilled = styled(LocationPointerAppV2).attrs(({ theme }) => ({
+const LocationPointerNotFilled = styled(LocationPointerAppV2).attrs(({ theme }) => ({
   color: theme.colors.greyMedium,
   size: theme.icons.sizes.small,
 }))({})

--- a/src/features/location/components/LocationWidgetDesktop.web.test.tsx
+++ b/src/features/location/components/LocationWidgetDesktop.web.test.tsx
@@ -2,17 +2,12 @@ import { NavigationContainer } from '@react-navigation/native'
 import React from 'react'
 
 import { LocationWidgetDesktop } from 'features/location/components/LocationWidgetDesktop'
-import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { act, fireEvent, render, screen } from 'tests/utils/web'
 
 jest.unmock('@react-navigation/native')
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 
 describe('LocationWidgetDesktop', () => {
-  beforeEach(() => {
-    setFeatureFlags() // TODO(PC-34435): add tests for WIP_APP_V2_LOCATION_WIDGET
-  })
-
   afterEach(async () => {
     await act(async () => {
       jest.runOnlyPendingTimers()

--- a/src/features/location/components/LocationWidgetWrapperDesktop.tsx
+++ b/src/features/location/components/LocationWidgetWrapperDesktop.tsx
@@ -5,16 +5,12 @@ import styled, { useTheme } from 'styled-components/native'
 import { useLocationForLocationWidgetDesktop } from 'features/location/components/useLocationForLocationWidgetDesktop'
 import { ScreenOrigin } from 'features/location/enums'
 import { useLocationWidgetTooltip } from 'features/location/helpers/useLocationWidgetTooltip'
-import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
-import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { styledButton } from 'ui/components/buttons/styledButton'
 import { useModal } from 'ui/components/modals/useModal'
 import { Tooltip } from 'ui/components/Tooltip'
 import { Touchable } from 'ui/components/touchable/Touchable'
 import { ArrowDown } from 'ui/svg/icons/ArrowDown'
-import { LocationPointer } from 'ui/svg/icons/LocationPointer'
 import { LocationPointerAppV2 } from 'ui/svg/icons/LocationPointerAppV2'
-import { LocationPointerNotFilled } from 'ui/svg/icons/LocationPointerNotFilled'
 import { getSpacing, Spacer, TypoDS } from 'ui/theme'
 
 const TOOLTIP_WIDTH = getSpacing(58)
@@ -42,9 +38,6 @@ export const LocationWidgetWrapperDesktop: React.FC<LocationWidgetWrapperDesktop
   children,
   screenOrigin,
 }) => {
-  const shouldDisplayLocationWidgetAppV2 = useFeatureFlag(
-    RemoteStoreFeatureFlags.WIP_APP_V2_LOCATION_WIDGET
-  )
   const { icons } = useTheme()
   const {
     title: locationTitle,
@@ -72,19 +65,12 @@ export const LocationWidgetWrapperDesktop: React.FC<LocationWidgetWrapperDesktop
     showLocationModal()
   }
 
-  const locationIconAppV2 = isWidgetHighlighted ? (
-    <LocationPointerAppV2Filled />
-  ) : (
-    <LocationPointerAppV2NotFilled />
-  )
   const locationIcon = isWidgetHighlighted ? (
-    <LocationPointerFilled size={icons.sizes.extraSmall} testID="location pointer filled" />
+    <LocationPointerFilled testID="location pointer filled" />
   ) : (
-    <SmallLocationPointerNotFilled
-      size={icons.sizes.extraSmall}
-      testID="location pointer not filled"
-    />
+    <LocationPointerNotFilled testID="location pointer not filled" />
   )
+
   return (
     <React.Fragment>
       {enableTooltip ? (
@@ -100,7 +86,7 @@ export const LocationWidgetWrapperDesktop: React.FC<LocationWidgetWrapperDesktop
         onPress={onPressLocationButton}
         testID={testId}
         accessibilityLabel={testId}>
-        <NotShrunk>{shouldDisplayLocationWidgetAppV2 ? locationIconAppV2 : locationIcon}</NotShrunk>
+        <NotShrunk>{locationIcon}</NotShrunk>
         <Spacer.Row numberOfSpaces={1} />
         <LocationTitle>{locationTitle}</LocationTitle>
         <Spacer.Row numberOfSpaces={2} />
@@ -133,21 +119,12 @@ const NotShrunk = styled.View({
   flexShrink: undefined,
 })
 
-const LocationPointerFilled = styled(LocationPointer).attrs(({ theme }) => ({
+const LocationPointerFilled = styled(LocationPointerAppV2).attrs(({ theme }) => ({
   color: theme.colors.primary,
   size: theme.icons.sizes.small,
 }))({})
 
-const SmallLocationPointerNotFilled = styled(LocationPointerNotFilled).attrs(({ theme }) => ({
-  size: theme.icons.sizes.small,
-}))``
-
-const LocationPointerAppV2Filled = styled(LocationPointerAppV2).attrs(({ theme }) => ({
-  color: theme.colors.primary,
-  size: theme.icons.sizes.small,
-}))({})
-
-const LocationPointerAppV2NotFilled = styled(LocationPointerAppV2).attrs(({ theme }) => ({
+const LocationPointerNotFilled = styled(LocationPointerAppV2).attrs(({ theme }) => ({
   color: theme.colors.greyMedium,
   size: theme.icons.sizes.small,
 }))({})

--- a/src/libs/firebase/firestore/types.ts
+++ b/src/libs/firebase/firestore/types.ts
@@ -58,7 +58,6 @@ export enum RemoteStoreFeatureFlags {
   TARGET_XP_CINE_FROM_OFFER = 'targetXpCineFromOffer',
   WIP_APP_V2_BUSINESS_BLOCK = 'wipAppV2BusinessBlock',
   WIP_APP_V2_CATEGORY_BLOCK = 'wipAppV2CategoryBlock',
-  WIP_APP_V2_LOCATION_WIDGET = 'wipAppV2LocationWidget',
   WIP_APP_V2_MULTI_VIDEO_MODULE = 'wipAppV2MultiVideoModule',
   WIP_APP_V2_SEARCH_LANDING_HEADER = 'wipAppV2SearchLandingHeader',
   WIP_APP_V2_THEMATIC_HOME_HEADER = 'wipAppV2ThematicHomeHeader',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34965

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |![Capture d’écran 2025-03-05 à 17 16 01](https://github.com/user-attachments/assets/d21ccea8-1b85-4642-9714-2a57215f04d4) ![Capture d’écran 2025-03-05 à 17 16 11](https://github.com/user-attachments/assets/3eba6922-4a21-4646-9c38-ea85e1eebdd9)|![Capture d’écran 2025-03-05 à 17 27 58](https://github.com/user-attachments/assets/38a5afd1-5302-4534-9488-1521a3482c26) ![Capture d’écran 2025-03-05 à 17 28 06](https://github.com/user-attachments/assets/6069f443-db30-4362-b9d3-2414a674ae47)|
| Android          |<img width="415" alt="Capture d’écran 2025-03-05 à 17 26 41" src="https://github.com/user-attachments/assets/ae6fcb09-b5f5-4739-9143-bab9c32e49b1" /> <img width="406" alt="Capture d’écran 2025-03-05 à 17 27 05" src="https://github.com/user-attachments/assets/09c7d20f-9d5e-490c-ac5f-6fc3bb2e0554" />|<img width="402" alt="Capture d’écran 2025-03-05 à 17 27 23" src="https://github.com/user-attachments/assets/1d1da574-e18f-47ef-9239-0b22cd7c209d" /> <img width="406" alt="Capture d’écran 2025-03-05 à 17 27 33" src="https://github.com/user-attachments/assets/403beb68-04d2-453c-bc35-b0eb15d987a2" />|
| Phone - Chrome   |               |<img width="377" alt="Capture d’écran 2025-03-05 à 17 28 39" src="https://github.com/user-attachments/assets/7e4fde87-d22b-437e-8520-08e265040319" /> <img width="377" alt="Capture d’écran 2025-03-05 à 17 28 47" src="https://github.com/user-attachments/assets/6a3500f9-bcf1-4fd5-b57a-8ba3febb6a1d" />|
| Desktop - Chrome |![Capture d’écran 2025-03-05 à 17 16 32](https://github.com/user-attachments/assets/89c2791f-823c-4955-9e79-521526ec3897) ![Capture d’écran 2025-03-05 à 17 16 40](https://github.com/user-attachments/assets/7cb6a0e0-207e-441d-8381-8d1af58d8106)|<img width="1725" alt="Capture d’écran 2025-03-05 à 17 28 24" src="https://github.com/user-attachments/assets/2cc2fbfc-8f77-4322-849f-6453579a76b9" /> <img width="1720" alt="Capture d’écran 2025-03-05 à 17 28 31" src="https://github.com/user-attachments/assets/7b77f2d5-ffb4-4011-a5cd-9effa248a725" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>
These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs
</details>
