### PR TITLE
(BSR) chore(env): avoid spamming when proxy is not installed

### DIFF
--- a/scripts/is_proxy_enabled.sh
+++ b/scripts/is_proxy_enabled.sh
@@ -4,7 +4,7 @@ set -o errexit -o nounset -o pipefail
 PROXY_DIAGNOSTIC="$(realpath '/Library/Application Support'/*/*/*diag 2>/dev/null || echo '')"
 
 if [ -n "${PROXY_DIAGNOSTIC+x}" ]; then
-	"$PROXY_DIAGNOSTIC" -f | grep "TUNNEL_CONNECTED" >/dev/null
+	"$PROXY_DIAGNOSTIC" -f 2>/dev/null | grep "TUNNEL_CONNECTED" >/dev/null
 else
 	return 1
 fi


### PR DESCRIPTION


Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
