### PR TITLE
(PC-34933) fix(TicketCutout): bump rn-svg to handle filters in native application

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -25,7 +25,8 @@ module.exports = {
           types: './src/types',
           ui: './src/ui',
           web: './src/web',
-
+          // if you add something below, it should also be added to main config file in resolve > alias
+          'react-native-svg': 'react-native-svg-web',
           'react-native-linear-gradient': 'react-native-web-linear-gradient',
           'react-native-fast-image': path.join(appSrc, 'libs/react-native-web-fast-image'),
           'react-native-email-link': path.join(appSrc, 'libs/react-native-email-link'),

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -784,7 +784,7 @@ PODS:
     - Sentry/HybridSDK (= 8.45.0)
   - RNShare (8.2.2):
     - React-Core
-  - RNSVG (13.6.0):
+  - RNSVG (15.7.1):
     - React-Core
   - SDWebImage (5.11.1):
     - SDWebImage/Core (= 5.11.1)
@@ -1257,7 +1257,7 @@ SPEC CHECKSUMS:
   RNScreens: 67ef1c8d83aa7cef8ebfb461209bc7150e2aa077
   RNSentry: 2310196edf0069566a1eb38f8774b0ada42d9f10
   RNShare: 128220f40b8d6bcd7217fa19ede9eeb273f1d5d8
-  RNSVG: 1aa3ce1340e2ae326ba6a0091475542d4716fd1a
+  RNSVG: 38b927ba26d717c85522fbf9a04b87dcd2d8227a
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   Sentry: f7c0c4b82e2f7e5909a660544dfaff84e35d5e03

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "react-native-safe-area-context": "3.4.1",
     "react-native-screens": "^3.32.0",
     "react-native-share": "^8.2.2",
-    "react-native-svg": "^13.6.0",
+    "react-native-svg": "15.7.1",
     "react-native-tracking-transparency": "^0.1.2",
     "react-native-url-polyfill": "^1.3.0",
     "react-native-web": "^0.18.10",

--- a/src/features/bookings/components/TicketCutout.tsx
+++ b/src/features/bookings/components/TicketCutout.tsx
@@ -73,14 +73,6 @@ export const TicketCutout = ({
   )
 }
 
-const MiddleBlock = styled.View({
-  flexDirection: 'row',
-  width: '100%',
-  height: getSpacing(21.5),
-  backgroundColor: 'white',
-  zIndex: 1,
-})
-
 const ContainerStrokedLine = styled.View({
   flex: 1,
 })
@@ -89,6 +81,14 @@ const StyledStrokedLine = styled(Stroke).attrs(({ theme }) => ({
   size: '100%',
   color: theme.colors.greyMedium,
 }))({})
+
+const MiddleBlock = styled.View({
+  flexDirection: 'row',
+  width: '100%',
+  height: getSpacing(21.5),
+  backgroundColor: 'white',
+  zIndex: 1,
+})
 
 const StyledClockFilled = styled(ClockFilled).attrs(({ theme }) => ({
   size: theme.icons.sizes.small,

--- a/src/ui/svg/Stroke.tsx
+++ b/src/ui/svg/Stroke.tsx
@@ -21,7 +21,7 @@ const StrokeSvg: React.FunctionComponent<AccessibleIcon> = ({
       stroke={color}
       strokeWidth="4"
       strokeLinecap="round"
-      vector-effect="non-scaling-stroke"
+      vectorEffect="non-scaling-stroke"
       d="M254 2L2 1.99998"
       strokeDasharray="2,16"
     />

--- a/src/ui/svg/TicketCutoutLeft.tsx
+++ b/src/ui/svg/TicketCutoutLeft.tsx
@@ -1,62 +1,65 @@
 import * as React from 'react'
-import { Defs, G, Path } from 'react-native-svg'
+import {
+  ClipPath,
+  Defs,
+  FeBlend,
+  FeColorMatrix,
+  FeGaussianBlur,
+  Filter,
+  G,
+  Path,
+  Rect,
+  Use,
+} from 'react-native-svg'
 import styled from 'styled-components/native'
 
 import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
 import { AccessibleIcon } from 'ui/svg/icons/types'
+import { svgIdentifier } from 'ui/svg/utils'
 
 const TicketCutoutLeftSvg: React.FunctionComponent<AccessibleIcon> = ({
   accessibilityLabel,
   testID,
-}) => (
-  <AccessibleSvg width="54" height="86" testID={testID} accessibilityLabel={accessibilityLabel}>
-    <G clip-path="url(#clip0_4957_1718)">
-      <G filter="url(#filter0_d_4957_1718)">
-        <Path
-          fill-rule="evenodd"
-          clip-rule="evenodd"
-          d="M54 0H24V23C35.0457 23 44 31.9543 44 43C44 54.0457 35.0457 63 24 63L24 86H54V0Z"
-          fill="white"
-        />
+}) => {
+  const { id: clipPathId, fill: clipPath } = svgIdentifier()
+  const { id: filterId, fill: filter } = svgIdentifier()
+  const { id: pathId } = svgIdentifier()
+  return (
+    <AccessibleSvg width="54" height="86" testID={testID} accessibilityLabel={accessibilityLabel}>
+      <G clipPath={clipPath}>
+        <G filter={filter} id="toto">
+          <Path
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            d="M54 0H24V23C35.0457 23 44 31.9543 44 43C44 54.0457 35.0457 63 24 63L24 86H54V0Z"
+            fill="white"
+            id={pathId}
+          />
+        </G>
+        <Use href={`url(#${pathId})`} />
       </G>
-    </G>
-    <Defs>
-      <filter
-        id="filter0_d_4957_1718"
-        x="8"
-        y="-16"
-        width="62"
-        height="118"
-        filterUnits="userSpaceOnUse"
-        colorInterpolationFilters="sRGB">
-        <feFlood floodOpacity="0" result="BackgroundImageFix" />
-        <feColorMatrix
-          in="SourceAlpha"
-          type="matrix"
-          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-          result="hardAlpha"
-        />
-        <feOffset />
-        <feGaussianBlur stdDeviation="8" />
-        <feColorMatrix
-          type="matrix"
-          values="0 0 0 0 0.0862745 0 0 0 0 0.0862745 0 0 0 0 0.0901961 0 0 0 0.15 0"
-        />
-        <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4957_1718" />
-        <feBlend
-          mode="normal"
-          in="SourceGraphic"
-          in2="effect1_dropShadow_4957_1718"
-          result="shape"
-        />
-      </filter>
-      <clipPath id="clip0_4957_1718">
-        <rect width="54" height="86" fill="white" />
-      </clipPath>
-    </Defs>
-  </AccessibleSvg>
-)
-
+      <Defs>
+        <Filter id={filterId} x="8" y="-16" width="62" height="118" filterUnits="userSpaceOnUse">
+          <FeGaussianBlur stdDeviation="8" />
+          <FeColorMatrix
+            type="matrix"
+            values="0 0 0 0 0.0862745 0 0 0 0 0.0862745 0 0 0 0 0.0901961 0 0 0 0.15 0"
+          />
+          <FeBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4957_1718" />
+          <FeBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect1_dropShadow_4957_1718"
+            result="shape"
+          />
+        </Filter>
+        <ClipPath id={clipPathId}>
+          <Rect width="54" height="86" fill="white" />
+        </ClipPath>
+      </Defs>
+    </AccessibleSvg>
+  )
+}
 export const TicketCutoutLeft = styled(TicketCutoutLeftSvg).attrs(({ color, theme }) => ({
   color: color ?? theme.colors.black,
 }))``

--- a/src/ui/svg/TicketCutoutLeft.web.tsx
+++ b/src/ui/svg/TicketCutoutLeft.web.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react'
+import styled from 'styled-components/native'
+
+import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
+import { AccessibleIcon } from 'ui/svg/icons/types'
+import { svgIdentifier } from 'ui/svg/utils'
+
+const TicketCutoutLeftSvg: React.FunctionComponent<AccessibleIcon> = ({
+  accessibilityLabel,
+  testID,
+}) => {
+  const { id: clipPathId, fill: clipPath } = svgIdentifier()
+  const { id: filterId, fill: filter } = svgIdentifier()
+
+  return (
+    <AccessibleSvg
+      fill="none"
+      width="54"
+      height="86"
+      testID={testID}
+      accessibilityLabel={accessibilityLabel}>
+      <g clipPath={clipPath}>
+        <g filter={filter}>
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M54 0H24V23C35.0457 23 44 31.9543 44 43C44 54.0457 35.0457 63 24 63L24 86H54V0Z"
+            fill="white"
+          />
+        </g>
+      </g>
+      <defs>
+        <filter
+          id={filterId}
+          x="8"
+          y="-16"
+          width="62"
+          height="118"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB">
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation="8" />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0.0862745 0 0 0 0 0.0862745 0 0 0 0 0.0901961 0 0 0 0.15 0"
+          />
+          <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4957_1718" />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect1_dropShadow_4957_1718"
+            result="shape"
+          />
+        </filter>
+        <clipPath id={clipPathId}>
+          <rect width="54" height="86" fill="white" />
+        </clipPath>
+      </defs>
+    </AccessibleSvg>
+  )
+}
+export const TicketCutoutLeft = styled(TicketCutoutLeftSvg).attrs(({ color, theme }) => ({
+  color: color ?? theme.colors.black,
+}))``

--- a/src/ui/svg/TicketCutoutRight.tsx
+++ b/src/ui/svg/TicketCutoutRight.tsx
@@ -1,62 +1,61 @@
 import * as React from 'react'
-import { Defs, G, Path } from 'react-native-svg'
-import styled from 'styled-components/native'
+import {
+  G,
+  Path,
+  Defs,
+  Filter,
+  FeColorMatrix,
+  FeGaussianBlur,
+  FeBlend,
+  ClipPath,
+  Rect,
+  Use,
+} from 'react-native-svg'
 
 import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
 import { AccessibleIcon } from 'ui/svg/icons/types'
+import { svgIdentifier } from 'ui/svg/utils'
 
-const TicketCutoutRightSvg: React.FunctionComponent<AccessibleIcon> = ({
+export const TicketCutoutRight: React.FunctionComponent<AccessibleIcon> = ({
   accessibilityLabel,
   testID,
-}) => (
-  <AccessibleSvg width="54" height="86" testID={testID} accessibilityLabel={accessibilityLabel}>
-    <G clip-path="url(#clip0_4957_1722)">
-      <G filter="url(#filter0_d_4957_1722)">
-        <Path
-          fill-rule="evenodd"
-          clip-rule="evenodd"
-          d="M-1.90735e-06 86H30L30 63C18.9543 63 10 54.0457 10 43C10 31.9543 18.9543 23 30 23L30 0H-1.90735e-06L-1.90735e-06 86Z"
-          fill="white"
-        />
+}) => {
+  const { id: clipPathId, fill: clipPath } = svgIdentifier()
+  const { id: filterId, fill: filter } = svgIdentifier()
+  const { id: pathId } = svgIdentifier()
+  return (
+    <AccessibleSvg width="54" height="86" testID={testID} accessibilityLabel={accessibilityLabel}>
+      <G clipPath={clipPath}>
+        <G filter={filter}>
+          <Path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M-1.90735e-06 86H30L30 63C18.9543 63 10 54.0457 10 43C10 31.9543 18.9543 23 30 23L30 0H-1.90735e-06L-1.90735e-06 86Z"
+            fill="white"
+            id={pathId}
+          />
+        </G>
+        <Use href={`url(#${pathId})`} />
       </G>
-    </G>
-    <Defs>
-      <filter
-        id="filter0_d_4957_1722"
-        x="-16"
-        y="-16"
-        width="62"
-        height="118"
-        filterUnits="userSpaceOnUse"
-        colorInterpolationFilters="sRGB">
-        <feFlood floodOpacity="0" result="BackgroundImageFix" />
-        <feColorMatrix
-          in="SourceAlpha"
-          type="matrix"
-          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-          result="hardAlpha"
-        />
-        <feOffset />
-        <feGaussianBlur stdDeviation="8" />
-        <feColorMatrix
-          type="matrix"
-          values="0 0 0 0 0.0862745 0 0 0 0 0.0862745 0 0 0 0 0.0901961 0 0 0 0.15 0"
-        />
-        <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4957_1722" />
-        <feBlend
-          mode="normal"
-          in="SourceGraphic"
-          in2="effect1_dropShadow_4957_1722"
-          result="shape"
-        />
-      </filter>
-      <clipPath id="clip0_4957_1722">
-        <rect width="54" height="86" fill="white" transform="matrix(-1 0 0 -1 54 86)" />
-      </clipPath>
-    </Defs>
-  </AccessibleSvg>
-)
-
-export const TicketCutoutRight = styled(TicketCutoutRightSvg).attrs(({ color, theme }) => ({
-  color: color ?? theme.colors.black,
-}))``
+      <Defs>
+        <Filter id={filterId} x="-16" y="-16" width="62" height="118" filterUnits="userSpaceOnUse">
+          <FeGaussianBlur stdDeviation="8" />
+          <FeColorMatrix
+            type="matrix"
+            values="0 0 0 0 0.0862745 0 0 0 0 0.0862745 0 0 0 0 0.0901961 0 0 0 0.15 0"
+          />
+          <FeBlend mode="normal" in2="BackgroundImageFix" result="efFect1_dropShadow_4957_1722" />
+          <FeBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect1_dropShadow_4957_1722"
+            result="shape"
+          />
+        </Filter>
+        <ClipPath id={clipPathId}>
+          <Rect width="54" height="86" fill="white" transform="matrix(-1 0 0 -1 54 86)" />
+        </ClipPath>
+      </Defs>
+    </AccessibleSvg>
+  )
+}

--- a/src/ui/svg/TicketCutoutRight.web.tsx
+++ b/src/ui/svg/TicketCutoutRight.web.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+import styled from 'styled-components/native'
+
+import { AccessibleSvg } from 'ui/svg/AccessibleSvg'
+import { AccessibleIcon } from 'ui/svg/icons/types'
+import { svgIdentifier } from 'ui/svg/utils'
+
+const TicketCutoutRightSvg: React.FunctionComponent<AccessibleIcon> = ({
+  accessibilityLabel,
+  testID,
+}) => {
+  const { id: clipPathId, fill: clipPath } = svgIdentifier()
+  const { id: filterId, fill: filter } = svgIdentifier()
+  return (
+    <AccessibleSvg
+      viewBox="0 0 54 86"
+      width="54"
+      height="86"
+      testID={testID}
+      fill="none"
+      accessibilityLabel={accessibilityLabel}>
+      <g clipPath={clipPath}>
+        <g filter={filter}>
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M-1.90735e-06 86H30L30 63C18.9543 63 10 54.0457 10 43C10 31.9543 18.9543 23 30 23L30 0H-1.90735e-06L-1.90735e-06 86Z"
+            fill="white"
+          />
+        </g>
+      </g>
+      <defs>
+        <filter
+          id={filterId}
+          x="-16"
+          y="-16"
+          width="62"
+          height="118"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB">
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation="8" />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0.0862745 0 0 0 0 0.0862745 0 0 0 0 0.0901961 0 0 0 0.15 0"
+          />
+          <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_4957_1722" />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect1_dropShadow_4957_1722"
+            result="shape"
+          />
+        </filter>
+        <clipPath id={clipPathId}>
+          <rect width="54" height="86" fill="white" transform="matrix(-1 0 0 -1 54 86)" />
+        </clipPath>
+      </defs>
+    </AccessibleSvg>
+  )
+}
+
+export const TicketCutoutRight = styled(TicketCutoutRightSvg).attrs(({ color, theme }) => ({
+  color: color ?? theme.colors.black,
+}))``

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,6 +15,7 @@ const libsThatHaveJSFilesContainingJSX = [
   'node_modules/@ptomasroos/react-native-multi-slider',
   'node_modules/react-native-calendars',
   'node_modules/react-native-swipe-gestures',
+  'node_modules/@react-native/assets-registry',
 ]
 
 const packageJson = require('./package.json')
@@ -121,7 +122,9 @@ export default ({ mode }) => {
           find: /^((api|cheatcodes|features|fixtures|libs|queries|shared|theme|ui|web).*)/,
           replacement: '/src/$1',
         },
+        // if you add something below, it should also be added to storybook config file in modulesToAlias
         { find: 'react-native', replacement: 'react-native-web' },
+        { find: 'react-native-svg', replacement: 'react-native-svg-web' },
         {
           find: 'react-native-email-link',
           replacement: '/src/libs/react-native-email-link',

--- a/yarn.lock
+++ b/yarn.lock
@@ -13137,7 +13137,7 @@ __metadata:
     react-native-safe-area-context: 3.4.1
     react-native-screens: ^3.32.0
     react-native-share: ^8.2.2
-    react-native-svg: ^13.6.0
+    react-native-svg: 15.7.1
     react-native-svg-web: ^1.0.9
     react-native-tracking-transparency: ^0.1.2
     react-native-url-polyfill: ^1.3.0
@@ -29668,16 +29668,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-svg@npm:^13.6.0":
-  version: 13.6.0
-  resolution: "react-native-svg@npm:13.6.0"
+"react-native-svg@npm:15.7.1":
+  version: 15.7.1
+  resolution: "react-native-svg@npm:15.7.1"
   dependencies:
     css-select: ^5.1.0
     css-tree: ^1.1.3
+    warn-once: 0.1.1
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 6d9b43d12c885982e69fe81d0bccc9b417d977782d4f66ef6964eb33d87ebc79c0a7b7b2dcae60be2857a9ce9178efe35e28de1bc9da92a69bc736177d507770
+  checksum: ad7f711883ee45673486fe6bedadf8490bb06fd36e6de5d2f00898e6ac6c61ed34a5a8f7e6b25684c93e44ab51f9ea76642abfcca6a29462bc525f97204e6f41
   languageName: node
   linkType: hard
 
@@ -34157,7 +34158,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"warn-once@npm:^0.1.0":
+"warn-once@npm:0.1.1, warn-once@npm:^0.1.0":
   version: 0.1.1
   resolution: "warn-once@npm:0.1.1"
   checksum: e6a5a1f5a8dba7744399743d3cfb571db4c3947897875d4962a7c5b1bf2195ab4518c838cb4cea652e71729f21bba2e98dc75686f5fccde0fabbd894e2ed0c0d


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34933

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              | <img width="195" alt="Screenshot 2025-03-13 at 12 13 35" src="https://github.com/user-attachments/assets/7add6d56-a875-44c5-98fc-6793f23e9bfe" />| ![Simulator Screenshot - iPhone SE (3rd generation) - 2025-03-13 at 12 08 20](https://github.com/user-attachments/assets/d11c1f34-b991-4bac-a1cc-328a01a039eb)|
| Android          |               |       |
| Desktop - Chrome |               |<img width="1440" alt="Screenshot 2025-03-13 at 12 08 15" src="https://github.com/user-attachments/assets/af886690-9f23-41ea-9fca-0f2f145115c8" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
