### PR TITLE
(PC-34992) feat(offer): reaction feature from offer header

### DIFF
--- a/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx
+++ b/src/features/identityCheck/pages/confirmation/BeneficiaryAccountCreated.native.test.tsx
@@ -14,7 +14,7 @@ import { DEFAULT_REMOTE_CONFIG } from 'libs/firebase/remoteConfig/remoteConfig.c
 import { BatchProfile } from 'libs/react-native-batch'
 import { mockAuthContextWithUser } from 'tests/AuthContextUtils'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { userEvent, render, screen, act } from 'tests/utils'
+import { userEvent, render, screen, act, waitFor } from 'tests/utils'
 
 jest.mock('libs/firebase/analytics/analytics')
 jest.mock('libs/firebase/remoteConfig/remoteConfig.services')
@@ -85,9 +85,7 @@ describe('<BeneficiaryAccountCreated/>', () => {
 
     await user.press(await screen.findByLabelText('C’est parti !'))
 
-    await act(() => {
-      expect(mockShowAppModal).not.toHaveBeenCalled()
-    })
+    await waitFor(() => expect(mockShowAppModal).not.toHaveBeenCalled())
   })
 
   it('should redirect to native cultural survey page when "C’est parti !"button is clicked and user is supposed to see cultural survey', async () => {

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -40,9 +40,17 @@ type Props = {
   offer: OfferResponseV2
   subcategory: Subcategory
   children: ReactNode
+  likesCount?: number
+  chroniclesCount?: number
 }
 
-export const OfferBody: FunctionComponent<Props> = ({ offer, subcategory, children }) => {
+export const OfferBody: FunctionComponent<Props> = ({
+  offer,
+  subcategory,
+  children,
+  likesCount,
+  chroniclesCount,
+}) => {
   const { navigate } = useNavigation<UseNavigationType>()
 
   const hasArtistPage = useFeatureFlag(RemoteStoreFeatureFlags.WIP_ARTIST_PAGE)
@@ -136,7 +144,7 @@ export const OfferBody: FunctionComponent<Props> = ({ offer, subcategory, childr
 
         {prices ? <TypoDS.Title3 {...getHeadingAttrs(2)}>{displayedPrice}</TypoDS.Title3> : null}
 
-        <OfferReactionSection offer={offer} />
+        <OfferReactionSection likesCount={likesCount} chroniclesCount={chroniclesCount} />
 
         <GroupWithSeparator
           showTopComponent={shouldUseIsOpenToPublic ? isOpenToPublicVenue : offer.venue.isPermanent}

--- a/src/features/offer/components/OfferContent/OfferContent.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.tsx
@@ -16,6 +16,8 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
   searchGroupList,
   subcategory,
   chronicles,
+  defaultReaction,
+  onReactionButtonPress,
 }) => {
   const { navigate } = useNavigation<UseNavigationType>()
   const handlePress = (defaultIndex = 0) => {
@@ -32,6 +34,8 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
         BodyWrapper={BodyWrapper}
         chronicles={chronicles}
         subcategory={subcategory}
+        defaultReaction={defaultReaction}
+        onReactionButtonPress={onReactionButtonPress}
       />
     </OfferCTAProvider>
   )

--- a/src/features/offer/components/OfferContent/OfferContent.web.tsx
+++ b/src/features/offer/components/OfferContent/OfferContent.web.tsx
@@ -16,6 +16,8 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
   searchGroupList,
   subcategory,
   chronicles,
+  defaultReaction,
+  onReactionButtonPress,
 }) => {
   const { visible, showModal, hideModal } = useModal(false)
   const headerHeight = useGetHeaderHeight()
@@ -58,6 +60,8 @@ export const OfferContent: FunctionComponent<OfferContentProps> = ({
           chronicles={chronicles}
           onOfferPreviewPress={handlePress}
           BodyWrapper={BodyWrapper}
+          defaultReaction={defaultReaction}
+          onReactionButtonPress={onReactionButtonPress}
         />
       </React.Fragment>
     </OfferCTAProvider>

--- a/src/features/offer/components/OfferContent/OfferContentBase.tsx
+++ b/src/features/offer/components/OfferContent/OfferContentBase.tsx
@@ -11,7 +11,7 @@ import { IOScrollView as IntersectionObserverScrollView } from 'react-native-int
 import { useQueryClient } from 'react-query'
 import styled, { useTheme } from 'styled-components/native'
 
-import { OfferResponseV2, RecommendationApiParams } from 'api/gen'
+import { OfferResponseV2, ReactionTypeEnum, RecommendationApiParams } from 'api/gen'
 import { ChronicleCardData } from 'features/chronicle/type'
 import { useFavorite } from 'features/favorites/hooks/useFavorite'
 import { UseNavigationType, UseRouteType } from 'features/navigation/RootNavigator/types'
@@ -20,6 +20,7 @@ import { ChronicleSection } from 'features/offer/components/OfferContent/Chronic
 import { OfferCTAButton } from 'features/offer/components/OfferCTAButton/OfferCTAButton'
 import { OfferFooter } from 'features/offer/components/OfferFooter/OfferFooter'
 import { OfferHeader } from 'features/offer/components/OfferHeader/OfferHeader'
+import { OfferReactionHeaderButton } from 'features/offer/components/OfferHeader/OfferReactionHeaderButton'
 import { OfferImageContainer } from 'features/offer/components/OfferImageContainer/OfferImageContainer'
 import { OfferMessagingApps } from 'features/offer/components/OfferMessagingApps/OfferMessagingApps'
 import { OfferPlaylistList } from 'features/offer/components/OfferPlaylistList/OfferPlaylistList'
@@ -48,6 +49,9 @@ type OfferContentBaseProps = OfferContentProps & {
   BodyWrapper: FunctionComponent
   onOfferPreviewPress: (index?: number) => void
   chronicles?: ChronicleCardData[]
+  likesCount?: number
+  defaultReaction?: ReactionTypeEnum | null
+  onReactionButtonPress?: () => void
   contentContainerStyle?: StyleProp<ViewStyle>
 }
 
@@ -60,6 +64,8 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
   chronicles,
   onOfferPreviewPress,
   contentContainerStyle,
+  defaultReaction,
+  onReactionButtonPress,
   BodyWrapper = React.Fragment,
 }) => {
   const theme = useTheme()
@@ -197,15 +203,23 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
       <AnchorProvider scrollViewRef={scrollViewRef} handleCheckScrollY={handleCheckScrollY}>
         <OfferWebMetaHeader offer={offer} />
         <OfferHeader title={offer.name} headerTransition={headerTransition} offer={offer}>
-          <FavoriteButton
-            animationState={animationState}
-            offerId={offer.id}
-            addFavorite={addFavorite}
-            isAddFavoriteLoading={isAddFavoriteLoading}
-            removeFavorite={removeFavorite}
-            isRemoveFavoriteLoading={isRemoveFavoriteLoading}
-            favorite={favorite}
-          />
+          {onReactionButtonPress ? (
+            <OfferReactionHeaderButton
+              onPress={onReactionButtonPress}
+              defaultReaction={defaultReaction}
+              animationState={animationState}
+            />
+          ) : (
+            <FavoriteButton
+              animationState={animationState}
+              offerId={offer.id}
+              addFavorite={addFavorite}
+              isAddFavoriteLoading={isAddFavoriteLoading}
+              removeFavorite={removeFavorite}
+              isRemoveFavoriteLoading={isRemoveFavoriteLoading}
+              favorite={favorite}
+            />
+          )}
         </OfferHeader>
         <ScrollViewContainer
           testID="offerv2-container"
@@ -222,7 +236,11 @@ export const OfferContentBase: FunctionComponent<OfferContentBaseProps> = ({
               onPress={onOfferPreviewPress}
               placeholderImage={placeholderImage}
             />
-            <OfferBody offer={offer} subcategory={subcategory}>
+            <OfferBody
+              offer={offer}
+              subcategory={subcategory}
+              likesCount={offer.reactionsCount.likes}
+              chroniclesCount={chronicles?.length}>
               {theme.isDesktopViewport ? offerCtaButton : null}
             </OfferBody>
           </BodyWrapper>

--- a/src/features/offer/components/OfferHeader/OfferReactionHeaderButton.native.test.tsx
+++ b/src/features/offer/components/OfferHeader/OfferReactionHeaderButton.native.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Animated } from 'react-native'
+
+import { ReactionTypeEnum } from 'api/gen'
+import { render, screen } from 'tests/utils'
+
+import { OfferReactionHeaderButton } from './OfferReactionHeaderButton'
+
+const ANIMATION_STATE_PROP = {
+  iconBackgroundColor: {} as Animated.AnimatedInterpolation<string>,
+  iconBorderColor: {} as Animated.AnimatedInterpolation<string>,
+  transition: {
+    interpolate: jest.fn(),
+  } as unknown as Animated.AnimatedInterpolation<number>,
+}
+
+describe('<OfferReactionHeaderButton />', () => {
+  it('should render correctly by default', async () => {
+    render(<OfferReactionHeaderButton onPress={jest.fn()} animationState={ANIMATION_STATE_PROP} />)
+
+    expect(await screen.findByTestId('animated-icon-like')).toBeOnTheScreen()
+  })
+
+  it.each([
+    { reactionType: ReactionTypeEnum.LIKE, icon: 'animated-icon-like-filled' },
+    { reactionType: ReactionTypeEnum.DISLIKE, icon: 'animated-icon-like-filled' },
+    { reactionType: ReactionTypeEnum.NO_REACTION, icon: 'animated-icon-like' },
+  ])('should render correctly for $reactionType reaction', async ({ reactionType, icon }) => {
+    render(
+      <OfferReactionHeaderButton
+        onPress={jest.fn()}
+        animationState={ANIMATION_STATE_PROP}
+        defaultReaction={reactionType}
+      />
+    )
+
+    expect(await screen.findByTestId(icon)).toBeOnTheScreen()
+  })
+})

--- a/src/features/offer/components/OfferHeader/OfferReactionHeaderButton.tsx
+++ b/src/features/offer/components/OfferHeader/OfferReactionHeaderButton.tsx
@@ -1,9 +1,9 @@
 import React, { ComponentProps, useRef } from 'react'
 import { Animated, View } from 'react-native'
+import { DefaultTheme, useTheme } from 'styled-components/native'
 
 import { ReactionTypeEnum } from 'api/gen'
 import { accessibleCheckboxProps } from 'shared/accessibilityProps/accessibleCheckboxProps'
-import { theme } from 'theme'
 import { RoundedButton } from 'ui/components/buttons/RoundedButton'
 import { IconNames } from 'ui/components/icons/iconFactory'
 // eslint-disable-next-line no-restricted-imports
@@ -14,9 +14,13 @@ type ReactionHeaderButtonProps = Omit<
   'scaleAnimatedValue'
 > & { defaultReaction?: ReactionTypeEnum | null }
 
-const getIconAndColorFromReactionType = (
+const getIconAndColorFromReactionType = ({
+  theme,
+  reactionType,
+}: {
+  theme: DefaultTheme
   reactionType?: ReactionTypeEnum | null
-): { iconName: IconNames; color: ColorsEnum } => {
+}): { iconName: IconNames; color: ColorsEnum } => {
   switch (reactionType) {
     case ReactionTypeEnum.LIKE:
       return { iconName: 'like-filled', color: theme.colors.primary }
@@ -33,8 +37,12 @@ export const OfferReactionHeaderButton = ({
   disabled,
   defaultReaction,
 }: ReactionHeaderButtonProps) => {
+  const theme = useTheme()
   const scaleFavoriteIconAnimatedValueRef = useRef(new Animated.Value(1))
-  const { iconName, color } = getIconAndColorFromReactionType(defaultReaction)
+  const { iconName, color } = getIconAndColorFromReactionType({
+    theme,
+    reactionType: defaultReaction,
+  })
   return (
     <View style={{ transform: [{ scale: defaultReaction === ReactionTypeEnum.DISLIKE ? -1 : 1 }] }}>
       <RoundedButton

--- a/src/features/offer/components/OfferHeader/OfferReactionHeaderButton.tsx
+++ b/src/features/offer/components/OfferHeader/OfferReactionHeaderButton.tsx
@@ -1,0 +1,52 @@
+import React, { ComponentProps, useRef } from 'react'
+import { Animated, View } from 'react-native'
+
+import { ReactionTypeEnum } from 'api/gen'
+import { accessibleCheckboxProps } from 'shared/accessibilityProps/accessibleCheckboxProps'
+import { theme } from 'theme'
+import { RoundedButton } from 'ui/components/buttons/RoundedButton'
+import { IconNames } from 'ui/components/icons/iconFactory'
+// eslint-disable-next-line no-restricted-imports
+import { ColorsEnum } from 'ui/theme/colors'
+
+type ReactionHeaderButtonProps = Omit<
+  ComponentProps<typeof RoundedButton>,
+  'scaleAnimatedValue'
+> & { defaultReaction?: ReactionTypeEnum | null }
+
+const getIconAndColorFromReactionType = (
+  reactionType?: ReactionTypeEnum | null
+): { iconName: IconNames; color: ColorsEnum } => {
+  switch (reactionType) {
+    case ReactionTypeEnum.LIKE:
+      return { iconName: 'like-filled', color: theme.colors.primary }
+    case ReactionTypeEnum.DISLIKE:
+      return { iconName: 'like-filled', color: theme.colors.black }
+    default:
+      return { iconName: 'like', color: theme.colors.black }
+  }
+}
+
+export const OfferReactionHeaderButton = ({
+  animationState,
+  onPress,
+  disabled,
+  defaultReaction,
+}: ReactionHeaderButtonProps) => {
+  const scaleFavoriteIconAnimatedValueRef = useRef(new Animated.Value(1))
+  const { iconName, color } = getIconAndColorFromReactionType(defaultReaction)
+  return (
+    <View style={{ transform: [{ scale: defaultReaction === ReactionTypeEnum.DISLIKE ? -1 : 1 }] }}>
+      <RoundedButton
+        animationState={animationState}
+        scaleAnimatedValue={scaleFavoriteIconAnimatedValueRef.current}
+        finalColor={color}
+        initialColor={color}
+        iconName={iconName}
+        onPress={onPress}
+        disabled={disabled}
+        {...accessibleCheckboxProps({ checked: !!defaultReaction, label: 'Réagir à cette offre' })}
+      />
+    </View>
+  )
+}

--- a/src/features/offer/components/OfferReactionSection/OfferReactionSection.native.test.tsx
+++ b/src/features/offer/components/OfferReactionSection/OfferReactionSection.native.test.tsx
@@ -1,69 +1,17 @@
 import React, { ComponentProps } from 'react'
 
-import { ReactionTypeEnum } from 'api/gen'
-import { bookingsSnap } from 'features/bookings/fixtures/bookingsSnap'
 import { OfferReactionSection } from 'features/offer/components/OfferReactionSection/OfferReactionSection'
-import { offerResponseSnap } from 'features/offer/fixtures/offerResponse'
 import { setFeatureFlags } from 'libs/firebase/firestore/featureFlags/__tests__/setFeatureFlags'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import { useBookingsQuery } from 'queries/bookings/useBookingsQuery'
 import { reactQueryProviderHOC } from 'tests/reactQueryProviderHOC'
-import { render, screen, userEvent } from 'tests/utils'
-
-const mockBookingsWithoutReaction = {
-  ...bookingsSnap,
-  ended_bookings: [
-    {
-      ...bookingsSnap.ended_bookings[1],
-      canReact: true,
-      stock: {
-        ...bookingsSnap.ended_bookings[1].stock,
-        offer: { ...bookingsSnap.ended_bookings[1].stock.offer, id: offerResponseSnap.id },
-      },
-    },
-  ],
-}
-const mockBookingsWithLike = {
-  ...bookingsSnap,
-  ended_bookings: [
-    {
-      ...bookingsSnap.ended_bookings[1],
-      canReact: true,
-      stock: {
-        ...bookingsSnap.ended_bookings[1].stock,
-        offer: { ...bookingsSnap.ended_bookings[1].stock.offer, id: offerResponseSnap.id },
-      },
-      userReaction: ReactionTypeEnum.LIKE,
-    },
-  ],
-}
-const mockBookingsWithDislike = {
-  ...bookingsSnap,
-  ended_bookings: [
-    {
-      ...bookingsSnap.ended_bookings[1],
-      canReact: true,
-      stock: {
-        ...bookingsSnap.ended_bookings[1].stock,
-        offer: { ...bookingsSnap.ended_bookings[1].stock.offer, id: offerResponseSnap.id },
-      },
-      userReaction: ReactionTypeEnum.DISLIKE,
-    },
-  ],
-}
+import { render, screen } from 'tests/utils'
 
 jest.mock('queries/bookings/useBookingsQuery')
-const mockUseBookings = useBookingsQuery as jest.Mock
-
 const mockMutate = jest.fn()
 let mockIsSuccess = true
 jest.mock('features/reactions/api/useReactionMutation', () => ({
   useReactionMutation: () => ({ mutate: mockMutate, isSuccess: mockIsSuccess }),
 }))
-
-const user = userEvent.setup()
-
-jest.useFakeTimers()
 
 describe('<OfferReactionSection />', () => {
   describe('When FF is enabled', () => {
@@ -72,164 +20,49 @@ describe('<OfferReactionSection />', () => {
       mockIsSuccess = true
     })
 
-    it("should display 'J'aime' or 'Je n'aime pas' button when user booked the offer", async () => {
-      mockUseBookings.mockReturnValueOnce({ data: mockBookingsWithoutReaction })
-      renderOfferReactionSection({})
-
-      expect(await screen.findByText('J’aime')).toBeOnTheScreen()
-      expect(await screen.findByText('Je n’aime pas')).toBeOnTheScreen()
-    })
-
     it('should display likes information when other users have reacted to the offer', async () => {
-      mockUseBookings.mockReturnValueOnce({ data: mockBookingsWithoutReaction })
-
-      renderOfferReactionSection({})
+      renderOfferReactionSection({ likesCount: 1 })
 
       expect(await screen.findByText('1 j’aime')).toBeOnTheScreen()
     })
 
     it('should not display likes information when not exists', async () => {
-      const offerWithoutLikes = {
-        ...offerResponseSnap,
-        reactionsCount: { likes: 0 },
-      }
-      mockUseBookings.mockReturnValueOnce({ data: mockBookingsWithoutReaction })
-
-      renderOfferReactionSection({ offer: offerWithoutLikes })
+      renderOfferReactionSection({ chroniclesCount: 1 })
 
       expect(screen.queryByTestId('likesCounterIcon')).not.toBeOnTheScreen()
     })
 
     it('should display chronicles information when exist', async () => {
-      mockUseBookings.mockReturnValueOnce({ data: mockBookingsWithoutReaction })
-
-      renderOfferReactionSection({})
+      renderOfferReactionSection({ chroniclesCount: 3 })
 
       expect(await screen.findByText('3 avis')).toBeOnTheScreen()
       expect(screen.getByTestId('chroniclesCounterIcon')).toBeOnTheScreen()
     })
 
     it('should not display chronicles information when not exists', async () => {
-      const offerWithoutChronicles = {
-        ...offerResponseSnap,
-        chronicles: [],
-      }
-      mockUseBookings.mockReturnValueOnce({ data: mockBookingsWithoutReaction })
-
-      renderOfferReactionSection({ offer: offerWithoutChronicles })
+      renderOfferReactionSection({ likesCount: 2 })
 
       expect(screen.queryByTestId('chroniclesCounterIcon')).not.toBeOnTheScreen()
     })
 
     it('should display nothing when there are not chronicles and likes information', async () => {
-      const offerWithoutLikesAndChronicles = {
-        ...offerResponseSnap,
-        reactionsCount: { likes: 0 },
-        chronicles: [],
-      }
-      mockUseBookings.mockReturnValueOnce({ data: mockBookingsWithoutReaction })
-
-      renderOfferReactionSection({ offer: offerWithoutLikesAndChronicles })
+      renderOfferReactionSection({})
 
       expect(screen.queryByTestId('chroniclesCounterIcon')).not.toBeOnTheScreen()
       expect(screen.queryByTestId('likesCounterIcon')).not.toBeOnTheScreen()
-    })
-
-    it('should send like reaction when pressing J’aime button and user not already send a reaction', async () => {
-      mockUseBookings.mockReturnValueOnce({ data: mockBookingsWithoutReaction })
-
-      renderOfferReactionSection({})
-
-      await user.press(screen.getByText('J’aime'))
-
-      expect(mockMutate).toHaveBeenNthCalledWith(1, {
-        reactions: [
-          {
-            offerId: offerResponseSnap.id,
-            reactionType: ReactionTypeEnum.LIKE,
-          },
-        ],
-      })
-    })
-
-    it('should send no reaction when pressing J’aime button and user already liked the offer', async () => {
-      mockUseBookings.mockReturnValueOnce({ data: mockBookingsWithLike })
-
-      renderOfferReactionSection({})
-
-      await user.press(screen.getByText('J’aime'))
-
-      expect(mockMutate).toHaveBeenNthCalledWith(1, {
-        reactions: [
-          {
-            offerId: offerResponseSnap.id,
-            reactionType: ReactionTypeEnum.NO_REACTION,
-          },
-        ],
-      })
-    })
-
-    it('should send dislike reaction when pressing Je n’aime pas button and user not already send a reaction', async () => {
-      mockUseBookings.mockReturnValueOnce({ data: mockBookingsWithoutReaction })
-
-      renderOfferReactionSection({})
-
-      await user.press(screen.getByText('Je n’aime pas'))
-
-      expect(mockMutate).toHaveBeenNthCalledWith(1, {
-        reactions: [
-          {
-            offerId: offerResponseSnap.id,
-            reactionType: ReactionTypeEnum.DISLIKE,
-          },
-        ],
-      })
-    })
-
-    it('should send no reaction when pressing Je n’aime pas button and user already disliked the offer', async () => {
-      mockUseBookings.mockReturnValueOnce({ data: mockBookingsWithDislike })
-
-      renderOfferReactionSection({})
-
-      await user.press(screen.getByText('Je n’aime pas'))
-
-      expect(mockMutate).toHaveBeenNthCalledWith(1, {
-        reactions: [
-          {
-            offerId: offerResponseSnap.id,
-            reactionType: ReactionTypeEnum.NO_REACTION,
-          },
-        ],
-      })
-    })
-  })
-
-  describe('When FF is disabled', () => {
-    beforeEach(() => {
-      setFeatureFlags()
-    })
-
-    it("should not display 'J'aime' or 'Je n'aime pas' button when user booked the offer", () => {
-      mockUseBookings.mockReturnValueOnce({ data: mockBookingsWithoutReaction })
-
-      renderOfferReactionSection({})
-
-      expect(screen.queryByText('J’aime')).not.toBeOnTheScreen()
-      expect(screen.queryByText('Je n’aime pas')).not.toBeOnTheScreen()
-    })
-
-    it('should not display reaction count when other users have reacted to the offer', () => {
-      mockUseBookings.mockReturnValueOnce({ data: mockBookingsWithoutReaction })
-
-      renderOfferReactionSection({})
-
-      expect(screen.queryByText('1 j’aime')).not.toBeOnTheScreen()
     })
   })
 })
 
 type RenderOfferReactionSectionType = Partial<ComponentProps<typeof OfferReactionSection>>
 
-function renderOfferReactionSection({ offer = offerResponseSnap }: RenderOfferReactionSectionType) {
-  render(reactQueryProviderHOC(<OfferReactionSection offer={offer} />))
+function renderOfferReactionSection({
+  chroniclesCount = 0,
+  likesCount = 0,
+}: RenderOfferReactionSectionType) {
+  render(
+    reactQueryProviderHOC(
+      <OfferReactionSection chroniclesCount={chroniclesCount} likesCount={likesCount} />
+    )
+  )
 }

--- a/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
+++ b/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
@@ -1,76 +1,30 @@
-import React, { FunctionComponent, useCallback, useMemo } from 'react'
+import React, { FunctionComponent } from 'react'
 import styled from 'styled-components/native'
 
-import { OfferResponseV2, PostReactionRequest, ReactionTypeEnum } from 'api/gen'
 import { InfoCounter } from 'features/offer/components/InfoCounter/InfoCounter'
-import { useReactionMutation } from 'features/reactions/api/useReactionMutation'
-import { ReactionChoiceValidation } from 'features/reactions/components/ReactionChoiceValidation/ReactionChoiceValidation'
-import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
-import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import { useBookingsQuery } from 'queries/bookings/useBookingsQuery'
 import { ViewGap } from 'ui/components/ViewGap/ViewGap'
 import { BookClubCertification } from 'ui/svg/BookClubCertification'
 import { ThumbUpFilled } from 'ui/svg/icons/ThumbUpFilled'
 
 type Props = {
-  offer: OfferResponseV2
+  likesCount?: number
+  chroniclesCount?: number
 }
 
-export const OfferReactionSection: FunctionComponent<Props> = ({ offer }) => {
-  const isReactionFeatureActive = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
-  const { data: bookings } = useBookingsQuery()
-  const { mutate: addReaction } = useReactionMutation()
-
-  const userBooking = useMemo(
-    () => bookings?.ended_bookings?.find((booking) => booking.stock.offer.id === offer.id),
-    [bookings, offer.id]
-  )
-
-  const hasLikes = offer.reactionsCount.likes > 0
-  const hasChronicles = offer.chronicles.length > 0
-  const shouldDisplayReactions = hasLikes || hasChronicles
-  const canDisplayReactionSection =
-    isReactionFeatureActive && (shouldDisplayReactions || userBooking?.canReact)
-
-  const handleSaveReaction = useCallback(
-    (reactionType: ReactionTypeEnum) => {
-      const currentReactionType =
-        reactionType === userBooking?.userReaction ? ReactionTypeEnum.NO_REACTION : reactionType
-
-      const reactionRequest: PostReactionRequest = {
-        reactions: [{ offerId: offer.id, reactionType: currentReactionType }],
-      }
-
-      addReaction(reactionRequest)
-      return Promise.resolve(true)
-    },
-    [addReaction, offer.id, userBooking?.userReaction]
-  )
-
-  const likesCounterElement = hasLikes ? (
-    <LikesInfoCounter text={`${offer.reactionsCount.likes} j’aime`} />
-  ) : null
-  const chroniclesCounterElement = hasChronicles ? (
-    <ChroniclesInfoCounter text={`${offer.chronicles.length} avis`} />
+export const OfferReactionSection: FunctionComponent<Props> = ({ likesCount, chroniclesCount }) => {
+  const likesCounterElement = likesCount ? <LikesInfoCounter text={`${likesCount} j’aime`} /> : null
+  const chroniclesCounterElement = chroniclesCount ? (
+    <ChroniclesInfoCounter text={`${chroniclesCount} avis`} />
   ) : null
 
-  if (!canDisplayReactionSection) return null
+  if (!(likesCounterElement || chroniclesCounterElement)) return null
 
   return (
     <ViewGap gap={4}>
-      {shouldDisplayReactions ? (
-        <InfosCounterContainer gap={2}>
-          {likesCounterElement}
-          {chroniclesCounterElement}
-        </InfosCounterContainer>
-      ) : null}
-
-      {userBooking?.canReact ? (
-        <ReactionChoiceValidation
-          handleOnPressReactionButton={handleSaveReaction}
-          reactionStatus={userBooking?.userReaction}
-        />
-      ) : null}
+      <InfosCounterContainer gap={2}>
+        {likesCounterElement}
+        {chroniclesCounterElement}
+      </InfosCounterContainer>
     </ViewGap>
   )
 }

--- a/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
+++ b/src/features/offer/components/OfferReactionSection/OfferReactionSection.tsx
@@ -20,12 +20,10 @@ export const OfferReactionSection: FunctionComponent<Props> = ({ likesCount, chr
   if (!(likesCounterElement || chroniclesCounterElement)) return null
 
   return (
-    <ViewGap gap={4}>
-      <InfosCounterContainer gap={2}>
-        {likesCounterElement}
-        {chroniclesCounterElement}
-      </InfosCounterContainer>
-    </ViewGap>
+    <InfosCounterContainer gap={2}>
+      {likesCounterElement}
+      {chroniclesCounterElement}
+    </InfosCounterContainer>
   )
 }
 

--- a/src/features/offer/helpers/renderOfferPageTestUtil.tsx
+++ b/src/features/offer/helpers/renderOfferPageTestUtil.tsx
@@ -34,7 +34,7 @@ jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ bottom: 16, right: 16, left: 16, top: 16 }),
 }))
 
-const offerId = 116656
+const offerId = offerResponseSnap.id
 
 type MockOffer =
   | (OfferResponseV2 & {

--- a/src/features/offer/pages/Offer/Offer.tsx
+++ b/src/features/offer/pages/Offer/Offer.tsx
@@ -1,16 +1,22 @@
 import { useRoute } from '@react-navigation/native'
-import React from 'react'
+import React, { Fragment, useCallback } from 'react'
 
+import { ReactionTypeEnum } from 'api/gen'
 import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { chroniclePreviewToChronicalCardData } from 'features/offer/adapters/chroniclePreviewToChronicleCardData'
 import { OfferContent } from 'features/offer/components/OfferContent/OfferContent'
 import { OfferContentPlaceholder } from 'features/offer/components/OfferContentPlaceholder/OfferContentPlaceholder'
+import { useReactionMutation } from 'features/reactions/api/useReactionMutation'
+import { ReactionChoiceModal } from 'features/reactions/components/ReactionChoiceModal/ReactionChoiceModal'
+import { ReactionChoiceModalBodyEnum, ReactionFromEnum } from 'features/reactions/enum'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { useIsFalseWithDelay } from 'libs/hooks/useIsFalseWithDelay'
 import { useSubcategoriesMapping } from 'libs/subcategories/mappings'
 import { useSubcategories } from 'libs/subcategories/useSubcategories'
+import { useEndedBookingFromOfferIdQuery } from 'queries/bookings/useEndedBookingFromOfferIdQuery'
 import { useOfferQuery } from 'queries/offer/useOfferQuery'
+import { useModal } from 'ui/components/modals/useModal'
 
 const ANIMATION_DURATION = 700
 
@@ -18,28 +24,65 @@ export function Offer() {
   const route = useRoute<UseRouteType<'Offer'>>()
   const offerId = route.params?.id
 
-  const { data: offer, isLoading } = useOfferQuery({ offerId })
-  const showSkeleton = useIsFalseWithDelay(isLoading, ANIMATION_DURATION)
-  const { data: subcategories } = useSubcategories()
-  const subcategoriesMapping = useSubcategoriesMapping()
   const hasOfferChronicleSection = useFeatureFlag(
     RemoteStoreFeatureFlags.WIP_OFFER_CHRONICLE_SECTION
   )
+  const isReactionEnabled = useFeatureFlag(RemoteStoreFeatureFlags.WIP_REACTION_FEATURE)
+
+  const { data: offer, isLoading } = useOfferQuery({
+    offerId,
+    select: (data) => ({
+      ...data,
+      reactionsCount: { likes: isReactionEnabled ? data.reactionsCount.likes : 0 },
+    }),
+  })
+  const showSkeleton = useIsFalseWithDelay(isLoading, ANIMATION_DURATION)
+  const { data: subcategories } = useSubcategories()
+  const subcategoriesMapping = useSubcategoriesMapping()
+
+  const { visible, hideModal, showModal } = useModal(false)
+  const { data: booking } = useEndedBookingFromOfferIdQuery(offer?.id ?? -1, {
+    enabled: isReactionEnabled && !!offer?.id,
+  })
+  const { mutate: saveReaction } = useReactionMutation()
+
+  const handleSaveReaction = useCallback(
+    ({ offerId, reactionType }: { offerId: number; reactionType: ReactionTypeEnum }) => {
+      saveReaction({ reactions: [{ offerId, reactionType }] })
+      hideModal()
+    },
+    [hideModal, saveReaction]
+  )
+
+  const chronicles = hasOfferChronicleSection
+    ? offer?.chronicles?.map((value) => chroniclePreviewToChronicalCardData(value))
+    : undefined
 
   if (!offer || !subcategories) return null
 
   if (showSkeleton) return <OfferContentPlaceholder />
 
-  const chronicles = hasOfferChronicleSection
-    ? offer.chronicles?.map((value) => chroniclePreviewToChronicalCardData(value))
-    : undefined
-
   return (
-    <OfferContent
-      offer={offer}
-      chronicles={chronicles}
-      searchGroupList={subcategories.searchGroups}
-      subcategory={subcategoriesMapping[offer.subcategoryId]}
-    />
+    <Fragment>
+      <ReactionChoiceModal
+        dateUsed={booking?.dateUsed ?? ''}
+        offer={offer}
+        closeModal={hideModal}
+        visible={visible}
+        defaultReaction={booking?.userReaction}
+        onSave={handleSaveReaction}
+        from={ReactionFromEnum.ENDED_BOOKING}
+        bodyType={ReactionChoiceModalBodyEnum.VALIDATION}
+      />
+
+      <OfferContent
+        offer={offer}
+        chronicles={chronicles}
+        searchGroupList={subcategories.searchGroups}
+        subcategory={subcategoriesMapping[offer.subcategoryId]}
+        defaultReaction={booking?.userReaction}
+        onReactionButtonPress={booking ? showModal : undefined}
+      />
+    </Fragment>
   )
 }

--- a/src/features/offer/types.ts
+++ b/src/features/offer/types.ts
@@ -4,6 +4,7 @@ import {
   CategoryIdEnum,
   FavoriteResponse,
   OfferResponseV2,
+  ReactionTypeEnum,
   RecommendationApiParams,
   SearchGroupResponseModelv2,
   SubcategoryIdEnum,
@@ -76,4 +77,6 @@ export type OfferContentProps = {
   searchGroupList: SearchGroupResponseModelv2[]
   subcategory: Subcategory
   chronicles?: ChronicleCardData[]
+  defaultReaction?: ReactionTypeEnum | null
+  onReactionButtonPress?: () => void
 }

--- a/src/queries/bookings/useEndedBookingFromOfferIdQuery.ts
+++ b/src/queries/bookings/useEndedBookingFromOfferIdQuery.ts
@@ -1,12 +1,14 @@
-import { UseQueryResult } from 'react-query'
+import { UseQueryOptions, UseQueryResult } from 'react-query'
 
 import { BookingReponse, BookingsResponse } from 'api/gen'
 import { useBookingsQuery } from 'queries/bookings/useBookingsQuery'
 
 export function useEndedBookingFromOfferIdQuery(
-  offerId: number
+  offerId: number,
+  options?: UseQueryOptions<BookingsResponse>
 ): UseQueryResult<BookingReponse | null> {
   return useBookingsQuery({
+    ...options,
     select(bookings: BookingsResponse | null) {
       if (!bookings) {
         return null

--- a/src/queries/offer/useOfferQuery.native.test.ts
+++ b/src/queries/offer/useOfferQuery.native.test.ts
@@ -22,4 +22,17 @@ describe('useOfferQuery', () => {
 
     expect(JSON.stringify(result.current.data)).toEqual(JSON.stringify(offerResponseSnap))
   })
+
+  it('should call and API return formated data', async () => {
+    const { result } = renderHook(
+      () => useOfferQuery<string>({ offerId: offerResponseSnap.id, select: (data) => data?.name }),
+      {
+        wrapper: ({ children }) => reactQueryProviderHOC(children),
+      }
+    )
+
+    await act(async () => {})
+
+    expect(result.current.data).toBe(offerResponseSnap.name)
+  })
 })

--- a/src/queries/offer/useOfferQuery.ts
+++ b/src/queries/offer/useOfferQuery.ts
@@ -30,10 +30,17 @@ const getOfferById = async (offerId: number, logType: LogTypeEnum) => {
   }
 }
 
-export const useOfferQuery = ({ offerId }: { offerId: number }) => {
+export const useOfferQuery = <T = OfferResponseV2>({
+  offerId,
+  select,
+}: {
+  offerId: number
+  select?: (data: OfferResponseV2) => T | undefined
+}) => {
   const { logType } = useLogTypeFromRemoteConfig()
 
-  return useQuery<OfferResponseV2 | undefined>([QueryKeys.OFFER, offerId], () =>
-    offerId ? getOfferById(offerId, logType) : undefined
-  )
+  return useQuery([QueryKeys.OFFER, offerId], () => getOfferById(offerId, logType), {
+    enabled: !!offerId,
+    select,
+  })
 }


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34992

Mise en place de la fonctionnalité de réaction à une offre via un bouton dans le header de la page Offre.
Suppression des boutons **J'aime / Je n'aime pas**

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [x] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [x] I am aware of all the best practices and respected them.

## Screenshots

iOS

https://github.com/user-attachments/assets/f0114a5a-9661-4259-a92c-0cbb9afbc696

Android

https://github.com/user-attachments/assets/72a6ecb2-fc26-49be-8361-579646a8ed31

Web

https://github.com/user-attachments/assets/91317e47-d665-48f6-bf52-6a2d41b3605b




[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
