### PR TITLE
(BSR) docs(alias): try to not forgot aliases

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -305,6 +305,7 @@ module.exports = {
       },
       alias: {
         map: [
+           // if you change those lignes, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
           ['__mocks__', './__mocks__'],
           ['api', './src/api'],
           ['cheatcodes', './src/cheatcodes'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -305,7 +305,7 @@ module.exports = {
       },
       alias: {
         map: [
-           // if you change those lignes, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
+           // if you change those lines, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
           ['__mocks__', './__mocks__'],
           ['api', './src/api'],
           ['cheatcodes', './src/cheatcodes'],

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -12,6 +12,7 @@ module.exports = {
       name: '@storybook/addon-react-native-web',
       options: {
         modulesToAlias: {
+          // if you change those lignes, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
           __mocks__: './__mocks__',
           api: './src/api',
           cheatcodes: './src/cheatcodes',

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -12,7 +12,7 @@ module.exports = {
       name: '@storybook/addon-react-native-web',
       options: {
         modulesToAlias: {
-          // if you change those lignes, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
+          // if you change those lines, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
           __mocks__: './__mocks__',
           api: './src/api',
           cheatcodes: './src/cheatcodes',

--- a/babel.config.js
+++ b/babel.config.js
@@ -9,6 +9,7 @@ module.exports = {
         extensions: ['.js', '.jsx', '.ts', '.tsx', '.js', '.ios.js', '.android.js'],
         root: ['./src/'],
         alias: {
+          // if you change those lignes, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
           __mocks__: './__mocks__',
           api: './src/api',
           cheatcodes: './src/cheatcodes',

--- a/babel.config.js
+++ b/babel.config.js
@@ -9,7 +9,7 @@ module.exports = {
         extensions: ['.js', '.jsx', '.ts', '.tsx', '.js', '.ios.js', '.android.js'],
         root: ['./src/'],
         alias: {
-          // if you change those lignes, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
+          // if you change those lines, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
           __mocks__: './__mocks__',
           api: './src/api',
           cheatcodes: './src/cheatcodes',

--- a/doc/development/alias.md
+++ b/doc/development/alias.md
@@ -22,5 +22,6 @@ They are configured on several tools :
 - [Babel](https://github.com/pass-culture/pass-culture-app-native/blob/7bd66f82d47fc41dec8e0f0e32c743931de41f97/babel.config.js#L11)
 - [Jest](https://github.com/pass-culture/pass-culture-app-native/blob/7bd66f82d47fc41dec8e0f0e32c743931de41f97/jest.config.js#L7)
 - [TSConfig](https://github.com/pass-culture/pass-culture-app-native/blob/7bd66f82d47fc41dec8e0f0e32c743931de41f97/tsconfig.json#L4)
+- [Knip](https://github.com/pass-culture/pass-culture-app-native/blob/8267d4b7ae0d69d1ad0c5c8238806765da31a735/knip.ts#L5)
 
 If you change one, please make sure to change the other

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,7 @@ module.exports = {
   testEnvironment: process.env.RUN_ALLURE === 'true' ? 'allure-jest/node' : undefined,
   testEnvironmentOptions: { customExportConditions: [''] },
   moduleNameMapper: {
-    // if you change those lignes, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
+    // if you change those lines, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
     '^__mocks__(.*)$': '<rootDir>/__mocks__$1',
     '^api(.*)$': '<rootDir>/src/api$1',
     '^cheatcodes(.*)$': '<rootDir>/src/cheatcodes$1',

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,7 @@ module.exports = {
   testEnvironment: process.env.RUN_ALLURE === 'true' ? 'allure-jest/node' : undefined,
   testEnvironmentOptions: { customExportConditions: [''] },
   moduleNameMapper: {
+    // if you change those lignes, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
     '^__mocks__(.*)$': '<rootDir>/__mocks__$1',
     '^api(.*)$': '<rootDir>/src/api$1',
     '^cheatcodes(.*)$': '<rootDir>/src/cheatcodes$1',

--- a/knip.ts
+++ b/knip.ts
@@ -2,7 +2,7 @@ import type { KnipConfig } from './node_modules/knip'
 
 const config: KnipConfig = {
   entry: ['index.js', 'src/index.tsx', 'server/src/index.ts'],
-  project: ['src/**/*.{ts,tsx}'], // if you change this ligne, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
+  project: ['src/**/*.{ts,tsx}'], // if you change this line, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
   ignore: [
     'src/**/*.ios.*',
     'src/**/*.android.*',

--- a/knip.ts
+++ b/knip.ts
@@ -2,7 +2,7 @@ import type { KnipConfig } from './node_modules/knip'
 
 const config: KnipConfig = {
   entry: ['index.js', 'src/index.tsx', 'server/src/index.ts'],
-  project: ['src/**/*.{ts,tsx}'],
+  project: ['src/**/*.{ts,tsx}'], // if you change this ligne, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
   ignore: [
     'src/**/*.ios.*',
     'src/**/*.android.*',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "*": ["src/*", "*"] // if you change this ligne, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
+      "*": ["src/*", "*"] // if you change this line, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
     },
     "allowJs": true,
     "allowSyntheticDefaultImports": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "*": ["src/*", "*"]
+      "*": ["src/*", "*"] // if you change this ligne, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
     },
     "allowJs": true,
     "allowSyntheticDefaultImports": true,

--- a/vite.config.js
+++ b/vite.config.js
@@ -118,7 +118,7 @@ export default ({ mode }) => {
       extensions: allExtensions,
       alias: [
         {
-          find: /^((api|cheatcodes|features|fixtures|libs|queries|shared|theme|ui|web).*)/,
+          find: /^((api|cheatcodes|features|fixtures|libs|queries|shared|theme|ui|web).*)/, // if you change this ligne, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
           replacement: '/src/$1',
         },
         { find: 'react-native', replacement: 'react-native-web' },

--- a/vite.config.js
+++ b/vite.config.js
@@ -118,7 +118,7 @@ export default ({ mode }) => {
       extensions: allExtensions,
       alias: [
         {
-          find: /^((api|cheatcodes|features|fixtures|libs|queries|shared|theme|ui|web).*)/, // if you change this ligne, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
+          find: /^((api|cheatcodes|features|fixtures|libs|queries|shared|theme|ui|web).*)/, // if you change this line, check this doc https://github.com/pass-culture/pass-culture-app-native/blob/5ff5fba596244a759d60f8c9cdb67d56ac86a1a7/doc/development/alias.md
           replacement: '/src/$1',
         },
         { find: 'react-native', replacement: 'react-native-web' },


### PR DESCRIPTION
Quand on ajoute un alias (c'est rare) souvent on oublie d'ajouter la config aux autres endroits

Cette PR tente de palier à ça en mettant un rappel qu'il faut changer aux autres endroits

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]


[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4
