### PR TITLE
(BSR) chore(deps): update tools

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -1,6 +1,9 @@
 {
   "lockfile_version": "1",
   "packages": {
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "resolved": "github:NixOS/nixpkgs/02032da4af073d0f6110540c8677f16d4be0117f?lastModified=1741037377&narHash=sha256-SvtvVKHaUX4Owb%2BPasySwZsoc5VUeTf1px34BByiOxw%3D"
+    },
     "nodejs@20.10.0": {
       "last_modified": "2024-01-14T03:55:27Z",
       "plugin_version": "0.0.2",
@@ -118,50 +121,50 @@
       }
     },
     "watchman@latest": {
-      "last_modified": "2025-02-09T21:53:45Z",
-      "resolved": "github:NixOS/nixpkgs/b2243f41e860ac85c0b446eadc6930359b294e79#watchman",
+      "last_modified": "2025-02-23T09:42:26Z",
+      "resolved": "github:NixOS/nixpkgs/2d068ae5c6516b2d04562de50a58c682540de9bf#watchman",
       "source": "devbox-search",
-      "version": "2025.01.06.00",
+      "version": "2025.02.10.00",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/949r217qcgj3gkghr4g4za2qd1ib7c64-watchman-2025.01.06.00",
+              "path": "/nix/store/s1m8b0757s9kjfa5lrw6a1q9czsl614a-watchman-2025.02.10.00",
               "default": true
             }
           ],
-          "store_path": "/nix/store/949r217qcgj3gkghr4g4za2qd1ib7c64-watchman-2025.01.06.00"
+          "store_path": "/nix/store/s1m8b0757s9kjfa5lrw6a1q9czsl614a-watchman-2025.02.10.00"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/fddh8mnv3h0acakzd6fmigdfsb7s3rx0-watchman-2025.01.06.00",
+              "path": "/nix/store/562hi6js3q6dflx1cfh6lqbmp4bby3wb-watchman-2025.02.10.00",
               "default": true
             }
           ],
-          "store_path": "/nix/store/fddh8mnv3h0acakzd6fmigdfsb7s3rx0-watchman-2025.01.06.00"
+          "store_path": "/nix/store/562hi6js3q6dflx1cfh6lqbmp4bby3wb-watchman-2025.02.10.00"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/slna805vss31iajkgqb7zagpywa0maxj-watchman-2025.01.06.00",
+              "path": "/nix/store/g6nr5i8h7jlk5dk471sfccc6nfxs5629-watchman-2025.02.10.00",
               "default": true
             }
           ],
-          "store_path": "/nix/store/slna805vss31iajkgqb7zagpywa0maxj-watchman-2025.01.06.00"
+          "store_path": "/nix/store/g6nr5i8h7jlk5dk471sfccc6nfxs5629-watchman-2025.02.10.00"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/wlaa8gzf696nnffscxnyhjh5kpramqsi-watchman-2025.01.06.00",
+              "path": "/nix/store/ddg1viq1jk86hr5nbyg3is637j5rsrz9-watchman-2025.02.10.00",
               "default": true
             }
           ],
-          "store_path": "/nix/store/wlaa8gzf696nnffscxnyhjh5kpramqsi-watchman-2025.01.06.00"
+          "store_path": "/nix/store/ddg1viq1jk86hr5nbyg3is637j5rsrz9-watchman-2025.02.10.00"
         }
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725910328,
-        "narHash": "sha256-n9pCtzGZ0httmTwMuEbi5E78UQ4ZbQMr1pzi5N0LAG8=",
+        "lastModified": 1741037377,
+        "narHash": "sha256-SvtvVKHaUX4Owb+PasySwZsoc5VUeTf1px34BByiOxw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5775c2583f1801df7b790bf7f7d710a19bac66f4",
+        "rev": "02032da4af073d0f6110540c8677f16d4be0117f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

sur master: setup fonctionnel avec Nix avec proxy désactivé (https://github.com/DeterminateSystems/nix-installer/issues/1465)
EDIT: ios CLI erreur 65

I have:

```sh
npx rn-game-over --all --no-install ; direnv deny
rm -rf .direnv .devbox .venv ios/Pods
direnv allow
```

Then:

Xcode > Product > Clean build folder

Then:

- [ ] `yarn start:web:testing`
- [ ] `yarn android:testing`
- [ ] ~~`yarn ios:staging` (j'ai pas cherché le google truc json de testing)~~ ne fonctionne plus sur master alors que ça fonctionnait il y a 1 semaine, ne fonctionne pas sur cette branche (erreur 65)
- [ ] Android Studio build
- [ ] XCode build
- [ ] `yarn test:e2e:android:testing`
- [ ] `yarn test:unit src/features/artist/pages/Artist.native.test.tsx`
- [ ] `yarn test:unit:web src/features/auth/pages/login/Login.web.test.tsx`

||Before|After|
|:--|:--|:--|
|`devbox version`|0.12.0|0.14.0|
|`java --version`|openjdk 17.0.10 2024-01-16 LTS|openjdk 17.0.12 2024-07-16 LTS|
|`jq --version`|jq-1.7.1|jq-1.7.1|
|`python3 --version`|Python 3.12.5|Python 3.12.9|
|`maestro --version`|1.37.9|1.39.13|
|`act --version`|act version 0.2.66|act version 0.2.74|
|`gh --version`|gh version 2.55.0 (1980-01-01)|gh version 2.67.0 (1980-01-01)|
|`podman --version`|podman version 5.2.2|podman version 5.4.0|
|`node --version`|v20.10.0|v20.10.0|
|`ruby --version`|ruby 2.7.5p203 (2021-11-24) [arm64-darwin21]|ruby 2.7.5p203 (2021-11-24) [arm64-darwin21]|
|`bundle --version`|Bundler version 2.1.4|Bundler version 2.1.4|
|`watchman version`|version: 2025.01.06.00|🤔|

🤔 ça affiche `2025.01.06.00` alors que ça pointe sur `/nix/store/s1m8b0757s9kjfa5lrw6a1q9czsl614a-watchman-2025.02.10.00/bin/watchman`

## End of Life

- [Ruby](https://endoflife.date/ruby) ❌
- [NodeJS](https://endoflife.date/nodejs) ✅ 
- [Java](https://endoflife.date/eclipse-temurin) ✅ ou [Java](https://endoflife.date/azul-zulu) ✅ 
- [podman](https://endoflife.date/podman) ✅ 
- [python](https://endoflife.date/python) ✅ 

[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>

- [ ] setup fonctionnel avec Nix avec proxy actif Yassin
- [ ] setup fonctionnel avec Nix sans proxy Bruno
- [ ] setup fonctionnel avec Nix avec proxy inactif Nolwen
- [ ] setup fonctionnel sans Nix avec proxy actif Chris
- [ ] setup fonctionnel sans Nix sans proxy Xavier
- [ ] setup fonctionnel sans Nix avec proxy inactif Inès
- [ ] jesaisplus Maestro Axel