### PR TITLE
(BSR) build(Android): try to avoid flaky certificate added

### DIFF
--- a/scripts/start_android_emulator_with_certificate.sh
+++ b/scripts/start_android_emulator_with_certificate.sh
@@ -5,6 +5,8 @@ SSL_CERT_FILE="$(realpath '/Library/Application Support'/*/*/data/*cacert.pem 2>
 
 SCRIPT_FOLDER="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
+WAIT_BOOT_COMPLETED="${WAIT_BOOT_COMPLETED:-5}"
+
 choose_an_emulator() {
 	emulator -list-avds |
 		grep -v 'INFO' |
@@ -44,6 +46,8 @@ if sh "$SCRIPT_FOLDER/is_proxy_enabled.sh"; then
 	start_android_emulator >/dev/null &
 
 	adb wait-for-device
+
+	sleep "${WAIT_BOOT_COMPLETED}" # try to avoid flakiness : sometimes certificate is added, sometimes it isn't probably because the device hasn't finished to boot
 
 	add_certificate_to_this_session
 fi


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-XXXXX

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on Android simulator

[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4


