### PR TITLE
(PC-34975) refactor(venueMap): remove wipVenueMapPinV2 FF

### DIFF
--- a/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.native.test.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.native.test.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { State } from 'react-native-gesture-handler'
 import { fireGestureHandler, getByGestureTestId } from 'react-native-gesture-handler/jest-utils'
 import { UseQueryResult } from 'react-query'
+import { ReactTestInstance } from 'react-test-renderer'
 
 import { PlaylistType } from 'features/offer/enums'
 import * as useVenueOffers from 'features/venue/api/useVenueOffers'
@@ -315,7 +316,8 @@ describe('VenueMapViewContainer', () => {
     await pressVenueMarker(venuesFixture[1])
     await screen.findByTestId('venueMapPreview')
 
-    await user.press(screen.getByText(venuesFixture[1].label))
+    // Using as because links is never undefined and the typing is not correct
+    await user.press(screen.getAllByText(venuesFixture[1].label)[0] as ReactTestInstance)
 
     expect(screen.queryByTestId('RightFilled')).not.toBeOnTheScreen()
   })
@@ -335,7 +337,8 @@ describe('VenueMapViewContainer', () => {
     await pressVenueMarker(venuesFixture[0])
     await waitFor(() => expect(screen.getByTestId('venueMapPreview')).toBeOnTheScreen())
 
-    await user.press(screen.getByText(venuesFixture[0].label))
+    // Using as because links is never undefined and the typing is not correct
+    await user.press(screen.getAllByText(venuesFixture[0].label)[0] as ReactTestInstance)
 
     expect(screen.getByTestId('RightFilled')).toBeOnTheScreen()
   })
@@ -377,11 +380,10 @@ describe('VenueMapViewContainer', () => {
     await waitFor(() => expect(mockUseCenterOnLocation).toHaveBeenCalledWith(expect.any(Object)))
   })
 
-  it('should display venue label when wipVenueMapPinV2 FF is activated', async () => {
+  it('should display venue label', async () => {
     setFeatureFlags([
       RemoteStoreFeatureFlags.WIP_OFFERS_IN_BOTTOM_SHEET,
       RemoteStoreFeatureFlags.WIP_VENUE_MAP,
-      RemoteStoreFeatureFlags.WIP_VENUE_MAP_PIN_V2,
     ])
     renderVenueMapViewContainer()
 
@@ -390,11 +392,10 @@ describe('VenueMapViewContainer', () => {
     expect(screen.getByText('Cinéma de la fin')).toBeOnTheScreen()
   })
 
-  it('should not display venue label when wipVenueMapPinV2 FF is activated and zoom is too low', async () => {
+  it('should not display venue label when zoom is too low', async () => {
     setFeatureFlags([
       RemoteStoreFeatureFlags.WIP_OFFERS_IN_BOTTOM_SHEET,
       RemoteStoreFeatureFlags.WIP_VENUE_MAP,
-      RemoteStoreFeatureFlags.WIP_VENUE_MAP_PIN_V2,
     ])
     Object.assign(constants.MARKER_LABEL_VISIBILITY_LIMIT, {
       zoom: 16,
@@ -412,7 +413,6 @@ describe('VenueMapViewContainer', () => {
     setFeatureFlags([
       RemoteStoreFeatureFlags.WIP_OFFERS_IN_BOTTOM_SHEET,
       RemoteStoreFeatureFlags.WIP_VENUE_MAP,
-      RemoteStoreFeatureFlags.WIP_VENUE_MAP_PIN_V2,
     ])
     renderVenueMapViewContainer()
 
@@ -423,14 +423,6 @@ describe('VenueMapViewContainer', () => {
         ).length
       )
     )
-  })
-
-  it('should not display venue label wipVenueMapPinV2 when FF is disabled', async () => {
-    setFeatureFlags([RemoteStoreFeatureFlags.WIP_VENUE_MAP])
-    renderVenueMapViewContainer()
-    await screen.findByTestId('venue-map-view')
-
-    expect(screen.queryByText('Cinéma de la fin')).not.toBeOnTheScreen()
   })
 })
 

--- a/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.tsx
+++ b/src/features/venueMap/components/VenueMapView/VenueMapViewContainer.tsx
@@ -61,7 +61,6 @@ export const VenueMapViewContainer: FunctionComponent = () => {
   const isInVenueMapScreen = routeName.toLowerCase() === 'venuemap'
 
   const isPreviewEnabled = useFeatureFlag(RemoteStoreFeatureFlags.WIP_VENUE_MAP)
-  const shouldDisplayPinV2 = useFeatureFlag(RemoteStoreFeatureFlags.WIP_VENUE_MAP_PIN_V2)
   const shouldNavigateToVenueOnFling = useFeatureFlag(
     RemoteStoreFeatureFlags.WIP_FLING_BOTTOM_SHEET_NAVIGATE_TO_VENUE
   )
@@ -246,7 +245,7 @@ export const VenueMapViewContainer: FunctionComponent = () => {
       />
       <VenueMapView
         ref={mapViewRef}
-        showLabel={shouldDisplayPinV2}
+        showLabel
         initialRegion={initialRegion}
         selectedVenueId={selectedVenue?.venueId}
         onLayout={handleMapLayout}

--- a/src/libs/firebase/firestore/types.ts
+++ b/src/libs/firebase/firestore/types.ts
@@ -81,5 +81,4 @@ export enum RemoteStoreFeatureFlags {
   WIP_VENUE_HEADLINE_OFFER = 'wipVenueHeadlineOffer',
   WIP_VENUE_MAP = 'wipVenueMap',
   WIP_VENUE_MAP_IN_SEARCH = 'wipVenueMapInSearch',
-  WIP_VENUE_MAP_PIN_V2 = 'wipVenueMapPinV2',
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34975

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |![Capture d’écran 2025-03-11 à 12 13 24](https://github.com/user-attachments/assets/7a87101b-9e38-4b6f-b89e-9053ac5e4acf)|
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
