### PR TITLE
(PC-35092) fix(artist): artist page access

### DIFF
--- a/src/features/artist/components/ArtistBody/ArtistBody.tsx
+++ b/src/features/artist/components/ArtistBody/ArtistBody.tsx
@@ -43,7 +43,7 @@ export const ArtistBody: FunctionComponent<Props> = ({ offer, artist, subcategor
   const artists = getOfferArtists(subcategory.categoryId, offer)
   const { artistPlaylist, artistTopOffers } = useArtistResults({
     artists,
-    searchGroupName: subcategory.searchGroupName,
+    subcategoryId: offer.subcategoryId,
   })
 
   const { top } = useSafeAreaInsets()

--- a/src/features/offer/api/fetchOffersByArtist/fetchOffersByArtist.test.ts
+++ b/src/features/offer/api/fetchOffersByArtist/fetchOffersByArtist.test.ts
@@ -1,6 +1,6 @@
 import { SearchResponse } from '@algolia/client-search'
 
-import { SearchGroupNameEnumv2 } from 'api/gen'
+import { SubcategoryIdEnum } from 'api/gen'
 import {
   buildAlgoliaFilter,
   fetchOffersByArtist,
@@ -15,7 +15,7 @@ const mockMultipleQueries = jest.spyOn(multipleQueries, 'multipleQueries')
 const mockUserLocation: Position = { latitude: 2, longitude: 2 }
 
 describe('fetchOffersByArtist', () => {
-  it('should execute the multiple queries if artist is provided, searchGroupName is a book, and artist is not "collectif"', async () => {
+  it('should execute the multiple queries if artist is provided, subcategory is a book, and artist is not "collectif"', async () => {
     mockMultipleQueries.mockResolvedValueOnce([
       {
         hits: [],
@@ -26,7 +26,7 @@ describe('fetchOffersByArtist', () => {
     ])
     await fetchOffersByArtist({
       artists: 'Eiichiro Oda',
-      searchGroupName: SearchGroupNameEnumv2.LIVRES,
+      subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
       userLocation: mockUserLocation,
     })
 
@@ -65,37 +65,37 @@ describe('fetchOffersByArtist', () => {
 
     const result = await fetchOffersByArtist({
       artists: 'Eiichiro Oda',
-      searchGroupName: SearchGroupNameEnumv2.LIVRES,
+      subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
       userLocation: mockUserLocation,
     })
 
     expect(result).toEqual({ playlistHits: [], topOffersHits: [] })
   })
 
-  it('should not execute the query if artist is provided, searchGroupName is not a book and artist is not "collectif"', async () => {
+  it('should not execute the query if artist is provided, subcategory is not a book and artist is not "collectif"', async () => {
     await fetchOffersByArtist({
       artists: 'Eiichiro Oda',
-      searchGroupName: SearchGroupNameEnumv2.CINEMA,
+      subcategoryId: SubcategoryIdEnum.SEANCE_CINE,
       userLocation: mockUserLocation,
     })
 
     expect(mockMultipleQueries).not.toHaveBeenCalled()
   })
 
-  it('should not execute the query if artist is provided, searchGroupName is a book, and artist is "COLLECTIF"', async () => {
+  it('should not execute the query if artist is provided, subcategory is a book, and artist is "COLLECTIF"', async () => {
     await fetchOffersByArtist({
       artists: 'COLLECTIF',
-      searchGroupName: SearchGroupNameEnumv2.CINEMA,
+      subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
       userLocation: mockUserLocation,
     })
 
     expect(mockMultipleQueries).not.toHaveBeenCalled()
   })
 
-  it('should not execute the query if artist is provided, searchGroupName is a book, and artist is "COLLECTIFS"', async () => {
+  it('should not execute the query if artist is provided, subcategory is a book, and artist is "COLLECTIFS"', async () => {
     await fetchOffersByArtist({
       artists: 'COLLECTIFS',
-      searchGroupName: SearchGroupNameEnumv2.CINEMA,
+      subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
       userLocation: mockUserLocation,
     })
 

--- a/src/features/offer/api/fetchOffersByArtist/fetchOffersByArtist.ts
+++ b/src/features/offer/api/fetchOffersByArtist/fetchOffersByArtist.ts
@@ -1,6 +1,7 @@
 import { MultipleQueriesQuery, SearchResponse } from '@algolia/client-search'
 
-import { SearchGroupNameEnumv2 } from 'api/gen'
+import { SubcategoryIdEnum } from 'api/gen'
+import { ARTIST_PAGE_SUBCATEGORIES } from 'features/artist/constants'
 import { EXCLUDED_ARTISTS } from 'features/offer/helpers/constants'
 import { captureAlgoliaError } from 'libs/algolia/fetchAlgolia/AlgoliaError'
 import { offerAttributesToRetrieve } from 'libs/algolia/fetchAlgolia/buildAlgoliaParameters/offerAttributesToRetrieve'
@@ -14,13 +15,13 @@ type BuildAlgoliaFilterType = {
 }
 
 export type FetchOfferByArtist = BuildAlgoliaFilterType & {
-  searchGroupName: SearchGroupNameEnumv2
+  subcategoryId: SubcategoryIdEnum
   userLocation: Position
 }
 
 export const fetchOffersByArtist = async ({
   artists,
-  searchGroupName,
+  subcategoryId,
   userLocation,
 }: FetchOfferByArtist) => {
   const queries: MultipleQueriesQuery[] = [
@@ -62,8 +63,7 @@ export const fetchOffersByArtist = async ({
   if (
     !artists ||
     EXCLUDED_ARTISTS.includes(artists.toLowerCase()) ||
-    (searchGroupName !== SearchGroupNameEnumv2.CD_VINYLE_MUSIQUE_EN_LIGNE &&
-      searchGroupName !== SearchGroupNameEnumv2.LIVRES)
+    !ARTIST_PAGE_SUBCATEGORIES.includes(subcategoryId)
   )
     return { playlistHits: [], topOffersHits: [] }
 

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -67,7 +67,7 @@ export const OfferBody: FunctionComponent<Props> = ({ offer, subcategory, childr
 
   const { artistPlaylist: artistOffers } = useArtistResults({
     artists,
-    searchGroupName: subcategory.searchGroupName,
+    subcategoryId: offer.subcategoryId,
   })
 
   const hasAccessToArtistPage =

--- a/src/features/offer/helpers/useArtistResults/useArtistResults.native.test.ts
+++ b/src/features/offer/helpers/useArtistResults/useArtistResults.native.test.ts
@@ -1,4 +1,4 @@
-import { SearchGroupNameEnumv2 } from 'api/gen'
+import { SubcategoryIdEnum } from 'api/gen'
 import { useArtistResults } from 'features/offer/helpers/useArtistResults/useArtistResults'
 import { mockedAlgoliaOffersWithSameArtistResponse } from 'libs/algolia/fixtures/algoliaFixtures'
 import { Position } from 'libs/location/types'
@@ -31,7 +31,7 @@ describe('useArtistResults', () => {
       () =>
         useArtistResults({
           artists: 'Eiichiro Oda',
-          searchGroupName: SearchGroupNameEnumv2.LIVRES,
+          subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
         }),
       {
         wrapper: ({ children }) => reactQueryProviderHOC(children),
@@ -41,7 +41,7 @@ describe('useArtistResults', () => {
     await waitFor(() => {
       expect(fetchOffersByArtistSpy).toHaveBeenCalledWith({
         artists: 'Eiichiro Oda',
-        searchGroupName: SearchGroupNameEnumv2.LIVRES,
+        subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
         userLocation: mockUserLocation,
       })
     })
@@ -54,7 +54,7 @@ describe('useArtistResults', () => {
       () =>
         useArtistResults({
           artists: 'Eiichiro Oda',
-          searchGroupName: SearchGroupNameEnumv2.LIVRES,
+          subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
         }),
       {
         wrapper: ({ children }) => reactQueryProviderHOC(children),
@@ -73,7 +73,7 @@ describe('useArtistResults', () => {
       () =>
         useArtistResults({
           artists: 'Eiichiro Oda',
-          searchGroupName: SearchGroupNameEnumv2.LIVRES,
+          subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
         }),
       {
         wrapper: ({ children }) => reactQueryProviderHOC(children),

--- a/src/features/offer/helpers/useArtistResults/useArtistResults.tsx
+++ b/src/features/offer/helpers/useArtistResults/useArtistResults.tsx
@@ -2,7 +2,7 @@ import { Hit } from '@algolia/client-search'
 import { useCallback, useMemo } from 'react'
 import { useQuery } from 'react-query'
 
-import { SearchGroupNameEnumv2 } from 'api/gen'
+import { SubcategoryIdEnum } from 'api/gen'
 import { fetchOffersByArtist } from 'features/offer/api/fetchOffersByArtist/fetchOffersByArtist'
 import { useTransformOfferHits } from 'libs/algolia/fetchAlgolia/transformOfferHit'
 import { AlgoliaOfferWithArtistAndEan } from 'libs/algolia/types'
@@ -11,11 +11,11 @@ import { formatDistance } from 'libs/parsers/formatDistance'
 import { QueryKeys } from 'libs/queryKeys'
 
 type UseArtistResultsProps = {
-  searchGroupName: SearchGroupNameEnumv2
+  subcategoryId: SubcategoryIdEnum
   artists?: string | null
 }
 
-export const useArtistResults = ({ artists, searchGroupName }: UseArtistResultsProps) => {
+export const useArtistResults = ({ artists, subcategoryId }: UseArtistResultsProps) => {
   const transformHits = useTransformOfferHits()
   const { userLocation } = useLocation()
 
@@ -24,7 +24,7 @@ export const useArtistResults = ({ artists, searchGroupName }: UseArtistResultsP
     async () => {
       const { playlistHits, topOffersHits } = await fetchOffersByArtist({
         artists,
-        searchGroupName,
+        subcategoryId,
         userLocation,
       })
       return { playlistHits, topOffersHits }


### PR DESCRIPTION
L'accès à la page artiste dépendait en partie d'une condition au searchGroupName qui n'est plus associé à la subcategory. Cette condition se base maintenant sur l'id de la subcategory.

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35092

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

Before :

https://github.com/user-attachments/assets/b09ad0ee-70ab-4756-9d5d-09fcda57415e


https://github.com/user-attachments/assets/dd0dbbdb-1032-4f4d-9cb7-9b073f51fe02

After :

https://github.com/user-attachments/assets/2df3008a-48b1-4caf-ae57-a3c3451326a1


https://github.com/user-attachments/assets/7c593eb4-cd22-4aba-af6d-e6429a319dca



[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
