### PR TITLE
spike: offer tile tracking

### DIFF
--- a/src/features/home/components/modules/HomeModule.tsx
+++ b/src/features/home/components/modules/HomeModule.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from 'react'
+import { FlatListProps } from 'react-native'
 
 import { BusinessModule } from 'features/home/components/modules/business/BusinessModule'
 import { CategoryListModule } from 'features/home/components/modules/categories/CategoryListModule'
@@ -40,17 +41,20 @@ const UnmemoizedModule = ({
   homeEntryId,
   data,
   videoModuleId,
+  onViewableItemsChanged,
 }: {
   item: HomepageModule
   index: number
   homeEntryId: string
   data?: ModuleData
   videoModuleId?: string
+  onViewableItemsChanged: FlatListProps<unknown>['onViewableItemsChanged']
 }) => {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   if (isExclusivityModule(item)) return null
   const ComponentModule: any = modules[item.type]
   if (!ComponentModule) return null
+
   return (
     <ComponentModule
       {...item}
@@ -59,6 +63,7 @@ const UnmemoizedModule = ({
       moduleId={item.id}
       data={data}
       shouldShowModal={item.id === videoModuleId}
+      onViewableItemsChanged={onViewableItemsChanged}
     />
   )
 }

--- a/src/features/home/components/modules/HomeModule.tsx
+++ b/src/features/home/components/modules/HomeModule.tsx
@@ -1,11 +1,10 @@
 import React, { memo } from 'react'
-import { FlatListProps } from 'react-native'
 
 import { BusinessModule } from 'features/home/components/modules/business/BusinessModule'
 import { CategoryListModule } from 'features/home/components/modules/categories/CategoryListModule'
 import { ExclusivityModule } from 'features/home/components/modules/exclusivity/ExclusivityModule'
 import { HighlightOfferModule } from 'features/home/components/modules/HighlightOfferModule'
-import { OffersModule } from 'features/home/components/modules/OffersModule'
+import { OffersModule, OffersModuleProps } from 'features/home/components/modules/OffersModule'
 import { RecommendationModule } from 'features/home/components/modules/RecommendationModule'
 import { ThematicHighlightModule } from 'features/home/components/modules/ThematicHighlightModule'
 import { TrendsModule } from 'features/home/components/modules/TrendsModule'
@@ -41,14 +40,21 @@ const UnmemoizedModule = ({
   homeEntryId,
   data,
   videoModuleId,
-  onViewableItemsChanged,
+  onModuleViewableItemsChanged,
 }: {
   item: HomepageModule
   index: number
   homeEntryId: string
   data?: ModuleData
   videoModuleId?: string
-  onViewableItemsChanged: FlatListProps<unknown>['onViewableItemsChanged']
+  onModuleViewableItemsChanged?: ({
+    moduleId,
+    index,
+    changedItemIds,
+    homeEntryId,
+  }: Pick<OffersModuleProps, 'homeEntryId' | 'index' | 'moduleId'> & {
+    changedItemIds: string[]
+  }) => void
 }) => {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   if (isExclusivityModule(item)) return null
@@ -63,7 +69,9 @@ const UnmemoizedModule = ({
       moduleId={item.id}
       data={data}
       shouldShowModal={item.id === videoModuleId}
-      onViewableItemsChanged={onViewableItemsChanged}
+      onViewableItemsChanged={(changedItemIds: string[]) =>
+        onModuleViewableItemsChanged?.({ index, moduleId: item.id, changedItemIds, homeEntryId })
+      }
     />
   )
 }

--- a/src/features/home/pages/GenericHome.tsx
+++ b/src/features/home/pages/GenericHome.tsx
@@ -2,6 +2,7 @@ import { useScrollToTop } from '@react-navigation/native'
 import { without } from 'lodash'
 import React, { FunctionComponent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
+  FlatListProps,
   NativeScrollEvent,
   NativeSyntheticEvent,
   Platform,
@@ -62,6 +63,12 @@ type GenericHomeProps = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const keyExtractor = (item: any) => item.id
 
+const handleViewableItemsChanged: FlatListProps<unknown>['onViewableItemsChanged'] = ({
+  changed,
+}) => {
+  console.log(changed)
+}
+
 const renderModule = (
   { item, index }: { item: HomepageModule; index: number },
   homeId: string,
@@ -73,6 +80,7 @@ const renderModule = (
     homeEntryId={homeId}
     data={isOffersModule(item) || isVenuesModule(item) ? item.data : undefined}
     videoModuleId={videoModuleId}
+    onViewableItemsChanged={handleViewableItemsChanged}
   />
 )
 

--- a/src/shared/analytics/trackOfferPlaylistView.ts
+++ b/src/shared/analytics/trackOfferPlaylistView.ts
@@ -1,0 +1,32 @@
+import { PageTrackingInfo } from 'store/tracking/types'
+
+type TrackingFunction<P = unknown> = (params: P) => Promise<void>
+
+let trackingFn: TrackingFunction | null = null
+
+export const setOfferPlaylistViewTrackingFn = <P>(fn: TrackingFunction<P>) => {
+  trackingFn = fn as TrackingFunction
+}
+
+export const trackOfferPlaylistView = async (trackingInfo: PageTrackingInfo) => {
+  const tracking = trackingFn
+
+  if (!tracking) {
+    throw new Error('Tracking function is not set.')
+  }
+
+  // Get state from store
+  const { pageId, pageLocation, playlists } = trackingInfo
+  // chain promises to send them sequentially
+  try {
+    await playlists.reduce(
+      (previous, current) =>
+        previous.then(() => {
+          tracking({ id: pageId, location: pageLocation, ...current })
+        }),
+      Promise.resolve()
+    )
+  } catch (err) {
+    console.error(err)
+  }
+}


### PR DESCRIPTION
Link to JIRA ticket: 
https://passculture.atlassian.net/browse/PC-34999
https://passculture.atlassian.net/browse/PC-33729

Base de départ pour pouvoir tracker toutes les offres vues par l'utilisateur sur la home.
Strat Tech : 
- on utilise une combinaison entre `IntersectionObserver` et l'event `onViewableItemsChanged` de la FlatList

⚠️  Effacer cette branche une fois que la feature sera mise en place 

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.


[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
