### PR TITLE
(BSR) chore(setup): remove explicit dependency to git

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,6 @@
         pkgs.mkShellNoCC {
           packages = [
             pkgs.devbox
-            pkgs.git
             pkgs.jdk17 # needed by Android
             pkgs.jq # needed by some scripts run in the pipeline
             pkgs.python3 # needed by scripts/add_tracker.py


### PR DESCRIPTION
it is already installed with others tools

it seems to create some issues with the custom certificate authorities

the issues are not present when using `/usr/bin/git`
