### PR TITLE
(BSR) chore(setup): better proxy handling

### DIFF
--- a/scripts/install_certificate_java.sh
+++ b/scripts/install_certificate_java.sh
@@ -45,7 +45,7 @@ add_certificate_safe() {
 	fi
 }
 
-if [ -n "${SSL_CERT_FILE+x}" ]; then
+if [ -n "${SSL_CERT_FILE}" ]; then
 	SSL_CERT_DIR="$(dirname "$SSL_CERT_FILE")"
 	SSL_CERT_TENANT="$(realpath "$SSL_CERT_DIR"/*tenantcert.pem)"
 	SSL_CERT_BUNDLE_FILE="$SSL_CERT_DIR/cert-bundle.pem"

--- a/scripts/is_proxy_enabled.sh
+++ b/scripts/is_proxy_enabled.sh
@@ -3,8 +3,8 @@ set -o errexit -o nounset -o pipefail
 
 PROXY_DIAGNOSTIC="$(realpath '/Library/Application Support'/*/*/*diag 2>/dev/null || echo '')"
 
-if [ -n "${PROXY_DIAGNOSTIC+x}" ]; then
-	"$PROXY_DIAGNOSTIC" -f 2>/dev/null | grep "TUNNEL_CONNECTED" >/dev/null
+if [ -n "${PROXY_DIAGNOSTIC}" ]; then
+	"$PROXY_DIAGNOSTIC" -f | grep "TUNNEL_CONNECTED" >/dev/null
 else
 	return 1
 fi


### PR DESCRIPTION
I had red that to check if a bash variable is not empty we should do

```sh
if [ -n "${variable+x}" ]; then
```

the `+x` should be here to not fail if `set -o nounset` and the variable is not defined

in our case, the variables are defined

if the `+x` is added, the condition is resolved as not empty

but it was a mistake

to check if a variable is empty we should do

```sh
if [ -z "${variable+x}" ]; then
```

it seems that the `+x` should not be added for `-n`

this better handling than #7799


## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]


[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
