### PR TITLE
(PC-35112) fix(e2e): update wording for book/cinema category

### DIFF
--- a/.maestro/tests/subFolder/booking/BookCinemaOffer.yml
+++ b/.maestro/tests/subFolder/booking/BookCinemaOffer.yml
@@ -9,7 +9,7 @@ appId: ${MAESTRO_APP_ID}
     direction: UP
 - tapOn:
     label: 'Sélection de la 1ère offre disponible'
-    text: "Films à l'affiche"
+    text: 'Séance de cinéma'
     index: 1
 
 - waitForAnimationToEnd
@@ -31,7 +31,7 @@ appId: ${MAESTRO_APP_ID}
       - pressKey: back
       - scroll
       - tapOn:
-          text: "Films à l'affiche"
+          text: 'Séance de cinéma'
           index: 1
       - swipe:
           from:
@@ -51,7 +51,7 @@ appId: ${MAESTRO_APP_ID}
       - pressKey: back
       - scroll
       - tapOn:
-          text: "Films à l'affiche"
+          text: 'Séance de cinéma'
           index: 1
       - swipe:
           from:

--- a/.maestro/tests/subFolder/booking/BookDuoOffer.yml
+++ b/.maestro/tests/subFolder/booking/BookDuoOffer.yml
@@ -9,7 +9,7 @@ env:
     direction: UP
 - tapOn:
     label: 'Sélection de la 1ère offre disponible'
-    text: "Films à l'affiche"
+    text: 'Séance de cinéma'
     index: 1
 
 - repeat: #Vérifier que l'offre est bien réservable
@@ -19,7 +19,7 @@ env:
       - pressKey: back
       - scroll
       - tapOn:
-          text: "Films à l'affiche"
+          text: 'Séance de cinéma'
           index: 1
 
 - swipe:
@@ -39,7 +39,7 @@ env:
       - pressKey: back
       - scroll
       - tapOn:
-          text: "Films à l'affiche"
+          text: 'Séance de cinéma'
           index: 1
       - swipe:
           from:
@@ -59,7 +59,7 @@ env:
       - pressKey: back
       - scroll
       - tapOn:
-          text: "Films à l'affiche"
+          text: 'Séance de cinéma'
           index: 1
       - swipe:
           from:

--- a/.maestro/tests/subFolder/booking/BookPhysicalOffer.yml
+++ b/.maestro/tests/subFolder/booking/BookPhysicalOffer.yml
@@ -13,7 +13,7 @@ appId: ${MAESTRO_APP_ID}
     when:
       platform: iOS
     commands:
-    - tapOn: ".*catégorie Livres.*"
+    - tapOn: ".*catégorie Livre.*"
 
 - waitForAnimationToEnd
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35112

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Run Android sans KO
- [ ] Run iOS sans KO
