### PR TITLE
(BSR) feat(cheatcodes): add staging and production buttons in RemoteC…

### DIFF
--- a/src/cheatcodes/pages/others/CheatcodesScreenRemoteConfig.tsx
+++ b/src/cheatcodes/pages/others/CheatcodesScreenRemoteConfig.tsx
@@ -4,10 +4,14 @@ import { FlatList } from 'react-native'
 import styled from 'styled-components/native'
 
 import { CheatcodesTemplateScreen } from 'cheatcodes/components/CheatcodesTemplateScreen'
+import { env } from 'libs/environment/env'
 import { useRemoteConfigQuery } from 'libs/firebase/remoteConfig/queries/useRemoteConfigQuery'
 import { GenericRemoteConfig } from 'libs/firebase/remoteConfig/remoteConfig.types'
+import { ButtonInsideText } from 'ui/components/buttons/buttonInsideText/ButtonInsideText'
 import { Separator } from 'ui/components/Separator'
-import { TypoDS, getSpacing } from 'ui/theme'
+import { ExternalTouchableLink } from 'ui/components/touchableLink/ExternalTouchableLink'
+import { ExternalSiteFilled } from 'ui/svg/icons/ExternalSiteFilled'
+import { Spacer, TypoDS, getSpacing } from 'ui/theme'
 
 const ConfigItem = ({ label, value }: { label: string; value: GenericRemoteConfig }) => (
   <React.Fragment>
@@ -44,8 +48,46 @@ export const CheatcodesScreenRemoteConfig = () => {
     }
   }
 
+  const title = `Remote config ${env.ENV} 📊`
+  const showTestingFeatureFlags = env.ENV !== 'testing'
+  const showStagingFeatureFlags = env.ENV !== 'staging'
+  const showProductionFeatureFlags = env.ENV !== 'production'
+
   return (
-    <CheatcodesTemplateScreen title="Remote config 📊" flexDirection="column">
+    <CheatcodesTemplateScreen title={title} flexDirection="column">
+      {showTestingFeatureFlags ? (
+        <ExternalTouchableLink
+          as={ButtonInsideTextBlack}
+          buttonHeight="extraSmall"
+          icon={ExternalSiteFilled}
+          wording="Voir les feature flags testing"
+          externalNav={{
+            url: 'https://app.testing.passculture.team/cheatcodes/other/remote-config',
+          }}
+        />
+      ) : null}
+      {showStagingFeatureFlags ? (
+        <ExternalTouchableLink
+          as={ButtonInsideTextBlack}
+          buttonHeight="extraSmall"
+          icon={ExternalSiteFilled}
+          wording="Voir les feature flags staging"
+          externalNav={{
+            url: 'https://app.staging.passculture.team/cheatcodes/other/remote-config',
+          }}
+        />
+      ) : null}
+      {showProductionFeatureFlags ? (
+        <ExternalTouchableLink
+          as={ButtonInsideTextBlack}
+          buttonHeight="extraSmall"
+          icon={ExternalSiteFilled}
+          wording="Voir les feature flags production"
+          externalNav={{ url: 'https://passculture.app/cheatcodes/other/remote-config' }}
+        />
+      ) : null}
+      <Spacer.Column numberOfSpaces={6} />
+
       <FlatList
         data={sortedRemoteConfigEntries}
         keyExtractor={([label]) => label}
@@ -59,3 +101,7 @@ export const CheatcodesScreenRemoteConfig = () => {
 const StyledSeparator = styled(Separator.Horizontal)({
   marginVertical: getSpacing(2),
 })
+
+const ButtonInsideTextBlack = styled(ButtonInsideText).attrs(({ theme }) => ({
+  buttonColor: theme.colors.black,
+}))``


### PR DESCRIPTION
…onfig

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |   ![Capture d’écran 2025-03-12 à 17 40 19](https://github.com/user-attachments/assets/701e184d-c871-4e7c-9650-e0e94066e850)    |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4