### PR TITLE
(PC-34787) feat(Prices): paper books subcategory should have fixed pr…

### DIFF
--- a/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
+++ b/__snapshots__/features/home/components/modules/video/VideoModal.native.test.tsx.native-snap
@@ -651,7 +651,7 @@ exports[`VideoModal should render correctly if modal visible 1`] = `
                       ]
                     }
                   >
-                    Dès 0,28 €
+                    0,28 €
                   </Text>
                 </View>
               </View>

--- a/src/features/artist/components/ArtistPlaylist/ArtistPlaylist.tsx
+++ b/src/features/artist/components/ArtistPlaylist/ArtistPlaylist.tsx
@@ -5,7 +5,11 @@ import { OfferPlaylistItem } from 'features/offer/components/OfferPlaylistItem/O
 import { PlaylistType } from 'features/offer/enums'
 import { AlgoliaOfferWithArtistAndEan } from 'libs/algolia/types'
 import { usePlaylistItemDimensionsFromLayout } from 'libs/contentful/usePlaylistItemDimensionsFromLayout'
-import { getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
+import {
+  getDisplayedPrice,
+  getIfPricesShouldBeFix,
+  formatStartPrice,
+} from 'libs/parsers/getDisplayedPrice'
 import { useCategoryIdMapping } from 'libs/subcategories'
 import { useSubcategoryOfferLabelMapping } from 'libs/subcategories/mappings'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
@@ -46,7 +50,12 @@ export const ArtistPlaylist: FunctionComponent<ArtistPlaylistProps> = ({
         analyticsFrom: 'artist',
         artistName,
         priceDisplay: (item: Offer) =>
-          getDisplayedPrice(item.offer.prices, currency, euroToPacificFrancRate),
+          getDisplayedPrice(
+            item.offer.prices,
+            currency,
+            euroToPacificFrancRate,
+            getIfPricesShouldBeFix(item.offer.subcategoryId) ? undefined : formatStartPrice
+          ),
       })}
       itemWidth={itemWidth}
       itemHeight={itemHeight}

--- a/src/features/chronicle/pages/Chronicles/Chronicles.web.tsx
+++ b/src/features/chronicle/pages/Chronicles/Chronicles.web.tsx
@@ -14,7 +14,11 @@ import { UseRouteType } from 'features/navigation/RootNavigator/types'
 import { OfferCTAButton } from 'features/offer/components/OfferCTAButton/OfferCTAButton'
 import { getOfferPrices } from 'features/offer/helpers/getOfferPrice/getOfferPrice'
 import { useOfferBatchTracking } from 'features/offer/helpers/useOfferBatchTracking/useOfferBatchTracking'
-import { getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
+import {
+  getDisplayedPrice,
+  getIfPricesShouldBeFix,
+  formatPrice,
+} from 'libs/parsers/getDisplayedPrice'
 import { useSubcategoriesMapping } from 'libs/subcategories'
 import { useOfferQuery } from 'queries/offer/useOfferQuery'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
@@ -48,8 +52,13 @@ export const Chronicles: FunctionComponent = () => {
     prices,
     currency,
     euroToPacificFrancRate,
-    offer?.isDuo && user?.isBeneficiary,
-    { fractionDigits: 2 }
+    formatPrice(
+      getIfPricesShouldBeFix(offer?.subcategoryId),
+      !!(offer?.isDuo && user?.isBeneficiary)
+    ),
+    {
+      fractionDigits: 2,
+    }
   )
 
   if (!offer || !chronicleCardsData) return null

--- a/src/features/headlineOffer/adapters/offerToHeadlineOfferData.ts
+++ b/src/features/headlineOffer/adapters/offerToHeadlineOfferData.ts
@@ -1,7 +1,11 @@
 import { HeadlineOfferData } from 'features/headlineOffer/type'
 import { Position } from 'libs/location'
 import { formatDistance } from 'libs/parsers/formatDistance'
-import { getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
+import {
+  formatStartPrice,
+  getDisplayedPrice,
+  getIfPricesShouldBeFix,
+} from 'libs/parsers/getDisplayedPrice'
 import { CategoryHomeLabelMapping, CategoryIdMapping } from 'libs/subcategories/types'
 import { Currency } from 'shared/currency/useGetCurrencyToDisplay'
 import { Offer } from 'shared/offer/types'
@@ -29,7 +33,12 @@ export function offerToHeadlineOfferData({
   const { mapping, labelMapping, currency, euroToPacificFrancRate, userLocation } =
     transformParameters
 
-  const displayedPrice = getDisplayedPrice(hitOffer.prices, currency, euroToPacificFrancRate)
+  const displayedPrice = getDisplayedPrice(
+    hitOffer.prices,
+    currency,
+    euroToPacificFrancRate,
+    getIfPricesShouldBeFix(hitOffer.subcategoryId) ? formatStartPrice : undefined
+  )
 
   return {
     id: objectID,

--- a/src/features/home/components/AttachedModuleCard/AttachedOfferCard.tsx
+++ b/src/features/home/components/AttachedModuleCard/AttachedOfferCard.tsx
@@ -6,7 +6,11 @@ import { getExclusivityAccessibilityLabel } from 'features/home/helpers/getExclu
 import { useLocation } from 'libs/location'
 import { getDistance } from 'libs/location/getDistance'
 import { formatDates, getTimeStampInMillis } from 'libs/parsers/formatDates'
-import { getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
+import {
+  formatPrice,
+  getDisplayedPrice,
+  getIfPricesShouldBeFix,
+} from 'libs/parsers/getDisplayedPrice'
 import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { useGetPacificFrancToEuroRate } from 'shared/exchangeRates/useGetPacificFrancToEuroRate'
@@ -36,7 +40,10 @@ export const AttachedOfferCard: React.FC<Props> = ({ offer, shouldFixHeight, com
     attachedOffer.prices,
     currency,
     euroToPacificFrancRate,
-    attachedOffer.isDuo && user?.isBeneficiary
+    formatPrice(
+      getIfPricesShouldBeFix(attachedOffer.subcategoryId),
+      !!(attachedOffer.isDuo && user?.isBeneficiary)
+    )
   )
   const distance = getDistance(offer._geoloc, { userLocation, selectedPlace, selectedLocationMode })
   const distanceLabel = distance ? `à ${distance}` : undefined

--- a/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMonoOfferTile.tsx
@@ -10,7 +10,11 @@ import { triggerConsultOfferLog } from 'libs/analytics/helpers/triggerLogConsult
 import { OfferAnalyticsParams } from 'libs/analytics/types'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import { getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
+import {
+  formatPrice,
+  getDisplayedPrice,
+  getIfPricesShouldBeFix,
+} from 'libs/parsers/getDisplayedPrice'
 import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { getOfferDates } from 'shared/date/getOfferDates'
@@ -58,7 +62,10 @@ export const VideoMonoOfferTile: FunctionComponent<Props> = ({
     offer?.offer?.prices,
     currency,
     euroToPacificFrancRate,
-    offer.offer.isDuo && user?.isBeneficiary
+    formatPrice(
+      getIfPricesShouldBeFix(offer.offer.subcategoryId),
+      !!(offer.offer.isDuo && user?.isBeneficiary)
+    )
   )
 
   const offerHeight = theme.isDesktopViewport ? getSpacing(45) : getSpacing(35)

--- a/src/features/home/components/modules/video/VideoMultiOfferTile.tsx
+++ b/src/features/home/components/modules/video/VideoMultiOfferTile.tsx
@@ -10,7 +10,11 @@ import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureF
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { useLocation } from 'libs/location'
 import { getDistance } from 'libs/location/getDistance'
-import { getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
+import {
+  formatPrice,
+  getDisplayedPrice,
+  getIfPricesShouldBeFix,
+} from 'libs/parsers/getDisplayedPrice'
 import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { getOfferDates } from 'shared/date/getOfferDates'
@@ -47,7 +51,10 @@ export const VideoMultiOfferTile: FunctionComponent<Props> = ({
     offer?.offer?.prices,
     currency,
     euroToPacificFrancRate,
-    offer.offer.isDuo && user?.isBeneficiary
+    formatPrice(
+      getIfPricesShouldBeFix(offer.offer.subcategoryId),
+      !!(offer.offer.isDuo && user?.isBeneficiary)
+    )
   )
 
   const displayDate = getOfferDates(

--- a/src/features/offer/components/OfferBody/OfferBody.tsx
+++ b/src/features/offer/components/OfferBody/OfferBody.tsx
@@ -24,7 +24,11 @@ import { useOfferSummaryInfoList } from 'features/offer/helpers/useOfferSummaryI
 import { analytics } from 'libs/analytics/provider'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
-import { getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
+import {
+  formatPrice,
+  getDisplayedPrice,
+  getIfPricesShouldBeFix,
+} from 'libs/parsers/getDisplayedPrice'
 import { Subcategory } from 'libs/subcategories/types'
 import { formatFullAddress } from 'shared/address/addressFormatter'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
@@ -61,7 +65,10 @@ export const OfferBody: FunctionComponent<Props> = ({ offer, subcategory, childr
     prices,
     currency,
     euroToPacificFrancRate,
-    offer.isDuo && user?.isBeneficiary,
+    formatPrice(
+      getIfPricesShouldBeFix(offer.subcategoryId),
+      !!(offer.isDuo && user?.isBeneficiary)
+    ),
     { fractionDigits: 2 }
   )
 

--- a/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.tsx
+++ b/src/features/offer/components/OfferPlaylistList/OfferPlaylistList.tsx
@@ -10,7 +10,11 @@ import { useLogPlaylist } from 'features/offer/helpers/useLogPlaylistVertical/us
 import { useLogScrollHandler } from 'features/offer/helpers/useLogScrolHandler/useLogScrollHandler'
 import { analytics } from 'libs/analytics/provider'
 import { usePlaylistItemDimensionsFromLayout } from 'libs/contentful/usePlaylistItemDimensionsFromLayout'
-import { getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
+import {
+  formatStartPrice,
+  getDisplayedPrice,
+  getIfPricesShouldBeFix,
+} from 'libs/parsers/getDisplayedPrice'
 import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { useGetPacificFrancToEuroRate } from 'shared/exchangeRates/useGetPacificFrancToEuroRate'
@@ -121,7 +125,12 @@ export function OfferPlaylistList({
                 navigationMethod: 'push',
                 apiRecoParams: playlist.apiRecoParams,
                 priceDisplay: (item: Offer) =>
-                  getDisplayedPrice(item.offer.prices, currency, euroToPacificFrancRate),
+                  getDisplayedPrice(
+                    item.offer.prices,
+                    currency,
+                    euroToPacificFrancRate,
+                    getIfPricesShouldBeFix(item.offer.subcategoryId) ? undefined : formatStartPrice
+                  ),
               })}
               title={playlist.title}
               onEndReached={() => trackingOnHorizontalScroll(playlist.type, playlist.apiRecoParams)}

--- a/src/features/offer/components/OfferTile/OfferTileWrapper.tsx
+++ b/src/features/offer/components/OfferTile/OfferTileWrapper.tsx
@@ -3,7 +3,11 @@ import React from 'react'
 import { useAuthContext } from 'features/auth/context/AuthContext'
 import { OfferTile } from 'features/offer/components/OfferTile/OfferTile'
 import { OfferTileProps } from 'features/offer/types'
-import { getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
+import {
+  formatPrice,
+  getDisplayedPrice,
+  getIfPricesShouldBeFix,
+} from 'libs/parsers/getDisplayedPrice'
 import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { getOfferDates } from 'shared/date/getOfferDates'
@@ -34,7 +38,10 @@ export const OfferTileWrapper = (props: Props) => {
     item.offer?.prices,
     currency,
     euroToPacificFrancRate,
-    item.offer.isDuo && user?.isBeneficiary
+    formatPrice(
+      getIfPricesShouldBeFix(item.offer.subcategoryId),
+      !!(item.offer.isDuo && user?.isBeneficiary)
+    )
   )
 
   return (

--- a/src/features/venue/components/VenueOffers/VenueOffersList.tsx
+++ b/src/features/venue/components/VenueOffers/VenueOffersList.tsx
@@ -14,7 +14,11 @@ import { analytics } from 'libs/analytics/provider'
 import { useFeatureFlag } from 'libs/firebase/firestore/featureFlags/useFeatureFlag'
 import { RemoteStoreFeatureFlags } from 'libs/firebase/firestore/types'
 import { formatDates, getTimeStampInMillis } from 'libs/parsers/formatDates'
-import { getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
+import {
+  formatPrice,
+  getDisplayedPrice,
+  getIfPricesShouldBeFix,
+} from 'libs/parsers/getDisplayedPrice'
 import { VenueTypeCode } from 'libs/parsers/venueType'
 import { CategoryHomeLabelMapping, CategoryIdMapping } from 'libs/subcategories/types'
 import { Currency } from 'shared/currency/useGetCurrencyToDisplay'
@@ -91,7 +95,10 @@ export const VenueOffersList: FunctionComponent<VenueOffersListProps> = ({
           item.offer.prices,
           currency,
           euroToPacificFrancRate,
-          item.offer.isDuo && user?.isBeneficiary
+          formatPrice(
+            getIfPricesShouldBeFix(item.offer.subcategoryId),
+            !!(item.offer.isDuo && user?.isBeneficiary)
+          )
         )}
         venueId={venue?.id}
         width={width}

--- a/src/features/venueMap/components/VenueMapBottomSheet/VenueMapOfferPlaylist.tsx
+++ b/src/features/venueMap/components/VenueMapBottomSheet/VenueMapOfferPlaylist.tsx
@@ -4,7 +4,11 @@ import styled from 'styled-components/native'
 
 import { OfferTile } from 'features/offer/components/OfferTile/OfferTile'
 import { PlaylistType } from 'features/offer/enums'
-import { getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
+import {
+  formatStartPrice,
+  getDisplayedPrice,
+  getIfPricesShouldBeFix,
+} from 'libs/parsers/getDisplayedPrice'
 import { useCategoryHomeLabelMapping, useCategoryIdMapping } from 'libs/subcategories'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
 import { useGetPacificFrancToEuroRate } from 'shared/exchangeRates/useGetPacificFrancToEuroRate'
@@ -46,7 +50,12 @@ export const VenueMapOfferPlaylist = ({
         offerLocation={item._geoloc}
         analyticsFrom="venueMap"
         thumbUrl={item.offer.thumbUrl}
-        price={getDisplayedPrice(item.offer.prices, currency, euroToPacificFrancRate)}
+        price={getDisplayedPrice(
+          item.offer.prices,
+          currency,
+          euroToPacificFrancRate,
+          getIfPricesShouldBeFix(item.offer.subcategoryId) ? undefined : formatStartPrice
+        )}
         width={PLAYLIST_ITEM_WIDTH}
         height={PLAYLIST_ITEM_HEIGHT}
         playlistType={playlistType}

--- a/src/libs/parsers/getDisplayedPrice.native.test.ts
+++ b/src/libs/parsers/getDisplayedPrice.native.test.ts
@@ -1,7 +1,15 @@
+import { SubcategoryIdEnum } from 'api/gen'
 import { Currency } from 'shared/currency/useGetCurrencyToDisplay'
 import { DEFAULT_PACIFIC_FRANC_TO_EURO_RATE } from 'shared/exchangeRates/defaultRateValues'
 
-import { getDisplayedPrice } from './getDisplayedPrice'
+import {
+  formatDuoPrice,
+  formatPrice,
+  formatStartPrice,
+  getDisplayedPrice,
+  getIfPricesShouldBeFix,
+  identityPrice,
+} from './getDisplayedPrice'
 
 describe('getDisplayedPrice', () => {
   it.each`
@@ -10,15 +18,15 @@ describe('getDisplayedPrice', () => {
     ${[]}                | ${Currency.EURO}                | ${''}
     ${[0]}               | ${Currency.EURO}                | ${'Gratuit'}
     ${[0, 700]}          | ${Currency.EURO}                | ${'Gratuit'}
-    ${[100]}             | ${Currency.EURO}                | ${'Dès 1\u00a0€'}
-    ${[200]}             | ${Currency.EURO}                | ${'Dès 2\u00a0€'}
-    ${[345]}             | ${Currency.EURO}                | ${'Dès 3,45\u00a0€'}
-    ${[350]}             | ${Currency.EURO}                | ${'Dès 3,50\u00a0€'}
-    ${[560, 300]}        | ${Currency.EURO}                | ${'Dès 3\u00a0€'}
-    ${[200, 1000, 3000]} | ${Currency.EURO}                | ${'Dès 2\u00a0€'}
-    ${[-300, 560]}       | ${Currency.EURO}                | ${'Dès 5,60\u00a0€'}
-    ${[800, 800]}        | ${Currency.EURO}                | ${'Dès 8\u00a0€'}
-    ${[100]}             | ${Currency.PACIFIC_FRANC_SHORT} | ${'Dès 120\u00a0F'}
+    ${[100]}             | ${Currency.EURO}                | ${'1\u00a0€'}
+    ${[200]}             | ${Currency.EURO}                | ${'2\u00a0€'}
+    ${[345]}             | ${Currency.EURO}                | ${'3,45\u00a0€'}
+    ${[350]}             | ${Currency.EURO}                | ${'3,50\u00a0€'}
+    ${[560, 300]}        | ${Currency.EURO}                | ${'3\u00a0€'}
+    ${[200, 1000, 3000]} | ${Currency.EURO}                | ${'2\u00a0€'}
+    ${[-300, 560]}       | ${Currency.EURO}                | ${'5,60\u00a0€'}
+    ${[800, 800]}        | ${Currency.EURO}                | ${'8\u00a0€'}
+    ${[100]}             | ${Currency.PACIFIC_FRANC_SHORT} | ${'120\u00a0F'}
   `(
     'getDisplayedPrice($prices) \t= $expected without format price options',
     ({ prices, currency, expected }) => {
@@ -27,28 +35,89 @@ describe('getDisplayedPrice', () => {
   )
 
   it.each`
-    prices               | currency                        | isDuoDisplayable | expected
-    ${undefined}         | ${Currency.EURO}                | ${undefined}     | ${''}
-    ${[]}                | ${Currency.EURO}                | ${undefined}     | ${''}
-    ${[0]}               | ${Currency.EURO}                | ${true}          | ${'Gratuit'}
-    ${[0, 700]}          | ${Currency.EURO}                | ${false}         | ${'Gratuit'}
-    ${[100]}             | ${Currency.EURO}                | ${false}         | ${'Dès 1,00\u00a0€'}
-    ${[200]}             | ${Currency.EURO}                | ${true}          | ${'Dès 2,00\u00a0€ - Duo'}
-    ${[345]}             | ${Currency.EURO}                | ${false}         | ${'Dès 3,45\u00a0€'}
-    ${[350]}             | ${Currency.EURO}                | ${undefined}     | ${'Dès 3,50\u00a0€'}
-    ${[560, 300]}        | ${Currency.EURO}                | ${undefined}     | ${'Dès 3,00\u00a0€'}
-    ${[200, 1000, 3000]} | ${Currency.EURO}                | ${undefined}     | ${'Dès 2,00\u00a0€'}
-    ${[-300, 560]}       | ${Currency.EURO}                | ${undefined}     | ${'Dès 5,60\u00a0€'}
-    ${[800, 800]}        | ${Currency.EURO}                | ${undefined}     | ${'Dès 8,00\u00a0€'}
-    ${[100]}             | ${Currency.PACIFIC_FRANC_SHORT} | ${true}          | ${'Dès 120\u00a0F - Duo'}
+    prices               | currency                        | isDuoDisplayable | subcategoryId                      | expected
+    ${undefined}         | ${Currency.EURO}                | ${undefined}     | ${SubcategoryIdEnum.FESTIVAL_CINE} | ${''}
+    ${[]}                | ${Currency.EURO}                | ${undefined}     | ${SubcategoryIdEnum.FESTIVAL_CINE} | ${''}
+    ${[0]}               | ${Currency.EURO}                | ${true}          | ${SubcategoryIdEnum.FESTIVAL_CINE} | ${'Gratuit'}
+    ${[0, 700]}          | ${Currency.EURO}                | ${false}         | ${SubcategoryIdEnum.FESTIVAL_CINE} | ${'Gratuit'}
+    ${[100]}             | ${Currency.EURO}                | ${false}         | ${SubcategoryIdEnum.FESTIVAL_CINE} | ${'Dès 1,00\u00a0€'}
+    ${[200]}             | ${Currency.EURO}                | ${true}          | ${SubcategoryIdEnum.FESTIVAL_CINE} | ${'Dès 2,00\u00a0€ - Duo'}
+    ${[345]}             | ${Currency.EURO}                | ${false}         | ${SubcategoryIdEnum.FESTIVAL_CINE} | ${'Dès 3,45\u00a0€'}
+    ${[350]}             | ${Currency.EURO}                | ${undefined}     | ${SubcategoryIdEnum.FESTIVAL_CINE} | ${'Dès 3,50\u00a0€'}
+    ${[560, 300]}        | ${Currency.EURO}                | ${undefined}     | ${SubcategoryIdEnum.FESTIVAL_CINE} | ${'Dès 3,00\u00a0€'}
+    ${[200, 1000, 3000]} | ${Currency.EURO}                | ${undefined}     | ${SubcategoryIdEnum.FESTIVAL_CINE} | ${'Dès 2,00\u00a0€'}
+    ${[-300, 560]}       | ${Currency.EURO}                | ${undefined}     | ${SubcategoryIdEnum.FESTIVAL_CINE} | ${'Dès 5,60\u00a0€'}
+    ${[800, 800]}        | ${Currency.EURO}                | ${undefined}     | ${SubcategoryIdEnum.FESTIVAL_CINE} | ${'Dès 8,00\u00a0€'}
+    ${[100]}             | ${Currency.PACIFIC_FRANC_SHORT} | ${true}          | ${SubcategoryIdEnum.FESTIVAL_CINE} | ${'Dès 120\u00a0F - Duo'}
+    ${[100]}             | ${Currency.PACIFIC_FRANC_SHORT} | ${undefined}     | ${SubcategoryIdEnum.LIVRE_PAPIER}  | ${'120\u00a0F'}
+    ${[800]}             | ${Currency.EURO}                | ${undefined}     | ${SubcategoryIdEnum.LIVRE_PAPIER}  | ${'8,00\u00a0€'}
+    ${[800]}             | ${Currency.EURO}                | ${true}          | ${SubcategoryIdEnum.LIVRE_PAPIER}  | ${'8,00\u00a0€ - Duo'}
+    ${[560, 300]}        | ${Currency.EURO}                | ${undefined}     | ${SubcategoryIdEnum.LIVRE_PAPIER}  | ${'3,00\u00a0€'}
   `(
     'getDisplayedPrice($prices) \t= $expected with format price options',
-    ({ prices, currency, isDuoDisplayable, expected }) => {
+    ({ prices, currency, isDuoDisplayable, subcategoryId, expected }) => {
       expect(
-        getDisplayedPrice(prices, currency, DEFAULT_PACIFIC_FRANC_TO_EURO_RATE, isDuoDisplayable, {
-          fractionDigits: 2,
-        })
+        getDisplayedPrice(
+          prices,
+          currency,
+          DEFAULT_PACIFIC_FRANC_TO_EURO_RATE,
+          formatPrice(getIfPricesShouldBeFix(subcategoryId), isDuoDisplayable),
+          {
+            fractionDigits: 2,
+          }
+        )
       ).toBe(expected)
     }
   )
+})
+
+describe('identityPrice', () => {
+  it('should render the same price as given', () => {
+    const price = '5,00'
+
+    expect(identityPrice(price)).toBe(price)
+  })
+})
+
+describe('formatDuoPrice', () => {
+  it('should render price with sufix " - Duo"', () => {
+    const price = '6,00'
+
+    expect(formatDuoPrice(price)).toBe(`${price} - Duo`)
+  })
+})
+
+describe('formatStartPrice', () => {
+  it('should render price with sufix "Dès "', () => {
+    const price = '7,00'
+
+    expect(formatStartPrice(price)).toBe(`Dès ${price}`)
+  })
+})
+
+describe('formatPrice', () => {
+  const price = '8,00'
+
+  it.each`
+    isFixed  | isDuo    | expected
+    ${true}  | ${true}  | ${`${price} - Duo`}
+    ${true}  | ${false} | ${price}
+    ${false} | ${true}  | ${`Dès ${price} - Duo`}
+    ${false} | ${false} | ${`Dès ${price}`}
+  `('$should render \t= $expected', ({ isFixed, isDuo, expected }) => {
+    const formatDisplayedPrice = formatPrice(isFixed, isDuo)
+
+    expect(formatDisplayedPrice(price)).toBe(expected)
+  })
+})
+
+describe('getIfPricesShouldBeFix', () => {
+  it.each`
+    subcategoryId                             | expected
+    ${SubcategoryIdEnum.LIVRE_PAPIER}         | ${true}
+    ${undefined}                              | ${false}
+    ${SubcategoryIdEnum.MATERIEL_ART_CREATIF} | ${false}
+  `('getIfPricesShouldBeFix($subcategoryId) \t= $expected', ({ subcategoryId, expected }) => {
+    expect(getIfPricesShouldBeFix(subcategoryId)).toBe(expected)
+  })
 })

--- a/src/libs/parsers/getDisplayedPrice.ts
+++ b/src/libs/parsers/getDisplayedPrice.ts
@@ -1,3 +1,6 @@
+import compose from 'lodash/fp/compose'
+
+import { SubcategoryIdEnum } from 'api/gen'
 import { formatCurrencyFromCents } from 'shared/currency/formatCurrencyFromCents'
 import { Currency } from 'shared/currency/useGetCurrencyToDisplay'
 
@@ -9,7 +12,7 @@ export const getDisplayedPrice = (
   prices: number[] | undefined,
   currency: Currency,
   euroToPacificFrancRate: number,
-  isDuoDisplayable?: boolean,
+  formatDisplayedPrice = identityPrice,
   options?: FormatPriceOptions
 ): string => {
   if (prices?.length) {
@@ -22,9 +25,24 @@ export const getDisplayedPrice = (
     const sortedPrices = [...uniquePrices].sort((a, b) => a - b)
     const firstPrice = sortedPrices[0]
     if (firstPrice !== undefined) {
-      const displayedPrice = `Dès ${formatCurrencyFromCents(firstPrice, currency, euroToPacificFrancRate, options)}`
-      return isDuoDisplayable ? `${displayedPrice} - Duo` : displayedPrice
+      const displayedPrice = formatCurrencyFromCents(
+        firstPrice,
+        currency,
+        euroToPacificFrancRate,
+        options
+      )
+      return formatDisplayedPrice(displayedPrice)
     }
   }
   return ''
+}
+
+export const identityPrice = (price: string): string => price
+export const formatDuoPrice = (price: string): string => `${price} - Duo`
+export const formatStartPrice = (price: string): string => `Dès ${price}`
+export const formatPrice = (isFixed: boolean, isDuo: boolean) =>
+  compose([isFixed ? identityPrice : formatStartPrice, isDuo ? formatDuoPrice : identityPrice])
+
+export const getIfPricesShouldBeFix = (subcategoryId?: SubcategoryIdEnum | undefined): boolean => {
+  return subcategoryId == SubcategoryIdEnum.LIVRE_PAPIER
 }

--- a/src/ui/components/tiles/HorizontalOfferTile.tsx
+++ b/src/ui/components/tiles/HorizontalOfferTile.tsx
@@ -10,7 +10,11 @@ import { OfferAnalyticsParams } from 'libs/analytics/types'
 import { useLocation } from 'libs/location'
 import { getDistance } from 'libs/location/getDistance'
 import { LocationMode } from 'libs/location/types'
-import { getDisplayedPrice } from 'libs/parsers/getDisplayedPrice'
+import {
+  formatPrice,
+  getDisplayedPrice,
+  getIfPricesShouldBeFix,
+} from 'libs/parsers/getDisplayedPrice'
 import { useSubcategory } from 'libs/subcategories'
 import { tileAccessibilityLabel, TileContentType } from 'libs/tileAccessibilityLabel'
 import { useGetCurrencyToDisplay } from 'shared/currency/useGetCurrencyToDisplay'
@@ -85,7 +89,10 @@ export const HorizontalOfferTile = ({
     prices,
     currency,
     euroToPacificFrancRate,
-    offerDetails.isDuo && user?.isBeneficiary
+    formatPrice(
+      getIfPricesShouldBeFix(offerDetails.subcategoryId),
+      !!(offerDetails.isDuo && user?.isBeneficiary)
+    )
   )
 
   const accessibilityLabel = tileAccessibilityLabel(TileContentType.OFFER, {


### PR DESCRIPTION
…ices

Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-34787

## Flakiness

If I had to re-run tests in the CI due to flakiness, I add the incident [on Notion][2]

## Checklist

I have:

- [x] Made sure my feature is working on web.
- [ ] Made sure my feature is working on mobile (depending on relevance : real or virtual devices)
- [x] Written **unit tests** native (and web when implementation is different) for my feature.
- [ ] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change
- [ ] If my PR is a bugfix, I add the link of the "résolution de problème sur le bug" [on Notion][1]
- [ ] I am aware of all the best practices and respected them.

## Screenshots

**delete** _if no UI change_

| Platform         | Mockup/Before | After |
| :--------------- | :-----------: | :---: |
| Desktop - Chrome | <img width="1435" alt="Screenshot 2025-03-14 at 10 55 55" src="https://github.com/user-attachments/assets/2dc3260f-0a34-41cf-ac70-bd0543c16ffe" />| <img width="1439" alt="Screenshot 2025-03-14 at 10 56 37" src="https://github.com/user-attachments/assets/0e7d0965-5391-4b0b-98c2-3422fd194fbe" />|

[1]: https://www.notion.so/passcultureapp/R-solution-de-probl-mes-sur-les-bugs-5dd6df8f6a754e6887066cf613467d0a
[2]: https://www.notion.so/passcultureapp/cb45383351b44723a6f2d9e1481ad6bb?v=10fe47258701423985aa7d25bb04cfee&pvs=4

## Best Practices

<details>
  <summary>Click to expand</summary>

These rules apply to files that you make changes to.
If you can't respect one of these rules, be sure to explain why with a comment.
If you consider correcting the issue is too time consuming/complex: create a ticket. Link the ticket in the code.

- In the production code: remove type assertions with `as` (type assertions are removed at compile-time, there is no runtime checking associated with a type assertion. There won’t be an exception or `null` generated if the type assertion is wrong). In certain cases `as const` is acceptable (for example when defining readonly arrays/objects). Using `as` in tests is tolerable.
- Remove bypass type checking with `any` (when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`). Using `any` in tests is tolerable.
- Remove non-null assertion operators (just like other type assertions, this doesn’t change the runtime behavior of your code, so it’s important to only use `!` when you know that the value can’t be `null` or `undefined`).
- Remove all `@ts-expect-error` and `@eslint-disable`.
- Remove all warnings, and errors that we are used to ignore (`yarn test:lint`, `yarn test:types`, `yarn start:web`...).
- Use `gap` (`ViewGap`) instead of `<Spacer.Column />`, `<Spacer.Row />` or `<Spacer.Flex />`.
- Don't add new "alias hooks" (hooks created to group other hooks together). When adding new logic, this hook will progressively become more complex and harder to maintain.
- Remove logic from components that should be dumb.
- undefined != null : undefined should be used for optionals and null when no value

### Request specific:

- A request must use `react-query`
- A hook that use `react-query` must:
  - folder
    - when used in one feature
      - be in `src/<feature>/queries/`
    - when used by several features
      - be in `src/queries/<the main feature related to the query>/`
  - file
    - when use `useQuery` or hook related (like `useInfiniteQuery`)
      - named `use<the content retrieved by the query>Query.ts`
      - returns the type `UseQueryResult<the content retrieved by the query>`
    - when use `useMutation`
      - named `use<the content mutated by the query>Mutation.ts`
      - returns the type `UseMutationResult<the content mutated by the query>`

### Test specific:

- Avoid mocking internal parts of our code. Ideally, mock only external calls.
- When you see a local variable that is over-written in every test, mock it.
- Prefer `user` to `fireEvent`.
- When mocking feature flags, use `setFeatureFlags`. If not possible, mention which one(s) you want to mock in a comment (example: `jest.spyOn(useFeatureFlagAPI, 'useFeatureFlag').mockReturnValue(true) // WIP_NEW_OFFER_TILE in renderPassPlaylist.tsx` )
- In component tests, replace `await act(async () => {})` and `await waitFor(/* ... */)` by `await screen.findBySomething()`.
- In hooks tests, use `act` by default and `waitFor` as a last resort.
- Make a snapshot test for pages and modals ONLY.
- Make a web specific snapshot when your web page/modal is specific to the web.
- Make an a11y test for web pages.

### Advice:

- Use TDD
- Use Storybook
- Use pair programming/mobs

</details>
