### PR TITLE
(PC-34985) feat(reaction): use new UI to display likes on offer page

### DIFF
--- a/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
+++ b/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent, useCallback, useMemo } from 'react'
 
 import { OfferResponseV2, PostReactionRequest, ReactionTypeEnum } from 'api/gen'
-import { useAuthContext } from 'features/auth/context/AuthContext'
 import { OfferReactions } from 'features/offer/components/OfferReactions/OfferReactions'
 import { useReactionMutation } from 'features/reactions/api/useReactionMutation'
 import { ReactionChoiceValidation } from 'features/reactions/components/ReactionChoiceValidation/ReactionChoiceValidation'
@@ -16,7 +15,6 @@ type Props = {
 
 export const OfferReactionSection: FunctionComponent<Props> = ({ offer }) => {
   const isReactionFeatureActive = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
-  const { isLoggedIn, user } = useAuthContext()
   const { data: bookings } = useBookingsQuery()
   const { mutate: addReaction } = useReactionMutation()
 
@@ -47,13 +45,7 @@ export const OfferReactionSection: FunctionComponent<Props> = ({ offer }) => {
 
   return (
     <ViewGap gap={4}>
-      <OfferReactions
-        user={user}
-        isLoggedIn={isLoggedIn}
-        offer={offer}
-        userCanReact={userBooking?.canReact}
-        userBooking={userBooking}
-      />
+      <OfferReactions offer={offer} />
 
       {userBooking?.canReact ? (
         <ReactionChoiceValidation

--- a/src/features/offer/components/OfferReactions/OfferReactions.native.test.tsx
+++ b/src/features/offer/components/OfferReactions/OfferReactions.native.test.tsx
@@ -1,148 +1,31 @@
 import React from 'react'
 
-import { OfferResponseV2, ReactionTypeEnum } from 'api/gen'
-import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
+import { OfferResponseV2 } from 'api/gen'
 import { OfferReactions } from 'features/offer/components/OfferReactions/OfferReactions'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
-import { beneficiaryUser, nonBeneficiaryUser } from 'fixtures/user'
-import { mockAuthContextWithUser, mockAuthContextWithoutUser } from 'tests/AuthContextUtils'
 import { render, screen } from 'tests/utils'
 
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
 jest.mock('libs/firebase/analytics/analytics')
-jest.mock('features/auth/context/AuthContext')
 
-const mockBookings = { ...bookingsSnap }
-const mockUseBookings = jest.fn(() => ({
-  data: mockBookings,
-}))
-jest.mock('queries/bookings/useBookingsQuery', () => ({
-  useBookingsQuery: jest.fn(() => mockUseBookings()),
-}))
-
-it('should display "Sois le premier à réagir :" when there are no likes and the user is connected, beneficiary and has possibility to react', async () => {
-  const offerWithoutLikes: OfferResponseV2 = {
-    ...offerResponseSnap,
-    reactionsCount: { likes: 0 },
-  }
-
-  mockAuthContextWithUser(beneficiaryUser, { persist: true })
-  render(
-    <OfferReactions isLoggedIn user={beneficiaryUser} offer={offerWithoutLikes} userCanReact />
-  )
-
-  expect(await screen.findByText('Sois le premier à réagir :')).toBeOnTheScreen()
-})
-
-it('should display "Aimé par 1 jeune" when there is 1 like and the user is connected and beneficiary', async () => {
+it('should display "1 j’aime" when there is 1 like', async () => {
   const offerWithOneLike = {
     ...offerResponseSnap,
     reactionsCount: { likes: 1 },
   }
+  render(<OfferReactions offer={offerWithOneLike} />)
 
-  mockAuthContextWithUser(beneficiaryUser, { persist: true })
-  render(<OfferReactions isLoggedIn user={beneficiaryUser} offer={offerWithOneLike} />)
-
-  expect(await screen.findByText('Aimé par 1 jeune')).toBeOnTheScreen()
+  expect(await screen.findByText('1 j’aime')).toBeOnTheScreen()
+  expect(screen.getByTestId('thumbUp')).toBeOnTheScreen()
 })
 
-it('should display "Aimé par X jeunes" when there are multiple likes and the user is connected and beneficiary', async () => {
-  const offerWithMultipleLikes = {
-    ...offerResponseSnap,
-    reactionsCount: { likes: 3 },
-  }
-
-  mockAuthContextWithUser(beneficiaryUser, { persist: true })
-  render(<OfferReactions isLoggedIn user={beneficiaryUser} offer={offerWithMultipleLikes} />)
-
-  expect(await screen.findByText('Aimé par 3 jeunes')).toBeOnTheScreen()
-})
-
-it('should display "Aimé par X jeunes" when the user is not connected', async () => {
-  const offerWithLikes = {
-    ...offerResponseSnap,
-    reactionsCount: { likes: 2 },
-  }
-
-  mockAuthContextWithoutUser()
-
-  render(<OfferReactions isLoggedIn={false} user={undefined} offer={offerWithLikes} />)
-
-  expect(screen.queryByText('Sois le premier à réagir :')).not.toBeOnTheScreen()
-  expect(await screen.findByText('Aimé par 2 jeunes')).toBeOnTheScreen()
-})
-
-it('should display "Aimé par X jeunes" when the user is not beneficiary', async () => {
-  const offerWithLikes = {
-    ...offerResponseSnap,
-    reactionsCount: { likes: 2 },
-  }
-
-  mockAuthContextWithUser(nonBeneficiaryUser, { persist: true })
-
-  render(<OfferReactions isLoggedIn={false} user={undefined} offer={offerWithLikes} />)
-
-  expect(screen.queryByText('Sois le premier à réagir :')).not.toBeOnTheScreen()
-  expect(await screen.findByText('Aimé par 2 jeunes')).toBeOnTheScreen()
-})
-
-it('should display nothing when the user is not connected', async () => {
-  const offerWithLikes = {
-    ...offerResponseSnap,
-    reactionsCount: { likes: 0 },
-  }
-
-  mockAuthContextWithoutUser()
-  render(<OfferReactions isLoggedIn user={nonBeneficiaryUser} offer={offerWithLikes} />)
-
-  expect(screen.queryByText('Sois le premier à réagir :')).not.toBeOnTheScreen()
-  expect(screen.queryByText(/Aimé par/)).not.toBeOnTheScreen()
-})
-
-it('should display nothing when the user is not a beneficiary', async () => {
-  const offerWithLikes = {
-    ...offerResponseSnap,
-    reactionsCount: { likes: 0 },
-  }
-
-  mockAuthContextWithUser(nonBeneficiaryUser, { persist: true })
-  render(<OfferReactions isLoggedIn user={nonBeneficiaryUser} offer={offerWithLikes} />)
-
-  expect(screen.queryByText('Sois le premier à réagir :')).not.toBeOnTheScreen()
-  expect(screen.queryByText(/Aimé par/)).not.toBeOnTheScreen()
-})
-
-it('should display nothing when there are no likes and the user is connected, beneficiary and has not possibility to react', async () => {
+it('should display nothing when there are no likes', async () => {
   const offerWithoutLikes: OfferResponseV2 = {
     ...offerResponseSnap,
     reactionsCount: { likes: 0 },
   }
 
-  mockAuthContextWithUser(beneficiaryUser, { persist: true })
-  render(<OfferReactions isLoggedIn user={beneficiaryUser} offer={offerWithoutLikes} />)
+  render(<OfferReactions offer={offerWithoutLikes} />)
 
-  expect(screen.queryByText('Sois le premier à réagir :')).not.toBeOnTheScreen()
-  expect(screen.queryByText(/Aimé par/)).not.toBeOnTheScreen()
-})
-
-it('should display nothing when the user is connected, beneficiary, has possibility to react, has disliked and there are no likes', async () => {
-  const offerWithoutLikes: OfferResponseV2 = {
-    ...offerResponseSnap,
-    reactionsCount: { likes: 0 },
-  }
-  const userBooking = { ...bookingsSnap.ended_bookings[0], userReaction: ReactionTypeEnum.DISLIKE }
-
-  mockAuthContextWithUser(beneficiaryUser, { persist: true })
-  render(
-    <OfferReactions
-      isLoggedIn
-      user={beneficiaryUser}
-      offer={offerWithoutLikes}
-      userBooking={userBooking}
-      userCanReact
-    />
-  )
-
-  expect(screen.queryByText('Sois le premier à réagir :')).not.toBeOnTheScreen()
-  expect(screen.queryByText(/Aimé par/)).not.toBeOnTheScreen()
+  expect(screen.queryByTestId('thumbUp')).not.toBeOnTheScreen()
 })

--- a/src/features/offer/components/OfferReactions/OfferReactions.tsx
+++ b/src/features/offer/components/OfferReactions/OfferReactions.tsx
@@ -1,78 +1,33 @@
-import React, { FunctionComponent, useMemo } from 'react'
+import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
-import { BookingReponse, OfferResponseV2, ReactionTypeEnum, UserProfileResponse } from 'api/gen'
-import { useBookingsQuery } from 'queries/bookings/useBookingsQuery'
+import { OfferResponseV2 } from 'api/gen'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { ThumbUpFilled } from 'ui/svg/icons/ThumbUpFilled'
 import { TypoDS, getSpacing } from 'ui/theme'
 
 type Props = {
-  isLoggedIn: boolean
   offer: OfferResponseV2
-  user?: UserProfileResponse
-  userCanReact?: boolean
-  userBooking?: BookingReponse
 }
 
-export const OfferReactions: FunctionComponent<Props> = ({
-  isLoggedIn,
-  user,
-  offer,
-  userCanReact,
-  userBooking,
-}) => {
-  const { data: bookings } = useBookingsQuery()
+export const OfferReactions: FunctionComponent<Props> = ({ offer }) => {
   const { reactionsCount } = offer
-  const hasLikes = reactionsCount?.likes > 0
+  const hasLikes = reactionsCount.likes > 0
 
-  const userHasLiked = useMemo(() => {
-    if (!bookings?.ended_bookings) return false
+  if (!hasLikes) return null
 
-    return bookings.ended_bookings.some(
-      (booking) => booking.stock.offer.id === offer.id && !!booking.userReaction
-    )
-  }, [bookings, offer.id])
-
-  const youngWording = reactionsCount?.likes === 1 ? 'jeune' : 'jeunes'
-
-  if (isLoggedIn && user?.isBeneficiary) {
-    if (hasLikes) {
-      return (
-        <StyledView gap={1}>
-          <StyledThumbUp isLiked={userHasLiked} testID="thumbUp" />
-          <TypoDS.BodyAccentXs>
-            Aimé par {reactionsCount?.likes} {youngWording}
-          </TypoDS.BodyAccentXs>
-        </StyledView>
-      )
-    } else if (userCanReact && userBooking?.userReaction !== ReactionTypeEnum.DISLIKE) {
-      return <TypoDS.BodyAccentXs>Sois le premier à réagir&nbsp;:</TypoDS.BodyAccentXs>
-    } else {
-      return null
-    }
-  }
-
-  if (!isLoggedIn || !user?.isBeneficiary) {
-    if (hasLikes) {
-      return (
-        <StyledView gap={1}>
-          <StyledThumbUp isLiked={false} testID="thumbUp" />
-          <TypoDS.BodyAccentXs>
-            Aimé par {reactionsCount?.likes} {youngWording}
-          </TypoDS.BodyAccentXs>
-        </StyledView>
-      )
-    }
-  }
-
-  return null
+  return (
+    <StyledView gap={1}>
+      <StyledThumbUp testID="thumbUp" />
+      <TypoDS.BodyAccentS>{reactionsCount?.likes} j’aime</TypoDS.BodyAccentS>
+    </StyledView>
+  )
 }
 
-const StyledThumbUp = styled(ThumbUpFilled).attrs<{ isLiked?: boolean }>(({ theme, isLiked }) => ({
-  size: theme.icons.sizes.smaller,
-  color: isLiked ? theme.colors.primary : theme.colors.greyDark,
-}))<{ isLiked?: boolean }>``
+const StyledThumbUp = styled(ThumbUpFilled).attrs(({ theme }) => ({
+  size: theme.icons.sizes.small,
+  color: theme.colors.primary,
+}))``
 
 const StyledView = styled(ViewGap)({
   flexDirection: 'row',


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34985

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
