### PR TITLE
(PC-35031) feat(offer): improve proposed by part and offer venue block

### DIFF
--- a/src/features/offer/components/OfferBody/ProposedBySection/ProposedBySection.tsx
+++ b/src/features/offer/components/OfferBody/ProposedBySection/ProposedBySection.tsx
@@ -32,7 +32,7 @@ export const ProposedBySection: FunctionComponent<ProposedBySectionProps> = ({
 
   return (
     <Wrapper>
-      <InternalTouchableLink navigateTo={navigateTo}>
+      <InternalTouchableLink navigateTo={navigateTo} hoverUnderlineColor={theme.colors.white}>
         <ViewGap gap={4}>
           <TypoDS.Title3 {...getHeadingAttrs(2)}>Proposé par</TypoDS.Title3>
           <InfoHeader

--- a/src/features/offer/components/OfferVenueBlock/VenueBlock.tsx
+++ b/src/features/offer/components/OfferVenueBlock/VenueBlock.tsx
@@ -52,6 +52,9 @@ export function VenueBlock({
       [hasVenuePage]
     )
 
+  const addressLabel = address?.label ?? undefined
+  const venueImageUrl = venue.bannerUrl ?? ''
+
   return (
     <React.Fragment>
       {shouldDisplayDistanceTag ? <StyledTag label={`à ${distance}`} /> : null}
@@ -60,11 +63,11 @@ export function VenueBlock({
         navigateTo={{ screen: 'Venue', params: { id: venue.id } }}
         onBeforeNavigate={onSeeVenuePress}>
         <VenueInfoHeader
-          title={venueName}
+          title={isOfferAddressDifferent ? addressLabel : venueName}
           subtitle={venueAddress}
           imageSize={thumbnailSize ?? VENUE_THUMBNAIL_SIZE}
           showArrow={hasVenuePage}
-          imageURL={venue.bannerUrl ?? ''}
+          imageURL={isOfferAddressDifferent ? '' : venueImageUrl}
         />
       </TouchableContainer>
     </React.Fragment>

--- a/src/ui/components/InfoHeader/InfoHeader.stories.tsx
+++ b/src/ui/components/InfoHeader/InfoHeader.stories.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components/native'
 import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { VariantsTemplate, type Variants, type VariantsStory } from 'ui/storybook/VariantsTemplate'
 import { All } from 'ui/svg/icons/bicolor/All'
+import { LocationPointer } from 'ui/svg/icons/LocationPointer'
 import { RightFilled } from 'ui/svg/icons/RightFilled'
 
 import { InfoHeader } from './InfoHeader'
@@ -33,6 +34,11 @@ const RightIcon = styled(RightFilled).attrs(({ theme }) => ({
   flexShrink: 0,
 })
 
+const LocationIcon = styled(LocationPointer).attrs(({ theme }) => ({
+  size: theme.icons.sizes.standard,
+  color: theme.colors.greyMedium,
+}))``
+
 const variantConfig: Variants<typeof InfoHeader> = [
   {
     label: 'InfoHeader default',
@@ -57,6 +63,20 @@ const variantConfig: Variants<typeof InfoHeader> = [
     props: {
       ...baseProps,
       subtitle: undefined,
+    },
+  },
+  {
+    label: 'InfoHeader without title and with subtitle',
+    props: {
+      ...baseProps,
+      title: undefined,
+    },
+  },
+  {
+    label: 'InfoHeader with custom icon placeholder',
+    props: {
+      ...baseProps,
+      placeholderIcon: <LocationIcon />,
     },
   },
 ]

--- a/src/ui/components/InfoHeader/InfoHeader.tsx
+++ b/src/ui/components/InfoHeader/InfoHeader.tsx
@@ -6,10 +6,11 @@ import { ThumbnailPlaceholder } from 'ui/components/InfoHeader/ThumbnailPlaceHol
 import { TypoDS, getSpacing } from 'ui/theme'
 
 type InfoHeaderProps = PropsWithChildren<{
-  title: string
   defaultThumbnailSize: number
+  title?: string
   subtitle?: string
   thumbnailComponent?: ReactNode
+  placeholderIcon?: ReactNode
   rightComponent?: ReactNode
   style?: StyleProp<ViewStyle>
 }>
@@ -20,27 +21,39 @@ export const InfoHeader: FunctionComponent<InfoHeaderProps> = ({
   rightComponent,
   defaultThumbnailSize,
   thumbnailComponent,
+  placeholderIcon,
   children,
   style,
-}) => (
-  <StyledView style={style}>
-    {thumbnailComponent || (
-      <ThumbnailPlaceholder
-        width={defaultThumbnailSize}
-        height={defaultThumbnailSize}
-        testID="VenuePreviewPlaceholder"
-      />
-    )}
-    <RightContainer>
-      {children}
-      <TitleContainer>
-        <Title>{title}</Title>
-        {rightComponent || null}
-      </TitleContainer>
-      {subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
-    </RightContainer>
-  </StyledView>
-)
+}) => {
+  const subtitleComponent = title ? (
+    <Subtitle testID="subtitileWithTitle">{subtitle}</Subtitle>
+  ) : (
+    <SubtitleWithoutTitle testID="subtitleWithoutTitle">{subtitle}</SubtitleWithoutTitle>
+  )
+
+  return (
+    <StyledView style={style}>
+      {thumbnailComponent || (
+        <ThumbnailPlaceholder
+          width={defaultThumbnailSize}
+          height={defaultThumbnailSize}
+          testID="VenuePreviewPlaceholder"
+          icon={placeholderIcon}
+        />
+      )}
+      <RightContainer>
+        {children}
+        {title ? (
+          <TitleContainer testID="titleContainer">
+            <Title>{title}</Title>
+            {rightComponent || null}
+          </TitleContainer>
+        ) : null}
+        {subtitle ? subtitleComponent : null}
+      </RightContainer>
+    </StyledView>
+  )
+}
 
 const StyledView = styled.View({
   flexShrink: 1,
@@ -64,6 +77,14 @@ const Title = styled(TypoDS.BodyAccent).attrs({ numberOfLines: 1 })({
   flexShrink: 1,
 })
 
-const Subtitle = styled(TypoDS.BodyAccentXs).attrs({ numberOfLines: 2 })(({ theme }) => ({
+const Subtitle = styled(TypoDS.BodyAccentXs).attrs({
+  numberOfLines: 2,
+})(({ theme }) => ({
   color: theme.colors.greyDark,
+}))
+
+const SubtitleWithoutTitle = styled(TypoDS.BodyAccentS).attrs({
+  numberOfLines: 2,
+})(({ theme }) => ({
+  color: theme.colors.black,
 }))

--- a/src/ui/components/InfoHeader/ThumbnailPlaceHolder.tsx
+++ b/src/ui/components/InfoHeader/ThumbnailPlaceHolder.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 import { ViewProps } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import styled from 'styled-components/native'
@@ -23,10 +23,16 @@ const ThumbnailPlaceholderIcon = styled(All).attrs(({ theme }) => ({
 type ThumbnailPlaceholderProps = ViewProps & {
   height: number
   width: number
+  icon?: ReactNode
 }
 
-export const ThumbnailPlaceholder = ({ height, width, ...props }: ThumbnailPlaceholderProps) => (
+export const ThumbnailPlaceholder = ({
+  height,
+  width,
+  icon,
+  ...props
+}: ThumbnailPlaceholderProps) => (
   <ThumbnailPlaceholderContainer height={height} width={width} {...props}>
-    <ThumbnailPlaceholderIcon />
+    {icon ? icon : <ThumbnailPlaceholderIcon testID="ThumbnailPlaceholderIcon" />}
   </ThumbnailPlaceholderContainer>
 )

--- a/src/ui/components/VenueInfoHeader/VenueInfoHeader.native.test.tsx
+++ b/src/ui/components/VenueInfoHeader/VenueInfoHeader.native.test.tsx
@@ -88,4 +88,32 @@ describe('<VenueInfoHeader />', () => {
 
     expect(screen.queryByTestId('RightFilled')).not.toBeOnTheScreen()
   })
+
+  it('should display custom thumbnail placeholder icon when no image URL', () => {
+    render(
+      <VenueInfoHeader
+        title="PATHE BEAUGRENELLE"
+        subtitle="Paris, France"
+        showArrow={false}
+        imageURL=""
+        imageSize={VENUE_THUMBNAIL_SIZE}
+      />
+    )
+
+    expect(screen.getByTestId('LocationIcon')).toBeOnTheScreen()
+  })
+
+  it('should not display default thumbnail placeholder icon', () => {
+    render(
+      <VenueInfoHeader
+        title="PATHE BEAUGRENELLE"
+        subtitle="Paris, France"
+        showArrow={false}
+        imageURL="https://example.com/image.jpg"
+        imageSize={VENUE_THUMBNAIL_SIZE}
+      />
+    )
+
+    expect(screen.queryByTestId('ThumbnailPlaceholderIcon')).not.toBeOnTheScreen()
+  })
 })

--- a/src/ui/components/VenueInfoHeader/VenueInfoHeader.tsx
+++ b/src/ui/components/VenueInfoHeader/VenueInfoHeader.tsx
@@ -3,11 +3,12 @@ import styled, { useTheme } from 'styled-components/native'
 
 import { Image } from 'libs/resizing-image-on-demand/Image'
 import { InfoHeader } from 'ui/components/InfoHeader/InfoHeader'
+import { LocationPointer } from 'ui/svg/icons/LocationPointer'
 import { RightFilled } from 'ui/svg/icons/RightFilled'
 
 type VenueInfoHeaderProps = {
-  title: string
   imageSize: number
+  title?: string
   subtitle?: string
   showArrow?: boolean
   imageURL?: string
@@ -39,6 +40,7 @@ export const VenueInfoHeader: FunctionComponent<VenueInfoHeaderProps> = ({
         ) : null
       }
       defaultThumbnailSize={imageSize}
+      placeholderIcon={<LocationIcon testID="LocationIcon" />}
     />
   )
 }
@@ -48,3 +50,8 @@ const VenueThumbnail = styled(Image)<{ height: number; width: number }>(({ heigh
   height,
   width,
 }))
+
+const LocationIcon = styled(LocationPointer).attrs(({ theme }) => ({
+  size: theme.icons.sizes.standard,
+  color: theme.colors.greyMedium,
+}))``


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-35031

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [ ] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [ ] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| iOS              |               |       |
| Android          |               |       |
| Phone - Chrome   |               |       |
| Desktop - Chrome |               |       |

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
